### PR TITLE
Automatically refit the service graph on resize.

### DIFF
--- a/src/components/CytoscapeLayout/CytoscapeLayout.tsx
+++ b/src/components/CytoscapeLayout/CytoscapeLayout.tsx
@@ -14,6 +14,7 @@ type CytoscapeLayoutProps = {
 
 export default class CytoscapeLayout extends React.Component<CytoscapeLayoutProps, CytoscapeLayoutState> {
   cy: any;
+  dimensions: [number, number];
 
   constructor(props: CytoscapeLayoutProps) {
     super(props);
@@ -37,6 +38,7 @@ export default class CytoscapeLayout extends React.Component<CytoscapeLayoutProp
   componentDidMount() {
     window.addEventListener('resize', this.resizeWindow);
     this.resizeWindow();
+
     if (this.props.namespace.length !== 0) {
       this.updateGraphElements(this.props.namespace);
     }
@@ -50,9 +52,14 @@ export default class CytoscapeLayout extends React.Component<CytoscapeLayoutProp
 
   cyRef(cy: any) {
     this.cy = cy;
+
     cy.on('tap', 'node', (evt: any) => {
       let node = evt.target;
       console.log('clicked on: ' + node.id());
+    });
+
+    cy.on('resize', (evt: any) => {
+            this.cy.fit();
     });
   }
 


### PR DESCRIPTION
Automatically refits the cytoscape graph on resize, trying to keep everything on screen.

Bad video (too fast, but it should show it changing automatically when the window size changes.

![](https://media.giphy.com/media/1etp4QZy66PZ8cCVUn/giphy.gif)