### PR TITLE
KIALI-590 allow cose to cycle through different cose layouts

### DIFF
--- a/src/components/GraphFilter/GraphFilter.tsx
+++ b/src/components/GraphFilter/GraphFilter.tsx
@@ -35,7 +35,7 @@ export default class GraphFilter extends React.Component<GraphFilterProps, Graph
   };
 
   updateLayout = (value: string) => {
-    if (this.props.activeLayout.name !== value) {
+    if ('cose' === value || this.props.activeLayout.name !== value) {
       // notify callback
       this.props.onLayoutChange({ name: value });
     }
@@ -68,7 +68,7 @@ export default class GraphFilter extends React.Component<GraphFilterProps, Graph
       [604800, '7 days'],
       [2592000, '30 days']
     ];
-    const graphsTypes = [
+    const graphLayouts = [
       ['breadthfirst', 'Breadthfirst'],
       ['cola', 'Cola'],
       ['cose', 'Cose'],
@@ -108,14 +108,14 @@ export default class GraphFilter extends React.Component<GraphFilterProps, Graph
           <ToolbarDropdown
             disabled={this.props.disabled}
             onClick={this.updateLayout}
-            nameDropdown={'Graph Type'}
+            nameDropdown={'Layout'}
             initialValue={this.props.activeLayout.name}
             initialLabel={String(
-              graphsTypes.filter(elem => {
+              graphLayouts.filter(elem => {
                 return elem[0] === String(this.props.activeLayout.name);
               })[0][1]
             )}
-            options={graphsTypes}
+            options={graphLayouts}
           />
           <Toolbar.RightContent>
             <Button disabled={this.props.disabled} onClick={this.handleRefresh}>

--- a/src/pages/ServiceGraph/ServiceGraphPage.tsx
+++ b/src/pages/ServiceGraph/ServiceGraphPage.tsx
@@ -11,7 +11,7 @@ import CytoscapeLayout from '../../components/CytoscapeLayout/CytoscapeLayout';
 import * as LayoutDictionary from '../../components/CytoscapeLayout/graphs/LayoutDictionary';
 import GraphFilter from '../../components/GraphFilter/GraphFilter';
 import PfContainerNavVertical from '../../components/Pf/PfContainerNavVertical';
-import PfHeader from '../../components/Pf/PfHeader';
+// import PfHeader from '../../components/Pf/PfHeader';
 import PfAlerts from '../../components/Pf/PfAlerts';
 import * as API from '../../services/Api';
 import { computePrometheusQueryInterval } from '../../services/Prometheus';
@@ -157,27 +157,21 @@ export default class ServiceGraphPage extends React.Component<
   render() {
     return (
       <PfContainerNavVertical>
-        <PfHeader>
-          <h2>Service Graph</h2>
-          <PfAlerts
-            alerts={this.buildAlertsArray()}
-            isVisible={this.state.alertVisible}
-            onDismiss={this.dismissAlert}
-          />
-          <GraphFilter
-            disabled={this.state.isLoading}
-            onLayoutChange={this.handleLayoutChange}
-            onFilterChange={this.handleFilterChange}
-            onNamespaceChange={this.handleNamespaceChange}
-            onBadgeStatusChange={this.handleBadgeStatusChange}
-            onRefresh={this.handleRefreshClick}
-            onError={this.handleError}
-            activeNamespace={this.state.params.namespace}
-            activeLayout={this.state.params.graphLayout}
-            activeDuration={this.state.params.graphDuration}
-            activeBadgeStatus={this.state.params.badgeStatus}
-          />
-        </PfHeader>
+        <h2>Service Graph</h2>
+        <PfAlerts alerts={this.buildAlertsArray()} isVisible={this.state.alertVisible} onDismiss={this.dismissAlert} />
+        <GraphFilter
+          disabled={this.state.isLoading}
+          onLayoutChange={this.handleLayoutChange}
+          onFilterChange={this.handleFilterChange}
+          onNamespaceChange={this.handleNamespaceChange}
+          onBadgeStatusChange={this.handleBadgeStatusChange}
+          onRefresh={this.handleRefreshClick}
+          onError={this.handleError}
+          activeNamespace={this.state.params.namespace}
+          activeLayout={this.state.params.graphLayout}
+          activeDuration={this.state.params.graphDuration}
+          activeBadgeStatus={this.state.params.badgeStatus}
+        />
         <div style={{ position: 'relative' }}>
           <CytoscapeLayout
             {...this.state.params}


### PR DESCRIPTION
Re-clicking the 'Cose' drop down option now generates the next cose variation

Also in this PR, some minor enhancements:
- Change option label 'Graph Type' to 'Layout'
- Remove PfHeader around page to remove excessive whitespace at top and
  give same look as service list page.