### PR TITLE
KIALI-752 Show traffic/latency as dots passing in the edges of the service graph

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "csstips": "0.2.3",
     "csx": "8.5.0",
     "cytoscape": "3.2.12",
+    "cytoscape-canvas": "3.0.1",
     "cytoscape-cola": "2.2.3",
     "cytoscape-cose-bilkent": "4.0.0",
     "cytoscape-dagre": "2.2.1",

--- a/src/actions/ServiceGraphFilterActions.ts
+++ b/src/actions/ServiceGraphFilterActions.ts
@@ -8,6 +8,7 @@ export enum ServiceGraphFilterActionKeys {
   TOGGLE_GRAPH_CIRCUIT_BREAKERS = 'TOGGLE_GRAPH_CIRCUIT_BREAKERS',
   TOGGLE_GRAPH_ROUTE_RULES = 'TOGGLE_GRAPH_ROUTE_RULES',
   TOGGLE_GRAPH_MISSING_SIDECARS = 'TOGGLE_GRAPH_MISSING_SIDECARS',
+  TOGGLE_TRAFFIC_ANIMATION = 'TOGGLE_TRAFFIC_ANIMATION',
   SET_GRAPH_EDGE_LABEL_MODE = 'SET_GRAPH_EDGE_LABEL_MODE',
   // Disable Actions
   ENABLE_GRAPH_FILTERS = 'ENABLE_GRAPH_FILTERS'
@@ -26,6 +27,7 @@ export const serviceGraphFilterActions = {
   toggleGraphRouteRules: createAction(ServiceGraphFilterActionKeys.TOGGLE_GRAPH_ROUTE_RULES),
   toggleGraphCircuitBreakers: createAction(ServiceGraphFilterActionKeys.TOGGLE_GRAPH_CIRCUIT_BREAKERS),
   toggleGraphMissingSidecars: createAction(ServiceGraphFilterActionKeys.TOGGLE_GRAPH_MISSING_SIDECARS),
+  toggleTrafficAnimation: createAction(ServiceGraphFilterActionKeys.TOGGLE_TRAFFIC_ANIMATION),
   showGraphFilters: createAction(ServiceGraphFilterActionKeys.ENABLE_GRAPH_FILTERS, (value: boolean) => ({
     type: ServiceGraphFilterActionKeys.ENABLE_GRAPH_FILTERS,
     payload: value

--- a/src/actions/__tests__/GraphFilterAction.test.tsx
+++ b/src/actions/__tests__/GraphFilterAction.test.tsx
@@ -41,6 +41,13 @@ describe('GraphFilterActions', () => {
     expect(serviceGraphFilterActions.toggleGraphMissingSidecars()).toEqual(expectedAction);
   });
 
+  it('should toggle traffic animations', () => {
+    const expectedAction = {
+      type: ServiceGraphFilterActionKeys.TOGGLE_TRAFFIC_ANIMATION
+    };
+    expect(serviceGraphFilterActions.toggleTrafficAnimation()).toEqual(expectedAction);
+  });
+
   it('should enable graph filters toggles', () => {
     const expectedAction = {
       type: ServiceGraphFilterActionKeys.ENABLE_GRAPH_FILTERS,

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -141,7 +141,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
       return;
     }
 
-    // Conveniently, the graph highlighter caches the cy instance that is currently in use.
+    // Caches the cy instance that is currently in use.
     // If that cy instance is the same one we are being asked to initialize, do NOT initialize it again;
     // this would add duplicate callbacks and would screw up the graph highlighter. If, however,
     // we are being asked to initialize a different cy instance, we assume the current one is now obsolete
@@ -202,6 +202,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
 
     cy.on('destroy', (evt: any) => {
       this.trafficRenderer.stop();
+      this.cy = undefined;
     });
   }
 

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -196,10 +196,6 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
       this.processGraphUpdate(cy);
     });
 
-    cy.on('viewport resize', (evt: any) => {
-      this.trafficRenderer.clear();
-    });
-
     cy.on('destroy', (evt: any) => {
       this.trafficRenderer.stop();
       this.cy = undefined;

--- a/src/components/CytoscapeGraph/CytoscapeReactWrapper.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeReactWrapper.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { GraphStyles } from './graphs/GraphStyles';
 import * as LayoutDictionary from './graphs/LayoutDictionary';
 
+import canvas from 'cytoscape-canvas';
 import cytoscape from 'cytoscape';
 import cycola from 'cytoscape-cola';
 import dagre from 'cytoscape-dagre';
@@ -10,6 +11,7 @@ import coseBilkent from 'cytoscape-cose-bilkent';
 import klay from 'cytoscape-klay';
 import popper from 'cytoscape-popper';
 
+cytoscape.use(canvas);
 cytoscape.use(cycola);
 cytoscape.use(dagre);
 cytoscape.use(coseBilkent);

--- a/src/components/CytoscapeGraph/__tests__/CytoscapeGraph.test.tsx
+++ b/src/components/CytoscapeGraph/__tests__/CytoscapeGraph.test.tsx
@@ -38,6 +38,7 @@ describe('CytoscapeGraph component test', () => {
         showCircuitBreakers={false}
         showRouteRules={true}
         showMissingSidecars={true}
+        showTrafficAnimation={false}
       />
     );
     const cytoscapeWrapper = wrapper.find(CytoscapeReactWrapper);

--- a/src/components/CytoscapeGraph/graphs/GraphHighlighter.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphHighlighter.ts
@@ -1,6 +1,7 @@
 import { CytoscapeClickEvent, CytoscapeMouseInEvent, CytoscapeMouseOutEvent } from '../CytoscapeGraph';
+import { DimClass } from './GraphStyles';
 
-const DIM_CLASS: string = 'mousedim';
+const DIM_CLASS: string = DimClass;
 const HIGHLIGHT_CLASS: string = 'mousehighlight';
 
 export class GraphHighlighter {

--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -1,6 +1,8 @@
 import { PfColors } from '../../../components/Pf/PfColors';
 import { EdgeLabelMode } from '../../../types/GraphFilter';
 
+export const DimClass = 'mousedim';
+
 export class GraphStyles {
   static options() {
     return { wheelSensitivity: 0.1, autounselectify: false, autoungrabify: true };
@@ -146,13 +148,13 @@ export class GraphStyles {
         }
       },
       {
-        selector: 'node.mousedim',
+        selector: 'node.' + DimClass,
         style: {
           opacity: '0.3'
         }
       },
       {
-        selector: 'edge.mousedim',
+        selector: 'edge.' + DimClass,
         style: {
           opacity: '0.3'
         }

--- a/src/components/CytoscapeGraph/graphs/TrafficRenderer.ts
+++ b/src/components/CytoscapeGraph/graphs/TrafficRenderer.ts
@@ -1,0 +1,238 @@
+import { clamp } from '../../../utils/MathUtils';
+
+/**
+ * Traffic Point, it defines in an edge
+ * speed - defines how fast the point is going to travel from the start to the end
+ *  of the edge a speed o 1000 travels the edge in about 1 second.
+ * delta - defines in what part of the edge is the point,  is a normalized number
+ *  from 0 to 1, 0 means at the start of the path, and 1 is the end. The position
+ *  is interpolated.
+ */
+type TrafficPoint = {
+  speed: number;
+  delta: number;
+};
+
+/**
+ * Helps generate traffic points
+ * timer - defines how fast to generate a new point, its in milliseconds.
+ * timerForNextPoint - keeps track of how many milliseconds to generate the next point.
+ * speed - defines the speed of the next point (see TrafficPoint.speed)
+ */
+class TrafficPointGenerator {
+  private timer?: number;
+  private timerForNextPoint?: number;
+  private speed: number;
+
+  // initialize values, if timer is undefined, no point is going to be generated
+  // There is no traffic.
+  constructor(speed: number, timer: number | undefined) {
+    this.speed = speed;
+    this.timer = timer;
+    this.timerForNextPoint = timer;
+  }
+
+  /**
+   * Process a step, decrements the timerForNextPoint and returns a new point
+   * if it reaches zero or is close.
+   * This method adds some randomness to avoid the "flat" look that all the points
+   * are syncronized.
+   */
+  processStep(step: number): TrafficPoint | undefined {
+    if (this.timerForNextPoint) {
+      this.timerForNextPoint -= step;
+      // Add some random-ness to make it less "flat"
+      if (this.timerForNextPoint <= Math.random() * 200) {
+        this.timerForNextPoint = this.timer;
+        return { speed: this.speed, delta: 0 };
+      }
+    }
+    return undefined;
+  }
+
+  setTimer(timer: number | undefined) {
+    this.timer = timer;
+    this.timerForNextPoint = timer;
+  }
+
+  setSpeed(speed: number) {
+    this.speed = speed;
+  }
+}
+
+/**
+ * Holds the list of points an edge has.
+ * points - list of active points the edge has, points are discarded when they
+ *  reach their target.
+ * generator - Generates the next point
+ * edge - Edge where the traffic is tracked
+ */
+class TrafficEdge {
+  private points: Array<TrafficPoint> = [];
+  private generator: TrafficPointGenerator;
+  private edge: any;
+
+  constructor(speed: number, timer: number | undefined, edge: any) {
+    this.generator = new TrafficPointGenerator(speed, timer);
+    this.edge = edge;
+  }
+
+  processStep(step: number) {
+    this.points = this.points.map(p => {
+      p.delta += step / p.speed;
+      p.delta = Math.min(p.delta, 1);
+      return p;
+    });
+    const point = this.generator.processStep(step);
+    if (point) {
+      this.points.push(point);
+    }
+  }
+
+  getPoints() {
+    return this.points;
+  }
+
+  getEdge() {
+    return this.edge;
+  }
+
+  setTimer(timer: number | undefined) {
+    this.generator.setTimer(timer);
+  }
+
+  removeFinishedPoints() {
+    this.points = this.points.filter(p => p.delta < 1);
+  }
+
+  setSpeed(speed: number) {
+    this.generator.setSpeed(speed);
+  }
+
+  setEdge(edge: any) {
+    this.edge = edge;
+  }
+}
+
+type TrafficEdgeHash = {
+  [edgeId: string]: TrafficEdge;
+};
+
+/**
+ * Renders the traffic going from edges using the edge information
+ */
+export default class TrafficRenderer {
+  private animationTimer;
+  private previousTimestamp;
+  private trafficEdges: TrafficEdgeHash = {};
+
+  private layer;
+  private canvas;
+  private ctx;
+
+  // private readonly TIMER_FOR_RATE_FACTOR = 100;
+  private readonly TIMER_FOR_RATE_MIN = 20;
+  private readonly TIMER_FOR_RATE_MAX = 1000;
+
+  constructor(cy: any, edges: any) {
+    this.layer = cy.cyCanvas();
+    this.canvas = this.layer.getCanvas();
+    this.ctx = this.canvas.getContext('2d');
+    this.setEdges(edges);
+  }
+
+  start = () => {
+    if (this.animationTimer) {
+      this.stop();
+    }
+    this.animationTimer = window.setInterval(this.processStep, 50);
+  };
+
+  stop = () => {
+    window.clearInterval(this.animationTimer);
+  };
+
+  setEdges = (edges: any) => {
+    this.trafficEdges = this.processEdges(edges);
+  };
+
+  clear = () => {
+    this.layer.clear(this.ctx);
+  };
+
+  processStep = () => {
+    if (this.previousTimestamp === undefined) {
+      this.previousTimestamp = Date.now();
+    }
+    const nextTimestamp = Date.now();
+    const step = this.currentStep();
+    this.layer.clear(this.ctx);
+    this.layer.setTransform(this.ctx);
+    Object.keys(this.trafficEdges).forEach(edgeId => {
+      const trafficEdge = this.trafficEdges[edgeId];
+      trafficEdge.processStep(step);
+      this.render(trafficEdge);
+      trafficEdge.removeFinishedPoints();
+    });
+
+    this.previousTimestamp = nextTimestamp;
+  };
+
+  private render(trafficEdge: TrafficEdge) {
+    const edge = trafficEdge.getEdge();
+    if (edge.hasClass('mousedim')) {
+      // Probably need to move this somewhere else
+      return;
+    }
+    trafficEdge.getPoints().forEach((point: TrafficPoint) => {
+      const source = edge.source().position();
+      const target = edge.target().position();
+      const x = source.x + (target.x - source.x) * point.delta;
+      const y = source.y + (target.y - source.y) * point.delta;
+      this.ctx.beginPath();
+      this.ctx.arc(x, y, 2, 0, 2 * Math.PI, true);
+      this.ctx.fill();
+    });
+  }
+
+  private currentStep(): number {
+    return Date.now() - this.previousTimestamp;
+  }
+
+  private processEdges(edges: any): TrafficEdgeHash {
+    return edges.map(edge => {
+      const edgeId = edge.data('id');
+      const timer = this.timerForRate(edge.data('rate'));
+      const speed = this.speedForLatency(edge.data('latency'));
+      if (edgeId in this.trafficEdges) {
+        const trafficEdge = this.trafficEdges[edgeId];
+        trafficEdge.setTimer(timer);
+        trafficEdge.setSpeed(speed);
+        trafficEdge.setEdge(edge);
+      } else {
+        this.trafficEdges[edgeId] = new TrafficEdge(speed, timer, edge);
+      }
+      return this.trafficEdges[edgeId];
+    });
+  }
+
+  private timerForRate(rate: number) {
+    if (isNaN(rate) || rate === 0) {
+      return undefined;
+    }
+    // Normalize from 0 rps to 1000 rps
+    const delta = clamp(rate, 0, 400) / 400;
+    // Invert and scale to (TIMER_FOR_RATE_MIN, TIMER_FOR_RATE_MAX)
+    return this.TIMER_FOR_RATE_MIN + (1 - delta) * (this.TIMER_FOR_RATE_MAX - this.TIMER_FOR_RATE_MIN);
+  }
+
+  private speedForLatency(latency: number) {
+    if (isNaN(latency)) {
+      return 800;
+    }
+    // Normalize from 0 to 10 seconds
+    const delta = clamp(latency, 0, 10);
+    // Scale from (800 to 8000)
+    return 800 + delta * (8000 - 800);
+  }
+}

--- a/src/components/CytoscapeGraph/graphs/TrafficRenderer.ts
+++ b/src/components/CytoscapeGraph/graphs/TrafficRenderer.ts
@@ -20,7 +20,7 @@ const SPEED_RATE_MIN = 0.1;
 const SPEED_RATE_MAX = 2.0;
 
 // How often paint a frame
-const FRAME_RATE = 1 / 30;
+const FRAME_RATE = 1 / 60;
 
 /**
  * Traffic Point, it defines in an edge
@@ -52,7 +52,7 @@ class TrafficPointGenerator {
   constructor(speed: number, timer: number | undefined) {
     this.speed = speed;
     this.timer = timer;
-    this.timerForNextPoint = timer;
+    this.timerForNextPoint = 0; // Start as soon as posible
   }
 
   /**
@@ -62,7 +62,7 @@ class TrafficPointGenerator {
    * are syncronized.
    */
   processStep(step: number): TrafficPoint | undefined {
-    if (this.timerForNextPoint) {
+    if (this.timerForNextPoint !== undefined) {
       this.timerForNextPoint -= step;
       // Add some random-ness to make it less "flat"
       if (this.timerForNextPoint <= Math.random() * 200) {
@@ -75,7 +75,9 @@ class TrafficPointGenerator {
 
   setTimer(timer: number | undefined) {
     this.timer = timer;
-    this.timerForNextPoint = timer;
+    if (this.timerForNextPoint === undefined) {
+      this.timerForNextPoint = timer;
+    }
   }
 
   setSpeed(speed: number) {

--- a/src/containers/GraphLayersContainer.tsx
+++ b/src/containers/GraphLayersContainer.tsx
@@ -11,6 +11,7 @@ interface ServiceGraphDispatch {
   toggleGraphCircuitBreakers(): void;
   toggleGraphRouteRules(): void;
   toggleGraphMissingSidecars(): void;
+  toggleTrafficAnimation(): void;
 }
 
 // inherit all of our Reducer state section  and Dispatch methods for redux
@@ -21,7 +22,8 @@ const mapStateToProps = (state: KialiAppState) => ({
   showNodeLabels: state.serviceGraphFilterState.showNodeLabels,
   showCircuitBreakers: state.serviceGraphFilterState.showCircuitBreakers,
   showRouteRules: state.serviceGraphFilterState.showRouteRules,
-  showMissingSidecars: state.serviceGraphFilterState.showMissingSidecars
+  showMissingSidecars: state.serviceGraphFilterState.showMissingSidecars,
+  showTrafficAnimation: state.serviceGraphFilterState.showTrafficAnimation
 });
 
 // Map our actions to Redux
@@ -31,7 +33,8 @@ const mapDispatchToProps = (dispatch: any) => {
     setGraphEdgeLabelMode: bindActionCreators(serviceGraphFilterActions.setGraphEdgeLabelMode, dispatch),
     toggleGraphCircuitBreakers: bindActionCreators(serviceGraphFilterActions.toggleGraphCircuitBreakers, dispatch),
     toggleGraphRouteRules: bindActionCreators(serviceGraphFilterActions.toggleGraphRouteRules, dispatch),
-    toggleGraphMissingSidecars: bindActionCreators(serviceGraphFilterActions.toggleGraphMissingSidecars, dispatch)
+    toggleGraphMissingSidecars: bindActionCreators(serviceGraphFilterActions.toggleGraphMissingSidecars, dispatch),
+    toggleTrafficAnimation: bindActionCreators(serviceGraphFilterActions.toggleTrafficAnimation, dispatch)
   };
 };
 
@@ -46,13 +49,14 @@ interface VisibilityLayersType {
 // Right now it is a toolbar with Switch Buttons -- this will change once with UXD input
 export const GraphLayers: React.SFC<GraphLayersProps> = props => {
   // map our attributes from redux
-  const { showCircuitBreakers, showRouteRules, showNodeLabels, showMissingSidecars } = props;
+  const { showCircuitBreakers, showRouteRules, showNodeLabels, showMissingSidecars, showTrafficAnimation } = props;
   // // map or dispatchers for redux
   const {
     toggleGraphCircuitBreakers,
     toggleGraphRouteRules,
     toggleGraphNodeLabels,
-    toggleGraphMissingSidecars
+    toggleGraphMissingSidecars,
+    toggleTrafficAnimation
   } = props;
 
   const visibilityLayers: VisibilityLayersType[] = [
@@ -79,6 +83,12 @@ export const GraphLayers: React.SFC<GraphLayersProps> = props => {
       labelText: 'Missing Sidecars',
       value: showMissingSidecars,
       onChange: toggleGraphMissingSidecars
+    },
+    {
+      id: 'filterTrafficAnimation',
+      labelText: 'Traffic Animation',
+      value: showTrafficAnimation,
+      onChange: toggleTrafficAnimation
     }
   ];
 

--- a/src/reducers/ServiceGraphFilterState.ts
+++ b/src/reducers/ServiceGraphFilterState.ts
@@ -8,6 +8,7 @@ const INITIAL_STATE: ServiceGraphFilterState = {
   showCircuitBreakers: false,
   showRouteRules: true,
   showMissingSidecars: true,
+  showTrafficAnimation: false,
   // @ todo: add disableLayers back in later
   // disableLayers: false
   edgeLabelMode: EdgeLabelMode.HIDE
@@ -26,6 +27,8 @@ const serviceGraphFilterState = (state: ServiceGraphFilterState = INITIAL_STATE,
       return updateState(state, { showRouteRules: !state.showRouteRules });
     case ServiceGraphFilterActionKeys.TOGGLE_GRAPH_MISSING_SIDECARS:
       return updateState(state, { showMissingSidecars: !state.showMissingSidecars });
+    case ServiceGraphFilterActionKeys.TOGGLE_TRAFFIC_ANIMATION:
+      return updateState(state, { showTrafficAnimation: !state.showTrafficAnimation });
     case ServiceGraphFilterActionKeys.ENABLE_GRAPH_FILTERS:
       return updateState(state, { disableLayers: action.payload });
     default:

--- a/src/reducers/__tests__/ServiceGraphFilterStateReducer.test.ts
+++ b/src/reducers/__tests__/ServiceGraphFilterStateReducer.test.ts
@@ -9,7 +9,8 @@ describe('ServiceGraphFilterState reducer', () => {
       edgeLabelMode: EdgeLabelMode.HIDE,
       showCircuitBreakers: false,
       showRouteRules: true,
-      showMissingSidecars: true
+      showMissingSidecars: true,
+      showTrafficAnimation: false
     });
   });
 
@@ -21,7 +22,8 @@ describe('ServiceGraphFilterState reducer', () => {
           edgeLabelMode: EdgeLabelMode.HIDE,
           showCircuitBreakers: false,
           showRouteRules: true,
-          showMissingSidecars: true
+          showMissingSidecars: true,
+          showTrafficAnimation: false
         },
         {
           type: ServiceGraphFilterActionKeys.TOGGLE_GRAPH_NODE_LABEL
@@ -32,7 +34,8 @@ describe('ServiceGraphFilterState reducer', () => {
       edgeLabelMode: EdgeLabelMode.HIDE,
       showCircuitBreakers: false,
       showRouteRules: true,
-      showMissingSidecars: true
+      showMissingSidecars: true,
+      showTrafficAnimation: false
     });
   });
 
@@ -44,7 +47,8 @@ describe('ServiceGraphFilterState reducer', () => {
           edgeLabelMode: EdgeLabelMode.HIDE,
           showCircuitBreakers: false,
           showRouteRules: true,
-          showMissingSidecars: true
+          showMissingSidecars: true,
+          showTrafficAnimation: false
         },
         {
           type: ServiceGraphFilterActionKeys.SET_GRAPH_EDGE_LABEL_MODE,
@@ -56,7 +60,8 @@ describe('ServiceGraphFilterState reducer', () => {
       edgeLabelMode: EdgeLabelMode.LATENCY_95TH_PERCENTILE,
       showCircuitBreakers: false,
       showRouteRules: true,
-      showMissingSidecars: true
+      showMissingSidecars: true,
+      showTrafficAnimation: false
     });
   });
   it('should handle TOGGLE_GRAPH_CIRCUIT_BREAKERS', () => {
@@ -67,7 +72,8 @@ describe('ServiceGraphFilterState reducer', () => {
           edgeLabelMode: EdgeLabelMode.HIDE,
           showCircuitBreakers: false,
           showRouteRules: true,
-          showMissingSidecars: true
+          showMissingSidecars: true,
+          showTrafficAnimation: false
         },
         {
           type: ServiceGraphFilterActionKeys.TOGGLE_GRAPH_CIRCUIT_BREAKERS
@@ -78,7 +84,8 @@ describe('ServiceGraphFilterState reducer', () => {
       edgeLabelMode: EdgeLabelMode.HIDE,
       showCircuitBreakers: true,
       showRouteRules: true,
-      showMissingSidecars: true
+      showMissingSidecars: true,
+      showTrafficAnimation: false
     });
   });
   it('should handle TOGGLE_GRAPH_ROUTE_RULES', () => {
@@ -89,7 +96,8 @@ describe('ServiceGraphFilterState reducer', () => {
           edgeLabelMode: EdgeLabelMode.HIDE,
           showCircuitBreakers: false,
           showRouteRules: true,
-          showMissingSidecars: true
+          showMissingSidecars: true,
+          showTrafficAnimation: false
         },
         {
           type: ServiceGraphFilterActionKeys.TOGGLE_GRAPH_ROUTE_RULES
@@ -100,7 +108,8 @@ describe('ServiceGraphFilterState reducer', () => {
       edgeLabelMode: EdgeLabelMode.HIDE,
       showCircuitBreakers: false,
       showRouteRules: false,
-      showMissingSidecars: true
+      showMissingSidecars: true,
+      showTrafficAnimation: false
     });
   });
   it('should handle TOGGLE_GRAPH_MISSING_SIDECARS', () => {
@@ -111,7 +120,8 @@ describe('ServiceGraphFilterState reducer', () => {
           showCircuitBreakers: false,
           showRouteRules: true,
           showMissingSidecars: true,
-          edgeLabelMode: EdgeLabelMode.HIDE
+          edgeLabelMode: EdgeLabelMode.HIDE,
+          showTrafficAnimation: false
         },
         {
           type: ServiceGraphFilterActionKeys.TOGGLE_GRAPH_MISSING_SIDECARS
@@ -122,7 +132,32 @@ describe('ServiceGraphFilterState reducer', () => {
       showCircuitBreakers: false,
       showRouteRules: true,
       showMissingSidecars: false,
-      edgeLabelMode: EdgeLabelMode.HIDE
+      edgeLabelMode: EdgeLabelMode.HIDE,
+      showTrafficAnimation: false
+    });
+  });
+  it('should handle TOGGLE_TRAFFIC_ANIMATION', () => {
+    expect(
+      serviceGraphFilterState(
+        {
+          showNodeLabels: true,
+          showCircuitBreakers: false,
+          showRouteRules: true,
+          showMissingSidecars: true,
+          edgeLabelMode: EdgeLabelMode.HIDE,
+          showTrafficAnimation: false
+        },
+        {
+          type: ServiceGraphFilterActionKeys.TOGGLE_TRAFFIC_ANIMATION
+        }
+      )
+    ).toEqual({
+      showNodeLabels: true,
+      showCircuitBreakers: false,
+      showRouteRules: true,
+      showMissingSidecars: true,
+      edgeLabelMode: EdgeLabelMode.HIDE,
+      showTrafficAnimation: true
     });
   });
 });

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -9,6 +9,7 @@ export interface ServiceGraphFilterState {
   readonly showCircuitBreakers: boolean;
   readonly showRouteRules: boolean;
   readonly showMissingSidecars: boolean;
+  readonly showTrafficAnimation: boolean;
   // disable the service graph layers toolbar
   // @todo: add this back in later
   // readonly disableLayers: boolean;

--- a/src/utils/MathUtils.ts
+++ b/src/utils/MathUtils.ts
@@ -1,0 +1,3 @@
+export const clamp = (x, min, max) => {
+  return x < min ? min : x > max ? max : x;
+};

--- a/src/utils/__tests__/MathUtils.test.ts
+++ b/src/utils/__tests__/MathUtils.test.ts
@@ -1,0 +1,19 @@
+import * as MathUtils from '../MathUtils';
+
+describe('MathUtils', () => {
+  it('should clamp to lower value', () => {
+    expect(MathUtils.clamp(0, 5, 8)).toEqual(5);
+  });
+  it('should clamp to higher value', () => {
+    expect(MathUtils.clamp(10, 5, 8)).toEqual(8);
+  });
+  it('should return value if in range', () => {
+    expect(MathUtils.clamp(6, 5, 8)).toEqual(6);
+  });
+  it('should return be inclusive on the lower bound', () => {
+    expect(MathUtils.clamp(5, 5, 8)).toEqual(5);
+  });
+  it('should return be inclusive on the upper bound', () => {
+    expect(MathUtils.clamp(8, 5, 8)).toEqual(8);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2106,6 +2106,10 @@ cyclist@~0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
 
+cytoscape-canvas@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/cytoscape-canvas/-/cytoscape-canvas-3.0.1.tgz#7d963be51e6e5f3f2482b05d22562c8ee941d125"
+
 cytoscape-cola@2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/cytoscape-cola/-/cytoscape-cola-2.2.3.tgz#96c50e7230f0056324089bdae3996a17d82f7dd9"


### PR DESCRIPTION
This is Work in progress.
- [x] Need to move stuff ~~over the config~~ to constants
- [x] Clean the code 
- [x] Put some way to turn the animation off
- [x] Probably find a way to get the edge path, so the "dots" don't appear over the nodes.
- [x] ~~Normalize the "speed" of the dots over the edge length~~
  - ~~Currently, large edges make quicker dots than small edges~~
  - This looked weird, large edges doesn't mean that the packets travel slower from source to target.
- [x] React to the graceful update 
  - [x] stopping animation
  - [x] starting a new one with the new edges

It currently uses the rate and latency to decide how fast to display the nodes, I need a more complex scenario with a "fixed" server response to make it easier to test it.
If there is any highlighting, only related edges show traffic

![peek 2018-05-23 13-29](https://user-images.githubusercontent.com/3845764/40443915-61267820-5e8d-11e8-86a6-80859b698e6b.gif)


old gifs:
![peek 2018-05-22 09-11](https://user-images.githubusercontent.com/3845764/40368070-87c94ba8-5da0-11e8-9cd7-e27a39d4e7e0.gif)

![peek 2018-05-22 18-18](https://user-images.githubusercontent.com/3845764/40395236-b30d42e6-5dec-11e8-9244-c9c159c4fd58.gif)
