### PR TITLE
KIALI-447 Ad latency to edge summary

### DIFF
--- a/src/components/SummaryPanel/LatencyChart.tsx
+++ b/src/components/SummaryPanel/LatencyChart.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import { AreaChart } from 'patternfly-react';
+import { PfColors } from '../../components/Pf/PfColors';
+
+type LatencyChartTypeProp = {
+  label: string;
+  latAvg: [string, number][];
+  latMed: [string, number][];
+  lat95: [string, number][];
+  lat99: [string, number][];
+};
+
+export default class LatencyChart extends React.Component<LatencyChartTypeProp, {}> {
+  constructor(props: LatencyChartTypeProp) {
+    super(props);
+  }
+
+  render() {
+    const axis: any = {
+      x: {
+        show: false,
+        type: 'timeseries',
+        tick: {
+          fit: true,
+          count: 15,
+          multiline: false,
+          format: '%H:%M:%S'
+        }
+      },
+      y: { show: false }
+    };
+
+    const chartData = {
+      x: 'x',
+      columns: (this.props.latAvg as [string, number][])
+        .concat(this.props.latMed as [string, number][])
+        .concat(this.props.lat95 as [string, number][])
+        .concat(this.props.lat99 as [string, number][]),
+      type: 'area-spline',
+      hide: ['Average', '95th', '99th']
+    };
+
+    return (
+      <>
+        <div>
+          <strong>{this.props.label}:</strong>
+        </div>
+        <AreaChart
+          size={{ height: 80 }}
+          color={{ pattern: [PfColors.Black, PfColors.Green, PfColors.Blue, PfColors.Orange] }}
+          legend={{ show: true }}
+          grid={{ y: { show: false } }}
+          axis={axis}
+          data={chartData}
+        />
+      </>
+    );
+  }
+}


### PR DESCRIPTION
This PR adds a latency sparkline chart to the edge summary.  It presents our four standard histogram metric values: average, median, 95th and 99th percentiles.  By default the median shows but the legend is clickable to allow selection of the other values.  Hover shows the actual values.

![screenshot](https://user-images.githubusercontent.com/2104052/40022587-7435be6a-5796-11e8-8b89-69fdd4f72f8a.jpg)
