### PR TITLE
KIALI-742 Show errors and warnings as a toast notification

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react-scripts-ts": "2.15.1",
     "redux": "3.7.2",
     "redux-logger": "3.0.6",
+    "redux-mock-store": "1.5.1",
     "redux-thunk": "2.2.0",
     "ssri": "6.0.0",
     "typesafe-actions": "1.1.2",

--- a/src/actions/MessageCenterActions.ts
+++ b/src/actions/MessageCenterActions.ts
@@ -2,54 +2,65 @@ import { MessageType } from '../types/MessageCenter';
 import { createAction } from 'typesafe-actions';
 
 export const enum MessageCenterActionKeys {
-  MESSAGE_CENTER_ADD = 'MESSAGE_CENTER_ADD',
-  MESSAGE_CENTER_REMOVE = 'MESSAGE_CENTER_REMOVE',
-  MESSAGE_CENTER_MARK_AS_READ = 'MESSAGE_CENTER_MARK_AS_READ',
-  MESSAGE_CENTER_SHOW = 'MESSAGE_CENTER_SHOW',
-  MESSAGE_CENTER_HIDE = 'MESSAGE_CENTER_HIDE',
-  MESSAGE_CENTER_TOGGLE_EXPAND = 'MESSAGE_CENTER_TOGGLE_EXPAND',
-  MESSAGE_CENTER_TOGGLE_GROUP = 'MESSAGE_CENTER_TOGGLE_GROUP'
+  ADD_MESSAGE = 'ADD_MESSAGE',
+  REMOVE_MESSAGE = 'REMOVE_MESSAGE',
+  MARK_MESSAGE_AS_READ = 'MARK_MESSAGE_AS_READ',
+  SHOW = 'SHOW',
+  HIDE = 'HIDE',
+  TOGGLE_EXPAND = 'TOGGLE_EXPAND',
+  TOGGLE_GROUP = 'TOGGLE_GROUP',
+  HIDE_NOTIFICATION = 'HIDE_NOTIFICATION'
 }
 
-const numberArray = (n: number | number[]) => (Array.isArray(n) ? n : [n]);
+type numberOrNumberArray = number | number[];
+
+const toNumberArray = (n: numberOrNumberArray) => (Array.isArray(n) ? n : [n]);
 
 export const MessageCenterActions = {
   addMessage: createAction(
-    MessageCenterActionKeys.MESSAGE_CENTER_ADD,
+    MessageCenterActionKeys.ADD_MESSAGE,
     (content: string, groupId: string, messageType: MessageType) => ({
-      type: MessageCenterActionKeys.MESSAGE_CENTER_ADD,
+      type: MessageCenterActionKeys.ADD_MESSAGE,
       content,
       groupId,
       messageType
     })
   ),
-  removeMessage: createAction(MessageCenterActionKeys.MESSAGE_CENTER_REMOVE, (messageId: number | number[]) => {
-    const type = MessageCenterActionKeys.MESSAGE_CENTER_REMOVE;
-    messageId = numberArray(messageId);
+  removeMessage: createAction(MessageCenterActionKeys.REMOVE_MESSAGE, (messageId: numberOrNumberArray) => {
+    const type = MessageCenterActionKeys.REMOVE_MESSAGE;
+    messageId = toNumberArray(messageId);
     return {
       type,
       messageId
     };
   }),
-  markAsRead: createAction(MessageCenterActionKeys.MESSAGE_CENTER_MARK_AS_READ, (messageId: number | number[]) => {
-    const type = MessageCenterActionKeys.MESSAGE_CENTER_MARK_AS_READ;
-    messageId = numberArray(messageId);
+  markAsRead: createAction(MessageCenterActionKeys.MARK_MESSAGE_AS_READ, (messageId: numberOrNumberArray) => {
+    const type = MessageCenterActionKeys.MARK_MESSAGE_AS_READ;
+    messageId = toNumberArray(messageId);
     return {
       type,
       messageId
     };
   }),
-  toggleGroup: createAction(MessageCenterActionKeys.MESSAGE_CENTER_TOGGLE_GROUP, (groupId: number) => {
-    const type = MessageCenterActionKeys.MESSAGE_CENTER_TOGGLE_GROUP;
+  toggleGroup: createAction(MessageCenterActionKeys.TOGGLE_GROUP, (groupId: string) => {
+    const type = MessageCenterActionKeys.TOGGLE_GROUP;
     return {
       type,
       groupId
     };
   }),
+  hideNotification: createAction(MessageCenterActionKeys.HIDE_NOTIFICATION, (messageId: numberOrNumberArray) => {
+    const type = MessageCenterActionKeys.HIDE_NOTIFICATION;
+    messageId = toNumberArray(messageId);
+    return {
+      type,
+      messageId
+    };
+  }),
 
-  showMessageCenter: createAction(MessageCenterActionKeys.MESSAGE_CENTER_SHOW),
-  hideMessageCenter: createAction(MessageCenterActionKeys.MESSAGE_CENTER_HIDE),
-  togleExpandedMessageCenter: createAction(MessageCenterActionKeys.MESSAGE_CENTER_TOGGLE_EXPAND),
+  showMessageCenter: createAction(MessageCenterActionKeys.SHOW),
+  hideMessageCenter: createAction(MessageCenterActionKeys.HIDE),
+  togleExpandedMessageCenter: createAction(MessageCenterActionKeys.TOGGLE_EXPAND),
 
   toggleMessageCenter: () => {
     return (dispatch, getState) => {
@@ -62,22 +73,24 @@ export const MessageCenterActions = {
       return Promise.resolve();
     };
   },
-  markGroupAsRead: (groupId: number) => {
+  markGroupAsRead: (groupId: string) => {
     return (dispatch, getState) => {
       const state = getState();
       const foundGroup = state.messageCenter.groups.find(group => group.id === groupId);
       if (foundGroup) {
         dispatch(MessageCenterActions.markAsRead(foundGroup.messages.map(message => message.id)));
       }
+      return Promise.resolve();
     };
   },
-  clearGroup: (groupId: number) => {
+  clearGroup: (groupId: string) => {
     return (dispatch, getState) => {
       const state = getState();
       const foundGroup = state.messageCenter.groups.find(group => group.id === groupId);
       if (foundGroup) {
         dispatch(MessageCenterActions.removeMessage(foundGroup.messages.map(message => message.id)));
       }
+      return Promise.resolve();
     };
   }
 };

--- a/src/actions/__tests__/MessageCenterAction.test.ts
+++ b/src/actions/__tests__/MessageCenterAction.test.ts
@@ -1,0 +1,161 @@
+import { MessageCenterActions, MessageCenterActionKeys } from '../MessageCenterActions';
+import { MessageType } from '../../types/MessageCenter';
+
+import thunk from 'redux-thunk';
+import configureMockStore from 'redux-mock-store';
+
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
+
+describe('MessageCenterAtions', () => {
+  it('should add a message', () => {
+    const expectedAction = {
+      type: MessageCenterActionKeys.ADD_MESSAGE,
+      content: 'my message',
+      groupId: 'great-messages',
+      messageType: MessageType.WARNING
+    };
+    expect(MessageCenterActions.addMessage('my message', 'great-messages', MessageType.WARNING)).toEqual(
+      expectedAction
+    );
+  });
+  it('should remove a single message', () => {
+    const expectedAction = {
+      type: MessageCenterActionKeys.REMOVE_MESSAGE,
+      messageId: [5]
+    };
+    expect(MessageCenterActions.removeMessage(5)).toEqual(expectedAction);
+  });
+  it('should remove multiple messages', () => {
+    const expectedAction = {
+      type: MessageCenterActionKeys.REMOVE_MESSAGE,
+      messageId: [5, 6, 8]
+    };
+    expect(MessageCenterActions.removeMessage([5, 6, 8])).toEqual(expectedAction);
+  });
+  it('should mark as read a single message', () => {
+    const expectedAction = {
+      type: MessageCenterActionKeys.MARK_MESSAGE_AS_READ,
+      messageId: [3]
+    };
+    expect(MessageCenterActions.markAsRead(3)).toEqual(expectedAction);
+  });
+  it('should mark as read multiple messages', () => {
+    const expectedAction = {
+      type: MessageCenterActionKeys.MARK_MESSAGE_AS_READ,
+      messageId: [1, 2, 3, 4]
+    };
+    expect(MessageCenterActions.markAsRead([1, 2, 3, 4])).toEqual(expectedAction);
+  });
+  it('should toggle group', () => {
+    const expectedAction = {
+      type: MessageCenterActionKeys.TOGGLE_GROUP,
+      groupId: 'my-awesome-group'
+    };
+    expect(MessageCenterActions.toggleGroup('my-awesome-group')).toEqual(expectedAction);
+  });
+  it('should hide a single notification', () => {
+    const expectedAction = {
+      type: MessageCenterActionKeys.HIDE_NOTIFICATION,
+      messageId: [2]
+    };
+    expect(MessageCenterActions.hideNotification(2)).toEqual(expectedAction);
+  });
+  it('should hide a multiple notifications', () => {
+    const expectedAction = {
+      type: MessageCenterActionKeys.HIDE_NOTIFICATION,
+      messageId: [8, 9, 7]
+    };
+    expect(MessageCenterActions.hideNotification([8, 9, 7])).toEqual(expectedAction);
+  });
+  it('should show the message center', () => {
+    const expectedAction = {
+      type: MessageCenterActionKeys.SHOW
+    };
+    expect(MessageCenterActions.showMessageCenter()).toEqual(expectedAction);
+  });
+  it('should hide the message center', () => {
+    const expectedAction = {
+      type: MessageCenterActionKeys.HIDE
+    };
+    expect(MessageCenterActions.hideMessageCenter()).toEqual(expectedAction);
+  });
+  it('should toggle the exapended state of the message center', () => {
+    const expectedAction = {
+      type: MessageCenterActionKeys.TOGGLE_EXPAND
+    };
+    expect(MessageCenterActions.togleExpandedMessageCenter()).toEqual(expectedAction);
+  });
+  it('should open a closed message center', () => {
+    const expectedActions = [
+      {
+        type: MessageCenterActionKeys.SHOW
+      }
+    ];
+    const store = mockStore({ messageCenter: { hidden: true } });
+    return store.dispatch(MessageCenterActions.toggleMessageCenter()).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+  it('should close an opened message center', () => {
+    const expectedActions = [
+      {
+        type: MessageCenterActionKeys.HIDE
+      }
+    ];
+    const store = mockStore({ messageCenter: { hidden: false } });
+    return store.dispatch(MessageCenterActions.toggleMessageCenter()).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+  it('should only mark selected group as read', () => {
+    const expectedActions = [
+      {
+        type: MessageCenterActionKeys.MARK_MESSAGE_AS_READ,
+        messageId: [1, 2, 3]
+      }
+    ];
+    const store = mockStore({
+      messageCenter: {
+        groups: [
+          {
+            id: 'my-group',
+            messages: [{ id: 1 }, { id: 2 }, { id: 3 }]
+          },
+          {
+            id: 'other',
+            messages: [{ id: 5 }, { id: 6 }, { id: 7 }]
+          }
+        ]
+      }
+    });
+    return store.dispatch(MessageCenterActions.markGroupAsRead('my-group')).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+  it('should only clear messages of selected group', () => {
+    const expectedActions = [
+      {
+        type: MessageCenterActionKeys.REMOVE_MESSAGE,
+        messageId: [5, 6, 7]
+      }
+    ];
+    const store = mockStore({
+      messageCenter: {
+        groups: [
+          {
+            id: 'my-group',
+            messages: [{ id: 1 }, { id: 2 }, { id: 3 }]
+          },
+          {
+            id: 'other',
+            messages: [{ id: 5 }, { id: 6 }, { id: 7 }]
+          }
+        ]
+      }
+    });
+    return store.dispatch(MessageCenterActions.clearGroup('other')).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+});

--- a/src/app/App.scss
+++ b/src/app/App.scss
@@ -21,6 +21,10 @@ $icon-font-path: "~bootstrap-sass/assets/fonts/bootstrap/";
   }
 }
 
+.navbar-pf-vertical .nav .nav-item-iconic .badge-danger {
+  background-color: #cc0000; // Red100
+}
+
 a:hover,
 a:focus {
   text-decoration: none;

--- a/src/components/MessageCenter/MessageCenter.tsx
+++ b/src/components/MessageCenter/MessageCenter.tsx
@@ -20,8 +20,12 @@ export default class MessageCenter extends React.Component<MessageCenterPropsTyp
     }, []);
   };
 
-  onDismissNotification = (message: NotificationMessage) => {
-    this.props.onDismissNotification(message, this.props.groups.find(group => group.id === message.groupId)!);
+  onDismissNotification = (message: NotificationMessage, userDismissed: boolean) => {
+    this.props.onDismissNotification(
+      message,
+      this.props.groups.find(group => group.id === message.groupId)!,
+      userDismissed
+    );
   };
 
   render() {

--- a/src/components/MessageCenter/MessageCenterTrigger.tsx
+++ b/src/components/MessageCenter/MessageCenterTrigger.tsx
@@ -4,6 +4,7 @@ import * as PfReact from 'patternfly-react';
 type StateType = {};
 type PropsType = {
   newMessagesCount: number;
+  badgeDanger: boolean;
   toggleMessageCenter: () => void;
 };
 
@@ -14,7 +15,9 @@ export default class MessageCenterTrigger extends React.PureComponent<PropsType,
         <a className="nav-item-iconic" onClick={this.props.toggleMessageCenter}>
           <PfReact.Icon name="bell" />
           {this.props.newMessagesCount > 0 && (
-            <PfReact.Badge className="pf-badge-bodered">{this.props.newMessagesCount}</PfReact.Badge>
+            <PfReact.Badge className={'pf-badge-bodered' + (this.props.badgeDanger ? ' badge-danger' : '')}>
+              {this.props.newMessagesCount}
+            </PfReact.Badge>
           )}
         </a>
       </li>

--- a/src/components/MessageCenter/NotificationList.tsx
+++ b/src/components/MessageCenter/NotificationList.tsx
@@ -8,7 +8,7 @@ const DEFAULT_TIMER_DELAY = 5000;
 
 type PropsType = {
   messages: NotificationMessage[];
-  onDismiss: (message: NotificationMessage) => void;
+  onDismiss: (message: NotificationMessage, userDismissed: boolean) => void;
 };
 type StateType = {};
 
@@ -22,7 +22,7 @@ export default class NotificationList extends React.PureComponent<PropsType, Sta
             persistent={false}
             paused={false}
             timerdelay={DEFAULT_TIMER_DELAY}
-            onDismiss={() => this.props.onDismiss(message)}
+            onDismiss={event => this.props.onDismiss(message, event !== undefined)}
             type={message.type}
           >
             <span>{message.content}</span>

--- a/src/reducers/MessageCenter.ts
+++ b/src/reducers/MessageCenter.ts
@@ -23,14 +23,32 @@ const createMessage = (id: number, content: string, type: MessageType) => {
     id,
     content,
     type,
+    show_notification: type === MessageType.ERROR || type === MessageType.WARNING,
     seen: false,
     created: new Date()
   };
 };
 
+// Updates several messages with the same payload, useful for marking messages
+// returns the updated state
+const updateMessage = (state: MessageCenterState, messageIds: number[], updater) => {
+  const groups = state.groups.map(group => {
+    group = Object.assign({}, group, {
+      messages: group.messages.map(message => {
+        if (messageIds.includes(message.id)) {
+          message = updater(message);
+        }
+        return message;
+      })
+    });
+    return group;
+  });
+  return mergeToState(state, { groups });
+};
+
 const Messages = (state: MessageCenterState = INITIAL_STATE, action) => {
   switch (action.type) {
-    case MessageCenterActionKeys.MESSAGE_CENTER_ADD: {
+    case MessageCenterActionKeys.ADD_MESSAGE: {
       const { groupId, content, messageType } = action;
       const groups = state.groups.map(group => {
         if (group.id === groupId) {
@@ -43,7 +61,7 @@ const Messages = (state: MessageCenterState = INITIAL_STATE, action) => {
       });
       return mergeToState(state, { groups: groups, nextId: state.nextId + 1 });
     }
-    case MessageCenterActionKeys.MESSAGE_CENTER_REMOVE: {
+    case MessageCenterActionKeys.REMOVE_MESSAGE: {
       const messageId = action.messageId;
       const groups = state.groups.map(group => {
         group = Object.assign({}, group, {
@@ -55,35 +73,26 @@ const Messages = (state: MessageCenterState = INITIAL_STATE, action) => {
       });
       return mergeToState(state, { groups });
     }
-    case MessageCenterActionKeys.MESSAGE_CENTER_MARK_AS_READ: {
-      const messageId = action.messageId;
-      const groups = state.groups.map(group => {
-        group = Object.assign({}, group, {
-          messages: group.messages.map(message => {
-            if (messageId.includes(message.id)) {
-              message = Object.assign({}, message, { seen: true });
-            }
-            return message;
-          })
-        });
-        return group;
-      });
-      return mergeToState(state, { groups });
+    case MessageCenterActionKeys.MARK_MESSAGE_AS_READ: {
+      return updateMessage(state, action.messageId, message => ({ ...message, seen: true, show_notification: false }));
     }
-    case MessageCenterActionKeys.MESSAGE_CENTER_SHOW:
+    case MessageCenterActionKeys.HIDE_NOTIFICATION: {
+      return updateMessage(state, action.messageId, message => ({ ...message, show_notification: false }));
+    }
+    case MessageCenterActionKeys.SHOW:
       if (state.hidden) {
         return mergeToState(state, { hidden: false });
       }
       return state;
-    case MessageCenterActionKeys.MESSAGE_CENTER_HIDE:
+    case MessageCenterActionKeys.HIDE:
       if (!state.hidden) {
         return mergeToState(state, { hidden: true });
       }
       return state;
-    case MessageCenterActionKeys.MESSAGE_CENTER_TOGGLE_EXPAND:
+    case MessageCenterActionKeys.TOGGLE_EXPAND:
       return mergeToState(state, { expanded: !state.expanded });
 
-    case MessageCenterActionKeys.MESSAGE_CENTER_TOGGLE_GROUP: {
+    case MessageCenterActionKeys.TOGGLE_GROUP: {
       const { groupId } = action;
       if (state.expandedGroupId === groupId) {
         return mergeToState(state, { expandedGroupId: undefined });

--- a/src/reducers/__tests__/MessageCenterReducer.test.ts
+++ b/src/reducers/__tests__/MessageCenterReducer.test.ts
@@ -1,0 +1,477 @@
+import MessageCenter from '../MessageCenter';
+import { MessageCenterActionKeys } from '../../actions/MessageCenterActions';
+import { MessageType } from '../../types/MessageCenter';
+
+describe('MessageCenter reducer', () => {
+  const RealDate = Date;
+
+  const mockDate = date => {
+    global.Date = jest.fn(() => date) as any;
+    return date;
+  };
+
+  afterEach(() => {
+    global.Date = RealDate;
+  });
+
+  it('should return the initial state', () => {
+    expect(MessageCenter(undefined, {})).toEqual({
+      expanded: false,
+      expandedGroupId: 'default',
+      groups: [
+        {
+          id: 'default',
+          messages: [],
+          title: 'Default'
+        }
+      ],
+      hidden: true,
+      nextId: 0
+    });
+  });
+  it('should handle ADD_MESSAGE', () => {
+    const date = mockDate(new Date());
+    expect(
+      MessageCenter(
+        {
+          expanded: false,
+          expandedGroupId: 'default',
+          groups: [
+            {
+              id: 'default',
+              messages: [],
+              title: 'Default'
+            }
+          ],
+          hidden: true,
+          nextId: 0
+        },
+        {
+          type: MessageCenterActionKeys.ADD_MESSAGE,
+          groupId: 'default',
+          content: 'my new message',
+          messageType: MessageType.WARNING
+        }
+      )
+    ).toEqual({
+      expanded: false,
+      expandedGroupId: 'default',
+      groups: [
+        {
+          id: 'default',
+          messages: [
+            {
+              id: 0,
+              seen: false,
+              show_notification: true,
+              content: 'my new message',
+              type: MessageType.WARNING,
+              created: date
+            }
+          ],
+          title: 'Default'
+        }
+      ],
+      hidden: true,
+      nextId: 1
+    });
+  });
+  it('should handle REMOVE_MESSAGE', () => {
+    const date = mockDate(new Date());
+    expect(
+      MessageCenter(
+        {
+          expanded: false,
+          expandedGroupId: 'default',
+          groups: [
+            {
+              id: 'default',
+              messages: [
+                {
+                  id: 0,
+                  seen: false,
+                  show_notification: true,
+                  content: 'my new message',
+                  type: MessageType.WARNING,
+                  created: date
+                },
+                {
+                  id: 1,
+                  seen: true,
+                  show_notification: false,
+                  content: 'other message',
+                  type: MessageType.ERROR,
+                  created: date
+                },
+                {
+                  id: 2,
+                  seen: true,
+                  show_notification: false,
+                  content: 'other',
+                  type: MessageType.INFO,
+                  created: date
+                }
+              ],
+              title: 'Default'
+            }
+          ],
+          hidden: true,
+          nextId: 1
+        },
+        {
+          type: MessageCenterActionKeys.REMOVE_MESSAGE,
+          messageId: [0, 2]
+        }
+      )
+    ).toEqual({
+      expanded: false,
+      expandedGroupId: 'default',
+      groups: [
+        {
+          id: 'default',
+          messages: [
+            {
+              id: 1,
+              seen: true,
+              show_notification: false,
+              content: 'other message',
+              type: MessageType.ERROR,
+              created: date
+            }
+          ],
+          title: 'Default'
+        }
+      ],
+      hidden: true,
+      nextId: 1
+    });
+  });
+  it('should handle MARK_MESSAGE_AS_READ', () => {
+    const date = mockDate(new Date());
+    expect(
+      MessageCenter(
+        {
+          expanded: false,
+          expandedGroupId: 'default',
+          groups: [
+            {
+              id: 'default',
+              messages: [
+                {
+                  id: 0,
+                  seen: false,
+                  show_notification: true,
+                  content: 'my new message',
+                  type: MessageType.WARNING,
+                  created: date
+                },
+                {
+                  id: 1,
+                  seen: true,
+                  show_notification: false,
+                  content: 'other message',
+                  type: MessageType.ERROR,
+                  created: date
+                },
+                {
+                  id: 2,
+                  seen: false,
+                  show_notification: false,
+                  content: 'other',
+                  type: MessageType.INFO,
+                  created: date
+                }
+              ],
+              title: 'Default'
+            }
+          ],
+          hidden: true,
+          nextId: 1
+        },
+        {
+          type: MessageCenterActionKeys.MARK_MESSAGE_AS_READ,
+          messageId: [0, 1]
+        }
+      )
+    ).toEqual({
+      expanded: false,
+      expandedGroupId: 'default',
+      groups: [
+        {
+          id: 'default',
+          messages: [
+            {
+              id: 0,
+              seen: true,
+              show_notification: false,
+              content: 'my new message',
+              type: MessageType.WARNING,
+              created: date
+            },
+            {
+              id: 1,
+              seen: true,
+              show_notification: false,
+              content: 'other message',
+              type: MessageType.ERROR,
+              created: date
+            },
+            {
+              id: 2,
+              seen: false,
+              show_notification: false,
+              content: 'other',
+              type: MessageType.INFO,
+              created: date
+            }
+          ],
+          title: 'Default'
+        }
+      ],
+      hidden: true,
+      nextId: 1
+    });
+  });
+  it('should handle HIDE_NOTIFICATION', () => {
+    const date = mockDate(new Date());
+    expect(
+      MessageCenter(
+        {
+          expanded: false,
+          expandedGroupId: 'default',
+          groups: [
+            {
+              id: 'default',
+              messages: [
+                {
+                  id: 0,
+                  seen: false,
+                  show_notification: true,
+                  content: 'my new message',
+                  type: MessageType.WARNING,
+                  created: date
+                },
+                {
+                  id: 1,
+                  seen: false,
+                  show_notification: true,
+                  content: 'other message',
+                  type: MessageType.ERROR,
+                  created: date
+                }
+              ],
+              title: 'Default'
+            }
+          ],
+          hidden: true,
+          nextId: 1
+        },
+        {
+          type: MessageCenterActionKeys.HIDE_NOTIFICATION,
+          messageId: [0]
+        }
+      )
+    ).toEqual({
+      expanded: false,
+      expandedGroupId: 'default',
+      groups: [
+        {
+          id: 'default',
+          messages: [
+            {
+              id: 0,
+              seen: false,
+              show_notification: false,
+              content: 'my new message',
+              type: MessageType.WARNING,
+              created: date
+            },
+            {
+              id: 1,
+              seen: false,
+              show_notification: true,
+              content: 'other message',
+              type: MessageType.ERROR,
+              created: date
+            }
+          ],
+          title: 'Default'
+        }
+      ],
+      hidden: true,
+      nextId: 1
+    });
+  });
+  it('should handle SHOW', () => {
+    expect(
+      MessageCenter(
+        {
+          expanded: false,
+          expandedGroupId: 'default',
+          groups: [
+            {
+              id: 'default',
+              messages: [],
+              title: 'Default'
+            }
+          ],
+          hidden: true,
+          nextId: 0
+        },
+        {
+          type: MessageCenterActionKeys.SHOW
+        }
+      )
+    ).toEqual({
+      expanded: false,
+      expandedGroupId: 'default',
+      groups: [
+        {
+          id: 'default',
+          messages: [],
+          title: 'Default'
+        }
+      ],
+      hidden: false,
+      nextId: 0
+    });
+  });
+  it('should handle HIDE', () => {
+    expect(
+      MessageCenter(
+        {
+          expanded: false,
+          expandedGroupId: 'default',
+          groups: [
+            {
+              id: 'default',
+              messages: [],
+              title: 'Default'
+            }
+          ],
+          hidden: false,
+          nextId: 0
+        },
+        {
+          type: MessageCenterActionKeys.HIDE
+        }
+      )
+    ).toEqual({
+      expanded: false,
+      expandedGroupId: 'default',
+      groups: [
+        {
+          id: 'default',
+          messages: [],
+          title: 'Default'
+        }
+      ],
+      hidden: true,
+      nextId: 0
+    });
+  });
+  it('should handle TOGGLE_EXPAND', () => {
+    expect(
+      MessageCenter(
+        {
+          expanded: false,
+          expandedGroupId: 'default',
+          groups: [
+            {
+              id: 'default',
+              messages: [],
+              title: 'Default'
+            }
+          ],
+          hidden: false,
+          nextId: 0
+        },
+        {
+          type: MessageCenterActionKeys.TOGGLE_EXPAND
+        }
+      )
+    ).toEqual({
+      expanded: true,
+      expandedGroupId: 'default',
+      groups: [
+        {
+          id: 'default',
+          messages: [],
+          title: 'Default'
+        }
+      ],
+      hidden: false,
+      nextId: 0
+    });
+  });
+  it('should handle TOGGLE_GROUP to hide a group', () => {
+    expect(
+      MessageCenter(
+        {
+          expanded: false,
+          expandedGroupId: 'default',
+          groups: [
+            {
+              id: 'default',
+              messages: [],
+              title: 'Default'
+            }
+          ],
+          hidden: false,
+          nextId: 0
+        },
+        {
+          type: MessageCenterActionKeys.TOGGLE_GROUP,
+          groupId: 'default'
+        }
+      )
+    ).toEqual({
+      expanded: false,
+      expandedGroupId: undefined,
+      groups: [
+        {
+          id: 'default',
+          messages: [],
+          title: 'Default'
+        }
+      ],
+      hidden: false,
+      nextId: 0
+    });
+  });
+  it('should handle TOGGLE_GROUP to show a group', () => {
+    expect(
+      MessageCenter(
+        {
+          expanded: false,
+          expandedGroupId: undefined,
+          groups: [
+            {
+              id: 'default',
+              messages: [],
+              title: 'Default'
+            }
+          ],
+          hidden: false,
+          nextId: 0
+        },
+        {
+          type: MessageCenterActionKeys.TOGGLE_GROUP,
+          groupId: 'default'
+        }
+      )
+    ).toEqual({
+      expanded: false,
+      expandedGroupId: 'default',
+      groups: [
+        {
+          id: 'default',
+          messages: [],
+          title: 'Default'
+        }
+      ],
+      hidden: false,
+      nextId: 0
+    });
+  });
+});

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -21,7 +21,7 @@ export interface MessageCenterState {
   groups: NotificationGroup[];
   hidden: boolean;
   expanded: boolean;
-  expandedGroupId: string;
+  expandedGroupId?: string;
 }
 
 export interface ServiceGraphDataState {

--- a/src/types/MessageCenter.ts
+++ b/src/types/MessageCenter.ts
@@ -36,7 +36,7 @@ export interface MessageCenterPropsType {
   onClearGroup: (group: NotificationGroup) => void;
   onNotificationClick: (message: NotificationMessage, group: NotificationGroup) => void;
 
-  onDismissNotification: (message: NotificationMessage, group: NotificationGroup) => void;
+  onDismissNotification: (message: NotificationMessage, group: NotificationGroup, userDismissed: boolean) => void;
 
   groups: NotificationGroup[];
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "outDir": "build/dist",
     "module": "esnext",
     "target": "es5",
-    "lib": ["es6", "dom"],
+    "lib": ["es2016", "dom"],
     "sourceMap": true,
     "allowJs": true,
     "jsx": "react",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5035,6 +5035,10 @@ lodash.isfunction@^3.0.8:
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz#06de25df4db327ac931981d1bdb067e5af68d051"
 
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+
 lodash.isstring@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
@@ -7040,6 +7044,12 @@ redux-logger@3.0.6:
   resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-3.0.6.tgz#f7555966f3098f3c88604c449cf0baf5778274bf"
   dependencies:
     deep-diff "^0.3.5"
+
+redux-mock-store@1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/redux-mock-store/-/redux-mock-store-1.5.1.tgz#fca4335392e66605420b5559fe02fc5b8bb6d63c"
+  dependencies:
+    lodash.isplainobject "^4.0.6"
 
 redux-thunk@2.2.0:
   version "2.2.0"


### PR DESCRIPTION
- If the message is not manually dismissed, is still unread in the Message Center, otherwise is marked as read.
- Errors and warnings make the bell icon to show a red ball instead of blue
- Added tests for MessageCenter's action and reducers.

Had to move from es6 to [es2016](http://2ality.com/2016/01/ecmascript-2016.html#the-features-of-es2016) to use `Array.includes` method.

![peek 2018-05-18 15-04](https://user-images.githubusercontent.com/3845764/40255560-37afd7f4-5aad-11e8-967a-a478ef87c5f2.gif)
