### PR TITLE
KIALI-679 Allows graph to show latency in the edges

### DIFF
--- a/src/actions/ServiceGraphFilterActions.ts
+++ b/src/actions/ServiceGraphFilterActions.ts
@@ -1,13 +1,14 @@
 // Action Creators allow us to create typesafe utilities for dispatching actions
 import { createAction } from 'typesafe-actions';
+import { EdgeLabelMode } from '../types/GraphFilter';
 
 export enum ServiceGraphFilterActionKeys {
   // Toggle Actions
   TOGGLE_GRAPH_NODE_LABEL = 'TOGGLE_GRAPH_NODE_LABEL',
-  TOGGLE_GRAPH_EDGE_LABEL = 'TOGGLE_GRAPH_EDGE_LABEL',
   TOGGLE_GRAPH_CIRCUIT_BREAKERS = 'TOGGLE_GRAPH_CIRCUIT_BREAKERS',
   TOGGLE_GRAPH_ROUTE_RULES = 'TOGGLE_GRAPH_ROUTE_RULES',
   TOGGLE_GRAPH_MISSING_SIDECARS = 'TOGGLE_GRAPH_MISSING_SIDECARS',
+  SET_GRAPH_EDGE_LABEL_MODE = 'SET_GRAPH_EDGE_LABEL_MODE',
   // Disable Actions
   ENABLE_GRAPH_FILTERS = 'ENABLE_GRAPH_FILTERS'
 }
@@ -15,7 +16,13 @@ export enum ServiceGraphFilterActionKeys {
 export const serviceGraphFilterActions = {
   // Toggle actions
   toggleGraphNodeLabel: createAction(ServiceGraphFilterActionKeys.TOGGLE_GRAPH_NODE_LABEL),
-  toggleGraphEdgeLabel: createAction(ServiceGraphFilterActionKeys.TOGGLE_GRAPH_EDGE_LABEL),
+  setGraphEdgeLabelMode: createAction(
+    ServiceGraphFilterActionKeys.SET_GRAPH_EDGE_LABEL_MODE,
+    (edgeLabelMode: EdgeLabelMode) => ({
+      type: ServiceGraphFilterActionKeys.SET_GRAPH_EDGE_LABEL_MODE,
+      payload: edgeLabelMode
+    })
+  ),
   toggleGraphRouteRules: createAction(ServiceGraphFilterActionKeys.TOGGLE_GRAPH_ROUTE_RULES),
   toggleGraphCircuitBreakers: createAction(ServiceGraphFilterActionKeys.TOGGLE_GRAPH_CIRCUIT_BREAKERS),
   toggleGraphMissingSidecars: createAction(ServiceGraphFilterActionKeys.TOGGLE_GRAPH_MISSING_SIDECARS),

--- a/src/actions/__tests__/GraphFilterAction.test.tsx
+++ b/src/actions/__tests__/GraphFilterAction.test.tsx
@@ -1,12 +1,14 @@
 import { ServiceGraphFilterActionKeys, serviceGraphFilterActions } from '../ServiceGraphFilterActions';
+import { EdgeLabelMode } from '../../types/GraphFilter';
 
 // Test our ActionCreators for proper message format
 describe('GraphFilterActions', () => {
   it('should toggle an edge label ', () => {
     const expectedAction = {
-      type: ServiceGraphFilterActionKeys.TOGGLE_GRAPH_EDGE_LABEL
+      type: ServiceGraphFilterActionKeys.SET_GRAPH_EDGE_LABEL_MODE,
+      payload: EdgeLabelMode.LATENCY
     };
-    expect(serviceGraphFilterActions.toggleGraphEdgeLabel()).toEqual(expectedAction);
+    expect(serviceGraphFilterActions.setGraphEdgeLabelMode(EdgeLabelMode.LATENCY)).toEqual(expectedAction);
   });
 
   it('should toggle a node label ', () => {

--- a/src/actions/__tests__/GraphFilterAction.test.tsx
+++ b/src/actions/__tests__/GraphFilterAction.test.tsx
@@ -6,9 +6,11 @@ describe('GraphFilterActions', () => {
   it('should toggle an edge label ', () => {
     const expectedAction = {
       type: ServiceGraphFilterActionKeys.SET_GRAPH_EDGE_LABEL_MODE,
-      payload: EdgeLabelMode.LATENCY
+      payload: EdgeLabelMode.LATENCY_95TH_PERCENTILE
     };
-    expect(serviceGraphFilterActions.setGraphEdgeLabelMode(EdgeLabelMode.LATENCY)).toEqual(expectedAction);
+    expect(serviceGraphFilterActions.setGraphEdgeLabelMode(EdgeLabelMode.LATENCY_95TH_PERCENTILE)).toEqual(
+      expectedAction
+    );
   });
 
   it('should toggle a node label ', () => {

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -9,13 +9,14 @@ import EmptyGraphLayout from './EmptyGraphLayout';
 import CytoscapeReactWrapper from './CytoscapeReactWrapper';
 
 import { GraphParamsType } from '../../types/Graph';
+import { EdgeLabelMode } from '../../types/GraphFilter';
 import { KialiAppState } from '../../store/Store';
 import * as GraphBadge from './graphs/GraphBadge';
 
 type CytoscapeGraphType = {
   elements?: any;
   isLoading?: boolean;
-  showEdgeLabels: boolean;
+  edgeLabelMode: EdgeLabelMode;
   showNodeLabels: boolean;
   showCircuitBreakers: boolean;
   showRouteRules: boolean;
@@ -59,7 +60,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
     return (
       this.props.isLoading !== nextProps.isLoading ||
       this.props.graphLayout !== nextProps.graphLayout ||
-      this.props.showEdgeLabels !== nextProps.showEdgeLabels ||
+      this.props.edgeLabelMode !== nextProps.edgeLabelMode ||
       this.props.showNodeLabels !== nextProps.showNodeLabels ||
       this.props.showCircuitBreakers !== nextProps.showCircuitBreakers ||
       this.props.showRouteRules !== nextProps.showRouteRules ||
@@ -112,11 +113,11 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
     this.cyInitialization(this.getCy());
   }
 
-  private turnEdgeLabelsTo = (value: boolean) => {
+  private turnEdgeLabelsTo = (value: EdgeLabelMode) => {
     let elements = this.props.elements;
     if (elements && elements.edges) {
       elements.edges.forEach(edge => {
-        edge.data.showEdgeLabels = value;
+        edge.data.edgeLabelMode = value;
       });
     }
   };
@@ -208,7 +209,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
     }
 
     // Create and destroy labels
-    this.turnEdgeLabelsTo(this.props.showEdgeLabels);
+    this.turnEdgeLabelsTo(this.props.edgeLabelMode);
     this.turnNodeLabelsTo(this.props.showNodeLabels);
 
     // Create and destroy badges
@@ -258,7 +259,6 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
 }
 
 const mapStateToProps = (state: KialiAppState) => ({
-  showEdgeLabels: state.serviceGraphFilterState.showEdgeLabels,
   showNodeLabels: state.serviceGraphFilterState.showNodeLabels,
   showCircuitBreakers: state.serviceGraphFilterState.showCircuitBreakers,
   showRouteRules: state.serviceGraphFilterState.showRouteRules,

--- a/src/components/CytoscapeGraph/__tests__/CytoscapeGraph.test.tsx
+++ b/src/components/CytoscapeGraph/__tests__/CytoscapeGraph.test.tsx
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 
 import { CytoscapeGraph } from '../CytoscapeGraph';
 import * as GRAPH_DATA from '../../../services/__mockData__/getGraphElements';
-import { Duration, Layout } from '../../../types/GraphFilter';
+import { Duration, Layout, EdgeLabelMode } from '../../../types/GraphFilter';
 import { CytoscapeReactWrapper } from '../CytoscapeReactWrapper';
 
 jest.mock('../../../services/Api');
@@ -22,6 +22,7 @@ describe('CytoscapeGraph component test', () => {
   it('should set correct elements data', () => {
     const myLayout: Layout = { name: 'breadthfirst' };
     const myDuration: Duration = { value: 300 };
+    const myEdgeLabelMode: EdgeLabelMode = EdgeLabelMode.NONE;
 
     const wrapper = shallow(
       <CytoscapeGraph
@@ -29,10 +30,10 @@ describe('CytoscapeGraph component test', () => {
         elements={GRAPH_DATA[testNamespace]}
         graphLayout={myLayout}
         graphDuration={myDuration}
+        edgeLabelMode={myEdgeLabelMode}
         onClick={testClickHandler}
         onReady={testReadyHandler}
         refresh={testClickHandler}
-        showEdgeLabels={false}
         showNodeLabels={true}
         showCircuitBreakers={false}
         showRouteRules={true}

--- a/src/components/CytoscapeGraph/__tests__/CytoscapeGraph.test.tsx
+++ b/src/components/CytoscapeGraph/__tests__/CytoscapeGraph.test.tsx
@@ -22,7 +22,7 @@ describe('CytoscapeGraph component test', () => {
   it('should set correct elements data', () => {
     const myLayout: Layout = { name: 'breadthfirst' };
     const myDuration: Duration = { value: 300 };
-    const myEdgeLabelMode: EdgeLabelMode = EdgeLabelMode.NONE;
+    const myEdgeLabelMode: EdgeLabelMode = EdgeLabelMode.HIDE;
 
     const wrapper = shallow(
       <CytoscapeGraph

--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -75,13 +75,21 @@ export class GraphStyles {
         selector: 'edge',
         css: {
           content: (ele: any) => {
-            if (!ele.data('showEdgeLabels')) {
+            const edgeLabelMode = ele.data('edgeLabelMode');
+            if (!edgeLabelMode) {
               return '';
             }
-            const rate = ele.data('rate') ? parseFloat(ele.data('rate')) : 0;
-            const pErr = ele.data('percentErr') ? parseFloat(ele.data('percentErr')) : 0;
-            if (rate > 0) {
-              return pErr > 0 ? rate.toFixed(2) + ', ' + pErr.toFixed(1) + '%' : rate.toFixed(2);
+            if (edgeLabelMode === 'REQUEST_RATE') {
+              const rate = ele.data('rate') ? parseFloat(ele.data('rate')) : 0;
+              const pErr = ele.data('percentErr') ? parseFloat(ele.data('percentErr')) : 0;
+              if (rate > 0) {
+                return pErr > 0 ? rate.toFixed(2) + ', ' + pErr.toFixed(1) + '%' : rate.toFixed(2);
+              }
+            } else if (edgeLabelMode === 'LATENCY') {
+              const latency = ele.data('latency') ? parseFloat(ele.data('latency')) : 0;
+              if (latency > 0) {
+                return latency.toFixed(2) + 's';
+              }
             }
             return '';
           },

--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -1,4 +1,5 @@
 import { PfColors } from '../../../components/Pf/PfColors';
+import { EdgeLabelMode } from '../../../types/GraphFilter';
 
 export class GraphStyles {
   static options() {
@@ -79,13 +80,13 @@ export class GraphStyles {
             if (!edgeLabelMode) {
               return '';
             }
-            if (edgeLabelMode === 'REQUEST_RATE') {
+            if (edgeLabelMode === EdgeLabelMode.REQUESTS_PER_SECOND) {
               const rate = ele.data('rate') ? parseFloat(ele.data('rate')) : 0;
               const pErr = ele.data('percentErr') ? parseFloat(ele.data('percentErr')) : 0;
               if (rate > 0) {
                 return pErr > 0 ? rate.toFixed(2) + ', ' + pErr.toFixed(1) + '%' : rate.toFixed(2);
               }
-            } else if (edgeLabelMode === 'LATENCY') {
+            } else if (edgeLabelMode === EdgeLabelMode.LATENCY_95TH_PERCENTILE) {
               const latency = ele.data('latency') ? parseFloat(ele.data('latency')) : 0;
               if (latency > 0) {
                 return latency.toFixed(2) + 's';

--- a/src/components/GraphFilter/GraphFilter.tsx
+++ b/src/components/GraphFilter/GraphFilter.tsx
@@ -115,7 +115,7 @@ export default class GraphFilter extends React.Component<GraphFilterProps, Graph
             id={'graph_filter_edges'}
             disabled={this.props.disabled}
             handleSelect={this.updateEdges}
-            nameDropdown={'Edge Mode'}
+            nameDropdown={'Edge Labels'}
             initialValue={this.props.edgeLabelMode}
             initialLabel={GraphFilter.EDGE_LABEL_MODES[this.props.edgeLabelMode]}
             options={GraphFilter.EDGE_LABEL_MODES}

--- a/src/components/GraphFilter/GraphFilter.tsx
+++ b/src/components/GraphFilter/GraphFilter.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Toolbar, Button, Icon, FormGroup } from 'patternfly-react';
 
-import { Duration, Layout } from '../../types/GraphFilter';
+import { Duration, Layout, EdgeLabelMode } from '../../types/GraphFilter';
 import { ToolbarDropdown } from '../ToolbarDropdown/ToolbarDropdown';
 import NamespaceDropdownContainer from '../../containers/NamespaceDropdownContainer';
 import { config } from '../../config';
@@ -10,11 +10,14 @@ import { style } from 'typestyle';
 import { GraphParamsType } from '../../types/Graph';
 import Namespace from '../../types/Namespace';
 
+import * as _ from 'lodash';
+
 export interface GraphFilterProps extends GraphParamsType {
   disabled: boolean;
   onLayoutChange: (newLayout: Layout) => void;
   onFilterChange: (newDuration: Duration) => void;
   onNamespaceChange: (newValue: Namespace) => void;
+  onEdgeLabelModeChange: (newEdges: EdgeLabelMode) => void;
   onRefresh: () => void;
 }
 
@@ -32,6 +35,10 @@ export default class GraphFilter extends React.Component<GraphFilterProps, Graph
   // GraphFilter should be minimal and used for assembling those filtering components.
   static readonly INTERVAL_DURATION = config().toolbar.intervalDuration;
   static readonly GRAPH_LAYOUTS = config().toolbar.graphLayouts;
+  static readonly EDGE_LABEL_MODES = EdgeLabelMode.getValues().reduce((map, edgeLabelMode) => {
+    map[edgeLabelMode] = _.capitalize(_.startCase(edgeLabelMode));
+    return map;
+  }, {});
 
   constructor(props: GraphFilterProps) {
     super(props);
@@ -56,6 +63,13 @@ export default class GraphFilter extends React.Component<GraphFilterProps, Graph
     if (this.props.namespace.name !== selected) {
       // notify callback
       this.props.onNamespaceChange({ name: selected });
+    }
+  };
+
+  updateEdges = (selected: EdgeLabelMode) => {
+    if (this.props.edgeLabelMode !== selected) {
+      // notify callback
+      this.props.onEdgeLabelModeChange(selected);
     }
   };
 
@@ -96,6 +110,15 @@ export default class GraphFilter extends React.Component<GraphFilterProps, Graph
             initialValue={this.props.graphLayout.name}
             initialLabel={String(GraphFilter.GRAPH_LAYOUTS[this.props.graphLayout.name])}
             options={GraphFilter.GRAPH_LAYOUTS}
+          />
+          <ToolbarDropdown
+            id={'graph_filter_edges'}
+            disabled={this.props.disabled}
+            handleSelect={this.updateEdges}
+            nameDropdown={'Edge Mode'}
+            initialValue={this.props.edgeLabelMode}
+            initialLabel={GraphFilter.EDGE_LABEL_MODES[this.props.edgeLabelMode]}
+            options={GraphFilter.EDGE_LABEL_MODES}
           />
           <FormGroup className={zeroPaddingLeft}>
             <label className={labelPaddingRight}>Filters:</label>

--- a/src/containers/GraphLayersContainer.tsx
+++ b/src/containers/GraphLayersContainer.tsx
@@ -7,7 +7,6 @@ import { KialiAppState, ServiceGraphFilterState } from '../store/Store';
 
 interface ServiceGraphDispatch {
   // Dispatch methods
-  toggleGraphEdgeLabels(): void;
   toggleGraphNodeLabels(): void;
   toggleGraphCircuitBreakers(): void;
   toggleGraphRouteRules(): void;
@@ -19,7 +18,6 @@ type GraphLayersProps = ServiceGraphDispatch & ServiceGraphFilterState;
 
 // Allow Redux to map sections of our global app state to our props
 const mapStateToProps = (state: KialiAppState) => ({
-  showEdgeLabels: state.serviceGraphFilterState.showEdgeLabels,
   showNodeLabels: state.serviceGraphFilterState.showNodeLabels,
   showCircuitBreakers: state.serviceGraphFilterState.showCircuitBreakers,
   showRouteRules: state.serviceGraphFilterState.showRouteRules,
@@ -30,7 +28,7 @@ const mapStateToProps = (state: KialiAppState) => ({
 const mapDispatchToProps = (dispatch: any) => {
   return {
     toggleGraphNodeLabels: bindActionCreators(serviceGraphFilterActions.toggleGraphNodeLabel, dispatch),
-    toggleGraphEdgeLabels: bindActionCreators(serviceGraphFilterActions.toggleGraphEdgeLabel, dispatch),
+    setGraphEdgeLabelMode: bindActionCreators(serviceGraphFilterActions.setGraphEdgeLabelMode, dispatch),
     toggleGraphCircuitBreakers: bindActionCreators(serviceGraphFilterActions.toggleGraphCircuitBreakers, dispatch),
     toggleGraphRouteRules: bindActionCreators(serviceGraphFilterActions.toggleGraphRouteRules, dispatch),
     toggleGraphMissingSidecars: bindActionCreators(serviceGraphFilterActions.toggleGraphMissingSidecars, dispatch)
@@ -48,12 +46,11 @@ interface VisibilityLayersType {
 // Right now it is a toolbar with Switch Buttons -- this will change once with UXD input
 export const GraphLayers: React.SFC<GraphLayersProps> = props => {
   // map our attributes from redux
-  const { showCircuitBreakers, showRouteRules, showEdgeLabels, showNodeLabels, showMissingSidecars } = props;
+  const { showCircuitBreakers, showRouteRules, showNodeLabels, showMissingSidecars } = props;
   // // map or dispatchers for redux
   const {
     toggleGraphCircuitBreakers,
     toggleGraphRouteRules,
-    toggleGraphEdgeLabels,
     toggleGraphNodeLabels,
     toggleGraphMissingSidecars
   } = props;
@@ -70,12 +67,6 @@ export const GraphLayers: React.SFC<GraphLayersProps> = props => {
       labelText: 'Route Rules',
       value: showRouteRules,
       onChange: toggleGraphRouteRules
-    },
-    {
-      id: 'filterEdges',
-      labelText: 'Edge Labels',
-      value: showEdgeLabels,
-      onChange: toggleGraphEdgeLabels
     },
     {
       id: 'filterNodes',

--- a/src/pages/ServiceGraph/ServiceGraphPage.tsx
+++ b/src/pages/ServiceGraph/ServiceGraphPage.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import Namespace from '../../types/Namespace';
 import { GraphParamsType, SummaryData } from '../../types/Graph';
-import { Duration, Layout } from '../../types/GraphFilter';
+import { Duration, Layout, EdgeLabelMode } from '../../types/GraphFilter';
 
 import SummaryPanel from './SummaryPanel';
 import CytoscapeGraph from '../../components/CytoscapeGraph/CytoscapeGraph';
@@ -82,6 +82,7 @@ export default class ServiceGraphPage extends React.Component<ServiceGraphPagePr
     const graphParams: GraphParamsType = {
       namespace: this.props.namespace,
       graphLayout: this.props.graphLayout,
+      edgeLabelMode: this.props.edgeLabelMode,
       graphDuration: { value: Number(sessionStorage.getItem('appDuration')) } || this.props.graphDuration
     };
     return (
@@ -92,6 +93,7 @@ export default class ServiceGraphPage extends React.Component<ServiceGraphPagePr
           onLayoutChange={this.handleLayoutChange}
           onFilterChange={this.handleFilterChange}
           onNamespaceChange={this.handleNamespaceChange}
+          onEdgeLabelModeChange={this.handleEdgeLabelModeChange}
           onRefresh={this.handleRefreshClick}
           {...graphParams}
         />
@@ -118,31 +120,44 @@ export default class ServiceGraphPage extends React.Component<ServiceGraphPagePr
     );
   }
 
-  handleLayoutChange = (layout: Layout) => {
-    const newParams: GraphParamsType = {
-      namespace: this.props.namespace,
-      graphDuration: this.props.graphDuration,
-      graphLayout: layout
-    };
-    this.props.onParamsChange(newParams);
+  handleLayoutChange = (graphLayout: Layout) => {
+    const { namespace, graphDuration, edgeLabelMode } = this.getGraphParams();
+    this.props.onParamsChange({
+      graphDuration,
+      namespace,
+      graphLayout,
+      edgeLabelMode
+    });
   };
 
-  handleFilterChange = (duration: Duration) => {
-    const newParams: GraphParamsType = {
-      namespace: this.props.namespace,
-      graphDuration: duration,
-      graphLayout: this.props.graphLayout
-    };
-    this.props.onParamsChange(newParams);
+  handleFilterChange = (graphDuration: Duration) => {
+    const { namespace, graphLayout, edgeLabelMode } = this.getGraphParams();
+    this.props.onParamsChange({
+      graphDuration,
+      namespace,
+      graphLayout,
+      edgeLabelMode
+    });
   };
 
   handleNamespaceChange = (namespace: Namespace) => {
-    const newParams: GraphParamsType = {
-      namespace: namespace,
-      graphDuration: this.props.graphDuration,
-      graphLayout: this.props.graphLayout
-    };
-    this.props.onParamsChange(newParams);
+    const { graphDuration, graphLayout, edgeLabelMode } = this.getGraphParams();
+    this.props.onParamsChange({
+      namespace,
+      graphDuration,
+      graphLayout,
+      edgeLabelMode
+    });
+  };
+
+  handleEdgeLabelModeChange = (edgeLabelMode: EdgeLabelMode) => {
+    const { namespace, graphDuration, graphLayout } = this.getGraphParams();
+    this.props.onParamsChange({
+      namespace,
+      graphDuration,
+      graphLayout,
+      edgeLabelMode
+    });
   };
 
   /** Fetch graph data */
@@ -153,5 +168,14 @@ export default class ServiceGraphPage extends React.Component<ServiceGraphPagePr
     this.setState({
       summaryData: null
     });
+  };
+
+  private getGraphParams: () => GraphParamsType = () => {
+    return {
+      namespace: this.props.namespace,
+      graphDuration: this.props.graphDuration,
+      graphLayout: this.props.graphLayout,
+      edgeLabelMode: this.props.edgeLabelMode
+    };
   };
 }

--- a/src/pages/ServiceGraph/ServiceGraphRouteHandler.tsx
+++ b/src/pages/ServiceGraph/ServiceGraphRouteHandler.tsx
@@ -51,7 +51,7 @@ export class ServiceGraphRouteHandler extends React.Component<
     const _duration = urlParams.get('duration');
     const _hideCBs = urlParams.get('hideCBs') ? urlParams.get('hideCBs') === 'true' : false;
     const _hideRRs = urlParams.get('hideRRs') ? urlParams.get('hideRRs') === 'true' : false;
-    const _edgeLabelMode = EdgeLabelMode.fromString(urlParams.get('edges'), EdgeLabelMode.NONE);
+    const _edgeLabelMode = EdgeLabelMode.fromString(urlParams.get('edges'), EdgeLabelMode.HIDE);
     return {
       graphDuration: _duration ? { value: _duration } : { value: DEFAULT_DURATION },
       graphLayout: LayoutDictionary.getLayout({ name: urlParams.get('layout') }),

--- a/src/pages/ServiceGraph/ServiceGraphRouteHandler.tsx
+++ b/src/pages/ServiceGraph/ServiceGraphRouteHandler.tsx
@@ -3,6 +3,7 @@ import { RouteComponentProps } from 'react-router-dom';
 import { PropTypes } from 'prop-types';
 
 import { GraphParamsType } from '../../types/Graph';
+import { EdgeLabelMode } from '../../types/GraphFilter';
 import * as LayoutDictionary from '../../components/CytoscapeGraph/graphs/LayoutDictionary';
 import ServiceGraphPage from '../../containers/ServiceGraphPageContainer';
 
@@ -50,10 +51,12 @@ export class ServiceGraphRouteHandler extends React.Component<
     const _duration = urlParams.get('duration');
     const _hideCBs = urlParams.get('hideCBs') ? urlParams.get('hideCBs') === 'true' : false;
     const _hideRRs = urlParams.get('hideRRs') ? urlParams.get('hideRRs') === 'true' : false;
+    const _edgeLabelMode = EdgeLabelMode.fromString(urlParams.get('edges'), EdgeLabelMode.NONE);
     return {
       graphDuration: _duration ? { value: _duration } : { value: DEFAULT_DURATION },
       graphLayout: LayoutDictionary.getLayout({ name: urlParams.get('layout') }),
-      badgeStatus: { hideCBs: _hideCBs, hideRRs: _hideRRs }
+      badgeStatus: { hideCBs: _hideCBs, hideRRs: _hideRRs },
+      edgeLabelMode: _edgeLabelMode
     };
   };
 
@@ -64,17 +67,21 @@ export class ServiceGraphRouteHandler extends React.Component<
 
   componentWillReceiveProps(nextProps: RouteComponentProps<ServiceGraphURLProps>) {
     const nextNamespace = { name: nextProps.match.params.namespace };
-    const { graphDuration: nextDuration, graphLayout: nextLayout } = this.parseProps(nextProps.location.search);
+    const { graphDuration: nextDuration, graphLayout: nextLayout, edgeLabelMode: nextEdgeLabelMode } = this.parseProps(
+      nextProps.location.search
+    );
 
     const layoutHasChanged = nextLayout.name !== this.state.graphLayout.name;
     const namespaceHasChanged = nextNamespace.name !== this.state.namespace.name;
     const durationHasChanged = nextDuration.value !== this.state.graphDuration.value;
+    const edgeLabelModeChanged = nextEdgeLabelMode !== this.state.edgeLabelMode;
 
-    if (layoutHasChanged || namespaceHasChanged || durationHasChanged) {
+    if (layoutHasChanged || namespaceHasChanged || durationHasChanged || edgeLabelModeChanged) {
       const newParams: GraphParamsType = {
         namespace: nextNamespace,
         graphDuration: nextDuration,
-        graphLayout: nextLayout
+        graphLayout: nextLayout,
+        edgeLabelMode: nextEdgeLabelMode
       };
       sessionStorage.setItem(SESSION_KEY, JSON.stringify(newParams));
       this.setState({ ...newParams });
@@ -82,7 +89,9 @@ export class ServiceGraphRouteHandler extends React.Component<
   }
 
   makeURLFromParams = (params: GraphParamsType) =>
-    `/service-graph/${params.namespace.name}?layout=${params.graphLayout.name}&duration=${params.graphDuration.value}`;
+    `/service-graph/${params.namespace.name}?layout=${params.graphLayout.name}&duration=${
+      params.graphDuration.value
+    }&edges=${params.edgeLabelMode}`;
 
   /** Change browser address bar and trigger new props propagation */
   onParamsChange = (params: GraphParamsType) => {

--- a/src/pages/ServiceGraph/__tests__/ServiceGraphPage.test.tsx
+++ b/src/pages/ServiceGraph/__tests__/ServiceGraphPage.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 
 import { GraphParamsType } from '../../../types/Graph';
-import { Duration, Layout } from '../../../types/GraphFilter';
+import { Duration, Layout, EdgeLabelMode } from '../../../types/GraphFilter';
 import Namespace from '../../../types/Namespace';
 
 import ServiceGraphPage from '../ServiceGraphPage';
@@ -12,7 +12,8 @@ const dummyFunction = () => 0;
 const PARAMS: GraphParamsType = {
   namespace: { name: 'itsio-system' },
   graphDuration: { value: 60 },
-  graphLayout: { name: 'Cose' }
+  graphLayout: { name: 'Cose' },
+  edgeLabelMode: EdgeLabelMode.NONE
 };
 describe('ServiceGraphPage test', () => {
   it('should propagate filter params change with correct value', () => {

--- a/src/pages/ServiceGraph/__tests__/ServiceGraphPage.test.tsx
+++ b/src/pages/ServiceGraph/__tests__/ServiceGraphPage.test.tsx
@@ -13,7 +13,7 @@ const PARAMS: GraphParamsType = {
   namespace: { name: 'itsio-system' },
   graphDuration: { value: 60 },
   graphLayout: { name: 'Cose' },
-  edgeLabelMode: EdgeLabelMode.NONE
+  edgeLabelMode: EdgeLabelMode.HIDE
 };
 describe('ServiceGraphPage test', () => {
   it('should propagate filter params change with correct value', () => {

--- a/src/reducers/ServiceGraphFilterState.ts
+++ b/src/reducers/ServiceGraphFilterState.ts
@@ -10,7 +10,7 @@ const INITIAL_STATE: ServiceGraphFilterState = {
   showMissingSidecars: true,
   // @ todo: add disableLayers back in later
   // disableLayers: false
-  edgeLabelMode: EdgeLabelMode.NONE
+  edgeLabelMode: EdgeLabelMode.HIDE
 };
 
 // This Reducer allows changes to the 'serviceGraphFilterState' portion of Redux Store

--- a/src/reducers/ServiceGraphFilterState.ts
+++ b/src/reducers/ServiceGraphFilterState.ts
@@ -1,15 +1,16 @@
 import { ServiceGraphFilterState } from '../store/Store';
 import { ServiceGraphFilterActionKeys } from '../actions/ServiceGraphFilterActions';
 import { updateState } from '../utils/Reducer';
+import { EdgeLabelMode } from '../types/GraphFilter';
 
 const INITIAL_STATE: ServiceGraphFilterState = {
   showNodeLabels: true,
-  showEdgeLabels: false,
   showCircuitBreakers: false,
   showRouteRules: true,
-  showMissingSidecars: true
+  showMissingSidecars: true,
   // @ todo: add disableLayers back in later
   // disableLayers: false
+  edgeLabelMode: EdgeLabelMode.NONE
 };
 
 // This Reducer allows changes to the 'serviceGraphFilterState' portion of Redux Store
@@ -17,8 +18,8 @@ const serviceGraphFilterState = (state: ServiceGraphFilterState = INITIAL_STATE,
   switch (action.type) {
     case ServiceGraphFilterActionKeys.TOGGLE_GRAPH_NODE_LABEL:
       return updateState(state, { showNodeLabels: !state.showNodeLabels });
-    case ServiceGraphFilterActionKeys.TOGGLE_GRAPH_EDGE_LABEL:
-      return updateState(state, { showEdgeLabels: !state.showEdgeLabels });
+    case ServiceGraphFilterActionKeys.SET_GRAPH_EDGE_LABEL_MODE:
+      return updateState(state, { edgeLabelMode: action.payload });
     case ServiceGraphFilterActionKeys.TOGGLE_GRAPH_CIRCUIT_BREAKERS:
       return updateState(state, { showCircuitBreakers: !state.showCircuitBreakers });
     case ServiceGraphFilterActionKeys.TOGGLE_GRAPH_ROUTE_RULES:

--- a/src/reducers/__tests__/ServiceGraphFilterStateReducer.test.ts
+++ b/src/reducers/__tests__/ServiceGraphFilterStateReducer.test.ts
@@ -1,11 +1,12 @@
 import serviceGraphFilterState from '../ServiceGraphFilterState';
 import { ServiceGraphFilterActionKeys } from '../../actions/ServiceGraphFilterActions';
+import { EdgeLabelMode } from '../../types/GraphFilter';
 
 describe('ServiceGraphFilterState reducer', () => {
   it('should return the initial state', () => {
     expect(serviceGraphFilterState(undefined, {})).toEqual({
       showNodeLabels: true,
-      showEdgeLabels: false,
+      edgeLabelMode: EdgeLabelMode.NONE,
       showCircuitBreakers: false,
       showRouteRules: true,
       showMissingSidecars: true
@@ -17,7 +18,7 @@ describe('ServiceGraphFilterState reducer', () => {
       serviceGraphFilterState(
         {
           showNodeLabels: true,
-          showEdgeLabels: true,
+          edgeLabelMode: EdgeLabelMode.NONE,
           showCircuitBreakers: false,
           showRouteRules: true,
           showMissingSidecars: true
@@ -28,7 +29,7 @@ describe('ServiceGraphFilterState reducer', () => {
       )
     ).toEqual({
       showNodeLabels: false,
-      showEdgeLabels: true,
+      edgeLabelMode: EdgeLabelMode.NONE,
       showCircuitBreakers: false,
       showRouteRules: true,
       showMissingSidecars: true
@@ -40,18 +41,19 @@ describe('ServiceGraphFilterState reducer', () => {
       serviceGraphFilterState(
         {
           showNodeLabels: true,
-          showEdgeLabels: true,
+          edgeLabelMode: EdgeLabelMode.NONE,
           showCircuitBreakers: false,
           showRouteRules: true,
           showMissingSidecars: true
         },
         {
-          type: ServiceGraphFilterActionKeys.TOGGLE_GRAPH_EDGE_LABEL
+          type: ServiceGraphFilterActionKeys.SET_GRAPH_EDGE_LABEL_MODE,
+          payload: EdgeLabelMode.LATENCY
         }
       )
     ).toEqual({
       showNodeLabels: true,
-      showEdgeLabels: false,
+      edgeLabelMode: EdgeLabelMode.LATENCY,
       showCircuitBreakers: false,
       showRouteRules: true,
       showMissingSidecars: true
@@ -62,7 +64,7 @@ describe('ServiceGraphFilterState reducer', () => {
       serviceGraphFilterState(
         {
           showNodeLabels: true,
-          showEdgeLabels: false,
+          edgeLabelMode: EdgeLabelMode.NONE,
           showCircuitBreakers: false,
           showRouteRules: true,
           showMissingSidecars: true
@@ -73,7 +75,7 @@ describe('ServiceGraphFilterState reducer', () => {
       )
     ).toEqual({
       showNodeLabels: true,
-      showEdgeLabels: false,
+      edgeLabelMode: EdgeLabelMode.NONE,
       showCircuitBreakers: true,
       showRouteRules: true,
       showMissingSidecars: true
@@ -84,7 +86,7 @@ describe('ServiceGraphFilterState reducer', () => {
       serviceGraphFilterState(
         {
           showNodeLabels: true,
-          showEdgeLabels: false,
+          edgeLabelMode: EdgeLabelMode.NONE,
           showCircuitBreakers: false,
           showRouteRules: true,
           showMissingSidecars: true
@@ -95,7 +97,7 @@ describe('ServiceGraphFilterState reducer', () => {
       )
     ).toEqual({
       showNodeLabels: true,
-      showEdgeLabels: false,
+      edgeLabelMode: EdgeLabelMode.NONE,
       showCircuitBreakers: false,
       showRouteRules: false,
       showMissingSidecars: true
@@ -106,10 +108,10 @@ describe('ServiceGraphFilterState reducer', () => {
       serviceGraphFilterState(
         {
           showNodeLabels: true,
-          showEdgeLabels: false,
           showCircuitBreakers: false,
           showRouteRules: true,
-          showMissingSidecars: true
+          showMissingSidecars: true,
+          edgeLabelMode: EdgeLabelMode.NONE
         },
         {
           type: ServiceGraphFilterActionKeys.TOGGLE_GRAPH_MISSING_SIDECARS
@@ -117,10 +119,10 @@ describe('ServiceGraphFilterState reducer', () => {
       )
     ).toEqual({
       showNodeLabels: true,
-      showEdgeLabels: false,
       showCircuitBreakers: false,
       showRouteRules: true,
-      showMissingSidecars: false
+      showMissingSidecars: false,
+      edgeLabelMode: EdgeLabelMode.NONE
     });
   });
 });

--- a/src/reducers/__tests__/ServiceGraphFilterStateReducer.test.ts
+++ b/src/reducers/__tests__/ServiceGraphFilterStateReducer.test.ts
@@ -6,7 +6,7 @@ describe('ServiceGraphFilterState reducer', () => {
   it('should return the initial state', () => {
     expect(serviceGraphFilterState(undefined, {})).toEqual({
       showNodeLabels: true,
-      edgeLabelMode: EdgeLabelMode.NONE,
+      edgeLabelMode: EdgeLabelMode.HIDE,
       showCircuitBreakers: false,
       showRouteRules: true,
       showMissingSidecars: true
@@ -18,7 +18,7 @@ describe('ServiceGraphFilterState reducer', () => {
       serviceGraphFilterState(
         {
           showNodeLabels: true,
-          edgeLabelMode: EdgeLabelMode.NONE,
+          edgeLabelMode: EdgeLabelMode.HIDE,
           showCircuitBreakers: false,
           showRouteRules: true,
           showMissingSidecars: true
@@ -29,7 +29,7 @@ describe('ServiceGraphFilterState reducer', () => {
       )
     ).toEqual({
       showNodeLabels: false,
-      edgeLabelMode: EdgeLabelMode.NONE,
+      edgeLabelMode: EdgeLabelMode.HIDE,
       showCircuitBreakers: false,
       showRouteRules: true,
       showMissingSidecars: true
@@ -41,19 +41,19 @@ describe('ServiceGraphFilterState reducer', () => {
       serviceGraphFilterState(
         {
           showNodeLabels: true,
-          edgeLabelMode: EdgeLabelMode.NONE,
+          edgeLabelMode: EdgeLabelMode.HIDE,
           showCircuitBreakers: false,
           showRouteRules: true,
           showMissingSidecars: true
         },
         {
           type: ServiceGraphFilterActionKeys.SET_GRAPH_EDGE_LABEL_MODE,
-          payload: EdgeLabelMode.LATENCY
+          payload: EdgeLabelMode.LATENCY_95TH_PERCENTILE
         }
       )
     ).toEqual({
       showNodeLabels: true,
-      edgeLabelMode: EdgeLabelMode.LATENCY,
+      edgeLabelMode: EdgeLabelMode.LATENCY_95TH_PERCENTILE,
       showCircuitBreakers: false,
       showRouteRules: true,
       showMissingSidecars: true
@@ -64,7 +64,7 @@ describe('ServiceGraphFilterState reducer', () => {
       serviceGraphFilterState(
         {
           showNodeLabels: true,
-          edgeLabelMode: EdgeLabelMode.NONE,
+          edgeLabelMode: EdgeLabelMode.HIDE,
           showCircuitBreakers: false,
           showRouteRules: true,
           showMissingSidecars: true
@@ -75,7 +75,7 @@ describe('ServiceGraphFilterState reducer', () => {
       )
     ).toEqual({
       showNodeLabels: true,
-      edgeLabelMode: EdgeLabelMode.NONE,
+      edgeLabelMode: EdgeLabelMode.HIDE,
       showCircuitBreakers: true,
       showRouteRules: true,
       showMissingSidecars: true
@@ -86,7 +86,7 @@ describe('ServiceGraphFilterState reducer', () => {
       serviceGraphFilterState(
         {
           showNodeLabels: true,
-          edgeLabelMode: EdgeLabelMode.NONE,
+          edgeLabelMode: EdgeLabelMode.HIDE,
           showCircuitBreakers: false,
           showRouteRules: true,
           showMissingSidecars: true
@@ -97,7 +97,7 @@ describe('ServiceGraphFilterState reducer', () => {
       )
     ).toEqual({
       showNodeLabels: true,
-      edgeLabelMode: EdgeLabelMode.NONE,
+      edgeLabelMode: EdgeLabelMode.HIDE,
       showCircuitBreakers: false,
       showRouteRules: false,
       showMissingSidecars: true
@@ -111,7 +111,7 @@ describe('ServiceGraphFilterState reducer', () => {
           showCircuitBreakers: false,
           showRouteRules: true,
           showMissingSidecars: true,
-          edgeLabelMode: EdgeLabelMode.NONE
+          edgeLabelMode: EdgeLabelMode.HIDE
         },
         {
           type: ServiceGraphFilterActionKeys.TOGGLE_GRAPH_MISSING_SIDECARS
@@ -122,7 +122,7 @@ describe('ServiceGraphFilterState reducer', () => {
       showCircuitBreakers: false,
       showRouteRules: true,
       showMissingSidecars: false,
-      edgeLabelMode: EdgeLabelMode.NONE
+      edgeLabelMode: EdgeLabelMode.HIDE
     });
   });
 });

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -1,10 +1,10 @@
 import { NotificationGroup } from '../types/MessageCenter';
+import { EdgeLabelMode } from '../types/GraphFilter';
 // Store is the Redux Data store
 
 // Various pages are described here with their various sections
 export interface ServiceGraphFilterState {
   // Toggle props
-  readonly showEdgeLabels: boolean;
   readonly showNodeLabels: boolean;
   readonly showCircuitBreakers: boolean;
   readonly showRouteRules: boolean;
@@ -12,6 +12,8 @@ export interface ServiceGraphFilterState {
   // disable the service graph layers toolbar
   // @todo: add this back in later
   // readonly disableLayers: boolean;
+
+  readonly edgeLabelMode: EdgeLabelMode;
 }
 
 export interface MessageCenterState {

--- a/src/types/Graph.ts
+++ b/src/types/Graph.ts
@@ -1,4 +1,4 @@
-import { Duration, Layout } from './GraphFilter';
+import { Duration, Layout, EdgeLabelMode } from './GraphFilter';
 import Namespace from './Namespace';
 
 // SummaryData will have two fields:
@@ -22,4 +22,5 @@ export interface GraphParamsType {
   namespace: Namespace;
   graphDuration: Duration;
   graphLayout: Layout;
+  edgeLabelMode: EdgeLabelMode;
 }

--- a/src/types/GraphFilter.ts
+++ b/src/types/GraphFilter.ts
@@ -5,3 +5,26 @@ export interface Layout {
 export interface Duration {
   value: number;
 }
+
+export enum EdgeLabelMode {
+  NONE = 'NONE',
+  REQUEST_RATE = 'REQUEST_RATE',
+  LATENCY = 'LATENCY'
+}
+
+export namespace EdgeLabelMode {
+  export const getValues: () => EdgeLabelMode[] = () =>
+    Object.keys(EdgeLabelMode)
+      .map(stringValue => EdgeLabelMode[stringValue])
+      .filter(v => typeof v === 'string');
+  export const fromString: (value: string, defaultValue?: EdgeLabelMode) => EdgeLabelMode = (value, defaultValue) => {
+    if (value in EdgeLabelMode) {
+      return EdgeLabelMode[value] as EdgeLabelMode;
+    }
+    if (!defaultValue) {
+      throw TypeError(`${value} is not a EdgeLabelMode`);
+    }
+
+    return defaultValue;
+  };
+}

--- a/src/types/GraphFilter.ts
+++ b/src/types/GraphFilter.ts
@@ -7,9 +7,9 @@ export interface Duration {
 }
 
 export enum EdgeLabelMode {
-  NONE = 'NONE',
-  REQUEST_RATE = 'REQUEST_RATE',
-  LATENCY = 'LATENCY'
+  HIDE = 'HIDE',
+  REQUESTS_PER_SECOND = 'REQUESTS_PER_SECOND',
+  LATENCY_95TH_PERCENTILE = 'LATENCY_95TH_PERCENTILE'
 }
 
 export namespace EdgeLabelMode {


### PR DESCRIPTION
Got a first pass on this, I had to update some redux actions to better match with this, but not yet using them I would need to connect the GraphFilter to redux and decided that other PR would better fit it.

So i setup the latency scenario like this, using this yml for openshift:
```yaml
apiVersion: config.istio.io/v1alpha2
kind: RouteRule
metadata:
  name: ratings-delay-abort
  namespace: bookinfo
spec:
  destination:
    name: ratings
  match:
    source:
      name: reviews
  route:
  - labels:
      version: v1
  httpFault:
    delay:
      fixedDelay: 1.000s
      percent: 100
  precedence: 2
```

Delay of 1 second from reviews to rating, I suspect that [this](https://github.com/istio/istio/issues/4323) issue prevents us from seeing the delay from reviews to rating (see gif), but is definetly happening and we can see it from productpage to review.

![peek 2018-05-14 18-20](https://user-images.githubusercontent.com/3845764/40028757-40824f4c-57a6-11e8-91cb-f5a874dbb1d4.gif)
