### PR TITLE
KIALI-427 bump version of ssri.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2903,7 +2903,7 @@
         "move-concurrently": "1.0.1",
         "promise-inflight": "1.0.1",
         "rimraf": "2.6.2",
-        "ssri": "5.2.1",
+        "ssri": "5.2.2",
         "unique-filename": "1.1.0",
         "y18n": "3.2.1"
       }
@@ -12069,10 +12069,9 @@
       }
     },
     "ssri": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.2.1.tgz",
-      "integrity": "sha512-y4PjOWlAuxt+yAcXitQYOnOzZpKaH3+f/qGV3OWxbyC2noC9FA9GNC9uILnVdV7jruA1aDKr4OKz3ZDBcVZwFQ==",
-      "dev": true,
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.2.2.tgz",
+      "integrity": "sha512-hm46mN8YSzjGuJtVocXPjwo0yTRXobXqYuK/tV6gr557/tRck4yWXKPRW8OxyJgRvcL3QgX+5ng/kMHBMco7KA==",
       "requires": {
         "safe-buffer": "5.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react-dom": "~16.2.0",
     "react-router-dom": "^4.2.2",
     "react-scripts-ts": "2.13.0",
+    "ssri": "5.2.2",
     "url-search-params": "^0.10.0"
   },
   "scripts": {


### PR DESCRIPTION
I locally see an error

```
events.js:137
      throw er; // Unhandled 'error' event
      ^
``` 
on `npm test`, but I see the same with the current version