### PR TITLE
Kiali 544 Adding creation time to all resources within service detail page

### DIFF
--- a/src/components/Time/LocalTime.tsx
+++ b/src/components/Time/LocalTime.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+
+interface TimeProps {
+  time: string;
+}
+
+export default class LocalTime extends React.Component<TimeProps> {
+  render() {
+    return new Date(this.props.time).toLocaleString();
+  }
+}

--- a/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -14,6 +14,7 @@ type ServiceInfoState = {
   labels?: Map<string, string>;
   type: string;
   name: string;
+  created_at: string;
   ip: string;
   ports?: Port[];
   endpoints?: Endpoints[];
@@ -33,6 +34,7 @@ class ServiceInfo extends React.Component<ServiceId, ServiceInfoState> {
     this.state = {
       labels: new Map(),
       name: '',
+      created_at: '',
       type: '',
       ip: '',
       ports: [],
@@ -61,6 +63,7 @@ class ServiceInfo extends React.Component<ServiceId, ServiceInfoState> {
         this.setState({
           labels: data.labels,
           name: data.name,
+          created_at: data.created_at,
           type: data.type,
           ports: data.ports,
           endpoints: data.endpoints,
@@ -129,6 +132,7 @@ class ServiceInfo extends React.Component<ServiceId, ServiceInfoState> {
             <Col xs={12} sm={12} md={12} lg={12}>
               <ServiceInfoDescription
                 name={this.state.name}
+                created_at={this.state.created_at}
                 istio_sidecar={this.state.istio_sidecar}
                 labels={this.state.labels}
                 ports={this.state.ports}

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDeployments.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDeployments.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Col, Row, Icon } from 'patternfly-react';
+import LocalTime from '../../../components/Time/LocalTime';
 import Badge from '../../../components/Badge/Badge';
 import { Deployment } from '../../../types/ServiceInfo';
 import PfInfoCard from '../../../components/Pf/PfInfoCard';
@@ -51,6 +52,10 @@ class ServiceInfoDeployments extends React.Component<ServiceInfoDeploymentsProps
                     }% CPU)
                   </div>
                 )}
+                <p>
+                  <strong>Created at: </strong>
+                  <LocalTime time={deployment.created_at} />
+                </p>
               </div>
               <hr />
             </Col>

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Col, Row } from 'patternfly-react';
 
 import Badge from '../../../components/Badge/Badge';
+import LocalTime from '../../../components/Time/LocalTime';
 import { HealthIndicator, DisplayMode } from '../../../components/ServiceHealth/HealthIndicator';
 import { Health } from '../../../types/Health';
 import { Endpoints, Port } from '../../../types/ServiceInfo';
@@ -12,6 +13,7 @@ import { IstioLogo } from '../../../types/ServiceListComponent';
 
 interface ServiceInfoDescriptionProps {
   name: string;
+  created_at: string;
   istio_sidecar?: boolean;
   labels?: Map<string, string>;
   type?: string;
@@ -65,6 +67,9 @@ class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps
                 ) : (
                   ' Undeployed'
                 )}
+              </div>
+              <div>
+                <strong>Created at</strong> <LocalTime time={this.props.created_at} />
               </div>
             </Col>
             <Col xs={12} sm={6} md={3} lg={3}>

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDestinationPolicies.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDestinationPolicies.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { DestinationPolicy } from '../../../types/ServiceInfo';
+import LocalTime from '../../../components/Time/LocalTime';
 import PfInfoCard from '../../../components/Pf/PfInfoCard';
 import RouteRuleIstioService from './ServiceInfoRouteRules/RouteRuleIstioService';
 
@@ -83,6 +84,11 @@ class ServiceInfoDestinationPolicies extends React.Component<ServiceInfoDestinat
                 <strong>Name</strong>
                 {': '}
                 {dPolicy.name}
+              </div>
+              <div>
+                <strong>Created at</strong>
+                {': '}
+                <LocalTime time={dPolicy.created_at} />
               </div>
               {dPolicy.destination ? <RouteRuleIstioService name="Destination" service={dPolicy.destination} /> : null}
               {dPolicy.source ? <RouteRuleIstioService name="Source" service={dPolicy.source} /> : null}

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoRouteRules.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoRouteRules.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { RouteRule } from '../../../types/ServiceInfo';
+import LocalTime from '../../../components/Time/LocalTime';
 import PfInfoCard from '../../../components/Pf/PfInfoCard';
 import RouteRuleMatch from './ServiceInfoRouteRules/RouteRuleMatch';
 import RouteRuleRoute from './ServiceInfoRouteRules/RouteRuleRoute';
@@ -30,6 +31,9 @@ class ServiceInfoRouteRules extends React.Component<ServiceInfoRouteRulesProps> 
           <div key={'rule' + i}>
             <div>
               <strong>Name</strong>: {rule.name}
+            </div>
+            <div>
+              <strong>Created at</strong>: <LocalTime time={rule.created_at} />
             </div>
             <div>
               <strong>Precedence</strong>: {rule.precedence}

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/ServiceInfoDescription.test.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/ServiceInfoDescription.test.tsx
@@ -36,7 +36,14 @@ const endpoints = [
 describe('#ServiceInfoDescription render correctly with data', () => {
   it('should render service description', () => {
     const wrapper = shallow(
-      <ServiceInfoDescription name="reviews" labels={labels} type="ClusterIP" ip="172.30.78.33" endpoints={endpoints} />
+      <ServiceInfoDescription
+        name="reviews"
+        labels={labels}
+        type="ClusterIP"
+        ip="172.30.78.33"
+        endpoints={endpoints}
+        created_at="2018-04-04T15:11:46Z"
+      />
     );
     expect(wrapper).toBeDefined();
     expect(wrapper).toMatchSnapshot();

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/ServiceInfoRouteRules.test.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/ServiceInfoRouteRules.test.tsx
@@ -6,6 +6,7 @@ import { RouteRule } from '../../../../types/ServiceInfo';
 const rules: RouteRule[] = [
   {
     name: 'reviews-default',
+    created_at: '2018-03-14T10:17:52Z',
     destination: {
       name: 'reviews'
     },
@@ -19,6 +20,7 @@ const rules: RouteRule[] = [
   },
   {
     name: 'reviews-test-v2',
+    created_at: '2018-03-14T10:17:52Z',
     destination: {
       name: 'reviews'
     },

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDeployments.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDeployments.test.tsx.snap
@@ -118,6 +118,14 @@ ShallowWrapper {
                 50
                 % CPU)
               </div>
+              <p>
+                <strong>
+                  Created at: 
+                </strong>
+                <LocalTime
+                  time="2018-03-14T10:17:52Z"
+                />
+              </p>
             </div>
             <hr />
           </Col>
@@ -164,6 +172,14 @@ ShallowWrapper {
                 50
                 % CPU)
               </div>
+              <p>
+                <strong>
+                  Created at: 
+                </strong>
+                <LocalTime
+                  time="2018-03-14T10:17:52Z"
+                />
+              </p>
             </div>
             <hr />
           </Col>
@@ -210,6 +226,14 @@ ShallowWrapper {
                 50
                 % CPU)
               </div>
+              <p>
+                <strong>
+                  Created at: 
+                </strong>
+                <LocalTime
+                  time="2018-03-14T10:17:52Z"
+                />
+              </p>
             </div>
             <hr />
           </Col>
@@ -272,6 +296,14 @@ ShallowWrapper {
                   50
                   % CPU)
                 </div>
+                <p>
+                  <strong>
+                    Created at: 
+                  </strong>
+                  <LocalTime
+                    time="2018-03-14T10:17:52Z"
+                  />
+                </p>
               </div>
               <hr />
             </Col>
@@ -318,6 +350,14 @@ ShallowWrapper {
                   50
                   % CPU)
                 </div>
+                <p>
+                  <strong>
+                    Created at: 
+                  </strong>
+                  <LocalTime
+                    time="2018-03-14T10:17:52Z"
+                  />
+                </p>
               </div>
               <hr />
             </Col>
@@ -364,6 +404,14 @@ ShallowWrapper {
                   50
                   % CPU)
                 </div>
+                <p>
+                  <strong>
+                    Created at: 
+                  </strong>
+                  <LocalTime
+                    time="2018-03-14T10:17:52Z"
+                  />
+                </p>
               </div>
               <hr />
             </Col>

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
@@ -5,6 +5,7 @@ ShallowWrapper {
   "length": 1,
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <ServiceInfoDescription
+    created_at="2018-04-04T15:11:46Z"
     endpoints={
       Array [
         Object {
@@ -96,6 +97,15 @@ ShallowWrapper {
               Istio Sidecar
             </strong>
              Undeployed
+          </div>
+          <div>
+            <strong>
+              Created at
+            </strong>
+             
+            <LocalTime
+              time="2018-04-04T15:11:46Z"
+            />
           </div>
         </Col>
         <Col
@@ -258,6 +268,15 @@ ShallowWrapper {
                 Istio Sidecar
               </strong>
                Undeployed
+            </div>
+            <div>
+              <strong>
+                Created at
+              </strong>
+               
+              <LocalTime
+                time="2018-04-04T15:11:46Z"
+              />
             </div>
           </Col>
           <Col

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoRouteRules.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoRouteRules.test.tsx.snap
@@ -8,6 +8,7 @@ ShallowWrapper {
     routeRules={
       Array [
         Object {
+          "created_at": "2018-03-14T10:17:52Z",
           "destination": Object {
             "name": "reviews",
           },
@@ -23,6 +24,7 @@ ShallowWrapper {
           ],
         },
         Object {
+          "created_at": "2018-03-14T10:17:52Z",
           "destination": Object {
             "name": "reviews",
           },
@@ -65,6 +67,15 @@ ShallowWrapper {
           </div>
           <div>
             <strong>
+              Created at
+            </strong>
+            : 
+            <LocalTime
+              time="2018-03-14T10:17:52Z"
+            />
+          </div>
+          <div>
+            <strong>
               Precedence
             </strong>
             : 
@@ -90,6 +101,15 @@ ShallowWrapper {
             </strong>
             : 
             reviews-test-v2
+          </div>
+          <div>
+            <strong>
+              Created at
+            </strong>
+            : 
+            <LocalTime
+              time="2018-03-14T10:17:52Z"
+            />
           </div>
           <div>
             <strong>
@@ -137,6 +157,15 @@ ShallowWrapper {
             </div>
             <div>
               <strong>
+                Created at
+              </strong>
+              : 
+              <LocalTime
+                time="2018-03-14T10:17:52Z"
+              />
+            </div>
+            <div>
+              <strong>
                 Precedence
               </strong>
               : 
@@ -162,6 +191,15 @@ ShallowWrapper {
               </strong>
               : 
               reviews-test-v2
+            </div>
+            <div>
+              <strong>
+                Created at
+              </strong>
+              : 
+              <LocalTime
+                time="2018-03-14T10:17:52Z"
+              />
             </div>
             <div>
               <strong>

--- a/src/pages/ServiceDetails/__tests__/__snapshots__/ServiceInfo.test.tsx.snap
+++ b/src/pages/ServiceDetails/__tests__/__snapshots__/ServiceInfo.test.tsx.snap
@@ -39,6 +39,7 @@ ShallowWrapper {
               xs={12}
             >
               <ServiceInfoDescription
+                created_at=""
                 endpoints={undefined}
                 health={undefined}
                 ip=""
@@ -81,6 +82,7 @@ ShallowWrapper {
                 xs={12}
               >
                 <ServiceInfoDescription
+                  created_at=""
                   endpoints={undefined}
                   health={undefined}
                   ip=""
@@ -117,6 +119,7 @@ ShallowWrapper {
                 xs={12}
               >
                 <ServiceInfoDescription
+                  created_at=""
                   endpoints={undefined}
                   health={undefined}
                   ip=""
@@ -138,6 +141,7 @@ ShallowWrapper {
               "props": Object {
                 "bsClass": "col",
                 "children": <ServiceInfoDescription
+                  created_at=""
                   endpoints={undefined}
                   health={undefined}
                   ip=""
@@ -159,6 +163,7 @@ ShallowWrapper {
                 "key": undefined,
                 "nodeType": "class",
                 "props": Object {
+                  "created_at": "",
                   "endpoints": undefined,
                   "health": undefined,
                   "ip": "",
@@ -229,6 +234,7 @@ ShallowWrapper {
                 xs={12}
               >
                 <ServiceInfoDescription
+                  created_at=""
                   endpoints={undefined}
                   health={undefined}
                   ip=""
@@ -271,6 +277,7 @@ ShallowWrapper {
                   xs={12}
                 >
                   <ServiceInfoDescription
+                    created_at=""
                     endpoints={undefined}
                     health={undefined}
                     ip=""
@@ -307,6 +314,7 @@ ShallowWrapper {
                   xs={12}
                 >
                   <ServiceInfoDescription
+                    created_at=""
                     endpoints={undefined}
                     health={undefined}
                     ip=""
@@ -328,6 +336,7 @@ ShallowWrapper {
                 "props": Object {
                   "bsClass": "col",
                   "children": <ServiceInfoDescription
+                    created_at=""
                     endpoints={undefined}
                     health={undefined}
                     ip=""
@@ -349,6 +358,7 @@ ShallowWrapper {
                   "key": undefined,
                   "nodeType": "class",
                   "props": Object {
+                    "created_at": "",
                     "endpoints": undefined,
                     "health": undefined,
                     "ip": "",
@@ -444,6 +454,7 @@ ShallowWrapper {
               xs={12}
             >
               <ServiceInfoDescription
+                created_at=""
                 endpoints={
                   Array [
                     Object {
@@ -581,6 +592,7 @@ ShallowWrapper {
                 xs={12}
               >
                 <ServiceInfoDescription
+                  created_at=""
                   endpoints={
                     Array [
                       Object {
@@ -712,6 +724,7 @@ ShallowWrapper {
                 xs={12}
               >
                 <ServiceInfoDescription
+                  created_at=""
                   endpoints={
                     Array [
                       Object {
@@ -774,6 +787,7 @@ ShallowWrapper {
               "props": Object {
                 "bsClass": "col",
                 "children": <ServiceInfoDescription
+                  created_at=""
                   endpoints={
                     Array [
                       Object {
@@ -836,6 +850,7 @@ ShallowWrapper {
                 "key": undefined,
                 "nodeType": "class",
                 "props": Object {
+                  "created_at": "",
                   "endpoints": Array [
                     Object {
                       "addresses": Array [
@@ -1107,6 +1122,7 @@ ShallowWrapper {
                 xs={12}
               >
                 <ServiceInfoDescription
+                  created_at=""
                   endpoints={
                     Array [
                       Object {
@@ -1244,6 +1260,7 @@ ShallowWrapper {
                   xs={12}
                 >
                   <ServiceInfoDescription
+                    created_at=""
                     endpoints={
                       Array [
                         Object {
@@ -1375,6 +1392,7 @@ ShallowWrapper {
                   xs={12}
                 >
                   <ServiceInfoDescription
+                    created_at=""
                     endpoints={
                       Array [
                         Object {
@@ -1437,6 +1455,7 @@ ShallowWrapper {
                 "props": Object {
                   "bsClass": "col",
                   "children": <ServiceInfoDescription
+                    created_at=""
                     endpoints={
                       Array [
                         Object {
@@ -1499,6 +1518,7 @@ ShallowWrapper {
                   "key": undefined,
                   "nodeType": "class",
                   "props": Object {
+                    "created_at": "",
                     "endpoints": Array [
                       Object {
                         "addresses": Array [

--- a/src/types/ServiceInfo.ts
+++ b/src/types/ServiceInfo.ts
@@ -40,6 +40,7 @@ export interface Autoscaler {
 
 export interface RouteRule {
   name: string;
+  created_at: string;
   destination?: IstioService;
   precedence?: number;
   match?: MatchCondition;
@@ -195,6 +196,7 @@ export interface CircuitBreaker {
 
 export interface DestinationPolicy {
   name: string;
+  created_at: string;
   destination: IstioService;
   source: IstioService;
   loadbalancing: LoadBalancing;


### PR DESCRIPTION
This PR needs [kiali/kiali#158](https://github.com/kiali/kiali/pull/158) to be merged.

Times shown for each resource displayed within this service page are in user's timezone.
Here you have the screenshots for each creation datetime added:

Service creation time:
![created-at-service](https://user-images.githubusercontent.com/613814/38881052-6e6b72e8-4267-11e8-995b-3e9a8c4494cd.png)

Deployments creation time:
![created-at-deployment](https://user-images.githubusercontent.com/613814/38881051-6e5300b4-4267-11e8-9778-ab01fccee2f7.png)

Route Rule creation time:
![created-at-route-rule](https://user-images.githubusercontent.com/613814/38881050-6e39435e-4267-11e8-827a-0bc03791966d.png)

Destination policy creation time:
![created-at-destination-policy](https://user-images.githubusercontent.com/613814/38881049-6e1dae00-4267-11e8-9c24-4a0818dabd24.png)