### PR TITLE
Improve l+f by moving summary labels into panel header

### DIFF
--- a/src/pages/ServiceGraph/SummaryPanelEdge.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelEdge.tsx
@@ -66,14 +66,15 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
     const isUnknown = sourceServiceName === 'unknown';
     return (
       <div className="panel panel-default" style={SummaryPanelEdge.panelStyle}>
-        <div className="panel-heading">Source: {isUnknown ? 'unknown' : sourceLink}</div>
-        <div className="panel-body">
-          <p>{this.renderLabels(sourceNamespace, sourceVersion)}</p>
+        <div className="panel-heading">
+          Source: {isUnknown ? 'unknown' : sourceLink}
+          {this.renderLabels(sourceNamespace, sourceVersion)}
         </div>
-        <div className="panel-heading">Destination: {destLink}</div>
+        <div className="panel-heading">
+          Destination: {destLink}
+          {this.renderLabels(destNamespace, destVersion)}
+        </div>
         <div className="panel-body">
-          <p>{this.renderLabels(destNamespace, destVersion)}</p>
-          <hr />
           <RateTable
             title="Traffic (requests per second):"
             rate={rate}
@@ -135,10 +136,10 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
 
   private renderLabels = (ns: string, ver: string) => (
     // color="#2d7623" is pf-green-500
-    <>
-      <Badge scale={0.8} style="plastic" leftText="namespace" rightText={ns} color="#2d7623" />
-      <Badge scale={0.8} style="plastic" leftText="version" rightText={ver} color="#2d7623" />
-    </>
+    <div style={{ paddingTop: '3px' }}>
+      <Badge scale={0.9} style="plastic" leftText="namespace" rightText={ns} color="#2d7623" />
+      <Badge scale={0.9} style="plastic" leftText="version" rightText={ver} color="#2d7623" />
+    </div>
   );
 
   private renderRpsChart = () => {

--- a/src/pages/ServiceGraph/SummaryPanelGraph.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelGraph.tsx
@@ -79,25 +79,26 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
 
     return (
       <div className="panel panel-default" style={SummaryPanelGraph.panelStyle}>
-        <div className="panel-heading">Namespace: {servicesLink}</div>
+        <div className="panel-heading">
+          Namespace: {servicesLink}
+          <div hidden={!cy}>{this.renderLabels(numNodes.toString(), numEdges.toString())}</div>
+        </div>
         <div className="panel-body" hidden={cy}>
           <h3>Click graph for details...</h3>
         </div>
-        <div hidden={!cy}>
-          <div className="panel-body">
-            <p>{this.renderLabels(numNodes.toString(), numEdges.toString())}</p>
-          </div>
-          <hr />
-          <RateTable
-            title="Traffic (requests per second):"
-            rate={rate}
-            rate3xx={rate3xx}
-            rate4xx={rate4xx}
-            rate5xx={rate5xx}
-          />
+        <div className="panel-body" hidden={!cy}>
           <div>
-            <hr />
-            {this.renderRpsChart()}
+            <RateTable
+              title="Traffic (requests per second):"
+              rate={rate}
+              rate3xx={rate3xx}
+              rate4xx={rate4xx}
+              rate5xx={rate5xx}
+            />
+            <div>
+              <hr />
+              {this.renderRpsChart()}
+            </div>
           </div>
         </div>
       </div>
@@ -132,10 +133,10 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
 
   private renderLabels = (numNodes: string, numEdges: string) => (
     // color="#2d7623" is pf-green-500
-    <>
-      <Badge scale={0.8} style="plastic" leftText="services" rightText={numNodes} color="#2d7623" />
-      <Badge scale={0.8} style="plastic" leftText="edges" rightText={numEdges} color="#2d7623" />
-    </>
+    <div style={{ paddingTop: '3px' }}>
+      <Badge scale={0.9} style="plastic" leftText="services" rightText={numNodes} color="#2d7623" />
+      <Badge scale={0.9} style="plastic" leftText="edges" rightText={numEdges} color="#2d7623" />
+    </div>
   );
 
   private renderRpsChart = () => {

--- a/src/pages/ServiceGraph/SummaryPanelGroup.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelGroup.tsx
@@ -100,13 +100,11 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
 
     return (
       <div className="panel panel-default" style={SummaryPanelGroup.panelStyle}>
-        <div className="panel-heading">Versioned Group: {serviceHotLink}</div>
-        <div className="panel-body">
-          <p>
-            <strong>Labels:</strong>
-            <br />
+        <div className="panel-heading">
+          Versioned Group: {serviceHotLink}
+          <div style={{ paddingTop: '3px' }}>
             <Badge
-              scale={0.8}
+              scale={0.9}
               style="plastic"
               leftText="namespace"
               rightText={namespace}
@@ -114,8 +112,9 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
               color="#2d7623" // pf-green-500
             />
             {this.renderVersionBadges()}
-          </p>
-          <hr />
+          </div>
+        </div>
+        <div className="panel-body">
           <InOutRateTable
             title="Request Traffic (requests per second):"
             inRate={incoming.rate}
@@ -174,7 +173,7 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
       .toArray()
       .map((c, i) => (
         <Badge
-          scale={0.8}
+          scale={0.9}
           style="plastic"
           leftText="version"
           rightText={c.data('version')}

--- a/src/pages/ServiceGraph/SummaryPanelNode.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelNode.tsx
@@ -106,13 +106,11 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
     const isUnknown = service === 'unknown';
     return (
       <div className="panel panel-default" style={SummaryPanelNode.panelStyle}>
-        <div className="panel-heading">Microservice: {isUnknown ? 'unknown' : serviceHotLink}</div>
-        <div className="panel-body">
-          <p>
-            <strong>Labels:</strong>
-            <br />
+        <div className="panel-heading">
+          Microservice: {isUnknown ? 'unknown' : serviceHotLink}
+          <div style={{ paddingTop: '3px' }}>
             <Badge
-              scale={0.8}
+              scale={0.9}
               style="plastic"
               leftText="namespace"
               rightText={namespace}
@@ -120,15 +118,16 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
               color="#2d7623" // pf-green-500
             />
             <Badge
-              scale={0.8}
+              scale={0.9}
               style="plastic"
               leftText="version"
               rightText={this.props.data.summaryTarget.data('version')}
               key={this.props.data.summaryTarget.data('version')}
               color="#2d7623" // pf-green-500
             />
-          </p>
-          <hr />
+          </div>
+        </div>
+        <div className="panel-body">
           <InOutRateTable
             title="Request Traffic (requests per second):"
             inRate={parseFloat(node.data('rate')) || 0}


### PR DESCRIPTION
increase size for readability.  This also saves space as we look to add
more summary info to the side panels.

Here is an idea of what it looks like using edge as an example:

![screen](https://user-images.githubusercontent.com/2104052/38097552-adfeda68-3343-11e8-8913-0ee058e1fa77.png)
