### PR TITLE
KIALI-360 request percentage as new edge label option

### DIFF
--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -77,22 +77,29 @@ export class GraphStyles {
         css: {
           content: (ele: any) => {
             const edgeLabelMode = ele.data('edgeLabelMode');
-            if (!edgeLabelMode) {
-              return '';
-            }
-            if (edgeLabelMode === EdgeLabelMode.REQUESTS_PER_SECOND) {
-              const rate = ele.data('rate') ? parseFloat(ele.data('rate')) : 0;
-              const pErr = ele.data('percentErr') ? parseFloat(ele.data('percentErr')) : 0;
-              if (rate > 0) {
-                return pErr > 0 ? rate.toFixed(2) + ', ' + pErr.toFixed(1) + '%' : rate.toFixed(2);
+            switch (edgeLabelMode) {
+              case EdgeLabelMode.REQUESTS_PER_SECOND: {
+                const rate = ele.data('rate') ? parseFloat(ele.data('rate')) : 0;
+                if (rate > 0) {
+                  const pErr = ele.data('percentErr') ? parseFloat(ele.data('percentErr')) : 0;
+                  return pErr > 0 ? rate.toFixed(2) + ', ' + pErr.toFixed(1) + '%' : rate.toFixed(2);
+                }
+                return '';
               }
-            } else if (edgeLabelMode === EdgeLabelMode.LATENCY_95TH_PERCENTILE) {
-              const latency = ele.data('latency') ? parseFloat(ele.data('latency')) : 0;
-              if (latency > 0) {
-                return latency.toFixed(2) + 's';
+              case EdgeLabelMode.LATENCY_95TH_PERCENTILE: {
+                const latency = ele.data('latency') ? parseFloat(ele.data('latency')) : 0;
+                if (latency > 0) {
+                  return latency < 1.0 ? (latency * 1000).toFixed(0) + 'ms' : latency.toFixed(2) + 's';
+                }
+                return '';
               }
+              case EdgeLabelMode.REQUESTS_PERCENT_OF_TOTAL: {
+                const percentRate = ele.data('percentRate') ? parseFloat(ele.data('percentRate')) : 0;
+                return percentRate > 0 ? percentRate.toFixed(0) + '%' : '';
+              }
+              default:
+                return '';
             }
-            return '';
           },
           'curve-style': 'bezier',
           'font-size': '7px',

--- a/src/components/SummaryPanel/LatencyChart.tsx
+++ b/src/components/SummaryPanel/LatencyChart.tsx
@@ -37,7 +37,7 @@ export default class LatencyChart extends React.Component<LatencyChartTypeProp, 
         .concat(this.props.lat95 as [string, number][])
         .concat(this.props.lat99 as [string, number][]),
       type: 'area-spline',
-      hide: ['Average', '95th', '99th']
+      hide: ['Average', 'Median', '99th']
     };
 
     return (

--- a/src/types/GraphFilter.ts
+++ b/src/types/GraphFilter.ts
@@ -7,9 +7,10 @@ export interface Duration {
 }
 
 export enum EdgeLabelMode {
-  HIDE = 'HIDE',
-  REQUESTS_PER_SECOND = 'REQUESTS_PER_SECOND',
-  LATENCY_95TH_PERCENTILE = 'LATENCY_95TH_PERCENTILE'
+  HIDE = 'hide',
+  REQUESTS_PER_SECOND = 'requestsPerSecond',
+  REQUESTS_PERCENT_OF_TOTAL = 'requestsPercentOfTotal',
+  LATENCY_95TH_PERCENTILE = 'latency95thPercentile'
 }
 
 export namespace EdgeLabelMode {
@@ -18,13 +19,13 @@ export namespace EdgeLabelMode {
       .map(stringValue => EdgeLabelMode[stringValue])
       .filter(v => typeof v === 'string');
   export const fromString: (value: string, defaultValue?: EdgeLabelMode) => EdgeLabelMode = (value, defaultValue) => {
-    if (value in EdgeLabelMode) {
-      return EdgeLabelMode[value] as EdgeLabelMode;
+    const key = Object.keys(EdgeLabelMode).find(k => EdgeLabelMode[k] === value);
+    if (key) {
+      return EdgeLabelMode[key];
     }
     if (!defaultValue) {
       throw TypeError(`${value} is not a EdgeLabelMode`);
     }
-
     return defaultValue;
   };
 }


### PR DESCRIPTION
other:
- switch to camel case for edge label options for 'prettier' urls
- fix bug in EdgeLabelMode.fromString
- show latency < 1s as 'ms'
- change edge summary latency chart to default to 95th percentile to
  match current graph setting