### PR TITLE
KIALI-629 Use the ACE editor on Services Istio objects

### DIFF
--- a/src/pages/IstioRuleDetails/IstioRuleInfo.tsx
+++ b/src/pages/IstioRuleDetails/IstioRuleInfo.tsx
@@ -72,19 +72,62 @@ class IstioRuleInfo extends React.Component<RuleDetailsId, RuleInfoState> {
       });
   }
 
+  // Handlers and Instances have a type attached to the name with '.'
+  // i.e. handler=myhandler.kubernetes
+  validateParams(parsed: ParsedSearch): boolean {
+    if (!parsed.type || !parsed.name || this.state.actions.length === 0) {
+      return false;
+    }
+    let validationType = ['handler', 'instance'];
+    if (parsed.type && validationType.indexOf(parsed.type) < 0) {
+      return false;
+    }
+    for (let i = 0; i < this.state.actions.length; i++) {
+      let splitName = parsed.name.split('.');
+      if (splitName.length !== 2) {
+        continue;
+      }
+      // i.e. handler=myhandler.kubernetes
+      // innerName == myhandler
+      // innerType == kubernetes
+      let innerName = splitName[0];
+      let innerType = splitName[1];
+      if (
+        parsed.type === 'handler' &&
+        this.state.actions[i].handler.name === innerName &&
+        this.state.actions[i].handler.adapter === innerType
+      ) {
+        return true;
+      }
+      if (parsed.type === 'instance') {
+        for (let j = 0; j < this.state.actions[i].instances.length; j++) {
+          if (
+            this.state.actions[i].instances[j].name === innerName &&
+            this.state.actions[i].instances[j].template === innerType
+          ) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  }
+
   // Helper method to extract search urls with format
-  // ?handler=name or ?instance=name
+  // ?handler=name.handlertype or ?instance=name.instancetype
   // Those url are expected to be received on this page.
   parseSearch(): ParsedSearch {
+    let parsed: ParsedSearch = {};
     if (this.props.search) {
       let firstParams = this.props.search
         .split('&')[0]
         .replace('?', '')
         .split('=');
-      return {
-        type: firstParams[0],
-        name: firstParams[1]
-      };
+      parsed.type = firstParams[0];
+      parsed.name = firstParams[1];
+    }
+    if (this.validateParams(parsed)) {
+      return parsed;
     }
     if (this.state.actions.length > 0) {
       let defaultAction = this.state.actions[0];
@@ -95,7 +138,7 @@ class IstioRuleInfo extends React.Component<RuleDetailsId, RuleInfoState> {
         };
       }
     }
-    return {};
+    return parsed;
   }
 
   editorContent(parsedSearch: ParsedSearch) {

--- a/src/pages/IstioRuleDetails/IstioRuleInfo.tsx
+++ b/src/pages/IstioRuleDetails/IstioRuleInfo.tsx
@@ -82,16 +82,17 @@ class IstioRuleInfo extends React.Component<RuleDetailsId, RuleInfoState> {
     if (parsed.type && validationType.indexOf(parsed.type) < 0) {
       return false;
     }
+    let splitName = parsed.name.split('.');
+    if (splitName.length !== 2) {
+      return false;
+    }
+    // i.e. handler=myhandler.kubernetes
+    // innerName == myhandler
+    // innerType == kubernetes
+    let innerName = splitName[0];
+    let innerType = splitName[1];
+
     for (let i = 0; i < this.state.actions.length; i++) {
-      let splitName = parsed.name.split('.');
-      if (splitName.length !== 2) {
-        continue;
-      }
-      // i.e. handler=myhandler.kubernetes
-      // innerName == myhandler
-      // innerType == kubernetes
-      let innerName = splitName[0];
-      let innerType = splitName[1];
       if (
         parsed.type === 'handler' &&
         this.state.actions[i].handler.name === innerName &&

--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Link, RouteComponentProps } from 'react-router-dom';
+import { Col, Row } from 'patternfly-react';
 import ServiceInfo from './ServiceInfo';
 import ServiceMetrics from './ServiceMetrics';
 import ServiceId from '../../types/ServiceId';
@@ -15,11 +16,35 @@ import {
 import { NamespaceFilterSelected } from '../../components/NamespaceFilter/NamespaceFilter';
 import { ActiveFilter } from '../../types/NamespaceFilter';
 import * as API from '../../services/Api';
+import { hasIstioSidecar, ServiceDetailsInfo } from '../../types/ServiceInfo';
+import AceEditor, { AceOptions } from 'react-ace';
+import 'brace/mode/yaml';
+import 'brace/theme/eclipse';
+
+const yaml = require('js-yaml');
 
 type ServiceDetailsState = {
   jaegerUri: string;
+  serviceDetailsInfo: ServiceDetailsInfo;
   error: boolean;
   errorMessage: string;
+};
+
+interface ParsedSearch {
+  type?: string;
+  name?: string;
+}
+
+const aceOptions: AceOptions = {
+  readOnly: true,
+  showPrintMargin: false,
+  autoScrollEditorIntoView: true
+};
+
+const safeDumpOptions = {
+  styles: {
+    '!!null': 'canonical' // dump null as ~
+  }
 };
 
 class ServiceDetails extends React.Component<RouteComponentProps<ServiceId>, ServiceDetailsState> {
@@ -27,10 +52,19 @@ class ServiceDetails extends React.Component<RouteComponentProps<ServiceId>, Ser
     super(props);
     this.state = {
       jaegerUri: '',
+      serviceDetailsInfo: {
+        type: '',
+        name: '',
+        created_at: '',
+        istio_sidecar: false,
+        resource_version: '',
+        ip: ''
+      },
       error: false,
       errorMessage: ''
     };
   }
+
   updateFilter = () => {
     let activeFilter: ActiveFilter = {
       label: 'Namespace: ' + this.props.match.params.namespace,
@@ -39,6 +73,113 @@ class ServiceDetails extends React.Component<RouteComponentProps<ServiceId>, Ser
     };
     NamespaceFilterSelected.setSelected([activeFilter]);
   };
+
+  parseServiceDetailsInfo = data => {
+    let parsed: ServiceDetailsInfo = {
+      labels: data.labels,
+      name: data.name,
+      created_at: data.created_at,
+      resource_version: data.resource_version,
+      type: data.type,
+      ports: data.ports,
+      endpoints: data.endpoints,
+      istio_sidecar: hasIstioSidecar(data.deployments),
+      deployments: data.deployments,
+      dependencies: data.dependencies,
+      routeRules: data.route_rules,
+      destinationPolicies: data.destination_policies,
+      virtualServices: data.virtual_services,
+      destinationRules: data.destination_rules,
+      ip: data.ip,
+      health: data.health
+    };
+    return parsed;
+  };
+
+  validateParams(parsed: ParsedSearch): boolean {
+    if (!parsed.type || !parsed.name) {
+      return false;
+    }
+    // Check we have the right parameter
+    let validateTypes = ['routerule', 'destinationpolicy', 'virtualservice', 'destinationrule'];
+    if (parsed.type && validateTypes.indexOf(parsed.type) < 0) {
+      return false;
+    }
+    if (parsed.type === 'routerule' && this.state.serviceDetailsInfo.routeRules) {
+      for (let i = 0; i < this.state.serviceDetailsInfo.routeRules.length; i++) {
+        if (parsed.name === this.state.serviceDetailsInfo.routeRules[i].name) {
+          return true;
+        }
+      }
+    } else if (parsed.type === 'destinationpolicy' && this.state.serviceDetailsInfo.destinationPolicies) {
+      for (let i = 0; i < this.state.serviceDetailsInfo.destinationPolicies.length; i++) {
+        if (parsed.name === this.state.serviceDetailsInfo.destinationPolicies[i].name) {
+          return true;
+        }
+      }
+    } else if (parsed.type === 'virtualservice' && this.state.serviceDetailsInfo.virtualServices) {
+      for (let i = 0; i < this.state.serviceDetailsInfo.virtualServices.length; i++) {
+        if (parsed.name === this.state.serviceDetailsInfo.virtualServices[i].name) {
+          return true;
+        }
+      }
+    } else if (parsed.type === 'destinationrule' && this.state.serviceDetailsInfo.destinationRules) {
+      for (let i = 0; i < this.state.serviceDetailsInfo.destinationRules.length; i++) {
+        if (parsed.name === this.state.serviceDetailsInfo.destinationRules[i].name) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  // Helper method to extract search urls with format
+  // ?routerule=name or ?destinationpolicy=name or ?virtualservice=name or ?destinationrule=name
+  parseSearch(): ParsedSearch {
+    let parsed: ParsedSearch = {};
+    if (this.props.location.search) {
+      let firstParams = this.props.location.search
+        .split('&')[0]
+        .replace('?', '')
+        .split('=');
+      parsed.type = firstParams[0];
+      parsed.name = firstParams[1];
+    }
+    if (this.validateParams(parsed)) {
+      return parsed;
+    }
+    return {};
+  }
+
+  editorContent(parsed: ParsedSearch) {
+    if (parsed.type === 'routerule' && this.state.serviceDetailsInfo.routeRules) {
+      for (let i = 0; i < this.state.serviceDetailsInfo.routeRules.length; i++) {
+        if (parsed.name === this.state.serviceDetailsInfo.routeRules[i].name) {
+          return yaml.safeDump(this.state.serviceDetailsInfo.routeRules[i], safeDumpOptions);
+        }
+      }
+    } else if (parsed.type === 'destinationpolicy' && this.state.serviceDetailsInfo.destinationPolicies) {
+      for (let i = 0; i < this.state.serviceDetailsInfo.destinationPolicies.length; i++) {
+        if (parsed.name === this.state.serviceDetailsInfo.destinationPolicies[i].name) {
+          return yaml.safeDump(this.state.serviceDetailsInfo.destinationPolicies[i], safeDumpOptions);
+        }
+      }
+    } else if (parsed.type === 'virtualservice' && this.state.serviceDetailsInfo.virtualServices) {
+      for (let i = 0; i < this.state.serviceDetailsInfo.virtualServices.length; i++) {
+        if (parsed.name === this.state.serviceDetailsInfo.virtualServices[i].name) {
+          return yaml.safeDump(this.state.serviceDetailsInfo.virtualServices[i], safeDumpOptions);
+        }
+      }
+    } else if (parsed.type === 'destinationrule' && this.state.serviceDetailsInfo.destinationRules) {
+      for (let i = 0; i < this.state.serviceDetailsInfo.destinationRules.length; i++) {
+        if (parsed.name === this.state.serviceDetailsInfo.destinationRules[i].name) {
+          return yaml.safeDump(this.state.serviceDetailsInfo.destinationRules[i], safeDumpOptions);
+        }
+      }
+    }
+    return '';
+  }
+
   componentDidMount() {
     API.getJaegerInfo()
       .then(response => {
@@ -53,9 +194,26 @@ class ServiceDetails extends React.Component<RouteComponentProps<ServiceId>, Ser
         });
         console.log(error);
       });
+    API.getServiceDetail(this.props.match.params.namespace, this.props.match.params.service)
+      .then(response => {
+        let data = response['data'];
+        this.setState({
+          serviceDetailsInfo: this.parseServiceDetailsInfo(data)
+        });
+      })
+      .catch(error => {
+        this.setState({
+          error: true,
+          errorMessage: API.getErrorMsg('Could not fetch Service Details.', error)
+        });
+        console.log(error);
+      });
   }
 
   render() {
+    let parsedSearch = this.parseSearch();
+    let editorVisible = parsedSearch.name && parsedSearch.type;
+    let to = '/namespaces/' + this.props.match.params.namespace + '/services/' + this.props.match.params.service;
     return (
       <div className="container-fluid container-pf-nav-pf-vertical">
         {this.state.error ? (
@@ -74,37 +232,68 @@ class ServiceDetails extends React.Component<RouteComponentProps<ServiceId>, Ser
             <Link to="/services" onClick={this.updateFilter}>
               {this.props.match.params.namespace}
             </Link>{' '}
-            / {this.props.match.params.service}
+            /
+            {editorVisible ? (
+              <span>
+                <Link to={to}>{' ' + this.props.match.params.service}</Link> / {parsedSearch.type}
+              </span>
+            ) : (
+              <span>{' ' + this.props.match.params.service}</span>
+            )}
           </h2>
         </div>
-        <TabContainer id="basic-tabs" defaultActiveKey={1}>
-          <div>
-            <Nav bsClass="nav nav-tabs nav-tabs-pf">
-              <NavItem eventKey={1}>
-                <div dangerouslySetInnerHTML={{ __html: 'Info' }} />
-              </NavItem>
-              <NavItem eventKey={2}>
-                <div dangerouslySetInnerHTML={{ __html: 'Metrics' }} />
-              </NavItem>
-              <li role="presentation">
-                <a href={this.state.jaegerUri} target="_blank">
-                  <div dangerouslySetInnerHTML={{ __html: 'Traces' }} />
-                </a>
-              </li>
-            </Nav>
-            <TabContent>
-              <TabPane eventKey={1}>
-                <ServiceInfo namespace={this.props.match.params.namespace} service={this.props.match.params.service} />
-              </TabPane>
-              <TabPane eventKey={2} mountOnEnter={true} unmountOnExit={true}>
-                <ServiceMetrics
-                  namespace={this.props.match.params.namespace}
-                  service={this.props.match.params.service}
+        {editorVisible ? (
+          <div className="container-fluid container-cards-pf">
+            <Row className="row-cards-pf">
+              <Col>
+                <h1>{parsedSearch.type + ': ' + parsedSearch.name}</h1>
+                <AceEditor
+                  mode="yaml"
+                  theme="eclipse"
+                  readOnly={true}
+                  width={'100%'}
+                  height={'50vh'}
+                  className={'istio-ace-editor'}
+                  setOptions={aceOptions}
+                  value={this.editorContent(parsedSearch)}
                 />
-              </TabPane>
-            </TabContent>
+              </Col>
+            </Row>
           </div>
-        </TabContainer>
+        ) : (
+          <TabContainer id="basic-tabs" defaultActiveKey={1}>
+            <div>
+              <Nav bsClass="nav nav-tabs nav-tabs-pf">
+                <NavItem eventKey={1}>
+                  <div dangerouslySetInnerHTML={{ __html: 'Info' }} />
+                </NavItem>
+                <NavItem eventKey={2}>
+                  <div dangerouslySetInnerHTML={{ __html: 'Metrics' }} />
+                </NavItem>
+                <li role="presentation">
+                  <a href={this.state.jaegerUri} target="_blank">
+                    <div dangerouslySetInnerHTML={{ __html: 'Traces' }} />
+                  </a>
+                </li>
+              </Nav>
+              <TabContent>
+                <TabPane eventKey={1}>
+                  <ServiceInfo
+                    namespace={this.props.match.params.namespace}
+                    service={this.props.match.params.service}
+                    serviceDetails={this.state.serviceDetailsInfo}
+                  />
+                </TabPane>
+                <TabPane eventKey={2} mountOnEnter={true} unmountOnExit={true}>
+                  <ServiceMetrics
+                    namespace={this.props.match.params.namespace}
+                    service={this.props.match.params.service}
+                  />
+                </TabPane>
+              </TabContent>
+            </div>
+          </TabContainer>
+        )}
       </div>
     );
   }

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDestinationPolicies.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDestinationPolicies.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { Col, Row } from 'patternfly-react';
-import { DestinationPolicy } from '../../../types/ServiceInfo';
+import { DestinationPolicy, EditorLink } from '../../../types/ServiceInfo';
 import LocalTime from '../../../components/Time/LocalTime';
 import DetailObject from '../../../components/Details/DetailObject';
+import { Link } from 'react-router-dom';
 
-interface ServiceInfoDestinationPoliciesProps {
+interface ServiceInfoDestinationPoliciesProps extends EditorLink {
   destinationPolicies?: DestinationPolicy[];
 }
 
@@ -24,7 +25,7 @@ class ServiceInfoDestinationPolicies extends React.Component<ServiceInfoDestinat
                   <div>
                     <strong>Name</strong>
                     {': '}
-                    {dPolicy.name}
+                    <Link to={this.props.editorLink + '?destinationpolicy=' + dPolicy.name}>{dPolicy.name}</Link>
                   </div>
                   <div>
                     <strong>Created at</strong>

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDestinationRules.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDestinationRules.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
-import { DestinationRule } from '../../../types/ServiceInfo';
+import { DestinationRule, EditorLink } from '../../../types/ServiceInfo';
 import { Col, Row } from 'patternfly-react';
 import LocalTime from '../../../components/Time/LocalTime';
 import DetailObject from '../../../components/Details/DetailObject';
+import { Link } from 'react-router-dom';
 
-interface ServiceInfoDestinationRulesProps {
+interface ServiceInfoDestinationRulesProps extends EditorLink {
   destinationRules?: DestinationRule[];
 }
 
@@ -21,7 +22,10 @@ class ServiceInfoDestinationRules extends React.Component<ServiceInfoDestination
             {(this.props.destinationRules || []).map((destinationRule, i) => (
               <div className="card-pf-body" key={'virtualService' + i}>
                 <div>
-                  <strong>Name</strong>: {destinationRule.name}
+                  <strong>Name</strong>:{' '}
+                  <Link to={this.props.editorLink + '?destinationrule=' + destinationRule.name}>
+                    {destinationRule.name}
+                  </Link>
                 </div>
                 <div>
                   <strong>Created at</strong>: <LocalTime time={destinationRule.created_at} />

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoRouteRules.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoRouteRules.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { Col, Row } from 'patternfly-react';
-import { RouteRule } from '../../../types/ServiceInfo';
+import { EditorLink, RouteRule } from '../../../types/ServiceInfo';
 import LocalTime from '../../../components/Time/LocalTime';
 import RouteRuleRoute from './ServiceInfoRouteRules/RouteRuleRoute';
 import DetailObject from '../../../components/Details/DetailObject';
+import { Link } from 'react-router-dom';
 
-interface ServiceInfoRouteRulesProps {
+interface ServiceInfoRouteRulesProps extends EditorLink {
   routeRules?: RouteRule[];
 }
 
@@ -22,7 +23,7 @@ class ServiceInfoRouteRules extends React.Component<ServiceInfoRouteRulesProps> 
             {(this.props.routeRules || []).map((rule, i) => (
               <div className="card-pf-body" key={'rule' + i}>
                 <div>
-                  <strong>Name</strong>: {rule.name}
+                  <strong>Name</strong>: <Link to={this.props.editorLink + '?routerule=' + rule.name}>{rule.name}</Link>
                 </div>
                 <div>
                   <strong>Created at</strong>: <LocalTime time={rule.created_at} />

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoVirtualServices.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoVirtualServices.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { Col, Row } from 'patternfly-react';
-import { VirtualService } from '../../../types/ServiceInfo';
+import { EditorLink, VirtualService } from '../../../types/ServiceInfo';
 import LocalTime from '../../../components/Time/LocalTime';
 import DetailObject from '../../../components/Details/DetailObject';
+import { Link } from 'react-router-dom';
 
-interface ServiceInfoVirtualServicesProps {
+interface ServiceInfoVirtualServicesProps extends EditorLink {
   virtualServices?: VirtualService[];
 }
 
@@ -21,7 +22,10 @@ class ServiceInfoVirtualServices extends React.Component<ServiceInfoVirtualServi
             {(this.props.virtualServices || []).map((virtualService, i) => (
               <div className="card-pf-body" key={'virtualService' + i}>
                 <div>
-                  <strong>Name</strong>: {virtualService.name}
+                  <strong>Name</strong>:{' '}
+                  <Link to={this.props.editorLink + '?virtualservice=' + virtualService.name}>
+                    {virtualService.name}
+                  </Link>
                 </div>
                 <div>
                   <strong>Created at</strong>: <LocalTime time={virtualService.created_at} />

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/ServiceInfoRouteRules.test.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/ServiceInfoRouteRules.test.tsx
@@ -38,7 +38,9 @@ const rules: RouteRule[] = [
 
 describe('#ServiceInfoRouteRules render correctly with data', () => {
   it('should render service rules', () => {
-    const wrapper = shallow(<ServiceInfoRouteRules routeRules={rules} />);
+    const wrapper = shallow(
+      <ServiceInfoRouteRules routeRules={rules} editorLink={'/namespaces/test_namespace/services/test_services'} />
+    );
     expect(wrapper).toBeDefined();
     expect(wrapper).toMatchSnapshot();
   });

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoRouteRules.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoRouteRules.test.tsx.snap
@@ -5,6 +5,7 @@ ShallowWrapper {
   "length": 1,
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <ServiceInfoRouteRules
+    editorLink="/namespaces/test_namespace/services/test_services"
     routeRules={
       Array [
         Object {
@@ -77,7 +78,12 @@ ShallowWrapper {
                 Name
               </strong>
               : 
-              reviews-default
+              <Link
+                replace={false}
+                to="/namespaces/test_namespace/services/test_services?routerule=reviews-default"
+              >
+                reviews-default
+              </Link>
             </div>
             <div>
               <strong>
@@ -123,7 +129,12 @@ ShallowWrapper {
                 Name
               </strong>
               : 
-              reviews-test-v2
+              <Link
+                replace={false}
+                to="/namespaces/test_namespace/services/test_services?routerule=reviews-test-v2"
+              >
+                reviews-test-v2
+              </Link>
             </div>
             <div>
               <strong>
@@ -188,7 +199,12 @@ ShallowWrapper {
                 Name
               </strong>
               : 
-              reviews-default
+              <Link
+                replace={false}
+                to="/namespaces/test_namespace/services/test_services?routerule=reviews-default"
+              >
+                reviews-default
+              </Link>
             </div>
             <div>
               <strong>
@@ -234,7 +250,12 @@ ShallowWrapper {
                 Name
               </strong>
               : 
-              reviews-test-v2
+              <Link
+                replace={false}
+                to="/namespaces/test_namespace/services/test_services?routerule=reviews-test-v2"
+              >
+                reviews-test-v2
+              </Link>
             </div>
             <div>
               <strong>
@@ -292,7 +313,12 @@ ShallowWrapper {
                   Name
                 </strong>
                 : 
-                reviews-default
+                <Link
+                  replace={false}
+                  to="/namespaces/test_namespace/services/test_services?routerule=reviews-default"
+                >
+                  reviews-default
+                </Link>
               </div>
               <div>
                 <strong>
@@ -338,7 +364,12 @@ ShallowWrapper {
                   Name
                 </strong>
                 : 
-                reviews-test-v2
+                <Link
+                  replace={false}
+                  to="/namespaces/test_namespace/services/test_services?routerule=reviews-test-v2"
+                >
+                  reviews-test-v2
+                </Link>
               </div>
               <div>
                 <strong>
@@ -396,7 +427,12 @@ ShallowWrapper {
                     Name
                   </strong>
                   : 
-                  reviews-default
+                  <Link
+                    replace={false}
+                    to="/namespaces/test_namespace/services/test_services?routerule=reviews-default"
+                  >
+                    reviews-default
+                  </Link>
                 </div>,
                 <div>
                   <strong>
@@ -457,7 +493,12 @@ ShallowWrapper {
                       Name
                     </strong>,
                     ": ",
-                    "reviews-default",
+                    <Link
+                      replace={false}
+                      to="/namespaces/test_namespace/services/test_services?routerule=reviews-default"
+                    >
+                      reviews-default
+                    </Link>,
                   ],
                 },
                 "ref": null,
@@ -474,7 +515,19 @@ ShallowWrapper {
                     "type": "strong",
                   },
                   ": ",
-                  "reviews-default",
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "class",
+                    "props": Object {
+                      "children": "reviews-default",
+                      "replace": false,
+                      "to": "/namespaces/test_namespace/services/test_services?routerule=reviews-default",
+                    },
+                    "ref": null,
+                    "rendered": "reviews-default",
+                    "type": [Function],
+                  },
                 ],
                 "type": "div",
               },
@@ -632,7 +685,12 @@ ShallowWrapper {
                     Name
                   </strong>
                   : 
-                  reviews-test-v2
+                  <Link
+                    replace={false}
+                    to="/namespaces/test_namespace/services/test_services?routerule=reviews-test-v2"
+                  >
+                    reviews-test-v2
+                  </Link>
                 </div>,
                 <div>
                   <strong>
@@ -693,7 +751,12 @@ ShallowWrapper {
                       Name
                     </strong>,
                     ": ",
-                    "reviews-test-v2",
+                    <Link
+                      replace={false}
+                      to="/namespaces/test_namespace/services/test_services?routerule=reviews-test-v2"
+                    >
+                      reviews-test-v2
+                    </Link>,
                   ],
                 },
                 "ref": null,
@@ -710,7 +773,19 @@ ShallowWrapper {
                     "type": "strong",
                   },
                   ": ",
-                  "reviews-test-v2",
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "class",
+                    "props": Object {
+                      "children": "reviews-test-v2",
+                      "replace": false,
+                      "to": "/namespaces/test_namespace/services/test_services?routerule=reviews-test-v2",
+                    },
+                    "ref": null,
+                    "rendered": "reviews-test-v2",
+                    "type": [Function],
+                  },
                 ],
                 "type": "div",
               },
@@ -891,7 +966,12 @@ ShallowWrapper {
                   Name
                 </strong>
                 : 
-                reviews-default
+                <Link
+                  replace={false}
+                  to="/namespaces/test_namespace/services/test_services?routerule=reviews-default"
+                >
+                  reviews-default
+                </Link>
               </div>
               <div>
                 <strong>
@@ -937,7 +1017,12 @@ ShallowWrapper {
                   Name
                 </strong>
                 : 
-                reviews-test-v2
+                <Link
+                  replace={false}
+                  to="/namespaces/test_namespace/services/test_services?routerule=reviews-test-v2"
+                >
+                  reviews-test-v2
+                </Link>
               </div>
               <div>
                 <strong>
@@ -1002,7 +1087,12 @@ ShallowWrapper {
                   Name
                 </strong>
                 : 
-                reviews-default
+                <Link
+                  replace={false}
+                  to="/namespaces/test_namespace/services/test_services?routerule=reviews-default"
+                >
+                  reviews-default
+                </Link>
               </div>
               <div>
                 <strong>
@@ -1048,7 +1138,12 @@ ShallowWrapper {
                   Name
                 </strong>
                 : 
-                reviews-test-v2
+                <Link
+                  replace={false}
+                  to="/namespaces/test_namespace/services/test_services?routerule=reviews-test-v2"
+                >
+                  reviews-test-v2
+                </Link>
               </div>
               <div>
                 <strong>
@@ -1106,7 +1201,12 @@ ShallowWrapper {
                     Name
                   </strong>
                   : 
-                  reviews-default
+                  <Link
+                    replace={false}
+                    to="/namespaces/test_namespace/services/test_services?routerule=reviews-default"
+                  >
+                    reviews-default
+                  </Link>
                 </div>
                 <div>
                   <strong>
@@ -1152,7 +1252,12 @@ ShallowWrapper {
                     Name
                   </strong>
                   : 
-                  reviews-test-v2
+                  <Link
+                    replace={false}
+                    to="/namespaces/test_namespace/services/test_services?routerule=reviews-test-v2"
+                  >
+                    reviews-test-v2
+                  </Link>
                 </div>
                 <div>
                   <strong>
@@ -1210,7 +1315,12 @@ ShallowWrapper {
                       Name
                     </strong>
                     : 
-                    reviews-default
+                    <Link
+                      replace={false}
+                      to="/namespaces/test_namespace/services/test_services?routerule=reviews-default"
+                    >
+                      reviews-default
+                    </Link>
                   </div>,
                   <div>
                     <strong>
@@ -1271,7 +1381,12 @@ ShallowWrapper {
                         Name
                       </strong>,
                       ": ",
-                      "reviews-default",
+                      <Link
+                        replace={false}
+                        to="/namespaces/test_namespace/services/test_services?routerule=reviews-default"
+                      >
+                        reviews-default
+                      </Link>,
                     ],
                   },
                   "ref": null,
@@ -1288,7 +1403,19 @@ ShallowWrapper {
                       "type": "strong",
                     },
                     ": ",
-                    "reviews-default",
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "class",
+                      "props": Object {
+                        "children": "reviews-default",
+                        "replace": false,
+                        "to": "/namespaces/test_namespace/services/test_services?routerule=reviews-default",
+                      },
+                      "ref": null,
+                      "rendered": "reviews-default",
+                      "type": [Function],
+                    },
                   ],
                   "type": "div",
                 },
@@ -1446,7 +1573,12 @@ ShallowWrapper {
                       Name
                     </strong>
                     : 
-                    reviews-test-v2
+                    <Link
+                      replace={false}
+                      to="/namespaces/test_namespace/services/test_services?routerule=reviews-test-v2"
+                    >
+                      reviews-test-v2
+                    </Link>
                   </div>,
                   <div>
                     <strong>
@@ -1507,7 +1639,12 @@ ShallowWrapper {
                         Name
                       </strong>,
                       ": ",
-                      "reviews-test-v2",
+                      <Link
+                        replace={false}
+                        to="/namespaces/test_namespace/services/test_services?routerule=reviews-test-v2"
+                      >
+                        reviews-test-v2
+                      </Link>,
                     ],
                   },
                   "ref": null,
@@ -1524,7 +1661,19 @@ ShallowWrapper {
                       "type": "strong",
                     },
                     ": ",
-                    "reviews-test-v2",
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "class",
+                      "props": Object {
+                        "children": "reviews-test-v2",
+                        "replace": false,
+                        "to": "/namespaces/test_namespace/services/test_services?routerule=reviews-test-v2",
+                      },
+                      "ref": null,
+                      "rendered": "reviews-test-v2",
+                      "type": [Function],
+                    },
                   ],
                   "type": "div",
                 },

--- a/src/pages/ServiceDetails/__tests__/ServiceInfo.test.tsx
+++ b/src/pages/ServiceDetails/__tests__/ServiceInfo.test.tsx
@@ -1,30 +1,21 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import ServiceInfo from '../ServiceInfo';
-import { hasIstioSidecar } from '../../../types/ServiceInfo';
+import { hasIstioSidecar, ServiceDetailsInfo } from '../../../types/ServiceInfo';
 
 jest.mock('../../../services/Api');
 
 const API = require('../../../services/Api');
 
 describe('#ServiceInfo render correctly with data', () => {
-  it('should render serviceInfo', () => {
-    const wrapper = shallow(<ServiceInfo namespace="istio-system" service="reviews" />);
-    expect(wrapper).toBeDefined();
-    expect(wrapper).toMatchSnapshot();
-    expect(wrapper.find('ServiceInfoDescription').length === 1).toBeTruthy();
-    expect(wrapper.find('ServiceInfoDeployments').length === 1).toBeFalsy();
-    expect(wrapper.find('ServiceInfoRoutes').length === 1).toBeFalsy();
-    expect(wrapper.find('ServiceInfoRouteRules').length === 1).toBeFalsy();
-    expect(wrapper.find('ServiceInfoDestinationPolicies').length === 1).toBeFalsy();
-  });
-
   it('should render serviceInfo with data', () => {
     return API.getServiceDetail('istio-system', 'reviews').then(response => {
       let data = response;
-      const wrapper = shallow(<ServiceInfo namespace="istio-system" service="reviews" />).setState({
+      let serviceDetailsInfo: ServiceDetailsInfo = {
         labels: data.labels,
         name: data.name,
+        created_at: data.created_at,
+        resource_version: data.resource_version,
         type: data.type,
         ports: data.ports,
         endpoints: data.endpoints,
@@ -33,9 +24,14 @@ describe('#ServiceInfo render correctly with data', () => {
         dependencies: data.dependencies,
         routeRules: data.route_rules,
         destinationPolicies: data.destination_policies,
+        virtualServices: data.virtual_services,
+        destinationRules: data.destination_rules,
         ip: data.ip,
         health: data.health
-      });
+      };
+      const wrapper = shallow(
+        <ServiceInfo namespace="istio-system" service="reviews" serviceDetails={serviceDetailsInfo} />
+      );
       expect(wrapper).toBeDefined();
       expect(wrapper).toMatchSnapshot();
       expect(wrapper.find('ServiceInfoDescription').length === 1).toBeTruthy();

--- a/src/pages/ServiceDetails/__tests__/__snapshots__/ServiceInfo.test.tsx.snap
+++ b/src/pages/ServiceDetails/__tests__/__snapshots__/ServiceInfo.test.tsx.snap
@@ -1,2118 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`#ServiceInfo render correctly with data should render serviceInfo 1`] = `
-ShallowWrapper {
-  "length": 1,
-  Symbol(enzyme.__root__): [Circular],
-  Symbol(enzyme.__unrendered__): <ServiceInfo
-    namespace="istio-system"
-    service="reviews"
-  />,
-  Symbol(enzyme.__renderer__): Object {
-    "batchedUpdates": [Function],
-    "getNode": [Function],
-    "render": [Function],
-    "simulateEvent": [Function],
-    "unmount": [Function],
-  },
-  Symbol(enzyme.__node__): Object {
-    "instance": null,
-    "key": undefined,
-    "nodeType": "host",
-    "props": Object {
-      "children": Array [
-        null,
-        <div
-          className="container-fluid container-cards-pf"
-        >
-          <Row
-            bsClass="row"
-            className="row-cards-pf"
-            componentClass="div"
-          >
-            <Col
-              bsClass="col"
-              componentClass="div"
-              lg={12}
-              md={12}
-              sm={12}
-              xs={12}
-            >
-              <ServiceInfoDescription
-                created_at=""
-                endpoints={undefined}
-                health={undefined}
-                ip=""
-                istio_sidecar={false}
-                labels={Map {}}
-                name=""
-                ports={Array []}
-                resource_version=""
-                type=""
-              />
-            </Col>
-          </Row>
-          <Row
-            bsClass="row"
-            className="row-cards-pf"
-            componentClass="div"
-          >
-            <Col
-              bsClass="col"
-              componentClass="div"
-              lg={12}
-              md={12}
-              sm={12}
-              xs={12}
-            >
-              <Uncontrolled(TabContainer)
-                defaultActiveKey={1}
-                id="service-tabs"
-              >
-                <div>
-                  <Nav
-                    bsClass="nav nav-tabs nav-tabs-pf"
-                    justified={false}
-                    pullLeft={false}
-                    pullRight={false}
-                    stacked={false}
-                  >
-                    <NavItem
-                      active={false}
-                      disabled={false}
-                      eventKey={1}
-                    >
-                      Deployments (0)
-                    </NavItem>
-                    <NavItem
-                      active={false}
-                      disabled={false}
-                      eventKey={2}
-                    >
-                      Source Services (0)
-                    </NavItem>
-                    <NavItem
-                      active={false}
-                      disabled={false}
-                      eventKey={3}
-                    >
-                      Route Rules (0)
-                    </NavItem>
-                    <NavItem
-                      active={false}
-                      disabled={false}
-                      eventKey={4}
-                    >
-                      Destination Policies (0)
-                    </NavItem>
-                    <NavItem
-                      active={false}
-                      disabled={false}
-                      eventKey={5}
-                    >
-                      Virtual Services (0)
-                    </NavItem>
-                    <NavItem
-                      active={false}
-                      disabled={false}
-                      eventKey={6}
-                    >
-                      Destination Rules (0)
-                    </NavItem>
-                  </Nav>
-                  <TabContent
-                    animation={true}
-                    bsClass="tab"
-                    componentClass="div"
-                    mountOnEnter={false}
-                    unmountOnExit={false}
-                  >
-                    <TabPane
-                      bsClass="tab-pane"
-                      eventKey={1}
-                    />
-                    <TabPane
-                      bsClass="tab-pane"
-                      eventKey={2}
-                    />
-                    <TabPane
-                      bsClass="tab-pane"
-                      eventKey={3}
-                    />
-                    <TabPane
-                      bsClass="tab-pane"
-                      eventKey={4}
-                    />
-                    <TabPane
-                      bsClass="tab-pane"
-                      eventKey={5}
-                    />
-                    <TabPane
-                      bsClass="tab-pane"
-                      eventKey={6}
-                    />
-                  </TabContent>
-                </div>
-              </Uncontrolled(TabContainer)>
-            </Col>
-          </Row>
-        </div>,
-      ],
-    },
-    "ref": null,
-    "rendered": Array [
-      null,
-      Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "host",
-        "props": Object {
-          "children": Array [
-            <Row
-              bsClass="row"
-              className="row-cards-pf"
-              componentClass="div"
-            >
-              <Col
-                bsClass="col"
-                componentClass="div"
-                lg={12}
-                md={12}
-                sm={12}
-                xs={12}
-              >
-                <ServiceInfoDescription
-                  created_at=""
-                  endpoints={undefined}
-                  health={undefined}
-                  ip=""
-                  istio_sidecar={false}
-                  labels={Map {}}
-                  name=""
-                  ports={Array []}
-                  resource_version=""
-                  type=""
-                />
-              </Col>
-            </Row>,
-            <Row
-              bsClass="row"
-              className="row-cards-pf"
-              componentClass="div"
-            >
-              <Col
-                bsClass="col"
-                componentClass="div"
-                lg={12}
-                md={12}
-                sm={12}
-                xs={12}
-              >
-                <Uncontrolled(TabContainer)
-                  defaultActiveKey={1}
-                  id="service-tabs"
-                >
-                  <div>
-                    <Nav
-                      bsClass="nav nav-tabs nav-tabs-pf"
-                      justified={false}
-                      pullLeft={false}
-                      pullRight={false}
-                      stacked={false}
-                    >
-                      <NavItem
-                        active={false}
-                        disabled={false}
-                        eventKey={1}
-                      >
-                        Deployments (0)
-                      </NavItem>
-                      <NavItem
-                        active={false}
-                        disabled={false}
-                        eventKey={2}
-                      >
-                        Source Services (0)
-                      </NavItem>
-                      <NavItem
-                        active={false}
-                        disabled={false}
-                        eventKey={3}
-                      >
-                        Route Rules (0)
-                      </NavItem>
-                      <NavItem
-                        active={false}
-                        disabled={false}
-                        eventKey={4}
-                      >
-                        Destination Policies (0)
-                      </NavItem>
-                      <NavItem
-                        active={false}
-                        disabled={false}
-                        eventKey={5}
-                      >
-                        Virtual Services (0)
-                      </NavItem>
-                      <NavItem
-                        active={false}
-                        disabled={false}
-                        eventKey={6}
-                      >
-                        Destination Rules (0)
-                      </NavItem>
-                    </Nav>
-                    <TabContent
-                      animation={true}
-                      bsClass="tab"
-                      componentClass="div"
-                      mountOnEnter={false}
-                      unmountOnExit={false}
-                    >
-                      <TabPane
-                        bsClass="tab-pane"
-                        eventKey={1}
-                      />
-                      <TabPane
-                        bsClass="tab-pane"
-                        eventKey={2}
-                      />
-                      <TabPane
-                        bsClass="tab-pane"
-                        eventKey={3}
-                      />
-                      <TabPane
-                        bsClass="tab-pane"
-                        eventKey={4}
-                      />
-                      <TabPane
-                        bsClass="tab-pane"
-                        eventKey={5}
-                      />
-                      <TabPane
-                        bsClass="tab-pane"
-                        eventKey={6}
-                      />
-                    </TabContent>
-                  </div>
-                </Uncontrolled(TabContainer)>
-              </Col>
-            </Row>,
-          ],
-          "className": "container-fluid container-cards-pf",
-        },
-        "ref": null,
-        "rendered": Array [
-          Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "class",
-            "props": Object {
-              "bsClass": "row",
-              "children": <Col
-                bsClass="col"
-                componentClass="div"
-                lg={12}
-                md={12}
-                sm={12}
-                xs={12}
-              >
-                <ServiceInfoDescription
-                  created_at=""
-                  endpoints={undefined}
-                  health={undefined}
-                  ip=""
-                  istio_sidecar={false}
-                  labels={Map {}}
-                  name=""
-                  ports={Array []}
-                  resource_version=""
-                  type=""
-                />
-              </Col>,
-              "className": "row-cards-pf",
-              "componentClass": "div",
-            },
-            "ref": null,
-            "rendered": Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "class",
-              "props": Object {
-                "bsClass": "col",
-                "children": <ServiceInfoDescription
-                  created_at=""
-                  endpoints={undefined}
-                  health={undefined}
-                  ip=""
-                  istio_sidecar={false}
-                  labels={Map {}}
-                  name=""
-                  ports={Array []}
-                  resource_version=""
-                  type=""
-                />,
-                "componentClass": "div",
-                "lg": 12,
-                "md": 12,
-                "sm": 12,
-                "xs": 12,
-              },
-              "ref": null,
-              "rendered": Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "class",
-                "props": Object {
-                  "created_at": "",
-                  "endpoints": undefined,
-                  "health": undefined,
-                  "ip": "",
-                  "istio_sidecar": false,
-                  "labels": Map {},
-                  "name": "",
-                  "ports": Array [],
-                  "resource_version": "",
-                  "type": "",
-                },
-                "ref": null,
-                "rendered": null,
-                "type": [Function],
-              },
-              "type": [Function],
-            },
-            "type": [Function],
-          },
-          Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "class",
-            "props": Object {
-              "bsClass": "row",
-              "children": <Col
-                bsClass="col"
-                componentClass="div"
-                lg={12}
-                md={12}
-                sm={12}
-                xs={12}
-              >
-                <Uncontrolled(TabContainer)
-                  defaultActiveKey={1}
-                  id="service-tabs"
-                >
-                  <div>
-                    <Nav
-                      bsClass="nav nav-tabs nav-tabs-pf"
-                      justified={false}
-                      pullLeft={false}
-                      pullRight={false}
-                      stacked={false}
-                    >
-                      <NavItem
-                        active={false}
-                        disabled={false}
-                        eventKey={1}
-                      >
-                        Deployments (0)
-                      </NavItem>
-                      <NavItem
-                        active={false}
-                        disabled={false}
-                        eventKey={2}
-                      >
-                        Source Services (0)
-                      </NavItem>
-                      <NavItem
-                        active={false}
-                        disabled={false}
-                        eventKey={3}
-                      >
-                        Route Rules (0)
-                      </NavItem>
-                      <NavItem
-                        active={false}
-                        disabled={false}
-                        eventKey={4}
-                      >
-                        Destination Policies (0)
-                      </NavItem>
-                      <NavItem
-                        active={false}
-                        disabled={false}
-                        eventKey={5}
-                      >
-                        Virtual Services (0)
-                      </NavItem>
-                      <NavItem
-                        active={false}
-                        disabled={false}
-                        eventKey={6}
-                      >
-                        Destination Rules (0)
-                      </NavItem>
-                    </Nav>
-                    <TabContent
-                      animation={true}
-                      bsClass="tab"
-                      componentClass="div"
-                      mountOnEnter={false}
-                      unmountOnExit={false}
-                    >
-                      <TabPane
-                        bsClass="tab-pane"
-                        eventKey={1}
-                      />
-                      <TabPane
-                        bsClass="tab-pane"
-                        eventKey={2}
-                      />
-                      <TabPane
-                        bsClass="tab-pane"
-                        eventKey={3}
-                      />
-                      <TabPane
-                        bsClass="tab-pane"
-                        eventKey={4}
-                      />
-                      <TabPane
-                        bsClass="tab-pane"
-                        eventKey={5}
-                      />
-                      <TabPane
-                        bsClass="tab-pane"
-                        eventKey={6}
-                      />
-                    </TabContent>
-                  </div>
-                </Uncontrolled(TabContainer)>
-              </Col>,
-              "className": "row-cards-pf",
-              "componentClass": "div",
-            },
-            "ref": null,
-            "rendered": Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "class",
-              "props": Object {
-                "bsClass": "col",
-                "children": <Uncontrolled(TabContainer)
-                  defaultActiveKey={1}
-                  id="service-tabs"
-                >
-                  <div>
-                    <Nav
-                      bsClass="nav nav-tabs nav-tabs-pf"
-                      justified={false}
-                      pullLeft={false}
-                      pullRight={false}
-                      stacked={false}
-                    >
-                      <NavItem
-                        active={false}
-                        disabled={false}
-                        eventKey={1}
-                      >
-                        Deployments (0)
-                      </NavItem>
-                      <NavItem
-                        active={false}
-                        disabled={false}
-                        eventKey={2}
-                      >
-                        Source Services (0)
-                      </NavItem>
-                      <NavItem
-                        active={false}
-                        disabled={false}
-                        eventKey={3}
-                      >
-                        Route Rules (0)
-                      </NavItem>
-                      <NavItem
-                        active={false}
-                        disabled={false}
-                        eventKey={4}
-                      >
-                        Destination Policies (0)
-                      </NavItem>
-                      <NavItem
-                        active={false}
-                        disabled={false}
-                        eventKey={5}
-                      >
-                        Virtual Services (0)
-                      </NavItem>
-                      <NavItem
-                        active={false}
-                        disabled={false}
-                        eventKey={6}
-                      >
-                        Destination Rules (0)
-                      </NavItem>
-                    </Nav>
-                    <TabContent
-                      animation={true}
-                      bsClass="tab"
-                      componentClass="div"
-                      mountOnEnter={false}
-                      unmountOnExit={false}
-                    >
-                      <TabPane
-                        bsClass="tab-pane"
-                        eventKey={1}
-                      />
-                      <TabPane
-                        bsClass="tab-pane"
-                        eventKey={2}
-                      />
-                      <TabPane
-                        bsClass="tab-pane"
-                        eventKey={3}
-                      />
-                      <TabPane
-                        bsClass="tab-pane"
-                        eventKey={4}
-                      />
-                      <TabPane
-                        bsClass="tab-pane"
-                        eventKey={5}
-                      />
-                      <TabPane
-                        bsClass="tab-pane"
-                        eventKey={6}
-                      />
-                    </TabContent>
-                  </div>
-                </Uncontrolled(TabContainer)>,
-                "componentClass": "div",
-                "lg": 12,
-                "md": 12,
-                "sm": 12,
-                "xs": 12,
-              },
-              "ref": null,
-              "rendered": Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "class",
-                "props": Object {
-                  "children": <div>
-                    <Nav
-                      bsClass="nav nav-tabs nav-tabs-pf"
-                      justified={false}
-                      pullLeft={false}
-                      pullRight={false}
-                      stacked={false}
-                    >
-                      <NavItem
-                        active={false}
-                        disabled={false}
-                        eventKey={1}
-                      >
-                        Deployments (0)
-                      </NavItem>
-                      <NavItem
-                        active={false}
-                        disabled={false}
-                        eventKey={2}
-                      >
-                        Source Services (0)
-                      </NavItem>
-                      <NavItem
-                        active={false}
-                        disabled={false}
-                        eventKey={3}
-                      >
-                        Route Rules (0)
-                      </NavItem>
-                      <NavItem
-                        active={false}
-                        disabled={false}
-                        eventKey={4}
-                      >
-                        Destination Policies (0)
-                      </NavItem>
-                      <NavItem
-                        active={false}
-                        disabled={false}
-                        eventKey={5}
-                      >
-                        Virtual Services (0)
-                      </NavItem>
-                      <NavItem
-                        active={false}
-                        disabled={false}
-                        eventKey={6}
-                      >
-                        Destination Rules (0)
-                      </NavItem>
-                    </Nav>
-                    <TabContent
-                      animation={true}
-                      bsClass="tab"
-                      componentClass="div"
-                      mountOnEnter={false}
-                      unmountOnExit={false}
-                    >
-                      <TabPane
-                        bsClass="tab-pane"
-                        eventKey={1}
-                      />
-                      <TabPane
-                        bsClass="tab-pane"
-                        eventKey={2}
-                      />
-                      <TabPane
-                        bsClass="tab-pane"
-                        eventKey={3}
-                      />
-                      <TabPane
-                        bsClass="tab-pane"
-                        eventKey={4}
-                      />
-                      <TabPane
-                        bsClass="tab-pane"
-                        eventKey={5}
-                      />
-                      <TabPane
-                        bsClass="tab-pane"
-                        eventKey={6}
-                      />
-                    </TabContent>
-                  </div>,
-                  "defaultActiveKey": 1,
-                  "id": "service-tabs",
-                },
-                "ref": null,
-                "rendered": Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": Array [
-                      <Nav
-                        bsClass="nav nav-tabs nav-tabs-pf"
-                        justified={false}
-                        pullLeft={false}
-                        pullRight={false}
-                        stacked={false}
-                      >
-                        <NavItem
-                          active={false}
-                          disabled={false}
-                          eventKey={1}
-                        >
-                          Deployments (0)
-                        </NavItem>
-                        <NavItem
-                          active={false}
-                          disabled={false}
-                          eventKey={2}
-                        >
-                          Source Services (0)
-                        </NavItem>
-                        <NavItem
-                          active={false}
-                          disabled={false}
-                          eventKey={3}
-                        >
-                          Route Rules (0)
-                        </NavItem>
-                        <NavItem
-                          active={false}
-                          disabled={false}
-                          eventKey={4}
-                        >
-                          Destination Policies (0)
-                        </NavItem>
-                        <NavItem
-                          active={false}
-                          disabled={false}
-                          eventKey={5}
-                        >
-                          Virtual Services (0)
-                        </NavItem>
-                        <NavItem
-                          active={false}
-                          disabled={false}
-                          eventKey={6}
-                        >
-                          Destination Rules (0)
-                        </NavItem>
-                      </Nav>,
-                      <TabContent
-                        animation={true}
-                        bsClass="tab"
-                        componentClass="div"
-                        mountOnEnter={false}
-                        unmountOnExit={false}
-                      >
-                        <TabPane
-                          bsClass="tab-pane"
-                          eventKey={1}
-                        />
-                        <TabPane
-                          bsClass="tab-pane"
-                          eventKey={2}
-                        />
-                        <TabPane
-                          bsClass="tab-pane"
-                          eventKey={3}
-                        />
-                        <TabPane
-                          bsClass="tab-pane"
-                          eventKey={4}
-                        />
-                        <TabPane
-                          bsClass="tab-pane"
-                          eventKey={5}
-                        />
-                        <TabPane
-                          bsClass="tab-pane"
-                          eventKey={6}
-                        />
-                      </TabContent>,
-                    ],
-                  },
-                  "ref": null,
-                  "rendered": Array [
-                    Object {
-                      "instance": null,
-                      "key": undefined,
-                      "nodeType": "class",
-                      "props": Object {
-                        "bsClass": "nav nav-tabs nav-tabs-pf",
-                        "children": Array [
-                          <NavItem
-                            active={false}
-                            disabled={false}
-                            eventKey={1}
-                          >
-                            Deployments (0)
-                          </NavItem>,
-                          <NavItem
-                            active={false}
-                            disabled={false}
-                            eventKey={2}
-                          >
-                            Source Services (0)
-                          </NavItem>,
-                          <NavItem
-                            active={false}
-                            disabled={false}
-                            eventKey={3}
-                          >
-                            Route Rules (0)
-                          </NavItem>,
-                          <NavItem
-                            active={false}
-                            disabled={false}
-                            eventKey={4}
-                          >
-                            Destination Policies (0)
-                          </NavItem>,
-                          <NavItem
-                            active={false}
-                            disabled={false}
-                            eventKey={5}
-                          >
-                            Virtual Services (0)
-                          </NavItem>,
-                          <NavItem
-                            active={false}
-                            disabled={false}
-                            eventKey={6}
-                          >
-                            Destination Rules (0)
-                          </NavItem>,
-                        ],
-                        "justified": false,
-                        "pullLeft": false,
-                        "pullRight": false,
-                        "stacked": false,
-                      },
-                      "ref": null,
-                      "rendered": Array [
-                        Object {
-                          "instance": null,
-                          "key": undefined,
-                          "nodeType": "class",
-                          "props": Object {
-                            "active": false,
-                            "children": "Deployments (0)",
-                            "disabled": false,
-                            "eventKey": 1,
-                          },
-                          "ref": null,
-                          "rendered": "Deployments (0)",
-                          "type": [Function],
-                        },
-                        Object {
-                          "instance": null,
-                          "key": undefined,
-                          "nodeType": "class",
-                          "props": Object {
-                            "active": false,
-                            "children": "Source Services (0)",
-                            "disabled": false,
-                            "eventKey": 2,
-                          },
-                          "ref": null,
-                          "rendered": "Source Services (0)",
-                          "type": [Function],
-                        },
-                        Object {
-                          "instance": null,
-                          "key": undefined,
-                          "nodeType": "class",
-                          "props": Object {
-                            "active": false,
-                            "children": "Route Rules (0)",
-                            "disabled": false,
-                            "eventKey": 3,
-                          },
-                          "ref": null,
-                          "rendered": "Route Rules (0)",
-                          "type": [Function],
-                        },
-                        Object {
-                          "instance": null,
-                          "key": undefined,
-                          "nodeType": "class",
-                          "props": Object {
-                            "active": false,
-                            "children": "Destination Policies (0)",
-                            "disabled": false,
-                            "eventKey": 4,
-                          },
-                          "ref": null,
-                          "rendered": "Destination Policies (0)",
-                          "type": [Function],
-                        },
-                        Object {
-                          "instance": null,
-                          "key": undefined,
-                          "nodeType": "class",
-                          "props": Object {
-                            "active": false,
-                            "children": "Virtual Services (0)",
-                            "disabled": false,
-                            "eventKey": 5,
-                          },
-                          "ref": null,
-                          "rendered": "Virtual Services (0)",
-                          "type": [Function],
-                        },
-                        Object {
-                          "instance": null,
-                          "key": undefined,
-                          "nodeType": "class",
-                          "props": Object {
-                            "active": false,
-                            "children": "Destination Rules (0)",
-                            "disabled": false,
-                            "eventKey": 6,
-                          },
-                          "ref": null,
-                          "rendered": "Destination Rules (0)",
-                          "type": [Function],
-                        },
-                      ],
-                      "type": [Function],
-                    },
-                    Object {
-                      "instance": null,
-                      "key": undefined,
-                      "nodeType": "class",
-                      "props": Object {
-                        "animation": true,
-                        "bsClass": "tab",
-                        "children": Array [
-                          <TabPane
-                            bsClass="tab-pane"
-                            eventKey={1}
-                          />,
-                          <TabPane
-                            bsClass="tab-pane"
-                            eventKey={2}
-                          />,
-                          <TabPane
-                            bsClass="tab-pane"
-                            eventKey={3}
-                          />,
-                          <TabPane
-                            bsClass="tab-pane"
-                            eventKey={4}
-                          />,
-                          <TabPane
-                            bsClass="tab-pane"
-                            eventKey={5}
-                          />,
-                          <TabPane
-                            bsClass="tab-pane"
-                            eventKey={6}
-                          />,
-                        ],
-                        "componentClass": "div",
-                        "mountOnEnter": false,
-                        "unmountOnExit": false,
-                      },
-                      "ref": null,
-                      "rendered": Array [
-                        Object {
-                          "instance": null,
-                          "key": undefined,
-                          "nodeType": "class",
-                          "props": Object {
-                            "bsClass": "tab-pane",
-                            "children": false,
-                            "eventKey": 1,
-                          },
-                          "ref": null,
-                          "rendered": false,
-                          "type": [Function],
-                        },
-                        Object {
-                          "instance": null,
-                          "key": undefined,
-                          "nodeType": "class",
-                          "props": Object {
-                            "bsClass": "tab-pane",
-                            "children": false,
-                            "eventKey": 2,
-                          },
-                          "ref": null,
-                          "rendered": false,
-                          "type": [Function],
-                        },
-                        Object {
-                          "instance": null,
-                          "key": undefined,
-                          "nodeType": "class",
-                          "props": Object {
-                            "bsClass": "tab-pane",
-                            "children": false,
-                            "eventKey": 3,
-                          },
-                          "ref": null,
-                          "rendered": false,
-                          "type": [Function],
-                        },
-                        Object {
-                          "instance": null,
-                          "key": undefined,
-                          "nodeType": "class",
-                          "props": Object {
-                            "bsClass": "tab-pane",
-                            "children": false,
-                            "eventKey": 4,
-                          },
-                          "ref": null,
-                          "rendered": false,
-                          "type": [Function],
-                        },
-                        Object {
-                          "instance": null,
-                          "key": undefined,
-                          "nodeType": "class",
-                          "props": Object {
-                            "bsClass": "tab-pane",
-                            "children": false,
-                            "eventKey": 5,
-                          },
-                          "ref": null,
-                          "rendered": false,
-                          "type": [Function],
-                        },
-                        Object {
-                          "instance": null,
-                          "key": undefined,
-                          "nodeType": "class",
-                          "props": Object {
-                            "bsClass": "tab-pane",
-                            "children": false,
-                            "eventKey": 6,
-                          },
-                          "ref": null,
-                          "rendered": false,
-                          "type": [Function],
-                        },
-                      ],
-                      "type": [Function],
-                    },
-                  ],
-                  "type": "div",
-                },
-                "type": [Function],
-              },
-              "type": [Function],
-            },
-            "type": [Function],
-          },
-        ],
-        "type": "div",
-      },
-    ],
-    "type": "div",
-  },
-  Symbol(enzyme.__nodes__): Array [
-    Object {
-      "instance": null,
-      "key": undefined,
-      "nodeType": "host",
-      "props": Object {
-        "children": Array [
-          null,
-          <div
-            className="container-fluid container-cards-pf"
-          >
-            <Row
-              bsClass="row"
-              className="row-cards-pf"
-              componentClass="div"
-            >
-              <Col
-                bsClass="col"
-                componentClass="div"
-                lg={12}
-                md={12}
-                sm={12}
-                xs={12}
-              >
-                <ServiceInfoDescription
-                  created_at=""
-                  endpoints={undefined}
-                  health={undefined}
-                  ip=""
-                  istio_sidecar={false}
-                  labels={Map {}}
-                  name=""
-                  ports={Array []}
-                  resource_version=""
-                  type=""
-                />
-              </Col>
-            </Row>
-            <Row
-              bsClass="row"
-              className="row-cards-pf"
-              componentClass="div"
-            >
-              <Col
-                bsClass="col"
-                componentClass="div"
-                lg={12}
-                md={12}
-                sm={12}
-                xs={12}
-              >
-                <Uncontrolled(TabContainer)
-                  defaultActiveKey={1}
-                  id="service-tabs"
-                >
-                  <div>
-                    <Nav
-                      bsClass="nav nav-tabs nav-tabs-pf"
-                      justified={false}
-                      pullLeft={false}
-                      pullRight={false}
-                      stacked={false}
-                    >
-                      <NavItem
-                        active={false}
-                        disabled={false}
-                        eventKey={1}
-                      >
-                        Deployments (0)
-                      </NavItem>
-                      <NavItem
-                        active={false}
-                        disabled={false}
-                        eventKey={2}
-                      >
-                        Source Services (0)
-                      </NavItem>
-                      <NavItem
-                        active={false}
-                        disabled={false}
-                        eventKey={3}
-                      >
-                        Route Rules (0)
-                      </NavItem>
-                      <NavItem
-                        active={false}
-                        disabled={false}
-                        eventKey={4}
-                      >
-                        Destination Policies (0)
-                      </NavItem>
-                      <NavItem
-                        active={false}
-                        disabled={false}
-                        eventKey={5}
-                      >
-                        Virtual Services (0)
-                      </NavItem>
-                      <NavItem
-                        active={false}
-                        disabled={false}
-                        eventKey={6}
-                      >
-                        Destination Rules (0)
-                      </NavItem>
-                    </Nav>
-                    <TabContent
-                      animation={true}
-                      bsClass="tab"
-                      componentClass="div"
-                      mountOnEnter={false}
-                      unmountOnExit={false}
-                    >
-                      <TabPane
-                        bsClass="tab-pane"
-                        eventKey={1}
-                      />
-                      <TabPane
-                        bsClass="tab-pane"
-                        eventKey={2}
-                      />
-                      <TabPane
-                        bsClass="tab-pane"
-                        eventKey={3}
-                      />
-                      <TabPane
-                        bsClass="tab-pane"
-                        eventKey={4}
-                      />
-                      <TabPane
-                        bsClass="tab-pane"
-                        eventKey={5}
-                      />
-                      <TabPane
-                        bsClass="tab-pane"
-                        eventKey={6}
-                      />
-                    </TabContent>
-                  </div>
-                </Uncontrolled(TabContainer)>
-              </Col>
-            </Row>
-          </div>,
-        ],
-      },
-      "ref": null,
-      "rendered": Array [
-        null,
-        Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "host",
-          "props": Object {
-            "children": Array [
-              <Row
-                bsClass="row"
-                className="row-cards-pf"
-                componentClass="div"
-              >
-                <Col
-                  bsClass="col"
-                  componentClass="div"
-                  lg={12}
-                  md={12}
-                  sm={12}
-                  xs={12}
-                >
-                  <ServiceInfoDescription
-                    created_at=""
-                    endpoints={undefined}
-                    health={undefined}
-                    ip=""
-                    istio_sidecar={false}
-                    labels={Map {}}
-                    name=""
-                    ports={Array []}
-                    resource_version=""
-                    type=""
-                  />
-                </Col>
-              </Row>,
-              <Row
-                bsClass="row"
-                className="row-cards-pf"
-                componentClass="div"
-              >
-                <Col
-                  bsClass="col"
-                  componentClass="div"
-                  lg={12}
-                  md={12}
-                  sm={12}
-                  xs={12}
-                >
-                  <Uncontrolled(TabContainer)
-                    defaultActiveKey={1}
-                    id="service-tabs"
-                  >
-                    <div>
-                      <Nav
-                        bsClass="nav nav-tabs nav-tabs-pf"
-                        justified={false}
-                        pullLeft={false}
-                        pullRight={false}
-                        stacked={false}
-                      >
-                        <NavItem
-                          active={false}
-                          disabled={false}
-                          eventKey={1}
-                        >
-                          Deployments (0)
-                        </NavItem>
-                        <NavItem
-                          active={false}
-                          disabled={false}
-                          eventKey={2}
-                        >
-                          Source Services (0)
-                        </NavItem>
-                        <NavItem
-                          active={false}
-                          disabled={false}
-                          eventKey={3}
-                        >
-                          Route Rules (0)
-                        </NavItem>
-                        <NavItem
-                          active={false}
-                          disabled={false}
-                          eventKey={4}
-                        >
-                          Destination Policies (0)
-                        </NavItem>
-                        <NavItem
-                          active={false}
-                          disabled={false}
-                          eventKey={5}
-                        >
-                          Virtual Services (0)
-                        </NavItem>
-                        <NavItem
-                          active={false}
-                          disabled={false}
-                          eventKey={6}
-                        >
-                          Destination Rules (0)
-                        </NavItem>
-                      </Nav>
-                      <TabContent
-                        animation={true}
-                        bsClass="tab"
-                        componentClass="div"
-                        mountOnEnter={false}
-                        unmountOnExit={false}
-                      >
-                        <TabPane
-                          bsClass="tab-pane"
-                          eventKey={1}
-                        />
-                        <TabPane
-                          bsClass="tab-pane"
-                          eventKey={2}
-                        />
-                        <TabPane
-                          bsClass="tab-pane"
-                          eventKey={3}
-                        />
-                        <TabPane
-                          bsClass="tab-pane"
-                          eventKey={4}
-                        />
-                        <TabPane
-                          bsClass="tab-pane"
-                          eventKey={5}
-                        />
-                        <TabPane
-                          bsClass="tab-pane"
-                          eventKey={6}
-                        />
-                      </TabContent>
-                    </div>
-                  </Uncontrolled(TabContainer)>
-                </Col>
-              </Row>,
-            ],
-            "className": "container-fluid container-cards-pf",
-          },
-          "ref": null,
-          "rendered": Array [
-            Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "class",
-              "props": Object {
-                "bsClass": "row",
-                "children": <Col
-                  bsClass="col"
-                  componentClass="div"
-                  lg={12}
-                  md={12}
-                  sm={12}
-                  xs={12}
-                >
-                  <ServiceInfoDescription
-                    created_at=""
-                    endpoints={undefined}
-                    health={undefined}
-                    ip=""
-                    istio_sidecar={false}
-                    labels={Map {}}
-                    name=""
-                    ports={Array []}
-                    resource_version=""
-                    type=""
-                  />
-                </Col>,
-                "className": "row-cards-pf",
-                "componentClass": "div",
-              },
-              "ref": null,
-              "rendered": Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "class",
-                "props": Object {
-                  "bsClass": "col",
-                  "children": <ServiceInfoDescription
-                    created_at=""
-                    endpoints={undefined}
-                    health={undefined}
-                    ip=""
-                    istio_sidecar={false}
-                    labels={Map {}}
-                    name=""
-                    ports={Array []}
-                    resource_version=""
-                    type=""
-                  />,
-                  "componentClass": "div",
-                  "lg": 12,
-                  "md": 12,
-                  "sm": 12,
-                  "xs": 12,
-                },
-                "ref": null,
-                "rendered": Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "class",
-                  "props": Object {
-                    "created_at": "",
-                    "endpoints": undefined,
-                    "health": undefined,
-                    "ip": "",
-                    "istio_sidecar": false,
-                    "labels": Map {},
-                    "name": "",
-                    "ports": Array [],
-                    "resource_version": "",
-                    "type": "",
-                  },
-                  "ref": null,
-                  "rendered": null,
-                  "type": [Function],
-                },
-                "type": [Function],
-              },
-              "type": [Function],
-            },
-            Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "class",
-              "props": Object {
-                "bsClass": "row",
-                "children": <Col
-                  bsClass="col"
-                  componentClass="div"
-                  lg={12}
-                  md={12}
-                  sm={12}
-                  xs={12}
-                >
-                  <Uncontrolled(TabContainer)
-                    defaultActiveKey={1}
-                    id="service-tabs"
-                  >
-                    <div>
-                      <Nav
-                        bsClass="nav nav-tabs nav-tabs-pf"
-                        justified={false}
-                        pullLeft={false}
-                        pullRight={false}
-                        stacked={false}
-                      >
-                        <NavItem
-                          active={false}
-                          disabled={false}
-                          eventKey={1}
-                        >
-                          Deployments (0)
-                        </NavItem>
-                        <NavItem
-                          active={false}
-                          disabled={false}
-                          eventKey={2}
-                        >
-                          Source Services (0)
-                        </NavItem>
-                        <NavItem
-                          active={false}
-                          disabled={false}
-                          eventKey={3}
-                        >
-                          Route Rules (0)
-                        </NavItem>
-                        <NavItem
-                          active={false}
-                          disabled={false}
-                          eventKey={4}
-                        >
-                          Destination Policies (0)
-                        </NavItem>
-                        <NavItem
-                          active={false}
-                          disabled={false}
-                          eventKey={5}
-                        >
-                          Virtual Services (0)
-                        </NavItem>
-                        <NavItem
-                          active={false}
-                          disabled={false}
-                          eventKey={6}
-                        >
-                          Destination Rules (0)
-                        </NavItem>
-                      </Nav>
-                      <TabContent
-                        animation={true}
-                        bsClass="tab"
-                        componentClass="div"
-                        mountOnEnter={false}
-                        unmountOnExit={false}
-                      >
-                        <TabPane
-                          bsClass="tab-pane"
-                          eventKey={1}
-                        />
-                        <TabPane
-                          bsClass="tab-pane"
-                          eventKey={2}
-                        />
-                        <TabPane
-                          bsClass="tab-pane"
-                          eventKey={3}
-                        />
-                        <TabPane
-                          bsClass="tab-pane"
-                          eventKey={4}
-                        />
-                        <TabPane
-                          bsClass="tab-pane"
-                          eventKey={5}
-                        />
-                        <TabPane
-                          bsClass="tab-pane"
-                          eventKey={6}
-                        />
-                      </TabContent>
-                    </div>
-                  </Uncontrolled(TabContainer)>
-                </Col>,
-                "className": "row-cards-pf",
-                "componentClass": "div",
-              },
-              "ref": null,
-              "rendered": Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "class",
-                "props": Object {
-                  "bsClass": "col",
-                  "children": <Uncontrolled(TabContainer)
-                    defaultActiveKey={1}
-                    id="service-tabs"
-                  >
-                    <div>
-                      <Nav
-                        bsClass="nav nav-tabs nav-tabs-pf"
-                        justified={false}
-                        pullLeft={false}
-                        pullRight={false}
-                        stacked={false}
-                      >
-                        <NavItem
-                          active={false}
-                          disabled={false}
-                          eventKey={1}
-                        >
-                          Deployments (0)
-                        </NavItem>
-                        <NavItem
-                          active={false}
-                          disabled={false}
-                          eventKey={2}
-                        >
-                          Source Services (0)
-                        </NavItem>
-                        <NavItem
-                          active={false}
-                          disabled={false}
-                          eventKey={3}
-                        >
-                          Route Rules (0)
-                        </NavItem>
-                        <NavItem
-                          active={false}
-                          disabled={false}
-                          eventKey={4}
-                        >
-                          Destination Policies (0)
-                        </NavItem>
-                        <NavItem
-                          active={false}
-                          disabled={false}
-                          eventKey={5}
-                        >
-                          Virtual Services (0)
-                        </NavItem>
-                        <NavItem
-                          active={false}
-                          disabled={false}
-                          eventKey={6}
-                        >
-                          Destination Rules (0)
-                        </NavItem>
-                      </Nav>
-                      <TabContent
-                        animation={true}
-                        bsClass="tab"
-                        componentClass="div"
-                        mountOnEnter={false}
-                        unmountOnExit={false}
-                      >
-                        <TabPane
-                          bsClass="tab-pane"
-                          eventKey={1}
-                        />
-                        <TabPane
-                          bsClass="tab-pane"
-                          eventKey={2}
-                        />
-                        <TabPane
-                          bsClass="tab-pane"
-                          eventKey={3}
-                        />
-                        <TabPane
-                          bsClass="tab-pane"
-                          eventKey={4}
-                        />
-                        <TabPane
-                          bsClass="tab-pane"
-                          eventKey={5}
-                        />
-                        <TabPane
-                          bsClass="tab-pane"
-                          eventKey={6}
-                        />
-                      </TabContent>
-                    </div>
-                  </Uncontrolled(TabContainer)>,
-                  "componentClass": "div",
-                  "lg": 12,
-                  "md": 12,
-                  "sm": 12,
-                  "xs": 12,
-                },
-                "ref": null,
-                "rendered": Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "class",
-                  "props": Object {
-                    "children": <div>
-                      <Nav
-                        bsClass="nav nav-tabs nav-tabs-pf"
-                        justified={false}
-                        pullLeft={false}
-                        pullRight={false}
-                        stacked={false}
-                      >
-                        <NavItem
-                          active={false}
-                          disabled={false}
-                          eventKey={1}
-                        >
-                          Deployments (0)
-                        </NavItem>
-                        <NavItem
-                          active={false}
-                          disabled={false}
-                          eventKey={2}
-                        >
-                          Source Services (0)
-                        </NavItem>
-                        <NavItem
-                          active={false}
-                          disabled={false}
-                          eventKey={3}
-                        >
-                          Route Rules (0)
-                        </NavItem>
-                        <NavItem
-                          active={false}
-                          disabled={false}
-                          eventKey={4}
-                        >
-                          Destination Policies (0)
-                        </NavItem>
-                        <NavItem
-                          active={false}
-                          disabled={false}
-                          eventKey={5}
-                        >
-                          Virtual Services (0)
-                        </NavItem>
-                        <NavItem
-                          active={false}
-                          disabled={false}
-                          eventKey={6}
-                        >
-                          Destination Rules (0)
-                        </NavItem>
-                      </Nav>
-                      <TabContent
-                        animation={true}
-                        bsClass="tab"
-                        componentClass="div"
-                        mountOnEnter={false}
-                        unmountOnExit={false}
-                      >
-                        <TabPane
-                          bsClass="tab-pane"
-                          eventKey={1}
-                        />
-                        <TabPane
-                          bsClass="tab-pane"
-                          eventKey={2}
-                        />
-                        <TabPane
-                          bsClass="tab-pane"
-                          eventKey={3}
-                        />
-                        <TabPane
-                          bsClass="tab-pane"
-                          eventKey={4}
-                        />
-                        <TabPane
-                          bsClass="tab-pane"
-                          eventKey={5}
-                        />
-                        <TabPane
-                          bsClass="tab-pane"
-                          eventKey={6}
-                        />
-                      </TabContent>
-                    </div>,
-                    "defaultActiveKey": 1,
-                    "id": "service-tabs",
-                  },
-                  "ref": null,
-                  "rendered": Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "host",
-                    "props": Object {
-                      "children": Array [
-                        <Nav
-                          bsClass="nav nav-tabs nav-tabs-pf"
-                          justified={false}
-                          pullLeft={false}
-                          pullRight={false}
-                          stacked={false}
-                        >
-                          <NavItem
-                            active={false}
-                            disabled={false}
-                            eventKey={1}
-                          >
-                            Deployments (0)
-                          </NavItem>
-                          <NavItem
-                            active={false}
-                            disabled={false}
-                            eventKey={2}
-                          >
-                            Source Services (0)
-                          </NavItem>
-                          <NavItem
-                            active={false}
-                            disabled={false}
-                            eventKey={3}
-                          >
-                            Route Rules (0)
-                          </NavItem>
-                          <NavItem
-                            active={false}
-                            disabled={false}
-                            eventKey={4}
-                          >
-                            Destination Policies (0)
-                          </NavItem>
-                          <NavItem
-                            active={false}
-                            disabled={false}
-                            eventKey={5}
-                          >
-                            Virtual Services (0)
-                          </NavItem>
-                          <NavItem
-                            active={false}
-                            disabled={false}
-                            eventKey={6}
-                          >
-                            Destination Rules (0)
-                          </NavItem>
-                        </Nav>,
-                        <TabContent
-                          animation={true}
-                          bsClass="tab"
-                          componentClass="div"
-                          mountOnEnter={false}
-                          unmountOnExit={false}
-                        >
-                          <TabPane
-                            bsClass="tab-pane"
-                            eventKey={1}
-                          />
-                          <TabPane
-                            bsClass="tab-pane"
-                            eventKey={2}
-                          />
-                          <TabPane
-                            bsClass="tab-pane"
-                            eventKey={3}
-                          />
-                          <TabPane
-                            bsClass="tab-pane"
-                            eventKey={4}
-                          />
-                          <TabPane
-                            bsClass="tab-pane"
-                            eventKey={5}
-                          />
-                          <TabPane
-                            bsClass="tab-pane"
-                            eventKey={6}
-                          />
-                        </TabContent>,
-                      ],
-                    },
-                    "ref": null,
-                    "rendered": Array [
-                      Object {
-                        "instance": null,
-                        "key": undefined,
-                        "nodeType": "class",
-                        "props": Object {
-                          "bsClass": "nav nav-tabs nav-tabs-pf",
-                          "children": Array [
-                            <NavItem
-                              active={false}
-                              disabled={false}
-                              eventKey={1}
-                            >
-                              Deployments (0)
-                            </NavItem>,
-                            <NavItem
-                              active={false}
-                              disabled={false}
-                              eventKey={2}
-                            >
-                              Source Services (0)
-                            </NavItem>,
-                            <NavItem
-                              active={false}
-                              disabled={false}
-                              eventKey={3}
-                            >
-                              Route Rules (0)
-                            </NavItem>,
-                            <NavItem
-                              active={false}
-                              disabled={false}
-                              eventKey={4}
-                            >
-                              Destination Policies (0)
-                            </NavItem>,
-                            <NavItem
-                              active={false}
-                              disabled={false}
-                              eventKey={5}
-                            >
-                              Virtual Services (0)
-                            </NavItem>,
-                            <NavItem
-                              active={false}
-                              disabled={false}
-                              eventKey={6}
-                            >
-                              Destination Rules (0)
-                            </NavItem>,
-                          ],
-                          "justified": false,
-                          "pullLeft": false,
-                          "pullRight": false,
-                          "stacked": false,
-                        },
-                        "ref": null,
-                        "rendered": Array [
-                          Object {
-                            "instance": null,
-                            "key": undefined,
-                            "nodeType": "class",
-                            "props": Object {
-                              "active": false,
-                              "children": "Deployments (0)",
-                              "disabled": false,
-                              "eventKey": 1,
-                            },
-                            "ref": null,
-                            "rendered": "Deployments (0)",
-                            "type": [Function],
-                          },
-                          Object {
-                            "instance": null,
-                            "key": undefined,
-                            "nodeType": "class",
-                            "props": Object {
-                              "active": false,
-                              "children": "Source Services (0)",
-                              "disabled": false,
-                              "eventKey": 2,
-                            },
-                            "ref": null,
-                            "rendered": "Source Services (0)",
-                            "type": [Function],
-                          },
-                          Object {
-                            "instance": null,
-                            "key": undefined,
-                            "nodeType": "class",
-                            "props": Object {
-                              "active": false,
-                              "children": "Route Rules (0)",
-                              "disabled": false,
-                              "eventKey": 3,
-                            },
-                            "ref": null,
-                            "rendered": "Route Rules (0)",
-                            "type": [Function],
-                          },
-                          Object {
-                            "instance": null,
-                            "key": undefined,
-                            "nodeType": "class",
-                            "props": Object {
-                              "active": false,
-                              "children": "Destination Policies (0)",
-                              "disabled": false,
-                              "eventKey": 4,
-                            },
-                            "ref": null,
-                            "rendered": "Destination Policies (0)",
-                            "type": [Function],
-                          },
-                          Object {
-                            "instance": null,
-                            "key": undefined,
-                            "nodeType": "class",
-                            "props": Object {
-                              "active": false,
-                              "children": "Virtual Services (0)",
-                              "disabled": false,
-                              "eventKey": 5,
-                            },
-                            "ref": null,
-                            "rendered": "Virtual Services (0)",
-                            "type": [Function],
-                          },
-                          Object {
-                            "instance": null,
-                            "key": undefined,
-                            "nodeType": "class",
-                            "props": Object {
-                              "active": false,
-                              "children": "Destination Rules (0)",
-                              "disabled": false,
-                              "eventKey": 6,
-                            },
-                            "ref": null,
-                            "rendered": "Destination Rules (0)",
-                            "type": [Function],
-                          },
-                        ],
-                        "type": [Function],
-                      },
-                      Object {
-                        "instance": null,
-                        "key": undefined,
-                        "nodeType": "class",
-                        "props": Object {
-                          "animation": true,
-                          "bsClass": "tab",
-                          "children": Array [
-                            <TabPane
-                              bsClass="tab-pane"
-                              eventKey={1}
-                            />,
-                            <TabPane
-                              bsClass="tab-pane"
-                              eventKey={2}
-                            />,
-                            <TabPane
-                              bsClass="tab-pane"
-                              eventKey={3}
-                            />,
-                            <TabPane
-                              bsClass="tab-pane"
-                              eventKey={4}
-                            />,
-                            <TabPane
-                              bsClass="tab-pane"
-                              eventKey={5}
-                            />,
-                            <TabPane
-                              bsClass="tab-pane"
-                              eventKey={6}
-                            />,
-                          ],
-                          "componentClass": "div",
-                          "mountOnEnter": false,
-                          "unmountOnExit": false,
-                        },
-                        "ref": null,
-                        "rendered": Array [
-                          Object {
-                            "instance": null,
-                            "key": undefined,
-                            "nodeType": "class",
-                            "props": Object {
-                              "bsClass": "tab-pane",
-                              "children": false,
-                              "eventKey": 1,
-                            },
-                            "ref": null,
-                            "rendered": false,
-                            "type": [Function],
-                          },
-                          Object {
-                            "instance": null,
-                            "key": undefined,
-                            "nodeType": "class",
-                            "props": Object {
-                              "bsClass": "tab-pane",
-                              "children": false,
-                              "eventKey": 2,
-                            },
-                            "ref": null,
-                            "rendered": false,
-                            "type": [Function],
-                          },
-                          Object {
-                            "instance": null,
-                            "key": undefined,
-                            "nodeType": "class",
-                            "props": Object {
-                              "bsClass": "tab-pane",
-                              "children": false,
-                              "eventKey": 3,
-                            },
-                            "ref": null,
-                            "rendered": false,
-                            "type": [Function],
-                          },
-                          Object {
-                            "instance": null,
-                            "key": undefined,
-                            "nodeType": "class",
-                            "props": Object {
-                              "bsClass": "tab-pane",
-                              "children": false,
-                              "eventKey": 4,
-                            },
-                            "ref": null,
-                            "rendered": false,
-                            "type": [Function],
-                          },
-                          Object {
-                            "instance": null,
-                            "key": undefined,
-                            "nodeType": "class",
-                            "props": Object {
-                              "bsClass": "tab-pane",
-                              "children": false,
-                              "eventKey": 5,
-                            },
-                            "ref": null,
-                            "rendered": false,
-                            "type": [Function],
-                          },
-                          Object {
-                            "instance": null,
-                            "key": undefined,
-                            "nodeType": "class",
-                            "props": Object {
-                              "bsClass": "tab-pane",
-                              "children": false,
-                              "eventKey": 6,
-                            },
-                            "ref": null,
-                            "rendered": false,
-                            "type": [Function],
-                          },
-                        ],
-                        "type": [Function],
-                      },
-                    ],
-                    "type": "div",
-                  },
-                  "type": [Function],
-                },
-                "type": [Function],
-              },
-              "type": [Function],
-            },
-          ],
-          "type": "div",
-        },
-      ],
-      "type": "div",
-    },
-  ],
-  Symbol(enzyme.__options__): Object {
-    "adapter": ReactSixteenAdapter {
-      "options": Object {
-        "enableComponentDidUpdateOnSetState": true,
-      },
-    },
-  },
-}
-`;
-
 exports[`#ServiceInfo render correctly with data should render serviceInfo with data 1`] = `
 ShallowWrapper {
   "length": 1,
@@ -2120,6 +7,100 @@ ShallowWrapper {
   Symbol(enzyme.__unrendered__): <ServiceInfo
     namespace="istio-system"
     service="reviews"
+    serviceDetails={
+      Object {
+        "created_at": undefined,
+        "dependencies": Object {},
+        "deployments": undefined,
+        "destinationPolicies": undefined,
+        "destinationRules": undefined,
+        "endpoints": Array [
+          Object {
+            "addresses": Array [
+              Object {
+                "ip": "172.17.0.11",
+                "kind": "Pod",
+                "name": "reviews-v2-4140793682-qrpm9",
+              },
+              Object {
+                "ip": "172.17.0.14",
+                "kind": "Pod",
+                "name": "reviews-v3-3651831602-zn9g6",
+              },
+              Object {
+                "ip": "172.17.0.16",
+                "kind": "Pod",
+                "name": "reviews-v1-401049526-tfstp",
+              },
+            ],
+            "ports": Array [
+              Object {
+                "name": "http",
+                "port": 9080,
+                "protocol": "TCP",
+              },
+            ],
+          },
+        ],
+        "health": undefined,
+        "ip": "172.30.78.33",
+        "istio_sidecar": false,
+        "labels": Object {
+          "app": "reviews",
+        },
+        "name": "reviews",
+        "ports": Array [
+          Object {
+            "name": "http",
+            "port": 9080,
+            "protocol": "TCP",
+          },
+        ],
+        "resource_version": undefined,
+        "routeRules": Array [
+          Object {
+            "destination": Object {
+              "name": "reviews",
+            },
+            "match": Object {
+              "request": Object {
+                "headers": Object {
+                  "cookie": Object {
+                    "regex": "^(.*?;)?(user=jason)(;.*)?$",
+                  },
+                },
+              },
+            },
+            "name": "reviews-test-v2",
+            "precedence": 2,
+            "route": Array [
+              Object {
+                "labels": Object {
+                  "version": "v2",
+                },
+              },
+            ],
+          },
+          Object {
+            "destination": Object {
+              "name": "reviews",
+            },
+            "match": null,
+            "name": "reviews-default",
+            "precedence": 1,
+            "route": Array [
+              Object {
+                "labels": Object {
+                  "version": "v1",
+                },
+              },
+            ],
+          },
+        ],
+        "type": "ClusterIP",
+        "virtualServices": undefined,
+      }
+    }
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -2152,7 +133,7 @@ ShallowWrapper {
               xs={12}
             >
               <ServiceInfoDescription
-                created_at=""
+                created_at={undefined}
                 endpoints={
                   Array [
                     Object {
@@ -2186,11 +167,7 @@ ShallowWrapper {
                 health={undefined}
                 ip="172.30.78.33"
                 istio_sidecar={false}
-                labels={
-                  Object {
-                    "app": "reviews",
-                  }
-                }
+                labels={Map {}}
                 name="reviews"
                 ports={
                   Array [
@@ -2201,7 +178,7 @@ ShallowWrapper {
                     },
                   ]
                 }
-                resource_version=""
+                resource_version={undefined}
                 type="ClusterIP"
               />
             </Col>
@@ -2294,23 +271,9 @@ ShallowWrapper {
                       eventKey={3}
                     >
                       <ServiceInfoRouteRules
+                        editorLink="/namespaces/istio-system/services/reviews"
                         routeRules={
                           Array [
-                            Object {
-                              "destination": Object {
-                                "name": "reviews",
-                              },
-                              "match": null,
-                              "name": "reviews-default",
-                              "precedence": 1,
-                              "route": Array [
-                                Object {
-                                  "labels": Object {
-                                    "version": "v1",
-                                  },
-                                },
-                              ],
-                            },
                             Object {
                               "destination": Object {
                                 "name": "reviews",
@@ -2330,6 +293,21 @@ ShallowWrapper {
                                 Object {
                                   "labels": Object {
                                     "version": "v2",
+                                  },
+                                },
+                              ],
+                            },
+                            Object {
+                              "destination": Object {
+                                "name": "reviews",
+                              },
+                              "match": null,
+                              "name": "reviews-default",
+                              "precedence": 1,
+                              "route": Array [
+                                Object {
+                                  "labels": Object {
+                                    "version": "v1",
                                   },
                                 },
                               ],
@@ -2381,7 +359,7 @@ ShallowWrapper {
                 xs={12}
               >
                 <ServiceInfoDescription
-                  created_at=""
+                  created_at={undefined}
                   endpoints={
                     Array [
                       Object {
@@ -2415,11 +393,7 @@ ShallowWrapper {
                   health={undefined}
                   ip="172.30.78.33"
                   istio_sidecar={false}
-                  labels={
-                    Object {
-                      "app": "reviews",
-                    }
-                  }
+                  labels={Map {}}
                   name="reviews"
                   ports={
                     Array [
@@ -2430,7 +404,7 @@ ShallowWrapper {
                       },
                     ]
                   }
-                  resource_version=""
+                  resource_version={undefined}
                   type="ClusterIP"
                 />
               </Col>
@@ -2523,23 +497,9 @@ ShallowWrapper {
                         eventKey={3}
                       >
                         <ServiceInfoRouteRules
+                          editorLink="/namespaces/istio-system/services/reviews"
                           routeRules={
                             Array [
-                              Object {
-                                "destination": Object {
-                                  "name": "reviews",
-                                },
-                                "match": null,
-                                "name": "reviews-default",
-                                "precedence": 1,
-                                "route": Array [
-                                  Object {
-                                    "labels": Object {
-                                      "version": "v1",
-                                    },
-                                  },
-                                ],
-                              },
                               Object {
                                 "destination": Object {
                                   "name": "reviews",
@@ -2559,6 +519,21 @@ ShallowWrapper {
                                   Object {
                                     "labels": Object {
                                       "version": "v2",
+                                    },
+                                  },
+                                ],
+                              },
+                              Object {
+                                "destination": Object {
+                                  "name": "reviews",
+                                },
+                                "match": null,
+                                "name": "reviews-default",
+                                "precedence": 1,
+                                "route": Array [
+                                  Object {
+                                    "labels": Object {
+                                      "version": "v1",
                                     },
                                   },
                                 ],
@@ -2604,7 +579,7 @@ ShallowWrapper {
                 xs={12}
               >
                 <ServiceInfoDescription
-                  created_at=""
+                  created_at={undefined}
                   endpoints={
                     Array [
                       Object {
@@ -2638,11 +613,7 @@ ShallowWrapper {
                   health={undefined}
                   ip="172.30.78.33"
                   istio_sidecar={false}
-                  labels={
-                    Object {
-                      "app": "reviews",
-                    }
-                  }
+                  labels={Map {}}
                   name="reviews"
                   ports={
                     Array [
@@ -2653,7 +624,7 @@ ShallowWrapper {
                       },
                     ]
                   }
-                  resource_version=""
+                  resource_version={undefined}
                   type="ClusterIP"
                 />
               </Col>,
@@ -2668,7 +639,7 @@ ShallowWrapper {
               "props": Object {
                 "bsClass": "col",
                 "children": <ServiceInfoDescription
-                  created_at=""
+                  created_at={undefined}
                   endpoints={
                     Array [
                       Object {
@@ -2702,11 +673,7 @@ ShallowWrapper {
                   health={undefined}
                   ip="172.30.78.33"
                   istio_sidecar={false}
-                  labels={
-                    Object {
-                      "app": "reviews",
-                    }
-                  }
+                  labels={Map {}}
                   name="reviews"
                   ports={
                     Array [
@@ -2717,7 +684,7 @@ ShallowWrapper {
                       },
                     ]
                   }
-                  resource_version=""
+                  resource_version={undefined}
                   type="ClusterIP"
                 />,
                 "componentClass": "div",
@@ -2732,7 +699,7 @@ ShallowWrapper {
                 "key": undefined,
                 "nodeType": "class",
                 "props": Object {
-                  "created_at": "",
+                  "created_at": undefined,
                   "endpoints": Array [
                     Object {
                       "addresses": Array [
@@ -2764,9 +731,7 @@ ShallowWrapper {
                   "health": undefined,
                   "ip": "172.30.78.33",
                   "istio_sidecar": false,
-                  "labels": Object {
-                    "app": "reviews",
-                  },
+                  "labels": Map {},
                   "name": "reviews",
                   "ports": Array [
                     Object {
@@ -2775,7 +740,7 @@ ShallowWrapper {
                       "protocol": "TCP",
                     },
                   ],
-                  "resource_version": "",
+                  "resource_version": undefined,
                   "type": "ClusterIP",
                 },
                 "ref": null,
@@ -2875,23 +840,9 @@ ShallowWrapper {
                         eventKey={3}
                       >
                         <ServiceInfoRouteRules
+                          editorLink="/namespaces/istio-system/services/reviews"
                           routeRules={
                             Array [
-                              Object {
-                                "destination": Object {
-                                  "name": "reviews",
-                                },
-                                "match": null,
-                                "name": "reviews-default",
-                                "precedence": 1,
-                                "route": Array [
-                                  Object {
-                                    "labels": Object {
-                                      "version": "v1",
-                                    },
-                                  },
-                                ],
-                              },
                               Object {
                                 "destination": Object {
                                   "name": "reviews",
@@ -2911,6 +862,21 @@ ShallowWrapper {
                                   Object {
                                     "labels": Object {
                                       "version": "v2",
+                                    },
+                                  },
+                                ],
+                              },
+                              Object {
+                                "destination": Object {
+                                  "name": "reviews",
+                                },
+                                "match": null,
+                                "name": "reviews-default",
+                                "precedence": 1,
+                                "route": Array [
+                                  Object {
+                                    "labels": Object {
+                                      "version": "v1",
                                     },
                                   },
                                 ],
@@ -3020,23 +986,9 @@ ShallowWrapper {
                         eventKey={3}
                       >
                         <ServiceInfoRouteRules
+                          editorLink="/namespaces/istio-system/services/reviews"
                           routeRules={
                             Array [
-                              Object {
-                                "destination": Object {
-                                  "name": "reviews",
-                                },
-                                "match": null,
-                                "name": "reviews-default",
-                                "precedence": 1,
-                                "route": Array [
-                                  Object {
-                                    "labels": Object {
-                                      "version": "v1",
-                                    },
-                                  },
-                                ],
-                              },
                               Object {
                                 "destination": Object {
                                   "name": "reviews",
@@ -3056,6 +1008,21 @@ ShallowWrapper {
                                   Object {
                                     "labels": Object {
                                       "version": "v2",
+                                    },
+                                  },
+                                ],
+                              },
+                              Object {
+                                "destination": Object {
+                                  "name": "reviews",
+                                },
+                                "match": null,
+                                "name": "reviews-default",
+                                "precedence": 1,
+                                "route": Array [
+                                  Object {
+                                    "labels": Object {
+                                      "version": "v1",
                                     },
                                   },
                                 ],
@@ -3162,23 +1129,9 @@ ShallowWrapper {
                         eventKey={3}
                       >
                         <ServiceInfoRouteRules
+                          editorLink="/namespaces/istio-system/services/reviews"
                           routeRules={
                             Array [
-                              Object {
-                                "destination": Object {
-                                  "name": "reviews",
-                                },
-                                "match": null,
-                                "name": "reviews-default",
-                                "precedence": 1,
-                                "route": Array [
-                                  Object {
-                                    "labels": Object {
-                                      "version": "v1",
-                                    },
-                                  },
-                                ],
-                              },
                               Object {
                                 "destination": Object {
                                   "name": "reviews",
@@ -3198,6 +1151,21 @@ ShallowWrapper {
                                   Object {
                                     "labels": Object {
                                       "version": "v2",
+                                    },
+                                  },
+                                ],
+                              },
+                              Object {
+                                "destination": Object {
+                                  "name": "reviews",
+                                },
+                                "match": null,
+                                "name": "reviews-default",
+                                "precedence": 1,
+                                "route": Array [
+                                  Object {
+                                    "labels": Object {
+                                      "version": "v1",
                                     },
                                   },
                                 ],
@@ -3300,23 +1268,9 @@ ShallowWrapper {
                           eventKey={3}
                         >
                           <ServiceInfoRouteRules
+                            editorLink="/namespaces/istio-system/services/reviews"
                             routeRules={
                               Array [
-                                Object {
-                                  "destination": Object {
-                                    "name": "reviews",
-                                  },
-                                  "match": null,
-                                  "name": "reviews-default",
-                                  "precedence": 1,
-                                  "route": Array [
-                                    Object {
-                                      "labels": Object {
-                                        "version": "v1",
-                                      },
-                                    },
-                                  ],
-                                },
                                 Object {
                                   "destination": Object {
                                     "name": "reviews",
@@ -3336,6 +1290,21 @@ ShallowWrapper {
                                     Object {
                                       "labels": Object {
                                         "version": "v2",
+                                      },
+                                    },
+                                  ],
+                                },
+                                Object {
+                                  "destination": Object {
+                                    "name": "reviews",
+                                  },
+                                  "match": null,
+                                  "name": "reviews-default",
+                                  "precedence": 1,
+                                  "route": Array [
+                                    Object {
+                                      "labels": Object {
+                                        "version": "v1",
                                       },
                                     },
                                   ],
@@ -3526,23 +1495,9 @@ ShallowWrapper {
                             eventKey={3}
                           >
                             <ServiceInfoRouteRules
+                              editorLink="/namespaces/istio-system/services/reviews"
                               routeRules={
                                 Array [
-                                  Object {
-                                    "destination": Object {
-                                      "name": "reviews",
-                                    },
-                                    "match": null,
-                                    "name": "reviews-default",
-                                    "precedence": 1,
-                                    "route": Array [
-                                      Object {
-                                        "labels": Object {
-                                          "version": "v1",
-                                        },
-                                      },
-                                    ],
-                                  },
                                   Object {
                                     "destination": Object {
                                       "name": "reviews",
@@ -3562,6 +1517,21 @@ ShallowWrapper {
                                       Object {
                                         "labels": Object {
                                           "version": "v2",
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  Object {
+                                    "destination": Object {
+                                      "name": "reviews",
+                                    },
+                                    "match": null,
+                                    "name": "reviews-default",
+                                    "precedence": 1,
+                                    "route": Array [
+                                      Object {
+                                        "labels": Object {
+                                          "version": "v1",
                                         },
                                       },
                                     ],
@@ -3622,23 +1592,9 @@ ShallowWrapper {
                           "props": Object {
                             "bsClass": "tab-pane",
                             "children": <ServiceInfoRouteRules
+                              editorLink="/namespaces/istio-system/services/reviews"
                               routeRules={
                                 Array [
-                                  Object {
-                                    "destination": Object {
-                                      "name": "reviews",
-                                    },
-                                    "match": null,
-                                    "name": "reviews-default",
-                                    "precedence": 1,
-                                    "route": Array [
-                                      Object {
-                                        "labels": Object {
-                                          "version": "v1",
-                                        },
-                                      },
-                                    ],
-                                  },
                                   Object {
                                     "destination": Object {
                                       "name": "reviews",
@@ -3662,6 +1618,21 @@ ShallowWrapper {
                                       },
                                     ],
                                   },
+                                  Object {
+                                    "destination": Object {
+                                      "name": "reviews",
+                                    },
+                                    "match": null,
+                                    "name": "reviews-default",
+                                    "precedence": 1,
+                                    "route": Array [
+                                      Object {
+                                        "labels": Object {
+                                          "version": "v1",
+                                        },
+                                      },
+                                    ],
+                                  },
                                 ]
                               }
                             />,
@@ -3673,22 +1644,8 @@ ShallowWrapper {
                             "key": undefined,
                             "nodeType": "class",
                             "props": Object {
+                              "editorLink": "/namespaces/istio-system/services/reviews",
                               "routeRules": Array [
-                                Object {
-                                  "destination": Object {
-                                    "name": "reviews",
-                                  },
-                                  "match": null,
-                                  "name": "reviews-default",
-                                  "precedence": 1,
-                                  "route": Array [
-                                    Object {
-                                      "labels": Object {
-                                        "version": "v1",
-                                      },
-                                    },
-                                  ],
-                                },
                                 Object {
                                   "destination": Object {
                                     "name": "reviews",
@@ -3708,6 +1665,21 @@ ShallowWrapper {
                                     Object {
                                       "labels": Object {
                                         "version": "v2",
+                                      },
+                                    },
+                                  ],
+                                },
+                                Object {
+                                  "destination": Object {
+                                    "name": "reviews",
+                                  },
+                                  "match": null,
+                                  "name": "reviews-default",
+                                  "precedence": 1,
+                                  "route": Array [
+                                    Object {
+                                      "labels": Object {
+                                        "version": "v1",
                                       },
                                     },
                                   ],
@@ -3802,7 +1774,7 @@ ShallowWrapper {
                 xs={12}
               >
                 <ServiceInfoDescription
-                  created_at=""
+                  created_at={undefined}
                   endpoints={
                     Array [
                       Object {
@@ -3836,11 +1808,7 @@ ShallowWrapper {
                   health={undefined}
                   ip="172.30.78.33"
                   istio_sidecar={false}
-                  labels={
-                    Object {
-                      "app": "reviews",
-                    }
-                  }
+                  labels={Map {}}
                   name="reviews"
                   ports={
                     Array [
@@ -3851,7 +1819,7 @@ ShallowWrapper {
                       },
                     ]
                   }
-                  resource_version=""
+                  resource_version={undefined}
                   type="ClusterIP"
                 />
               </Col>
@@ -3944,23 +1912,9 @@ ShallowWrapper {
                         eventKey={3}
                       >
                         <ServiceInfoRouteRules
+                          editorLink="/namespaces/istio-system/services/reviews"
                           routeRules={
                             Array [
-                              Object {
-                                "destination": Object {
-                                  "name": "reviews",
-                                },
-                                "match": null,
-                                "name": "reviews-default",
-                                "precedence": 1,
-                                "route": Array [
-                                  Object {
-                                    "labels": Object {
-                                      "version": "v1",
-                                    },
-                                  },
-                                ],
-                              },
                               Object {
                                 "destination": Object {
                                   "name": "reviews",
@@ -3980,6 +1934,21 @@ ShallowWrapper {
                                   Object {
                                     "labels": Object {
                                       "version": "v2",
+                                    },
+                                  },
+                                ],
+                              },
+                              Object {
+                                "destination": Object {
+                                  "name": "reviews",
+                                },
+                                "match": null,
+                                "name": "reviews-default",
+                                "precedence": 1,
+                                "route": Array [
+                                  Object {
+                                    "labels": Object {
+                                      "version": "v1",
                                     },
                                   },
                                 ],
@@ -4031,7 +2000,7 @@ ShallowWrapper {
                   xs={12}
                 >
                   <ServiceInfoDescription
-                    created_at=""
+                    created_at={undefined}
                     endpoints={
                       Array [
                         Object {
@@ -4065,11 +2034,7 @@ ShallowWrapper {
                     health={undefined}
                     ip="172.30.78.33"
                     istio_sidecar={false}
-                    labels={
-                      Object {
-                        "app": "reviews",
-                      }
-                    }
+                    labels={Map {}}
                     name="reviews"
                     ports={
                       Array [
@@ -4080,7 +2045,7 @@ ShallowWrapper {
                         },
                       ]
                     }
-                    resource_version=""
+                    resource_version={undefined}
                     type="ClusterIP"
                   />
                 </Col>
@@ -4173,23 +2138,9 @@ ShallowWrapper {
                           eventKey={3}
                         >
                           <ServiceInfoRouteRules
+                            editorLink="/namespaces/istio-system/services/reviews"
                             routeRules={
                               Array [
-                                Object {
-                                  "destination": Object {
-                                    "name": "reviews",
-                                  },
-                                  "match": null,
-                                  "name": "reviews-default",
-                                  "precedence": 1,
-                                  "route": Array [
-                                    Object {
-                                      "labels": Object {
-                                        "version": "v1",
-                                      },
-                                    },
-                                  ],
-                                },
                                 Object {
                                   "destination": Object {
                                     "name": "reviews",
@@ -4209,6 +2160,21 @@ ShallowWrapper {
                                     Object {
                                       "labels": Object {
                                         "version": "v2",
+                                      },
+                                    },
+                                  ],
+                                },
+                                Object {
+                                  "destination": Object {
+                                    "name": "reviews",
+                                  },
+                                  "match": null,
+                                  "name": "reviews-default",
+                                  "precedence": 1,
+                                  "route": Array [
+                                    Object {
+                                      "labels": Object {
+                                        "version": "v1",
                                       },
                                     },
                                   ],
@@ -4254,7 +2220,7 @@ ShallowWrapper {
                   xs={12}
                 >
                   <ServiceInfoDescription
-                    created_at=""
+                    created_at={undefined}
                     endpoints={
                       Array [
                         Object {
@@ -4288,11 +2254,7 @@ ShallowWrapper {
                     health={undefined}
                     ip="172.30.78.33"
                     istio_sidecar={false}
-                    labels={
-                      Object {
-                        "app": "reviews",
-                      }
-                    }
+                    labels={Map {}}
                     name="reviews"
                     ports={
                       Array [
@@ -4303,7 +2265,7 @@ ShallowWrapper {
                         },
                       ]
                     }
-                    resource_version=""
+                    resource_version={undefined}
                     type="ClusterIP"
                   />
                 </Col>,
@@ -4318,7 +2280,7 @@ ShallowWrapper {
                 "props": Object {
                   "bsClass": "col",
                   "children": <ServiceInfoDescription
-                    created_at=""
+                    created_at={undefined}
                     endpoints={
                       Array [
                         Object {
@@ -4352,11 +2314,7 @@ ShallowWrapper {
                     health={undefined}
                     ip="172.30.78.33"
                     istio_sidecar={false}
-                    labels={
-                      Object {
-                        "app": "reviews",
-                      }
-                    }
+                    labels={Map {}}
                     name="reviews"
                     ports={
                       Array [
@@ -4367,7 +2325,7 @@ ShallowWrapper {
                         },
                       ]
                     }
-                    resource_version=""
+                    resource_version={undefined}
                     type="ClusterIP"
                   />,
                   "componentClass": "div",
@@ -4382,7 +2340,7 @@ ShallowWrapper {
                   "key": undefined,
                   "nodeType": "class",
                   "props": Object {
-                    "created_at": "",
+                    "created_at": undefined,
                     "endpoints": Array [
                       Object {
                         "addresses": Array [
@@ -4414,9 +2372,7 @@ ShallowWrapper {
                     "health": undefined,
                     "ip": "172.30.78.33",
                     "istio_sidecar": false,
-                    "labels": Object {
-                      "app": "reviews",
-                    },
+                    "labels": Map {},
                     "name": "reviews",
                     "ports": Array [
                       Object {
@@ -4425,7 +2381,7 @@ ShallowWrapper {
                         "protocol": "TCP",
                       },
                     ],
-                    "resource_version": "",
+                    "resource_version": undefined,
                     "type": "ClusterIP",
                   },
                   "ref": null,
@@ -4525,23 +2481,9 @@ ShallowWrapper {
                           eventKey={3}
                         >
                           <ServiceInfoRouteRules
+                            editorLink="/namespaces/istio-system/services/reviews"
                             routeRules={
                               Array [
-                                Object {
-                                  "destination": Object {
-                                    "name": "reviews",
-                                  },
-                                  "match": null,
-                                  "name": "reviews-default",
-                                  "precedence": 1,
-                                  "route": Array [
-                                    Object {
-                                      "labels": Object {
-                                        "version": "v1",
-                                      },
-                                    },
-                                  ],
-                                },
                                 Object {
                                   "destination": Object {
                                     "name": "reviews",
@@ -4561,6 +2503,21 @@ ShallowWrapper {
                                     Object {
                                       "labels": Object {
                                         "version": "v2",
+                                      },
+                                    },
+                                  ],
+                                },
+                                Object {
+                                  "destination": Object {
+                                    "name": "reviews",
+                                  },
+                                  "match": null,
+                                  "name": "reviews-default",
+                                  "precedence": 1,
+                                  "route": Array [
+                                    Object {
+                                      "labels": Object {
+                                        "version": "v1",
                                       },
                                     },
                                   ],
@@ -4670,23 +2627,9 @@ ShallowWrapper {
                           eventKey={3}
                         >
                           <ServiceInfoRouteRules
+                            editorLink="/namespaces/istio-system/services/reviews"
                             routeRules={
                               Array [
-                                Object {
-                                  "destination": Object {
-                                    "name": "reviews",
-                                  },
-                                  "match": null,
-                                  "name": "reviews-default",
-                                  "precedence": 1,
-                                  "route": Array [
-                                    Object {
-                                      "labels": Object {
-                                        "version": "v1",
-                                      },
-                                    },
-                                  ],
-                                },
                                 Object {
                                   "destination": Object {
                                     "name": "reviews",
@@ -4706,6 +2649,21 @@ ShallowWrapper {
                                     Object {
                                       "labels": Object {
                                         "version": "v2",
+                                      },
+                                    },
+                                  ],
+                                },
+                                Object {
+                                  "destination": Object {
+                                    "name": "reviews",
+                                  },
+                                  "match": null,
+                                  "name": "reviews-default",
+                                  "precedence": 1,
+                                  "route": Array [
+                                    Object {
+                                      "labels": Object {
+                                        "version": "v1",
                                       },
                                     },
                                   ],
@@ -4812,23 +2770,9 @@ ShallowWrapper {
                           eventKey={3}
                         >
                           <ServiceInfoRouteRules
+                            editorLink="/namespaces/istio-system/services/reviews"
                             routeRules={
                               Array [
-                                Object {
-                                  "destination": Object {
-                                    "name": "reviews",
-                                  },
-                                  "match": null,
-                                  "name": "reviews-default",
-                                  "precedence": 1,
-                                  "route": Array [
-                                    Object {
-                                      "labels": Object {
-                                        "version": "v1",
-                                      },
-                                    },
-                                  ],
-                                },
                                 Object {
                                   "destination": Object {
                                     "name": "reviews",
@@ -4848,6 +2792,21 @@ ShallowWrapper {
                                     Object {
                                       "labels": Object {
                                         "version": "v2",
+                                      },
+                                    },
+                                  ],
+                                },
+                                Object {
+                                  "destination": Object {
+                                    "name": "reviews",
+                                  },
+                                  "match": null,
+                                  "name": "reviews-default",
+                                  "precedence": 1,
+                                  "route": Array [
+                                    Object {
+                                      "labels": Object {
+                                        "version": "v1",
                                       },
                                     },
                                   ],
@@ -4950,23 +2909,9 @@ ShallowWrapper {
                             eventKey={3}
                           >
                             <ServiceInfoRouteRules
+                              editorLink="/namespaces/istio-system/services/reviews"
                               routeRules={
                                 Array [
-                                  Object {
-                                    "destination": Object {
-                                      "name": "reviews",
-                                    },
-                                    "match": null,
-                                    "name": "reviews-default",
-                                    "precedence": 1,
-                                    "route": Array [
-                                      Object {
-                                        "labels": Object {
-                                          "version": "v1",
-                                        },
-                                      },
-                                    ],
-                                  },
                                   Object {
                                     "destination": Object {
                                       "name": "reviews",
@@ -4986,6 +2931,21 @@ ShallowWrapper {
                                       Object {
                                         "labels": Object {
                                           "version": "v2",
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  Object {
+                                    "destination": Object {
+                                      "name": "reviews",
+                                    },
+                                    "match": null,
+                                    "name": "reviews-default",
+                                    "precedence": 1,
+                                    "route": Array [
+                                      Object {
+                                        "labels": Object {
+                                          "version": "v1",
                                         },
                                       },
                                     ],
@@ -5176,23 +3136,9 @@ ShallowWrapper {
                               eventKey={3}
                             >
                               <ServiceInfoRouteRules
+                                editorLink="/namespaces/istio-system/services/reviews"
                                 routeRules={
                                   Array [
-                                    Object {
-                                      "destination": Object {
-                                        "name": "reviews",
-                                      },
-                                      "match": null,
-                                      "name": "reviews-default",
-                                      "precedence": 1,
-                                      "route": Array [
-                                        Object {
-                                          "labels": Object {
-                                            "version": "v1",
-                                          },
-                                        },
-                                      ],
-                                    },
                                     Object {
                                       "destination": Object {
                                         "name": "reviews",
@@ -5212,6 +3158,21 @@ ShallowWrapper {
                                         Object {
                                           "labels": Object {
                                             "version": "v2",
+                                          },
+                                        },
+                                      ],
+                                    },
+                                    Object {
+                                      "destination": Object {
+                                        "name": "reviews",
+                                      },
+                                      "match": null,
+                                      "name": "reviews-default",
+                                      "precedence": 1,
+                                      "route": Array [
+                                        Object {
+                                          "labels": Object {
+                                            "version": "v1",
                                           },
                                         },
                                       ],
@@ -5272,23 +3233,9 @@ ShallowWrapper {
                             "props": Object {
                               "bsClass": "tab-pane",
                               "children": <ServiceInfoRouteRules
+                                editorLink="/namespaces/istio-system/services/reviews"
                                 routeRules={
                                   Array [
-                                    Object {
-                                      "destination": Object {
-                                        "name": "reviews",
-                                      },
-                                      "match": null,
-                                      "name": "reviews-default",
-                                      "precedence": 1,
-                                      "route": Array [
-                                        Object {
-                                          "labels": Object {
-                                            "version": "v1",
-                                          },
-                                        },
-                                      ],
-                                    },
                                     Object {
                                       "destination": Object {
                                         "name": "reviews",
@@ -5312,6 +3259,21 @@ ShallowWrapper {
                                         },
                                       ],
                                     },
+                                    Object {
+                                      "destination": Object {
+                                        "name": "reviews",
+                                      },
+                                      "match": null,
+                                      "name": "reviews-default",
+                                      "precedence": 1,
+                                      "route": Array [
+                                        Object {
+                                          "labels": Object {
+                                            "version": "v1",
+                                          },
+                                        },
+                                      ],
+                                    },
                                   ]
                                 }
                               />,
@@ -5323,22 +3285,8 @@ ShallowWrapper {
                               "key": undefined,
                               "nodeType": "class",
                               "props": Object {
+                                "editorLink": "/namespaces/istio-system/services/reviews",
                                 "routeRules": Array [
-                                  Object {
-                                    "destination": Object {
-                                      "name": "reviews",
-                                    },
-                                    "match": null,
-                                    "name": "reviews-default",
-                                    "precedence": 1,
-                                    "route": Array [
-                                      Object {
-                                        "labels": Object {
-                                          "version": "v1",
-                                        },
-                                      },
-                                    ],
-                                  },
                                   Object {
                                     "destination": Object {
                                       "name": "reviews",
@@ -5358,6 +3306,21 @@ ShallowWrapper {
                                       Object {
                                         "labels": Object {
                                           "version": "v2",
+                                        },
+                                      },
+                                    ],
+                                  },
+                                  Object {
+                                    "destination": Object {
+                                      "name": "reviews",
+                                    },
+                                    "match": null,
+                                    "name": "reviews-default",
+                                    "precedence": 1,
+                                    "route": Array [
+                                      Object {
+                                        "labels": Object {
+                                          "version": "v1",
                                         },
                                       },
                                     ],

--- a/src/types/ServiceInfo.ts
+++ b/src/types/ServiceInfo.ts
@@ -1,3 +1,5 @@
+import { Health } from './Health';
+
 export interface Endpoints {
   addresses?: EndpointAddress[];
   ports?: Port[];
@@ -341,3 +343,26 @@ export const hasIstioSidecar = (deployments: Deployment[]) => {
   }
   return false;
 };
+
+export interface ServiceDetailsInfo {
+  labels?: Map<string, string>;
+  type: string;
+  name: string;
+  created_at: string;
+  resource_version: string;
+  ip: string;
+  ports?: Port[];
+  endpoints?: Endpoints[];
+  istio_sidecar: boolean;
+  deployments?: Deployment[];
+  routeRules?: RouteRule[];
+  destinationPolicies?: DestinationPolicy[];
+  virtualServices?: VirtualService[];
+  destinationRules?: DestinationRule[];
+  dependencies?: Map<string, string[]>;
+  health?: Health;
+}
+
+export interface EditorLink {
+  editorLink: string;
+}


### PR DESCRIPTION
This PR introduces the ACE editor on Service Istio Object level.
In a preliminar iteration it follows style defined in the OpenShift Console.

From the Istio name object we can navigate to the editor like this:
![image](https://user-images.githubusercontent.com/1662329/39435535-fbbecdbe-4c9b-11e8-8a81-381af21c50ab.png)

![image](https://user-images.githubusercontent.com/1662329/39435560-0b892ece-4c9c-11e8-95f5-da3c8625d764.png)

