### PR TITLE
[WIP] Add new tslint rule to forbid null 

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -47,6 +47,7 @@
         "no-duplicate-variable": true,
         "no-empty": true,
         "no-eval": true,
+        "no-null-keyword": true,
         "no-shadowed-variable": true,
         "no-string-literal": false,
         "no-switch-case-fall-through": true,


### PR DESCRIPTION
- most of the time its a carryover from another language (notably java). 'undefined' is your new friend. Of course, if you really want a 'null' condition: Meaning, it's already defined but it is truly null (never from a component but only from data), then you can exclude the tslint rules via: https://palantir.github.io/tslint/usage/rule-flags/

Basically, if you know you want `null` then override the rule otherwise it's probably an oversight.

Also, there is no need for explicit checking of `null` or even `undefined`
```
if(x !== null) { }
```
Because `null` and `undefined` are `falsey`
Here are the `falsey` values:

- 0 (zero)
- '' or "" (empty string)
- null.
- undefined.
- NaN (e.g. the result of 1/0 )

So `if(x) { } or if(!x) { }` will suffice since it tests for truthy/falsy values


- [x] Add the tslint rule
- [ ] Fix tslint errors in codebase