### PR TITLE
KIALI-180: Disallow the user from repositioning nodes

### DIFF
--- a/src/components/CytoscapeLayout/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeLayout/graphs/GraphStyles.ts
@@ -1,6 +1,6 @@
 export class GraphStyles {
   static options() {
-    return { wheelSensitivity: 0.1, autounselectify: false };
+    return { wheelSensitivity: 0.1, autounselectify: false, autoungrabify: true };
   }
 
   static styles() {


### PR DESCRIPTION
With this change, the user won't be allowed to change nodes positioning of the service graph.