### PR TITLE
KIALI-517 Several perf enhancement on metrics page

### DIFF
--- a/src/components/MetricsOptions/MetricsOptionsBar.tsx
+++ b/src/components/MetricsOptions/MetricsOptionsBar.tsx
@@ -5,7 +5,8 @@ import ValueSelectHelper from './ValueSelectHelper';
 import MetricsOptions from '../../types/MetricsOptions';
 
 interface Props {
-  onOptionsChanged: (opts: MetricsOptions, interval: number) => void;
+  onOptionsChanged: (opts: MetricsOptions) => void;
+  onPollIntervalChanged: (interval: number) => void;
   loading?: boolean;
 }
 
@@ -100,6 +101,7 @@ export class MetricsOptionsBar extends React.Component<Props, MetricsOptionsStat
   componentDidMount() {
     // Init state upstream
     this.reportOptions();
+    this.props.onPollIntervalChanged(this.state.pollInterval);
   }
 
   onRateIntervalChanged(key: string) {
@@ -109,9 +111,10 @@ export class MetricsOptionsBar extends React.Component<Props, MetricsOptionsStat
   }
 
   onPollIntervalChanged(key: number) {
-    this.setState({ pollInterval: key }, () => {
-      this.reportOptions();
-    });
+    // We use a specific handler so that changing poll interval doesn't trigger a metrics refresh in parent
+    // Especially useful when pausing
+    this.props.onPollIntervalChanged(key);
+    this.setState({ pollInterval: key });
   }
 
   onDurationChanged(key: number) {
@@ -130,17 +133,14 @@ export class MetricsOptionsBar extends React.Component<Props, MetricsOptionsStat
     // State-to-options converter (removes unnecessary properties)
     const labelsIn = this.state.groupByLabels.map(lbl => MetricsOptionsBar.GroupByLabelOptions[lbl].labelIn);
     const labelsOut = this.state.groupByLabels.map(lbl => MetricsOptionsBar.GroupByLabelOptions[lbl].labelOut);
-    this.props.onOptionsChanged(
-      {
-        rateInterval: this.state.rateInterval,
-        rateFunc: 'irate',
-        duration: this.state.duration,
-        step: this.state.duration / this.state.ticks,
-        byLabelsIn: labelsIn,
-        byLabelsOut: labelsOut
-      },
-      this.state.pollInterval
-    );
+    this.props.onOptionsChanged({
+      rateInterval: this.state.rateInterval,
+      rateFunc: 'irate',
+      duration: this.state.duration,
+      step: this.state.duration / this.state.ticks,
+      byLabelsIn: labelsIn,
+      byLabelsOut: labelsOut
+    });
   }
 
   changedGroupByLabel(labels: string[]) {

--- a/src/components/MetricsOptions/__tests__/MetricsOptionsBar.test.tsx
+++ b/src/components/MetricsOptions/__tests__/MetricsOptionsBar.test.tsx
@@ -10,12 +10,12 @@ const lastOptionsChanged = () => {
 
 describe('MetricsOptionsBar', () => {
   it('renders initial layout', () => {
-    const wrapper = shallow(<MetricsOptionsBar onOptionsChanged={jest.fn()} />);
+    const wrapper = shallow(<MetricsOptionsBar onOptionsChanged={jest.fn()} onPollIntervalChanged={jest.fn()} />);
     expect(wrapper).toMatchSnapshot();
   });
 
   it('changes trigger parent callback', () => {
-    const wrapper = mount(<MetricsOptionsBar onOptionsChanged={optionsChanged} />);
+    const wrapper = mount(<MetricsOptionsBar onOptionsChanged={optionsChanged} onPollIntervalChanged={jest.fn()} />);
     expect(optionsChanged).toHaveBeenCalledTimes(1);
     const opts = lastOptionsChanged();
     // Step = duration / ticks

--- a/src/components/MetricsOptions/__tests__/__snapshots__/MetricsOptionsBar.test.tsx.snap
+++ b/src/components/MetricsOptions/__tests__/__snapshots__/MetricsOptionsBar.test.tsx.snap
@@ -17,6 +17,14 @@ ShallowWrapper {
               "rateInterval": "1m",
               "step": 20,
             },
+          ],
+        ],
+      }
+    }
+    onPollIntervalChanged={
+      [MockFunction] {
+        "calls": Array [
+          Array [
             5000,
           ],
         ],

--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -96,7 +96,7 @@ class ServiceDetails extends React.Component<RouteComponentProps<ServiceId>, Ser
               <TabPane eventKey={1}>
                 <ServiceInfo namespace={this.props.match.params.namespace} service={this.props.match.params.service} />
               </TabPane>
-              <TabPane eventKey={2}>
+              <TabPane eventKey={2} mountOnEnter={true} unmountOnExit={true}>
                 <ServiceMetrics
                   namespace={this.props.match.params.namespace}
                   service={this.props.match.params.service}


### PR DESCRIPTION
- Do not mount metrics page before its tab is actually displayed
- Clear interval timer on exit
- Do not fetch metrics when pausing / changing poll interval