### PR TITLE
minor - apply default export convention to summary panel components

### DIFF
--- a/src/components/SummaryPanel/ErrorRatePieChart.tsx
+++ b/src/components/SummaryPanel/ErrorRatePieChart.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-
 import { PieChart } from 'patternfly-react';
 
 type ErrorRatePieChartPropType = {
@@ -10,7 +9,7 @@ type ErrorRatePieChartPropType = {
   legendPos?: string; // e.g. right, left
 };
 
-export class ErrorRatePieChart extends React.Component<ErrorRatePieChartPropType, {}> {
+export default class ErrorRatePieChart extends React.Component<ErrorRatePieChartPropType> {
   static defaultProps: ErrorRatePieChartPropType = {
     percentError: 0,
     width: 200,
@@ -18,6 +17,10 @@ export class ErrorRatePieChart extends React.Component<ErrorRatePieChartPropType
     showLegend: true,
     legendPos: 'right'
   };
+
+  constructor(props: ErrorRatePieChartPropType) {
+    super(props);
+  }
 
   render() {
     const successRate: number = 100 - this.props.percentError;

--- a/src/components/SummaryPanel/InOutRateTable.tsx
+++ b/src/components/SummaryPanel/InOutRateTable.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ErrorRatePieChart } from './ErrorRatePieChart';
+import ErrorRatePieChart from './ErrorRatePieChart';
 
 type InOutRateTablePropType = {
   title: string;
@@ -13,7 +13,7 @@ type InOutRateTablePropType = {
   outRate5xx: number;
 };
 
-export class InOutRateTable extends React.Component<InOutRateTablePropType, {}> {
+export default class InOutRateTable extends React.Component<InOutRateTablePropType, {}> {
   render() {
     const inErrRate: number = this.props.inRate4xx + this.props.inRate5xx;
     const outErrRate: number = this.props.outRate4xx + this.props.outRate5xx;

--- a/src/components/SummaryPanel/RateTable.tsx
+++ b/src/components/SummaryPanel/RateTable.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ErrorRatePieChart } from './ErrorRatePieChart';
+import ErrorRatePieChart from './ErrorRatePieChart';
 
 type RateTablePropType = {
   title: string;
@@ -9,7 +9,7 @@ type RateTablePropType = {
   rate5xx: number;
 };
 
-export class RateTable extends React.Component<RateTablePropType, {}> {
+export default class RateTable extends React.Component<RateTablePropType, {}> {
   render() {
     const errRate: number = this.props.rate4xx + this.props.rate5xx;
     const percentErr = this.props.rate === 0 ? 0 : errRate / this.props.rate * 100;

--- a/src/components/SummaryPanel/RpsChart.tsx
+++ b/src/components/SummaryPanel/RpsChart.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-
 import { AreaChart } from 'patternfly-react';
 
 type RpsChartTypeProp = {
@@ -8,7 +7,7 @@ type RpsChartTypeProp = {
   dataErrors: [string, number][];
 };
 
-export class RpsChart extends React.Component<RpsChartTypeProp, {}> {
+export default class RpsChart extends React.Component<RpsChartTypeProp, {}> {
   constructor(props: RpsChartTypeProp) {
     super(props);
   }

--- a/src/pages/ServiceGraph/SummaryPanelEdge.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelEdge.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Badge from '../../components/Badge/Badge';
-import { RateTable } from '../../components/SummaryPanel/RateTable';
-import { RpsChart } from '../../components/SummaryPanel/RpsChart';
+import RateTable from '../../components/SummaryPanel/RateTable';
+import RpsChart from '../../components/SummaryPanel/RpsChart';
 import { SummaryPanelPropType } from '../../types/Graph';
 import * as API from '../../services/Api';
 import * as M from '../../types/Metrics';

--- a/src/pages/ServiceGraph/SummaryPanelGraph.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelGraph.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import Badge from '../../components/Badge/Badge';
-import { RateTable } from '../../components/SummaryPanel/RateTable';
-import { RpsChart } from '../../components/SummaryPanel/RpsChart';
+import RateTable from '../../components/SummaryPanel/RateTable';
+import RpsChart from '../../components/SummaryPanel/RpsChart';
 import { SummaryPanelPropType } from '../../types/Graph';
 import graphUtils from '../../utils/graphing';
 import * as API from '../../services/Api';

--- a/src/pages/ServiceGraph/SummaryPanelGroup.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelGroup.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Badge from '../../components/Badge/Badge';
-import { InOutRateTable } from '../../components/SummaryPanel/InOutRateTable';
-import { RpsChart } from '../../components/SummaryPanel/RpsChart';
+import InOutRateTable from '../../components/SummaryPanel/InOutRateTable';
+import RpsChart from '../../components/SummaryPanel/RpsChart';
 import { SummaryPanelPropType } from '../../types/Graph';
 import * as API from '../../services/Api';
 import * as M from '../../types/Metrics';

--- a/src/pages/ServiceGraph/SummaryPanelNode.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelNode.tsx
@@ -3,8 +3,8 @@ import * as API from '../../services/Api';
 
 import graphUtils from '../../utils/graphing';
 import Badge from '../../components/Badge/Badge';
-import { InOutRateTable } from '../../components/SummaryPanel/InOutRateTable';
-import { RpsChart } from '../../components/SummaryPanel/RpsChart';
+import InOutRateTable from '../../components/SummaryPanel/InOutRateTable';
+import RpsChart from '../../components/SummaryPanel/RpsChart';
 import { SummaryPanelPropType } from '../../types/Graph';
 import MetricsOptions from '../../types/MetricsOptions';
 


### PR DESCRIPTION
I was doing a little react learning and saw that we were inconsistent on the use of export default.  I'll let Mike decide if this makes sense.