### PR TITLE
KIALI-480 Global health indicator

### DIFF
--- a/src/components/ServiceHealth/ServiceHealth.tsx
+++ b/src/components/ServiceHealth/ServiceHealth.tsx
@@ -17,7 +17,7 @@ interface Status {
   name: string;
   color: string;
   priority: number;
-  jsx: (size?: string) => JSX.Element;
+  jsx: (size: number, title: string) => JSX.Element;
 }
 
 // Colors from Patternfly status palette https://www.patternfly.org/styles/color-palette/
@@ -25,25 +25,27 @@ const FAILURE: Status = {
   name: 'Failure',
   color: '#cc0000',
   priority: 3,
-  jsx: size => <Icon type="pf" name="error-circle-o" style={{ fontSize: size }} />
+  jsx: (size, title) => <Icon type="pf" name="error-circle-o" style={{ fontSize: String(size) + 'px' }} title={title} />
 };
 const DEGRADED: Status = {
   name: 'Degraded',
   color: '#ec7a08',
   priority: 2,
-  jsx: size => <Icon type="pf" name="warning-triangle-o" style={{ fontSize: size }} />
+  jsx: (size, title) => (
+    <Icon type="pf" name="warning-triangle-o" style={{ fontSize: String(size) + 'px' }} title={title} />
+  )
 };
 const HEALTHY: Status = {
   name: 'Healthy',
   color: '#3f9c35',
   priority: 1,
-  jsx: size => <Icon type="pf" name="ok" style={{ fontSize: size }} />
+  jsx: (size, title) => <Icon type="pf" name="ok" style={{ fontSize: String(size) + 'px' }} title={title} />
 };
 const NA: Status = {
   name: 'No health information',
   color: '#707070',
   priority: 0,
-  jsx: size => <span style={{ color: '#707070', fontSize: size ? '24px' : undefined }}>N/A</span>
+  jsx: (size, title) => <span style={{ color: '#707070', fontSize: String(Math.floor(size * 2 / 3)) + 'px' }}>N/A</span>
 };
 
 export class ServiceHealth extends React.Component<Props, {}> {
@@ -114,20 +116,20 @@ export class ServiceHealth extends React.Component<Props, {}> {
   }
 
   renderSmall(health: H.Health) {
-    const tooltip = this.info.length === 1 ? this.info[0] : this.info.map(str => '- ' + str).join('&#13;');
-    return (
-      <span>
-        {this.globalStatus.jsx()}&nbsp;
-        {tooltip && <Icon type="pf" name="info" title={tooltip} />}
-      </span>
-    );
+    let tooltip = this.globalStatus.name;
+    if (this.info.length === 1) {
+      tooltip += '\n' + this.info[0];
+    } else if (this.info.length > 1) {
+      tooltip += '\n' + this.info.map(str => '- ' + str).join('\n');
+    }
+    return <span>{this.globalStatus.jsx(18, tooltip)}&nbsp;</span>;
   }
 
   renderLarge(health: H.Health) {
     return (
-      <div>
-        {this.globalStatus.jsx('35px')}
-        <div style={{ color: this.globalStatus.color }}>{this.globalStatus.name}</div>
+      <div style={{ color: this.globalStatus.color }}>
+        {this.globalStatus.jsx(35, this.globalStatus.name)}
+        <br />
         {this.info.length === 1 && this.info[0]}
         {this.info.length > 1 && (
           <ul style={{ padding: 0 }}>{this.info.map((line, idx) => <li key={idx}>{line}</li>)}</ul>

--- a/src/components/ServiceHealth/ServiceHealth.tsx
+++ b/src/components/ServiceHealth/ServiceHealth.tsx
@@ -1,78 +1,138 @@
 import * as React from 'react';
-import { DonutChart } from 'patternfly-react';
-import Health from '../../types/Health';
+import { Icon } from 'patternfly-react';
 
-interface Props {
-  health?: Health;
-  size: number;
-  thickness?: number;
-  showTitle?: boolean;
+import * as H from '../../types/Health';
+
+export enum DisplayMode {
+  LARGE,
+  SMALL
 }
 
-const KEY_HEALTHY = 'Healthy';
-const KEY_FAILURE = 'Failure';
-const KEY_NA = 'N/A';
-const DONUT_COLORS: { [key: string]: string } = {};
-// From Patternfly status palette
-DONUT_COLORS[KEY_HEALTHY] = '#3f9c35';
-DONUT_COLORS[KEY_FAILURE] = '#cc0000';
-DONUT_COLORS[KEY_NA] = '#707070';
+interface Props {
+  health?: H.Health;
+  mode: DisplayMode;
+}
 
-class ServiceHealth extends React.Component<Props, {}> {
-  donutData: any;
-  donutSize: any;
-  donutTitle: string;
+interface Status {
+  name: string;
+  color: string;
+  priority: number;
+  jsx: (size?: string) => JSX.Element;
+}
+
+// Colors from Patternfly status palette https://www.patternfly.org/styles/color-palette/
+const FAILURE: Status = {
+  name: 'Failure',
+  color: '#cc0000',
+  priority: 3,
+  jsx: size => <Icon type="pf" name="error-circle-o" style={{ fontSize: size }} />
+};
+const DEGRADED: Status = {
+  name: 'Degraded',
+  color: '#ec7a08',
+  priority: 2,
+  jsx: size => <Icon type="pf" name="warning-triangle-o" style={{ fontSize: size }} />
+};
+const HEALTHY: Status = {
+  name: 'Healthy',
+  color: '#3f9c35',
+  priority: 1,
+  jsx: size => <Icon type="pf" name="ok" style={{ fontSize: size }} />
+};
+const NA: Status = {
+  name: 'No health information',
+  color: '#707070',
+  priority: 0,
+  jsx: size => <span style={{ color: '#707070', fontSize: size ? '24px' : undefined }}>N/A</span>
+};
+
+export class ServiceHealth extends React.Component<Props, {}> {
+  globalStatus: Status;
+  info: string[];
 
   constructor(props: Props) {
     super(props);
-    this.onGetProps(props);
+    this.updateHealth(props.health);
   }
 
   componentWillReceiveProps(nextProps: Props) {
-    this.onGetProps(nextProps);
+    this.updateHealth(nextProps.health);
   }
 
-  onGetProps(props: Props) {
-    this.donutSize = {
-      width: props.size,
-      height: props.size
-    };
-    let columns: [string, number][] = [];
-    if (props.health && props.health.totalReplicas > 0) {
-      columns = [
-        [KEY_NA, 0],
-        [KEY_HEALTHY, props.health.healthyReplicas],
-        [KEY_FAILURE, props.health.totalReplicas - props.health.healthyReplicas]
-      ];
-      this.donutTitle = Math.round(100 * props.health.healthyReplicas / props.health.totalReplicas) + '%';
+  ratioCheck(valid: number, total: number, errorMsg: string): Status {
+    if (total === 0) {
+      return NA;
+    } else if (valid === 0) {
+      this.info.push(errorMsg + 'failure');
+      return FAILURE;
+    } else if (valid === total) {
+      return HEALTHY;
+    }
+    this.info.push(errorMsg + 'degraded');
+    return DEGRADED;
+  }
+
+  mergeStatus(s1: Status, s2: Status): Status {
+    return s1.priority > s2.priority ? s1 : s2;
+  }
+
+  updateHealth(health?: H.Health) {
+    this.info = [];
+    let countInactiveDeployments = 0;
+    if (health) {
+      const envoyStatus = this.ratioCheck(health.envoy.healthy, health.envoy.total, 'Envoy health ');
+      this.globalStatus = health.deploymentStatuses.reduce((prev, cur) => {
+        const status = this.ratioCheck(cur.available, cur.replicas, 'Pod deployment ');
+        if (status === NA) {
+          countInactiveDeployments++;
+        }
+        return this.mergeStatus(prev, status);
+      }, envoyStatus);
     } else {
-      columns = [[KEY_NA, 1], [KEY_HEALTHY, 0], [KEY_FAILURE, 0]];
-      this.donutTitle = 'n/a';
+      this.globalStatus = NA;
     }
-    if (props.showTitle !== undefined && !props.showTitle) {
-      this.donutTitle = ' ';
+    if (health && countInactiveDeployments > 0 && countInactiveDeployments === health.deploymentStatuses.length) {
+      // No active deployment => special case for failure
+      this.globalStatus = FAILURE;
+      this.info.push('No active deployment!');
+    } else if (countInactiveDeployments === 1) {
+      this.info.push('One inactive deployment');
+    } else if (countInactiveDeployments > 1) {
+      this.info.push(`${countInactiveDeployments} inactive deployments`);
     }
-    this.donutData = {
-      colors: DONUT_COLORS,
-      columns: columns,
-      type: 'donut'
-    };
   }
 
   render() {
     if (this.props.health) {
-      return (
-        <DonutChart
-          size={this.donutSize}
-          data={this.donutData}
-          title={{ type: '', primary: this.donutTitle, secondary: ' ' }}
-          legend={{ show: false }}
-          donut={this.props.thickness ? { width: this.props.thickness } : {}}
-        />
-      );
+      if (this.props.mode === DisplayMode.SMALL) {
+        return this.renderSmall(this.props.health);
+      } else {
+        return this.renderLarge(this.props.health);
+      }
     }
-    return <div />;
+    return <span />;
+  }
+
+  renderSmall(health: H.Health) {
+    const tooltip = this.info.length === 1 ? this.info[0] : this.info.map(str => '- ' + str).join('&#13;');
+    return (
+      <span>
+        {this.globalStatus.jsx()}&nbsp;
+        {tooltip && <Icon type="pf" name="info" title={tooltip} />}
+      </span>
+    );
+  }
+
+  renderLarge(health: H.Health) {
+    return (
+      <div>
+        {this.globalStatus.jsx('35px')}
+        <div style={{ color: this.globalStatus.color }}>{this.globalStatus.name}</div>
+        {this.info.length === 1 && this.info[0]}
+        {this.info.length > 1 && (
+          <ul style={{ padding: 0 }}>{this.info.map((line, idx) => <li key={idx}>{line}</li>)}</ul>
+        )}
+      </div>
+    );
   }
 }
-
-export default ServiceHealth;

--- a/src/components/ServiceHealth/__tests__/ServiceHealth.test.tsx
+++ b/src/components/ServiceHealth/__tests__/ServiceHealth.test.tsx
@@ -26,7 +26,7 @@ describe('ServiceHealth', () => {
     expect(wrapper).toMatchSnapshot();
     let html = wrapper.html();
     expect(html).toContain('pficon-ok');
-    expect(html).not.toContain('Healthy');
+    expect(html).toContain('Healthy');
 
     // LARGE
     wrapper = shallow(<ServiceHealth health={health} mode={DisplayMode.LARGE} />);
@@ -47,7 +47,7 @@ describe('ServiceHealth', () => {
     expect(wrapper).toMatchSnapshot();
     let html = wrapper.html();
     expect(html).toContain('pficon-warning');
-    expect(html).not.toContain('Degraded');
+    expect(html).toContain('Degraded');
     expect(html).toContain('Pod deployment degraded');
 
     // LARGE
@@ -70,7 +70,7 @@ describe('ServiceHealth', () => {
     expect(wrapper).toMatchSnapshot();
     let html = wrapper.html();
     expect(html).toContain('pficon-warning');
-    expect(html).not.toContain('Degraded');
+    expect(html).toContain('Degraded');
     expect(html).toContain('Envoy health degraded');
 
     // LARGE
@@ -93,7 +93,7 @@ describe('ServiceHealth', () => {
     expect(wrapper).toMatchSnapshot();
     let html = wrapper.html();
     expect(html).toContain('pficon-warning');
-    expect(html).not.toContain('Degraded');
+    expect(html).toContain('Degraded');
     expect(html).toContain('Pod deployment degraded');
     expect(html).toContain('Envoy health degraded');
 
@@ -118,7 +118,7 @@ describe('ServiceHealth', () => {
     expect(wrapper).toMatchSnapshot();
     let html = wrapper.html();
     expect(html).toContain('pficon-error');
-    expect(html).not.toContain('Failure');
+    expect(html).toContain('Failure');
     expect(html).toContain('Pod deployment failure');
     expect(html).toContain('Envoy health degraded');
 
@@ -143,7 +143,7 @@ describe('ServiceHealth', () => {
     expect(wrapper).toMatchSnapshot();
     let html = wrapper.html();
     expect(html).toContain('pficon-error');
-    expect(html).not.toContain('Failure');
+    expect(html).toContain('Failure');
     expect(html).toContain('Pod deployment degraded');
     expect(html).toContain('Envoy health failure');
 
@@ -168,7 +168,7 @@ describe('ServiceHealth', () => {
     expect(wrapper).toMatchSnapshot();
     let html = wrapper.html();
     expect(html).toContain('pficon-ok');
-    expect(html).not.toContain('Healthy');
+    expect(html).toContain('Healthy');
     expect(html).toContain('inactive deployment');
 
     // LARGE
@@ -191,7 +191,7 @@ describe('ServiceHealth', () => {
     expect(wrapper).toMatchSnapshot();
     let html = wrapper.html();
     expect(html).toContain('pficon-error');
-    expect(html).not.toContain('Failure');
+    expect(html).toContain('Failure');
     expect(html).toContain('No active deployment');
 
     // LARGE

--- a/src/components/ServiceHealth/__tests__/ServiceHealth.test.tsx
+++ b/src/components/ServiceHealth/__tests__/ServiceHealth.test.tsx
@@ -1,16 +1,205 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 
-import ServiceHealth from '../ServiceHealth';
+import { ServiceHealth, DisplayMode } from '../ServiceHealth';
+import { Health } from '../../../types/Health';
 
 describe('ServiceHealth', () => {
-  it('renders chart', () => {
-    const wrapper = shallow(<ServiceHealth size={100} health={{ healthyReplicas: 1, totalReplicas: 1 }} />);
-    expect(wrapper.find('DonutChart')).toHaveLength(1);
+  it('renders when empty', () => {
+    // SMALL
+    let wrapper = shallow(<ServiceHealth mode={DisplayMode.SMALL} />);
+    expect(wrapper.html()).not.toContain('pficon');
+
+    // LARGE
+    wrapper = shallow(<ServiceHealth mode={DisplayMode.LARGE} />);
+    expect(wrapper.html()).not.toContain('pficon');
   });
 
-  it('renders no chart while empty', () => {
-    const wrapper = shallow(<ServiceHealth size={100} />);
-    expect(wrapper.find('DonutChart')).toHaveLength(0);
+  it('renders healthy', () => {
+    const health: Health = {
+      envoy: { healthy: 1, total: 1 },
+      deploymentStatuses: [{ available: 1, replicas: 1 }, { available: 2, replicas: 2 }]
+    };
+
+    // SMALL
+    let wrapper = shallow(<ServiceHealth health={health} mode={DisplayMode.SMALL} />);
+    expect(wrapper).toMatchSnapshot();
+    let html = wrapper.html();
+    expect(html).toContain('pficon-ok');
+    expect(html).not.toContain('Healthy');
+
+    // LARGE
+    wrapper = shallow(<ServiceHealth health={health} mode={DisplayMode.LARGE} />);
+    expect(wrapper).toMatchSnapshot();
+    html = wrapper.html();
+    expect(html).toContain('pficon-ok');
+    expect(html).toContain('Healthy');
+  });
+
+  it('renders deployments degraded', () => {
+    const health: Health = {
+      envoy: { healthy: 1, total: 1 },
+      deploymentStatuses: [{ available: 1, replicas: 10 }, { available: 2, replicas: 2 }]
+    };
+
+    // SMALL
+    let wrapper = shallow(<ServiceHealth health={health} mode={DisplayMode.SMALL} />);
+    expect(wrapper).toMatchSnapshot();
+    let html = wrapper.html();
+    expect(html).toContain('pficon-warning');
+    expect(html).not.toContain('Degraded');
+    expect(html).toContain('Pod deployment degraded');
+
+    // LARGE
+    wrapper = shallow(<ServiceHealth health={health} mode={DisplayMode.LARGE} />);
+    expect(wrapper).toMatchSnapshot();
+    html = wrapper.html();
+    expect(html).toContain('pficon-warning');
+    expect(html).toContain('Degraded');
+    expect(html).toContain('Pod deployment degraded');
+  });
+
+  it('renders envoy degraded', () => {
+    const health: Health = {
+      envoy: { healthy: 1, total: 10 },
+      deploymentStatuses: [{ available: 1, replicas: 1 }, { available: 2, replicas: 2 }]
+    };
+
+    // SMALL
+    let wrapper = shallow(<ServiceHealth health={health} mode={DisplayMode.SMALL} />);
+    expect(wrapper).toMatchSnapshot();
+    let html = wrapper.html();
+    expect(html).toContain('pficon-warning');
+    expect(html).not.toContain('Degraded');
+    expect(html).toContain('Envoy health degraded');
+
+    // LARGE
+    wrapper = shallow(<ServiceHealth health={health} mode={DisplayMode.LARGE} />);
+    expect(wrapper).toMatchSnapshot();
+    html = wrapper.html();
+    expect(html).toContain('pficon-warning');
+    expect(html).toContain('Degraded');
+    expect(html).toContain('Envoy health degraded');
+  });
+
+  it('renders both degraded', () => {
+    const health: Health = {
+      envoy: { healthy: 1, total: 10 },
+      deploymentStatuses: [{ available: 1, replicas: 10 }, { available: 2, replicas: 10 }]
+    };
+
+    // SMALL
+    let wrapper = shallow(<ServiceHealth health={health} mode={DisplayMode.SMALL} />);
+    expect(wrapper).toMatchSnapshot();
+    let html = wrapper.html();
+    expect(html).toContain('pficon-warning');
+    expect(html).not.toContain('Degraded');
+    expect(html).toContain('Pod deployment degraded');
+    expect(html).toContain('Envoy health degraded');
+
+    // LARGE
+    wrapper = shallow(<ServiceHealth health={health} mode={DisplayMode.LARGE} />);
+    expect(wrapper).toMatchSnapshot();
+    html = wrapper.html();
+    expect(html).toContain('pficon-warning');
+    expect(html).toContain('Degraded');
+    expect(html).toContain('Pod deployment degraded');
+    expect(html).toContain('Envoy health degraded');
+  });
+
+  it('renders deployments failure', () => {
+    const health: Health = {
+      envoy: { healthy: 1, total: 10 },
+      deploymentStatuses: [{ available: 0, replicas: 10 }, { available: 2, replicas: 2 }]
+    };
+
+    // SMALL
+    let wrapper = shallow(<ServiceHealth health={health} mode={DisplayMode.SMALL} />);
+    expect(wrapper).toMatchSnapshot();
+    let html = wrapper.html();
+    expect(html).toContain('pficon-error');
+    expect(html).not.toContain('Failure');
+    expect(html).toContain('Pod deployment failure');
+    expect(html).toContain('Envoy health degraded');
+
+    // LARGE
+    wrapper = shallow(<ServiceHealth health={health} mode={DisplayMode.LARGE} />);
+    expect(wrapper).toMatchSnapshot();
+    html = wrapper.html();
+    expect(html).toContain('pficon-error');
+    expect(html).toContain('Failure');
+    expect(html).toContain('Pod deployment failure');
+    expect(html).toContain('Envoy health degraded');
+  });
+
+  it('renders envoy failure', () => {
+    const health: Health = {
+      envoy: { healthy: 0, total: 10 },
+      deploymentStatuses: [{ available: 1, replicas: 10 }, { available: 2, replicas: 2 }]
+    };
+
+    // SMALL
+    let wrapper = shallow(<ServiceHealth health={health} mode={DisplayMode.SMALL} />);
+    expect(wrapper).toMatchSnapshot();
+    let html = wrapper.html();
+    expect(html).toContain('pficon-error');
+    expect(html).not.toContain('Failure');
+    expect(html).toContain('Pod deployment degraded');
+    expect(html).toContain('Envoy health failure');
+
+    // LARGE
+    wrapper = shallow(<ServiceHealth health={health} mode={DisplayMode.LARGE} />);
+    expect(wrapper).toMatchSnapshot();
+    html = wrapper.html();
+    expect(html).toContain('pficon-error');
+    expect(html).toContain('Failure');
+    expect(html).toContain('Pod deployment degraded');
+    expect(html).toContain('Envoy health failure');
+  });
+
+  it('renders some scaled down deployment', () => {
+    const health: Health = {
+      envoy: { healthy: 1, total: 1 },
+      deploymentStatuses: [{ available: 0, replicas: 0 }, { available: 2, replicas: 2 }]
+    };
+
+    // SMALL
+    let wrapper = shallow(<ServiceHealth health={health} mode={DisplayMode.SMALL} />);
+    expect(wrapper).toMatchSnapshot();
+    let html = wrapper.html();
+    expect(html).toContain('pficon-ok');
+    expect(html).not.toContain('Healthy');
+    expect(html).toContain('inactive deployment');
+
+    // LARGE
+    wrapper = shallow(<ServiceHealth health={health} mode={DisplayMode.LARGE} />);
+    expect(wrapper).toMatchSnapshot();
+    html = wrapper.html();
+    expect(html).toContain('pficon-ok');
+    expect(html).toContain('Healthy');
+    expect(html).toContain('inactive deployment');
+  });
+
+  it('renders all deployments down', () => {
+    const health: Health = {
+      envoy: { healthy: 1, total: 1 },
+      deploymentStatuses: [{ available: 0, replicas: 0 }, { available: 0, replicas: 0 }]
+    };
+
+    // SMALL
+    let wrapper = shallow(<ServiceHealth health={health} mode={DisplayMode.SMALL} />);
+    expect(wrapper).toMatchSnapshot();
+    let html = wrapper.html();
+    expect(html).toContain('pficon-error');
+    expect(html).not.toContain('Failure');
+    expect(html).toContain('No active deployment');
+
+    // LARGE
+    wrapper = shallow(<ServiceHealth health={health} mode={DisplayMode.LARGE} />);
+    expect(wrapper).toMatchSnapshot();
+    html = wrapper.html();
+    expect(html).toContain('pficon-error');
+    expect(html).toContain('Failure');
+    expect(html).toContain('No active deployment');
   });
 });

--- a/src/components/ServiceHealth/__tests__/__snapshots__/ServiceHealth.test.tsx.snap
+++ b/src/components/ServiceHealth/__tests__/__snapshots__/ServiceHealth.test.tsx.snap
@@ -1,0 +1,2979 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ServiceHealth renders all deployments down 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <ServiceHealth
+    health={
+      Object {
+        "deploymentStatuses": Array [
+          Object {
+            "available": 0,
+            "replicas": 0,
+          },
+          Object {
+            "available": 0,
+            "replicas": 0,
+          },
+        ],
+        "envoy": Object {
+          "healthy": 1,
+          "total": 1,
+        },
+      }
+    }
+    mode={1}
+  />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <Icon
+          name="error-circle-o"
+          style={
+            Object {
+              "fontSize": undefined,
+            }
+          }
+          type="pf"
+        />,
+        " ",
+        <Icon
+          name="info"
+          title="No active deployment!"
+          type="pf"
+        />,
+      ],
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "function",
+        "props": Object {
+          "name": "error-circle-o",
+          "style": Object {
+            "fontSize": undefined,
+          },
+          "type": "pf",
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      " ",
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "function",
+        "props": Object {
+          "name": "info",
+          "title": "No active deployment!",
+          "type": "pf",
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+    ],
+    "type": "span",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <Icon
+            name="error-circle-o"
+            style={
+              Object {
+                "fontSize": undefined,
+              }
+            }
+            type="pf"
+          />,
+          " ",
+          <Icon
+            name="info"
+            title="No active deployment!"
+            type="pf"
+          />,
+        ],
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "name": "error-circle-o",
+            "style": Object {
+              "fontSize": undefined,
+            },
+            "type": "pf",
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        " ",
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "name": "info",
+            "title": "No active deployment!",
+            "type": "pf",
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+      ],
+      "type": "span",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;
+
+exports[`ServiceHealth renders all deployments down 2`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <ServiceHealth
+    health={
+      Object {
+        "deploymentStatuses": Array [
+          Object {
+            "available": 0,
+            "replicas": 0,
+          },
+          Object {
+            "available": 0,
+            "replicas": 0,
+          },
+        ],
+        "envoy": Object {
+          "healthy": 1,
+          "total": 1,
+        },
+      }
+    }
+    mode={0}
+  />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <Icon
+          name="error-circle-o"
+          style={
+            Object {
+              "fontSize": "35px",
+            }
+          }
+          type="pf"
+        />,
+        <div
+          style={
+            Object {
+              "color": "#cc0000",
+            }
+          }
+        >
+          Failure
+        </div>,
+        "No active deployment!",
+        false,
+      ],
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "function",
+        "props": Object {
+          "name": "error-circle-o",
+          "style": Object {
+            "fontSize": "35px",
+          },
+          "type": "pf",
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": "Failure",
+          "style": Object {
+            "color": "#cc0000",
+          },
+        },
+        "ref": null,
+        "rendered": "Failure",
+        "type": "div",
+      },
+      "No active deployment!",
+      false,
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <Icon
+            name="error-circle-o"
+            style={
+              Object {
+                "fontSize": "35px",
+              }
+            }
+            type="pf"
+          />,
+          <div
+            style={
+              Object {
+                "color": "#cc0000",
+              }
+            }
+          >
+            Failure
+          </div>,
+          "No active deployment!",
+          false,
+        ],
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "name": "error-circle-o",
+            "style": Object {
+              "fontSize": "35px",
+            },
+            "type": "pf",
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": "Failure",
+            "style": Object {
+              "color": "#cc0000",
+            },
+          },
+          "ref": null,
+          "rendered": "Failure",
+          "type": "div",
+        },
+        "No active deployment!",
+        false,
+      ],
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;
+
+exports[`ServiceHealth renders both degraded 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <ServiceHealth
+    health={
+      Object {
+        "deploymentStatuses": Array [
+          Object {
+            "available": 1,
+            "replicas": 10,
+          },
+          Object {
+            "available": 2,
+            "replicas": 10,
+          },
+        ],
+        "envoy": Object {
+          "healthy": 1,
+          "total": 10,
+        },
+      }
+    }
+    mode={1}
+  />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <Icon
+          name="warning-triangle-o"
+          style={
+            Object {
+              "fontSize": undefined,
+            }
+          }
+          type="pf"
+        />,
+        " ",
+        <Icon
+          name="info"
+          title="- Envoy health degraded&#13;- Pod deployment degraded&#13;- Pod deployment degraded"
+          type="pf"
+        />,
+      ],
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "function",
+        "props": Object {
+          "name": "warning-triangle-o",
+          "style": Object {
+            "fontSize": undefined,
+          },
+          "type": "pf",
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      " ",
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "function",
+        "props": Object {
+          "name": "info",
+          "title": "- Envoy health degraded&#13;- Pod deployment degraded&#13;- Pod deployment degraded",
+          "type": "pf",
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+    ],
+    "type": "span",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <Icon
+            name="warning-triangle-o"
+            style={
+              Object {
+                "fontSize": undefined,
+              }
+            }
+            type="pf"
+          />,
+          " ",
+          <Icon
+            name="info"
+            title="- Envoy health degraded&#13;- Pod deployment degraded&#13;- Pod deployment degraded"
+            type="pf"
+          />,
+        ],
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "name": "warning-triangle-o",
+            "style": Object {
+              "fontSize": undefined,
+            },
+            "type": "pf",
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        " ",
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "name": "info",
+            "title": "- Envoy health degraded&#13;- Pod deployment degraded&#13;- Pod deployment degraded",
+            "type": "pf",
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+      ],
+      "type": "span",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;
+
+exports[`ServiceHealth renders both degraded 2`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <ServiceHealth
+    health={
+      Object {
+        "deploymentStatuses": Array [
+          Object {
+            "available": 1,
+            "replicas": 10,
+          },
+          Object {
+            "available": 2,
+            "replicas": 10,
+          },
+        ],
+        "envoy": Object {
+          "healthy": 1,
+          "total": 10,
+        },
+      }
+    }
+    mode={0}
+  />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <Icon
+          name="warning-triangle-o"
+          style={
+            Object {
+              "fontSize": "35px",
+            }
+          }
+          type="pf"
+        />,
+        <div
+          style={
+            Object {
+              "color": "#ec7a08",
+            }
+          }
+        >
+          Degraded
+        </div>,
+        false,
+        <ul
+          style={
+            Object {
+              "padding": 0,
+            }
+          }
+        >
+          <li>
+            Envoy health degraded
+          </li>
+          <li>
+            Pod deployment degraded
+          </li>
+          <li>
+            Pod deployment degraded
+          </li>
+        </ul>,
+      ],
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "function",
+        "props": Object {
+          "name": "warning-triangle-o",
+          "style": Object {
+            "fontSize": "35px",
+          },
+          "type": "pf",
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": "Degraded",
+          "style": Object {
+            "color": "#ec7a08",
+          },
+        },
+        "ref": null,
+        "rendered": "Degraded",
+        "type": "div",
+      },
+      false,
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            <li>
+              Envoy health degraded
+            </li>,
+            <li>
+              Pod deployment degraded
+            </li>,
+            <li>
+              Pod deployment degraded
+            </li>,
+          ],
+          "style": Object {
+            "padding": 0,
+          },
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": "0",
+            "nodeType": "host",
+            "props": Object {
+              "children": "Envoy health degraded",
+            },
+            "ref": null,
+            "rendered": "Envoy health degraded",
+            "type": "li",
+          },
+          Object {
+            "instance": null,
+            "key": "1",
+            "nodeType": "host",
+            "props": Object {
+              "children": "Pod deployment degraded",
+            },
+            "ref": null,
+            "rendered": "Pod deployment degraded",
+            "type": "li",
+          },
+          Object {
+            "instance": null,
+            "key": "2",
+            "nodeType": "host",
+            "props": Object {
+              "children": "Pod deployment degraded",
+            },
+            "ref": null,
+            "rendered": "Pod deployment degraded",
+            "type": "li",
+          },
+        ],
+        "type": "ul",
+      },
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <Icon
+            name="warning-triangle-o"
+            style={
+              Object {
+                "fontSize": "35px",
+              }
+            }
+            type="pf"
+          />,
+          <div
+            style={
+              Object {
+                "color": "#ec7a08",
+              }
+            }
+          >
+            Degraded
+          </div>,
+          false,
+          <ul
+            style={
+              Object {
+                "padding": 0,
+              }
+            }
+          >
+            <li>
+              Envoy health degraded
+            </li>
+            <li>
+              Pod deployment degraded
+            </li>
+            <li>
+              Pod deployment degraded
+            </li>
+          </ul>,
+        ],
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "name": "warning-triangle-o",
+            "style": Object {
+              "fontSize": "35px",
+            },
+            "type": "pf",
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": "Degraded",
+            "style": Object {
+              "color": "#ec7a08",
+            },
+          },
+          "ref": null,
+          "rendered": "Degraded",
+          "type": "div",
+        },
+        false,
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              <li>
+                Envoy health degraded
+              </li>,
+              <li>
+                Pod deployment degraded
+              </li>,
+              <li>
+                Pod deployment degraded
+              </li>,
+            ],
+            "style": Object {
+              "padding": 0,
+            },
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": "0",
+              "nodeType": "host",
+              "props": Object {
+                "children": "Envoy health degraded",
+              },
+              "ref": null,
+              "rendered": "Envoy health degraded",
+              "type": "li",
+            },
+            Object {
+              "instance": null,
+              "key": "1",
+              "nodeType": "host",
+              "props": Object {
+                "children": "Pod deployment degraded",
+              },
+              "ref": null,
+              "rendered": "Pod deployment degraded",
+              "type": "li",
+            },
+            Object {
+              "instance": null,
+              "key": "2",
+              "nodeType": "host",
+              "props": Object {
+                "children": "Pod deployment degraded",
+              },
+              "ref": null,
+              "rendered": "Pod deployment degraded",
+              "type": "li",
+            },
+          ],
+          "type": "ul",
+        },
+      ],
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;
+
+exports[`ServiceHealth renders deployments degraded 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <ServiceHealth
+    health={
+      Object {
+        "deploymentStatuses": Array [
+          Object {
+            "available": 1,
+            "replicas": 10,
+          },
+          Object {
+            "available": 2,
+            "replicas": 2,
+          },
+        ],
+        "envoy": Object {
+          "healthy": 1,
+          "total": 1,
+        },
+      }
+    }
+    mode={1}
+  />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <Icon
+          name="warning-triangle-o"
+          style={
+            Object {
+              "fontSize": undefined,
+            }
+          }
+          type="pf"
+        />,
+        " ",
+        <Icon
+          name="info"
+          title="Pod deployment degraded"
+          type="pf"
+        />,
+      ],
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "function",
+        "props": Object {
+          "name": "warning-triangle-o",
+          "style": Object {
+            "fontSize": undefined,
+          },
+          "type": "pf",
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      " ",
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "function",
+        "props": Object {
+          "name": "info",
+          "title": "Pod deployment degraded",
+          "type": "pf",
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+    ],
+    "type": "span",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <Icon
+            name="warning-triangle-o"
+            style={
+              Object {
+                "fontSize": undefined,
+              }
+            }
+            type="pf"
+          />,
+          " ",
+          <Icon
+            name="info"
+            title="Pod deployment degraded"
+            type="pf"
+          />,
+        ],
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "name": "warning-triangle-o",
+            "style": Object {
+              "fontSize": undefined,
+            },
+            "type": "pf",
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        " ",
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "name": "info",
+            "title": "Pod deployment degraded",
+            "type": "pf",
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+      ],
+      "type": "span",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;
+
+exports[`ServiceHealth renders deployments degraded 2`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <ServiceHealth
+    health={
+      Object {
+        "deploymentStatuses": Array [
+          Object {
+            "available": 1,
+            "replicas": 10,
+          },
+          Object {
+            "available": 2,
+            "replicas": 2,
+          },
+        ],
+        "envoy": Object {
+          "healthy": 1,
+          "total": 1,
+        },
+      }
+    }
+    mode={0}
+  />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <Icon
+          name="warning-triangle-o"
+          style={
+            Object {
+              "fontSize": "35px",
+            }
+          }
+          type="pf"
+        />,
+        <div
+          style={
+            Object {
+              "color": "#ec7a08",
+            }
+          }
+        >
+          Degraded
+        </div>,
+        "Pod deployment degraded",
+        false,
+      ],
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "function",
+        "props": Object {
+          "name": "warning-triangle-o",
+          "style": Object {
+            "fontSize": "35px",
+          },
+          "type": "pf",
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": "Degraded",
+          "style": Object {
+            "color": "#ec7a08",
+          },
+        },
+        "ref": null,
+        "rendered": "Degraded",
+        "type": "div",
+      },
+      "Pod deployment degraded",
+      false,
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <Icon
+            name="warning-triangle-o"
+            style={
+              Object {
+                "fontSize": "35px",
+              }
+            }
+            type="pf"
+          />,
+          <div
+            style={
+              Object {
+                "color": "#ec7a08",
+              }
+            }
+          >
+            Degraded
+          </div>,
+          "Pod deployment degraded",
+          false,
+        ],
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "name": "warning-triangle-o",
+            "style": Object {
+              "fontSize": "35px",
+            },
+            "type": "pf",
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": "Degraded",
+            "style": Object {
+              "color": "#ec7a08",
+            },
+          },
+          "ref": null,
+          "rendered": "Degraded",
+          "type": "div",
+        },
+        "Pod deployment degraded",
+        false,
+      ],
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;
+
+exports[`ServiceHealth renders deployments failure 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <ServiceHealth
+    health={
+      Object {
+        "deploymentStatuses": Array [
+          Object {
+            "available": 0,
+            "replicas": 10,
+          },
+          Object {
+            "available": 2,
+            "replicas": 2,
+          },
+        ],
+        "envoy": Object {
+          "healthy": 1,
+          "total": 10,
+        },
+      }
+    }
+    mode={1}
+  />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <Icon
+          name="error-circle-o"
+          style={
+            Object {
+              "fontSize": undefined,
+            }
+          }
+          type="pf"
+        />,
+        " ",
+        <Icon
+          name="info"
+          title="- Envoy health degraded&#13;- Pod deployment failure"
+          type="pf"
+        />,
+      ],
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "function",
+        "props": Object {
+          "name": "error-circle-o",
+          "style": Object {
+            "fontSize": undefined,
+          },
+          "type": "pf",
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      " ",
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "function",
+        "props": Object {
+          "name": "info",
+          "title": "- Envoy health degraded&#13;- Pod deployment failure",
+          "type": "pf",
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+    ],
+    "type": "span",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <Icon
+            name="error-circle-o"
+            style={
+              Object {
+                "fontSize": undefined,
+              }
+            }
+            type="pf"
+          />,
+          " ",
+          <Icon
+            name="info"
+            title="- Envoy health degraded&#13;- Pod deployment failure"
+            type="pf"
+          />,
+        ],
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "name": "error-circle-o",
+            "style": Object {
+              "fontSize": undefined,
+            },
+            "type": "pf",
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        " ",
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "name": "info",
+            "title": "- Envoy health degraded&#13;- Pod deployment failure",
+            "type": "pf",
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+      ],
+      "type": "span",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;
+
+exports[`ServiceHealth renders deployments failure 2`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <ServiceHealth
+    health={
+      Object {
+        "deploymentStatuses": Array [
+          Object {
+            "available": 0,
+            "replicas": 10,
+          },
+          Object {
+            "available": 2,
+            "replicas": 2,
+          },
+        ],
+        "envoy": Object {
+          "healthy": 1,
+          "total": 10,
+        },
+      }
+    }
+    mode={0}
+  />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <Icon
+          name="error-circle-o"
+          style={
+            Object {
+              "fontSize": "35px",
+            }
+          }
+          type="pf"
+        />,
+        <div
+          style={
+            Object {
+              "color": "#cc0000",
+            }
+          }
+        >
+          Failure
+        </div>,
+        false,
+        <ul
+          style={
+            Object {
+              "padding": 0,
+            }
+          }
+        >
+          <li>
+            Envoy health degraded
+          </li>
+          <li>
+            Pod deployment failure
+          </li>
+        </ul>,
+      ],
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "function",
+        "props": Object {
+          "name": "error-circle-o",
+          "style": Object {
+            "fontSize": "35px",
+          },
+          "type": "pf",
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": "Failure",
+          "style": Object {
+            "color": "#cc0000",
+          },
+        },
+        "ref": null,
+        "rendered": "Failure",
+        "type": "div",
+      },
+      false,
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            <li>
+              Envoy health degraded
+            </li>,
+            <li>
+              Pod deployment failure
+            </li>,
+          ],
+          "style": Object {
+            "padding": 0,
+          },
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": "0",
+            "nodeType": "host",
+            "props": Object {
+              "children": "Envoy health degraded",
+            },
+            "ref": null,
+            "rendered": "Envoy health degraded",
+            "type": "li",
+          },
+          Object {
+            "instance": null,
+            "key": "1",
+            "nodeType": "host",
+            "props": Object {
+              "children": "Pod deployment failure",
+            },
+            "ref": null,
+            "rendered": "Pod deployment failure",
+            "type": "li",
+          },
+        ],
+        "type": "ul",
+      },
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <Icon
+            name="error-circle-o"
+            style={
+              Object {
+                "fontSize": "35px",
+              }
+            }
+            type="pf"
+          />,
+          <div
+            style={
+              Object {
+                "color": "#cc0000",
+              }
+            }
+          >
+            Failure
+          </div>,
+          false,
+          <ul
+            style={
+              Object {
+                "padding": 0,
+              }
+            }
+          >
+            <li>
+              Envoy health degraded
+            </li>
+            <li>
+              Pod deployment failure
+            </li>
+          </ul>,
+        ],
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "name": "error-circle-o",
+            "style": Object {
+              "fontSize": "35px",
+            },
+            "type": "pf",
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": "Failure",
+            "style": Object {
+              "color": "#cc0000",
+            },
+          },
+          "ref": null,
+          "rendered": "Failure",
+          "type": "div",
+        },
+        false,
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              <li>
+                Envoy health degraded
+              </li>,
+              <li>
+                Pod deployment failure
+              </li>,
+            ],
+            "style": Object {
+              "padding": 0,
+            },
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": "0",
+              "nodeType": "host",
+              "props": Object {
+                "children": "Envoy health degraded",
+              },
+              "ref": null,
+              "rendered": "Envoy health degraded",
+              "type": "li",
+            },
+            Object {
+              "instance": null,
+              "key": "1",
+              "nodeType": "host",
+              "props": Object {
+                "children": "Pod deployment failure",
+              },
+              "ref": null,
+              "rendered": "Pod deployment failure",
+              "type": "li",
+            },
+          ],
+          "type": "ul",
+        },
+      ],
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;
+
+exports[`ServiceHealth renders envoy degraded 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <ServiceHealth
+    health={
+      Object {
+        "deploymentStatuses": Array [
+          Object {
+            "available": 1,
+            "replicas": 1,
+          },
+          Object {
+            "available": 2,
+            "replicas": 2,
+          },
+        ],
+        "envoy": Object {
+          "healthy": 1,
+          "total": 10,
+        },
+      }
+    }
+    mode={1}
+  />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <Icon
+          name="warning-triangle-o"
+          style={
+            Object {
+              "fontSize": undefined,
+            }
+          }
+          type="pf"
+        />,
+        " ",
+        <Icon
+          name="info"
+          title="Envoy health degraded"
+          type="pf"
+        />,
+      ],
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "function",
+        "props": Object {
+          "name": "warning-triangle-o",
+          "style": Object {
+            "fontSize": undefined,
+          },
+          "type": "pf",
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      " ",
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "function",
+        "props": Object {
+          "name": "info",
+          "title": "Envoy health degraded",
+          "type": "pf",
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+    ],
+    "type": "span",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <Icon
+            name="warning-triangle-o"
+            style={
+              Object {
+                "fontSize": undefined,
+              }
+            }
+            type="pf"
+          />,
+          " ",
+          <Icon
+            name="info"
+            title="Envoy health degraded"
+            type="pf"
+          />,
+        ],
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "name": "warning-triangle-o",
+            "style": Object {
+              "fontSize": undefined,
+            },
+            "type": "pf",
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        " ",
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "name": "info",
+            "title": "Envoy health degraded",
+            "type": "pf",
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+      ],
+      "type": "span",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;
+
+exports[`ServiceHealth renders envoy degraded 2`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <ServiceHealth
+    health={
+      Object {
+        "deploymentStatuses": Array [
+          Object {
+            "available": 1,
+            "replicas": 1,
+          },
+          Object {
+            "available": 2,
+            "replicas": 2,
+          },
+        ],
+        "envoy": Object {
+          "healthy": 1,
+          "total": 10,
+        },
+      }
+    }
+    mode={0}
+  />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <Icon
+          name="warning-triangle-o"
+          style={
+            Object {
+              "fontSize": "35px",
+            }
+          }
+          type="pf"
+        />,
+        <div
+          style={
+            Object {
+              "color": "#ec7a08",
+            }
+          }
+        >
+          Degraded
+        </div>,
+        "Envoy health degraded",
+        false,
+      ],
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "function",
+        "props": Object {
+          "name": "warning-triangle-o",
+          "style": Object {
+            "fontSize": "35px",
+          },
+          "type": "pf",
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": "Degraded",
+          "style": Object {
+            "color": "#ec7a08",
+          },
+        },
+        "ref": null,
+        "rendered": "Degraded",
+        "type": "div",
+      },
+      "Envoy health degraded",
+      false,
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <Icon
+            name="warning-triangle-o"
+            style={
+              Object {
+                "fontSize": "35px",
+              }
+            }
+            type="pf"
+          />,
+          <div
+            style={
+              Object {
+                "color": "#ec7a08",
+              }
+            }
+          >
+            Degraded
+          </div>,
+          "Envoy health degraded",
+          false,
+        ],
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "name": "warning-triangle-o",
+            "style": Object {
+              "fontSize": "35px",
+            },
+            "type": "pf",
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": "Degraded",
+            "style": Object {
+              "color": "#ec7a08",
+            },
+          },
+          "ref": null,
+          "rendered": "Degraded",
+          "type": "div",
+        },
+        "Envoy health degraded",
+        false,
+      ],
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;
+
+exports[`ServiceHealth renders envoy failure 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <ServiceHealth
+    health={
+      Object {
+        "deploymentStatuses": Array [
+          Object {
+            "available": 1,
+            "replicas": 10,
+          },
+          Object {
+            "available": 2,
+            "replicas": 2,
+          },
+        ],
+        "envoy": Object {
+          "healthy": 0,
+          "total": 10,
+        },
+      }
+    }
+    mode={1}
+  />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <Icon
+          name="error-circle-o"
+          style={
+            Object {
+              "fontSize": undefined,
+            }
+          }
+          type="pf"
+        />,
+        " ",
+        <Icon
+          name="info"
+          title="- Envoy health failure&#13;- Pod deployment degraded"
+          type="pf"
+        />,
+      ],
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "function",
+        "props": Object {
+          "name": "error-circle-o",
+          "style": Object {
+            "fontSize": undefined,
+          },
+          "type": "pf",
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      " ",
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "function",
+        "props": Object {
+          "name": "info",
+          "title": "- Envoy health failure&#13;- Pod deployment degraded",
+          "type": "pf",
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+    ],
+    "type": "span",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <Icon
+            name="error-circle-o"
+            style={
+              Object {
+                "fontSize": undefined,
+              }
+            }
+            type="pf"
+          />,
+          " ",
+          <Icon
+            name="info"
+            title="- Envoy health failure&#13;- Pod deployment degraded"
+            type="pf"
+          />,
+        ],
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "name": "error-circle-o",
+            "style": Object {
+              "fontSize": undefined,
+            },
+            "type": "pf",
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        " ",
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "name": "info",
+            "title": "- Envoy health failure&#13;- Pod deployment degraded",
+            "type": "pf",
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+      ],
+      "type": "span",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;
+
+exports[`ServiceHealth renders envoy failure 2`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <ServiceHealth
+    health={
+      Object {
+        "deploymentStatuses": Array [
+          Object {
+            "available": 1,
+            "replicas": 10,
+          },
+          Object {
+            "available": 2,
+            "replicas": 2,
+          },
+        ],
+        "envoy": Object {
+          "healthy": 0,
+          "total": 10,
+        },
+      }
+    }
+    mode={0}
+  />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <Icon
+          name="error-circle-o"
+          style={
+            Object {
+              "fontSize": "35px",
+            }
+          }
+          type="pf"
+        />,
+        <div
+          style={
+            Object {
+              "color": "#cc0000",
+            }
+          }
+        >
+          Failure
+        </div>,
+        false,
+        <ul
+          style={
+            Object {
+              "padding": 0,
+            }
+          }
+        >
+          <li>
+            Envoy health failure
+          </li>
+          <li>
+            Pod deployment degraded
+          </li>
+        </ul>,
+      ],
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "function",
+        "props": Object {
+          "name": "error-circle-o",
+          "style": Object {
+            "fontSize": "35px",
+          },
+          "type": "pf",
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": "Failure",
+          "style": Object {
+            "color": "#cc0000",
+          },
+        },
+        "ref": null,
+        "rendered": "Failure",
+        "type": "div",
+      },
+      false,
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            <li>
+              Envoy health failure
+            </li>,
+            <li>
+              Pod deployment degraded
+            </li>,
+          ],
+          "style": Object {
+            "padding": 0,
+          },
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": "0",
+            "nodeType": "host",
+            "props": Object {
+              "children": "Envoy health failure",
+            },
+            "ref": null,
+            "rendered": "Envoy health failure",
+            "type": "li",
+          },
+          Object {
+            "instance": null,
+            "key": "1",
+            "nodeType": "host",
+            "props": Object {
+              "children": "Pod deployment degraded",
+            },
+            "ref": null,
+            "rendered": "Pod deployment degraded",
+            "type": "li",
+          },
+        ],
+        "type": "ul",
+      },
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <Icon
+            name="error-circle-o"
+            style={
+              Object {
+                "fontSize": "35px",
+              }
+            }
+            type="pf"
+          />,
+          <div
+            style={
+              Object {
+                "color": "#cc0000",
+              }
+            }
+          >
+            Failure
+          </div>,
+          false,
+          <ul
+            style={
+              Object {
+                "padding": 0,
+              }
+            }
+          >
+            <li>
+              Envoy health failure
+            </li>
+            <li>
+              Pod deployment degraded
+            </li>
+          </ul>,
+        ],
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "name": "error-circle-o",
+            "style": Object {
+              "fontSize": "35px",
+            },
+            "type": "pf",
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": "Failure",
+            "style": Object {
+              "color": "#cc0000",
+            },
+          },
+          "ref": null,
+          "rendered": "Failure",
+          "type": "div",
+        },
+        false,
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              <li>
+                Envoy health failure
+              </li>,
+              <li>
+                Pod deployment degraded
+              </li>,
+            ],
+            "style": Object {
+              "padding": 0,
+            },
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": "0",
+              "nodeType": "host",
+              "props": Object {
+                "children": "Envoy health failure",
+              },
+              "ref": null,
+              "rendered": "Envoy health failure",
+              "type": "li",
+            },
+            Object {
+              "instance": null,
+              "key": "1",
+              "nodeType": "host",
+              "props": Object {
+                "children": "Pod deployment degraded",
+              },
+              "ref": null,
+              "rendered": "Pod deployment degraded",
+              "type": "li",
+            },
+          ],
+          "type": "ul",
+        },
+      ],
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;
+
+exports[`ServiceHealth renders healthy 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <ServiceHealth
+    health={
+      Object {
+        "deploymentStatuses": Array [
+          Object {
+            "available": 1,
+            "replicas": 1,
+          },
+          Object {
+            "available": 2,
+            "replicas": 2,
+          },
+        ],
+        "envoy": Object {
+          "healthy": 1,
+          "total": 1,
+        },
+      }
+    }
+    mode={1}
+  />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <Icon
+          name="ok"
+          style={
+            Object {
+              "fontSize": undefined,
+            }
+          }
+          type="pf"
+        />,
+        " ",
+        "",
+      ],
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "function",
+        "props": Object {
+          "name": "ok",
+          "style": Object {
+            "fontSize": undefined,
+          },
+          "type": "pf",
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      " ",
+      "",
+    ],
+    "type": "span",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <Icon
+            name="ok"
+            style={
+              Object {
+                "fontSize": undefined,
+              }
+            }
+            type="pf"
+          />,
+          " ",
+          "",
+        ],
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "name": "ok",
+            "style": Object {
+              "fontSize": undefined,
+            },
+            "type": "pf",
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        " ",
+        "",
+      ],
+      "type": "span",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;
+
+exports[`ServiceHealth renders healthy 2`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <ServiceHealth
+    health={
+      Object {
+        "deploymentStatuses": Array [
+          Object {
+            "available": 1,
+            "replicas": 1,
+          },
+          Object {
+            "available": 2,
+            "replicas": 2,
+          },
+        ],
+        "envoy": Object {
+          "healthy": 1,
+          "total": 1,
+        },
+      }
+    }
+    mode={0}
+  />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <Icon
+          name="ok"
+          style={
+            Object {
+              "fontSize": "35px",
+            }
+          }
+          type="pf"
+        />,
+        <div
+          style={
+            Object {
+              "color": "#3f9c35",
+            }
+          }
+        >
+          Healthy
+        </div>,
+        false,
+        false,
+      ],
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "function",
+        "props": Object {
+          "name": "ok",
+          "style": Object {
+            "fontSize": "35px",
+          },
+          "type": "pf",
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": "Healthy",
+          "style": Object {
+            "color": "#3f9c35",
+          },
+        },
+        "ref": null,
+        "rendered": "Healthy",
+        "type": "div",
+      },
+      false,
+      false,
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <Icon
+            name="ok"
+            style={
+              Object {
+                "fontSize": "35px",
+              }
+            }
+            type="pf"
+          />,
+          <div
+            style={
+              Object {
+                "color": "#3f9c35",
+              }
+            }
+          >
+            Healthy
+          </div>,
+          false,
+          false,
+        ],
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "name": "ok",
+            "style": Object {
+              "fontSize": "35px",
+            },
+            "type": "pf",
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": "Healthy",
+            "style": Object {
+              "color": "#3f9c35",
+            },
+          },
+          "ref": null,
+          "rendered": "Healthy",
+          "type": "div",
+        },
+        false,
+        false,
+      ],
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;
+
+exports[`ServiceHealth renders some scaled down deployment 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <ServiceHealth
+    health={
+      Object {
+        "deploymentStatuses": Array [
+          Object {
+            "available": 0,
+            "replicas": 0,
+          },
+          Object {
+            "available": 2,
+            "replicas": 2,
+          },
+        ],
+        "envoy": Object {
+          "healthy": 1,
+          "total": 1,
+        },
+      }
+    }
+    mode={1}
+  />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <Icon
+          name="ok"
+          style={
+            Object {
+              "fontSize": undefined,
+            }
+          }
+          type="pf"
+        />,
+        " ",
+        <Icon
+          name="info"
+          title="One inactive deployment"
+          type="pf"
+        />,
+      ],
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "function",
+        "props": Object {
+          "name": "ok",
+          "style": Object {
+            "fontSize": undefined,
+          },
+          "type": "pf",
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      " ",
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "function",
+        "props": Object {
+          "name": "info",
+          "title": "One inactive deployment",
+          "type": "pf",
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+    ],
+    "type": "span",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <Icon
+            name="ok"
+            style={
+              Object {
+                "fontSize": undefined,
+              }
+            }
+            type="pf"
+          />,
+          " ",
+          <Icon
+            name="info"
+            title="One inactive deployment"
+            type="pf"
+          />,
+        ],
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "name": "ok",
+            "style": Object {
+              "fontSize": undefined,
+            },
+            "type": "pf",
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        " ",
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "name": "info",
+            "title": "One inactive deployment",
+            "type": "pf",
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+      ],
+      "type": "span",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;
+
+exports[`ServiceHealth renders some scaled down deployment 2`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <ServiceHealth
+    health={
+      Object {
+        "deploymentStatuses": Array [
+          Object {
+            "available": 0,
+            "replicas": 0,
+          },
+          Object {
+            "available": 2,
+            "replicas": 2,
+          },
+        ],
+        "envoy": Object {
+          "healthy": 1,
+          "total": 1,
+        },
+      }
+    }
+    mode={0}
+  />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <Icon
+          name="ok"
+          style={
+            Object {
+              "fontSize": "35px",
+            }
+          }
+          type="pf"
+        />,
+        <div
+          style={
+            Object {
+              "color": "#3f9c35",
+            }
+          }
+        >
+          Healthy
+        </div>,
+        "One inactive deployment",
+        false,
+      ],
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "function",
+        "props": Object {
+          "name": "ok",
+          "style": Object {
+            "fontSize": "35px",
+          },
+          "type": "pf",
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": "Healthy",
+          "style": Object {
+            "color": "#3f9c35",
+          },
+        },
+        "ref": null,
+        "rendered": "Healthy",
+        "type": "div",
+      },
+      "One inactive deployment",
+      false,
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <Icon
+            name="ok"
+            style={
+              Object {
+                "fontSize": "35px",
+              }
+            }
+            type="pf"
+          />,
+          <div
+            style={
+              Object {
+                "color": "#3f9c35",
+              }
+            }
+          >
+            Healthy
+          </div>,
+          "One inactive deployment",
+          false,
+        ],
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "name": "ok",
+            "style": Object {
+              "fontSize": "35px",
+            },
+            "type": "pf",
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": "Healthy",
+            "style": Object {
+              "color": "#3f9c35",
+            },
+          },
+          "ref": null,
+          "rendered": "Healthy",
+          "type": "div",
+        },
+        "One inactive deployment",
+        false,
+      ],
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;

--- a/src/components/ServiceHealth/__tests__/__snapshots__/ServiceHealth.test.tsx.snap
+++ b/src/components/ServiceHealth/__tests__/__snapshots__/ServiceHealth.test.tsx.snap
@@ -42,17 +42,14 @@ ShallowWrapper {
           name="error-circle-o"
           style={
             Object {
-              "fontSize": undefined,
+              "fontSize": "18px",
             }
           }
+          title="Failure
+No active deployment!"
           type="pf"
         />,
         " ",
-        <Icon
-          name="info"
-          title="No active deployment!"
-          type="pf"
-        />,
       ],
     },
     "ref": null,
@@ -64,8 +61,10 @@ ShallowWrapper {
         "props": Object {
           "name": "error-circle-o",
           "style": Object {
-            "fontSize": undefined,
+            "fontSize": "18px",
           },
+          "title": "Failure
+No active deployment!",
           "type": "pf",
         },
         "ref": null,
@@ -73,19 +72,6 @@ ShallowWrapper {
         "type": [Function],
       },
       " ",
-      Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "function",
-        "props": Object {
-          "name": "info",
-          "title": "No active deployment!",
-          "type": "pf",
-        },
-        "ref": null,
-        "rendered": null,
-        "type": [Function],
-      },
     ],
     "type": "span",
   },
@@ -100,17 +86,14 @@ ShallowWrapper {
             name="error-circle-o"
             style={
               Object {
-                "fontSize": undefined,
+                "fontSize": "18px",
               }
             }
+            title="Failure
+No active deployment!"
             type="pf"
           />,
           " ",
-          <Icon
-            name="info"
-            title="No active deployment!"
-            type="pf"
-          />,
         ],
       },
       "ref": null,
@@ -122,8 +105,10 @@ ShallowWrapper {
           "props": Object {
             "name": "error-circle-o",
             "style": Object {
-              "fontSize": undefined,
+              "fontSize": "18px",
             },
+            "title": "Failure
+No active deployment!",
             "type": "pf",
           },
           "ref": null,
@@ -131,19 +116,6 @@ ShallowWrapper {
           "type": [Function],
         },
         " ",
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "function",
-          "props": Object {
-            "name": "info",
-            "title": "No active deployment!",
-            "type": "pf",
-          },
-          "ref": null,
-          "rendered": null,
-          "type": [Function],
-        },
       ],
       "type": "span",
     },
@@ -203,20 +175,16 @@ ShallowWrapper {
               "fontSize": "35px",
             }
           }
+          title="Failure"
           type="pf"
         />,
-        <div
-          style={
-            Object {
-              "color": "#cc0000",
-            }
-          }
-        >
-          Failure
-        </div>,
+        <br />,
         "No active deployment!",
         false,
       ],
+      "style": Object {
+        "color": "#cc0000",
+      },
     },
     "ref": null,
     "rendered": Array [
@@ -229,6 +197,7 @@ ShallowWrapper {
           "style": Object {
             "fontSize": "35px",
           },
+          "title": "Failure",
           "type": "pf",
         },
         "ref": null,
@@ -239,15 +208,10 @@ ShallowWrapper {
         "instance": null,
         "key": undefined,
         "nodeType": "host",
-        "props": Object {
-          "children": "Failure",
-          "style": Object {
-            "color": "#cc0000",
-          },
-        },
+        "props": Object {},
         "ref": null,
-        "rendered": "Failure",
-        "type": "div",
+        "rendered": null,
+        "type": "br",
       },
       "No active deployment!",
       false,
@@ -268,20 +232,16 @@ ShallowWrapper {
                 "fontSize": "35px",
               }
             }
+            title="Failure"
             type="pf"
           />,
-          <div
-            style={
-              Object {
-                "color": "#cc0000",
-              }
-            }
-          >
-            Failure
-          </div>,
+          <br />,
           "No active deployment!",
           false,
         ],
+        "style": Object {
+          "color": "#cc0000",
+        },
       },
       "ref": null,
       "rendered": Array [
@@ -294,6 +254,7 @@ ShallowWrapper {
             "style": Object {
               "fontSize": "35px",
             },
+            "title": "Failure",
             "type": "pf",
           },
           "ref": null,
@@ -304,15 +265,10 @@ ShallowWrapper {
           "instance": null,
           "key": undefined,
           "nodeType": "host",
-          "props": Object {
-            "children": "Failure",
-            "style": Object {
-              "color": "#cc0000",
-            },
-          },
+          "props": Object {},
           "ref": null,
-          "rendered": "Failure",
-          "type": "div",
+          "rendered": null,
+          "type": "br",
         },
         "No active deployment!",
         false,
@@ -372,17 +328,16 @@ ShallowWrapper {
           name="warning-triangle-o"
           style={
             Object {
-              "fontSize": undefined,
+              "fontSize": "18px",
             }
           }
+          title="Degraded
+- Envoy health degraded
+- Pod deployment degraded
+- Pod deployment degraded"
           type="pf"
         />,
         " ",
-        <Icon
-          name="info"
-          title="- Envoy health degraded&#13;- Pod deployment degraded&#13;- Pod deployment degraded"
-          type="pf"
-        />,
       ],
     },
     "ref": null,
@@ -394,8 +349,12 @@ ShallowWrapper {
         "props": Object {
           "name": "warning-triangle-o",
           "style": Object {
-            "fontSize": undefined,
+            "fontSize": "18px",
           },
+          "title": "Degraded
+- Envoy health degraded
+- Pod deployment degraded
+- Pod deployment degraded",
           "type": "pf",
         },
         "ref": null,
@@ -403,19 +362,6 @@ ShallowWrapper {
         "type": [Function],
       },
       " ",
-      Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "function",
-        "props": Object {
-          "name": "info",
-          "title": "- Envoy health degraded&#13;- Pod deployment degraded&#13;- Pod deployment degraded",
-          "type": "pf",
-        },
-        "ref": null,
-        "rendered": null,
-        "type": [Function],
-      },
     ],
     "type": "span",
   },
@@ -430,17 +376,16 @@ ShallowWrapper {
             name="warning-triangle-o"
             style={
               Object {
-                "fontSize": undefined,
+                "fontSize": "18px",
               }
             }
+            title="Degraded
+- Envoy health degraded
+- Pod deployment degraded
+- Pod deployment degraded"
             type="pf"
           />,
           " ",
-          <Icon
-            name="info"
-            title="- Envoy health degraded&#13;- Pod deployment degraded&#13;- Pod deployment degraded"
-            type="pf"
-          />,
         ],
       },
       "ref": null,
@@ -452,8 +397,12 @@ ShallowWrapper {
           "props": Object {
             "name": "warning-triangle-o",
             "style": Object {
-              "fontSize": undefined,
+              "fontSize": "18px",
             },
+            "title": "Degraded
+- Envoy health degraded
+- Pod deployment degraded
+- Pod deployment degraded",
             "type": "pf",
           },
           "ref": null,
@@ -461,19 +410,6 @@ ShallowWrapper {
           "type": [Function],
         },
         " ",
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "function",
-          "props": Object {
-            "name": "info",
-            "title": "- Envoy health degraded&#13;- Pod deployment degraded&#13;- Pod deployment degraded",
-            "type": "pf",
-          },
-          "ref": null,
-          "rendered": null,
-          "type": [Function],
-        },
       ],
       "type": "span",
     },
@@ -533,17 +469,10 @@ ShallowWrapper {
               "fontSize": "35px",
             }
           }
+          title="Degraded"
           type="pf"
         />,
-        <div
-          style={
-            Object {
-              "color": "#ec7a08",
-            }
-          }
-        >
-          Degraded
-        </div>,
+        <br />,
         false,
         <ul
           style={
@@ -563,6 +492,9 @@ ShallowWrapper {
           </li>
         </ul>,
       ],
+      "style": Object {
+        "color": "#ec7a08",
+      },
     },
     "ref": null,
     "rendered": Array [
@@ -575,6 +507,7 @@ ShallowWrapper {
           "style": Object {
             "fontSize": "35px",
           },
+          "title": "Degraded",
           "type": "pf",
         },
         "ref": null,
@@ -585,15 +518,10 @@ ShallowWrapper {
         "instance": null,
         "key": undefined,
         "nodeType": "host",
-        "props": Object {
-          "children": "Degraded",
-          "style": Object {
-            "color": "#ec7a08",
-          },
-        },
+        "props": Object {},
         "ref": null,
-        "rendered": "Degraded",
-        "type": "div",
+        "rendered": null,
+        "type": "br",
       },
       false,
       Object {
@@ -671,17 +599,10 @@ ShallowWrapper {
                 "fontSize": "35px",
               }
             }
+            title="Degraded"
             type="pf"
           />,
-          <div
-            style={
-              Object {
-                "color": "#ec7a08",
-              }
-            }
-          >
-            Degraded
-          </div>,
+          <br />,
           false,
           <ul
             style={
@@ -701,6 +622,9 @@ ShallowWrapper {
             </li>
           </ul>,
         ],
+        "style": Object {
+          "color": "#ec7a08",
+        },
       },
       "ref": null,
       "rendered": Array [
@@ -713,6 +637,7 @@ ShallowWrapper {
             "style": Object {
               "fontSize": "35px",
             },
+            "title": "Degraded",
             "type": "pf",
           },
           "ref": null,
@@ -723,15 +648,10 @@ ShallowWrapper {
           "instance": null,
           "key": undefined,
           "nodeType": "host",
-          "props": Object {
-            "children": "Degraded",
-            "style": Object {
-              "color": "#ec7a08",
-            },
-          },
+          "props": Object {},
           "ref": null,
-          "rendered": "Degraded",
-          "type": "div",
+          "rendered": null,
+          "type": "br",
         },
         false,
         Object {
@@ -848,17 +768,14 @@ ShallowWrapper {
           name="warning-triangle-o"
           style={
             Object {
-              "fontSize": undefined,
+              "fontSize": "18px",
             }
           }
+          title="Degraded
+Pod deployment degraded"
           type="pf"
         />,
         " ",
-        <Icon
-          name="info"
-          title="Pod deployment degraded"
-          type="pf"
-        />,
       ],
     },
     "ref": null,
@@ -870,8 +787,10 @@ ShallowWrapper {
         "props": Object {
           "name": "warning-triangle-o",
           "style": Object {
-            "fontSize": undefined,
+            "fontSize": "18px",
           },
+          "title": "Degraded
+Pod deployment degraded",
           "type": "pf",
         },
         "ref": null,
@@ -879,19 +798,6 @@ ShallowWrapper {
         "type": [Function],
       },
       " ",
-      Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "function",
-        "props": Object {
-          "name": "info",
-          "title": "Pod deployment degraded",
-          "type": "pf",
-        },
-        "ref": null,
-        "rendered": null,
-        "type": [Function],
-      },
     ],
     "type": "span",
   },
@@ -906,17 +812,14 @@ ShallowWrapper {
             name="warning-triangle-o"
             style={
               Object {
-                "fontSize": undefined,
+                "fontSize": "18px",
               }
             }
+            title="Degraded
+Pod deployment degraded"
             type="pf"
           />,
           " ",
-          <Icon
-            name="info"
-            title="Pod deployment degraded"
-            type="pf"
-          />,
         ],
       },
       "ref": null,
@@ -928,8 +831,10 @@ ShallowWrapper {
           "props": Object {
             "name": "warning-triangle-o",
             "style": Object {
-              "fontSize": undefined,
+              "fontSize": "18px",
             },
+            "title": "Degraded
+Pod deployment degraded",
             "type": "pf",
           },
           "ref": null,
@@ -937,19 +842,6 @@ ShallowWrapper {
           "type": [Function],
         },
         " ",
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "function",
-          "props": Object {
-            "name": "info",
-            "title": "Pod deployment degraded",
-            "type": "pf",
-          },
-          "ref": null,
-          "rendered": null,
-          "type": [Function],
-        },
       ],
       "type": "span",
     },
@@ -1009,20 +901,16 @@ ShallowWrapper {
               "fontSize": "35px",
             }
           }
+          title="Degraded"
           type="pf"
         />,
-        <div
-          style={
-            Object {
-              "color": "#ec7a08",
-            }
-          }
-        >
-          Degraded
-        </div>,
+        <br />,
         "Pod deployment degraded",
         false,
       ],
+      "style": Object {
+        "color": "#ec7a08",
+      },
     },
     "ref": null,
     "rendered": Array [
@@ -1035,6 +923,7 @@ ShallowWrapper {
           "style": Object {
             "fontSize": "35px",
           },
+          "title": "Degraded",
           "type": "pf",
         },
         "ref": null,
@@ -1045,15 +934,10 @@ ShallowWrapper {
         "instance": null,
         "key": undefined,
         "nodeType": "host",
-        "props": Object {
-          "children": "Degraded",
-          "style": Object {
-            "color": "#ec7a08",
-          },
-        },
+        "props": Object {},
         "ref": null,
-        "rendered": "Degraded",
-        "type": "div",
+        "rendered": null,
+        "type": "br",
       },
       "Pod deployment degraded",
       false,
@@ -1074,20 +958,16 @@ ShallowWrapper {
                 "fontSize": "35px",
               }
             }
+            title="Degraded"
             type="pf"
           />,
-          <div
-            style={
-              Object {
-                "color": "#ec7a08",
-              }
-            }
-          >
-            Degraded
-          </div>,
+          <br />,
           "Pod deployment degraded",
           false,
         ],
+        "style": Object {
+          "color": "#ec7a08",
+        },
       },
       "ref": null,
       "rendered": Array [
@@ -1100,6 +980,7 @@ ShallowWrapper {
             "style": Object {
               "fontSize": "35px",
             },
+            "title": "Degraded",
             "type": "pf",
           },
           "ref": null,
@@ -1110,15 +991,10 @@ ShallowWrapper {
           "instance": null,
           "key": undefined,
           "nodeType": "host",
-          "props": Object {
-            "children": "Degraded",
-            "style": Object {
-              "color": "#ec7a08",
-            },
-          },
+          "props": Object {},
           "ref": null,
-          "rendered": "Degraded",
-          "type": "div",
+          "rendered": null,
+          "type": "br",
         },
         "Pod deployment degraded",
         false,
@@ -1178,17 +1054,15 @@ ShallowWrapper {
           name="error-circle-o"
           style={
             Object {
-              "fontSize": undefined,
+              "fontSize": "18px",
             }
           }
+          title="Failure
+- Envoy health degraded
+- Pod deployment failure"
           type="pf"
         />,
         " ",
-        <Icon
-          name="info"
-          title="- Envoy health degraded&#13;- Pod deployment failure"
-          type="pf"
-        />,
       ],
     },
     "ref": null,
@@ -1200,8 +1074,11 @@ ShallowWrapper {
         "props": Object {
           "name": "error-circle-o",
           "style": Object {
-            "fontSize": undefined,
+            "fontSize": "18px",
           },
+          "title": "Failure
+- Envoy health degraded
+- Pod deployment failure",
           "type": "pf",
         },
         "ref": null,
@@ -1209,19 +1086,6 @@ ShallowWrapper {
         "type": [Function],
       },
       " ",
-      Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "function",
-        "props": Object {
-          "name": "info",
-          "title": "- Envoy health degraded&#13;- Pod deployment failure",
-          "type": "pf",
-        },
-        "ref": null,
-        "rendered": null,
-        "type": [Function],
-      },
     ],
     "type": "span",
   },
@@ -1236,17 +1100,15 @@ ShallowWrapper {
             name="error-circle-o"
             style={
               Object {
-                "fontSize": undefined,
+                "fontSize": "18px",
               }
             }
+            title="Failure
+- Envoy health degraded
+- Pod deployment failure"
             type="pf"
           />,
           " ",
-          <Icon
-            name="info"
-            title="- Envoy health degraded&#13;- Pod deployment failure"
-            type="pf"
-          />,
         ],
       },
       "ref": null,
@@ -1258,8 +1120,11 @@ ShallowWrapper {
           "props": Object {
             "name": "error-circle-o",
             "style": Object {
-              "fontSize": undefined,
+              "fontSize": "18px",
             },
+            "title": "Failure
+- Envoy health degraded
+- Pod deployment failure",
             "type": "pf",
           },
           "ref": null,
@@ -1267,19 +1132,6 @@ ShallowWrapper {
           "type": [Function],
         },
         " ",
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "function",
-          "props": Object {
-            "name": "info",
-            "title": "- Envoy health degraded&#13;- Pod deployment failure",
-            "type": "pf",
-          },
-          "ref": null,
-          "rendered": null,
-          "type": [Function],
-        },
       ],
       "type": "span",
     },
@@ -1339,17 +1191,10 @@ ShallowWrapper {
               "fontSize": "35px",
             }
           }
+          title="Failure"
           type="pf"
         />,
-        <div
-          style={
-            Object {
-              "color": "#cc0000",
-            }
-          }
-        >
-          Failure
-        </div>,
+        <br />,
         false,
         <ul
           style={
@@ -1366,6 +1211,9 @@ ShallowWrapper {
           </li>
         </ul>,
       ],
+      "style": Object {
+        "color": "#cc0000",
+      },
     },
     "ref": null,
     "rendered": Array [
@@ -1378,6 +1226,7 @@ ShallowWrapper {
           "style": Object {
             "fontSize": "35px",
           },
+          "title": "Failure",
           "type": "pf",
         },
         "ref": null,
@@ -1388,15 +1237,10 @@ ShallowWrapper {
         "instance": null,
         "key": undefined,
         "nodeType": "host",
-        "props": Object {
-          "children": "Failure",
-          "style": Object {
-            "color": "#cc0000",
-          },
-        },
+        "props": Object {},
         "ref": null,
-        "rendered": "Failure",
-        "type": "div",
+        "rendered": null,
+        "type": "br",
       },
       false,
       Object {
@@ -1460,17 +1304,10 @@ ShallowWrapper {
                 "fontSize": "35px",
               }
             }
+            title="Failure"
             type="pf"
           />,
-          <div
-            style={
-              Object {
-                "color": "#cc0000",
-              }
-            }
-          >
-            Failure
-          </div>,
+          <br />,
           false,
           <ul
             style={
@@ -1487,6 +1324,9 @@ ShallowWrapper {
             </li>
           </ul>,
         ],
+        "style": Object {
+          "color": "#cc0000",
+        },
       },
       "ref": null,
       "rendered": Array [
@@ -1499,6 +1339,7 @@ ShallowWrapper {
             "style": Object {
               "fontSize": "35px",
             },
+            "title": "Failure",
             "type": "pf",
           },
           "ref": null,
@@ -1509,15 +1350,10 @@ ShallowWrapper {
           "instance": null,
           "key": undefined,
           "nodeType": "host",
-          "props": Object {
-            "children": "Failure",
-            "style": Object {
-              "color": "#cc0000",
-            },
-          },
+          "props": Object {},
           "ref": null,
-          "rendered": "Failure",
-          "type": "div",
+          "rendered": null,
+          "type": "br",
         },
         false,
         Object {
@@ -1620,17 +1456,14 @@ ShallowWrapper {
           name="warning-triangle-o"
           style={
             Object {
-              "fontSize": undefined,
+              "fontSize": "18px",
             }
           }
+          title="Degraded
+Envoy health degraded"
           type="pf"
         />,
         " ",
-        <Icon
-          name="info"
-          title="Envoy health degraded"
-          type="pf"
-        />,
       ],
     },
     "ref": null,
@@ -1642,8 +1475,10 @@ ShallowWrapper {
         "props": Object {
           "name": "warning-triangle-o",
           "style": Object {
-            "fontSize": undefined,
+            "fontSize": "18px",
           },
+          "title": "Degraded
+Envoy health degraded",
           "type": "pf",
         },
         "ref": null,
@@ -1651,19 +1486,6 @@ ShallowWrapper {
         "type": [Function],
       },
       " ",
-      Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "function",
-        "props": Object {
-          "name": "info",
-          "title": "Envoy health degraded",
-          "type": "pf",
-        },
-        "ref": null,
-        "rendered": null,
-        "type": [Function],
-      },
     ],
     "type": "span",
   },
@@ -1678,17 +1500,14 @@ ShallowWrapper {
             name="warning-triangle-o"
             style={
               Object {
-                "fontSize": undefined,
+                "fontSize": "18px",
               }
             }
+            title="Degraded
+Envoy health degraded"
             type="pf"
           />,
           " ",
-          <Icon
-            name="info"
-            title="Envoy health degraded"
-            type="pf"
-          />,
         ],
       },
       "ref": null,
@@ -1700,8 +1519,10 @@ ShallowWrapper {
           "props": Object {
             "name": "warning-triangle-o",
             "style": Object {
-              "fontSize": undefined,
+              "fontSize": "18px",
             },
+            "title": "Degraded
+Envoy health degraded",
             "type": "pf",
           },
           "ref": null,
@@ -1709,19 +1530,6 @@ ShallowWrapper {
           "type": [Function],
         },
         " ",
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "function",
-          "props": Object {
-            "name": "info",
-            "title": "Envoy health degraded",
-            "type": "pf",
-          },
-          "ref": null,
-          "rendered": null,
-          "type": [Function],
-        },
       ],
       "type": "span",
     },
@@ -1781,20 +1589,16 @@ ShallowWrapper {
               "fontSize": "35px",
             }
           }
+          title="Degraded"
           type="pf"
         />,
-        <div
-          style={
-            Object {
-              "color": "#ec7a08",
-            }
-          }
-        >
-          Degraded
-        </div>,
+        <br />,
         "Envoy health degraded",
         false,
       ],
+      "style": Object {
+        "color": "#ec7a08",
+      },
     },
     "ref": null,
     "rendered": Array [
@@ -1807,6 +1611,7 @@ ShallowWrapper {
           "style": Object {
             "fontSize": "35px",
           },
+          "title": "Degraded",
           "type": "pf",
         },
         "ref": null,
@@ -1817,15 +1622,10 @@ ShallowWrapper {
         "instance": null,
         "key": undefined,
         "nodeType": "host",
-        "props": Object {
-          "children": "Degraded",
-          "style": Object {
-            "color": "#ec7a08",
-          },
-        },
+        "props": Object {},
         "ref": null,
-        "rendered": "Degraded",
-        "type": "div",
+        "rendered": null,
+        "type": "br",
       },
       "Envoy health degraded",
       false,
@@ -1846,20 +1646,16 @@ ShallowWrapper {
                 "fontSize": "35px",
               }
             }
+            title="Degraded"
             type="pf"
           />,
-          <div
-            style={
-              Object {
-                "color": "#ec7a08",
-              }
-            }
-          >
-            Degraded
-          </div>,
+          <br />,
           "Envoy health degraded",
           false,
         ],
+        "style": Object {
+          "color": "#ec7a08",
+        },
       },
       "ref": null,
       "rendered": Array [
@@ -1872,6 +1668,7 @@ ShallowWrapper {
             "style": Object {
               "fontSize": "35px",
             },
+            "title": "Degraded",
             "type": "pf",
           },
           "ref": null,
@@ -1882,15 +1679,10 @@ ShallowWrapper {
           "instance": null,
           "key": undefined,
           "nodeType": "host",
-          "props": Object {
-            "children": "Degraded",
-            "style": Object {
-              "color": "#ec7a08",
-            },
-          },
+          "props": Object {},
           "ref": null,
-          "rendered": "Degraded",
-          "type": "div",
+          "rendered": null,
+          "type": "br",
         },
         "Envoy health degraded",
         false,
@@ -1950,17 +1742,15 @@ ShallowWrapper {
           name="error-circle-o"
           style={
             Object {
-              "fontSize": undefined,
+              "fontSize": "18px",
             }
           }
+          title="Failure
+- Envoy health failure
+- Pod deployment degraded"
           type="pf"
         />,
         " ",
-        <Icon
-          name="info"
-          title="- Envoy health failure&#13;- Pod deployment degraded"
-          type="pf"
-        />,
       ],
     },
     "ref": null,
@@ -1972,8 +1762,11 @@ ShallowWrapper {
         "props": Object {
           "name": "error-circle-o",
           "style": Object {
-            "fontSize": undefined,
+            "fontSize": "18px",
           },
+          "title": "Failure
+- Envoy health failure
+- Pod deployment degraded",
           "type": "pf",
         },
         "ref": null,
@@ -1981,19 +1774,6 @@ ShallowWrapper {
         "type": [Function],
       },
       " ",
-      Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "function",
-        "props": Object {
-          "name": "info",
-          "title": "- Envoy health failure&#13;- Pod deployment degraded",
-          "type": "pf",
-        },
-        "ref": null,
-        "rendered": null,
-        "type": [Function],
-      },
     ],
     "type": "span",
   },
@@ -2008,17 +1788,15 @@ ShallowWrapper {
             name="error-circle-o"
             style={
               Object {
-                "fontSize": undefined,
+                "fontSize": "18px",
               }
             }
+            title="Failure
+- Envoy health failure
+- Pod deployment degraded"
             type="pf"
           />,
           " ",
-          <Icon
-            name="info"
-            title="- Envoy health failure&#13;- Pod deployment degraded"
-            type="pf"
-          />,
         ],
       },
       "ref": null,
@@ -2030,8 +1808,11 @@ ShallowWrapper {
           "props": Object {
             "name": "error-circle-o",
             "style": Object {
-              "fontSize": undefined,
+              "fontSize": "18px",
             },
+            "title": "Failure
+- Envoy health failure
+- Pod deployment degraded",
             "type": "pf",
           },
           "ref": null,
@@ -2039,19 +1820,6 @@ ShallowWrapper {
           "type": [Function],
         },
         " ",
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "function",
-          "props": Object {
-            "name": "info",
-            "title": "- Envoy health failure&#13;- Pod deployment degraded",
-            "type": "pf",
-          },
-          "ref": null,
-          "rendered": null,
-          "type": [Function],
-        },
       ],
       "type": "span",
     },
@@ -2111,17 +1879,10 @@ ShallowWrapper {
               "fontSize": "35px",
             }
           }
+          title="Failure"
           type="pf"
         />,
-        <div
-          style={
-            Object {
-              "color": "#cc0000",
-            }
-          }
-        >
-          Failure
-        </div>,
+        <br />,
         false,
         <ul
           style={
@@ -2138,6 +1899,9 @@ ShallowWrapper {
           </li>
         </ul>,
       ],
+      "style": Object {
+        "color": "#cc0000",
+      },
     },
     "ref": null,
     "rendered": Array [
@@ -2150,6 +1914,7 @@ ShallowWrapper {
           "style": Object {
             "fontSize": "35px",
           },
+          "title": "Failure",
           "type": "pf",
         },
         "ref": null,
@@ -2160,15 +1925,10 @@ ShallowWrapper {
         "instance": null,
         "key": undefined,
         "nodeType": "host",
-        "props": Object {
-          "children": "Failure",
-          "style": Object {
-            "color": "#cc0000",
-          },
-        },
+        "props": Object {},
         "ref": null,
-        "rendered": "Failure",
-        "type": "div",
+        "rendered": null,
+        "type": "br",
       },
       false,
       Object {
@@ -2232,17 +1992,10 @@ ShallowWrapper {
                 "fontSize": "35px",
               }
             }
+            title="Failure"
             type="pf"
           />,
-          <div
-            style={
-              Object {
-                "color": "#cc0000",
-              }
-            }
-          >
-            Failure
-          </div>,
+          <br />,
           false,
           <ul
             style={
@@ -2259,6 +2012,9 @@ ShallowWrapper {
             </li>
           </ul>,
         ],
+        "style": Object {
+          "color": "#cc0000",
+        },
       },
       "ref": null,
       "rendered": Array [
@@ -2271,6 +2027,7 @@ ShallowWrapper {
             "style": Object {
               "fontSize": "35px",
             },
+            "title": "Failure",
             "type": "pf",
           },
           "ref": null,
@@ -2281,15 +2038,10 @@ ShallowWrapper {
           "instance": null,
           "key": undefined,
           "nodeType": "host",
-          "props": Object {
-            "children": "Failure",
-            "style": Object {
-              "color": "#cc0000",
-            },
-          },
+          "props": Object {},
           "ref": null,
-          "rendered": "Failure",
-          "type": "div",
+          "rendered": null,
+          "type": "br",
         },
         false,
         Object {
@@ -2392,13 +2144,13 @@ ShallowWrapper {
           name="ok"
           style={
             Object {
-              "fontSize": undefined,
+              "fontSize": "18px",
             }
           }
+          title="Healthy"
           type="pf"
         />,
         " ",
-        "",
       ],
     },
     "ref": null,
@@ -2410,8 +2162,9 @@ ShallowWrapper {
         "props": Object {
           "name": "ok",
           "style": Object {
-            "fontSize": undefined,
+            "fontSize": "18px",
           },
+          "title": "Healthy",
           "type": "pf",
         },
         "ref": null,
@@ -2419,7 +2172,6 @@ ShallowWrapper {
         "type": [Function],
       },
       " ",
-      "",
     ],
     "type": "span",
   },
@@ -2434,13 +2186,13 @@ ShallowWrapper {
             name="ok"
             style={
               Object {
-                "fontSize": undefined,
+                "fontSize": "18px",
               }
             }
+            title="Healthy"
             type="pf"
           />,
           " ",
-          "",
         ],
       },
       "ref": null,
@@ -2452,8 +2204,9 @@ ShallowWrapper {
           "props": Object {
             "name": "ok",
             "style": Object {
-              "fontSize": undefined,
+              "fontSize": "18px",
             },
+            "title": "Healthy",
             "type": "pf",
           },
           "ref": null,
@@ -2461,7 +2214,6 @@ ShallowWrapper {
           "type": [Function],
         },
         " ",
-        "",
       ],
       "type": "span",
     },
@@ -2521,20 +2273,16 @@ ShallowWrapper {
               "fontSize": "35px",
             }
           }
+          title="Healthy"
           type="pf"
         />,
-        <div
-          style={
-            Object {
-              "color": "#3f9c35",
-            }
-          }
-        >
-          Healthy
-        </div>,
+        <br />,
         false,
         false,
       ],
+      "style": Object {
+        "color": "#3f9c35",
+      },
     },
     "ref": null,
     "rendered": Array [
@@ -2547,6 +2295,7 @@ ShallowWrapper {
           "style": Object {
             "fontSize": "35px",
           },
+          "title": "Healthy",
           "type": "pf",
         },
         "ref": null,
@@ -2557,15 +2306,10 @@ ShallowWrapper {
         "instance": null,
         "key": undefined,
         "nodeType": "host",
-        "props": Object {
-          "children": "Healthy",
-          "style": Object {
-            "color": "#3f9c35",
-          },
-        },
+        "props": Object {},
         "ref": null,
-        "rendered": "Healthy",
-        "type": "div",
+        "rendered": null,
+        "type": "br",
       },
       false,
       false,
@@ -2586,20 +2330,16 @@ ShallowWrapper {
                 "fontSize": "35px",
               }
             }
+            title="Healthy"
             type="pf"
           />,
-          <div
-            style={
-              Object {
-                "color": "#3f9c35",
-              }
-            }
-          >
-            Healthy
-          </div>,
+          <br />,
           false,
           false,
         ],
+        "style": Object {
+          "color": "#3f9c35",
+        },
       },
       "ref": null,
       "rendered": Array [
@@ -2612,6 +2352,7 @@ ShallowWrapper {
             "style": Object {
               "fontSize": "35px",
             },
+            "title": "Healthy",
             "type": "pf",
           },
           "ref": null,
@@ -2622,15 +2363,10 @@ ShallowWrapper {
           "instance": null,
           "key": undefined,
           "nodeType": "host",
-          "props": Object {
-            "children": "Healthy",
-            "style": Object {
-              "color": "#3f9c35",
-            },
-          },
+          "props": Object {},
           "ref": null,
-          "rendered": "Healthy",
-          "type": "div",
+          "rendered": null,
+          "type": "br",
         },
         false,
         false,
@@ -2690,17 +2426,14 @@ ShallowWrapper {
           name="ok"
           style={
             Object {
-              "fontSize": undefined,
+              "fontSize": "18px",
             }
           }
+          title="Healthy
+One inactive deployment"
           type="pf"
         />,
         " ",
-        <Icon
-          name="info"
-          title="One inactive deployment"
-          type="pf"
-        />,
       ],
     },
     "ref": null,
@@ -2712,8 +2445,10 @@ ShallowWrapper {
         "props": Object {
           "name": "ok",
           "style": Object {
-            "fontSize": undefined,
+            "fontSize": "18px",
           },
+          "title": "Healthy
+One inactive deployment",
           "type": "pf",
         },
         "ref": null,
@@ -2721,19 +2456,6 @@ ShallowWrapper {
         "type": [Function],
       },
       " ",
-      Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "function",
-        "props": Object {
-          "name": "info",
-          "title": "One inactive deployment",
-          "type": "pf",
-        },
-        "ref": null,
-        "rendered": null,
-        "type": [Function],
-      },
     ],
     "type": "span",
   },
@@ -2748,17 +2470,14 @@ ShallowWrapper {
             name="ok"
             style={
               Object {
-                "fontSize": undefined,
+                "fontSize": "18px",
               }
             }
+            title="Healthy
+One inactive deployment"
             type="pf"
           />,
           " ",
-          <Icon
-            name="info"
-            title="One inactive deployment"
-            type="pf"
-          />,
         ],
       },
       "ref": null,
@@ -2770,8 +2489,10 @@ ShallowWrapper {
           "props": Object {
             "name": "ok",
             "style": Object {
-              "fontSize": undefined,
+              "fontSize": "18px",
             },
+            "title": "Healthy
+One inactive deployment",
             "type": "pf",
           },
           "ref": null,
@@ -2779,19 +2500,6 @@ ShallowWrapper {
           "type": [Function],
         },
         " ",
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "function",
-          "props": Object {
-            "name": "info",
-            "title": "One inactive deployment",
-            "type": "pf",
-          },
-          "ref": null,
-          "rendered": null,
-          "type": [Function],
-        },
       ],
       "type": "span",
     },
@@ -2851,20 +2559,16 @@ ShallowWrapper {
               "fontSize": "35px",
             }
           }
+          title="Healthy"
           type="pf"
         />,
-        <div
-          style={
-            Object {
-              "color": "#3f9c35",
-            }
-          }
-        >
-          Healthy
-        </div>,
+        <br />,
         "One inactive deployment",
         false,
       ],
+      "style": Object {
+        "color": "#3f9c35",
+      },
     },
     "ref": null,
     "rendered": Array [
@@ -2877,6 +2581,7 @@ ShallowWrapper {
           "style": Object {
             "fontSize": "35px",
           },
+          "title": "Healthy",
           "type": "pf",
         },
         "ref": null,
@@ -2887,15 +2592,10 @@ ShallowWrapper {
         "instance": null,
         "key": undefined,
         "nodeType": "host",
-        "props": Object {
-          "children": "Healthy",
-          "style": Object {
-            "color": "#3f9c35",
-          },
-        },
+        "props": Object {},
         "ref": null,
-        "rendered": "Healthy",
-        "type": "div",
+        "rendered": null,
+        "type": "br",
       },
       "One inactive deployment",
       false,
@@ -2916,20 +2616,16 @@ ShallowWrapper {
                 "fontSize": "35px",
               }
             }
+            title="Healthy"
             type="pf"
           />,
-          <div
-            style={
-              Object {
-                "color": "#3f9c35",
-              }
-            }
-          >
-            Healthy
-          </div>,
+          <br />,
           "One inactive deployment",
           false,
         ],
+        "style": Object {
+          "color": "#3f9c35",
+        },
       },
       "ref": null,
       "rendered": Array [
@@ -2942,6 +2638,7 @@ ShallowWrapper {
             "style": Object {
               "fontSize": "35px",
             },
+            "title": "Healthy",
             "type": "pf",
           },
           "ref": null,
@@ -2952,15 +2649,10 @@ ShallowWrapper {
           "instance": null,
           "key": undefined,
           "nodeType": "host",
-          "props": Object {
-            "children": "Healthy",
-            "style": Object {
-              "color": "#3f9c35",
-            },
-          },
+          "props": Object {},
           "ref": null,
-          "rendered": "Healthy",
-          "type": "div",
+          "rendered": null,
+          "type": "br",
         },
         "One inactive deployment",
         false,

--- a/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -7,7 +7,7 @@ import ServiceInfoRoutes from './ServiceInfo/ServiceInfoRoutes';
 import ServiceInfoDestinationPolicies from './ServiceInfo/ServiceInfoDestinationPolicies';
 
 import { Endpoints, Deployment, Port, RouteRule, DestinationPolicy } from '../../types/ServiceInfo';
-import Health from '../../types/Health';
+import { Health } from '../../types/Health';
 import * as API from '../../services/Api';
 import { ToastNotification, ToastNotificationList, Col, Row } from 'patternfly-react';
 
@@ -46,12 +46,10 @@ class ServiceInfo extends React.Component<ServiceId, ServiceInfoState> {
 
   componentDidMount() {
     this.fetchServiceDetails(this.props);
-    this.fetchHealth(this.props);
   }
 
   componentWillReceiveProps(nextProps: ServiceId) {
     this.fetchServiceDetails(nextProps);
-    this.fetchHealth(nextProps);
   }
 
   fetchServiceDetails(props: ServiceId) {
@@ -69,7 +67,8 @@ class ServiceInfo extends React.Component<ServiceId, ServiceInfoState> {
           dependencies: data.dependencies,
           routeRules: this.sortRouteRulesByPrecedence(data.route_rules),
           destinationPolicies: data.destination_policies,
-          ip: data.ip
+          ip: data.ip,
+          health: data.health
         });
       })
       .catch(error => {
@@ -92,24 +91,6 @@ class ServiceInfo extends React.Component<ServiceId, ServiceInfoState> {
       });
     }
     return sorted;
-  }
-
-  fetchHealth(props: ServiceId) {
-    // Health
-    API.getServiceHealth(props.namespace, props.service)
-      .then(response => {
-        this.setState({
-          health: response['data']
-        });
-      })
-      .catch(error => {
-        this.setState({
-          health: undefined,
-          error: true,
-          errorMessage: API.GetErrorMsg('Could not fetch service health.', error)
-        });
-        console.error(error);
-      });
   }
 
   render() {

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDeployments.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDeployments.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
+import { Col, Row } from 'patternfly-react';
 import Badge from '../../../components/Badge/Badge';
 import { Deployment } from '../../../types/ServiceInfo';
-import { Col, Row, Icon } from 'patternfly-react';
 import PfInfoCard from '../../../components/Pf/PfInfoCard';
+import { ratioCheck } from '../../../components/ServiceHealth/ServiceHealth';
 
 interface ServiceInfoDeploymentsProps {
   deployments?: Deployment[];
@@ -40,10 +41,7 @@ class ServiceInfoDeployments extends React.Component<ServiceInfoDeploymentsProps
                 </div>
                 <div>
                   <strong>Pod status: </strong> {deployment.available_replicas} / {deployment.replicas}{' '}
-                  <Icon
-                    type="pf"
-                    name={deployment.available_replicas < deployment.replicas ? 'warning-triangle-o' : 'ok'}
-                  />
+                  {ratioCheck(deployment.available_replicas, deployment.replicas).jsx(12, '')}
                 </div>
                 {deployment.autoscaler.name !== '' && (
                   <div>

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 import { Col, Row } from 'patternfly-react';
 
 import Badge from '../../../components/Badge/Badge';
-import ServiceHealth from '../../../components/ServiceHealth/ServiceHealth';
-import Health from '../../../types/Health';
+import { ServiceHealth, DisplayMode } from '../../../components/ServiceHealth/ServiceHealth';
+import { Health } from '../../../types/Health';
 import { Endpoints, Port } from '../../../types/ServiceInfo';
 import PfInfoCard from '../../../components/Pf/PfInfoCard';
 
@@ -88,9 +88,7 @@ class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps
               <div className="progress-description">
                 <strong>Health</strong>
               </div>
-              <div className="small-text-donut">
-                <ServiceHealth size={80} thickness={6} health={this.props.health} />
-              </div>
+              <ServiceHealth health={this.props.health} mode={DisplayMode.LARGE} />
             </Col>
           </Row>
         }

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDeployments.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDeployments.test.tsx.snap
@@ -103,6 +103,12 @@ ShallowWrapper {
                  
                 <Icon
                   name="warning-triangle-o"
+                  style={
+                    Object {
+                      "fontSize": "12px",
+                    }
+                  }
+                  title=""
                   type="pf"
                 />
               </div>
@@ -149,6 +155,12 @@ ShallowWrapper {
                  
                 <Icon
                   name="ok"
+                  style={
+                    Object {
+                      "fontSize": "12px",
+                    }
+                  }
+                  title=""
                   type="pf"
                 />
               </div>
@@ -195,6 +207,12 @@ ShallowWrapper {
                  
                 <Icon
                   name="ok"
+                  style={
+                    Object {
+                      "fontSize": "12px",
+                    }
+                  }
+                  title=""
                   type="pf"
                 />
               </div>
@@ -257,6 +275,12 @@ ShallowWrapper {
                    
                   <Icon
                     name="warning-triangle-o"
+                    style={
+                      Object {
+                        "fontSize": "12px",
+                      }
+                    }
+                    title=""
                     type="pf"
                   />
                 </div>
@@ -303,6 +327,12 @@ ShallowWrapper {
                    
                   <Icon
                     name="ok"
+                    style={
+                      Object {
+                        "fontSize": "12px",
+                      }
+                    }
+                    title=""
                     type="pf"
                   />
                 </div>
@@ -349,6 +379,12 @@ ShallowWrapper {
                    
                   <Icon
                     name="ok"
+                    style={
+                      Object {
+                        "fontSize": "12px",
+                      }
+                    }
+                    title=""
                     type="pf"
                   />
                 </div>

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
@@ -192,15 +192,10 @@ ShallowWrapper {
               Health
             </strong>
           </div>
-          <div
-            className="small-text-donut"
-          >
-            <ServiceHealth
-              health={undefined}
-              size={80}
-              thickness={6}
-            />
-          </div>
+          <ServiceHealth
+            health={undefined}
+            mode={0}
+          />
         </Col>
       </Row>,
       "title": "reviews",
@@ -351,15 +346,10 @@ ShallowWrapper {
                 Health
               </strong>
             </div>
-            <div
-              className="small-text-donut"
-            >
-              <ServiceHealth
-                health={undefined}
-                size={80}
-                thickness={6}
-              />
-            </div>
+            <ServiceHealth
+              health={undefined}
+              mode={0}
+            />
           </Col>
         </Row>,
         "title": "reviews",

--- a/src/pages/ServiceList/ServiceListComponent.tsx
+++ b/src/pages/ServiceList/ServiceListComponent.tsx
@@ -10,6 +10,7 @@ import { Pagination } from '../../types/Pagination';
 import { ServiceItem, ServiceList } from '../../types/ServiceListComponent';
 import PropTypes from 'prop-types';
 import MetricsOptionsBar from '../../components/MetricsOptions/MetricsOptionsBar';
+import { ServiceHealth, DisplayMode } from '../../components/ServiceHealth/ServiceHealth';
 
 type SortField = {
   id: string;
@@ -176,9 +177,7 @@ class ServiceListComponent extends React.Component<ServiceListComponentProps, Se
             let serviceItem: ServiceItem = {
               namespace: namespace.name,
               servicename: serviceName.name,
-              replicas: serviceName.replicas,
-              available_replicas: serviceName.available_replicas,
-              unavailable_replicas: serviceName.unavailable_replicas,
+              health: serviceName.health,
               request_count: serviceName.request_count,
               request_error_count: serviceName.request_error_count,
               error_rate: serviceName.error_rate
@@ -262,15 +261,8 @@ class ServiceListComponent extends React.Component<ServiceListComponentProps, Se
         <table style={{ width: '30em', tableLayout: 'fixed' }}>
           <tr>
             <td>
-              <strong>Pod status: </strong> {serviceItem.available_replicas} / {serviceItem.replicas}{' '}
-              <Icon
-                type="pf"
-                name={
-                  serviceItem.available_replicas < serviceItem.replicas || serviceItem.replicas === 0
-                    ? 'warning-triangle-o'
-                    : 'ok'
-                }
-              />
+              <strong>Health: </strong>
+              <ServiceHealth health={serviceItem.health} mode={DisplayMode.SMALL} />
             </td>
             <td>
               <strong>Error rate: </strong>

--- a/src/pages/ServiceList/ServiceListComponent.tsx
+++ b/src/pages/ServiceList/ServiceListComponent.tsx
@@ -255,9 +255,9 @@ class ServiceListComponent extends React.Component<ServiceListComponentProps, Se
     pageEnd = pageEnd < this.state.services.length ? pageEnd : this.state.services.length;
 
     for (let i = pageStart; i < pageEnd; i++) {
-      let serviceItem = this.state.services[i];
-      let to = '/namespaces/' + serviceItem.namespace + '/services/' + serviceItem.servicename;
-      let serviceDescriptor = (
+      const serviceItem = this.state.services[i];
+      const to = '/namespaces/' + serviceItem.namespace + '/services/' + serviceItem.servicename;
+      const serviceDescriptor = (
         <table style={{ width: '30em', tableLayout: 'fixed' }}>
           <tr>
             <td>

--- a/src/services/__mockData__/getServiceHealth.json
+++ b/src/services/__mockData__/getServiceHealth.json
@@ -1,4 +1,1 @@
-{
-  "healthyReplicas": 1,
-  "totalReplicas": 1
-}
+{ "envoy": { "healthy": 1, "total": 1 }, "deploymentStatuses": [{ "replicas": 1, "available": 1 }] }

--- a/src/types/Health.ts
+++ b/src/types/Health.ts
@@ -1,6 +1,14 @@
-interface Health {
-  healthyReplicas: number;
-  totalReplicas: number;
+export interface Health {
+  envoy: EnvoyHealth;
+  deploymentStatuses: DeploymentStatus[];
 }
 
-export default Health;
+export interface EnvoyHealth {
+  healthy: number;
+  total: number;
+}
+
+export interface DeploymentStatus {
+  replicas: number;
+  available: number;
+}

--- a/src/types/ServiceListComponent.ts
+++ b/src/types/ServiceListComponent.ts
@@ -1,10 +1,9 @@
 import Namespace from './Namespace';
+import { Health } from './Health';
 
 export interface ServiceName {
   name: string;
-  replicas: number;
-  available_replicas: number;
-  unavailable_replicas: number;
+  health: Health;
   request_count: number;
   request_error_count: number;
   error_rate: number;
@@ -18,9 +17,7 @@ export interface ServiceList {
 export interface ServiceItem {
   servicename: string;
   namespace: string;
-  replicas: number;
-  available_replicas: number;
-  unavailable_replicas: number;
+  health: Health;
   request_count: number;
   request_error_count: number;
   error_rate: number;


### PR DESCRIPTION
- Replace the donut with the global indicator (colored icon) in service details
- Replace global pod status with health in services list
- Aggregate health sources into a global health
- Unit tests

Related to https://github.com/kiali/kiali/pull/145