### PR TITLE
Kiali 589 remove toggle button filters and replace with popover checkboxes

### DIFF
--- a/src/components/GraphFilter/GraphFilter.tsx
+++ b/src/components/GraphFilter/GraphFilter.tsx
@@ -1,12 +1,24 @@
 import * as React from 'react';
 import { Toolbar, Button, Icon, FormGroup } from 'patternfly-react';
 
-import { GraphFilterProps, GraphFilterState } from '../../types/GraphFilter';
+import { Duration, Layout } from '../../types/GraphFilter';
 import { ToolbarDropdown } from '../ToolbarDropdown/ToolbarDropdown';
 import NamespaceDropdownContainer from '../../containers/NamespaceDropdownContainer';
 import { config } from '../../config';
 import GraphLayersContainer from '../../containers/GraphLayersContainer';
 import { style } from 'typestyle';
+import { GraphParamsType } from '../../types/Graph';
+import Namespace from '../../types/Namespace';
+
+export interface GraphFilterProps extends GraphParamsType {
+  disabled: boolean;
+  onLayoutChange: (newLayout: Layout) => void;
+  onFilterChange: (newDuration: Duration) => void;
+  onNamespaceChange: (newValue: Namespace) => void;
+  onRefresh: () => void;
+}
+
+export interface GraphFilterState {}
 
 const zeroPaddingLeft = style({
   paddingLeft: '0px'
@@ -85,14 +97,15 @@ export default class GraphFilter extends React.Component<GraphFilterProps, Graph
             initialLabel={String(GraphFilter.GRAPH_LAYOUTS[this.props.graphLayout.name])}
             options={GraphFilter.GRAPH_LAYOUTS}
           />
+          <FormGroup className={zeroPaddingLeft}>
+            <label className={labelPaddingRight}>Filters:</label>
+            <GraphLayersContainer />
+          </FormGroup>
           <Toolbar.RightContent>
             <Button disabled={this.props.disabled} onClick={this.handleRefresh}>
               <Icon name="refresh" />
             </Button>
           </Toolbar.RightContent>
-        </Toolbar>
-        <Toolbar>
-          <GraphLayersContainer />
         </Toolbar>
       </>
     );

--- a/src/containers/GraphLayersContainer.tsx
+++ b/src/containers/GraphLayersContainer.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
-import Switch from 'react-bootstrap-switch';
+import { Button, Icon, OverlayTrigger, Popover } from 'patternfly-react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { serviceGraphFilterActions } from '../actions/ServiceGraphFilterActions';
 import { KialiAppState, ServiceGraphFilterState } from '../store/Store';
-import { style } from 'typestyle';
 
 interface ServiceGraphDispatch {
   // Dispatch methods
@@ -35,12 +34,8 @@ const mapDispatchToProps = (dispatch: any) => {
   };
 };
 
-// Styles
-const switchButtonStyle = style({
-  paddingLeft: '10px'
-});
-
 interface VisibilityLayersType {
+  id: string;
   labelText: string;
   value: boolean;
   onChange: () => void;
@@ -51,39 +46,53 @@ interface VisibilityLayersType {
 export const GraphLayers: React.SFC<GraphLayersProps> = props => {
   // map our attributes from redux
   const { showCircuitBreakers, showRouteRules, showEdgeLabels, showNodeLabels } = props;
-  // map or dispatchers for redux
+  // // map or dispatchers for redux
   const { toggleGraphCircuitBreakers, toggleGraphRouteRules, toggleGraphEdgeLabels, toggleGraphNodeLabels } = props;
 
   const visibilityLayers: VisibilityLayersType[] = [
     {
+      id: 'filterCB',
       labelText: 'Circuit Breakers',
       value: showCircuitBreakers,
       onChange: toggleGraphCircuitBreakers
     },
     {
+      id: 'filterRR',
       labelText: 'Route Rules',
       value: showRouteRules,
       onChange: toggleGraphRouteRules
     },
     {
+      id: 'filterEdges',
       labelText: 'Edge Labels',
       value: showEdgeLabels,
       onChange: toggleGraphEdgeLabels
     },
     {
+      id: 'filterNodes',
       labelText: 'Node Labels',
       value: showNodeLabels,
       onChange: toggleGraphNodeLabels
     }
   ];
 
-  const toggleItems = visibilityLayers.map((item: any) => (
-    <span className={switchButtonStyle}>
-      <Switch bsSize={'medium'} labelText={item.labelText} value={item.value} onChange={() => item.onChange()} />
-    </span>
+  const toggleItems = visibilityLayers.map((item: VisibilityLayersType) => (
+    <div id={item.id}>
+      <label>
+        <input name="isGoing" type="checkbox" checked={item.value} onChange={() => item.onChange()} />
+        {item.labelText}
+      </label>
+    </div>
   ));
+  const popover = <Popover>{toggleItems}</Popover>;
 
-  return <>{toggleItems}</>;
+  return (
+    <OverlayTrigger overlay={popover} placement="bottom" trigger={['click']} rootClose={'true'}>
+      <Button>
+        <Icon name="filter" />
+      </Button>
+    </OverlayTrigger>
+  );
 };
 
 // hook up to Redux for our State to be mapped to props

--- a/src/types/GraphFilter.ts
+++ b/src/types/GraphFilter.ts
@@ -1,16 +1,3 @@
-import Namespace from './Namespace';
-import { GraphParamsType } from './Graph';
-
-export interface GraphFilterProps extends GraphParamsType {
-  disabled: boolean;
-  onLayoutChange: (newLayout: Layout) => void;
-  onFilterChange: (newDuration: Duration) => void;
-  onNamespaceChange: (newValue: Namespace) => void;
-  onRefresh: () => void;
-}
-
-export interface GraphFilterState {}
-
 export interface Layout {
   name: string;
 }


### PR DESCRIPTION
The current toggle button visibility filters doesn't look so great on laptop screens and there are some issues with clicking around fast.
This PR deletes the filter toolbar and just places the checkboxes in a popover to conserve screen space (and make it more appealing).

![checkbox-filters](https://user-images.githubusercontent.com/1312165/39894140-c20f5504-545a-11e8-88d2-42ae10340232.gif)

https://issues.jboss.org/browse/KIALI-589