### PR TITLE
KIALI-564 - Process all rates in one loop, calling cy.edges() only once.

### DIFF
--- a/src/pages/ServiceGraph/SummaryPanelGraph.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelGraph.tsx
@@ -5,6 +5,7 @@ import RateTable from '../../components/SummaryPanel/RateTable';
 import RpsChart from '../../components/SummaryPanel/RpsChart';
 import { SummaryPanelPropType } from '../../types/Graph';
 import graphUtils from '../../utils/graphing';
+import { getAccumulatedTrafficRate } from '../../utils/TrafficRate';
 import * as API from '../../services/Api';
 import { NamespaceFilterSelected } from '../../components/NamespaceFilter/NamespaceFilter';
 import { ActiveFilter } from '../../types/NamespaceFilter';
@@ -58,13 +59,7 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
       .filter('[!groupBy]')
       .size();
     const numEdges = cy.edges().size();
-    const safeRate = (s: string) => {
-      return s ? parseFloat(s) : 0.0;
-    };
-    const rate = cy.edges().reduce((r = 0, edge) => r + safeRate(edge.data('rate')), 0);
-    const rate3xx = cy.edges().reduce((r = 0, edge) => r + safeRate(edge.data('rate3XX')), 0);
-    const rate4xx = cy.edges().reduce((r = 0, edge) => r + safeRate(edge.data('rate4XX')), 0);
-    const rate5xx = cy.edges().reduce((r = 0, edge) => r + safeRate(edge.data('rate5XX')), 0);
+    const trafficRate = getAccumulatedTrafficRate(cy.edges());
     const servicesLink = (
       <Link to="../services" onClick={this.updateServicesFilter}>
         {this.props.namespace}
@@ -81,10 +76,10 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
           <div>
             <RateTable
               title="Traffic (requests per second):"
-              rate={rate}
-              rate3xx={rate3xx}
-              rate4xx={rate4xx}
-              rate5xx={rate5xx}
+              rate={trafficRate.rate}
+              rate3xx={trafficRate.rate3xx}
+              rate4xx={trafficRate.rate4xx}
+              rate5xx={trafficRate.rate5xx}
             />
             <div>
               <hr />

--- a/src/pages/ServiceGraph/SummaryPanelGroup.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelGroup.tsx
@@ -6,6 +6,7 @@ import { SummaryPanelPropType } from '../../types/Graph';
 import * as API from '../../services/Api';
 import * as M from '../../types/Metrics';
 import graphUtils from '../../utils/graphing';
+import { getAccumulatedTrafficRate } from '../../utils/TrafficRate';
 import MetricsOptions from '../../types/MetricsOptions';
 
 type SummaryPanelGroupState = {
@@ -50,30 +51,8 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
     const service = this.props.data.summaryTarget.data('service').split('.')[0];
     const serviceHotLink = <a href={`../namespaces/${namespace}/services/${service}`}>{service}</a>;
 
-    const RATE = 'rate';
-    const RATE3XX = 'rate3XX';
-    const RATE4XX = 'rate4XX';
-    const RATE5XX = 'rate5XX';
-
-    let incoming = { rate: 0, rate3xx: 0, rate4xx: 0, rate5xx: 0 };
-    let outgoing = { rate: 0, rate3xx: 0, rate4xx: 0, rate5xx: 0 };
-
-    // aggregate all incoming rates
-    const safeRate = (s: string) => {
-      return s ? parseFloat(s) : 0.0;
-    };
-    const nodes = this.props.data.summaryTarget.children();
-    incoming.rate = nodes.reduce((r = 0, node) => r + safeRate(node.data(RATE)), 0);
-    incoming.rate3xx = nodes.reduce((r = 0, node) => r + safeRate(node.data(RATE3XX)), 0);
-    incoming.rate4xx = nodes.reduce((r = 0, node) => r + safeRate(node.data(RATE4XX)), 0);
-    incoming.rate5xx = nodes.reduce((r = 0, node) => r + safeRate(node.data(RATE5XX)), 0);
-
-    // aggregate all outgoing rates
-    const edges = this.props.data.summaryTarget.children().edgesTo('*');
-    outgoing.rate = edges.reduce((r = 0, edge) => r + safeRate(edge.data(RATE)), 0);
-    outgoing.rate3xx = edges.reduce((r = 0, edge) => r + safeRate(edge.data(RATE3XX)), 0);
-    outgoing.rate4xx = edges.reduce((r = 0, edge) => r + safeRate(edge.data(RATE4XX)), 0);
-    outgoing.rate5xx = edges.reduce((r = 0, edge) => r + safeRate(edge.data(RATE5XX)), 0);
+    const incoming = getAccumulatedTrafficRate(this.props.data.summaryTarget.children());
+    const outgoing = getAccumulatedTrafficRate(this.props.data.summaryTarget.children().edgesTo('*'));
 
     return (
       <div className="panel panel-default" style={SummaryPanelGroup.panelStyle}>

--- a/src/pages/ServiceGraph/SummaryPanelNode.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelNode.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import * as API from '../../services/Api';
 
 import graphUtils from '../../utils/graphing';
+import { getTrafficRate, getAccumulatedTrafficRate } from '../../utils/TrafficRate';
 import Badge from '../../components/Badge/Badge';
 import InOutRateTable from '../../components/SummaryPanel/InOutRateTable';
 import RpsChart from '../../components/SummaryPanel/RpsChart';
@@ -83,11 +84,6 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
   }
 
   render() {
-    const RATE = 'rate';
-    const RATE3XX = 'rate3XX';
-    const RATE4XX = 'rate4XX';
-    const RATE5XX = 'rate5XX';
-
     const node = this.props.data.summaryTarget;
 
     const serviceSplit = node.data('service').split('.');
@@ -95,17 +91,8 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
     const service = serviceSplit[0];
     const serviceHotLink = <a href={`../namespaces/${namespace}/services/${service}`}>{service}</a>;
 
-    let outgoing = { rate: 0, rate3xx: 0, rate4xx: 0, rate5xx: 0 };
-
-    // aggregate all outgoing rates
-    const safeRate = (s: string) => {
-      return s ? parseFloat(s) : 0.0;
-    };
-    const edges = this.props.data.summaryTarget.edgesTo('*');
-    outgoing.rate = edges.reduce((r = 0, edge) => r + safeRate(edge.data(RATE)), 0);
-    outgoing.rate3xx = edges.reduce((r = 0, edge) => r + safeRate(edge.data(RATE3XX)), 0);
-    outgoing.rate4xx = edges.reduce((r = 0, edge) => r + safeRate(edge.data(RATE4XX)), 0);
-    outgoing.rate5xx = edges.reduce((r = 0, edge) => r + safeRate(edge.data(RATE5XX)), 0);
+    const incoming = getTrafficRate(node);
+    const outgoing = getAccumulatedTrafficRate(this.props.data.summaryTarget.edgesTo('*'));
 
     const isUnknown = service === 'unknown';
     return (
@@ -132,10 +119,10 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
         <div className="panel-body">
           <InOutRateTable
             title="Request Traffic (requests per second):"
-            inRate={parseFloat(node.data(RATE)) || 0}
-            inRate3xx={parseFloat(node.data(RATE3XX)) || 0}
-            inRate4xx={parseFloat(node.data(RATE4XX)) || 0}
-            inRate5xx={parseFloat(node.data(RATE5XX)) || 0}
+            inRate={incoming.rate}
+            inRate3xx={incoming.rate3xx}
+            inRate4xx={incoming.rate4xx}
+            inRate5xx={incoming.rate5xx}
             outRate={outgoing.rate}
             outRate3xx={outgoing.rate3xx}
             outRate4xx={outgoing.rate4xx}

--- a/src/utils/TrafficRate.ts
+++ b/src/utils/TrafficRate.ts
@@ -1,0 +1,35 @@
+const safeRate = (rate: string) => (rate ? parseFloat(rate) : 0.0);
+const RATE = 'rate';
+const RATE3XX = 'rate3XX';
+const RATE4XX = 'rate4XX';
+const RATE5XX = 'rate5XX';
+
+export interface TrafficRate {
+  rate: number;
+  rate3xx: number;
+  rate4xx: number;
+  rate5xx: number;
+}
+
+export const getTrafficRate = (element): TrafficRate => {
+  return {
+    rate: safeRate(element.data(RATE)),
+    rate3xx: safeRate(element.data(RATE3XX)),
+    rate4xx: safeRate(element.data(RATE4XX)),
+    rate5xx: safeRate(element.data(RATE5XX))
+  };
+};
+
+export const getAccumulatedTrafficRate = (elements): TrafficRate => {
+  return elements.reduce(
+    (r: TrafficRate, element): TrafficRate => {
+      const elementTrafficRate = getTrafficRate(element);
+      r.rate += elementTrafficRate.rate;
+      r.rate3xx += elementTrafficRate.rate3xx;
+      r.rate4xx += elementTrafficRate.rate4xx;
+      r.rate5xx += elementTrafficRate.rate5xx;
+      return r;
+    },
+    { rate: 0, rate3xx: 0, rate4xx: 0, rate5xx: 0 }
+  );
+};


### PR DESCRIPTION
This is an answer to  @jmazzitelli concern about looping 4x more than the original code.