### PR TITLE
[KIALI-357] consolidate state and callbacks in ServiceGraphPage

### DIFF
--- a/src/components/CytoscapeLayout/__tests__/CytoscapeLayout.test.tsx
+++ b/src/components/CytoscapeLayout/__tests__/CytoscapeLayout.test.tsx
@@ -1,41 +1,35 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import { Button } from 'patternfly-react';
 
-import { ColaGraph } from '../graphs/ColaGraph';
+import ReactCytoscape from '../ReactCytoscape';
 import CytoscapeLayout from '../CytoscapeLayout';
 import * as GRAPH_DATA from '../../../services/__mockData__/getGraphElements';
+import { Interval, Layout } from '../../../types/GraphFilter';
 
 jest.mock('../../../services/Api');
 
-jest.useFakeTimers();
-
 const testNamespace = 'ISTIO_SYSTEM';
+
 const testHandler = () => {
   console.log('click');
 };
 
 describe('CytographLayout component test', () => {
-  it('should set correct elements data', async () => {
-    const wrapper = await shallow(
-      <CytoscapeLayout namespace={testNamespace} layout={ColaGraph.getLayout()} duration="600" onClick={testHandler} />
-    );
-    wrapper.update();
-    expect(wrapper.instance().state.elements.nodes).toEqual(GRAPH_DATA[testNamespace].elements.nodes);
-    expect(wrapper.instance().state.elements.edges).toEqual(GRAPH_DATA[testNamespace].elements.edges);
-  });
-
-  it('should refresh data on click', () => {
-    // for spy to work updateGraphElements() must be regular function, not fat arrow =>
-    // see https://github.com/airbnb/enzyme/issues/944
-    const spyUpdateGraphElements = jest.spyOn(CytoscapeLayout.prototype, 'updateGraphElements');
+  it('should set correct elements data', () => {
+    const myLayout: Layout = { name: 'breadthfirst' };
+    const myInterval: Interval = { value: '5m' };
 
     const wrapper = shallow(
-      <CytoscapeLayout namespace={testNamespace} layout={ColaGraph.getLayout()} duration="600" onClick={testHandler} />
+      <CytoscapeLayout
+        namespace={{ name: testNamespace }}
+        elements={GRAPH_DATA[testNamespace]}
+        graphLayout={myLayout}
+        graphInterval={myInterval}
+        onClick={testHandler}
+      />
     );
-    expect(spyUpdateGraphElements).toHaveBeenCalledTimes(1);
-    const buttonWrapper = wrapper.find(Button);
-    buttonWrapper.simulate('click');
-    expect(spyUpdateGraphElements).toHaveBeenCalledTimes(2);
+    const cytoscapeWrapper = wrapper.find(ReactCytoscape);
+    expect(cytoscapeWrapper.prop('elements').elements.nodes).toEqual(GRAPH_DATA[testNamespace].elements.nodes);
+    expect(cytoscapeWrapper.prop('elements').elements.edges).toEqual(GRAPH_DATA[testNamespace].elements.edges);
   });
 });

--- a/src/components/CytoscapeLayout/graphs/LayoutDictionary.ts
+++ b/src/components/CytoscapeLayout/graphs/LayoutDictionary.ts
@@ -1,0 +1,19 @@
+import { BreadthFirstGraph } from './BreadthFirstGraph';
+import { ColaGraph } from './ColaGraph';
+import { CoseGraph } from './CoseGraph';
+import { DagreGraph } from './DagreGraph';
+import { KlayGraph } from './KlayGraph';
+import { Layout } from '../../../types/GraphFilter';
+
+const LayoutMap = {
+  breadthfirst: BreadthFirstGraph.getLayout(),
+  cola: ColaGraph.getLayout(),
+  dagre: DagreGraph.getLayout(),
+  cose: CoseGraph.getLayout(),
+  klay: KlayGraph.getLayout()
+};
+
+const getLayout = (layout: Layout) =>
+  LayoutMap.hasOwnProperty(layout.name) ? LayoutMap[layout.name] : LayoutMap.dagre;
+
+export { getLayout };

--- a/src/components/GraphFilter/GraphFilter.tsx
+++ b/src/components/GraphFilter/GraphFilter.tsx
@@ -1,104 +1,23 @@
 import * as React from 'react';
 import { ButtonGroup, DropdownButton, MenuItem, Toolbar } from 'patternfly-react';
 import { ButtonToolbar } from 'react-bootstrap';
+
 import { GraphFilterProps, GraphFilterState } from '../../types/GraphFilter';
 import * as API from '../../services/Api';
-import { DagreGraph } from '../../components/CytoscapeLayout/graphs/DagreGraph';
-import { ColaGraph } from '../../components/CytoscapeLayout/graphs/ColaGraph';
-import { CoseGraph } from '../../components/CytoscapeLayout/graphs/CoseGraph';
-import { BreadthFirstGraph } from '../../components/CytoscapeLayout/graphs/BreadthFirstGraph';
 import { DurationButtonGroup } from './DurationButtonGroup';
 import { LayoutButtonGroup } from './LayoutButtonGroup';
-import { KlayGraph } from '../CytoscapeLayout/graphs/KlayGraph';
-
-export namespace GraphFilters {
-  const graphQueryOptionsPerDuration = {
-    '60': { step: 2, rateInterval: '1m' }, // 1m - 60/2=30 buckets which is 1 datapoint per 2s
-    '600': { step: 20, rateInterval: '1m' }, // 10m - 600/20=30 buckets which is 1 datapoint per 20s
-    '1800': { step: 60, rateInterval: '1m' }, // 30m - 1800/60=30 buckets which is 1 datapoint per 1m
-    '3600': { step: 120, rateInterval: '1m' }, // 1h - 3600/120=30 buckets which is 1 datapoint per 2m
-    '14400': { step: 480, rateInterval: '1m' }, // 4h - 14400/480=30 buckets which is 1 datapoint per 8m
-    '28800': { step: 960, rateInterval: '1m' }, // 8h - 28800/960=30 buckets which is 1 datapoint per 16m
-    '86400': { step: 2880, rateInterval: '1m' }, // 1d - 86400/2880=30 buckets which is 1 datapoint per 48m
-    '604800': { step: 20160, rateInterval: '1m' }, // 7d - 604800/20160=30 buckets which is 1 datapoint per 5.6h
-    '2592000': { step: 86400, rateInterval: '1m' } // 30d - 2592000/86400=30 buckets which is 1 datapoint per 1d
-  };
-
-  let graphDuration: string = '600';
-  let graphStep: number = 100;
-  let graphRateInterval: string = '1m';
-  let graphLayout: any = DagreGraph.getLayout();
-  let graphNamespace: string = 'istio-system';
-
-  export const getGraphDuration = () => {
-    return graphDuration;
-  };
-
-  export const getGraphLayout = () => {
-    return graphLayout;
-  };
-
-  export const getGraphLayoutName = () => {
-    return graphLayout.name;
-  };
-
-  export const getGraphNamespace = () => {
-    return graphNamespace;
-  };
-
-  export const getGraphStep = () => {
-    return graphStep;
-  };
-
-  export const getGraphRateInterval = () => {
-    return graphRateInterval;
-  };
-
-  export const setGraphDuration = (value: string) => {
-    graphDuration = value;
-    graphStep = graphQueryOptionsPerDuration[value].step;
-    graphRateInterval = graphQueryOptionsPerDuration[value].rateInterval;
-  };
-
-  export const setGraphLayout = (value: string) => {
-    if (value === 'breadthfirst') {
-      graphLayout = BreadthFirstGraph.getLayout();
-    } else if (value === 'cola') {
-      graphLayout = ColaGraph.getLayout();
-    } else if (value === 'dagre') {
-      graphLayout = DagreGraph.getLayout();
-    } else if (value === 'cose-bilkent') {
-      graphLayout = CoseGraph.getLayout();
-    } else if (value === 'klay') {
-      graphLayout = KlayGraph.getLayout();
-    } else {
-      console.error('invalid graphLayout: ' + value);
-    }
-  };
-
-  export const setGraphNamespace = (value: string) => {
-    graphNamespace = value;
-  };
-}
 
 export class GraphFilter extends React.Component<GraphFilterProps, GraphFilterState> {
   constructor(props: GraphFilterProps) {
     super(props);
-
-    this.setNamespaces = this.setNamespaces.bind(this);
-    this.updateDuration = this.updateDuration.bind(this);
-    this.updateLayout = this.updateLayout.bind(this);
-    this.updateNamespace = this.updateNamespace.bind(this);
-
     this.state = {
-      graphDuration: GraphFilters.getGraphDuration(),
-      graphLayout: GraphFilters.getGraphLayout(),
-      graphNamespace: GraphFilters.getGraphNamespace(),
       availableNamespaces: []
     };
   }
 
   componentDidMount() {
+    // TODO: [KIALI-436] API.GetNamespaces() is also called in Services component.
+    // We should consolidate them into one.
     API.GetNamespaces()
       .then(this.setNamespaces)
       .catch(error => {
@@ -106,43 +25,50 @@ export class GraphFilter extends React.Component<GraphFilterProps, GraphFilterSt
       });
   }
 
-  setNamespaces(response: any) {
+  setNamespaces = (response: any) => {
     this.setState({ availableNamespaces: response['data'] });
-  }
+  };
 
-  updateDuration(value: string) {
-    GraphFilters.setGraphDuration(value);
-    this.setState({ graphDuration: GraphFilters.getGraphDuration() });
-    this.props.onFilterChange();
-  }
+  updateInterval = (value: string) => {
+    if (this.props.activeInterval.value !== value) {
+      // notify callback
+      this.props.onFilterChange({ value: value });
+    }
+  };
 
-  updateLayout(value: string) {
-    GraphFilters.setGraphLayout(value);
-    this.setState({ graphLayout: GraphFilters.getGraphLayout() });
-    this.props.onFilterChange();
-  }
+  updateLayout = (value: string) => {
+    if (this.props.activeLayout.name !== value) {
+      // notify callback
+      this.props.onLayoutChange({ name: value });
+    }
+  };
 
-  updateNamespace(selected: string) {
-    GraphFilters.setGraphNamespace(selected);
-    this.setState({ graphNamespace: GraphFilters.getGraphNamespace() });
-    this.props.onFilterChange();
-  }
+  updateNamespace = (selected: string) => {
+    if (this.props.activeNamespace.name !== selected) {
+      // notify callback
+      this.props.onNamespaceChange({ name: selected });
+    }
+  };
 
   render() {
     return (
       <div>
         <ButtonToolbar>
           <ButtonGroup>
-            <DropdownButton id="namespace-selector" title={this.state.graphNamespace} onSelect={this.updateNamespace}>
+            <DropdownButton
+              id="namespace-selector"
+              title={this.props.activeNamespace.name}
+              onSelect={this.updateNamespace}
+            >
               {this.state.availableNamespaces.map(ns => (
-                <MenuItem key={ns.name} active={ns.name === this.state.graphNamespace} eventKey={ns.name}>
+                <MenuItem key={ns.name} active={ns.name === this.props.activeNamespace.name} eventKey={ns.name}>
                   {ns.name}
                 </MenuItem>
               ))}
             </DropdownButton>
           </ButtonGroup>
-          <DurationButtonGroup onClick={this.updateDuration} initialDuration={GraphFilters.getGraphDuration()} />
-          <LayoutButtonGroup onClick={this.updateLayout} initialLayout={GraphFilters.getGraphLayoutName()} />
+          <DurationButtonGroup onClick={this.updateInterval} initialDuration={this.props.activeInterval.value} />
+          <LayoutButtonGroup onClick={this.updateLayout} initialLayout={this.props.activeLayout.name} />
         </ButtonToolbar>
         <Toolbar />
       </div>

--- a/src/components/GraphFilter/QueryOptions.ts
+++ b/src/components/GraphFilter/QueryOptions.ts
@@ -1,0 +1,24 @@
+// TODO [KIALI-437] Use enums instead of string keys
+const GraphQueryOptionsPerDuration = {
+  '60': { step: 2, rateInterval: '1m' }, // 1m - 60/2=30 buckets which is 1 datapoint per 2s
+  '600': { step: 20, rateInterval: '1m' }, // 10m - 600/20=30 buckets which is 1 datapoint per 20s
+  '1800': { step: 60, rateInterval: '1m' }, // 30m - 1800/60=30 buckets which is 1 datapoint per 1m
+  '3600': { step: 120, rateInterval: '1m' }, // 1h - 3600/120=30 buckets which is 1 datapoint per 2m
+  '14400': { step: 480, rateInterval: '1m' }, // 4h - 14400/480=30 buckets which is 1 datapoint per 8m
+  '28800': { step: 960, rateInterval: '1m' }, // 8h - 28800/960=30 buckets which is 1 datapoint per 16m
+  '86400': { step: 2880, rateInterval: '1m' }, // 1d - 86400/2880=30 buckets which is 1 datapoint per 48m
+  '604800': { step: 20160, rateInterval: '1m' }, // 7d - 604800/20160=30 buckets which is 1 datapoint per 5.6h
+  '2592000': { step: 86400, rateInterval: '1m' } // 30d - 2592000/86400=30 buckets which is 1 datapoint per 1d
+};
+
+const DEFAULT_KEY = '60';
+
+const DEFAULT = { key: DEFAULT_KEY, ...GraphQueryOptionsPerDuration[DEFAULT_KEY] };
+
+const getOption = (key: string) => {
+  return GraphQueryOptionsPerDuration.hasOwnProperty(key)
+    ? { key: key, ...GraphQueryOptionsPerDuration[key] }
+    : DEFAULT;
+};
+
+export { getOption, DEFAULT };

--- a/src/components/NamespaceFilter/NamespaceFilter.tsx
+++ b/src/components/NamespaceFilter/NamespaceFilter.tsx
@@ -8,7 +8,7 @@ import {
   NamespaceFilterState
 } from '../../types/NamespaceFilter';
 import * as API from '../../services/Api';
-import { Namespace } from '../../types/Namespace';
+import Namespace from '../../types/Namespace';
 
 export namespace NamespaceFilterSelected {
   let selectedFilters: ActiveFilter[] = [];

--- a/src/pages/IstioRulesList/IstioRuleListComponent.tsx
+++ b/src/pages/IstioRulesList/IstioRuleListComponent.tsx
@@ -5,7 +5,7 @@ import { NamespaceFilter, NamespaceFilterSelected } from '../../components/Names
 import { Paginator } from 'patternfly-react';
 import { ActiveFilter, FilterType } from '../../types/NamespaceFilter';
 import * as API from '../../services/Api';
-import { Namespace } from '../../types/Namespace';
+import Namespace from '../../types/Namespace';
 import { Pagination } from '../../types/Pagination';
 import { RuleItem, RuleList } from '../../types/IstioRuleListComponent';
 import PropTypes from 'prop-types';

--- a/src/pages/ServiceList/ServiceListComponent.tsx
+++ b/src/pages/ServiceList/ServiceListComponent.tsx
@@ -5,7 +5,7 @@ import { NamespaceFilter, NamespaceFilterSelected } from '../../components/Names
 import { Paginator } from 'patternfly-react';
 import { ActiveFilter, FilterType } from '../../types/NamespaceFilter';
 import * as API from '../../services/Api';
-import { Namespace } from '../../types/Namespace';
+import Namespace from '../../types/Namespace';
 import { Pagination } from '../../types/Pagination';
 import { ServiceItem, ServiceList } from '../../types/ServiceListComponent';
 import PropTypes from 'prop-types';

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { config } from '../config';
+import Namespace from '../types/Namespace';
 
 const auth = (user: string, pass: string) => {
   return {
@@ -63,8 +64,8 @@ export const getJaegerInfo = () => {
   return newRequest('get', `/api/jaeger`, {}, {});
 };
 
-export const GetGraphElements = (namespace: String, params: any) => {
-  return newRequest('get', `/api/namespaces/${namespace}/graph`, params, {});
+export const GetGraphElements = (namespace: Namespace, params: any) => {
+  return newRequest('get', `/api/namespaces/${namespace.name}/graph`, params, {});
 };
 
 export const GetServiceDetail = (namespace: String, service: String) => {

--- a/src/types/Graph.ts
+++ b/src/types/Graph.ts
@@ -1,7 +1,16 @@
+import { Interval, Layout } from './GraphFilter';
+import Namespace from './Namespace';
+
 export interface SummaryPanelPropType {
   data: any;
   namespace: string;
   duration: string;
   step: number;
   rateInterval: string;
+}
+
+export interface GraphParamsType {
+  namespace: Namespace;
+  graphInterval: Interval;
+  graphLayout: Layout;
 }

--- a/src/types/GraphFilter.ts
+++ b/src/types/GraphFilter.ts
@@ -1,13 +1,24 @@
 import PropTypes from 'prop-types';
+import Namespace from './Namespace';
 
 export interface GraphFilterProps {
-  onFilterChange: PropTypes.func;
+  onLayoutChange: (newLayout: Layout) => void;
+  onFilterChange: (newInterval: Interval) => void;
+  onNamespaceChange: (newValue: Namespace) => void;
   onError: PropTypes.func;
+  activeNamespace: Namespace;
+  activeLayout: Layout;
+  activeInterval: Interval;
 }
 
 export interface GraphFilterState {
-  graphDuration: string;
-  graphLayout: any;
-  graphNamespace: string;
   availableNamespaces: { name: string }[];
+}
+
+export interface Layout {
+  name: string;
+}
+
+export interface Interval {
+  value: string;
 }

--- a/src/types/IstioRuleListComponent.ts
+++ b/src/types/IstioRuleListComponent.ts
@@ -1,4 +1,4 @@
-import { Namespace } from './Namespace';
+import Namespace from './Namespace';
 
 export interface RuleList {
   namespace: Namespace;

--- a/src/types/Namespace.ts
+++ b/src/types/Namespace.ts
@@ -1,3 +1,5 @@
-export interface Namespace {
+interface Namespace {
   name: string;
 }
+
+export default Namespace;

--- a/src/types/ServiceListComponent.ts
+++ b/src/types/ServiceListComponent.ts
@@ -1,4 +1,4 @@
-import { Namespace } from './Namespace';
+import Namespace from './Namespace';
 
 export interface ServiceName {
   name: string;


### PR DESCRIPTION
Graph data, namespace, interval and layout are now in one place, `ServiceGraphPage`.   Browser URL will set namespace, interval and layout accordingly. 
1. Make sure Namespace, Layout, Interval are used consistently.  For example, `CytoscapeLayout.namespace` prop is now of Namespace type.  You can no longer pass a string to it.
2. `CytoscapeLayout`: move graph elements state and refresh logic to its parent.
3. `GraphFilter`: propagates namespace, filter, layout changes to parent via new separate callbacks, `filterChange(newVal)`, `namespaceChange(newVal)` and `layoutChange(newVal)`.  The callback payload contains the new value. `GraphFilters` getters/setters are no longer needed. 
4. Since I introduced `Interval` type and recent changes renamed it to `Duration` in order to keep my rebase/merge simple I decided to override the name change with mine ie keep it as Interval.  I'll address the rename in a separate PR.

Please review!