### PR TITLE
Use window.setInterval and not the node one.

### DIFF
--- a/src/pages/ServiceDetails/ServiceMetrics.tsx
+++ b/src/pages/ServiceDetails/ServiceMetrics.tsx
@@ -29,7 +29,7 @@ type ServiceMetricsState = {
   responseSizeOut?: M.Histogram;
   grafanaLinkIn?: string;
   grafanaLinkOut?: string;
-  pollMetrics?: NodeJS.Timer;
+  pollMetrics?: number;
 };
 
 class ServiceMetrics extends React.Component<ServiceId, ServiceMetricsState> {
@@ -59,12 +59,12 @@ class ServiceMetrics extends React.Component<ServiceId, ServiceMetricsState> {
   };
 
   onPollIntervalChanged = (pollInterval: number) => {
-    let newRefInterval: NodeJS.Timer | undefined = undefined;
+    let newRefInterval: number | undefined = undefined;
     if (this.state.pollMetrics) {
       clearInterval(this.state.pollMetrics);
     }
     if (pollInterval > 0) {
-      newRefInterval = setInterval(this.fetchMetrics, pollInterval);
+      newRefInterval = window.setInterval(this.fetchMetrics, pollInterval);
     }
     this.setState({ pollMetrics: newRefInterval });
   };


### PR DESCRIPTION
We are running it on a browser, in the end it will use that.
We are wrongly type-hinting that we are using the other one and could cause
problems if someone tries to access the `NodeJS.Timer` object created.

I tested and it returns a `number`, not a `NodeJS.Timer`, calling `ref()` on it
causes an error to be throw.