### PR TITLE
GraphStyles.styles() was never meant to be passed as a "style" attribute of a DomElement

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeReactWrapper.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeReactWrapper.tsx
@@ -67,8 +67,7 @@ export class CytoscapeReactWrapper extends React.Component<CytoscapeReactWrapper
 
   render() {
     console.log('CY: rendering cy div parent');
-    const style = GraphStyles.styles();
-    const styleContainer = Object.assign({ height: '100%', width: '100%', display: 'block' }, style);
+    const styleContainer = { height: '100%', width: '100%', display: 'block' };
     return <div id="cy" className="graph" style={styleContainer} ref={this.divParentRef} />;
   }
 


### PR DESCRIPTION
 It is meant to be passed as a cytoscape option.
 The reason it was failing, is because GraphStyle.styles() is an array, so we were
 passing each element of that array as index property to be assigned.
 e.g. Object.assign({width: '100px'}, ['im', 'an array']) yields
 {0: "im", 1: "an array", width: "100px"}
 Firefox gets upset because it can't find the property css style "0"