### PR TITLE
KIALI-635: Fix namespace chart lost

### DIFF
--- a/src/pages/ServiceGraph/SummaryPanelGraph.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelGraph.tsx
@@ -41,14 +41,8 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
   }
 
   componentDidMount() {
-    // don't load data here, wit until props are updated after the graph is loaded
     this._isMounted = true;
-  }
-
-  componentWillReceiveProps(nextProps: SummaryPanelPropType) {
-    if (nextProps.data.summaryTarget && nextProps.data.summaryTarget !== this.props.data.summaryTarget) {
-      this.updateRpsChart(nextProps);
-    }
+    this.updateRpsChart(this.props);
   }
 
   componentWillUnmount() {

--- a/src/types/Graph.ts
+++ b/src/types/Graph.ts
@@ -1,8 +1,16 @@
 import { Duration, Layout, BadgeStatus } from './GraphFilter';
 import Namespace from './Namespace';
 
+// SummaryData will have two fields:
+//   summaryTarget: The cytoscape element
+//   summaryType  : one of 'graph', 'node', 'edge', 'group'
+export interface SummaryData {
+  summaryType: string;
+  summaryTarget: any;
+}
+
 export interface SummaryPanelPropType {
-  data: any;
+  data: SummaryData;
   namespace: string;
   queryTime: string;
   duration: number;


### PR DESCRIPTION
After the graph is loaded, when the user clicks the background,
properties are pushed to the component only once. Because of this, the
side panel was not loading the required data.

Changing some code to ensure that "final" properties are always pushed
when the side panels are mounted. This allows to load chart data once
the component is mounted.