### PR TITLE
KIALI-507 Graph sidebar spark chart should use same time range as gra…

### DIFF
--- a/src/components/SummaryPanel/RpsChart.tsx
+++ b/src/components/SummaryPanel/RpsChart.tsx
@@ -41,26 +41,36 @@ export class RpsChart extends React.Component<RpsChartTypeProp, {}> {
       dataErrors = (this.props.dataErrors as [string, number][])[1];
     }
 
-    let len: number = dataRps.length;
-    let sum = 0;
-    for (let i = 1; i < len; ++i) {
-      sum += +dataRps[i];
+    let len = dataRps.length;
+    let minRps: number = len > 1 ? +dataRps[1] : 0;
+    let maxRps: number = len > 1 ? +dataRps[1] : 0;
+    let sumRps: number = 0;
+    for (let i = 2; i < len; ++i) {
+      let sample: number = +dataRps[i];
+      minRps = sample < minRps ? sample : minRps;
+      maxRps = sample > maxRps ? sample : maxRps;
+      sumRps += +sample;
     }
-    const avgRps = len === 0 ? 0 : sum / len;
+    const avgRps = len === 0 ? 0 : sumRps / (len - 1);
 
     len = dataErrors.length;
-    sum = 0;
-    for (let i = 1; i < len; ++i) {
-      sum += +dataErrors[i];
+    let minErr: number = len > 1 ? +dataErrors[1] : 0;
+    let maxErr: number = len > 1 ? +dataErrors[1] : 0;
+    for (let i = 2; i < len; ++i) {
+      let sample: number = +dataErrors[i];
+      minErr = sample < minErr ? sample : minErr;
+      maxErr = sample > maxErr ? sample : maxErr;
     }
-    const avgErr = len === 0 ? 0 : sum / len;
-    const pctErr = avgRps === 0 ? 0 : avgErr / avgRps * 100;
+    const pctMinErr = avgRps === 0 ? 0 : minErr / avgRps * 100;
+    const pctMaxErr = avgRps === 0 ? 0 : maxErr / avgRps * 100;
 
     return (
       <>
         <div>
-          <strong>{this.props.label}: </strong>
-          {avgRps.toFixed(2)} rps / {pctErr.toFixed(2)}% Err
+          <strong>{this.props.label} min / max:</strong>
+        </div>
+        <div>
+          RPS: {minRps.toFixed(2)} / {maxRps.toFixed(2)} , %Error {pctMinErr.toFixed(2)} / {pctMaxErr.toFixed(2)}
         </div>
         {this.props.dataRps.length > 0 && (
           <AreaChart

--- a/src/pages/ServiceGraph/ServiceGraphPage.tsx
+++ b/src/pages/ServiceGraph/ServiceGraphPage.tsx
@@ -25,7 +25,7 @@ type ServiceGraphPageState = {
   alertVisible: boolean;
   alertDetails: string;
   summaryData: any;
-  updateTime: string;
+  graphTimestamp: string;
   graphData: any;
   isLoading: boolean;
   params: GraphParamsType;
@@ -55,7 +55,7 @@ export default class ServiceGraphPage extends React.Component<
       alertVisible: false,
       alertDetails: '',
       summaryData: { summaryType: 'graph' },
-      updateTime: new Date().toLocaleString(),
+      graphTimestamp: new Date().toLocaleString(),
       graphData: EMPTY_GRAPH_DATA,
       params: {
         namespace: { name: routeProps.match.params.namespace },
@@ -113,7 +113,7 @@ export default class ServiceGraphPage extends React.Component<
 
   handleGraphClick = (data: any) => {
     if (data !== undefined) {
-      this.setState({ summaryData: data, updateTime: new Date().toLocaleString() });
+      this.setState({ summaryData: data });
     }
   };
 
@@ -146,6 +146,7 @@ export default class ServiceGraphPage extends React.Component<
           <SummaryPanel
             data={this.state.summaryData}
             namespace={this.state.params.namespace.name}
+            queryTime={this.state.graphTimestamp}
             duration={this.state.params.graphDuration.value}
             {...QueryOptions.getOption(this.state.params.graphDuration.value)}
           />
@@ -196,11 +197,13 @@ export default class ServiceGraphPage extends React.Component<
       .then(response => {
         const responseData = response['data'];
         const elements = responseData && responseData.elements ? responseData.elements : EMPTY_GRAPH_DATA;
-        this.setState({ graphData: elements, isLoading: false });
+        const timestamp = responseData && responseData.timestamp ? responseData.timestamp : '';
+        this.setState({ graphData: elements, graphTimestamp: timestamp, isLoading: false });
       })
       .catch(error => {
         this.setState({
           graphData: EMPTY_GRAPH_DATA,
+          graphTimestamp: new Date().toLocaleString(),
           isLoading: false
         });
         console.error(error);

--- a/src/pages/ServiceGraph/SummaryPanel.tsx
+++ b/src/pages/ServiceGraph/SummaryPanel.tsx
@@ -17,6 +17,7 @@ export default class SummaryPanel extends React.Component<SummaryPanelPropType, 
           <SummaryPanelEdge
             data={this.props.data}
             namespace={this.props.namespace}
+            queryTime={this.props.queryTime}
             duration={this.props.duration}
             step={this.props.step}
             rateInterval={this.props.rateInterval}
@@ -26,6 +27,7 @@ export default class SummaryPanel extends React.Component<SummaryPanelPropType, 
           <SummaryPanelGraph
             data={this.props.data}
             namespace={this.props.namespace}
+            queryTime={this.props.queryTime}
             duration={this.props.duration}
             step={this.props.step}
             rateInterval={this.props.rateInterval}
@@ -35,6 +37,7 @@ export default class SummaryPanel extends React.Component<SummaryPanelPropType, 
           <SummaryPanelGroup
             data={this.props.data}
             namespace={this.props.namespace}
+            queryTime={this.props.queryTime}
             duration={this.props.duration}
             step={this.props.step}
             rateInterval={this.props.rateInterval}
@@ -43,6 +46,7 @@ export default class SummaryPanel extends React.Component<SummaryPanelPropType, 
         {this.props.data.summaryType === 'node' ? (
           <SummaryPanelNode
             data={this.props.data}
+            queryTime={this.props.queryTime}
             namespace={this.props.namespace}
             duration={this.props.duration}
             step={this.props.step}

--- a/src/pages/ServiceGraph/SummaryPanelEdge.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelEdge.tsx
@@ -105,6 +105,7 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
     const options: MetricsOptions = {
       version: destVersion,
       byLabelsIn: ['source_service', 'source_version'],
+      queryTime: props.queryTime,
       duration: +props.duration,
       step: props.step,
       rateInterval: props.rateInterval,
@@ -147,7 +148,7 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
       return <strong>loading chart...</strong>;
     }
 
-    return <RpsChart label="Request Average" dataRps={this.state.reqRates} dataErrors={this.state.errRates} />;
+    return <RpsChart label="Request Traffic" dataRps={this.state.reqRates} dataErrors={this.state.errRates} />;
   };
 
   private getRates = (

--- a/src/pages/ServiceGraph/SummaryPanelGraph.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelGraph.tsx
@@ -107,6 +107,7 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
 
   private updateRpsChart = (props: SummaryPanelPropType) => {
     const options = {
+      queryTime: props.queryTime,
       duration: props.duration,
       step: props.step,
       rateInterval: props.rateInterval
@@ -144,7 +145,7 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
       return <strong>loading chart...</strong>;
     }
 
-    return <RpsChart label="Request Average" dataRps={this.state.reqRates} dataErrors={this.state.errRates} />;
+    return <RpsChart label="Total Request Traffic" dataRps={this.state.reqRates} dataErrors={this.state.errRates} />;
   };
 
   private getRates = (mg: M.MetricGroup, title: string): [string, number][] => {

--- a/src/pages/ServiceGraph/SummaryPanelGroup.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelGroup.tsx
@@ -137,6 +137,7 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
     const namespace = props.data.summaryTarget.data('service').split('.')[1];
     const service = props.data.summaryTarget.data('service').split('.')[0];
     const options: MetricsOptions = {
+      queryTime: props.queryTime,
       duration: +props.duration,
       step: props.step,
       rateInterval: props.rateInterval,
@@ -189,8 +190,16 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
     }
     return (
       <>
-        <RpsChart label="Incoming" dataRps={this.state.requestCountIn} dataErrors={this.state.errorCountIn} />
-        <RpsChart label="Outgoing" dataRps={this.state.requestCountOut} dataErrors={this.state.errorCountOut} />
+        <RpsChart
+          label="Incoming Request Traffic"
+          dataRps={this.state.requestCountIn}
+          dataErrors={this.state.errorCountIn}
+        />
+        <RpsChart
+          label="Outgoing Request Traffic"
+          dataRps={this.state.requestCountOut}
+          dataErrors={this.state.errorCountOut}
+        />
       </>
     );
   };

--- a/src/pages/ServiceGraph/SummaryPanelNode.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelNode.tsx
@@ -58,6 +58,7 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
     const version = props.data.summaryTarget.data('version');
     const options: MetricsOptions = {
       version: version,
+      queryTime: props.queryTime,
       duration: +props.duration,
       step: props.step,
       rateInterval: props.rateInterval,
@@ -150,8 +151,16 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
     }
     return (
       <>
-        <RpsChart label="Incoming" dataRps={this.state.requestCountIn} dataErrors={this.state.errorCountIn} />
-        <RpsChart label="Outgoing" dataRps={this.state.requestCountOut} dataErrors={this.state.errorCountOut} />
+        <RpsChart
+          label="Incoming Request Traffic"
+          dataRps={this.state.requestCountIn}
+          dataErrors={this.state.errorCountIn}
+        />
+        <RpsChart
+          label="Outgoing Request Traffic"
+          dataRps={this.state.requestCountOut}
+          dataErrors={this.state.errorCountOut}
+        />
       </>
     );
   };

--- a/src/types/Graph.ts
+++ b/src/types/Graph.ts
@@ -4,6 +4,7 @@ import Namespace from './Namespace';
 export interface SummaryPanelPropType {
   data: any;
   namespace: string;
+  queryTime: string;
   duration: string;
   step: number;
   rateInterval: string;

--- a/src/types/MetricsOptions.ts
+++ b/src/types/MetricsOptions.ts
@@ -1,6 +1,7 @@
 interface MetricsOptions {
   rateInterval?: string;
   rateFunc?: string;
+  queryTime?: string;
   duration?: number;
   step?: number;
   version?: string;


### PR DESCRIPTION
…ph and sidebar table

Make sure the sidebar queries prm using the same range as was used for
the graph generation.  This makes the sparkline charts be in line with the
graph data. Use the new graph timestamp to do this, as well as the new
queryTime param on metrics api requests.

Also, instead of duplicating the same request rate info in the sidebar table
and the rps chart, show [hopefully more useful] min/max info in the rps chart.
And make the rps chart labels consistent across sidebars.