### PR TITLE
KIALI-609: Don't allow an initial large zoom for the graph

### DIFF
--- a/src/components/CytoscapeLayout/CytoscapeLayout.tsx
+++ b/src/components/CytoscapeLayout/CytoscapeLayout.tsx
@@ -98,6 +98,12 @@ export default class CytoscapeLayout extends React.Component<CytoscapeLayoutProp
           new GraphBadge.RouteRuleBadge(ele).buildBadge();
         }
       });
+
+      // Don't allow a large zoom if the graph has a few nodes (nodes would look too big).
+      if (this.cy.zoom() > 2.5) {
+        this.cy.zoom(2.5);
+        this.cy.center();
+      }
     });
 
     this.cy.on('mouseover', 'node,edge', (evt: any) => {


### PR DESCRIPTION
Nodes look too big if there are only a few nodes in the graph. This will prevent large zooms when the graph loads. Thereafter, the user can zoom as he desires.