### PR TITLE
KIALI-681: Consoliate filter events to new GraphFilterToolbar component

### DIFF
--- a/src/components/GraphFilter/GraphFilter.tsx
+++ b/src/components/GraphFilter/GraphFilter.tsx
@@ -15,7 +15,7 @@ import * as _ from 'lodash';
 export interface GraphFilterProps extends GraphParamsType {
   disabled: boolean;
   onLayoutChange: (newLayout: Layout) => void;
-  onFilterChange: (newDuration: Duration) => void;
+  onDurationChange: (newDuration: Duration) => void;
   onNamespaceChange: (newValue: Namespace) => void;
   onEdgeLabelModeChange: (newEdges: EdgeLabelMode) => void;
   onRefresh: () => void;
@@ -48,7 +48,7 @@ export default class GraphFilter extends React.Component<GraphFilterProps, Graph
     if (this.props.graphDuration.value !== value) {
       // notify callback
       sessionStorage.setItem('appDuration', String(value));
-      this.props.onFilterChange({ value: value });
+      this.props.onDurationChange({ value: value });
     }
   };
 

--- a/src/components/GraphFilter/GraphFilterToolbar.tsx
+++ b/src/components/GraphFilter/GraphFilterToolbar.tsx
@@ -1,0 +1,91 @@
+import * as React from 'react';
+import { PropTypes } from 'prop-types';
+
+import { GraphParamsType } from '../../types/Graph';
+import { Duration, Layout, EdgeLabelMode } from '../../types/GraphFilter';
+import Namespace from '../../types/Namespace';
+import GraphFilterToolbarType from '../../types/GraphFilterToolbar';
+
+import { makeURLFromParams } from '../../components/Nav/NavUtils';
+
+import GraphFilter from './GraphFilter';
+
+export default class GraphFilterToolbar extends React.PureComponent<GraphFilterToolbarType, {}> {
+  static contextTypes = {
+    router: PropTypes.object
+  };
+
+  render() {
+    const graphParams: GraphParamsType = {
+      namespace: this.props.namespace,
+      graphLayout: this.props.graphLayout,
+      graphDuration: this.props.graphDuration,
+      edgeLabelMode: this.props.edgeLabelMode
+    };
+
+    return (
+      <GraphFilter
+        disabled={this.props.isLoading}
+        onLayoutChange={this.handleLayoutChange}
+        onDurationChange={this.handleDurationChange}
+        onNamespaceChange={this.handleNamespaceChange}
+        onEdgeLabelModeChange={this.handleEdgeLabelModeChange}
+        onRefresh={this.props.handleRefreshClick}
+        {...graphParams}
+      />
+    );
+  }
+
+  handleLayoutChange = (graphLayout: Layout) => {
+    const { namespace, graphDuration, edgeLabelMode } = this.getGraphParams();
+    this.handleFilterChange({
+      graphDuration,
+      namespace,
+      graphLayout,
+      edgeLabelMode
+    });
+  };
+
+  handleDurationChange = (graphDuration: Duration) => {
+    const { namespace, graphLayout, edgeLabelMode } = this.getGraphParams();
+    this.handleFilterChange({
+      graphDuration,
+      namespace,
+      graphLayout,
+      edgeLabelMode
+    });
+  };
+
+  handleNamespaceChange = (namespace: Namespace) => {
+    const { graphDuration, graphLayout, edgeLabelMode } = this.getGraphParams();
+    this.handleFilterChange({
+      namespace,
+      graphDuration,
+      graphLayout,
+      edgeLabelMode
+    });
+  };
+
+  handleEdgeLabelModeChange = (edgeLabelMode: EdgeLabelMode) => {
+    const { namespace, graphDuration, graphLayout } = this.getGraphParams();
+    this.handleFilterChange({
+      namespace,
+      graphDuration,
+      graphLayout,
+      edgeLabelMode
+    });
+  };
+
+  handleFilterChange = (params: GraphParamsType) => {
+    this.context.router.history.push(makeURLFromParams(params));
+  };
+
+  private getGraphParams: () => GraphParamsType = () => {
+    return {
+      namespace: this.props.namespace,
+      graphDuration: this.props.graphDuration,
+      graphLayout: this.props.graphLayout,
+      edgeLabelMode: this.props.edgeLabelMode
+    };
+  };
+}

--- a/src/components/GraphFilter/__tests__/GraphFilterToolbar.test.tsx
+++ b/src/components/GraphFilter/__tests__/GraphFilterToolbar.test.tsx
@@ -5,9 +5,7 @@ import { GraphParamsType } from '../../../types/Graph';
 import { Duration, Layout, EdgeLabelMode } from '../../../types/GraphFilter';
 import Namespace from '../../../types/Namespace';
 
-import ServiceGraphPage from '../ServiceGraphPage';
-
-const dummyFunction = () => 0;
+import GraphFilterToolbar from '../GraphFilterToolbar';
 
 const PARAMS: GraphParamsType = {
   namespace: { name: 'itsio-system' },
@@ -15,34 +13,28 @@ const PARAMS: GraphParamsType = {
   graphLayout: { name: 'Cose' },
   edgeLabelMode: EdgeLabelMode.HIDE
 };
+
 describe('ServiceGraphPage test', () => {
   it('should propagate filter params change with correct value', () => {
-    const onParamsChangeFn = jest.fn();
-    const wrapper = shallow(
-      <ServiceGraphPage
-        {...PARAMS}
-        onParamsChange={onParamsChangeFn}
-        fetchGraphData={dummyFunction}
-        graphTimestamp={'0'}
-        graphData={[]}
-        isLoading={false}
-      />
-    );
+    const onParamsChangeMockFn = jest.fn();
+    const wrapper = shallow(<GraphFilterToolbar {...PARAMS} isLoading={false} handleRefreshClick={jest.fn()} />);
 
-    const serviceGraph = wrapper.instance() as ServiceGraphPage;
+    const toolbar = wrapper.instance() as GraphFilterToolbar;
+    toolbar.handleFilterChange = onParamsChangeMockFn;
+
     const newLayout: Layout = { name: 'Cola' };
-    serviceGraph.handleLayoutChange(newLayout); // simulate layout change
+    toolbar.handleLayoutChange(newLayout); // simulate layout change
     const EXPECT1 = Object.assign({}, PARAMS, { graphLayout: newLayout });
-    expect(onParamsChangeFn).toHaveBeenLastCalledWith(EXPECT1);
+    expect(onParamsChangeMockFn).toHaveBeenLastCalledWith(EXPECT1);
 
     const newDuration: Duration = { value: 1800 };
-    serviceGraph.handleFilterChange(newDuration); // simulate duration change
+    toolbar.handleDurationChange(newDuration); // simulate duration change
     const EXPECT2 = Object.assign({}, PARAMS, { graphDuration: newDuration });
-    expect(onParamsChangeFn).toHaveBeenLastCalledWith(EXPECT2);
+    expect(onParamsChangeMockFn).toHaveBeenLastCalledWith(EXPECT2);
 
     const newNamespace: Namespace = { name: 'bookinfo' };
-    serviceGraph.handleNamespaceChange(newNamespace); // simulate name change
+    toolbar.handleNamespaceChange(newNamespace); // simulate name change
     const EXPECT3 = Object.assign({}, PARAMS, { namespace: newNamespace });
-    expect(onParamsChangeFn).toHaveBeenLastCalledWith(EXPECT3);
+    expect(onParamsChangeMockFn).toHaveBeenLastCalledWith(EXPECT3);
   });
 });

--- a/src/components/Nav/NavUtils.tsx
+++ b/src/components/Nav/NavUtils.tsx
@@ -1,0 +1,6 @@
+import { GraphParamsType } from '../../types/Graph';
+
+export const makeURLFromParams = (params: GraphParamsType) =>
+  `/service-graph/${params.namespace.name}?layout=${params.graphLayout.name}&duration=${
+    params.graphDuration.value
+  }&edges=${params.edgeLabelMode}`;

--- a/src/components/Nav/Navigation.tsx
+++ b/src/components/Nav/Navigation.tsx
@@ -11,7 +11,7 @@ import IstioRulesPage from '../../pages/IstioRulesList/IstioRuleListPage';
 import IstioRuleDetailsPage from '../../pages/IstioRuleDetails/IstioRuleDetailsPage';
 import HelpDropdown from './HelpDropdown';
 import ServiceDetailsPage from '../../pages/ServiceDetails/ServiceDetailsPage';
-import { ServiceGraphRouteHandler } from '../../pages/ServiceGraph';
+import ServiceGraphRouteHandler from '../../pages/ServiceGraph/ServiceGraphRouteHandler';
 import ServiceListPage from '../../pages/ServiceList/ServiceListPage';
 import ServiceJaegerPage from '../../pages/ServiceJaeger/ServiceJaegerPage';
 

--- a/src/pages/ServiceGraph/ServiceGraphPage.tsx
+++ b/src/pages/ServiceGraph/ServiceGraphPage.tsx
@@ -2,11 +2,11 @@ import * as React from 'react';
 
 import Namespace from '../../types/Namespace';
 import { GraphParamsType, SummaryData } from '../../types/Graph';
-import { Duration, Layout, EdgeLabelMode } from '../../types/GraphFilter';
+import { Duration } from '../../types/GraphFilter';
 
 import SummaryPanel from './SummaryPanel';
 import CytoscapeGraph from '../../components/CytoscapeGraph/CytoscapeGraph';
-import GraphFilter from '../../components/GraphFilter/GraphFilter';
+import GraphFilterToolbar from '../../components/GraphFilter/GraphFilterToolbar';
 import PfContainerNavVertical from '../../components/Pf/PfContainerNavVertical';
 import { computePrometheusQueryInterval } from '../../services/Prometheus';
 import { style } from 'typestyle';
@@ -19,7 +19,7 @@ type ServiceGraphPageProps = GraphParamsType & {
   graphTimestamp: string;
   graphData: any;
   isLoading: boolean;
-  onParamsChange: (params: GraphParamsType) => void;
+  isReady: boolean;
   fetchGraphData: (namespace: Namespace, graphDuration: Duration) => any;
 };
 const NUMBER_OF_DATAPOINTS = 30;
@@ -83,18 +83,17 @@ export default class ServiceGraphPage extends React.Component<ServiceGraphPagePr
       namespace: this.props.namespace,
       graphLayout: this.props.graphLayout,
       edgeLabelMode: this.props.edgeLabelMode,
+      // @todo: graphDuration should be coming from this.props.graphDuration
+      // since it's a required prop.  Getting the value from sessionStorage
+      // makes this component stateful.
       graphDuration: { value: Number(sessionStorage.getItem('appDuration')) } || this.props.graphDuration
     };
     return (
       <PfContainerNavVertical>
         <h2>Service Graph</h2>
-        <GraphFilter
-          disabled={this.props.isLoading}
-          onLayoutChange={this.handleLayoutChange}
-          onFilterChange={this.handleFilterChange}
-          onNamespaceChange={this.handleNamespaceChange}
-          onEdgeLabelModeChange={this.handleEdgeLabelModeChange}
-          onRefresh={this.handleRefreshClick}
+        <GraphFilterToolbar
+          isLoading={this.props.isLoading}
+          handleRefreshClick={this.handleRefreshClick}
           {...graphParams}
         />
         <div className={cytscapeGraphStyle}>
@@ -120,46 +119,6 @@ export default class ServiceGraphPage extends React.Component<ServiceGraphPagePr
     );
   }
 
-  handleLayoutChange = (graphLayout: Layout) => {
-    const { namespace, graphDuration, edgeLabelMode } = this.getGraphParams();
-    this.props.onParamsChange({
-      graphDuration,
-      namespace,
-      graphLayout,
-      edgeLabelMode
-    });
-  };
-
-  handleFilterChange = (graphDuration: Duration) => {
-    const { namespace, graphLayout, edgeLabelMode } = this.getGraphParams();
-    this.props.onParamsChange({
-      graphDuration,
-      namespace,
-      graphLayout,
-      edgeLabelMode
-    });
-  };
-
-  handleNamespaceChange = (namespace: Namespace) => {
-    const { graphDuration, graphLayout, edgeLabelMode } = this.getGraphParams();
-    this.props.onParamsChange({
-      namespace,
-      graphDuration,
-      graphLayout,
-      edgeLabelMode
-    });
-  };
-
-  handleEdgeLabelModeChange = (edgeLabelMode: EdgeLabelMode) => {
-    const { namespace, graphDuration, graphLayout } = this.getGraphParams();
-    this.props.onParamsChange({
-      namespace,
-      graphDuration,
-      graphLayout,
-      edgeLabelMode
-    });
-  };
-
   /** Fetch graph data */
   loadGraphDataFromBackend = (namespace?: Namespace, graphDuration?: Duration) => {
     namespace = namespace ? namespace : this.props.namespace;
@@ -168,14 +127,5 @@ export default class ServiceGraphPage extends React.Component<ServiceGraphPagePr
     this.setState({
       summaryData: null
     });
-  };
-
-  private getGraphParams: () => GraphParamsType = () => {
-    return {
-      namespace: this.props.namespace,
-      graphDuration: this.props.graphDuration,
-      graphLayout: this.props.graphLayout,
-      edgeLabelMode: this.props.edgeLabelMode
-    };
   };
 }

--- a/src/pages/ServiceGraph/ServiceGraphRouteHandler.tsx
+++ b/src/pages/ServiceGraph/ServiceGraphRouteHandler.tsx
@@ -6,6 +6,7 @@ import { GraphParamsType } from '../../types/Graph';
 import { EdgeLabelMode } from '../../types/GraphFilter';
 import * as LayoutDictionary from '../../components/CytoscapeGraph/graphs/LayoutDictionary';
 import ServiceGraphPage from '../../containers/ServiceGraphPageContainer';
+import { makeURLFromParams } from '../../components/Nav/NavUtils';
 
 const URLSearchParams = require('url-search-params');
 
@@ -25,7 +26,7 @@ const DEFAULT_DURATION = 60;
 /**
  * Handle URL parameters for ServiceGraph page
  */
-export class ServiceGraphRouteHandler extends React.Component<
+export default class ServiceGraphRouteHandler extends React.Component<
   RouteComponentProps<ServiceGraphURLProps>,
   GraphParamsType
 > {
@@ -62,7 +63,7 @@ export class ServiceGraphRouteHandler extends React.Component<
 
   componentDidMount() {
     // Note: `history.replace` simply changes the address bar text, not re-navigation
-    this.context.router.history.replace(this.makeURLFromParams(this.state));
+    this.context.router.history.replace(makeURLFromParams(this.state));
   }
 
   componentWillReceiveProps(nextProps: RouteComponentProps<ServiceGraphURLProps>) {
@@ -88,17 +89,7 @@ export class ServiceGraphRouteHandler extends React.Component<
     }
   }
 
-  makeURLFromParams = (params: GraphParamsType) =>
-    `/service-graph/${params.namespace.name}?layout=${params.graphLayout.name}&duration=${
-      params.graphDuration.value
-    }&edges=${params.edgeLabelMode}`;
-
-  /** Change browser address bar and trigger new props propagation */
-  onParamsChange = (params: GraphParamsType) => {
-    this.context.router.history.push(this.makeURLFromParams(params));
-  };
-
   render() {
-    return <ServiceGraphPage {...this.state} onParamsChange={this.onParamsChange} />;
+    return <ServiceGraphPage {...this.state} />;
   }
 }

--- a/src/pages/ServiceGraph/index.tsx
+++ b/src/pages/ServiceGraph/index.tsx
@@ -1,3 +1,0 @@
-import { ServiceGraphRouteHandler } from './ServiceGraphRouteHandler';
-
-export { ServiceGraphRouteHandler };

--- a/src/types/GraphFilterToolbar.ts
+++ b/src/types/GraphFilterToolbar.ts
@@ -1,0 +1,6 @@
+import { GraphParamsType } from './Graph';
+
+export default interface GraphFilterToolbarType extends GraphParamsType {
+  isLoading: boolean;
+  handleRefreshClick: () => void;
+}


### PR DESCRIPTION
- [x] Create a new `GraphFilterToolbar` component to handle filter change events.  Simplify `ServiceGraphPage`
- [x] Filter change events will now update browser URL directly instead of having to bubble changes all the way up to the top most `ServiceGraphRouteHandler`

![proposed-servicegraph-structure 1](https://user-images.githubusercontent.com/3805254/40146039-ee572516-5918-11e8-85d6-9249adf283d1.png)
