### PR TITLE
Add ActionCreator tests to test the Actions 

### DIFF
--- a/src/actions/ServiceGraphFilterActions.ts
+++ b/src/actions/ServiceGraphFilterActions.ts
@@ -8,7 +8,7 @@ export enum ServiceGraphFilterActionKeys {
   TOGGLE_GRAPH_CIRCUIT_BREAKERS = 'TOGGLE_GRAPH_CIRCUIT_BREAKERS',
   TOGGLE_GRAPH_ROUTE_RULES = 'TOGGLE_GRAPH_ROUTE_RULES',
   // Disable Actions
-  DISABLE_GRAPH_LAYERS = 'DISABLE_GRAPH_LAYERS'
+  ENABLE_GRAPH_FILTERS = 'ENABLE_GRAPH_FILTERS'
 }
 
 export const serviceGraphFilterActions = {
@@ -17,8 +17,8 @@ export const serviceGraphFilterActions = {
   toggleGraphEdgeLabel: createAction(ServiceGraphFilterActionKeys.TOGGLE_GRAPH_EDGE_LABEL),
   toggleGraphRouteRules: createAction(ServiceGraphFilterActionKeys.TOGGLE_GRAPH_ROUTE_RULES),
   toggleGraphCircuitBreakers: createAction(ServiceGraphFilterActionKeys.TOGGLE_GRAPH_CIRCUIT_BREAKERS),
-  disableGraphLayers: createAction(ServiceGraphFilterActionKeys.DISABLE_GRAPH_LAYERS, (value: boolean) => ({
-    type: ServiceGraphFilterActionKeys.DISABLE_GRAPH_LAYERS,
+  showGraphFilters: createAction(ServiceGraphFilterActionKeys.ENABLE_GRAPH_FILTERS, (value: boolean) => ({
+    type: ServiceGraphFilterActionKeys.ENABLE_GRAPH_FILTERS,
     payload: value
   }))
 };

--- a/src/actions/__tests__/GraphFilterAction.test.tsx
+++ b/src/actions/__tests__/GraphFilterAction.test.tsx
@@ -1,0 +1,48 @@
+import { ServiceGraphFilterActionKeys, serviceGraphFilterActions } from '../ServiceGraphFilterActions';
+
+// Test our ActionCreators for proper message format
+describe('GraphFilterActions', () => {
+  it('should toggle an edge label ', () => {
+    const expectedAction = {
+      type: ServiceGraphFilterActionKeys.TOGGLE_GRAPH_EDGE_LABEL
+    };
+    expect(serviceGraphFilterActions.toggleGraphEdgeLabel()).toEqual(expectedAction);
+  });
+
+  it('should toggle a node label ', () => {
+    const expectedAction = {
+      type: ServiceGraphFilterActionKeys.TOGGLE_GRAPH_NODE_LABEL
+    };
+    expect(serviceGraphFilterActions.toggleGraphNodeLabel()).toEqual(expectedAction);
+  });
+
+  it('should toggle a circuit breaker ', () => {
+    const expectedAction = {
+      type: ServiceGraphFilterActionKeys.TOGGLE_GRAPH_CIRCUIT_BREAKERS
+    };
+    expect(serviceGraphFilterActions.toggleGraphCircuitBreakers()).toEqual(expectedAction);
+  });
+
+  it('should toggle a route rule', () => {
+    const expectedAction = {
+      type: ServiceGraphFilterActionKeys.TOGGLE_GRAPH_ROUTE_RULES
+    };
+    expect(serviceGraphFilterActions.toggleGraphRouteRules()).toEqual(expectedAction);
+  });
+
+  it('should enable graph filters toggles', () => {
+    const expectedAction = {
+      type: ServiceGraphFilterActionKeys.ENABLE_GRAPH_FILTERS,
+      payload: true
+    };
+    expect(serviceGraphFilterActions.showGraphFilters(true)).toEqual(expectedAction);
+  });
+
+  it('should disable graph filters toggles', () => {
+    const expectedAction = {
+      type: ServiceGraphFilterActionKeys.ENABLE_GRAPH_FILTERS,
+      payload: false
+    };
+    expect(serviceGraphFilterActions.showGraphFilters(false)).toEqual(expectedAction);
+  });
+});

--- a/src/reducers/ServiceGraphFilterState.ts
+++ b/src/reducers/ServiceGraphFilterState.ts
@@ -22,7 +22,7 @@ const serviceGraphFilterState = (state: ServiceGraphFilterState = INITIAL_STATE,
       return updateState(state, { showCircuitBreakers: !state.showCircuitBreakers });
     case ServiceGraphFilterActionKeys.TOGGLE_GRAPH_ROUTE_RULES:
       return updateState(state, { showRouteRules: !state.showRouteRules });
-    case ServiceGraphFilterActionKeys.DISABLE_GRAPH_LAYERS:
+    case ServiceGraphFilterActionKeys.ENABLE_GRAPH_FILTERS:
       return updateState(state, { disableLayers: action.payload });
     default:
       return state;


### PR DESCRIPTION
Test the Redux ActionCreators to ensure the actions they create are what we think.

The testing part of https://issues.jboss.org/browse/KIALI-654