### PR TITLE
 Kiali-345 -Toggle node and edge labels (uses Redux)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -499,7 +499,7 @@
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
       "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
       "requires": {
-        "lodash": "4.17.10"
+        "lodash": "4.17.5"
       }
     },
     "async-each": {
@@ -597,7 +597,7 @@
         "convert-source-map": "1.5.1",
         "debug": "2.6.9",
         "json5": "0.5.1",
-        "lodash": "4.17.10",
+        "lodash": "4.17.5",
         "minimatch": "3.0.4",
         "path-is-absolute": "1.0.1",
         "private": "0.1.8",
@@ -622,7 +622,7 @@
         "babel-types": "6.26.0",
         "detect-indent": "4.0.0",
         "jsesc": "1.3.0",
-        "lodash": "4.17.10",
+        "lodash": "4.17.5",
         "source-map": "0.5.7",
         "trim-right": "1.0.1"
       },
@@ -678,7 +678,7 @@
         "babel-helper-function-name": "6.24.1",
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
-        "lodash": "4.17.10"
+        "lodash": "4.17.5"
       }
     },
     "babel-helper-explode-assignable-expression": {
@@ -737,7 +737,7 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
-        "lodash": "4.17.10"
+        "lodash": "4.17.5"
       }
     },
     "babel-helper-remap-async-to-generator": {
@@ -921,7 +921,7 @@
         "babel-template": "6.26.0",
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0",
-        "lodash": "4.17.10"
+        "lodash": "4.17.5"
       }
     },
     "babel-plugin-transform-es2015-classes": {
@@ -1301,7 +1301,7 @@
         "babel-runtime": "6.26.0",
         "core-js": "2.5.5",
         "home-or-tmp": "2.0.0",
-        "lodash": "4.17.10",
+        "lodash": "4.17.5",
         "mkdirp": "0.5.1",
         "source-map-support": "0.4.18"
       },
@@ -1338,7 +1338,7 @@
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0",
         "babylon": "6.18.0",
-        "lodash": "4.17.10"
+        "lodash": "4.17.5"
       }
     },
     "babel-traverse": {
@@ -1354,7 +1354,7 @@
         "debug": "2.6.9",
         "globals": "9.18.0",
         "invariant": "2.2.2",
-        "lodash": "4.17.10"
+        "lodash": "4.17.5"
       }
     },
     "babel-types": {
@@ -1364,7 +1364,7 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "esutils": "2.0.2",
-        "lodash": "4.17.10",
+        "lodash": "4.17.5",
         "to-fast-properties": "1.0.3"
       }
     },
@@ -1948,7 +1948,7 @@
         "dom-serializer": "0.1.0",
         "entities": "1.1.1",
         "htmlparser2": "3.9.2",
-        "lodash": "4.17.10",
+        "lodash": "4.17.5",
         "parse5": "3.0.3"
       },
       "dependencies": {
@@ -3312,7 +3312,7 @@
         "is-number-object": "1.0.3",
         "is-string": "1.0.4",
         "is-subset": "0.1.1",
-        "lodash": "4.17.10",
+        "lodash": "4.17.5",
         "object-inspect": "1.5.0",
         "object-is": "1.0.1",
         "object.assign": "4.1.0",
@@ -3329,7 +3329,7 @@
       "dev": true,
       "requires": {
         "enzyme-adapter-utils": "1.3.0",
-        "lodash": "4.17.10",
+        "lodash": "4.17.5",
         "object.assign": "4.1.0",
         "object.values": "1.0.4",
         "prop-types": "15.6.0",
@@ -3343,7 +3343,7 @@
       "integrity": "sha512-vVXSt6uDv230DIv+ebCG66T1Pm36Kv+m74L1TrF4kaE7e1V7Q/LcxO0QRkajk5cA6R3uu9wJf5h13wOTezTbjA==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.10",
+        "lodash": "4.17.5",
         "object.assign": "4.1.0",
         "prop-types": "15.6.0"
       }
@@ -5125,7 +5125,7 @@
       "dev": true,
       "requires": {
         "glob": "7.1.2",
-        "lodash": "4.17.10",
+        "lodash": "4.17.5",
         "minimatch": "3.0.4"
       }
     },
@@ -5442,7 +5442,7 @@
         "bluebird": "3.5.1",
         "html-minifier": "3.5.14",
         "loader-utils": "0.2.17",
-        "lodash": "4.17.10",
+        "lodash": "4.17.5",
         "pretty-error": "2.1.1",
         "toposort": "1.0.6"
       },
@@ -5539,7 +5539,7 @@
       "requires": {
         "http-proxy": "1.16.2",
         "is-glob": "3.1.0",
-        "lodash": "4.17.10",
+        "lodash": "4.17.5",
         "micromatch": "2.3.11"
       },
       "dependencies": {
@@ -5788,7 +5788,7 @@
         "cli-width": "2.2.0",
         "external-editor": "2.2.0",
         "figures": "2.0.0",
-        "lodash": "4.17.10",
+        "lodash": "4.17.5",
         "mute-stream": "0.0.7",
         "run-async": "2.3.0",
         "rx-lite": "4.0.8",
@@ -7375,9 +7375,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
     },
     "lodash-es": {
       "version": "4.17.8",
@@ -10624,7 +10624,7 @@
       "requires": {
         "hoist-non-react-statics": "2.5.0",
         "invariant": "2.2.2",
-        "lodash": "4.17.10",
+        "lodash": "4.17.5",
         "lodash-es": "4.17.8",
         "loose-envify": "1.3.1",
         "prop-types": "15.6.0"
@@ -10883,7 +10883,7 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
       "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
       "requires": {
-        "lodash": "4.17.10",
+        "lodash": "4.17.5",
         "lodash-es": "4.17.8",
         "loose-envify": "1.3.1",
         "symbol-observable": "1.2.0"
@@ -11060,7 +11060,7 @@
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
       "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
       "requires": {
-        "lodash": "4.17.10"
+        "lodash": "4.17.5"
       }
     },
     "request-promise-native": {
@@ -11272,7 +11272,7 @@
       "dev": true,
       "requires": {
         "glob": "7.1.2",
-        "lodash": "4.17.10",
+        "lodash": "4.17.5",
         "scss-tokenizer": "0.2.3",
         "yargs": "7.1.0"
       },
@@ -12620,6 +12620,11 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
+    "typesafe-actions": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/typesafe-actions/-/typesafe-actions-1.1.2.tgz",
+      "integrity": "sha512-4SparTfwBOWjegg89Ls5Ia0L6N8mXu7tb/REA5KYEfRohsLM9Uc8jtAa8bRAhtCg1cQJnvJJMjljI7dfu1JjVg=="
+    },
     "typescript": {
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.3.tgz",
@@ -13593,7 +13598,7 @@
       "integrity": "sha512-MX60Bv2G83Zks9pi3oLOmRgnPAnwrlMn+lftMrWBm199VQjk46/xgzBi9lPfpZldw2+EI2S+OevuLIaDuxCWRw==",
       "requires": {
         "fs-extra": "0.30.0",
-        "lodash": "4.17.10"
+        "lodash": "4.17.5"
       },
       "dependencies": {
         "fs-extra": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "cytoscape-klay": "3.1.1",
     "cytoscape-popper": "1.0.1",
     "js-yaml": "3.11.0",
-    "lodash": "4.17.10",
+    "lodash": "4.17.5",
     "patternfly": "3.45.0",
     "patternfly-react": "2.2.1",
     "react": "16.3.2",
@@ -31,6 +31,7 @@
     "redux-logger": "3.0.6",
     "redux-thunk": "2.2.0",
     "typestyle": "1.7.2",
+    "typesafe-actions": "1.1.2",
     "url-search-params": "0.10.0"
   },
   "scripts": {
@@ -63,7 +64,7 @@
     "enzyme-adapter-react-16": "1.1.1",
     "husky": "0.14.3",
     "jest-canvas-mock": "1.0.2",
-    "jest-localstorage-mock": "^2.2.0",
+    "jest-localstorage-mock": "2.2.0",
     "node-sass-chokidar": "1.2.2",
     "npm-snapshot": "1.0.3",
     "prettier": "1.12.1",
@@ -83,9 +84,8 @@
     "url": "git+https://github.com/kiali/kiali-ui.git"
   },
   "keywords": [
-    "service mesh",
+    "istio service mesh",
     "kiali",
-    "istio",
     "openshift",
     "observability",
     "monitoring"

--- a/src/actions/ServiceGraphActions.ts
+++ b/src/actions/ServiceGraphActions.ts
@@ -1,0 +1,16 @@
+// Action Creators allow us to create typesafe utilities for dispatching actions
+import { createAction } from 'typesafe-actions';
+
+export enum ServiceGraphActionsType {
+  TOGGLE_GRAPH_NODE_LABEL = 'TOGGLE_GRAPH_NODE_LABEL',
+  TOGGLE_GRAPH_EDGE_LABEL = 'TOGGLE_GRAPH_EDGE_LABEL'
+}
+
+export const serviceGraphActions = {
+  toggleGraphNodeLabel: createAction(ServiceGraphActionsType.TOGGLE_GRAPH_NODE_LABEL),
+  toggleGraphEdgeLabel: createAction(ServiceGraphActionsType.TOGGLE_GRAPH_EDGE_LABEL)
+  // add: createAction('ADD', (amount: number) => ({
+  //   type: 'ADD',
+  //   payload: amount,
+  // })),
+};

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,20 +1,9 @@
 import * as React from 'react';
 import { BrowserRouter, withRouter } from 'react-router-dom';
-import { createStore, applyMiddleware } from 'redux';
 import { Provider } from 'react-redux';
-import thunk from 'redux-thunk';
-import { createLogger } from 'redux-logger';
-
-import rootReducer from '../reducers';
 import './App.css';
 import Navigation from '../components/Nav/Navigation';
-
-const middleware = [thunk];
-if (process.env.NODE_ENV !== 'production') {
-  middleware.push(createLogger());
-}
-
-const store = createStore(rootReducer, applyMiddleware(...middleware));
+import store from '../store/ConfigStore';
 
 class App extends React.Component {
   render() {

--- a/src/components/CytoscapeLayout/__tests__/CytoscapeLayout.test.tsx
+++ b/src/components/CytoscapeLayout/__tests__/CytoscapeLayout.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 
 import ReactCytoscape from '../ReactCytoscape';
-import CytoscapeLayout from '../CytoscapeLayout';
+import { CytoscapeLayout } from '../CytoscapeLayout';
 import * as GRAPH_DATA from '../../../services/__mockData__/getGraphElements';
 import { Duration, Layout, BadgeStatus } from '../../../types/GraphFilter';
 
@@ -18,7 +18,7 @@ const testReadyHandler = () => {
   console.log('ready');
 };
 
-describe('CytographLayout component test', () => {
+describe('CytoscapeLayout component test', () => {
   it('should set correct elements data', () => {
     const myLayout: Layout = { name: 'breadthfirst' };
     const myDuration: Duration = { value: 300 };
@@ -34,6 +34,8 @@ describe('CytographLayout component test', () => {
         onReady={testReadyHandler}
         refresh={testClickHandler}
         badgeStatus={badgeStatus}
+        showEdgeLabels={false}
+        showNodeLabels={true}
       />
     );
     const cytoscapeWrapper = wrapper.find(ReactCytoscape);

--- a/src/components/CytoscapeLayout/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeLayout/graphs/GraphStyles.ts
@@ -13,6 +13,9 @@ export class GraphStyles {
           color: PfColors.Black,
           content: (ele: any) => {
             const version = ele.data('version');
+            if (!ele.data('showNodeLabels')) {
+              return '';
+            }
             if (ele.data('parent')) {
               return version;
             }
@@ -65,6 +68,9 @@ export class GraphStyles {
         selector: 'edge',
         css: {
           content: (ele: any) => {
+            if (!ele.data('showEdgeLabels')) {
+              return '';
+            }
             const rate = ele.data('rate') ? parseFloat(ele.data('rate')) : 0;
             const pErr = ele.data('percentErr') ? parseFloat(ele.data('percentErr')) : 0;
             if (rate > 0) {

--- a/src/components/GraphFilter/GraphFilter.tsx
+++ b/src/components/GraphFilter/GraphFilter.tsx
@@ -5,6 +5,7 @@ import { GraphFilterProps, GraphFilterState } from '../../types/GraphFilter';
 import { ToolbarDropdown } from '../ToolbarDropdown/ToolbarDropdown';
 import AutoUpdateNamespaceList from '../../containers/AutoUpdateNamespaceList';
 import { config } from '../../config';
+import GraphLayersConnected from '../../containers/GraphLayers/GraphLayers';
 
 export default class GraphFilter extends React.Component<GraphFilterProps, GraphFilterState> {
   // TODO:  We should keep these mappings with their corresponding filtering components.
@@ -122,6 +123,7 @@ export default class GraphFilter extends React.Component<GraphFilterProps, Graph
               onChange={this.handleToggleRRs}
             />
           </ButtonGroup>
+          <GraphLayersConnected />
         </Toolbar>
       </>
     );

--- a/src/containers/GraphLayers/GraphLayers.tsx
+++ b/src/containers/GraphLayers/GraphLayers.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+import Switch from 'react-bootstrap-switch';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { serviceGraphActions } from '../../actions/ServiceGraphActions';
+import { KialiAppState } from '../../store/Store';
+
+interface LabelFilterProps {
+  showEdgeLabels: boolean;
+  showNodeLabels: boolean;
+
+  toggleGraphEdgeLabels(): void;
+  toggleGraphNodeLabels(): void;
+}
+
+// Allow Redux to map sections of our global app state to our props
+const mapStateToProps = (state: KialiAppState) => ({
+  showEdgeLabels: state.serviceGraphState.showEdgeLabels,
+  showNodeLabels: state.serviceGraphState.showNodeLabels
+});
+
+// Map our actions to Redux
+const mapDispatchToProps = (dispatch: any) => {
+  return {
+    toggleGraphNodeLabels: bindActionCreators(serviceGraphActions.toggleGraphNodeLabel, dispatch),
+    toggleGraphEdgeLabels: bindActionCreators(serviceGraphActions.toggleGraphEdgeLabel, dispatch)
+  };
+};
+
+class GraphLayers extends React.Component<LabelFilterProps, null> {
+  constructor(props: LabelFilterProps) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <>
+        <span style={{ marginLeft: 10 }}>
+          <Switch
+            bsSize={'medium'}
+            labelText={'Edge Labels'}
+            defaultValue={false}
+            onChange={(el, state) => this.props.toggleGraphEdgeLabels()}
+          />
+        </span>
+        <span style={{ marginLeft: 5 }}>
+          <Switch
+            bsSize={'medium'}
+            labelText={'Node Labels'}
+            defaultValue={true}
+            onChange={(el, state) => this.props.toggleGraphNodeLabels()}
+          />
+        </span>
+      </>
+    );
+  }
+}
+
+// hook up to Redux for our State to be mapped to props
+const GraphLayersConnected = connect(mapStateToProps, mapDispatchToProps)(GraphLayers);
+export default GraphLayersConnected;

--- a/src/reducers/ServiceGraphState.ts
+++ b/src/reducers/ServiceGraphState.ts
@@ -1,0 +1,27 @@
+import { ServiceGraphState } from '../store/Store';
+import { ServiceGraphActionsType } from '../actions/ServiceGraphActions';
+
+const INITIAL_STATE: ServiceGraphState = {
+  showNodeLabels: true,
+  showEdgeLabels: false
+};
+
+// This Reducer allows changes to the 'serviceGraphState' portion of Redux Store
+const serviceGraphState = (state: ServiceGraphState = INITIAL_STATE, action) => {
+  switch (action.type) {
+    case ServiceGraphActionsType.TOGGLE_GRAPH_NODE_LABEL:
+      return {
+        ...state,
+        showNodeLabels: !state.showNodeLabels
+      };
+    case ServiceGraphActionsType.TOGGLE_GRAPH_EDGE_LABEL:
+      return {
+        ...state,
+        showEdgeLabels: !state.showEdgeLabels
+      };
+    default:
+      return state;
+  }
+};
+
+export default serviceGraphState;

--- a/src/reducers/__tests__/ServiceGraphStateReducer.test.ts
+++ b/src/reducers/__tests__/ServiceGraphStateReducer.test.ts
@@ -1,0 +1,45 @@
+import serviceGraphState from '../ServiceGraphState';
+import { ServiceGraphActionsType } from '../../actions/ServiceGraphActions';
+
+describe('ServiceGraphState reducer', () => {
+  it('should return the initial state', () => {
+    expect(serviceGraphState(undefined, {})).toEqual({
+      showNodeLabels: true,
+      showEdgeLabels: false
+    });
+  });
+
+  it('should handle TOGGLE_GRAPH_NODE_LABEL', () => {
+    expect(
+      serviceGraphState(
+        {
+          showNodeLabels: true,
+          showEdgeLabels: true
+        },
+        {
+          type: ServiceGraphActionsType.TOGGLE_GRAPH_NODE_LABEL
+        }
+      )
+    ).toEqual({
+      showNodeLabels: false,
+      showEdgeLabels: true
+    });
+  });
+
+  it('should handle TOGGLE_GRAPH_EDGE_LABEL', () => {
+    expect(
+      serviceGraphState(
+        {
+          showNodeLabels: true,
+          showEdgeLabels: true
+        },
+        {
+          type: ServiceGraphActionsType.TOGGLE_GRAPH_EDGE_LABEL
+        }
+      )
+    ).toEqual({
+      showNodeLabels: true,
+      showEdgeLabels: false
+    });
+  });
+});

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -1,9 +1,11 @@
 import { combineReducers } from 'redux';
 
 import namespaces from './namespaces';
+import serviceGraphState from './ServiceGraphState';
 
 const rootReducer = combineReducers({
-  namespaces
+  namespaces,
+  serviceGraphState
 });
 
 export default rootReducer;

--- a/src/store/ConfigStore.ts
+++ b/src/store/ConfigStore.ts
@@ -1,0 +1,25 @@
+import { createStore, applyMiddleware, compose } from 'redux';
+import { KialiAppState } from './Store';
+import rootReducer from '../reducers';
+import logger from 'redux-logger';
+import thunk from 'redux-thunk';
+
+declare const window;
+
+const composeEnhancers =
+  (process.env.NODE_ENV === 'development' && window && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) || compose;
+
+const configureStore = (initialState?: KialiAppState) => {
+  // configure middlewares
+  const middlewares = [thunk, logger];
+  // compose enhancers
+  const enhancer = composeEnhancers(applyMiddleware(...middlewares));
+  // create store
+  return createStore(rootReducer, initialState, enhancer);
+};
+
+// pass an optional param to rehydrate state on app start
+const store = configureStore();
+
+// export store singleton instance
+export default store;

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -1,0 +1,16 @@
+// Store is the Redux Data store
+
+// Various pages are described here with their various sections
+export interface ServiceGraphState {
+  showEdgeLabels: boolean;
+  showNodeLabels: boolean;
+}
+
+// @todo: Add namespaces interface
+
+// This defines the Kiali Global Application State
+export interface KialiAppState {
+  // page settings
+  namespaces: any;
+  serviceGraphState: ServiceGraphState;
+}


### PR DESCRIPTION

![edge-labels-redux](https://user-images.githubusercontent.com/1312165/39475935-100aa02c-4d0f-11e8-8028-acad4fd21115.gif)


This was originally blocked by the need of some pub/sub mechanism because the components that need to communicate are not within the same hierarchy (parent...child). With Redux we can now easily overcome this.
Component state management now using Redux. Also adds redux testing and type-safe state.

Redux libraries track with Jaeger-ui (with the addition of Redux-Thunk and typesafe-actions)

https://issues.jboss.org/browse/KIALI-345