### PR TITLE
KIALI-527: Consistency across the UI (badges, labels)

### DIFF
--- a/src/pages/ServiceGraph/SummaryPanelGraph.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelGraph.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import Badge from '../../components/Badge/Badge';
 import RateTable from '../../components/SummaryPanel/RateTable';
 import RpsChart from '../../components/SummaryPanel/RpsChart';
 import { SummaryPanelPropType } from '../../types/Graph';
@@ -9,6 +8,7 @@ import * as API from '../../services/Api';
 import { NamespaceFilterSelected } from '../../components/NamespaceFilter/NamespaceFilter';
 import { ActiveFilter } from '../../types/NamespaceFilter';
 import * as M from '../../types/Metrics';
+import { Icon } from 'patternfly-react';
 
 type SummaryPanelGraphState = {
   loading: boolean;
@@ -56,6 +56,7 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
     const numNodes = cy
       .nodes()
       .filter('[!groupBy]')
+      .filter('[service!="unknown"]')
       .size();
     const numEdges = cy.edges().size();
     const safeRate = (s: string) => {
@@ -75,7 +76,7 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
       <div className="panel panel-default" style={SummaryPanelGraph.panelStyle}>
         <div className="panel-heading">
           Namespace: {servicesLink}
-          <div>{this.renderLabels(numNodes.toString(), numEdges.toString())}</div>
+          {this.renderTopologySummary(numNodes, numEdges)}
         </div>
         <div className="panel-body">
           <div>
@@ -123,11 +124,12 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
       });
   };
 
-  private renderLabels = (numNodes: string, numEdges: string) => (
-    // color="#2d7623" is pf-green-500
-    <div style={{ paddingTop: '3px' }}>
-      <Badge scale={0.9} style="plastic" leftText="services" rightText={numNodes} color="#2d7623" />
-      <Badge scale={0.9} style="plastic" leftText="edges" rightText={numEdges} color="#2d7623" />
+  private renderTopologySummary = (numNodes: number, numEdges: number) => (
+    <div>
+      <Icon name="service" type="pf" style={{ padding: '0 1em' }} />
+      {numNodes.toString()} {numNodes === 1 ? 'service' : 'services'}
+      <Icon name="topology" type="pf" style={{ padding: '0 1em' }} />
+      {numEdges.toString()} {numEdges === 1 ? 'link' : 'links'}
     </div>
   );
 

--- a/src/pages/ServiceGraph/SummaryPanelNode.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelNode.tsx
@@ -113,7 +113,7 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
     return (
       <div className="panel panel-default" style={SummaryPanelNode.panelStyle}>
         <div className="panel-heading">
-          Microservice: {isUnknown ? 'unknown' : serviceHotLink}
+          Service: {isUnknown ? 'unknown' : serviceHotLink}
           <div style={{ paddingTop: '3px' }}>
             <Badge
               scale={0.9}


### PR DESCRIPTION
In the side panel:
- Don't use badges for non-label data
- Use "services" instead of "microservices"
- In the namespace side panel, fix service count (exclude unknown node)

![image](https://user-images.githubusercontent.com/23639005/38828858-f5d2335c-417c-11e8-82a8-9fccb41fdfa7.png)
