### PR TITLE
KIALI-591 remove duplicate fetching from ServiceInfo

### DIFF
--- a/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -47,10 +47,6 @@ class ServiceInfo extends React.Component<ServiceId, ServiceInfoState> {
     };
   }
 
-  componentDidMount() {
-    this.fetchServiceDetails(this.props);
-  }
-
   componentWillReceiveProps(nextProps: ServiceId) {
     this.fetchServiceDetails(nextProps);
   }


### PR DESCRIPTION
@aljesusg @xeviknal @lucasponce do you know if there was a good reason to have this "fetch" both from componentDidMount and componentWillReceiveProps ?

It makes 2 calls to the rest api where 1 would be enough.
I've tried and it seems to work properly, but maybe I missed some cases?