### PR TITLE
[WIP] Kiali 345  Node/Edge label toggle

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -7,9 +7,7 @@ class App extends React.Component {
   render() {
     return (
       <BrowserRouter basename="/console">
-        <div>
-          <Navigation />
-        </div>
+        <Navigation />
       </BrowserRouter>
     );
   }

--- a/src/components/CytoscapeLayout/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeLayout/graphs/GraphStyles.ts
@@ -13,11 +13,12 @@ export class GraphStyles {
           },
           color: '#030303', // pf-black
           'background-color': '#f9d67a', // pf-gold-200
+          'background-opacity': '0.8',
           'border-width': '1px',
           'border-color': '#030303', // pf-black
-          'font-size': '10px',
-          'text-valign': 'bottom',
-          'text-halign': 'right'
+          'font-size': '8px',
+          'text-valign': 'center',
+          'text-halign': 'center'
         }
       },
       {
@@ -31,11 +32,11 @@ export class GraphStyles {
         // version group boxes
         selector: '$node > node',
         css: {
-          'padding-top': '10px',
+          'padding-top': '20px',
           'padding-left': '20px',
-          'padding-bottom': '10px',
+          'padding-bottom': '8px',
           'padding-right': '20px',
-          'text-valign': 'top',
+          'text-valign': 'bottom',
           'text-halign': 'center',
           'background-color': '#fbeabc' // pf-gold-100
         }

--- a/src/components/GraphFilter/GraphFilter.tsx
+++ b/src/components/GraphFilter/GraphFilter.tsx
@@ -10,6 +10,7 @@ import { BreadthFirstGraph } from '../../components/CytoscapeLayout/graphs/Bread
 import { IntervalButtonGroup } from './IntervalButtonGroup';
 import { LayoutButtonGroup } from './LayoutButtonGroup';
 import { KlayGraph } from '../CytoscapeLayout/graphs/KlayGraph';
+import LabelFilter from './LabelFilter';
 
 export namespace GraphFilters {
   let graphInterval: string = '30s';
@@ -106,7 +107,7 @@ export class GraphFilter extends React.Component<GraphFilterProps, GraphFilterSt
 
   render() {
     return (
-      <div>
+      <>
         <ButtonToolbar>
           <ButtonGroup>
             <DropdownButton id="namespace-selector" title={this.state.graphNamespace} onSelect={this.updateNamespace}>
@@ -119,9 +120,10 @@ export class GraphFilter extends React.Component<GraphFilterProps, GraphFilterSt
           </ButtonGroup>
           <IntervalButtonGroup onClick={this.updateInterval} initialInterval={GraphFilters.getGraphInterval()} />
           <LayoutButtonGroup onClick={this.updateLayout} initialLayout={GraphFilters.getGraphLayoutName()} />
+          <LabelFilter showEdgeLabels={false} showNodeLabels={true} />
         </ButtonToolbar>
         <Toolbar />
-      </div>
+      </>
     );
   }
 }

--- a/src/components/GraphFilter/LabelFilter.tsx
+++ b/src/components/GraphFilter/LabelFilter.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import Switch from 'react-bootstrap-switch';
+import { Toolbar } from 'patternfly-react';
+
+interface LabelFilterType {
+  showEdgeLabels: boolean;
+  showNodeLabels: boolean;
+}
+
+type LabelFilterProps = LabelFilterType;
+type LabelFilterState = LabelFilterType;
+
+export default class LabelsFilter extends React.Component<LabelFilterProps, LabelFilterState> {
+  constructor(props: LabelFilterProps) {
+    super(props);
+    this.state = {
+      showEdgeLabels: false,
+      showNodeLabels: true
+    };
+  }
+
+  toggleEdgeLabels(elem: any, state: any) {
+    this.setState({ showEdgeLabels: !this.state.showEdgeLabels });
+    console.log('new edge state:', state);
+  }
+
+  toggleNodeLabels(elem: any, state: any) {
+    this.setState({ showEdgeLabels: !this.state.showEdgeLabels });
+    console.log('new node state:', state);
+  }
+
+  render() {
+    return (
+      <Toolbar.RightContent style={{ marginLeft: 10, marginRight: 15 }}>
+        <span style={{ marginLeft: 10 }}>
+          <Switch
+            bsSize={'medium'}
+            labelText={'Edges'}
+            defaultValue={false}
+            onChange={(el, state) => this.toggleEdgeLabels(el, state)}
+          />
+        </span>
+        <span style={{ marginLeft: 10 }}>
+          <Switch
+            bsSize={'medium'}
+            labelText={'Nodes'}
+            defaultValue={true}
+            onChange={(el, state) => this.toggleNodeLabels(el, state)}
+          />
+        </span>
+      </Toolbar.RightContent>
+    );
+  }
+}

--- a/src/components/Nav/Navigation.tsx
+++ b/src/components/Nav/Navigation.tsx
@@ -38,7 +38,7 @@ class Navigation extends React.Component {
     return (
       <div>
         <VerticalNav>
-          <VerticalNav.Masthead title="Swift Sunshine">
+          <VerticalNav.Masthead title="Kiala">
             <VerticalNav.Brand iconImg={pfLogo} titleImg={pfBrand} />
             <VerticalNav.IconBar>
               <HelpDropdown />


### PR DESCRIPTION
A preliminary version of the Edge and Node toggle. Visually this works. However, I have no handle to the CytoscapeLayout component because of no commonality in the component tree (it's not a parent, just another node in the tree somewhere). 

<img width="962" alt="label-toggle" src="https://user-images.githubusercontent.com/1312165/37808889-03e77b2c-2e0a-11e8-8b9c-38ee09405337.png">


- [ ] Use MobX to gain publish/subscribe capability to a common datastore.

https://issues.jboss.org/browse/KIALI-345