### PR TITLE
Kiali-484: Upgrade to typescript 2.8.1 from 2.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14805,9 +14805,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
-      "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.1.tgz",
+      "integrity": "sha512-Ao/f6d/4EPLq0YwzsQz8iXflezpTkQzqAyenTiw4kCUGr1uPiFLC3+fZ+gMZz6eeI/qdRUqvC+HxIJzUAzEFdg==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "node-sass-chokidar": "1.2.2",
     "npm-snapshot": "1.0.3",
     "prettier": "1.11.1",
-    "typescript": "2.7.2"
+    "typescript": "2.8.1"
   },
   "sassIncludes": {
     "src": "--include-path src",
@@ -79,7 +79,7 @@
     "url": "git+https://github.com/kiali/kiali-ui.git"
   },
   "keywords": [
-    "mesh",
+    "service mesh",
     "kiali",
     "istio",
     "openshift",


### PR DESCRIPTION
Announcement: https://blogs.msdn.microsoft.com/typescript/2018/03/27/announcing-typescript-2-8/

https://issues.jboss.org/browse/KIALI-484