### PR TITLE
[KIALI-610] Fix onClick in Toolbar Component

### DIFF
--- a/src/components/GraphFilter/GraphFilter.tsx
+++ b/src/components/GraphFilter/GraphFilter.tsx
@@ -70,7 +70,7 @@ export default class GraphFilter extends React.Component<GraphFilterProps, Graph
           </FormGroup>
           <ToolbarDropdown
             disabled={this.props.disabled}
-            onClick={this.updateDuration}
+            handleSelect={this.updateDuration}
             nameDropdown={'Duration'}
             initialValue={Number(sessionStorage.getItem('appDuration')) || this.props.graphDuration.value}
             initialLabel={String(
@@ -82,7 +82,7 @@ export default class GraphFilter extends React.Component<GraphFilterProps, Graph
           />
           <ToolbarDropdown
             disabled={this.props.disabled}
-            onClick={this.updateLayout}
+            handleSelect={this.updateLayout}
             nameDropdown={'Layout'}
             initialValue={this.props.graphLayout.name}
             initialLabel={String(GraphFilter.GRAPH_LAYOUTS[this.props.graphLayout.name])}

--- a/src/components/MetricsOptions/MetricsOptionsBar.tsx
+++ b/src/components/MetricsOptions/MetricsOptionsBar.tsx
@@ -110,7 +110,7 @@ export class MetricsOptionsBar extends React.Component<Props, MetricsOptionsStat
         {this.groupByLabelsHelper.renderDropdown()}
         <ToolbarDropdown
           disabled={false}
-          onClick={this.onDurationChanged}
+          handleSelect={this.onDurationChanged}
           id={'duration'}
           nameDropdown={'Duration'}
           initialValue={Number(sessionStorage.getItem('appDuration')) || MetricsOptionsBar.DefaultDuration}
@@ -123,7 +123,7 @@ export class MetricsOptionsBar extends React.Component<Props, MetricsOptionsStat
         />
         <ToolbarDropdown
           disabled={false}
-          onClick={this.onPollIntervalChanged}
+          handleSelect={this.onPollIntervalChanged}
           nameDropdown={'Pool Interval'}
           initialValue={MetricsOptionsBar.DefaultPollInterval}
           initialLabel={String(MetricsOptionsBar.PollIntervals[MetricsOptionsBar.DefaultPollInterval])}

--- a/src/components/MetricsOptions/__tests__/__snapshots__/MetricsOptionsBar.test.tsx.snap
+++ b/src/components/MetricsOptions/__tests__/__snapshots__/MetricsOptionsBar.test.tsx.snap
@@ -60,11 +60,11 @@ ShallowWrapper {
         </getContext(Filter)>,
         <ToolbarDropdown
           disabled={false}
+          handleSelect={[Function]}
           id="duration"
           initialLabel="Last minute"
           initialValue={60}
           nameDropdown="Duration"
-          onClick={[Function]}
           options={
             Object {
               "10800": "Last 3 hours",
@@ -83,10 +83,10 @@ ShallowWrapper {
         />,
         <ToolbarDropdown
           disabled={false}
+          handleSelect={[Function]}
           initialLabel="5 seconds"
           initialValue={5000}
           nameDropdown="Pool Interval"
-          onClick={[Function]}
           options={
             Object {
               "0": "Pause",
@@ -157,11 +157,11 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "disabled": false,
+          "handleSelect": [Function],
           "id": "duration",
           "initialLabel": "Last minute",
           "initialValue": 60,
           "nameDropdown": "Duration",
-          "onClick": [Function],
           "options": Object {
             "10800": "Last 3 hours",
             "1800": "Last 30 minutes",
@@ -186,10 +186,10 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "disabled": false,
+          "handleSelect": [Function],
           "initialLabel": "5 seconds",
           "initialValue": 5000,
           "nameDropdown": "Pool Interval",
-          "onClick": [Function],
           "options": Object {
             "0": "Pause",
             "10000": "10 seconds",
@@ -245,11 +245,11 @@ ShallowWrapper {
           </getContext(Filter)>,
           <ToolbarDropdown
             disabled={false}
+            handleSelect={[Function]}
             id="duration"
             initialLabel="Last minute"
             initialValue={60}
             nameDropdown="Duration"
-            onClick={[Function]}
             options={
               Object {
                 "10800": "Last 3 hours",
@@ -268,10 +268,10 @@ ShallowWrapper {
           />,
           <ToolbarDropdown
             disabled={false}
+            handleSelect={[Function]}
             initialLabel="5 seconds"
             initialValue={5000}
             nameDropdown="Pool Interval"
-            onClick={[Function]}
             options={
               Object {
                 "0": "Pause",
@@ -342,11 +342,11 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "disabled": false,
+            "handleSelect": [Function],
             "id": "duration",
             "initialLabel": "Last minute",
             "initialValue": 60,
             "nameDropdown": "Duration",
-            "onClick": [Function],
             "options": Object {
               "10800": "Last 3 hours",
               "1800": "Last 30 minutes",
@@ -371,10 +371,10 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "disabled": false,
+            "handleSelect": [Function],
             "initialLabel": "5 seconds",
             "initialValue": 5000,
             "nameDropdown": "Pool Interval",
-            "onClick": [Function],
             "options": Object {
               "0": "Pause",
               "10000": "10 seconds",

--- a/src/components/ToolbarDropdown/ToolbarDropdown.tsx
+++ b/src/components/ToolbarDropdown/ToolbarDropdown.tsx
@@ -8,7 +8,7 @@ type ToolbarDropdownProps = {
   nameDropdown?: string;
   initialValue: number | string;
   initialLabel: string | undefined;
-  onClick: PropTypes.func;
+  handleSelect: PropTypes.func;
   options: PropTypes.Map<string | number, string>;
 };
 
@@ -28,7 +28,7 @@ export class ToolbarDropdown extends React.Component<ToolbarDropdownProps, Toolb
 
   onKeyChanged = (key: any) => {
     this.setState({ currentValue: key, currentName: this.props.options[key] });
-    this.props.onClick(key);
+    this.props.handleSelect(key);
   };
 
   render() {


### PR DESCRIPTION
There is a bug when you click the dropdown....it's loading the graph/metrics, this is because I propaged this.props to the select component so when you do the action onClick, this trigger the action.

## Before
![before_onclick](https://user-images.githubusercontent.com/3019213/39422666-a20d5aba-4c6e-11e8-93b1-1a56cffe93fc.gif)

## After
![after_onclick](https://user-images.githubusercontent.com/3019213/39422673-a8170316-4c6e-11e8-8bd9-e84c6a5d2bb2.gif)
