### PR TITLE
KIALI-180: Visually identify versioned nodes in service graph.

### DIFF
--- a/src/components/CytoscapeLayout/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeLayout/graphs/GraphStyles.ts
@@ -36,13 +36,23 @@ export class GraphStyles {
         // version group boxes
         selector: '$node > node',
         css: {
-          'padding-top': '10px',
-          'padding-left': '20px',
-          'padding-bottom': '10px',
-          'padding-right': '20px',
+          'padding-top': '5px',
+          'padding-left': '5px',
+          'padding-bottom': '5px',
+          'padding-right': '5px',
           'text-valign': 'top',
           'text-halign': 'center',
-          'background-color': '#fbeabc' // pf-gold-100
+          'background-color': '#fbeabc', // pf-gold-100
+          'border-color': '#b58100', // pf-gold-500
+          'border-width': '2px'
+        }
+      },
+      {
+        // versioned node in a group
+        selector: 'node > $node',
+        css: {
+          'border-color': '#b58100', // pf-gold-500
+          'border-width': '2px'
         }
       },
       {


### PR DESCRIPTION
Changing borders of versioned microservices and making the group box to be more snug.
With these changes, the graph will look like this:

![image](https://user-images.githubusercontent.com/23639005/37941010-0be65272-3129-11e8-88ce-336e302b130a.png)


