### PR TITLE
move group label to right side and rotate.  

### DIFF
--- a/src/components/CytoscapeLayout/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeLayout/graphs/GraphStyles.ts
@@ -36,19 +36,18 @@ export class GraphStyles {
         // version group boxes
         selector: '$node > node',
         css: {
-          'padding-top': '10px',
-          'padding-left': '20px',
-          'padding-bottom': '10px',
-          'padding-right': '20px',
           'text-valign': 'top',
-          'text-halign': 'center',
+          'text-halign': 'right',
+          'text-margin-x': '2px',
+          'text-margin-y': '8px',
+          'text-rotation': '90deg',
           'background-color': '#fbeabc' // pf-gold-100
         }
       },
       {
         selector: 'edge',
         css: {
-          width: 3,
+          width: 2,
           'font-size': '9px',
           'text-margin-x': '10px',
           'text-rotation': 'autorotate',


### PR DESCRIPTION
Move away from center because there is likely always an edge through the center.  Also, thin edges
for a generally cleaner look and less overlap when crossing over text.

![screen](https://user-images.githubusercontent.com/2104052/37985509-ec3ea778-31c6-11e8-8de6-39097140d6fb.png)
