### PR TITLE
Trivial: Remove superflous 'div' tags

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -8,9 +8,7 @@ class App extends React.Component {
     const Sidebar = withRouter(Navigation);
     return (
       <BrowserRouter basename="/console">
-        <div>
-          <Sidebar />
-        </div>
+        <Sidebar />
       </BrowserRouter>
     );
   }

--- a/src/components/Nav/Navigation.tsx
+++ b/src/components/Nav/Navigation.tsx
@@ -88,7 +88,7 @@ class Navigation extends React.Component<PropsType, StateType> {
 
   render() {
     return (
-      <div>
+      <>
         <VerticalNav
           setControlledState={this.setControlledState}
           activePath={this.state.selectedItem}
@@ -114,7 +114,7 @@ class Navigation extends React.Component<PropsType, StateType> {
           <Route path="/namespaces/:namespace/rules/:rule" component={IstioRuleDetailsPage} />
           <Redirect to={serviceGraphPath} />
         </Switch>
-      </div>
+      </>
     );
   }
 }


### PR DESCRIPTION
Cleanup some unnecessary `div` nesting. At the very least, they bloat the DOM.
Using React 16 [Fragments](https://reactjs.org/docs/fragments.html) instead.