### PR TITLE
[KIALI-516] Use Redux-Namespace dropdown, part 2 of 2

### DIFF
--- a/src/components/NamespaceDropdown.tsx
+++ b/src/components/NamespaceDropdown.tsx
@@ -4,7 +4,7 @@ import { DropdownButton, MenuItem } from 'patternfly-react';
 import Namespace from '../types/Namespace';
 
 interface NamespaceListType {
-  disabled?: boolean;
+  disabled: boolean;
   activeNamespace: Namespace;
   items: Namespace[];
   onSelect: (newValue: Namespace) => void;

--- a/src/components/Nav/Navigation.tsx
+++ b/src/components/Nav/Navigation.tsx
@@ -10,7 +10,7 @@ import IstioRulesPage from '../../pages/IstioRulesList/IstioRuleListPage';
 import IstioRuleDetailsPage from '../../pages/IstioRuleDetails/IstioRuleDetailsPage';
 import HelpDropdown from './HelpDropdown';
 import ServiceDetailsPage from '../../pages/ServiceDetails/ServiceDetailsPage';
-import ServiceGraphPage from '../../pages/ServiceGraph/ServiceGraphPage';
+import { ServiceGraphRouteHandler } from '../../pages/ServiceGraph';
 import ServiceListPage from '../../pages/ServiceList/ServiceListPage';
 import ServiceJaegerPage from '../../pages/ServiceJaeger/ServiceJaegerPage';
 
@@ -115,7 +115,7 @@ class Navigation extends React.Component<PropsType, StateType> {
             </PfContainerNavVertical>
           )}
         >
-          <Route path="/service-graph/:namespace" component={ServiceGraphPage} />
+          <Route path="/service-graph/:namespace" component={ServiceGraphRouteHandler} />
           <Route path={servicesPath} component={ServiceListPage} />
           <Route path={servicesJaegerPath} component={ServiceJaegerPage} />
           <Route path="/namespaces/:namespace/services/:service" component={ServiceDetailsPage} />

--- a/src/containers/AutoUpdateNamespaceList.tsx
+++ b/src/containers/AutoUpdateNamespaceList.tsx
@@ -4,11 +4,11 @@ import { fetchNamespacesIfNeeded } from '../actions/NamespaceAction';
 import { NamespaceDropdown } from '../components/NamespaceDropdown';
 
 const mapStateToProps = state => {
-  console.log('mapStateToProps', state);
   return {
     items: state.namespaces.items
   };
 };
+
 const mapDispatchToProps = dispatch => {
   return {
     refresh: () => {

--- a/src/pages/ServiceGraph/ServiceGraphRouteHandler.tsx
+++ b/src/pages/ServiceGraph/ServiceGraphRouteHandler.tsx
@@ -1,0 +1,99 @@
+import * as React from 'react';
+import { RouteComponentProps } from 'react-router-dom';
+import { PropTypes } from 'prop-types';
+
+import { GraphParamsType } from '../../types/Graph';
+import * as LayoutDictionary from '../../components/CytoscapeLayout/graphs/LayoutDictionary';
+import ServiceGraphPage from './ServiceGraphPage';
+
+const URLSearchParams = require('url-search-params');
+
+const SESSION_KEY = 'service-graph-params';
+
+type ServiceGraphURLProps = {
+  duration: string;
+  namespace: string;
+  layout: string;
+  hideCBs: string;
+};
+
+// TODO put duration, step defaults and Prometheus translation in a single place
+const DEFAULT_DURATION = 60;
+
+/**
+ * Handle URL parameters for ServiceGraph page
+ */
+export class ServiceGraphRouteHandler extends React.Component<
+  RouteComponentProps<ServiceGraphURLProps>,
+  GraphParamsType
+> {
+  static contextTypes = {
+    router: PropTypes.object
+  };
+
+  constructor(routeProps: RouteComponentProps<ServiceGraphURLProps>) {
+    super(routeProps);
+    const previousParamsStr = sessionStorage.getItem(SESSION_KEY);
+    const graphParams: GraphParamsType = previousParamsStr
+      ? JSON.parse(previousParamsStr)
+      : {
+          namespace: { name: routeProps.match.params.namespace },
+          ...this.parseProps(routeProps.location.search)
+        };
+    this.state = graphParams;
+  }
+
+  parseProps = (queryString: string) => {
+    const urlParams = new URLSearchParams(queryString);
+    // TODO: [KIALI-357] validate `duration`
+    const _duration = urlParams.get('duration');
+    const _hideCBs = urlParams.get('hideCBs') ? urlParams.get('hideCBs') : true;
+    return {
+      graphDuration: _duration ? { value: _duration } : { value: DEFAULT_DURATION },
+      graphLayout: LayoutDictionary.getLayout({ name: urlParams.get('layout') }),
+      badgeStatus: { hideCBs: _hideCBs }
+    };
+  };
+
+  componentDidMount() {
+    // Note: `history.replace` simply changes the address bar text, not re-navigation
+    this.context.router.history.replace(this.makeURLFromParams(this.state));
+  }
+
+  componentWillReceiveProps(nextProps: RouteComponentProps<ServiceGraphURLProps>) {
+    const nextNamespace = { name: nextProps.match.params.namespace };
+    const { graphDuration: nextDuration, graphLayout: nextLayout, badgeStatus: nextBadgeStatus } = this.parseProps(
+      nextProps.location.search
+    );
+
+    const layoutHasChanged = nextLayout.name !== this.state.graphLayout.name;
+    const namespaceHasChanged = nextNamespace.name !== this.state.namespace.name;
+    const durationHasChanged = nextDuration.value !== this.state.graphDuration.value;
+    const badgeStatusHasChanged = nextBadgeStatus.hideCBs !== this.state.badgeStatus.hideCBs;
+
+    if (layoutHasChanged || namespaceHasChanged || durationHasChanged || badgeStatusHasChanged) {
+      const newParams: GraphParamsType = {
+        namespace: nextNamespace,
+        graphDuration: nextDuration,
+        graphLayout: nextLayout,
+        badgeStatus: nextBadgeStatus
+      };
+      sessionStorage.setItem(SESSION_KEY, JSON.stringify(newParams));
+      this.setState({ ...newParams });
+    }
+  }
+
+  makeURLFromParams = (params: GraphParamsType) =>
+    `/service-graph/${params.namespace.name}?layout=${params.graphLayout.name}&duration=${
+      params.graphDuration.value
+    }&hideCBs=${params.badgeStatus.hideCBs}`;
+
+  /** Change browser address bar and trigger new props propagation */
+  onParamsChange = (params: GraphParamsType) => {
+    this.context.router.history.push(this.makeURLFromParams(params));
+  };
+
+  render() {
+    return <ServiceGraphPage {...this.state} onParamsChange={this.onParamsChange} />;
+  }
+}

--- a/src/pages/ServiceGraph/__tests__/ServiceGraphPage.test.tsx
+++ b/src/pages/ServiceGraph/__tests__/ServiceGraphPage.test.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+
+import { GraphParamsType } from '../../../types/Graph';
+import { Duration, Layout, BadgeStatus } from '../../../types/GraphFilter';
+import Namespace from '../../../types/Namespace';
+
+import ServiceGraphPage from '../ServiceGraphPage';
+
+const PARAMS: GraphParamsType = {
+  namespace: { name: 'itsio-system' },
+  graphDuration: { value: 60 },
+  graphLayout: { name: 'Cose' },
+  badgeStatus: { hideCBs: true }
+};
+describe('ServiceGraphPage test', () => {
+  it('should propagate filter params change with correct value', () => {
+    const onParamsChangeFn = jest.fn();
+    const wrapper = shallow(<ServiceGraphPage {...PARAMS} onParamsChange={onParamsChangeFn} />);
+
+    const serviceGraph = wrapper.instance() as ServiceGraphPage;
+    const newLayout: Layout = { name: 'Cola' };
+    serviceGraph.handleLayoutChange(newLayout); // simulate layout change
+    const EXPECT1 = Object.assign({}, PARAMS, { graphLayout: newLayout });
+    expect(onParamsChangeFn).toHaveBeenLastCalledWith(EXPECT1);
+
+    const newDuration: Duration = { value: 1800 };
+    serviceGraph.handleFilterChange(newDuration); // simulate duration change
+    const EXPECT2 = Object.assign({}, PARAMS, { graphDuration: newDuration });
+    expect(onParamsChangeFn).toHaveBeenLastCalledWith(EXPECT2);
+
+    const newNamespace: Namespace = { name: 'bookinfo' };
+    serviceGraph.handleNamespaceChange(newNamespace); // simulate name change
+    const EXPECT3 = Object.assign({}, PARAMS, { namespace: newNamespace });
+    expect(onParamsChangeFn).toHaveBeenLastCalledWith(EXPECT3);
+
+    const badgeStatus: BadgeStatus = { hideCBs: false };
+    serviceGraph.handleBadgeStatusChange(badgeStatus); // simulate 'show Circuit breaker' status change
+    const EXPECT4 = Object.assign({}, PARAMS, { badgeStatus: badgeStatus });
+    expect(onParamsChangeFn).toHaveBeenLastCalledWith(EXPECT4);
+  });
+});

--- a/src/pages/ServiceGraph/index.tsx
+++ b/src/pages/ServiceGraph/index.tsx
@@ -1,0 +1,3 @@
+import { ServiceGraphRouteHandler } from './ServiceGraphRouteHandler';
+
+export { ServiceGraphRouteHandler };

--- a/src/types/GraphFilter.ts
+++ b/src/types/GraphFilter.ts
@@ -1,18 +1,13 @@
-import PropTypes from 'prop-types';
 import Namespace from './Namespace';
+import { GraphParamsType } from './Graph';
 
-export interface GraphFilterProps {
+export interface GraphFilterProps extends GraphParamsType {
   disabled: boolean;
   onLayoutChange: (newLayout: Layout) => void;
   onFilterChange: (newDuration: Duration) => void;
   onNamespaceChange: (newValue: Namespace) => void;
   onBadgeStatusChange: (newValue: BadgeStatus) => void;
   onRefresh: () => void;
-  onError: PropTypes.func;
-  activeNamespace: Namespace;
-  activeLayout: Layout;
-  activeDuration: Duration;
-  activeBadgeStatus: BadgeStatus;
 }
 
 export interface GraphFilterState {


### PR DESCRIPTION
[x] Introduce Redux, reducers and actions for managing namespace list
[x] `AutoUpdateNamespaceList` container component reloads the list on every click
[x] Save graph params to session [localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage) 
[x] extract URL-related props to a new component, `ServiceGraphRouteHandler` to make it easier to test.  `ServiceGraphPage` now requires namespace, duration, layout as props
[x] unit test change handlers

Todo:
[ ] USe stricter types for actions and reducers KIALI-588

@mtho11 I'm probably duplicating a bit of what you're doing.  I simply picked redux-thunk instead of saga because that's what the tutorial shows.