### PR TITLE
KIALI-506 Add Istio Sidecar flag on Service pages

### DIFF
--- a/src/assets/img/istio-logo.svg
+++ b/src/assets/img/istio-logo.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 240">
+  <g id="logo" fill="#007bff">
+    <polygon id="hull" points="0,210 160,210 60,240"/>
+    <polygon id="mainsail" points="0,200 60,190 60,80"/>
+    <polygon id="headsail" points="70,190 160,200 70,0"/>
+  </g>
+</svg>

--- a/src/components/NamespaceFilter/NamespaceFilter.tsx
+++ b/src/components/NamespaceFilter/NamespaceFilter.tsx
@@ -74,7 +74,6 @@ export class NamespaceFilter extends React.Component<NamespaceFilterProps, Names
           })
         };
         let initialFilters = this.initialFilterList(namespaceFilter);
-        console.log(initialFilters);
         this.setState({ filterTypeList: initialFilters });
       })
       .catch(error => {

--- a/src/index.css
+++ b/src/index.css
@@ -9,3 +9,22 @@ body {
 .left-spinner {
   margin: 10px 10px;
 }
+
+.IstioLogo {
+  height: 25px;
+}
+
+.ServiceList-Heading {
+  vertical-align: top;
+}
+
+.ServiceList-Title {
+  display: inline-block;
+}
+
+.ServiceList-IstioLogo {
+  display: inline-block;
+  position:relative;
+  top:-10px;
+  padding-right: 10px;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -10,21 +10,3 @@ body {
   margin: 10px 10px;
 }
 
-.IstioLogo {
-  height: 25px;
-}
-
-.ServiceList-Heading {
-  vertical-align: top;
-}
-
-.ServiceList-Title {
-  display: inline-block;
-}
-
-.ServiceList-IstioLogo {
-  display: inline-block;
-  position:relative;
-  top:-10px;
-  padding-right: 10px;
-}

--- a/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -5,8 +5,7 @@ import ServiceInfoDeployments from './ServiceInfo/ServiceInfoDeployments';
 import ServiceInfoRouteRules from './ServiceInfo/ServiceInfoRouteRules';
 import ServiceInfoRoutes from './ServiceInfo/ServiceInfoRoutes';
 import ServiceInfoDestinationPolicies from './ServiceInfo/ServiceInfoDestinationPolicies';
-
-import { Endpoints, Deployment, Port, RouteRule, DestinationPolicy } from '../../types/ServiceInfo';
+import { Endpoints, Deployment, Port, RouteRule, DestinationPolicy, HasIstioSidecar } from '../../types/ServiceInfo';
 import { Health } from '../../types/Health';
 import * as API from '../../services/Api';
 import { ToastNotification, ToastNotificationList, Col, Row } from 'patternfly-react';
@@ -18,6 +17,7 @@ type ServiceInfoState = {
   ip: string;
   ports?: Port[];
   endpoints?: Endpoints[];
+  istio_sidecar: boolean;
   deployments?: Deployment[];
   routeRules?: RouteRule[];
   destinationPolicies?: DestinationPolicy[];
@@ -36,6 +36,7 @@ class ServiceInfo extends React.Component<ServiceId, ServiceInfoState> {
       type: '',
       ip: '',
       ports: [],
+      istio_sidecar: false,
       deployments: [],
       routeRules: [],
       dependencies: new Map(),
@@ -63,6 +64,7 @@ class ServiceInfo extends React.Component<ServiceId, ServiceInfoState> {
           type: data.type,
           ports: data.ports,
           endpoints: data.endpoints,
+          istio_sidecar: HasIstioSidecar(data.deployments),
           deployments: data.deployments,
           dependencies: data.dependencies,
           routeRules: this.sortRouteRulesByPrecedence(data.route_rules),
@@ -111,6 +113,7 @@ class ServiceInfo extends React.Component<ServiceId, ServiceInfoState> {
             <Col xs={12} sm={12} md={12} lg={12}>
               <ServiceInfoDescription
                 name={this.state.name}
+                istio_sidecar={this.state.istio_sidecar}
                 labels={this.state.labels}
                 ports={this.state.ports}
                 type={this.state.type}

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
@@ -8,9 +8,11 @@ import { Endpoints, Port } from '../../../types/ServiceInfo';
 import PfInfoCard from '../../../components/Pf/PfInfoCard';
 
 import './ServiceInfoDescription.css';
+import { IstioLogo } from '../../../types/ServiceListComponent';
 
 interface ServiceInfoDescriptionProps {
   name?: string;
+  istio_sidecar?: boolean;
   labels?: Map<string, string>;
   type?: string;
   ip?: any;
@@ -52,6 +54,17 @@ class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps
               </div>
               <div>
                 <strong>IP</strong> {this.props.ip ? this.props.ip : ''}
+              </div>
+              <div>
+                <strong>Istio Sidecar</strong>
+                {this.props.istio_sidecar ? (
+                  <span>
+                    {' Deployed'}
+                    <img className="IstioLogo" src={IstioLogo} alt="Istio sidecar" />
+                  </span>
+                ) : (
+                  ' Undeployed'
+                )}
               </div>
             </Col>
             <Col xs={12} sm={6} md={3} lg={3}>

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
@@ -91,6 +91,12 @@ ShallowWrapper {
              
             172.30.78.33
           </div>
+          <div>
+            <strong>
+              Istio Sidecar
+            </strong>
+             Undeployed
+          </div>
         </Col>
         <Col
           bsClass="col"
@@ -244,6 +250,12 @@ ShallowWrapper {
               </strong>
                
               172.30.78.33
+            </div>
+            <div>
+              <strong>
+                Istio Sidecar
+              </strong>
+               Undeployed
             </div>
           </Col>
           <Col

--- a/src/pages/ServiceDetails/__tests__/__snapshots__/ServiceInfo.test.tsx.snap
+++ b/src/pages/ServiceDetails/__tests__/__snapshots__/ServiceInfo.test.tsx.snap
@@ -42,6 +42,7 @@ ShallowWrapper {
                 endpoints={undefined}
                 health={undefined}
                 ip=""
+                istio_sidecar={false}
                 labels={Map {}}
                 name=""
                 ports={Array []}
@@ -123,6 +124,7 @@ ShallowWrapper {
                   endpoints={undefined}
                   health={undefined}
                   ip=""
+                  istio_sidecar={false}
                   labels={Map {}}
                   name=""
                   ports={Array []}
@@ -198,6 +200,7 @@ ShallowWrapper {
                   endpoints={undefined}
                   health={undefined}
                   ip=""
+                  istio_sidecar={false}
                   labels={Map {}}
                   name=""
                   ports={Array []}
@@ -218,6 +221,7 @@ ShallowWrapper {
                   endpoints={undefined}
                   health={undefined}
                   ip=""
+                  istio_sidecar={false}
                   labels={Map {}}
                   name=""
                   ports={Array []}
@@ -238,6 +242,7 @@ ShallowWrapper {
                   "endpoints": undefined,
                   "health": undefined,
                   "ip": "",
+                  "istio_sidecar": false,
                   "labels": Map {},
                   "name": "",
                   "ports": Array [],
@@ -445,6 +450,7 @@ ShallowWrapper {
                   endpoints={undefined}
                   health={undefined}
                   ip=""
+                  istio_sidecar={false}
                   labels={Map {}}
                   name=""
                   ports={Array []}
@@ -526,6 +532,7 @@ ShallowWrapper {
                     endpoints={undefined}
                     health={undefined}
                     ip=""
+                    istio_sidecar={false}
                     labels={Map {}}
                     name=""
                     ports={Array []}
@@ -601,6 +608,7 @@ ShallowWrapper {
                     endpoints={undefined}
                     health={undefined}
                     ip=""
+                    istio_sidecar={false}
                     labels={Map {}}
                     name=""
                     ports={Array []}
@@ -621,6 +629,7 @@ ShallowWrapper {
                     endpoints={undefined}
                     health={undefined}
                     ip=""
+                    istio_sidecar={false}
                     labels={Map {}}
                     name=""
                     ports={Array []}
@@ -641,6 +650,7 @@ ShallowWrapper {
                     "endpoints": undefined,
                     "health": undefined,
                     "ip": "",
+                    "istio_sidecar": false,
                     "labels": Map {},
                     "name": "",
                     "ports": Array [],

--- a/src/pages/ServiceList/ServiceListComponent.scss
+++ b/src/pages/ServiceList/ServiceListComponent.scss
@@ -1,0 +1,18 @@
+.IstioLogo {
+  height: 25px;
+}
+
+.ServiceList-Heading {
+  vertical-align: top;
+}
+
+.ServiceList-Title {
+  display: inline-block;
+}
+
+.ServiceList-IstioLogo {
+  display: inline-block;
+  position:relative;
+  top:-10px;
+  padding-right: 10px;
+}

--- a/src/pages/ServiceList/ServiceListComponent.tsx
+++ b/src/pages/ServiceList/ServiceListComponent.tsx
@@ -12,6 +12,8 @@ import PropTypes from 'prop-types';
 import MetricsOptionsBar from '../../components/MetricsOptions/MetricsOptionsBar';
 import { ServiceHealth, DisplayMode } from '../../components/ServiceHealth/ServiceHealth';
 
+import './ServiceListComponent.css';
+
 type SortField = {
   id: string;
   title: string;

--- a/src/pages/ServiceList/ServiceListComponent.tsx
+++ b/src/pages/ServiceList/ServiceListComponent.tsx
@@ -7,7 +7,7 @@ import { ActiveFilter, FilterType } from '../../types/NamespaceFilter';
 import * as API from '../../services/Api';
 import Namespace from '../../types/Namespace';
 import { Pagination } from '../../types/Pagination';
-import { ServiceItem, ServiceList } from '../../types/ServiceListComponent';
+import { IstioLogo, ServiceItem, ServiceList } from '../../types/ServiceListComponent';
 import PropTypes from 'prop-types';
 import MetricsOptionsBar from '../../components/MetricsOptions/MetricsOptionsBar';
 import { ServiceHealth, DisplayMode } from '../../components/ServiceHealth/ServiceHealth';
@@ -30,6 +30,11 @@ const sortFields: SortField[] = [
     isNumeric: false
   },
   {
+    id: 'istio_sidecar',
+    title: 'Istio Sidecar',
+    isNumeric: false
+  },
+  {
     id: 'error_rate',
     title: 'Error Rate',
     isNumeric: true
@@ -42,6 +47,14 @@ const serviceNameFilter: FilterType = {
   placeholder: 'Filter by Service Name',
   filterType: 'text',
   filterValues: []
+};
+
+const istioFilter: FilterType = {
+  id: 'istio',
+  title: 'Istio Sidecar',
+  placeholder: 'Filter by Istio Sidecar',
+  filterType: 'select',
+  filterValues: [{ id: 'deployed', title: 'Deployed' }, { id: 'undeployed', title: 'Undeployed' }]
 };
 
 type ServiceListComponentState = {
@@ -149,23 +162,32 @@ class ServiceListComponent extends React.Component<ServiceListComponentProps, Se
     let servicenameFilters: string[] = activeFilters
       .filter(activeFilter => activeFilter.category === 'Service Name')
       .map(activeFilter => activeFilter.value);
+    let istioFilters: string[] = activeFilters
+      .filter(activeFilter => activeFilter.category === 'Istio Sidecar')
+      .map(activeFilter => activeFilter.value);
+    istioFilters = this.cleanIstioFilters(istioFilters);
 
     if (namespacesSelected.length === 0) {
       API.GetNamespaces()
         .then(namespacesResponse => {
           const namespaces: Namespace[] = namespacesResponse['data'];
-          this.fetchServices(namespaces.map(namespace => namespace.name), servicenameFilters, rateInterval);
+          this.fetchServices(
+            namespaces.map(namespace => namespace.name),
+            servicenameFilters,
+            istioFilters,
+            rateInterval
+          );
         })
         .catch(namespacesError => {
           console.error(JSON.stringify(namespacesError));
           this.handleError(API.GetErrorMsg('Could not fetch namespace list.', namespacesError));
         });
     } else {
-      this.fetchServices(namespacesSelected, servicenameFilters);
+      this.fetchServices(namespacesSelected, servicenameFilters, istioFilters);
     }
   }
 
-  fetchServices(namespaces: string[], servicenameFilters: string[], rateInterval?: string) {
+  fetchServices(namespaces: string[], servicenameFilters: string[], istioFilters: string[], rateInterval?: string) {
     const promises = namespaces.map(ns => API.GetServices(ns, { rateInterval: rateInterval }));
     Promise.all(promises)
       .then(servicesResponse => {
@@ -178,6 +200,7 @@ class ServiceListComponent extends React.Component<ServiceListComponentProps, Se
               namespace: namespace.name,
               servicename: serviceName.name,
               health: serviceName.health,
+              istio_sidecar: serviceName.istio_sidecar,
               request_count: serviceName.request_count,
               request_error_count: serviceName.request_error_count,
               error_rate: serviceName.error_rate
@@ -185,8 +208,8 @@ class ServiceListComponent extends React.Component<ServiceListComponentProps, Se
             updatedServices.push(serviceItem);
           });
         });
-        if (servicenameFilters.length > 0) {
-          updatedServices = this.filterServices(updatedServices, servicenameFilters);
+        if (servicenameFilters.length > 0 || istioFilters.length > 0) {
+          updatedServices = this.filterServices(updatedServices, servicenameFilters, istioFilters);
         }
         updatedServices = this.sortServices(updatedServices, this.state.currentSortField, this.state.isSortAscending);
         this.setState(prevState => {
@@ -207,17 +230,51 @@ class ServiceListComponent extends React.Component<ServiceListComponentProps, Se
       });
   }
 
-  isFiltered(service: ServiceItem, servicenameFilters: string[]) {
-    for (let i = 0; i < servicenameFilters.length; i++) {
-      if (service.servicename.includes(servicenameFilters[i])) {
-        return true;
-      }
+  // Patternfly-react Filter has not a boolean / checkbox filter option, so as we want to use the same component
+  // this function is used to optimize potential duplications on 'Deployed', 'Undeployed' values selected.
+  cleanIstioFilters(istioFilters: string[]) {
+    if (istioFilters.length === 0) {
+      return [];
     }
-    return false;
+    let cleanArray = istioFilters.filter((iFilter, i) => {
+      return istioFilters.indexOf(iFilter) === i;
+    });
+
+    if (cleanArray.length === 2) {
+      return [];
+    }
+    return cleanArray;
   }
 
-  filterServices(services: ServiceItem[], servicenameFilters: string[]) {
-    let filteredServices: ServiceItem[] = services.filter(service => this.isFiltered(service, servicenameFilters));
+  isFiltered(service: ServiceItem, servicenameFilters: string[], istioFilters: string[]) {
+    let serviceNameFiltered = true;
+    if (servicenameFilters.length > 0) {
+      serviceNameFiltered = false;
+      for (let i = 0; i < servicenameFilters.length; i++) {
+        if (service.servicename.includes(servicenameFilters[i])) {
+          serviceNameFiltered = true;
+          break;
+        }
+      }
+    }
+
+    let istioFiltered = true;
+    if (istioFilters.length === 1) {
+      if (istioFilters[0] === 'Deployed') {
+        istioFiltered = service.istio_sidecar;
+      }
+      if (istioFilters[0] === 'Undeployed') {
+        istioFiltered = !service.istio_sidecar;
+      }
+    }
+
+    return serviceNameFiltered && istioFiltered;
+  }
+
+  filterServices(services: ServiceItem[], servicenameFilters: string[], istioFilters: string[]) {
+    let filteredServices: ServiceItem[] = services.filter(service =>
+      this.isFiltered(service, servicenameFilters, istioFilters)
+    );
     return filteredServices;
   }
 
@@ -227,6 +284,15 @@ class ServiceListComponent extends React.Component<ServiceListComponentProps, Se
       if (sortField.id === 'namespace') {
         sortValue = a.namespace.localeCompare(b.namespace);
         if (sortValue === 0) {
+          sortValue = a.servicename.localeCompare(b.servicename);
+        }
+      } else if (sortField.id === 'istio_sidecar') {
+        // Special boolean value, Deployed values first
+        if (a.istio_sidecar && !b.istio_sidecar) {
+          sortValue = -1;
+        } else if (!a.istio_sidecar && b.istio_sidecar) {
+          sortValue = 1;
+        } else {
           sortValue = a.servicename.localeCompare(b.servicename);
         }
       } else {
@@ -285,10 +351,19 @@ class ServiceListComponent extends React.Component<ServiceListComponentProps, Se
           <ListViewItem
             leftContent={<ListViewIcon type="pf" name="service" />}
             heading={
-              <span>
-                {serviceItem.servicename}
-                <small>{serviceItem.namespace}</small>
-              </span>
+              <div className="ServiceList-Heading">
+                <div className="ServiceList-IstioLogo">
+                  {serviceItem.istio_sidecar ? (
+                    <img className="IstioLogo" src={IstioLogo} alt="Istio sidecar" />
+                  ) : (
+                    undefined
+                  )}
+                </div>
+                <div className="ServiceList-Title">
+                  {serviceItem.servicename}
+                  <small>{serviceItem.namespace}</small>
+                </div>
+              </div>
             }
             description={serviceDescriptor}
           />
@@ -307,7 +382,7 @@ class ServiceListComponent extends React.Component<ServiceListComponentProps, Se
       serviceListComponent = (
         <div>
           <NamespaceFilter
-            initialFilters={[serviceNameFilter]}
+            initialFilters={[serviceNameFilter, istioFilter]}
             onFilterChange={this.filterChange}
             onError={this.handleError}
           >

--- a/src/types/ServiceInfo.ts
+++ b/src/types/ServiceInfo.ts
@@ -17,6 +17,7 @@ export interface Port {
 
 export interface Deployment {
   name: string;
+  template_annotations?: any;
   labels?: Map<string, string>;
   created_at: string;
   replicas: number;
@@ -199,3 +200,15 @@ export interface DestinationPolicy {
   loadbalancing: LoadBalancing;
   circuitBreaker: CircuitBreaker;
 }
+
+export const HasIstioSidecar = (deployments: Deployment[]) => {
+  if (deployments && deployments.length > 0) {
+    for (let i = 0; i < deployments.length; i++) {
+      let annotations = deployments[i].template_annotations;
+      if (annotations && annotations['sidecar.istio.io/status']) {
+        return true;
+      }
+    }
+  }
+  return false;
+};

--- a/src/types/ServiceListComponent.ts
+++ b/src/types/ServiceListComponent.ts
@@ -4,6 +4,7 @@ import { Health } from './Health';
 export interface ServiceName {
   name: string;
   health: Health;
+  istio_sidecar: boolean;
   request_count: number;
   request_error_count: number;
   error_rate: number;
@@ -18,7 +19,10 @@ export interface ServiceItem {
   servicename: string;
   namespace: string;
   health: Health;
+  istio_sidecar: boolean;
   request_count: number;
   request_error_count: number;
   error_rate: number;
 }
+
+export const IstioLogo = require('../assets/img/istio-logo.svg');


### PR DESCRIPTION
- Add filtering and sorting by Istio services

Look and feel is temporal, pretty soon, it will change when UX teams suggest better design, but to keep things simple we have added an "Istio" icon on the service list and service details pages.

![image](https://user-images.githubusercontent.com/1662329/38619556-ab97bcbe-3d9c-11e8-83c9-a69f0921f05c.png)

![image](https://user-images.githubusercontent.com/1662329/38619579-bbe4247c-3d9c-11e8-93df-60bb0524d1df.png)

Service list page can now filter and sort by Istio based services:

![image](https://user-images.githubusercontent.com/1662329/38619642-e61e0726-3d9c-11e8-82af-2864cc52c319.png)

