### PR TITLE
KIALI-614: always refresh namespace list when dropdown is open

### DIFF
--- a/src/components/NamespaceDropdown.tsx
+++ b/src/components/NamespaceDropdown.tsx
@@ -15,14 +15,14 @@ export class NamespaceDropdown extends React.PureComponent<NamespaceListType, {}
   constructor(props: NamespaceListType) {
     super(props);
   }
+
   componentDidMount() {
     this.props.refresh();
   }
 
-  onSelectTypesafe = (value: string) => {
-    this.props.refresh();
-    this.props.onSelect({ name: value });
-  };
+  onSelectTypesafe = (value: string) => this.props.onSelect({ name: value });
+
+  onToggle = (isOpen: boolean) => (isOpen ? this.props.refresh() : undefined);
 
   render() {
     const disabled = this.props.disabled ? true : false;
@@ -32,6 +32,7 @@ export class NamespaceDropdown extends React.PureComponent<NamespaceListType, {}
         id="namespace-selector"
         title={this.props.activeNamespace.name}
         onSelect={this.onSelectTypesafe}
+        onToggle={this.onToggle}
       >
         {this.props.items &&
           this.props.items.map(ns => (


### PR DESCRIPTION
Previously the list was only updated when user switches to different namespace.  Now it updates every time users click on the dropdown.

---
# Before adding a new namespace
![kiali-614-before](https://user-images.githubusercontent.com/3805254/39318563-537f0666-4933-11e8-9cd6-e25f37660e32.png)
# After adding a new one
![kiali-614-after](https://user-images.githubusercontent.com/3805254/39318561-5365c14c-4933-11e8-9e4b-1eaf65c788ed.png)


