### PR TITLE
KIALI-721 fix the graph highlighter when switching layouts.

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -134,7 +134,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
       return;
     }
 
-    // Convienently, the graph highlighter caches the cy instance that is currently in use.
+    // Conveniently, the graph highlighter caches the cy instance that is currently in use.
     // If that cy instance is the same one we are being asked to initialize, do NOT initialize it again;
     // this would add duplicate callbacks and would screw up the graph highlighter. If, however,
     // we are being asked to initialize a different cy instance, we assume the current one is now obsolete

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -134,6 +134,15 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
       return;
     }
 
+    // Convienently, the graph highlighter caches the cy instance that is currently in use.
+    // If that cy instance is the same one we are being asked to initialize, do NOT initialize it again;
+    // this would add duplicate callbacks and would screw up the graph highlighter. If, however,
+    // we are being asked to initialize a different cy instance, we assume the current one is now obsolete
+    // so we do want to initialize the new cy instance.
+    if (this.graphHighlighter && this.graphHighlighter.cy === cy) {
+      return;
+    }
+
     this.graphHighlighter = new GraphHighlighter(cy);
 
     const getCytoscapeBaseEvent = (event: any): CytoscapeBaseEvent | null => {


### PR DESCRIPTION
When switching layouts and something is selected, the graph highlighter erronenously "unfreezes" - meaning the dimming and highlighting gets re-enabled when the graph should still be "frozen" (dimming and highlighting should not be affected on hover). This fixes that problem.

This also fixes multiple callbacks being triggered - turns out for each time the layout was switched, we were calling the callbacks (if we switched layouts 3 times, the callbacks were getting called 3 times). This fixes that, too. Now the callbacks are only ever called at most one time per event.