### PR TITLE
KIALI-739: filter duration erroneously set to 0

### DIFF
--- a/src/components/GraphFilter/GraphFilter.tsx
+++ b/src/components/GraphFilter/GraphFilter.tsx
@@ -47,7 +47,6 @@ export default class GraphFilter extends React.Component<GraphFilterProps, Graph
   updateDuration = (value: number) => {
     if (this.props.graphDuration.value !== value) {
       // notify callback
-      sessionStorage.setItem('appDuration', String(value));
       this.props.onDurationChange({ value: value });
     }
   };
@@ -94,12 +93,8 @@ export default class GraphFilter extends React.Component<GraphFilterProps, Graph
             disabled={this.props.disabled}
             handleSelect={this.updateDuration}
             nameDropdown={'Duration'}
-            initialValue={Number(sessionStorage.getItem('appDuration')) || this.props.graphDuration.value}
-            initialLabel={String(
-              GraphFilter.INTERVAL_DURATION[
-                Number(sessionStorage.getItem('appDuration')) || config().toolbar.defaultDuration
-              ]
-            )}
+            initialValue={this.props.graphDuration.value}
+            initialLabel={String(GraphFilter.INTERVAL_DURATION[this.props.graphDuration.value])}
             options={GraphFilter.INTERVAL_DURATION}
           />
           <ToolbarDropdown

--- a/src/pages/ServiceGraph/ServiceGraphPage.tsx
+++ b/src/pages/ServiceGraph/ServiceGraphPage.tsx
@@ -83,10 +83,7 @@ export default class ServiceGraphPage extends React.Component<ServiceGraphPagePr
       namespace: this.props.namespace,
       graphLayout: this.props.graphLayout,
       edgeLabelMode: this.props.edgeLabelMode,
-      // @todo: graphDuration should be coming from this.props.graphDuration
-      // since it's a required prop.  Getting the value from sessionStorage
-      // makes this component stateful.
-      graphDuration: { value: Number(sessionStorage.getItem('appDuration')) } || this.props.graphDuration
+      graphDuration: this.props.graphDuration
     };
     return (
       <PfContainerNavVertical>

--- a/src/pages/ServiceGraph/ServiceGraphRouteHandler.tsx
+++ b/src/pages/ServiceGraph/ServiceGraphRouteHandler.tsx
@@ -7,6 +7,7 @@ import { EdgeLabelMode } from '../../types/GraphFilter';
 import * as LayoutDictionary from '../../components/CytoscapeGraph/graphs/LayoutDictionary';
 import ServiceGraphPage from '../../containers/ServiceGraphPageContainer';
 import { makeURLFromParams } from '../../components/Nav/NavUtils';
+import { config } from '../../config';
 
 const URLSearchParams = require('url-search-params');
 
@@ -19,9 +20,6 @@ type ServiceGraphURLProps = {
   namespace: string;
   layout: string;
 };
-
-// TODO put duration, step defaults and Prometheus translation in a single place
-const DEFAULT_DURATION = 60;
 
 /**
  * Handle URL parameters for ServiceGraph page
@@ -54,7 +52,7 @@ export default class ServiceGraphRouteHandler extends React.Component<
     const _hideRRs = urlParams.get('hideRRs') ? urlParams.get('hideRRs') === 'true' : false;
     const _edgeLabelMode = EdgeLabelMode.fromString(urlParams.get('edges'), EdgeLabelMode.HIDE);
     return {
-      graphDuration: _duration ? { value: _duration } : { value: DEFAULT_DURATION },
+      graphDuration: _duration ? { value: _duration } : { value: config().toolbar.defaultDuration },
       graphLayout: LayoutDictionary.getLayout({ name: urlParams.get('layout') }),
       badgeStatus: { hideCBs: _hideCBs, hideRRs: _hideRRs },
       edgeLabelMode: _edgeLabelMode


### PR DESCRIPTION
Only write to and read from sessionStorage in top most component to avoid inconsistent props.  To verify the fix please remove appDuration and service-graph-params data in browser storage (Chrome -> developer tools -> Application)

@jshaughn  @mtho11 please review when you get a chance

---
![session-storage](https://user-images.githubusercontent.com/3805254/40252671-eddc3f52-5a91-11e8-9d72-bdf245bbed94.png)
