### PR TITLE
KIALI-438 Filter unnecessary metrics calls and customize rate function

### DIFF
--- a/src/components/MetricsOptions/MetricsOptionsBar.tsx
+++ b/src/components/MetricsOptions/MetricsOptionsBar.tsx
@@ -12,7 +12,6 @@ interface MetricsOptionsState {
   rateInterval: string;
   duration: number;
   ticks: number;
-  filterLabels: [string, string][];
   groupByLabels: string[];
 }
 
@@ -80,7 +79,6 @@ export class MetricsOptionsBar extends React.Component<Props, MetricsOptionsStat
       rateInterval: MetricsOptionsBar.DefaultRateInterval,
       duration: MetricsOptionsBar.DefaultDuration,
       ticks: MetricsOptionsBar.DefaultTicks,
-      filterLabels: [],
       groupByLabels: []
     };
   }
@@ -114,9 +112,9 @@ export class MetricsOptionsBar extends React.Component<Props, MetricsOptionsStat
     const labelsOut = this.state.groupByLabels.map(lbl => MetricsOptionsBar.GroupByLabelOptions[lbl].labelOut);
     this.props.onOptionsChanged({
       rateInterval: this.state.rateInterval,
+      rateFunc: 'irate',
       duration: this.state.duration,
       step: this.state.duration / this.state.ticks,
-      filterLabels: this.state.filterLabels,
       byLabelsIn: labelsIn,
       byLabelsOut: labelsOut
     });

--- a/src/pages/ServiceDetails/ServiceMetrics.tsx
+++ b/src/pages/ServiceDetails/ServiceMetrics.tsx
@@ -37,19 +37,16 @@ class ServiceMetrics extends React.Component<ServiceId, ServiceMetricsState> {
     this.state = {
       loading: false
     };
-    this.onOptionsChanged = this.onOptionsChanged.bind(this);
-    this.dismissAlert = this.dismissAlert.bind(this);
   }
 
   componentDidMount() {
     this.getGrafanaInfo();
   }
 
-  onOptionsChanged(options: MetricsOptions) {
-    this.fetchMetrics(options);
-  }
+  onOptionsChanged = (options: MetricsOptions) => this.fetchMetrics(options);
 
   fetchMetrics(options: MetricsOptions) {
+    options.filters = ['request_count', 'request_size', 'request_duration', 'response_size'];
     this.setState({ loading: true });
     API.getServiceMetrics(this.props.namespace, this.props.service, options)
       .then(response => {
@@ -104,11 +101,11 @@ class ServiceMetrics extends React.Component<ServiceId, ServiceMetricsState> {
       });
   }
 
-  nameMetric(metric: M.MetricGroup, familyName: string, labels: string[]): M.MetricGroup {
+  nameMetric(metric: M.MetricGroup, familyName: string, labels?: string[]): M.MetricGroup {
     if (metric) {
       metric.familyName = familyName;
       metric.matrix.forEach(ts => {
-        if (labels.length === 0) {
+        if (labels === undefined || labels.length === 0) {
           ts.name = familyName;
         } else {
           const strLabels = labels.map(lbl => ts.metric[lbl]).join(',');
@@ -119,7 +116,7 @@ class ServiceMetrics extends React.Component<ServiceId, ServiceMetricsState> {
     return metric;
   }
 
-  nameHistogram(histo: M.Histogram, familyName: string, labels: string[]): M.Histogram {
+  nameHistogram(histo: M.Histogram, familyName: string, labels?: string[]): M.Histogram {
     if (histo) {
       histo.familyName = familyName;
       histo.average = this.nameMetric(histo.average, familyName + '[avg]', labels);
@@ -165,9 +162,7 @@ class ServiceMetrics extends React.Component<ServiceId, ServiceMetricsState> {
     return Math.round(val * 100) / 100;
   }
 
-  dismissAlert() {
-    this.setState({ alertDetails: undefined });
-  }
+  dismissAlert = () => this.setState({ alertDetails: undefined });
 
   render() {
     return (

--- a/src/pages/ServiceGraph/SummaryPanelEdge.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelEdge.tsx
@@ -6,6 +6,7 @@ import { SummaryPanelPropType } from '../../types/Graph';
 import * as API from '../../services/Api';
 import * as M from '../../types/Metrics';
 import graphUtils from '../../utils/graphing';
+import MetricsOptions from '../../types/MetricsOptions';
 
 type SummaryPanelEdgeState = {
   loading: boolean;
@@ -100,12 +101,13 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
     const destServiceName = destSplit[0];
     const destNamespace = destSplit[1];
 
-    const options = {
+    const options: MetricsOptions = {
       version: destVersion,
-      'byLabelsIn[]': 'source_service,source_version',
-      duration: props.duration,
+      byLabelsIn: ['source_service', 'source_version'],
+      duration: +props.duration,
       step: props.step,
-      rateInterval: props.rateInterval
+      rateInterval: props.rateInterval,
+      filters: ['request_count', 'request_error_count']
     };
     API.getServiceMetrics(destNamespace, destServiceName, options)
       .then(response => {

--- a/src/pages/ServiceGraph/SummaryPanelGroup.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelGroup.tsx
@@ -6,6 +6,7 @@ import { SummaryPanelPropType } from '../../types/Graph';
 import * as API from '../../services/Api';
 import * as M from '../../types/Metrics';
 import graphUtils from '../../utils/graphing';
+import MetricsOptions from '../../types/MetricsOptions';
 
 type SummaryPanelGroupState = {
   loading: boolean;
@@ -136,10 +137,11 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
   private updateRpsCharts = (props: SummaryPanelPropType) => {
     const namespace = props.data.summaryTarget.data('service').split('.')[1];
     const service = props.data.summaryTarget.data('service').split('.')[0];
-    const options = {
-      duration: props.duration,
+    const options: MetricsOptions = {
+      duration: +props.duration,
       step: props.step,
-      rateInterval: props.rateInterval
+      rateInterval: props.rateInterval,
+      filters: ['request_count', 'request_error_count']
     };
     API.getServiceMetrics(namespace, service, options)
       .then(response => {

--- a/src/pages/ServiceGraph/SummaryPanelNode.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelNode.tsx
@@ -6,6 +6,7 @@ import Badge from '../../components/Badge/Badge';
 import { InOutRateTable } from '../../components/SummaryPanel/InOutRateTable';
 import { RpsChart } from '../../components/SummaryPanel/RpsChart';
 import { SummaryPanelPropType } from '../../types/Graph';
+import MetricsOptions from '../../types/MetricsOptions';
 
 type SummaryPanelStateType = {
   loading: boolean;
@@ -55,11 +56,12 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
     const namespace = props.data.summaryTarget.data('service').split('.')[1];
     const service = props.data.summaryTarget.data('service').split('.')[0];
     const version = props.data.summaryTarget.data('version');
-    const options = {
+    const options: MetricsOptions = {
       version: version,
-      duration: props.duration,
+      duration: +props.duration,
       step: props.step,
-      rateInterval: props.rateInterval
+      rateInterval: props.rateInterval,
+      filters: ['request_count', 'request_error_count']
     };
 
     API.getServiceMetrics(namespace, service, options)

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { config } from '../config';
 import Namespace from '../types/Namespace';
+import MetricsOptions from '../types/MetricsOptions';
 
 const auth = (user: string, pass: string) => {
   return {
@@ -48,7 +49,7 @@ export const GetServices = (namespace: String) => {
   return newRequest('get', `/api/namespaces/${namespace}/services`, {}, {});
 };
 
-export const getServiceMetrics = (namespace: String, service: String, params: any) => {
+export const getServiceMetrics = (namespace: String, service: String, params: MetricsOptions) => {
   return newRequest('get', `/api/namespaces/${namespace}/services/${service}/metrics`, params, {});
 };
 

--- a/src/types/MetricsOptions.ts
+++ b/src/types/MetricsOptions.ts
@@ -1,10 +1,12 @@
 interface MetricsOptions {
-  rateInterval: string;
-  duration: number;
-  step: number;
-  filterLabels: [string, string][];
-  byLabelsIn: string[];
-  byLabelsOut: string[];
+  rateInterval?: string;
+  rateFunc?: string;
+  duration?: number;
+  step?: number;
+  version?: string;
+  filters?: string[];
+  byLabelsIn?: string[];
+  byLabelsOut?: string[];
 }
 
 export default MetricsOptions;


### PR DESCRIPTION
Prometheus rate function is "rate" for graph pages and "irate" for service details
Also enforce type safety on MetricsOptions
Remove unused filterLabels