### PR TITLE
[KIALI-666] Fix Kiali UI console log error messages

### DIFF
--- a/src/components/GraphFilter/GraphFilter.tsx
+++ b/src/components/GraphFilter/GraphFilter.tsx
@@ -81,6 +81,7 @@ export default class GraphFilter extends React.Component<GraphFilterProps, Graph
             />
           </FormGroup>
           <ToolbarDropdown
+            id={'graph_filter_interval_duration'}
             disabled={this.props.disabled}
             handleSelect={this.updateDuration}
             nameDropdown={'Duration'}
@@ -93,6 +94,7 @@ export default class GraphFilter extends React.Component<GraphFilterProps, Graph
             options={GraphFilter.INTERVAL_DURATION}
           />
           <ToolbarDropdown
+            id={'graph_filter_layouts'}
             disabled={this.props.disabled}
             handleSelect={this.updateLayout}
             nameDropdown={'Layout'}

--- a/src/components/MetricsOptions/MetricsOptionsBar.tsx
+++ b/src/components/MetricsOptions/MetricsOptionsBar.tsx
@@ -110,9 +110,9 @@ export class MetricsOptionsBar extends React.Component<Props, MetricsOptionsStat
       <Toolbar>
         {this.groupByLabelsHelper.renderDropdown()}
         <ToolbarDropdown
+          id={'metrics_filter_interval_duration'}
           disabled={false}
           handleSelect={this.onDurationChanged}
-          id={'duration'}
           nameDropdown={'Duration'}
           initialValue={Number(sessionStorage.getItem('appDuration')) || MetricsOptionsBar.DefaultDuration}
           initialLabel={String(
@@ -123,6 +123,7 @@ export class MetricsOptionsBar extends React.Component<Props, MetricsOptionsStat
           options={MetricsOptionsBar.Durations}
         />
         <ToolbarDropdown
+          id={'metrics_filter_pool_interval'}
           disabled={false}
           handleSelect={this.onPollIntervalChanged}
           nameDropdown={'Pool Interval'}

--- a/src/components/MetricsOptions/__tests__/MetricsOptionsBar.test.tsx
+++ b/src/components/MetricsOptions/__tests__/MetricsOptionsBar.test.tsx
@@ -30,7 +30,7 @@ describe('MetricsOptionsBar', () => {
     expect(opts).toHaveProperty('duration', MetricsOptionsBar.DefaultDuration);
 
     let elt = wrapper
-      .find('#duration')
+      .find('#metrics_filter_interval_duration')
       .find('SafeAnchor')
       .first();
     elt.simulate('click');

--- a/src/components/MetricsOptions/__tests__/__snapshots__/MetricsOptionsBar.test.tsx.snap
+++ b/src/components/MetricsOptions/__tests__/__snapshots__/MetricsOptionsBar.test.tsx.snap
@@ -62,7 +62,7 @@ ShallowWrapper {
         <ToolbarDropdown
           disabled={false}
           handleSelect={[Function]}
-          id="duration"
+          id="metrics_filter_interval_duration"
           initialLabel="Last minute"
           initialValue={60}
           nameDropdown="Duration"
@@ -85,6 +85,7 @@ ShallowWrapper {
         <ToolbarDropdown
           disabled={false}
           handleSelect={[Function]}
+          id="metrics_filter_pool_interval"
           initialLabel="5 seconds"
           initialValue={5000}
           nameDropdown="Pool Interval"
@@ -173,7 +174,7 @@ ShallowWrapper {
         "props": Object {
           "disabled": false,
           "handleSelect": [Function],
-          "id": "duration",
+          "id": "metrics_filter_interval_duration",
           "initialLabel": "Last minute",
           "initialValue": 60,
           "nameDropdown": "Duration",
@@ -202,6 +203,7 @@ ShallowWrapper {
         "props": Object {
           "disabled": false,
           "handleSelect": [Function],
+          "id": "metrics_filter_pool_interval",
           "initialLabel": "5 seconds",
           "initialValue": 5000,
           "nameDropdown": "Pool Interval",
@@ -309,7 +311,7 @@ ShallowWrapper {
           <ToolbarDropdown
             disabled={false}
             handleSelect={[Function]}
-            id="duration"
+            id="metrics_filter_interval_duration"
             initialLabel="Last minute"
             initialValue={60}
             nameDropdown="Duration"
@@ -332,6 +334,7 @@ ShallowWrapper {
           <ToolbarDropdown
             disabled={false}
             handleSelect={[Function]}
+            id="metrics_filter_pool_interval"
             initialLabel="5 seconds"
             initialValue={5000}
             nameDropdown="Pool Interval"
@@ -420,7 +423,7 @@ ShallowWrapper {
           "props": Object {
             "disabled": false,
             "handleSelect": [Function],
-            "id": "duration",
+            "id": "metrics_filter_interval_duration",
             "initialLabel": "Last minute",
             "initialValue": 60,
             "nameDropdown": "Duration",
@@ -449,6 +452,7 @@ ShallowWrapper {
           "props": Object {
             "disabled": false,
             "handleSelect": [Function],
+            "id": "metrics_filter_pool_interval",
             "initialLabel": "5 seconds",
             "initialValue": 5000,
             "nameDropdown": "Pool Interval",

--- a/src/components/ToolbarDropdown/ToolbarDropdown.tsx
+++ b/src/components/ToolbarDropdown/ToolbarDropdown.tsx
@@ -35,7 +35,7 @@ export class ToolbarDropdown extends React.Component<ToolbarDropdownProps, Toolb
     return (
       <div className="form-group">
         {this.props.nameDropdown && <label style={{ paddingRight: '0.5em' }}>{this.props.nameDropdown}:</label>}
-        <DropdownButton title={this.state.currentName} onSelect={this.onKeyChanged} {...this.props}>
+        <DropdownButton title={this.state.currentName} onSelect={this.onKeyChanged} id={this.props.id}>
           {Object.keys(this.props.options).map(key => (
             <MenuItem key={key} active={key === this.state.currentValue} eventKey={key}>
               {this.props.options[key]}


### PR DESCRIPTION
Fix errors

Error index.js:2178 Warning: withRouter(Navigation): Stateless functional components do not support getDerivedStateFromProps is fixed in react-router 4.3. We must to wait until next release.

Jira: [KIALI-666](https://issues.jboss.org/browse/KIALI-666)
```
index.js:2178 Warning: Failed prop type: The prop `id` is required to make `Dropdown` accessible for users of assistive technologies such as screen readers.
in Dropdown (created by Uncontrolled(Dropdown))
in Uncontrolled(Dropdown) (created by DropdownButton)
in DropdownButton (created by DropdownButton)
in DropdownButton (created by ToolbarDropdown)
in div (created by ToolbarDropdown)
in ToolbarDropdown (created by GraphFilter)
in form (created by Toolbar)
in div (created by Col)
in Col (created by Toolbar)
in div (created by Row)
in Row (created by Toolbar)
in div (created by Grid)
in Grid (created by Toolbar)
in Unknown (created by withContext(Component))
in withContext(Component) (created by Toolbar)
in Toolbar (created by withContext(Toolbar))
in withContext(Toolbar) (created by GraphFilter)
in GraphFilter (created by ServiceGraphPage)
in div (created by PfContainerNavVertical)
in PfContainerNavVertical (created by ServiceGraphPage)
in ServiceGraphPage (created by ServiceGraphRouteHandler)
in ServiceGraphRouteHandler (created by Route)
in Route (created by Navigation)
in Switch (created by SwitchErrorBoundary)
in SwitchErrorBoundary (created by Navigation)
in Navigation (created by Route)
in Route (created by withRouter(Navigation))
in withRouter(Navigation) (created by App)
in Router (created by BrowserRouter)
in BrowserRouter (created by App)
in Provider (created by App)
in App
_stack_frame_overlay_proxy_console_ @ index.js:2178
printWarning @ warning.js:33
warning @ warning.js:57
checkPropTypes @ checkPropTypes.js:52
validatePropTypes @ react.development.js:1233
createElementWithValidation @ react.development.js:1321
render @ createUncontrollable.js:142
finishClassComponent @ react-dom.development.js:8389
updateClassComponent @ react-dom.development.js:8357
beginWork @ react-dom.development.js:8982
performUnitOfWork @ react-dom.development.js:11814
workLoop @ react-dom.development.js:11843
renderRoot @ react-dom.development.js:11874
performWorkOnRoot @ react-dom.development.js:12449
performWork @ react-dom.development.js:12370
performSyncWork @ react-dom.development.js:12347
requestWork @ react-dom.development.js:12247
scheduleWorkImpl @ react-dom.development.js:12122
scheduleWork @ react-dom.development.js:12082
scheduleRootUpdate @ react-dom.development.js:12710
updateContainerAtExpirationTime @ react-dom.development.js:12738
updateContainer @ react-dom.development.js:12765
./node_modules/react-dom/cjs/react-dom.development.js.ReactRoot.render @ react-dom.development.js:16069
(anonymous) @ react-dom.development.js:16488
unbatchedUpdates @ react-dom.development.js:12557
legacyRenderSubtreeIntoContainer @ react-dom.development.js:16484
render @ react-dom.development.js:16543
./src/index.tsx @ index.tsx:7
_webpack_require_ @ bootstrap 972aa9706a0c35fb077c:678
fn @ bootstrap 972aa9706a0c35fb077c:88
0 @ graphing.ts:21
_webpack_require_ @ bootstrap 972aa9706a0c35fb077c:678
./node_modules/ansi-regex/index.js.module.exports @ bootstrap 972aa9706a0c35fb077c:724
(anonymous) @ bootstrap 972aa9706a0c35fb077c:724
index.js:2178 Warning: React does not recognize the `handleSelect` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `handleselect` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
in button (created by Button)
in Button (created by DropdownToggle)
in DropdownToggle (created by Dropdown)
in div (created by ButtonGroup)
in ButtonGroup (created by Dropdown)
in Dropdown (created by Uncontrolled(Dropdown))
in Uncontrolled(Dropdown) (created by DropdownButton)
in DropdownButton (created by DropdownButton)
in DropdownButton (created by ToolbarDropdown)
in div (created by ToolbarDropdown)
in ToolbarDropdown (created by GraphFilter)
in form (created by Toolbar)
in div (created by Col)
in Col (created by Toolbar)
in div (created by Row)
in Row (created by Toolbar)
in div (created by Grid)
in Grid (created by Toolbar)
in Unknown (created by withContext(Component))
in withContext(Component) (created by Toolbar)
in Toolbar (created by withContext(Toolbar))
in withContext(Toolbar) (created by GraphFilter)
in GraphFilter (created by ServiceGraphPage)
in div (created by PfContainerNavVertical)
in PfContainerNavVertical (created by ServiceGraphPage)
in ServiceGraphPage (created by ServiceGraphRouteHandler)
in ServiceGraphRouteHandler (created by Route)
in Route (created by Navigation)
in Switch (created by SwitchErrorBoundary)
in SwitchErrorBoundary (created by Navigation)
in Navigation (created by Route)
in Route (created by withRouter(Navigation))
in withRouter(Navigation) (created by App)
in Router (created by BrowserRouter)
in BrowserRouter (created by App)
in Provider (created by App)
in App
_stack_frame_overlay_proxy_console_ @ index.js:2178
printWarning @ warning.js:33
warning @ warning.js:57
validateProperty$1 @ react-dom.development.js:14565
warnUnknownProperties @ react-dom.development.js:14599
validateProperties$2 @ react-dom.development.js:14619
validatePropertiesInDevelopment @ react-dom.development.js:14670
setInitialProperties$1 @ react-dom.development.js:14896
finalizeInitialChildren @ react-dom.development.js:16239
completeWork @ react-dom.development.js:9377
completeUnitOfWork @ react-dom.development.js:11671
performUnitOfWork @ react-dom.development.js:11831
workLoop @ react-dom.development.js:11843
renderRoot @ react-dom.development.js:11874
performWorkOnRoot @ react-dom.development.js:12449
performWork @ react-dom.development.js:12370
performSyncWork @ react-dom.development.js:12347
requestWork @ react-dom.development.js:12247
scheduleWorkImpl @ react-dom.development.js:12122
scheduleWork @ react-dom.development.js:12082
scheduleRootUpdate @ react-dom.development.js:12710
updateContainerAtExpirationTime @ react-dom.development.js:12738
updateContainer @ react-dom.development.js:12765
./node_modules/react-dom/cjs/react-dom.development.js.ReactRoot.render @ react-dom.development.js:16069
(anonymous) @ react-dom.development.js:16488
unbatchedUpdates @ react-dom.development.js:12557
legacyRenderSubtreeIntoContainer @ react-dom.development.js:16484
render @ react-dom.development.js:16543
./src/index.tsx @ index.tsx:7
_webpack_require_ @ bootstrap 972aa9706a0c35fb077c:678
fn @ bootstrap 972aa9706a0c35fb077c:88
0 @ graphing.ts:21
_webpack_require_ @ bootstrap 972aa9706a0c35fb077c:678
./node_modules/ansi-regex/index.js.module.exports @ bootstrap 972aa9706a0c35fb077c:724
(anonymous) @ bootstrap 972aa9706a0c35fb077c:724
index.js:2178 Warning: React does not recognize the `nameDropdown` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `namedropdown` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
in button (created by Button)
in Button (created by DropdownToggle)
in DropdownToggle (created by Dropdown)
in div (created by ButtonGroup)
in ButtonGroup (created by Dropdown)
in Dropdown (created by Uncontrolled(Dropdown))
in Uncontrolled(Dropdown) (created by DropdownButton)
in DropdownButton (created by DropdownButton)
in DropdownButton (created by ToolbarDropdown)
in div (created by ToolbarDropdown)
in ToolbarDropdown (created by GraphFilter)
in form (created by Toolbar)
in div (created by Col)
in Col (created by Toolbar)
in div (created by Row)
in Row (created by Toolbar)
in div (created by Grid)
in Grid (created by Toolbar)
in Unknown (created by withContext(Component))
in withContext(Component) (created by Toolbar)
in Toolbar (created by withContext(Toolbar))
in withContext(Toolbar) (created by GraphFilter)
in GraphFilter (created by ServiceGraphPage)
in div (created by PfContainerNavVertical)
in PfContainerNavVertical (created by ServiceGraphPage)
in ServiceGraphPage (created by ServiceGraphRouteHandler)
in ServiceGraphRouteHandler (created by Route)
in Route (created by Navigation)
in Switch (created by SwitchErrorBoundary)
in SwitchErrorBoundary (created by Navigation)
in Navigation (created by Route)
in Route (created by withRouter(Navigation))
in withRouter(Navigation) (created by App)
in Router (created by BrowserRouter)
in BrowserRouter (created by App)
in Provider (created by App)
in App
_stack_frame_overlay_proxy_console_ @ index.js:2178
printWarning @ warning.js:33
warning @ warning.js:57
validateProperty$1 @ react-dom.development.js:14565
warnUnknownProperties @ react-dom.development.js:14599
validateProperties$2 @ react-dom.development.js:14619
validatePropertiesInDevelopment @ react-dom.development.js:14670
setInitialProperties$1 @ react-dom.development.js:14896
finalizeInitialChildren @ react-dom.development.js:16239
completeWork @ react-dom.development.js:9377
completeUnitOfWork @ react-dom.development.js:11671
performUnitOfWork @ react-dom.development.js:11831
workLoop @ react-dom.development.js:11843
renderRoot @ react-dom.development.js:11874
performWorkOnRoot @ react-dom.development.js:12449
performWork @ react-dom.development.js:12370
performSyncWork @ react-dom.development.js:12347
requestWork @ react-dom.development.js:12247
scheduleWorkImpl @ react-dom.development.js:12122
scheduleWork @ react-dom.development.js:12082
scheduleRootUpdate @ react-dom.development.js:12710
updateContainerAtExpirationTime @ react-dom.development.js:12738
updateContainer @ react-dom.development.js:12765
./node_modules/react-dom/cjs/react-dom.development.js.ReactRoot.render @ react-dom.development.js:16069
(anonymous) @ react-dom.development.js:16488
unbatchedUpdates @ react-dom.development.js:12557
legacyRenderSubtreeIntoContainer @ react-dom.development.js:16484
render @ react-dom.development.js:16543
./src/index.tsx @ index.tsx:7
_webpack_require_ @ bootstrap 972aa9706a0c35fb077c:678
fn @ bootstrap 972aa9706a0c35fb077c:88
0 @ graphing.ts:21
_webpack_require_ @ bootstrap 972aa9706a0c35fb077c:678
./node_modules/ansi-regex/index.js.module.exports @ bootstrap 972aa9706a0c35fb077c:724
(anonymous) @ bootstrap 972aa9706a0c35fb077c:724
index.js:2178 Warning: React does not recognize the `initialValue` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `initialvalue` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
in button (created by Button)
in Button (created by DropdownToggle)
in DropdownToggle (created by Dropdown)
in div (created by ButtonGroup)
in ButtonGroup (created by Dropdown)
in Dropdown (created by Uncontrolled(Dropdown))
in Uncontrolled(Dropdown) (created by DropdownButton)
in DropdownButton (created by DropdownButton)
in DropdownButton (created by ToolbarDropdown)
in div (created by ToolbarDropdown)
in ToolbarDropdown (created by GraphFilter)
in form (created by Toolbar)
in div (created by Col)
in Col (created by Toolbar)
in div (created by Row)
in Row (created by Toolbar)
in div (created by Grid)
in Grid (created by Toolbar)
in Unknown (created by withContext(Component))
in withContext(Component) (created by Toolbar)
in Toolbar (created by withContext(Toolbar))
in withContext(Toolbar) (created by GraphFilter)
in GraphFilter (created by ServiceGraphPage)
in div (created by PfContainerNavVertical)
in PfContainerNavVertical (created by ServiceGraphPage)
in ServiceGraphPage (created by ServiceGraphRouteHandler)
in ServiceGraphRouteHandler (created by Route)
in Route (created by Navigation)
in Switch (created by SwitchErrorBoundary)
in SwitchErrorBoundary (created by Navigation)
in Navigation (created by Route)
in Route (created by withRouter(Navigation))
in withRouter(Navigation) (created by App)
in Router (created by BrowserRouter)
in BrowserRouter (created by App)
in Provider (created by App)
in App
_stack_frame_overlay_proxy_console_ @ index.js:2178
printWarning @ warning.js:33
warning @ warning.js:57
validateProperty$1 @ react-dom.development.js:14565
warnUnknownProperties @ react-dom.development.js:14599
validateProperties$2 @ react-dom.development.js:14619
validatePropertiesInDevelopment @ react-dom.development.js:14670
setInitialProperties$1 @ react-dom.development.js:14896
finalizeInitialChildren @ react-dom.development.js:16239
completeWork @ react-dom.development.js:9377
completeUnitOfWork @ react-dom.development.js:11671
performUnitOfWork @ react-dom.development.js:11831
workLoop @ react-dom.development.js:11843
renderRoot @ react-dom.development.js:11874
performWorkOnRoot @ react-dom.development.js:12449
performWork @ react-dom.development.js:12370
performSyncWork @ react-dom.development.js:12347
requestWork @ react-dom.development.js:12247
scheduleWorkImpl @ react-dom.development.js:12122
scheduleWork @ react-dom.development.js:12082
scheduleRootUpdate @ react-dom.development.js:12710
updateContainerAtExpirationTime @ react-dom.development.js:12738
updateContainer @ react-dom.development.js:12765
./node_modules/react-dom/cjs/react-dom.development.js.ReactRoot.render @ react-dom.development.js:16069
(anonymous) @ react-dom.development.js:16488
unbatchedUpdates @ react-dom.development.js:12557
legacyRenderSubtreeIntoContainer @ react-dom.development.js:16484
render @ react-dom.development.js:16543
./src/index.tsx @ index.tsx:7
_webpack_require_ @ bootstrap 972aa9706a0c35fb077c:678
fn @ bootstrap 972aa9706a0c35fb077c:88
0 @ graphing.ts:21
_webpack_require_ @ bootstrap 972aa9706a0c35fb077c:678
./node_modules/ansi-regex/index.js.module.exports @ bootstrap 972aa9706a0c35fb077c:724
(anonymous) @ bootstrap 972aa9706a0c35fb077c:724
index.js:2178 Warning: React does not recognize the `initialLabel` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `initiallabel` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
in button (created by Button)
in Button (created by DropdownToggle)
in DropdownToggle (created by Dropdown)
in div (created by ButtonGroup)
in ButtonGroup (created by Dropdown)
in Dropdown (created by Uncontrolled(Dropdown))
in Uncontrolled(Dropdown) (created by DropdownButton)
in DropdownButton (created by DropdownButton)
in DropdownButton (created by ToolbarDropdown)
in div (created by ToolbarDropdown)
in ToolbarDropdown (created by GraphFilter)
in form (created by Toolbar)
in div (created by Col)
in Col (created by Toolbar)
in div (created by Row)
in Row (created by Toolbar)
in div (created by Grid)
in Grid (created by Toolbar)
in Unknown (created by withContext(Component))
in withContext(Component) (created by Toolbar)
in Toolbar (created by withContext(Toolbar))
in withContext(Toolbar) (created by GraphFilter)
in GraphFilter (created by ServiceGraphPage)
in div (created by PfContainerNavVertical)
in PfContainerNavVertical (created by ServiceGraphPage)
in ServiceGraphPage (created by ServiceGraphRouteHandler)
in ServiceGraphRouteHandler (created by Route)
in Route (created by Navigation)
in Switch (created by SwitchErrorBoundary)
in SwitchErrorBoundary (created by Navigation)
in Navigation (created by Route)
in Route (created by withRouter(Navigation))
in withRouter(Navigation) (created by App)
in Router (created by BrowserRouter)
in BrowserRouter (created by App)
in Provider (created by App)
```