### PR TITLE
Fix storybook again

### DIFF
--- a/src/components/CytoscapeLayout/CytoscapeLayout.stories.tsx
+++ b/src/components/CytoscapeLayout/CytoscapeLayout.stories.tsx
@@ -29,6 +29,7 @@ class CytoscapeLayoutStorybook extends CytoscapeLayout {
 
 const BookInfoCytoscapeLayout = graphLayout => (
   <CytoscapeLayoutStorybook
+    onReady={action('onReady')}
     graphLayout={graphLayout.getLayout()}
     namespace={{ name: 'test' }}
     graphDuration={{ value: QueryOptions.DEFAULT.key }}
@@ -49,6 +50,7 @@ storiesOf('CytoscapeLayout/Bookinfo with layout', module)
 storiesOf('CytoscapeLayout', module)
   .add('Empty layout', () => (
     <CytoscapeLayoutStorybook
+      onReady={action('onReady')}
       graphLayout={DagreGraph.getLayout()}
       namespace={{ name: 'test' }}
       graphDuration={{ value: QueryOptions.DEFAULT.key }}
@@ -60,6 +62,7 @@ storiesOf('CytoscapeLayout', module)
   ))
   .add('Loading', () => (
     <CytoscapeLayoutStorybook
+      onReady={action('onReady')}
       graphLayout={DagreGraph.getLayout()}
       namespace={{ name: 'test' }}
       graphDuration={{ value: QueryOptions.DEFAULT.key }}

--- a/src/components/CytoscapeLayout/__stories__/bookinfo.json
+++ b/src/components/CytoscapeLayout/__stories__/bookinfo.json
@@ -4,6 +4,7 @@
       "data": {
         "id": "n2",
         "text": "details v1",
+        "style": "solid",
         "service": "details.bookinfo.svc.cluster.local",
         "version": "v1"
       }
@@ -12,14 +13,18 @@
       "data": {
         "id": "n1",
         "text": "productpage v1",
+        "style": "solid",
         "service": "productpage.bookinfo.svc.cluster.local",
-        "version": "v1"
+        "version": "v1",
+        "rate": "36.327",
+        "rate4XX": "36.308"
       }
     },
     {
       "data": {
         "id": "n4",
         "text": "ratings v1",
+        "style": "solid",
         "service": "ratings.bookinfo.svc.cluster.local",
         "version": "v1"
       }
@@ -28,6 +33,7 @@
       "data": {
         "id": "n7",
         "text": "reviews",
+        "style": "solid",
         "service": "reviews.bookinfo.svc.cluster.local",
         "groupBy": "version"
       }
@@ -36,6 +42,7 @@
       "data": {
         "id": "n5",
         "text": "reviews v1",
+        "style": "dotted",
         "parent": "n7",
         "service": "reviews.bookinfo.svc.cluster.local",
         "version": "v1"
@@ -45,6 +52,7 @@
       "data": {
         "id": "n6",
         "text": "reviews v2",
+        "style": "dotted",
         "parent": "n7",
         "service": "reviews.bookinfo.svc.cluster.local",
         "version": "v2"
@@ -54,6 +62,7 @@
       "data": {
         "id": "n3",
         "text": "reviews v3",
+        "style": "solid",
         "parent": "n7",
         "service": "reviews.bookinfo.svc.cluster.local",
         "version": "v3"
@@ -63,6 +72,7 @@
       "data": {
         "id": "n0",
         "text": "unknown",
+        "style": "solid",
         "service": "unknown",
         "version": "unknown"
       }
@@ -74,9 +84,11 @@
         "id": "e0",
         "source": "n0",
         "target": "n1",
-        "text": "",
-        "color": "black",
-        "style": "solid"
+        "text": "36.33 99.95%",
+        "color": "red",
+        "style": "solid",
+        "rate": "36.327",
+        "rate4XX": "36.308"
       }
     },
     {

--- a/src/components/MetricsOptions/MetricsOptions.stories.tsx
+++ b/src/components/MetricsOptions/MetricsOptions.stories.tsx
@@ -8,4 +8,9 @@ import MetricsOptionsBar from './MetricsOptionsBar';
 
 const stories = storiesOf('MetricsOptions', module);
 
-stories.add('MetricsOptionsBar', () => <MetricsOptionsBar onOptionsChanged={action('onOptionsChanged')} />);
+stories.add('MetricsOptionsBar', () => (
+  <MetricsOptionsBar
+    onPollIntervalChanged={action('onPollIntervalChanged')}
+    onOptionsChanged={action('onOptionsChanged')}
+  />
+));

--- a/src/pages/ServiceDetails/ServiceMetrics.tsx
+++ b/src/pages/ServiceDetails/ServiceMetrics.tsx
@@ -29,7 +29,7 @@ type ServiceMetricsState = {
   responseSizeOut?: M.Histogram;
   grafanaLinkIn?: string;
   grafanaLinkOut?: string;
-  pollMetrics?: NodeJS.Timer;
+  pollMetrics?: number;
 };
 
 class ServiceMetrics extends React.Component<ServiceId, ServiceMetricsState> {
@@ -59,12 +59,12 @@ class ServiceMetrics extends React.Component<ServiceId, ServiceMetricsState> {
   };
 
   onPollIntervalChanged = (pollInterval: number) => {
-    let newRefInterval: NodeJS.Timer | undefined = undefined;
+    let newRefInterval: number | undefined = undefined;
     if (this.state.pollMetrics) {
       clearInterval(this.state.pollMetrics);
     }
     if (pollInterval > 0) {
-      newRefInterval = setInterval(this.fetchMetrics, pollInterval);
+      newRefInterval = window.setInterval(this.fetchMetrics, pollInterval);
     }
     this.setState({ pollMetrics: newRefInterval });
   };

--- a/storybook/webpack.config.js
+++ b/storybook/webpack.config.js
@@ -1,7 +1,5 @@
 // load the default config generator.
-const genDefaultConfig = require('@storybook/react/dist/server/config/defaults/webpack.config.js');
-module.exports = (baseConfig, env) => {
-  const config = genDefaultConfig(baseConfig, env);
+module.exports = (baseConfig, env, config) => {
   // Extend it as you need.
   // For example, add typescript loader:
   config.module.rules.push({


### PR DESCRIPTION
When adding storybook support to kiali-ui, I ignored the stories files for being included into the build.
This has the side effect that these files are not being processed by tslint.

Should we try to find a way to make the linter fail on stories (but not include them in the build)?
If so, we would reduce the "downtime" of storybooks, but there will be more things to do when adding more code to a component (such as CytoscapeLayout).

Depends on #249 