### PR TITLE
KIALI-661: Graph badges for missing sidecars

### DIFF
--- a/src/actions/ServiceGraphFilterActions.ts
+++ b/src/actions/ServiceGraphFilterActions.ts
@@ -7,6 +7,7 @@ export enum ServiceGraphFilterActionKeys {
   TOGGLE_GRAPH_EDGE_LABEL = 'TOGGLE_GRAPH_EDGE_LABEL',
   TOGGLE_GRAPH_CIRCUIT_BREAKERS = 'TOGGLE_GRAPH_CIRCUIT_BREAKERS',
   TOGGLE_GRAPH_ROUTE_RULES = 'TOGGLE_GRAPH_ROUTE_RULES',
+  TOGGLE_GRAPH_MISSING_SIDECARS = 'TOGGLE_GRAPH_MISSING_SIDECARS',
   // Disable Actions
   ENABLE_GRAPH_FILTERS = 'ENABLE_GRAPH_FILTERS'
 }
@@ -17,6 +18,7 @@ export const serviceGraphFilterActions = {
   toggleGraphEdgeLabel: createAction(ServiceGraphFilterActionKeys.TOGGLE_GRAPH_EDGE_LABEL),
   toggleGraphRouteRules: createAction(ServiceGraphFilterActionKeys.TOGGLE_GRAPH_ROUTE_RULES),
   toggleGraphCircuitBreakers: createAction(ServiceGraphFilterActionKeys.TOGGLE_GRAPH_CIRCUIT_BREAKERS),
+  toggleGraphMissingSidecars: createAction(ServiceGraphFilterActionKeys.TOGGLE_GRAPH_MISSING_SIDECARS),
   showGraphFilters: createAction(ServiceGraphFilterActionKeys.ENABLE_GRAPH_FILTERS, (value: boolean) => ({
     type: ServiceGraphFilterActionKeys.ENABLE_GRAPH_FILTERS,
     payload: value

--- a/src/actions/__tests__/GraphFilterAction.test.tsx
+++ b/src/actions/__tests__/GraphFilterAction.test.tsx
@@ -30,6 +30,13 @@ describe('GraphFilterActions', () => {
     expect(serviceGraphFilterActions.toggleGraphRouteRules()).toEqual(expectedAction);
   });
 
+  it('should toggle missing sidecars', () => {
+    const expectedAction = {
+      type: ServiceGraphFilterActionKeys.TOGGLE_GRAPH_MISSING_SIDECARS
+    };
+    expect(serviceGraphFilterActions.toggleGraphMissingSidecars()).toEqual(expectedAction);
+  });
+
   it('should enable graph filters toggles', () => {
     const expectedAction = {
       type: ServiceGraphFilterActionKeys.ENABLE_GRAPH_FILTERS,

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -20,6 +20,7 @@ type CytoscapeGraphType = {
   showNodeLabels: boolean;
   showCircuitBreakers: boolean;
   showRouteRules: boolean;
+  showMissingSidecars: boolean;
   onClick: (event: CytoscapeClickEvent) => void;
   onReady: (event: CytoscapeBaseEvent) => void;
   refresh: any;
@@ -63,6 +64,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
       this.props.showNodeLabels !== nextProps.showNodeLabels ||
       this.props.showCircuitBreakers !== nextProps.showCircuitBreakers ||
       this.props.showRouteRules !== nextProps.showRouteRules ||
+      this.props.showMissingSidecars !== nextProps.showMissingSidecars ||
       this.props.elements !== nextProps.elements ||
       this.props.graphLayout !== nextProps.graphLayout
     );
@@ -207,6 +209,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
     // Create and destroy badges
     const cbBadge = new GraphBadge.CircuitBreakerBadge();
     const rrBadge = new GraphBadge.RouteRuleBadge();
+    const msBadge = new GraphBadge.MissingSidecarsBadge();
     cy.nodes().forEach(ele => {
       if (this.props.showCircuitBreakers && ele.data('hasCB') === 'true') {
         cbBadge.buildBadge(ele);
@@ -217,6 +220,11 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
         rrBadge.buildBadge(ele);
       } else {
         rrBadge.destroyBadge(ele);
+      }
+      if (this.props.showMissingSidecars && ele.data('hasMissingSidecars') && !ele.data('isGroup')) {
+        msBadge.buildBadge(ele);
+      } else {
+        msBadge.destroyBadge(ele);
       }
     });
 
@@ -249,6 +257,7 @@ const mapStateToProps = (state: KialiAppState) => ({
   showNodeLabels: state.serviceGraphFilterState.showNodeLabels,
   showCircuitBreakers: state.serviceGraphFilterState.showCircuitBreakers,
   showRouteRules: state.serviceGraphFilterState.showRouteRules,
+  showMissingSidecars: state.serviceGraphFilterState.showMissingSidecars,
   elements: state.serviceGraphDataState.graphData
 });
 

--- a/src/components/CytoscapeGraph/__tests__/CytoscapeGraph.test.tsx
+++ b/src/components/CytoscapeGraph/__tests__/CytoscapeGraph.test.tsx
@@ -36,6 +36,7 @@ describe('CytoscapeGraph component test', () => {
         showNodeLabels={true}
         showCircuitBreakers={false}
         showRouteRules={true}
+        showMissingSidecars={true}
       />
     );
     const cytoscapeWrapper = wrapper.find(CytoscapeReactWrapper);

--- a/src/components/CytoscapeGraph/graphs/GraphBadge.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphBadge.ts
@@ -3,6 +3,7 @@ import { PfColors } from '../../../components/Pf/PfColors';
 
 const FLASH_BADGE: string = 'fa fa-bolt';
 const ROUTE_BADGE: string = 'fa fa-code-fork';
+const SIDECAR_BADGE: string = 'pf pficon-blueprint';
 
 // Each node that has a badge will have custom data associated with it.
 // Each entry in the custom data is keyed on the badge type; an entry is itself
@@ -44,7 +45,7 @@ class GraphBadge {
 
     const setScale = () => {
       const zoom = node.cy().zoom();
-      div.style.transform = div.style.transform + `scale(${zoom},${zoom})`;
+      div.style.fontSize = `${zoom}em`;
     };
 
     const popper = node.popper({
@@ -125,5 +126,11 @@ export class CircuitBreakerBadge extends GraphBadge {
 export class RouteRuleBadge extends GraphBadge {
   constructor() {
     super(ROUTE_BADGE, PfColors.Purple300, 'top');
+  }
+}
+
+export class MissingSidecarsBadge extends GraphBadge {
+  constructor() {
+    super(SIDECAR_BADGE, PfColors.Red100, 'bottom');
   }
 }

--- a/src/containers/GraphLayersContainer.tsx
+++ b/src/containers/GraphLayersContainer.tsx
@@ -11,6 +11,7 @@ interface ServiceGraphDispatch {
   toggleGraphNodeLabels(): void;
   toggleGraphCircuitBreakers(): void;
   toggleGraphRouteRules(): void;
+  toggleGraphMissingSidecars(): void;
 }
 
 // inherit all of our Reducer state section  and Dispatch methods for redux
@@ -21,7 +22,8 @@ const mapStateToProps = (state: KialiAppState) => ({
   showEdgeLabels: state.serviceGraphFilterState.showEdgeLabels,
   showNodeLabels: state.serviceGraphFilterState.showNodeLabels,
   showCircuitBreakers: state.serviceGraphFilterState.showCircuitBreakers,
-  showRouteRules: state.serviceGraphFilterState.showRouteRules
+  showRouteRules: state.serviceGraphFilterState.showRouteRules,
+  showMissingSidecars: state.serviceGraphFilterState.showMissingSidecars
 });
 
 // Map our actions to Redux
@@ -30,7 +32,8 @@ const mapDispatchToProps = (dispatch: any) => {
     toggleGraphNodeLabels: bindActionCreators(serviceGraphFilterActions.toggleGraphNodeLabel, dispatch),
     toggleGraphEdgeLabels: bindActionCreators(serviceGraphFilterActions.toggleGraphEdgeLabel, dispatch),
     toggleGraphCircuitBreakers: bindActionCreators(serviceGraphFilterActions.toggleGraphCircuitBreakers, dispatch),
-    toggleGraphRouteRules: bindActionCreators(serviceGraphFilterActions.toggleGraphRouteRules, dispatch)
+    toggleGraphRouteRules: bindActionCreators(serviceGraphFilterActions.toggleGraphRouteRules, dispatch),
+    toggleGraphMissingSidecars: bindActionCreators(serviceGraphFilterActions.toggleGraphMissingSidecars, dispatch)
   };
 };
 
@@ -45,9 +48,15 @@ interface VisibilityLayersType {
 // Right now it is a toolbar with Switch Buttons -- this will change once with UXD input
 export const GraphLayers: React.SFC<GraphLayersProps> = props => {
   // map our attributes from redux
-  const { showCircuitBreakers, showRouteRules, showEdgeLabels, showNodeLabels } = props;
+  const { showCircuitBreakers, showRouteRules, showEdgeLabels, showNodeLabels, showMissingSidecars } = props;
   // // map or dispatchers for redux
-  const { toggleGraphCircuitBreakers, toggleGraphRouteRules, toggleGraphEdgeLabels, toggleGraphNodeLabels } = props;
+  const {
+    toggleGraphCircuitBreakers,
+    toggleGraphRouteRules,
+    toggleGraphEdgeLabels,
+    toggleGraphNodeLabels,
+    toggleGraphMissingSidecars
+  } = props;
 
   const visibilityLayers: VisibilityLayersType[] = [
     {
@@ -73,6 +82,12 @@ export const GraphLayers: React.SFC<GraphLayersProps> = props => {
       labelText: 'Node Labels',
       value: showNodeLabels,
       onChange: toggleGraphNodeLabels
+    },
+    {
+      id: 'filterSidecars',
+      labelText: 'Missing Sidecars',
+      value: showMissingSidecars,
+      onChange: toggleGraphMissingSidecars
     }
   ];
 

--- a/src/pages/ServiceGraph/SummaryPanelNode.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelNode.tsx
@@ -130,7 +130,7 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
               color={PfColors.Green500}
             />
           </div>
-          {this.renderBadgeSummary(node.data('hasCB'), node.data('hasRR'))}
+          {this.renderBadgeSummary(node.data('hasCB'), node.data('hasRR'), node.data('hasMissingSidecars').toString())}
         </div>
         <div className="panel-body">
           <InOutRateTable
@@ -170,9 +170,10 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
     );
   };
 
-  private renderBadgeSummary = (hasCB: string, hasRR: string) => {
+  private renderBadgeSummary = (hasCB: string, hasRR: string, hasMissingSC: string) => {
     const displayCB = hasCB === 'true';
     const displayRR = hasRR === 'true';
+    const displayMissingSC = hasMissingSC === 'true';
     return (
       <>
         {displayCB && (
@@ -185,6 +186,12 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
           <div>
             <Icon name="code-fork" type="fa" style={{ width: '10px' }} />
             Has Route Rule
+          </div>
+        )}
+        {displayMissingSC && (
+          <div>
+            <Icon name="blueprint" type="pf" style={{ width: '10px', fontSize: '0.7em' }} />
+            Has Missing Sidecars
           </div>
         )}
       </>

--- a/src/reducers/ServiceGraphFilterState.ts
+++ b/src/reducers/ServiceGraphFilterState.ts
@@ -6,7 +6,8 @@ const INITIAL_STATE: ServiceGraphFilterState = {
   showNodeLabels: true,
   showEdgeLabels: false,
   showCircuitBreakers: false,
-  showRouteRules: true
+  showRouteRules: true,
+  showMissingSidecars: true
   // @ todo: add disableLayers back in later
   // disableLayers: false
 };
@@ -22,6 +23,8 @@ const serviceGraphFilterState = (state: ServiceGraphFilterState = INITIAL_STATE,
       return updateState(state, { showCircuitBreakers: !state.showCircuitBreakers });
     case ServiceGraphFilterActionKeys.TOGGLE_GRAPH_ROUTE_RULES:
       return updateState(state, { showRouteRules: !state.showRouteRules });
+    case ServiceGraphFilterActionKeys.TOGGLE_GRAPH_MISSING_SIDECARS:
+      return updateState(state, { showMissingSidecars: !state.showMissingSidecars });
     case ServiceGraphFilterActionKeys.ENABLE_GRAPH_FILTERS:
       return updateState(state, { disableLayers: action.payload });
     default:

--- a/src/reducers/__tests__/ServiceGraphFilterStateReducer.test.ts
+++ b/src/reducers/__tests__/ServiceGraphFilterStateReducer.test.ts
@@ -7,7 +7,8 @@ describe('ServiceGraphFilterState reducer', () => {
       showNodeLabels: true,
       showEdgeLabels: false,
       showCircuitBreakers: false,
-      showRouteRules: true
+      showRouteRules: true,
+      showMissingSidecars: true
     });
   });
 
@@ -18,7 +19,8 @@ describe('ServiceGraphFilterState reducer', () => {
           showNodeLabels: true,
           showEdgeLabels: true,
           showCircuitBreakers: false,
-          showRouteRules: true
+          showRouteRules: true,
+          showMissingSidecars: true
         },
         {
           type: ServiceGraphFilterActionKeys.TOGGLE_GRAPH_NODE_LABEL
@@ -28,7 +30,8 @@ describe('ServiceGraphFilterState reducer', () => {
       showNodeLabels: false,
       showEdgeLabels: true,
       showCircuitBreakers: false,
-      showRouteRules: true
+      showRouteRules: true,
+      showMissingSidecars: true
     });
   });
 
@@ -39,7 +42,8 @@ describe('ServiceGraphFilterState reducer', () => {
           showNodeLabels: true,
           showEdgeLabels: true,
           showCircuitBreakers: false,
-          showRouteRules: true
+          showRouteRules: true,
+          showMissingSidecars: true
         },
         {
           type: ServiceGraphFilterActionKeys.TOGGLE_GRAPH_EDGE_LABEL
@@ -49,7 +53,8 @@ describe('ServiceGraphFilterState reducer', () => {
       showNodeLabels: true,
       showEdgeLabels: false,
       showCircuitBreakers: false,
-      showRouteRules: true
+      showRouteRules: true,
+      showMissingSidecars: true
     });
   });
   it('should handle TOGGLE_GRAPH_CIRCUIT_BREAKERS', () => {
@@ -59,7 +64,8 @@ describe('ServiceGraphFilterState reducer', () => {
           showNodeLabels: true,
           showEdgeLabels: false,
           showCircuitBreakers: false,
-          showRouteRules: true
+          showRouteRules: true,
+          showMissingSidecars: true
         },
         {
           type: ServiceGraphFilterActionKeys.TOGGLE_GRAPH_CIRCUIT_BREAKERS
@@ -69,7 +75,8 @@ describe('ServiceGraphFilterState reducer', () => {
       showNodeLabels: true,
       showEdgeLabels: false,
       showCircuitBreakers: true,
-      showRouteRules: true
+      showRouteRules: true,
+      showMissingSidecars: true
     });
   });
   it('should handle TOGGLE_GRAPH_ROUTE_RULES', () => {
@@ -79,7 +86,8 @@ describe('ServiceGraphFilterState reducer', () => {
           showNodeLabels: true,
           showEdgeLabels: false,
           showCircuitBreakers: false,
-          showRouteRules: true
+          showRouteRules: true,
+          showMissingSidecars: true
         },
         {
           type: ServiceGraphFilterActionKeys.TOGGLE_GRAPH_ROUTE_RULES
@@ -89,7 +97,30 @@ describe('ServiceGraphFilterState reducer', () => {
       showNodeLabels: true,
       showEdgeLabels: false,
       showCircuitBreakers: false,
-      showRouteRules: false
+      showRouteRules: false,
+      showMissingSidecars: true
+    });
+  });
+  it('should handle TOGGLE_GRAPH_MISSING_SIDECARS', () => {
+    expect(
+      serviceGraphFilterState(
+        {
+          showNodeLabels: true,
+          showEdgeLabels: false,
+          showCircuitBreakers: false,
+          showRouteRules: true,
+          showMissingSidecars: true
+        },
+        {
+          type: ServiceGraphFilterActionKeys.TOGGLE_GRAPH_MISSING_SIDECARS
+        }
+      )
+    ).toEqual({
+      showNodeLabels: true,
+      showEdgeLabels: false,
+      showCircuitBreakers: false,
+      showRouteRules: true,
+      showMissingSidecars: false
     });
   });
 });

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -8,6 +8,7 @@ export interface ServiceGraphFilterState {
   readonly showNodeLabels: boolean;
   readonly showCircuitBreakers: boolean;
   readonly showRouteRules: boolean;
+  readonly showMissingSidecars: boolean;
   // disable the service graph layers toolbar
   // @todo: add this back in later
   // readonly disableLayers: boolean;


### PR DESCRIPTION
Depends on https://github.com/kiali/kiali/pull/188

- Show a badge if API reports missing sidecars for a service. Badge is red to denote a problematic state.
![image](https://user-images.githubusercontent.com/23639005/39948820-4e9019cc-553d-11e8-800b-05622683aca0.png)

- List the badge of missing sidecars in the node summary.
![image](https://user-images.githubusercontent.com/23639005/40072191-960a2920-5838-11e8-89a4-0df9b9071d0a.png)


- Use CSS 'em' units instead of CSS 'transform' to let the browser so vector-based rendering instead of pixel-based rendering of the badges. Now graph badges are sharper regardless of zoom:
![image](https://user-images.githubusercontent.com/23639005/39949101-7317a46c-553e-11e8-83c3-94df91b13e11.png)

