### PR TITLE
R&D: View source of route rules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3436,6 +3436,11 @@
         }
       }
     },
+    "brace": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/brace/-/brace-0.11.1.tgz",
+      "integrity": "sha1-SJb8ydVE7vRfS7dmDbMg07N5/lg="
+    },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
@@ -4938,6 +4943,11 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+    },
+    "diff-match-patch": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.0.tgz",
+      "integrity": "sha1-HMPIOkkNZ/ldkeOfatHy4Ia2MEg="
     },
     "diffie-hellman": {
       "version": "5.0.2",
@@ -9575,6 +9585,11 @@
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -9586,6 +9601,11 @@
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
     "lodash.isfunction": {
       "version": "3.0.9",
@@ -12840,6 +12860,18 @@
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
         "object-assign": "4.1.1",
+        "prop-types": "15.6.0"
+      }
+    },
+    "react-ace": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/react-ace/-/react-ace-6.0.0.tgz",
+      "integrity": "sha512-SG+3s7zCGZX1n7wyYhLEmdad4CBx39TdOsgxe1bLo7LG6lACu65CJHyZL3fv+ClTUV/eSg242TD+EluAp2dlOg==",
+      "requires": {
+        "brace": "0.11.1",
+        "diff-match-patch": "1.0.0",
+        "lodash.get": "4.4.2",
+        "lodash.isequal": "4.5.0",
         "prop-types": "15.6.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "patternfly": "3.43.0",
     "patternfly-react": "1.16.4",
     "react": "16.3.1",
+    "react-ace": "^6.0.0",
     "react-bootstrap": "0.32.1",
     "react-dom": "16.3.1",
     "react-iframe": "1.1.0",

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoRouteRules.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoRouteRules.tsx
@@ -10,6 +10,8 @@ import RouteRuleHTTPFaultInjection from './ServiceInfoRouteRules/RouteRuleHTTPFa
 import RouteRuleL4FaultInjection from './ServiceInfoRouteRules/RouteRuleL4FaultInjection';
 import RouteRuleIstioService from './ServiceInfoRouteRules/RouteRuleIstioService';
 import RouteRuleCorsPolicy from './ServiceInfoRouteRules/RouteRuleCorsPolicy';
+import ViewSourceModal from './ViewSourceModal';
+import { Icon } from 'patternfly-react';
 
 interface ServiceInfoRouteRulesProps {
   routeRules?: RouteRule[];
@@ -31,9 +33,20 @@ class ServiceInfoRouteRules extends React.Component<ServiceInfoRouteRulesProps> 
             <div>
               <strong>Name</strong>: {rule.name}
             </div>
+            {rule.name.endsWith('_synth') ? (
+              <div className="warning">
+                <Icon type="pf" name="warning-triangle-o" style={{ marginRight: '5px' }} />
+                <strong>Synthetic</strong>
+              </div>
+            ) : null}
             <div>
               <strong>Precedence</strong>: {rule.precedence}
             </div>
+            {rule.destination && rule.destination.name ? (
+              <div>
+                <strong>Destination</strong>: {rule.destination.name}
+              </div>
+            ) : null}
             {rule.match ? <RouteRuleMatch match={rule.match} /> : null}
             {rule.route ? <RouteRuleRoute route={rule.route} /> : null}
             {rule.redirect ? <RouteRuleRedirect redirect={rule.redirect} /> : null}
@@ -48,6 +61,8 @@ class ServiceInfoRouteRules extends React.Component<ServiceInfoRouteRulesProps> 
             {rule.l4Fault ? <RouteRuleL4FaultInjection l4Fault={rule.l4Fault} /> : null}
             {rule.mirror ? <RouteRuleIstioService name="Mirror" service={rule.mirror} /> : null}
             {rule.corsPolicy ? <RouteRuleCorsPolicy corsPolicy={rule.corsPolicy} /> : null}
+
+            <ViewSourceModal rule={rule} />
             <hr />
           </div>
         ))}

--- a/src/pages/ServiceDetails/ServiceInfo/ViewSourceModal.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ViewSourceModal.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react';
+import { Button, Checkbox, Modal } from 'patternfly-react';
+
+// Import Brace and the AceEditor Component
+// import brace from 'brace';
+import AceEditor from 'react-ace';
+
+// Import a Mode (language)
+import 'brace/mode/json';
+// Import a Theme (okadia, github, xcode etc) for ACE
+import 'brace/theme/terminal';
+import { RouteRule } from '../../../types/ServiceInfo';
+
+interface ViewSourceModalProps {
+  rule: RouteRule;
+}
+
+interface ViewSourceModalState {
+  showModal: boolean;
+  allowEdit: boolean;
+}
+
+class ViewSourceModal extends React.Component<ViewSourceModalProps, ViewSourceModalState> {
+  constructor(props: ViewSourceModalProps) {
+    super(props);
+
+    this.handleShow = this.handleShow.bind(this);
+    this.handleClose = this.handleClose.bind(this);
+    this.toggleEdit = this.toggleEdit.bind(this);
+
+    this.state = {
+      showModal: false,
+      allowEdit: false
+    };
+  }
+
+  handleClose() {
+    this.setState({ showModal: false });
+  }
+
+  handleShow() {
+    this.setState({ showModal: true });
+  }
+
+  toggleEdit() {
+    this.setState({ allowEdit: !this.state.allowEdit });
+  }
+
+  render() {
+    let rule = this.props.rule;
+    return (
+      <div>
+        <Button bsStyle="primary" bsSize="small" onClick={this.handleShow}>
+          View source
+        </Button>
+        <Modal show={this.state.showModal} onHide={this.handleClose}>
+          <Modal.Header>
+            <Modal.Title>Source of {rule.name ? rule.name : 'Routing Rule'}</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            <AceEditor
+              mode="json"
+              theme="terminal"
+              readOnly={!this.state.allowEdit}
+              minLines={5}
+              value={JSON.stringify(rule, null, ' ')}
+            />
+          </Modal.Body>
+          <Modal.Footer>
+            <Checkbox bsStyle="Danger" title="Edit" checked={this.state.allowEdit} onClick={this.toggleEdit}>
+              Edit
+            </Checkbox>
+            <Button bsStyle="default" className="btn-cancel" onClick={this.handleClose}>
+              Done
+            </Button>
+          </Modal.Footer>
+        </Modal>
+      </div>
+    );
+  }
+}
+
+export default ViewSourceModal;


### PR DESCRIPTION
This is the counterpart of https://github.com/kiali/kiali/pull/155 to display routing rules and then optionally fire the ACE editor component to get a source view of the routing rule.

This is a synthetic rule generated via the above PR. It only shows 2 destinations for the reviews destination, as the v1 has been detected, but did not yet receive traffic.

![bildschirmfoto 2018-04-13 um 10 58 24](https://user-images.githubusercontent.com/208246/38726157-adcf853e-3f09-11e8-9370-a819a1c0c6b2.png)

Fired the viewer (ACE editor) 
![bildschirmfoto 2018-04-13 um 10 58 36](https://user-images.githubusercontent.com/208246/38726160-b2b2c52a-3f09-11e8-9c53-0eaab6fc92e1.png)
