### PR TITLE
KIALI-358 Wraps Switch into an ErrorBoundary object

### DIFF
--- a/src/components/Nav/Navigation.tsx
+++ b/src/components/Nav/Navigation.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import { VerticalNav } from 'patternfly-react';
 import PropTypes from 'prop-types';
-import { Route, Switch, Redirect } from 'react-router-dom';
+import { Route, Redirect } from 'react-router-dom';
+
+import SwitchErrorBoundary from '../SwitchErrorBoundary/SwitchErrorBoundary';
 
 import IstioRulesPage from '../../pages/IstioRulesList/IstioRuleListPage';
 import IstioRuleDetailsPage from '../../pages/IstioRuleDetails/IstioRuleDetailsPage';
@@ -105,7 +107,13 @@ class Navigation extends React.Component<PropsType, StateType> {
           <VerticalNav.Item title={istioRulesTitle} iconClass="fa pficon-migration" onClick={this.navigateTo} />
           <VerticalNav.Item title={servicesJaeger} iconClass="fa fa-paw" onClick={this.navigateTo} />
         </VerticalNav>
-        <Switch>
+        <SwitchErrorBoundary
+          fallBackComponent={() => (
+            <div className="container-fluid container-pf-nav-pf-vertical">
+              <h2>Something wrong happened, try refreshing or navigate to other section</h2>
+            </div>
+          )}
+        >
           <Route path="/service-graph/:namespace" component={ServiceGraphPage} />
           <Route path={servicesPath} component={ServiceListPage} />
           <Route path={servicesJaegerPath} component={ServiceJaegerPage} />
@@ -113,7 +121,7 @@ class Navigation extends React.Component<PropsType, StateType> {
           <Route path={istioRulesPath} component={IstioRulesPage} />
           <Route path="/namespaces/:namespace/rules/:rule" component={IstioRuleDetailsPage} />
           <Redirect to={serviceGraphPath} />
-        </Switch>
+        </SwitchErrorBoundary>
       </>
     );
   }

--- a/src/components/SwitchErrorBoundary/SwitchErrorBoundary.tsx
+++ b/src/components/SwitchErrorBoundary/SwitchErrorBoundary.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { Route, Switch } from 'react-router-dom';
+
+type ErrorHandlerFunction = (error: Error, componentStack: string) => void;
+
+type SwitchErrorBoundaryProps = {
+  fallBackComponent: any;
+  onError?: ErrorHandlerFunction;
+};
+
+type SwitchErrorBoundaryState = {
+  hasError: boolean;
+};
+
+export default class SwitchErrorBoundary extends React.Component<SwitchErrorBoundaryProps, SwitchErrorBoundaryState> {
+  private show: boolean;
+
+  constructor(props: SwitchErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+    this.show = false;
+  }
+
+  componentDidCatch(error: any, info: any) {
+    if (this.props.onError) {
+      this.props.onError(error, info);
+    }
+    this.setState({ hasError: true });
+  }
+
+  componentDidUpdate() {
+    if (this.state.hasError) {
+      if (this.show === true) {
+        this.setState({ hasError: false });
+      }
+      this.show = !this.show;
+    }
+  }
+
+  render() {
+    return (
+      <Switch>
+        {this.state.hasError && <Route component={this.props.fallBackComponent} />}
+        {this.props.children}
+      </Switch>
+    );
+  }
+}


### PR DESCRIPTION
 This make possible to catch unhandled render errors without breaking
 the whole application, the user is still able to change pages and use
 the rest of the application.

![peek 2018-04-09 17-53](https://user-images.githubusercontent.com/3845764/38570365-4b39c234-3cb3-11e8-88ca-97cb4a2382f4.gif)

Note: The flashy error screen is show only in development mode, while the "Something wrong happened" is show always.