### PR TITLE
KIALI-767 Show pods information + some typesafety refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 
 # testing
 /coverage
+kiali-browser-test.png
 
 # production
 /build

--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -9,7 +9,12 @@ import { NamespaceFilterSelected } from '../../components/NamespaceFilter/Namesp
 import { ActiveFilter } from '../../types/NamespaceFilter';
 import * as API from '../../services/Api';
 import * as MessageCenter from '../../utils/MessageCenter';
-import { hasIstioSidecar, ServiceDetailsInfo, ObjectValidation } from '../../types/ServiceInfo';
+import {
+  hasIstioSidecar,
+  ServiceDetailsInfo,
+  ServiceDetailsInfoFromAPI,
+  ObjectValidation
+} from '../../types/ServiceInfo';
 import AceEditor, { AceOptions } from 'react-ace';
 import 'brace/mode/yaml';
 import 'brace/theme/eclipse';
@@ -66,8 +71,8 @@ class ServiceDetails extends React.Component<RouteComponentProps<ServiceId>, Ser
     NamespaceFilterSelected.setSelected([activeFilter]);
   };
 
-  parseServiceDetailsInfo = data => {
-    let parsed: ServiceDetailsInfo = {
+  parseServiceDetailsInfo = (data: ServiceDetailsInfoFromAPI): ServiceDetailsInfo => {
+    return {
       labels: data.labels,
       name: data.name,
       created_at: data.created_at,
@@ -75,7 +80,8 @@ class ServiceDetails extends React.Component<RouteComponentProps<ServiceId>, Ser
       type: data.type,
       ports: data.ports,
       endpoints: data.endpoints,
-      istio_sidecar: hasIstioSidecar(data.deployments),
+      istio_sidecar: hasIstioSidecar(data.pods),
+      pods: data.pods,
       deployments: data.deployments,
       dependencies: data.dependencies,
       routeRules: data.route_rules,
@@ -85,7 +91,6 @@ class ServiceDetails extends React.Component<RouteComponentProps<ServiceId>, Ser
       ip: data.ip,
       health: data.health
     };
-    return parsed;
   };
 
   validateParams(parsed: ParsedSearch): boolean {
@@ -184,7 +189,7 @@ class ServiceDetails extends React.Component<RouteComponentProps<ServiceId>, Ser
       });
     API.getServiceDetail(this.props.match.params.namespace, this.props.match.params.service)
       .then(response => {
-        let data = response['data'];
+        const data: ServiceDetailsInfoFromAPI = response['data'];
         this.setState({
           serviceDetailsInfo: this.parseServiceDetailsInfo(data)
         });

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
@@ -17,7 +17,7 @@ interface ServiceInfoDescriptionProps {
   created_at: string;
   resource_version: string;
   istio_sidecar?: boolean;
-  labels?: Map<string, string>;
+  labels?: { [key: string]: string };
   type?: string;
   ip?: any;
   ports?: Port[];

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoPods.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoPods.tsx
@@ -12,16 +12,6 @@ interface Props {
 class ServiceInfoPods extends React.Component<Props> {
   constructor(props: Props) {
     super(props);
-    if (props.pods) {
-      props.pods.forEach(pod => {
-        if (pod.annotations && pod.annotations.hasOwnProperty('kubernetes.io/created-by')) {
-          pod.k8sCreatedBy = JSON.parse(pod.annotations['kubernetes.io/created-by']);
-        }
-        if (pod.annotations && pod.annotations.hasOwnProperty('sidecar.istio.io/status')) {
-          pod.istioSideCar = JSON.parse(pod.annotations['sidecar.istio.io/status']);
-        }
-      });
-    }
   }
 
   render() {
@@ -47,30 +37,30 @@ class ServiceInfoPods extends React.Component<Props> {
                 <div>
                   <span>
                     <strong>Created at: </strong>
-                    <LocalTime time={pod.created_at} />
+                    <LocalTime time={pod.createdAt} />
                   </span>
                 </div>
-                {pod.k8sCreatedBy && (
+                {pod.createdBy && (
                   <div>
                     <span>
                       <strong>Created by: </strong>
-                      {pod.k8sCreatedBy.reference.name + ' (' + pod.k8sCreatedBy.reference.kind + ')'}
+                      {pod.createdBy.name + ' (' + pod.createdBy.kind + ')'}
                     </span>
                   </div>
                 )}
-                {pod.istioSideCar && (
+                {pod.istioInitContainers && (
                   <div>
                     <span>
                       <strong>Istio init containers: </strong>
-                      {pod.istioSideCar.initContainers.join(', ')}
+                      {pod.istioInitContainers.map(c => `${c.name} [${c.image}]`).join(', ')}
                     </span>
                   </div>
                 )}
-                {pod.istioSideCar && (
+                {pod.istioContainers && (
                   <div>
                     <span>
                       <strong>Istio containers: </strong>
-                      {pod.istioSideCar.containers.join(', ')}
+                      {pod.istioContainers.map(c => `${c.name} [${c.image}]`).join(', ')}
                     </span>
                   </div>
                 )}

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoPods.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoPods.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+import { Col, Row } from 'patternfly-react';
+import LocalTime from '../../../components/Time/LocalTime';
+import Badge from '../../../components/Badge/Badge';
+import { Pod } from '../../../types/ServiceInfo';
+import { PfColors } from '../../../components/Pf/PfColors';
+
+interface Props {
+  pods?: Pod[];
+}
+
+class ServiceInfoPods extends React.Component<Props> {
+  constructor(props: Props) {
+    super(props);
+    if (props.pods) {
+      props.pods.forEach(pod => {
+        if (pod.annotations && pod.annotations.hasOwnProperty('kubernetes.io/created-by')) {
+          pod.k8sCreatedBy = JSON.parse(pod.annotations['kubernetes.io/created-by']);
+        }
+        if (pod.annotations && pod.annotations.hasOwnProperty('sidecar.istio.io/status')) {
+          pod.istioSideCar = JSON.parse(pod.annotations['sidecar.istio.io/status']);
+        }
+      });
+    }
+  }
+
+  render() {
+    return (
+      <div className="card-pf">
+        <Row className="row-cards-pf">
+          <Col xs={12} sm={12} md={12} lg={12}>
+            {(this.props.pods || []).map((pod, u) => (
+              <div className="card-pf-body" key={'pods_' + u}>
+                <h3>{pod.name}</h3>
+                <div key="labels">
+                  {Object.keys(pod.labels || {}).map((key, i) => (
+                    <Badge
+                      key={'pod_' + i}
+                      scale={0.8}
+                      style="plastic"
+                      color={PfColors.Green}
+                      leftText={key}
+                      rightText={pod.labels ? pod.labels[key] : ''}
+                    />
+                  ))}
+                </div>
+                <div>
+                  <span>
+                    <strong>Created at: </strong>
+                    <LocalTime time={pod.created_at} />
+                  </span>
+                </div>
+                {pod.k8sCreatedBy && (
+                  <div>
+                    <span>
+                      <strong>Created by: </strong>
+                      {pod.k8sCreatedBy.reference.name + ' (' + pod.k8sCreatedBy.reference.kind + ')'}
+                    </span>
+                  </div>
+                )}
+                {pod.istioSideCar && (
+                  <div>
+                    <span>
+                      <strong>Istio init containers: </strong>
+                      {pod.istioSideCar.initContainers.join(', ')}
+                    </span>
+                  </div>
+                )}
+                {pod.istioSideCar && (
+                  <div>
+                    <span>
+                      <strong>Istio containers: </strong>
+                      {pod.istioSideCar.containers.join(', ')}
+                    </span>
+                  </div>
+                )}
+                <hr />
+              </div>
+            ))}
+          </Col>
+        </Row>
+      </div>
+    );
+  }
+}
+
+export default ServiceInfoPods;

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoRouteRules/RouteRuleRoute.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoRouteRules/RouteRuleRoute.tsx
@@ -96,8 +96,8 @@ class RouteRuleRoute extends React.Component<RouteRuleRouteProps> {
     return <Popover id={this.props.name + '-weight-tooltip'}>{message}</Popover>;
   }
 
-  labelsFrom(routeLabels: Map<String, String>) {
-    return Object.keys(routeLabels || new Map()).map((key, n) => (
+  labelsFrom(routeLabels: { [key: string]: string }) {
+    return Object.keys(routeLabels || {}).map(key => (
       <Badge
         scale={0.8}
         style="plastic"

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/ServiceInfoDeployments.test.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/ServiceInfoDeployments.test.tsx
@@ -6,7 +6,7 @@ import { Deployment } from '../../../../types/ServiceInfo';
 const deployments: Deployment[] = [
   {
     name: 'reviews-v2',
-    labels: new Map([['app', 'reviews'], ['version', 'v2']]),
+    labels: { app: 'reviews', version: 'v2' },
     created_at: '2018-03-14T10:17:52Z',
     resource_version: '1234',
     replicas: 5,
@@ -21,7 +21,7 @@ const deployments: Deployment[] = [
   },
   {
     name: 'reviews-v3',
-    labels: new Map([['app', 'reviews'], ['version', 'v3']]),
+    labels: { app: 'reviews', version: 'v3' },
     created_at: '2018-03-14T10:17:52Z',
     resource_version: '1234',
     replicas: 2,
@@ -36,7 +36,7 @@ const deployments: Deployment[] = [
   },
   {
     name: 'reviews-v1',
-    labels: new Map([['app', 'reviews'], ['version', 'v1']]),
+    labels: { app: 'reviews', version: 'v1' },
     created_at: '2018-03-14T10:17:52Z',
     resource_version: '1234',
     replicas: 1,

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/ServiceInfoDescription.test.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/ServiceInfoDescription.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import ServiceInfoDescription from '../ServiceInfoDescription';
 
-const labels: Map<string, string> = new Map([['app', 'reviews']]);
+const labels = { app: 'reviews' };
 
 const endpoints = [
   {

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/ServiceInfoPods.test.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/ServiceInfoPods.test.tsx
@@ -7,17 +7,17 @@ const pods: Pod[] = [
   {
     name: 'reviews-v2-1234',
     labels: { app: 'reviews', version: 'v2' },
-    created_at: '2018-03-14T10:17:52Z'
+    createdAt: '2018-03-14T10:17:52Z'
   },
   {
     name: 'reviews-v3-1234',
     labels: { app: 'reviews', version: 'v3' },
-    created_at: '2018-03-14T10:17:52Z'
+    createdAt: '2018-03-14T10:17:52Z'
   },
   {
     name: 'reviews-v1-1234',
     labels: { app: 'reviews', version: 'v1' },
-    created_at: '2018-03-14T10:17:52Z'
+    createdAt: '2018-03-14T10:17:52Z'
   }
 ];
 

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/ServiceInfoPods.test.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/ServiceInfoPods.test.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import ServiceInfoPods from '../ServiceInfoPods';
+import { Pod } from '../../../../types/ServiceInfo';
+
+const pods: Pod[] = [
+  {
+    name: 'reviews-v2-1234',
+    labels: { app: 'reviews', version: 'v2' },
+    created_at: '2018-03-14T10:17:52Z'
+  },
+  {
+    name: 'reviews-v3-1234',
+    labels: { app: 'reviews', version: 'v3' },
+    created_at: '2018-03-14T10:17:52Z'
+  },
+  {
+    name: 'reviews-v1-1234',
+    labels: { app: 'reviews', version: 'v1' },
+    created_at: '2018-03-14T10:17:52Z'
+  }
+];
+
+describe('#ServiceInfoPods render correctly with data', () => {
+  it('should render service pods', () => {
+    const wrapper = shallow(<ServiceInfoPods pods={pods} />);
+    expect(wrapper).toBeDefined();
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/ServiceInfoRouteRules.test.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/ServiceInfoRouteRules.test.tsx
@@ -14,7 +14,7 @@ const rules: RouteRule[] = [
     precedence: 1,
     route: [
       {
-        labels: new Map([['version', 'v1']])
+        labels: { version: 'v1' }
       }
     ],
     match: undefined
@@ -29,7 +29,7 @@ const rules: RouteRule[] = [
     precedence: 2,
     route: [
       {
-        labels: new Map([['version', 'v2']])
+        labels: { version: 'v2' }
       }
     ],
     match: undefined

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
@@ -38,8 +38,8 @@ ShallowWrapper {
     }
     ip="172.30.78.33"
     labels={
-      Map {
-        "app" => "reviews",
+      Object {
+        "app": "reviews",
       }
     }
     name="reviews"
@@ -78,6 +78,15 @@ ShallowWrapper {
             <strong>
               Labels
             </strong>
+          </div>
+          <div>
+            <Badge
+              color="#0088ce"
+              leftText="app"
+              rightText="reviews"
+              scale={0.8}
+              style="plastic"
+            />
           </div>
           <div>
             <strong>
@@ -257,6 +266,15 @@ ShallowWrapper {
               <strong>
                 Labels
               </strong>
+            </div>
+            <div>
+              <Badge
+                color="#0088ce"
+                leftText="app"
+                rightText="reviews"
+                scale={0.8}
+                style="plastic"
+              />
             </div>
             <div>
               <strong>

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoPods.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoPods.test.tsx.snap
@@ -8,7 +8,7 @@ ShallowWrapper {
     pods={
       Array [
         Object {
-          "created_at": "2018-03-14T10:17:52Z",
+          "createdAt": "2018-03-14T10:17:52Z",
           "labels": Object {
             "app": "reviews",
             "version": "v2",
@@ -16,7 +16,7 @@ ShallowWrapper {
           "name": "reviews-v2-1234",
         },
         Object {
-          "created_at": "2018-03-14T10:17:52Z",
+          "createdAt": "2018-03-14T10:17:52Z",
           "labels": Object {
             "app": "reviews",
             "version": "v3",
@@ -24,7 +24,7 @@ ShallowWrapper {
           "name": "reviews-v3-1234",
         },
         Object {
-          "created_at": "2018-03-14T10:17:52Z",
+          "createdAt": "2018-03-14T10:17:52Z",
           "labels": Object {
             "app": "reviews",
             "version": "v1",

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoPods.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoPods.test.tsx.snap
@@ -1,65 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`#ServiceInfoDeployments render correctly with data should render service pods 1`] = `
+exports[`#ServiceInfoPods render correctly with data should render service pods 1`] = `
 ShallowWrapper {
   "length": 1,
   Symbol(enzyme.__root__): [Circular],
-  Symbol(enzyme.__unrendered__): <ServiceInfoDeployments
-    deployments={
+  Symbol(enzyme.__unrendered__): <ServiceInfoPods
+    pods={
       Array [
         Object {
-          "autoscaler": Object {
-            "max_replicas": 10,
-            "min_replicas": 2,
-            "name": "reviews-v2-autoscaler",
-            "target_cpu_utilization_percentage": 50,
-          },
-          "available_replicas": 3,
           "created_at": "2018-03-14T10:17:52Z",
           "labels": Object {
             "app": "reviews",
             "version": "v2",
           },
-          "name": "reviews-v2",
-          "replicas": 5,
-          "resource_version": "1234",
-          "unavailable_replicas": 2,
+          "name": "reviews-v2-1234",
         },
         Object {
-          "autoscaler": Object {
-            "max_replicas": 10,
-            "min_replicas": 2,
-            "name": "reviews-v2-autoscaler",
-            "target_cpu_utilization_percentage": 50,
-          },
-          "available_replicas": 2,
           "created_at": "2018-03-14T10:17:52Z",
           "labels": Object {
             "app": "reviews",
             "version": "v3",
           },
-          "name": "reviews-v3",
-          "replicas": 2,
-          "resource_version": "1234",
-          "unavailable_replicas": 0,
+          "name": "reviews-v3-1234",
         },
         Object {
-          "autoscaler": Object {
-            "max_replicas": 10,
-            "min_replicas": 2,
-            "name": "reviews-v2-autoscaler",
-            "target_cpu_utilization_percentage": 50,
-          },
-          "available_replicas": 1,
           "created_at": "2018-03-14T10:17:52Z",
           "labels": Object {
             "app": "reviews",
             "version": "v1",
           },
-          "name": "reviews-v1",
-          "replicas": 1,
-          "resource_version": "1234",
-          "unavailable_replicas": 0,
+          "name": "reviews-v1-1234",
         },
       ]
     }
@@ -93,7 +63,7 @@ ShallowWrapper {
             className="card-pf-body"
           >
             <h3>
-              reviews-v2
+              reviews-v2-1234
             </h3>
             <div>
               <Badge
@@ -112,32 +82,6 @@ ShallowWrapper {
               />
             </div>
             <div>
-              <strong>
-                Pod status: 
-              </strong>
-               
-              3
-               / 
-              5
-               
-              <Icon
-                name="warning-triangle-o"
-                type="pf"
-              />
-            </div>
-            <div>
-              <strong>
-                Autoscaler: 
-              </strong>
-              from 
-              2
-               to 
-              10
-               pods (
-              50
-              % CPU)
-            </div>
-            <div>
               <span>
                 <strong>
                   Created at: 
@@ -147,21 +91,13 @@ ShallowWrapper {
                 />
               </span>
             </div>
-            <div>
-              <span>
-                <strong>
-                  Resource Version: 
-                </strong>
-                1234
-              </span>
-            </div>
             <hr />
           </div>
           <div
             className="card-pf-body"
           >
             <h3>
-              reviews-v3
+              reviews-v3-1234
             </h3>
             <div>
               <Badge
@@ -180,32 +116,6 @@ ShallowWrapper {
               />
             </div>
             <div>
-              <strong>
-                Pod status: 
-              </strong>
-               
-              2
-               / 
-              2
-               
-              <Icon
-                name="ok"
-                type="pf"
-              />
-            </div>
-            <div>
-              <strong>
-                Autoscaler: 
-              </strong>
-              from 
-              2
-               to 
-              10
-               pods (
-              50
-              % CPU)
-            </div>
-            <div>
               <span>
                 <strong>
                   Created at: 
@@ -215,21 +125,13 @@ ShallowWrapper {
                 />
               </span>
             </div>
-            <div>
-              <span>
-                <strong>
-                  Resource Version: 
-                </strong>
-                1234
-              </span>
-            </div>
             <hr />
           </div>
           <div
             className="card-pf-body"
           >
             <h3>
-              reviews-v1
+              reviews-v1-1234
             </h3>
             <div>
               <Badge
@@ -248,32 +150,6 @@ ShallowWrapper {
               />
             </div>
             <div>
-              <strong>
-                Pod status: 
-              </strong>
-               
-              1
-               / 
-              1
-               
-              <Icon
-                name="ok"
-                type="pf"
-              />
-            </div>
-            <div>
-              <strong>
-                Autoscaler: 
-              </strong>
-              from 
-              2
-               to 
-              10
-               pods (
-              50
-              % CPU)
-            </div>
-            <div>
               <span>
                 <strong>
                   Created at: 
@@ -281,14 +157,6 @@ ShallowWrapper {
                 <LocalTime
                   time="2018-03-14T10:17:52Z"
                 />
-              </span>
-            </div>
-            <div>
-              <span>
-                <strong>
-                  Resource Version: 
-                </strong>
-                1234
               </span>
             </div>
             <hr />
@@ -316,7 +184,7 @@ ShallowWrapper {
             className="card-pf-body"
           >
             <h3>
-              reviews-v2
+              reviews-v2-1234
             </h3>
             <div>
               <Badge
@@ -335,32 +203,6 @@ ShallowWrapper {
               />
             </div>
             <div>
-              <strong>
-                Pod status: 
-              </strong>
-               
-              3
-               / 
-              5
-               
-              <Icon
-                name="warning-triangle-o"
-                type="pf"
-              />
-            </div>
-            <div>
-              <strong>
-                Autoscaler: 
-              </strong>
-              from 
-              2
-               to 
-              10
-               pods (
-              50
-              % CPU)
-            </div>
-            <div>
               <span>
                 <strong>
                   Created at: 
@@ -370,21 +212,13 @@ ShallowWrapper {
                 />
               </span>
             </div>
-            <div>
-              <span>
-                <strong>
-                  Resource Version: 
-                </strong>
-                1234
-              </span>
-            </div>
             <hr />
           </div>
           <div
             className="card-pf-body"
           >
             <h3>
-              reviews-v3
+              reviews-v3-1234
             </h3>
             <div>
               <Badge
@@ -403,32 +237,6 @@ ShallowWrapper {
               />
             </div>
             <div>
-              <strong>
-                Pod status: 
-              </strong>
-               
-              2
-               / 
-              2
-               
-              <Icon
-                name="ok"
-                type="pf"
-              />
-            </div>
-            <div>
-              <strong>
-                Autoscaler: 
-              </strong>
-              from 
-              2
-               to 
-              10
-               pods (
-              50
-              % CPU)
-            </div>
-            <div>
               <span>
                 <strong>
                   Created at: 
@@ -438,21 +246,13 @@ ShallowWrapper {
                 />
               </span>
             </div>
-            <div>
-              <span>
-                <strong>
-                  Resource Version: 
-                </strong>
-                1234
-              </span>
-            </div>
             <hr />
           </div>
           <div
             className="card-pf-body"
           >
             <h3>
-              reviews-v1
+              reviews-v1-1234
             </h3>
             <div>
               <Badge
@@ -471,32 +271,6 @@ ShallowWrapper {
               />
             </div>
             <div>
-              <strong>
-                Pod status: 
-              </strong>
-               
-              1
-               / 
-              1
-               
-              <Icon
-                name="ok"
-                type="pf"
-              />
-            </div>
-            <div>
-              <strong>
-                Autoscaler: 
-              </strong>
-              from 
-              2
-               to 
-              10
-               pods (
-              50
-              % CPU)
-            </div>
-            <div>
               <span>
                 <strong>
                   Created at: 
@@ -504,14 +278,6 @@ ShallowWrapper {
                 <LocalTime
                   time="2018-03-14T10:17:52Z"
                 />
-              </span>
-            </div>
-            <div>
-              <span>
-                <strong>
-                  Resource Version: 
-                </strong>
-                1234
               </span>
             </div>
             <hr />
@@ -532,7 +298,7 @@ ShallowWrapper {
               className="card-pf-body"
             >
               <h3>
-                reviews-v2
+                reviews-v2-1234
               </h3>
               <div>
                 <Badge
@@ -551,32 +317,6 @@ ShallowWrapper {
                 />
               </div>
               <div>
-                <strong>
-                  Pod status: 
-                </strong>
-                 
-                3
-                 / 
-                5
-                 
-                <Icon
-                  name="warning-triangle-o"
-                  type="pf"
-                />
-              </div>
-              <div>
-                <strong>
-                  Autoscaler: 
-                </strong>
-                from 
-                2
-                 to 
-                10
-                 pods (
-                50
-                % CPU)
-              </div>
-              <div>
                 <span>
                   <strong>
                     Created at: 
@@ -586,21 +326,13 @@ ShallowWrapper {
                   />
                 </span>
               </div>
-              <div>
-                <span>
-                  <strong>
-                    Resource Version: 
-                  </strong>
-                  1234
-                </span>
-              </div>
               <hr />
             </div>,
             <div
               className="card-pf-body"
             >
               <h3>
-                reviews-v3
+                reviews-v3-1234
               </h3>
               <div>
                 <Badge
@@ -619,32 +351,6 @@ ShallowWrapper {
                 />
               </div>
               <div>
-                <strong>
-                  Pod status: 
-                </strong>
-                 
-                2
-                 / 
-                2
-                 
-                <Icon
-                  name="ok"
-                  type="pf"
-                />
-              </div>
-              <div>
-                <strong>
-                  Autoscaler: 
-                </strong>
-                from 
-                2
-                 to 
-                10
-                 pods (
-                50
-                % CPU)
-              </div>
-              <div>
                 <span>
                   <strong>
                     Created at: 
@@ -654,21 +360,13 @@ ShallowWrapper {
                   />
                 </span>
               </div>
-              <div>
-                <span>
-                  <strong>
-                    Resource Version: 
-                  </strong>
-                  1234
-                </span>
-              </div>
               <hr />
             </div>,
             <div
               className="card-pf-body"
             >
               <h3>
-                reviews-v1
+                reviews-v1-1234
               </h3>
               <div>
                 <Badge
@@ -687,32 +385,6 @@ ShallowWrapper {
                 />
               </div>
               <div>
-                <strong>
-                  Pod status: 
-                </strong>
-                 
-                1
-                 / 
-                1
-                 
-                <Icon
-                  name="ok"
-                  type="pf"
-                />
-              </div>
-              <div>
-                <strong>
-                  Autoscaler: 
-                </strong>
-                from 
-                2
-                 to 
-                10
-                 pods (
-                50
-                % CPU)
-              </div>
-              <div>
                 <span>
                   <strong>
                     Created at: 
@@ -720,14 +392,6 @@ ShallowWrapper {
                   <LocalTime
                     time="2018-03-14T10:17:52Z"
                   />
-                </span>
-              </div>
-              <div>
-                <span>
-                  <strong>
-                    Resource Version: 
-                  </strong>
-                  1234
                 </span>
               </div>
               <hr />
@@ -743,12 +407,12 @@ ShallowWrapper {
         "rendered": Array [
           Object {
             "instance": null,
-            "key": "deployments_0",
+            "key": "pods_0",
             "nodeType": "host",
             "props": Object {
               "children": Array [
                 <h3>
-                  reviews-v2
+                  reviews-v2-1234
                 </h3>,
                 <div>
                   <Badge
@@ -767,32 +431,6 @@ ShallowWrapper {
                   />
                 </div>,
                 <div>
-                  <strong>
-                    Pod status: 
-                  </strong>
-                   
-                  3
-                   / 
-                  5
-                   
-                  <Icon
-                    name="warning-triangle-o"
-                    type="pf"
-                  />
-                </div>,
-                <div>
-                  <strong>
-                    Autoscaler: 
-                  </strong>
-                  from 
-                  2
-                   to 
-                  10
-                   pods (
-                  50
-                  % CPU)
-                </div>,
-                <div>
                   <span>
                     <strong>
                       Created at: 
@@ -802,14 +440,9 @@ ShallowWrapper {
                     />
                   </span>
                 </div>,
-                <div>
-                  <span>
-                    <strong>
-                      Resource Version: 
-                    </strong>
-                    1234
-                  </span>
-                </div>,
+                undefined,
+                undefined,
+                undefined,
                 <hr />,
               ],
               "className": "card-pf-body",
@@ -821,10 +454,10 @@ ShallowWrapper {
                 "key": undefined,
                 "nodeType": "host",
                 "props": Object {
-                  "children": "reviews-v2",
+                  "children": "reviews-v2-1234",
                 },
                 "ref": null,
-                "rendered": "reviews-v2",
+                "rendered": "reviews-v2-1234",
                 "type": "h3",
               },
               Object {
@@ -853,7 +486,7 @@ ShallowWrapper {
                 "rendered": Array [
                   Object {
                     "instance": null,
-                    "key": "deployment_0",
+                    "key": "pod_0",
                     "nodeType": "class",
                     "props": Object {
                       "color": "#3f9c35",
@@ -868,7 +501,7 @@ ShallowWrapper {
                   },
                   Object {
                     "instance": null,
-                    "key": "deployment_1",
+                    "key": "pod_1",
                     "nodeType": "class",
                     "props": Object {
                       "color": "#3f9c35",
@@ -881,100 +514,6 @@ ShallowWrapper {
                     "rendered": null,
                     "type": [Function],
                   },
-                ],
-                "type": "div",
-              },
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "children": Array [
-                    <strong>
-                      Pod status: 
-                    </strong>,
-                    " ",
-                    3,
-                    " / ",
-                    5,
-                    " ",
-                    <Icon
-                      name="warning-triangle-o"
-                      type="pf"
-                    />,
-                  ],
-                },
-                "ref": null,
-                "rendered": Array [
-                  Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "host",
-                    "props": Object {
-                      "children": "Pod status: ",
-                    },
-                    "ref": null,
-                    "rendered": "Pod status: ",
-                    "type": "strong",
-                  },
-                  " ",
-                  3,
-                  " / ",
-                  5,
-                  " ",
-                  Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "function",
-                    "props": Object {
-                      "name": "warning-triangle-o",
-                      "type": "pf",
-                    },
-                    "ref": null,
-                    "rendered": null,
-                    "type": [Function],
-                  },
-                ],
-                "type": "div",
-              },
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "children": Array [
-                    <strong>
-                      Autoscaler: 
-                    </strong>,
-                    "from ",
-                    2,
-                    " to ",
-                    10,
-                    " pods (",
-                    50,
-                    "% CPU)",
-                  ],
-                },
-                "ref": null,
-                "rendered": Array [
-                  Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "host",
-                    "props": Object {
-                      "children": "Autoscaler: ",
-                    },
-                    "ref": null,
-                    "rendered": "Autoscaler: ",
-                    "type": "strong",
-                  },
-                  "from ",
-                  2,
-                  " to ",
-                  10,
-                  " pods (",
-                  50,
-                  "% CPU)",
                 ],
                 "type": "div",
               },
@@ -1036,50 +575,9 @@ ShallowWrapper {
                 },
                 "type": "div",
               },
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "children": <span>
-                    <strong>
-                      Resource Version: 
-                    </strong>
-                    1234
-                  </span>,
-                },
-                "ref": null,
-                "rendered": Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": Array [
-                      <strong>
-                        Resource Version: 
-                      </strong>,
-                      "1234",
-                    ],
-                  },
-                  "ref": null,
-                  "rendered": Array [
-                    Object {
-                      "instance": null,
-                      "key": undefined,
-                      "nodeType": "host",
-                      "props": Object {
-                        "children": "Resource Version: ",
-                      },
-                      "ref": null,
-                      "rendered": "Resource Version: ",
-                      "type": "strong",
-                    },
-                    "1234",
-                  ],
-                  "type": "span",
-                },
-                "type": "div",
-              },
+              undefined,
+              undefined,
+              undefined,
               Object {
                 "instance": null,
                 "key": undefined,
@@ -1094,12 +592,12 @@ ShallowWrapper {
           },
           Object {
             "instance": null,
-            "key": "deployments_1",
+            "key": "pods_1",
             "nodeType": "host",
             "props": Object {
               "children": Array [
                 <h3>
-                  reviews-v3
+                  reviews-v3-1234
                 </h3>,
                 <div>
                   <Badge
@@ -1118,32 +616,6 @@ ShallowWrapper {
                   />
                 </div>,
                 <div>
-                  <strong>
-                    Pod status: 
-                  </strong>
-                   
-                  2
-                   / 
-                  2
-                   
-                  <Icon
-                    name="ok"
-                    type="pf"
-                  />
-                </div>,
-                <div>
-                  <strong>
-                    Autoscaler: 
-                  </strong>
-                  from 
-                  2
-                   to 
-                  10
-                   pods (
-                  50
-                  % CPU)
-                </div>,
-                <div>
                   <span>
                     <strong>
                       Created at: 
@@ -1153,14 +625,9 @@ ShallowWrapper {
                     />
                   </span>
                 </div>,
-                <div>
-                  <span>
-                    <strong>
-                      Resource Version: 
-                    </strong>
-                    1234
-                  </span>
-                </div>,
+                undefined,
+                undefined,
+                undefined,
                 <hr />,
               ],
               "className": "card-pf-body",
@@ -1172,10 +639,10 @@ ShallowWrapper {
                 "key": undefined,
                 "nodeType": "host",
                 "props": Object {
-                  "children": "reviews-v3",
+                  "children": "reviews-v3-1234",
                 },
                 "ref": null,
-                "rendered": "reviews-v3",
+                "rendered": "reviews-v3-1234",
                 "type": "h3",
               },
               Object {
@@ -1204,7 +671,7 @@ ShallowWrapper {
                 "rendered": Array [
                   Object {
                     "instance": null,
-                    "key": "deployment_0",
+                    "key": "pod_0",
                     "nodeType": "class",
                     "props": Object {
                       "color": "#3f9c35",
@@ -1219,7 +686,7 @@ ShallowWrapper {
                   },
                   Object {
                     "instance": null,
-                    "key": "deployment_1",
+                    "key": "pod_1",
                     "nodeType": "class",
                     "props": Object {
                       "color": "#3f9c35",
@@ -1232,100 +699,6 @@ ShallowWrapper {
                     "rendered": null,
                     "type": [Function],
                   },
-                ],
-                "type": "div",
-              },
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "children": Array [
-                    <strong>
-                      Pod status: 
-                    </strong>,
-                    " ",
-                    2,
-                    " / ",
-                    2,
-                    " ",
-                    <Icon
-                      name="ok"
-                      type="pf"
-                    />,
-                  ],
-                },
-                "ref": null,
-                "rendered": Array [
-                  Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "host",
-                    "props": Object {
-                      "children": "Pod status: ",
-                    },
-                    "ref": null,
-                    "rendered": "Pod status: ",
-                    "type": "strong",
-                  },
-                  " ",
-                  2,
-                  " / ",
-                  2,
-                  " ",
-                  Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "function",
-                    "props": Object {
-                      "name": "ok",
-                      "type": "pf",
-                    },
-                    "ref": null,
-                    "rendered": null,
-                    "type": [Function],
-                  },
-                ],
-                "type": "div",
-              },
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "children": Array [
-                    <strong>
-                      Autoscaler: 
-                    </strong>,
-                    "from ",
-                    2,
-                    " to ",
-                    10,
-                    " pods (",
-                    50,
-                    "% CPU)",
-                  ],
-                },
-                "ref": null,
-                "rendered": Array [
-                  Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "host",
-                    "props": Object {
-                      "children": "Autoscaler: ",
-                    },
-                    "ref": null,
-                    "rendered": "Autoscaler: ",
-                    "type": "strong",
-                  },
-                  "from ",
-                  2,
-                  " to ",
-                  10,
-                  " pods (",
-                  50,
-                  "% CPU)",
                 ],
                 "type": "div",
               },
@@ -1387,50 +760,9 @@ ShallowWrapper {
                 },
                 "type": "div",
               },
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "children": <span>
-                    <strong>
-                      Resource Version: 
-                    </strong>
-                    1234
-                  </span>,
-                },
-                "ref": null,
-                "rendered": Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": Array [
-                      <strong>
-                        Resource Version: 
-                      </strong>,
-                      "1234",
-                    ],
-                  },
-                  "ref": null,
-                  "rendered": Array [
-                    Object {
-                      "instance": null,
-                      "key": undefined,
-                      "nodeType": "host",
-                      "props": Object {
-                        "children": "Resource Version: ",
-                      },
-                      "ref": null,
-                      "rendered": "Resource Version: ",
-                      "type": "strong",
-                    },
-                    "1234",
-                  ],
-                  "type": "span",
-                },
-                "type": "div",
-              },
+              undefined,
+              undefined,
+              undefined,
               Object {
                 "instance": null,
                 "key": undefined,
@@ -1445,12 +777,12 @@ ShallowWrapper {
           },
           Object {
             "instance": null,
-            "key": "deployments_2",
+            "key": "pods_2",
             "nodeType": "host",
             "props": Object {
               "children": Array [
                 <h3>
-                  reviews-v1
+                  reviews-v1-1234
                 </h3>,
                 <div>
                   <Badge
@@ -1469,32 +801,6 @@ ShallowWrapper {
                   />
                 </div>,
                 <div>
-                  <strong>
-                    Pod status: 
-                  </strong>
-                   
-                  1
-                   / 
-                  1
-                   
-                  <Icon
-                    name="ok"
-                    type="pf"
-                  />
-                </div>,
-                <div>
-                  <strong>
-                    Autoscaler: 
-                  </strong>
-                  from 
-                  2
-                   to 
-                  10
-                   pods (
-                  50
-                  % CPU)
-                </div>,
-                <div>
                   <span>
                     <strong>
                       Created at: 
@@ -1504,14 +810,9 @@ ShallowWrapper {
                     />
                   </span>
                 </div>,
-                <div>
-                  <span>
-                    <strong>
-                      Resource Version: 
-                    </strong>
-                    1234
-                  </span>
-                </div>,
+                undefined,
+                undefined,
+                undefined,
                 <hr />,
               ],
               "className": "card-pf-body",
@@ -1523,10 +824,10 @@ ShallowWrapper {
                 "key": undefined,
                 "nodeType": "host",
                 "props": Object {
-                  "children": "reviews-v1",
+                  "children": "reviews-v1-1234",
                 },
                 "ref": null,
-                "rendered": "reviews-v1",
+                "rendered": "reviews-v1-1234",
                 "type": "h3",
               },
               Object {
@@ -1555,7 +856,7 @@ ShallowWrapper {
                 "rendered": Array [
                   Object {
                     "instance": null,
-                    "key": "deployment_0",
+                    "key": "pod_0",
                     "nodeType": "class",
                     "props": Object {
                       "color": "#3f9c35",
@@ -1570,7 +871,7 @@ ShallowWrapper {
                   },
                   Object {
                     "instance": null,
-                    "key": "deployment_1",
+                    "key": "pod_1",
                     "nodeType": "class",
                     "props": Object {
                       "color": "#3f9c35",
@@ -1583,100 +884,6 @@ ShallowWrapper {
                     "rendered": null,
                     "type": [Function],
                   },
-                ],
-                "type": "div",
-              },
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "children": Array [
-                    <strong>
-                      Pod status: 
-                    </strong>,
-                    " ",
-                    1,
-                    " / ",
-                    1,
-                    " ",
-                    <Icon
-                      name="ok"
-                      type="pf"
-                    />,
-                  ],
-                },
-                "ref": null,
-                "rendered": Array [
-                  Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "host",
-                    "props": Object {
-                      "children": "Pod status: ",
-                    },
-                    "ref": null,
-                    "rendered": "Pod status: ",
-                    "type": "strong",
-                  },
-                  " ",
-                  1,
-                  " / ",
-                  1,
-                  " ",
-                  Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "function",
-                    "props": Object {
-                      "name": "ok",
-                      "type": "pf",
-                    },
-                    "ref": null,
-                    "rendered": null,
-                    "type": [Function],
-                  },
-                ],
-                "type": "div",
-              },
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "children": Array [
-                    <strong>
-                      Autoscaler: 
-                    </strong>,
-                    "from ",
-                    2,
-                    " to ",
-                    10,
-                    " pods (",
-                    50,
-                    "% CPU)",
-                  ],
-                },
-                "ref": null,
-                "rendered": Array [
-                  Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "host",
-                    "props": Object {
-                      "children": "Autoscaler: ",
-                    },
-                    "ref": null,
-                    "rendered": "Autoscaler: ",
-                    "type": "strong",
-                  },
-                  "from ",
-                  2,
-                  " to ",
-                  10,
-                  " pods (",
-                  50,
-                  "% CPU)",
                 ],
                 "type": "div",
               },
@@ -1738,50 +945,9 @@ ShallowWrapper {
                 },
                 "type": "div",
               },
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "children": <span>
-                    <strong>
-                      Resource Version: 
-                    </strong>
-                    1234
-                  </span>,
-                },
-                "ref": null,
-                "rendered": Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": Array [
-                      <strong>
-                        Resource Version: 
-                      </strong>,
-                      "1234",
-                    ],
-                  },
-                  "ref": null,
-                  "rendered": Array [
-                    Object {
-                      "instance": null,
-                      "key": undefined,
-                      "nodeType": "host",
-                      "props": Object {
-                        "children": "Resource Version: ",
-                      },
-                      "ref": null,
-                      "rendered": "Resource Version: ",
-                      "type": "strong",
-                    },
-                    "1234",
-                  ],
-                  "type": "span",
-                },
-                "type": "div",
-              },
+              undefined,
+              undefined,
+              undefined,
               Object {
                 "instance": null,
                 "key": undefined,
@@ -1824,7 +990,7 @@ ShallowWrapper {
               className="card-pf-body"
             >
               <h3>
-                reviews-v2
+                reviews-v2-1234
               </h3>
               <div>
                 <Badge
@@ -1843,32 +1009,6 @@ ShallowWrapper {
                 />
               </div>
               <div>
-                <strong>
-                  Pod status: 
-                </strong>
-                 
-                3
-                 / 
-                5
-                 
-                <Icon
-                  name="warning-triangle-o"
-                  type="pf"
-                />
-              </div>
-              <div>
-                <strong>
-                  Autoscaler: 
-                </strong>
-                from 
-                2
-                 to 
-                10
-                 pods (
-                50
-                % CPU)
-              </div>
-              <div>
                 <span>
                   <strong>
                     Created at: 
@@ -1878,21 +1018,13 @@ ShallowWrapper {
                   />
                 </span>
               </div>
-              <div>
-                <span>
-                  <strong>
-                    Resource Version: 
-                  </strong>
-                  1234
-                </span>
-              </div>
               <hr />
             </div>
             <div
               className="card-pf-body"
             >
               <h3>
-                reviews-v3
+                reviews-v3-1234
               </h3>
               <div>
                 <Badge
@@ -1911,32 +1043,6 @@ ShallowWrapper {
                 />
               </div>
               <div>
-                <strong>
-                  Pod status: 
-                </strong>
-                 
-                2
-                 / 
-                2
-                 
-                <Icon
-                  name="ok"
-                  type="pf"
-                />
-              </div>
-              <div>
-                <strong>
-                  Autoscaler: 
-                </strong>
-                from 
-                2
-                 to 
-                10
-                 pods (
-                50
-                % CPU)
-              </div>
-              <div>
                 <span>
                   <strong>
                     Created at: 
@@ -1946,21 +1052,13 @@ ShallowWrapper {
                   />
                 </span>
               </div>
-              <div>
-                <span>
-                  <strong>
-                    Resource Version: 
-                  </strong>
-                  1234
-                </span>
-              </div>
               <hr />
             </div>
             <div
               className="card-pf-body"
             >
               <h3>
-                reviews-v1
+                reviews-v1-1234
               </h3>
               <div>
                 <Badge
@@ -1979,32 +1077,6 @@ ShallowWrapper {
                 />
               </div>
               <div>
-                <strong>
-                  Pod status: 
-                </strong>
-                 
-                1
-                 / 
-                1
-                 
-                <Icon
-                  name="ok"
-                  type="pf"
-                />
-              </div>
-              <div>
-                <strong>
-                  Autoscaler: 
-                </strong>
-                from 
-                2
-                 to 
-                10
-                 pods (
-                50
-                % CPU)
-              </div>
-              <div>
                 <span>
                   <strong>
                     Created at: 
@@ -2012,14 +1084,6 @@ ShallowWrapper {
                   <LocalTime
                     time="2018-03-14T10:17:52Z"
                   />
-                </span>
-              </div>
-              <div>
-                <span>
-                  <strong>
-                    Resource Version: 
-                  </strong>
-                  1234
                 </span>
               </div>
               <hr />
@@ -2047,7 +1111,7 @@ ShallowWrapper {
               className="card-pf-body"
             >
               <h3>
-                reviews-v2
+                reviews-v2-1234
               </h3>
               <div>
                 <Badge
@@ -2066,32 +1130,6 @@ ShallowWrapper {
                 />
               </div>
               <div>
-                <strong>
-                  Pod status: 
-                </strong>
-                 
-                3
-                 / 
-                5
-                 
-                <Icon
-                  name="warning-triangle-o"
-                  type="pf"
-                />
-              </div>
-              <div>
-                <strong>
-                  Autoscaler: 
-                </strong>
-                from 
-                2
-                 to 
-                10
-                 pods (
-                50
-                % CPU)
-              </div>
-              <div>
                 <span>
                   <strong>
                     Created at: 
@@ -2101,21 +1139,13 @@ ShallowWrapper {
                   />
                 </span>
               </div>
-              <div>
-                <span>
-                  <strong>
-                    Resource Version: 
-                  </strong>
-                  1234
-                </span>
-              </div>
               <hr />
             </div>
             <div
               className="card-pf-body"
             >
               <h3>
-                reviews-v3
+                reviews-v3-1234
               </h3>
               <div>
                 <Badge
@@ -2134,32 +1164,6 @@ ShallowWrapper {
                 />
               </div>
               <div>
-                <strong>
-                  Pod status: 
-                </strong>
-                 
-                2
-                 / 
-                2
-                 
-                <Icon
-                  name="ok"
-                  type="pf"
-                />
-              </div>
-              <div>
-                <strong>
-                  Autoscaler: 
-                </strong>
-                from 
-                2
-                 to 
-                10
-                 pods (
-                50
-                % CPU)
-              </div>
-              <div>
                 <span>
                   <strong>
                     Created at: 
@@ -2169,21 +1173,13 @@ ShallowWrapper {
                   />
                 </span>
               </div>
-              <div>
-                <span>
-                  <strong>
-                    Resource Version: 
-                  </strong>
-                  1234
-                </span>
-              </div>
               <hr />
             </div>
             <div
               className="card-pf-body"
             >
               <h3>
-                reviews-v1
+                reviews-v1-1234
               </h3>
               <div>
                 <Badge
@@ -2202,32 +1198,6 @@ ShallowWrapper {
                 />
               </div>
               <div>
-                <strong>
-                  Pod status: 
-                </strong>
-                 
-                1
-                 / 
-                1
-                 
-                <Icon
-                  name="ok"
-                  type="pf"
-                />
-              </div>
-              <div>
-                <strong>
-                  Autoscaler: 
-                </strong>
-                from 
-                2
-                 to 
-                10
-                 pods (
-                50
-                % CPU)
-              </div>
-              <div>
                 <span>
                   <strong>
                     Created at: 
@@ -2235,14 +1205,6 @@ ShallowWrapper {
                   <LocalTime
                     time="2018-03-14T10:17:52Z"
                   />
-                </span>
-              </div>
-              <div>
-                <span>
-                  <strong>
-                    Resource Version: 
-                  </strong>
-                  1234
                 </span>
               </div>
               <hr />
@@ -2263,7 +1225,7 @@ ShallowWrapper {
                 className="card-pf-body"
               >
                 <h3>
-                  reviews-v2
+                  reviews-v2-1234
                 </h3>
                 <div>
                   <Badge
@@ -2282,32 +1244,6 @@ ShallowWrapper {
                   />
                 </div>
                 <div>
-                  <strong>
-                    Pod status: 
-                  </strong>
-                   
-                  3
-                   / 
-                  5
-                   
-                  <Icon
-                    name="warning-triangle-o"
-                    type="pf"
-                  />
-                </div>
-                <div>
-                  <strong>
-                    Autoscaler: 
-                  </strong>
-                  from 
-                  2
-                   to 
-                  10
-                   pods (
-                  50
-                  % CPU)
-                </div>
-                <div>
                   <span>
                     <strong>
                       Created at: 
@@ -2317,21 +1253,13 @@ ShallowWrapper {
                     />
                   </span>
                 </div>
-                <div>
-                  <span>
-                    <strong>
-                      Resource Version: 
-                    </strong>
-                    1234
-                  </span>
-                </div>
                 <hr />
               </div>,
               <div
                 className="card-pf-body"
               >
                 <h3>
-                  reviews-v3
+                  reviews-v3-1234
                 </h3>
                 <div>
                   <Badge
@@ -2350,32 +1278,6 @@ ShallowWrapper {
                   />
                 </div>
                 <div>
-                  <strong>
-                    Pod status: 
-                  </strong>
-                   
-                  2
-                   / 
-                  2
-                   
-                  <Icon
-                    name="ok"
-                    type="pf"
-                  />
-                </div>
-                <div>
-                  <strong>
-                    Autoscaler: 
-                  </strong>
-                  from 
-                  2
-                   to 
-                  10
-                   pods (
-                  50
-                  % CPU)
-                </div>
-                <div>
                   <span>
                     <strong>
                       Created at: 
@@ -2385,21 +1287,13 @@ ShallowWrapper {
                     />
                   </span>
                 </div>
-                <div>
-                  <span>
-                    <strong>
-                      Resource Version: 
-                    </strong>
-                    1234
-                  </span>
-                </div>
                 <hr />
               </div>,
               <div
                 className="card-pf-body"
               >
                 <h3>
-                  reviews-v1
+                  reviews-v1-1234
                 </h3>
                 <div>
                   <Badge
@@ -2418,32 +1312,6 @@ ShallowWrapper {
                   />
                 </div>
                 <div>
-                  <strong>
-                    Pod status: 
-                  </strong>
-                   
-                  1
-                   / 
-                  1
-                   
-                  <Icon
-                    name="ok"
-                    type="pf"
-                  />
-                </div>
-                <div>
-                  <strong>
-                    Autoscaler: 
-                  </strong>
-                  from 
-                  2
-                   to 
-                  10
-                   pods (
-                  50
-                  % CPU)
-                </div>
-                <div>
                   <span>
                     <strong>
                       Created at: 
@@ -2451,14 +1319,6 @@ ShallowWrapper {
                     <LocalTime
                       time="2018-03-14T10:17:52Z"
                     />
-                  </span>
-                </div>
-                <div>
-                  <span>
-                    <strong>
-                      Resource Version: 
-                    </strong>
-                    1234
                   </span>
                 </div>
                 <hr />
@@ -2474,12 +1334,12 @@ ShallowWrapper {
           "rendered": Array [
             Object {
               "instance": null,
-              "key": "deployments_0",
+              "key": "pods_0",
               "nodeType": "host",
               "props": Object {
                 "children": Array [
                   <h3>
-                    reviews-v2
+                    reviews-v2-1234
                   </h3>,
                   <div>
                     <Badge
@@ -2498,32 +1358,6 @@ ShallowWrapper {
                     />
                   </div>,
                   <div>
-                    <strong>
-                      Pod status: 
-                    </strong>
-                     
-                    3
-                     / 
-                    5
-                     
-                    <Icon
-                      name="warning-triangle-o"
-                      type="pf"
-                    />
-                  </div>,
-                  <div>
-                    <strong>
-                      Autoscaler: 
-                    </strong>
-                    from 
-                    2
-                     to 
-                    10
-                     pods (
-                    50
-                    % CPU)
-                  </div>,
-                  <div>
                     <span>
                       <strong>
                         Created at: 
@@ -2533,14 +1367,9 @@ ShallowWrapper {
                       />
                     </span>
                   </div>,
-                  <div>
-                    <span>
-                      <strong>
-                        Resource Version: 
-                      </strong>
-                      1234
-                    </span>
-                  </div>,
+                  undefined,
+                  undefined,
+                  undefined,
                   <hr />,
                 ],
                 "className": "card-pf-body",
@@ -2552,10 +1381,10 @@ ShallowWrapper {
                   "key": undefined,
                   "nodeType": "host",
                   "props": Object {
-                    "children": "reviews-v2",
+                    "children": "reviews-v2-1234",
                   },
                   "ref": null,
-                  "rendered": "reviews-v2",
+                  "rendered": "reviews-v2-1234",
                   "type": "h3",
                 },
                 Object {
@@ -2584,7 +1413,7 @@ ShallowWrapper {
                   "rendered": Array [
                     Object {
                       "instance": null,
-                      "key": "deployment_0",
+                      "key": "pod_0",
                       "nodeType": "class",
                       "props": Object {
                         "color": "#3f9c35",
@@ -2599,7 +1428,7 @@ ShallowWrapper {
                     },
                     Object {
                       "instance": null,
-                      "key": "deployment_1",
+                      "key": "pod_1",
                       "nodeType": "class",
                       "props": Object {
                         "color": "#3f9c35",
@@ -2612,100 +1441,6 @@ ShallowWrapper {
                       "rendered": null,
                       "type": [Function],
                     },
-                  ],
-                  "type": "div",
-                },
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": Array [
-                      <strong>
-                        Pod status: 
-                      </strong>,
-                      " ",
-                      3,
-                      " / ",
-                      5,
-                      " ",
-                      <Icon
-                        name="warning-triangle-o"
-                        type="pf"
-                      />,
-                    ],
-                  },
-                  "ref": null,
-                  "rendered": Array [
-                    Object {
-                      "instance": null,
-                      "key": undefined,
-                      "nodeType": "host",
-                      "props": Object {
-                        "children": "Pod status: ",
-                      },
-                      "ref": null,
-                      "rendered": "Pod status: ",
-                      "type": "strong",
-                    },
-                    " ",
-                    3,
-                    " / ",
-                    5,
-                    " ",
-                    Object {
-                      "instance": null,
-                      "key": undefined,
-                      "nodeType": "function",
-                      "props": Object {
-                        "name": "warning-triangle-o",
-                        "type": "pf",
-                      },
-                      "ref": null,
-                      "rendered": null,
-                      "type": [Function],
-                    },
-                  ],
-                  "type": "div",
-                },
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": Array [
-                      <strong>
-                        Autoscaler: 
-                      </strong>,
-                      "from ",
-                      2,
-                      " to ",
-                      10,
-                      " pods (",
-                      50,
-                      "% CPU)",
-                    ],
-                  },
-                  "ref": null,
-                  "rendered": Array [
-                    Object {
-                      "instance": null,
-                      "key": undefined,
-                      "nodeType": "host",
-                      "props": Object {
-                        "children": "Autoscaler: ",
-                      },
-                      "ref": null,
-                      "rendered": "Autoscaler: ",
-                      "type": "strong",
-                    },
-                    "from ",
-                    2,
-                    " to ",
-                    10,
-                    " pods (",
-                    50,
-                    "% CPU)",
                   ],
                   "type": "div",
                 },
@@ -2767,50 +1502,9 @@ ShallowWrapper {
                   },
                   "type": "div",
                 },
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": <span>
-                      <strong>
-                        Resource Version: 
-                      </strong>
-                      1234
-                    </span>,
-                  },
-                  "ref": null,
-                  "rendered": Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "host",
-                    "props": Object {
-                      "children": Array [
-                        <strong>
-                          Resource Version: 
-                        </strong>,
-                        "1234",
-                      ],
-                    },
-                    "ref": null,
-                    "rendered": Array [
-                      Object {
-                        "instance": null,
-                        "key": undefined,
-                        "nodeType": "host",
-                        "props": Object {
-                          "children": "Resource Version: ",
-                        },
-                        "ref": null,
-                        "rendered": "Resource Version: ",
-                        "type": "strong",
-                      },
-                      "1234",
-                    ],
-                    "type": "span",
-                  },
-                  "type": "div",
-                },
+                undefined,
+                undefined,
+                undefined,
                 Object {
                   "instance": null,
                   "key": undefined,
@@ -2825,12 +1519,12 @@ ShallowWrapper {
             },
             Object {
               "instance": null,
-              "key": "deployments_1",
+              "key": "pods_1",
               "nodeType": "host",
               "props": Object {
                 "children": Array [
                   <h3>
-                    reviews-v3
+                    reviews-v3-1234
                   </h3>,
                   <div>
                     <Badge
@@ -2849,32 +1543,6 @@ ShallowWrapper {
                     />
                   </div>,
                   <div>
-                    <strong>
-                      Pod status: 
-                    </strong>
-                     
-                    2
-                     / 
-                    2
-                     
-                    <Icon
-                      name="ok"
-                      type="pf"
-                    />
-                  </div>,
-                  <div>
-                    <strong>
-                      Autoscaler: 
-                    </strong>
-                    from 
-                    2
-                     to 
-                    10
-                     pods (
-                    50
-                    % CPU)
-                  </div>,
-                  <div>
                     <span>
                       <strong>
                         Created at: 
@@ -2884,14 +1552,9 @@ ShallowWrapper {
                       />
                     </span>
                   </div>,
-                  <div>
-                    <span>
-                      <strong>
-                        Resource Version: 
-                      </strong>
-                      1234
-                    </span>
-                  </div>,
+                  undefined,
+                  undefined,
+                  undefined,
                   <hr />,
                 ],
                 "className": "card-pf-body",
@@ -2903,10 +1566,10 @@ ShallowWrapper {
                   "key": undefined,
                   "nodeType": "host",
                   "props": Object {
-                    "children": "reviews-v3",
+                    "children": "reviews-v3-1234",
                   },
                   "ref": null,
-                  "rendered": "reviews-v3",
+                  "rendered": "reviews-v3-1234",
                   "type": "h3",
                 },
                 Object {
@@ -2935,7 +1598,7 @@ ShallowWrapper {
                   "rendered": Array [
                     Object {
                       "instance": null,
-                      "key": "deployment_0",
+                      "key": "pod_0",
                       "nodeType": "class",
                       "props": Object {
                         "color": "#3f9c35",
@@ -2950,7 +1613,7 @@ ShallowWrapper {
                     },
                     Object {
                       "instance": null,
-                      "key": "deployment_1",
+                      "key": "pod_1",
                       "nodeType": "class",
                       "props": Object {
                         "color": "#3f9c35",
@@ -2963,100 +1626,6 @@ ShallowWrapper {
                       "rendered": null,
                       "type": [Function],
                     },
-                  ],
-                  "type": "div",
-                },
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": Array [
-                      <strong>
-                        Pod status: 
-                      </strong>,
-                      " ",
-                      2,
-                      " / ",
-                      2,
-                      " ",
-                      <Icon
-                        name="ok"
-                        type="pf"
-                      />,
-                    ],
-                  },
-                  "ref": null,
-                  "rendered": Array [
-                    Object {
-                      "instance": null,
-                      "key": undefined,
-                      "nodeType": "host",
-                      "props": Object {
-                        "children": "Pod status: ",
-                      },
-                      "ref": null,
-                      "rendered": "Pod status: ",
-                      "type": "strong",
-                    },
-                    " ",
-                    2,
-                    " / ",
-                    2,
-                    " ",
-                    Object {
-                      "instance": null,
-                      "key": undefined,
-                      "nodeType": "function",
-                      "props": Object {
-                        "name": "ok",
-                        "type": "pf",
-                      },
-                      "ref": null,
-                      "rendered": null,
-                      "type": [Function],
-                    },
-                  ],
-                  "type": "div",
-                },
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": Array [
-                      <strong>
-                        Autoscaler: 
-                      </strong>,
-                      "from ",
-                      2,
-                      " to ",
-                      10,
-                      " pods (",
-                      50,
-                      "% CPU)",
-                    ],
-                  },
-                  "ref": null,
-                  "rendered": Array [
-                    Object {
-                      "instance": null,
-                      "key": undefined,
-                      "nodeType": "host",
-                      "props": Object {
-                        "children": "Autoscaler: ",
-                      },
-                      "ref": null,
-                      "rendered": "Autoscaler: ",
-                      "type": "strong",
-                    },
-                    "from ",
-                    2,
-                    " to ",
-                    10,
-                    " pods (",
-                    50,
-                    "% CPU)",
                   ],
                   "type": "div",
                 },
@@ -3118,50 +1687,9 @@ ShallowWrapper {
                   },
                   "type": "div",
                 },
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": <span>
-                      <strong>
-                        Resource Version: 
-                      </strong>
-                      1234
-                    </span>,
-                  },
-                  "ref": null,
-                  "rendered": Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "host",
-                    "props": Object {
-                      "children": Array [
-                        <strong>
-                          Resource Version: 
-                        </strong>,
-                        "1234",
-                      ],
-                    },
-                    "ref": null,
-                    "rendered": Array [
-                      Object {
-                        "instance": null,
-                        "key": undefined,
-                        "nodeType": "host",
-                        "props": Object {
-                          "children": "Resource Version: ",
-                        },
-                        "ref": null,
-                        "rendered": "Resource Version: ",
-                        "type": "strong",
-                      },
-                      "1234",
-                    ],
-                    "type": "span",
-                  },
-                  "type": "div",
-                },
+                undefined,
+                undefined,
+                undefined,
                 Object {
                   "instance": null,
                   "key": undefined,
@@ -3176,12 +1704,12 @@ ShallowWrapper {
             },
             Object {
               "instance": null,
-              "key": "deployments_2",
+              "key": "pods_2",
               "nodeType": "host",
               "props": Object {
                 "children": Array [
                   <h3>
-                    reviews-v1
+                    reviews-v1-1234
                   </h3>,
                   <div>
                     <Badge
@@ -3200,32 +1728,6 @@ ShallowWrapper {
                     />
                   </div>,
                   <div>
-                    <strong>
-                      Pod status: 
-                    </strong>
-                     
-                    1
-                     / 
-                    1
-                     
-                    <Icon
-                      name="ok"
-                      type="pf"
-                    />
-                  </div>,
-                  <div>
-                    <strong>
-                      Autoscaler: 
-                    </strong>
-                    from 
-                    2
-                     to 
-                    10
-                     pods (
-                    50
-                    % CPU)
-                  </div>,
-                  <div>
                     <span>
                       <strong>
                         Created at: 
@@ -3235,14 +1737,9 @@ ShallowWrapper {
                       />
                     </span>
                   </div>,
-                  <div>
-                    <span>
-                      <strong>
-                        Resource Version: 
-                      </strong>
-                      1234
-                    </span>
-                  </div>,
+                  undefined,
+                  undefined,
+                  undefined,
                   <hr />,
                 ],
                 "className": "card-pf-body",
@@ -3254,10 +1751,10 @@ ShallowWrapper {
                   "key": undefined,
                   "nodeType": "host",
                   "props": Object {
-                    "children": "reviews-v1",
+                    "children": "reviews-v1-1234",
                   },
                   "ref": null,
-                  "rendered": "reviews-v1",
+                  "rendered": "reviews-v1-1234",
                   "type": "h3",
                 },
                 Object {
@@ -3286,7 +1783,7 @@ ShallowWrapper {
                   "rendered": Array [
                     Object {
                       "instance": null,
-                      "key": "deployment_0",
+                      "key": "pod_0",
                       "nodeType": "class",
                       "props": Object {
                         "color": "#3f9c35",
@@ -3301,7 +1798,7 @@ ShallowWrapper {
                     },
                     Object {
                       "instance": null,
-                      "key": "deployment_1",
+                      "key": "pod_1",
                       "nodeType": "class",
                       "props": Object {
                         "color": "#3f9c35",
@@ -3314,100 +1811,6 @@ ShallowWrapper {
                       "rendered": null,
                       "type": [Function],
                     },
-                  ],
-                  "type": "div",
-                },
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": Array [
-                      <strong>
-                        Pod status: 
-                      </strong>,
-                      " ",
-                      1,
-                      " / ",
-                      1,
-                      " ",
-                      <Icon
-                        name="ok"
-                        type="pf"
-                      />,
-                    ],
-                  },
-                  "ref": null,
-                  "rendered": Array [
-                    Object {
-                      "instance": null,
-                      "key": undefined,
-                      "nodeType": "host",
-                      "props": Object {
-                        "children": "Pod status: ",
-                      },
-                      "ref": null,
-                      "rendered": "Pod status: ",
-                      "type": "strong",
-                    },
-                    " ",
-                    1,
-                    " / ",
-                    1,
-                    " ",
-                    Object {
-                      "instance": null,
-                      "key": undefined,
-                      "nodeType": "function",
-                      "props": Object {
-                        "name": "ok",
-                        "type": "pf",
-                      },
-                      "ref": null,
-                      "rendered": null,
-                      "type": [Function],
-                    },
-                  ],
-                  "type": "div",
-                },
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": Array [
-                      <strong>
-                        Autoscaler: 
-                      </strong>,
-                      "from ",
-                      2,
-                      " to ",
-                      10,
-                      " pods (",
-                      50,
-                      "% CPU)",
-                    ],
-                  },
-                  "ref": null,
-                  "rendered": Array [
-                    Object {
-                      "instance": null,
-                      "key": undefined,
-                      "nodeType": "host",
-                      "props": Object {
-                        "children": "Autoscaler: ",
-                      },
-                      "ref": null,
-                      "rendered": "Autoscaler: ",
-                      "type": "strong",
-                    },
-                    "from ",
-                    2,
-                    " to ",
-                    10,
-                    " pods (",
-                    50,
-                    "% CPU)",
                   ],
                   "type": "div",
                 },
@@ -3469,50 +1872,9 @@ ShallowWrapper {
                   },
                   "type": "div",
                 },
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": <span>
-                      <strong>
-                        Resource Version: 
-                      </strong>
-                      1234
-                    </span>,
-                  },
-                  "ref": null,
-                  "rendered": Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "host",
-                    "props": Object {
-                      "children": Array [
-                        <strong>
-                          Resource Version: 
-                        </strong>,
-                        "1234",
-                      ],
-                    },
-                    "ref": null,
-                    "rendered": Array [
-                      Object {
-                        "instance": null,
-                        "key": undefined,
-                        "nodeType": "host",
-                        "props": Object {
-                          "children": "Resource Version: ",
-                        },
-                        "ref": null,
-                        "rendered": "Resource Version: ",
-                        "type": "strong",
-                      },
-                      "1234",
-                    ],
-                    "type": "span",
-                  },
-                  "type": "div",
-                },
+                undefined,
+                undefined,
+                undefined,
                 Object {
                   "instance": null,
                   "key": undefined,

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoRouteRules.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoRouteRules.test.tsx.snap
@@ -19,8 +19,8 @@ ShallowWrapper {
           "resource_version": "1234",
           "route": Array [
             Object {
-              "labels": Map {
-                "version" => "v1",
+              "labels": Object {
+                "version": "v1",
               },
             },
           ],
@@ -36,8 +36,8 @@ ShallowWrapper {
           "resource_version": "1234",
           "route": Array [
             Object {
-              "labels": Map {
-                "version" => "v2",
+              "labels": Object {
+                "version": "v2",
               },
             },
           ],
@@ -134,8 +134,8 @@ ShallowWrapper {
                 route={
                   Array [
                     Object {
-                      "labels": Map {
-                        "version" => "v1",
+                      "labels": Object {
+                        "version": "v1",
                       },
                     },
                   ]
@@ -207,8 +207,8 @@ ShallowWrapper {
                 route={
                   Array [
                     Object {
-                      "labels": Map {
-                        "version" => "v2",
+                      "labels": Object {
+                        "version": "v2",
                       },
                     },
                   ]
@@ -299,8 +299,8 @@ ShallowWrapper {
                 route={
                   Array [
                     Object {
-                      "labels": Map {
-                        "version" => "v1",
+                      "labels": Object {
+                        "version": "v1",
                       },
                     },
                   ]
@@ -372,8 +372,8 @@ ShallowWrapper {
                 route={
                   Array [
                     Object {
-                      "labels": Map {
-                        "version" => "v2",
+                      "labels": Object {
+                        "version": "v2",
                       },
                     },
                   ]
@@ -457,8 +457,8 @@ ShallowWrapper {
                   route={
                     Array [
                       Object {
-                        "labels": Map {
-                          "version" => "v1",
+                        "labels": Object {
+                          "version": "v1",
                         },
                       },
                     ]
@@ -530,8 +530,8 @@ ShallowWrapper {
                   route={
                     Array [
                       Object {
-                        "labels": Map {
-                          "version" => "v2",
+                        "labels": Object {
+                          "version": "v2",
                         },
                       },
                     ]
@@ -614,8 +614,8 @@ ShallowWrapper {
                     route={
                       Array [
                         Object {
-                          "labels": Map {
-                            "version" => "v1",
+                          "labels": Object {
+                            "version": "v1",
                           },
                         },
                       ]
@@ -889,8 +889,8 @@ ShallowWrapper {
                     route={
                       Array [
                         Object {
-                          "labels": Map {
-                            "version" => "v1",
+                          "labels": Object {
+                            "version": "v1",
                           },
                         },
                       ]
@@ -912,8 +912,8 @@ ShallowWrapper {
                     "name": "reviews-default",
                     "route": Array [
                       Object {
-                        "labels": Map {
-                          "version" => "v1",
+                        "labels": Object {
+                          "version": "v1",
                         },
                       },
                     ],
@@ -993,8 +993,8 @@ ShallowWrapper {
                     route={
                       Array [
                         Object {
-                          "labels": Map {
-                            "version" => "v2",
+                          "labels": Object {
+                            "version": "v2",
                           },
                         },
                       ]
@@ -1268,8 +1268,8 @@ ShallowWrapper {
                     route={
                       Array [
                         Object {
-                          "labels": Map {
-                            "version" => "v2",
+                          "labels": Object {
+                            "version": "v2",
                           },
                         },
                       ]
@@ -1291,8 +1291,8 @@ ShallowWrapper {
                     "name": "reviews-test-v2",
                     "route": Array [
                       Object {
-                        "labels": Map {
-                          "version" => "v2",
+                        "labels": Object {
+                          "version": "v2",
                         },
                       },
                     ],
@@ -1396,8 +1396,8 @@ ShallowWrapper {
                   route={
                     Array [
                       Object {
-                        "labels": Map {
-                          "version" => "v1",
+                        "labels": Object {
+                          "version": "v1",
                         },
                       },
                     ]
@@ -1469,8 +1469,8 @@ ShallowWrapper {
                   route={
                     Array [
                       Object {
-                        "labels": Map {
-                          "version" => "v2",
+                        "labels": Object {
+                          "version": "v2",
                         },
                       },
                     ]
@@ -1561,8 +1561,8 @@ ShallowWrapper {
                   route={
                     Array [
                       Object {
-                        "labels": Map {
-                          "version" => "v1",
+                        "labels": Object {
+                          "version": "v1",
                         },
                       },
                     ]
@@ -1634,8 +1634,8 @@ ShallowWrapper {
                   route={
                     Array [
                       Object {
-                        "labels": Map {
-                          "version" => "v2",
+                        "labels": Object {
+                          "version": "v2",
                         },
                       },
                     ]
@@ -1719,8 +1719,8 @@ ShallowWrapper {
                     route={
                       Array [
                         Object {
-                          "labels": Map {
-                            "version" => "v1",
+                          "labels": Object {
+                            "version": "v1",
                           },
                         },
                       ]
@@ -1792,8 +1792,8 @@ ShallowWrapper {
                     route={
                       Array [
                         Object {
-                          "labels": Map {
-                            "version" => "v2",
+                          "labels": Object {
+                            "version": "v2",
                           },
                         },
                       ]
@@ -1876,8 +1876,8 @@ ShallowWrapper {
                       route={
                         Array [
                           Object {
-                            "labels": Map {
-                              "version" => "v1",
+                            "labels": Object {
+                              "version": "v1",
                             },
                           },
                         ]
@@ -2151,8 +2151,8 @@ ShallowWrapper {
                       route={
                         Array [
                           Object {
-                            "labels": Map {
-                              "version" => "v1",
+                            "labels": Object {
+                              "version": "v1",
                             },
                           },
                         ]
@@ -2174,8 +2174,8 @@ ShallowWrapper {
                       "name": "reviews-default",
                       "route": Array [
                         Object {
-                          "labels": Map {
-                            "version" => "v1",
+                          "labels": Object {
+                            "version": "v1",
                           },
                         },
                       ],
@@ -2255,8 +2255,8 @@ ShallowWrapper {
                       route={
                         Array [
                           Object {
-                            "labels": Map {
-                              "version" => "v2",
+                            "labels": Object {
+                              "version": "v2",
                             },
                           },
                         ]
@@ -2530,8 +2530,8 @@ ShallowWrapper {
                       route={
                         Array [
                           Object {
-                            "labels": Map {
-                              "version" => "v2",
+                            "labels": Object {
+                              "version": "v2",
                             },
                           },
                         ]
@@ -2553,8 +2553,8 @@ ShallowWrapper {
                       "name": "reviews-test-v2",
                       "route": Array [
                         Object {
-                          "labels": Map {
-                            "version" => "v2",
+                          "labels": Object {
+                            "version": "v2",
                           },
                         },
                       ],

--- a/src/pages/ServiceDetails/__tests__/__snapshots__/ServiceInfo.test.tsx.snap
+++ b/src/pages/ServiceDetails/__tests__/__snapshots__/ServiceInfo.test.tsx.snap
@@ -168,7 +168,11 @@ ShallowWrapper {
                 health={undefined}
                 ip="172.30.78.33"
                 istio_sidecar={false}
-                labels={Map {}}
+                labels={
+                  Object {
+                    "app": "reviews",
+                  }
+                }
                 name="reviews"
                 ports={
                   Array [
@@ -198,7 +202,7 @@ ShallowWrapper {
               xs={12}
             >
               <Uncontrolled(TabContainer)
-                defaultActiveKey={1}
+                defaultActiveKey={0}
                 id="service-tabs"
               >
                 <div>
@@ -209,6 +213,13 @@ ShallowWrapper {
                     pullRight={false}
                     stacked={false}
                   >
+                    <NavItem
+                      active={false}
+                      disabled={false}
+                      eventKey={0}
+                    >
+                      Pods (0)
+                    </NavItem>
                     <NavItem
                       active={false}
                       disabled={false}
@@ -259,6 +270,10 @@ ShallowWrapper {
                     mountOnEnter={false}
                     unmountOnExit={false}
                   >
+                    <TabPane
+                      bsClass="tab-pane"
+                      eventKey={0}
+                    />
                     <TabPane
                       bsClass="tab-pane"
                       eventKey={1}
@@ -395,7 +410,11 @@ ShallowWrapper {
                   health={undefined}
                   ip="172.30.78.33"
                   istio_sidecar={false}
-                  labels={Map {}}
+                  labels={
+                    Object {
+                      "app": "reviews",
+                    }
+                  }
                   name="reviews"
                   ports={
                     Array [
@@ -425,7 +444,7 @@ ShallowWrapper {
                 xs={12}
               >
                 <Uncontrolled(TabContainer)
-                  defaultActiveKey={1}
+                  defaultActiveKey={0}
                   id="service-tabs"
                 >
                   <div>
@@ -436,6 +455,13 @@ ShallowWrapper {
                       pullRight={false}
                       stacked={false}
                     >
+                      <NavItem
+                        active={false}
+                        disabled={false}
+                        eventKey={0}
+                      >
+                        Pods (0)
+                      </NavItem>
                       <NavItem
                         active={false}
                         disabled={false}
@@ -486,6 +512,10 @@ ShallowWrapper {
                       mountOnEnter={false}
                       unmountOnExit={false}
                     >
+                      <TabPane
+                        bsClass="tab-pane"
+                        eventKey={0}
+                      />
                       <TabPane
                         bsClass="tab-pane"
                         eventKey={1}
@@ -616,7 +646,11 @@ ShallowWrapper {
                   health={undefined}
                   ip="172.30.78.33"
                   istio_sidecar={false}
-                  labels={Map {}}
+                  labels={
+                    Object {
+                      "app": "reviews",
+                    }
+                  }
                   name="reviews"
                   ports={
                     Array [
@@ -676,7 +710,11 @@ ShallowWrapper {
                   health={undefined}
                   ip="172.30.78.33"
                   istio_sidecar={false}
-                  labels={Map {}}
+                  labels={
+                    Object {
+                      "app": "reviews",
+                    }
+                  }
                   name="reviews"
                   ports={
                     Array [
@@ -734,7 +772,9 @@ ShallowWrapper {
                   "health": undefined,
                   "ip": "172.30.78.33",
                   "istio_sidecar": false,
-                  "labels": Map {},
+                  "labels": Object {
+                    "app": "reviews",
+                  },
                   "name": "reviews",
                   "ports": Array [
                     Object {
@@ -769,7 +809,7 @@ ShallowWrapper {
                 xs={12}
               >
                 <Uncontrolled(TabContainer)
-                  defaultActiveKey={1}
+                  defaultActiveKey={0}
                   id="service-tabs"
                 >
                   <div>
@@ -780,6 +820,13 @@ ShallowWrapper {
                       pullRight={false}
                       stacked={false}
                     >
+                      <NavItem
+                        active={false}
+                        disabled={false}
+                        eventKey={0}
+                      >
+                        Pods (0)
+                      </NavItem>
                       <NavItem
                         active={false}
                         disabled={false}
@@ -830,6 +877,10 @@ ShallowWrapper {
                       mountOnEnter={false}
                       unmountOnExit={false}
                     >
+                      <TabPane
+                        bsClass="tab-pane"
+                        eventKey={0}
+                      />
                       <TabPane
                         bsClass="tab-pane"
                         eventKey={1}
@@ -916,7 +967,7 @@ ShallowWrapper {
               "props": Object {
                 "bsClass": "col",
                 "children": <Uncontrolled(TabContainer)
-                  defaultActiveKey={1}
+                  defaultActiveKey={0}
                   id="service-tabs"
                 >
                   <div>
@@ -927,6 +978,13 @@ ShallowWrapper {
                       pullRight={false}
                       stacked={false}
                     >
+                      <NavItem
+                        active={false}
+                        disabled={false}
+                        eventKey={0}
+                      >
+                        Pods (0)
+                      </NavItem>
                       <NavItem
                         active={false}
                         disabled={false}
@@ -977,6 +1035,10 @@ ShallowWrapper {
                       mountOnEnter={false}
                       unmountOnExit={false}
                     >
+                      <TabPane
+                        bsClass="tab-pane"
+                        eventKey={0}
+                      />
                       <TabPane
                         bsClass="tab-pane"
                         eventKey={1}
@@ -1074,6 +1136,13 @@ ShallowWrapper {
                       <NavItem
                         active={false}
                         disabled={false}
+                        eventKey={0}
+                      >
+                        Pods (0)
+                      </NavItem>
+                      <NavItem
+                        active={false}
+                        disabled={false}
                         eventKey={1}
                       >
                         Deployments (0)
@@ -1121,6 +1190,10 @@ ShallowWrapper {
                       mountOnEnter={false}
                       unmountOnExit={false}
                     >
+                      <TabPane
+                        bsClass="tab-pane"
+                        eventKey={0}
+                      />
                       <TabPane
                         bsClass="tab-pane"
                         eventKey={1}
@@ -1194,7 +1267,7 @@ ShallowWrapper {
                       />
                     </TabContent>
                   </div>,
-                  "defaultActiveKey": 1,
+                  "defaultActiveKey": 0,
                   "id": "service-tabs",
                 },
                 "ref": null,
@@ -1211,6 +1284,13 @@ ShallowWrapper {
                         pullRight={false}
                         stacked={false}
                       >
+                        <NavItem
+                          active={false}
+                          disabled={false}
+                          eventKey={0}
+                        >
+                          Pods (0)
+                        </NavItem>
                         <NavItem
                           active={false}
                           disabled={false}
@@ -1261,6 +1341,10 @@ ShallowWrapper {
                         mountOnEnter={false}
                         unmountOnExit={false}
                       >
+                        <TabPane
+                          bsClass="tab-pane"
+                          eventKey={0}
+                        />
                         <TabPane
                           bsClass="tab-pane"
                           eventKey={1}
@@ -1347,6 +1431,13 @@ ShallowWrapper {
                           <NavItem
                             active={false}
                             disabled={false}
+                            eventKey={0}
+                          >
+                            Pods (0)
+                          </NavItem>,
+                          <NavItem
+                            active={false}
+                            disabled={false}
                             eventKey={1}
                           >
                             Deployments (0)
@@ -1394,6 +1485,20 @@ ShallowWrapper {
                       },
                       "ref": null,
                       "rendered": Array [
+                        Object {
+                          "instance": null,
+                          "key": undefined,
+                          "nodeType": "class",
+                          "props": Object {
+                            "active": false,
+                            "children": "Pods (0)",
+                            "disabled": false,
+                            "eventKey": 0,
+                          },
+                          "ref": null,
+                          "rendered": "Pods (0)",
+                          "type": [Function],
+                        },
                         Object {
                           "instance": null,
                           "key": undefined,
@@ -1491,6 +1596,10 @@ ShallowWrapper {
                         "children": Array [
                           <TabPane
                             bsClass="tab-pane"
+                            eventKey={0}
+                          />,
+                          <TabPane
+                            bsClass="tab-pane"
                             eventKey={1}
                           />,
                           <TabPane
@@ -1567,6 +1676,19 @@ ShallowWrapper {
                       },
                       "ref": null,
                       "rendered": Array [
+                        Object {
+                          "instance": null,
+                          "key": undefined,
+                          "nodeType": "class",
+                          "props": Object {
+                            "bsClass": "tab-pane",
+                            "children": false,
+                            "eventKey": 0,
+                          },
+                          "ref": null,
+                          "rendered": false,
+                          "type": [Function],
+                        },
                         Object {
                           "instance": null,
                           "key": undefined,
@@ -1818,7 +1940,11 @@ ShallowWrapper {
                   health={undefined}
                   ip="172.30.78.33"
                   istio_sidecar={false}
-                  labels={Map {}}
+                  labels={
+                    Object {
+                      "app": "reviews",
+                    }
+                  }
                   name="reviews"
                   ports={
                     Array [
@@ -1848,7 +1974,7 @@ ShallowWrapper {
                 xs={12}
               >
                 <Uncontrolled(TabContainer)
-                  defaultActiveKey={1}
+                  defaultActiveKey={0}
                   id="service-tabs"
                 >
                   <div>
@@ -1859,6 +1985,13 @@ ShallowWrapper {
                       pullRight={false}
                       stacked={false}
                     >
+                      <NavItem
+                        active={false}
+                        disabled={false}
+                        eventKey={0}
+                      >
+                        Pods (0)
+                      </NavItem>
                       <NavItem
                         active={false}
                         disabled={false}
@@ -1909,6 +2042,10 @@ ShallowWrapper {
                       mountOnEnter={false}
                       unmountOnExit={false}
                     >
+                      <TabPane
+                        bsClass="tab-pane"
+                        eventKey={0}
+                      />
                       <TabPane
                         bsClass="tab-pane"
                         eventKey={1}
@@ -2045,7 +2182,11 @@ ShallowWrapper {
                     health={undefined}
                     ip="172.30.78.33"
                     istio_sidecar={false}
-                    labels={Map {}}
+                    labels={
+                      Object {
+                        "app": "reviews",
+                      }
+                    }
                     name="reviews"
                     ports={
                       Array [
@@ -2075,7 +2216,7 @@ ShallowWrapper {
                   xs={12}
                 >
                   <Uncontrolled(TabContainer)
-                    defaultActiveKey={1}
+                    defaultActiveKey={0}
                     id="service-tabs"
                   >
                     <div>
@@ -2086,6 +2227,13 @@ ShallowWrapper {
                         pullRight={false}
                         stacked={false}
                       >
+                        <NavItem
+                          active={false}
+                          disabled={false}
+                          eventKey={0}
+                        >
+                          Pods (0)
+                        </NavItem>
                         <NavItem
                           active={false}
                           disabled={false}
@@ -2136,6 +2284,10 @@ ShallowWrapper {
                         mountOnEnter={false}
                         unmountOnExit={false}
                       >
+                        <TabPane
+                          bsClass="tab-pane"
+                          eventKey={0}
+                        />
                         <TabPane
                           bsClass="tab-pane"
                           eventKey={1}
@@ -2266,7 +2418,11 @@ ShallowWrapper {
                     health={undefined}
                     ip="172.30.78.33"
                     istio_sidecar={false}
-                    labels={Map {}}
+                    labels={
+                      Object {
+                        "app": "reviews",
+                      }
+                    }
                     name="reviews"
                     ports={
                       Array [
@@ -2326,7 +2482,11 @@ ShallowWrapper {
                     health={undefined}
                     ip="172.30.78.33"
                     istio_sidecar={false}
-                    labels={Map {}}
+                    labels={
+                      Object {
+                        "app": "reviews",
+                      }
+                    }
                     name="reviews"
                     ports={
                       Array [
@@ -2384,7 +2544,9 @@ ShallowWrapper {
                     "health": undefined,
                     "ip": "172.30.78.33",
                     "istio_sidecar": false,
-                    "labels": Map {},
+                    "labels": Object {
+                      "app": "reviews",
+                    },
                     "name": "reviews",
                     "ports": Array [
                       Object {
@@ -2419,7 +2581,7 @@ ShallowWrapper {
                   xs={12}
                 >
                   <Uncontrolled(TabContainer)
-                    defaultActiveKey={1}
+                    defaultActiveKey={0}
                     id="service-tabs"
                   >
                     <div>
@@ -2430,6 +2592,13 @@ ShallowWrapper {
                         pullRight={false}
                         stacked={false}
                       >
+                        <NavItem
+                          active={false}
+                          disabled={false}
+                          eventKey={0}
+                        >
+                          Pods (0)
+                        </NavItem>
                         <NavItem
                           active={false}
                           disabled={false}
@@ -2480,6 +2649,10 @@ ShallowWrapper {
                         mountOnEnter={false}
                         unmountOnExit={false}
                       >
+                        <TabPane
+                          bsClass="tab-pane"
+                          eventKey={0}
+                        />
                         <TabPane
                           bsClass="tab-pane"
                           eventKey={1}
@@ -2566,7 +2739,7 @@ ShallowWrapper {
                 "props": Object {
                   "bsClass": "col",
                   "children": <Uncontrolled(TabContainer)
-                    defaultActiveKey={1}
+                    defaultActiveKey={0}
                     id="service-tabs"
                   >
                     <div>
@@ -2577,6 +2750,13 @@ ShallowWrapper {
                         pullRight={false}
                         stacked={false}
                       >
+                        <NavItem
+                          active={false}
+                          disabled={false}
+                          eventKey={0}
+                        >
+                          Pods (0)
+                        </NavItem>
                         <NavItem
                           active={false}
                           disabled={false}
@@ -2627,6 +2807,10 @@ ShallowWrapper {
                         mountOnEnter={false}
                         unmountOnExit={false}
                       >
+                        <TabPane
+                          bsClass="tab-pane"
+                          eventKey={0}
+                        />
                         <TabPane
                           bsClass="tab-pane"
                           eventKey={1}
@@ -2724,6 +2908,13 @@ ShallowWrapper {
                         <NavItem
                           active={false}
                           disabled={false}
+                          eventKey={0}
+                        >
+                          Pods (0)
+                        </NavItem>
+                        <NavItem
+                          active={false}
+                          disabled={false}
                           eventKey={1}
                         >
                           Deployments (0)
@@ -2771,6 +2962,10 @@ ShallowWrapper {
                         mountOnEnter={false}
                         unmountOnExit={false}
                       >
+                        <TabPane
+                          bsClass="tab-pane"
+                          eventKey={0}
+                        />
                         <TabPane
                           bsClass="tab-pane"
                           eventKey={1}
@@ -2844,7 +3039,7 @@ ShallowWrapper {
                         />
                       </TabContent>
                     </div>,
-                    "defaultActiveKey": 1,
+                    "defaultActiveKey": 0,
                     "id": "service-tabs",
                   },
                   "ref": null,
@@ -2861,6 +3056,13 @@ ShallowWrapper {
                           pullRight={false}
                           stacked={false}
                         >
+                          <NavItem
+                            active={false}
+                            disabled={false}
+                            eventKey={0}
+                          >
+                            Pods (0)
+                          </NavItem>
                           <NavItem
                             active={false}
                             disabled={false}
@@ -2911,6 +3113,10 @@ ShallowWrapper {
                           mountOnEnter={false}
                           unmountOnExit={false}
                         >
+                          <TabPane
+                            bsClass="tab-pane"
+                            eventKey={0}
+                          />
                           <TabPane
                             bsClass="tab-pane"
                             eventKey={1}
@@ -2997,6 +3203,13 @@ ShallowWrapper {
                             <NavItem
                               active={false}
                               disabled={false}
+                              eventKey={0}
+                            >
+                              Pods (0)
+                            </NavItem>,
+                            <NavItem
+                              active={false}
+                              disabled={false}
                               eventKey={1}
                             >
                               Deployments (0)
@@ -3044,6 +3257,20 @@ ShallowWrapper {
                         },
                         "ref": null,
                         "rendered": Array [
+                          Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "class",
+                            "props": Object {
+                              "active": false,
+                              "children": "Pods (0)",
+                              "disabled": false,
+                              "eventKey": 0,
+                            },
+                            "ref": null,
+                            "rendered": "Pods (0)",
+                            "type": [Function],
+                          },
                           Object {
                             "instance": null,
                             "key": undefined,
@@ -3141,6 +3368,10 @@ ShallowWrapper {
                           "children": Array [
                             <TabPane
                               bsClass="tab-pane"
+                              eventKey={0}
+                            />,
+                            <TabPane
+                              bsClass="tab-pane"
                               eventKey={1}
                             />,
                             <TabPane
@@ -3217,6 +3448,19 @@ ShallowWrapper {
                         },
                         "ref": null,
                         "rendered": Array [
+                          Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "class",
+                            "props": Object {
+                              "bsClass": "tab-pane",
+                              "children": false,
+                              "eventKey": 0,
+                            },
+                            "ref": null,
+                            "rendered": false,
+                            "type": [Function],
+                          },
                           Object {
                             "instance": null,
                             "key": undefined,

--- a/src/types/ServiceInfo.ts
+++ b/src/types/ServiceInfo.ts
@@ -17,10 +17,19 @@ export interface Port {
   name: string;
 }
 
+export interface Pod {
+  name: string;
+  annotations?: { [key: string]: string };
+  labels?: { [key: string]: string };
+  created_at: string;
+  k8sCreatedBy?: any;
+  istioSideCar?: any;
+}
+
 export interface Deployment {
   name: string;
-  template_annotations?: any;
-  labels?: Map<string, string>;
+  template_annotations?: { [key: string]: string };
+  labels?: { [key: string]: string };
   created_at: string;
   resource_version: string;
   replicas: number;
@@ -31,7 +40,7 @@ export interface Deployment {
 
 export interface Autoscaler {
   name: string;
-  labels?: Map<string, string>;
+  labels?: { [key: string]: string };
   min_replicas: number;
   max_replicas: number;
   target_cpu_utilization_percentage: number;
@@ -66,7 +75,7 @@ export interface IstioService {
   namespace?: string;
   domain?: string;
   service?: string;
-  labels?: Map<String, String>;
+  labels?: { [key: string]: string };
 }
 
 export interface MatchCondition {
@@ -92,7 +101,7 @@ export interface StringMatch {
 }
 
 export interface DestinationWeight {
-  labels: Map<string, string>;
+  labels: { [key: string]: string };
   weight?: number;
 }
 
@@ -332,20 +341,18 @@ export interface DestinationRule {
 
 // Istio Sidecar
 
-export const hasIstioSidecar = (deployments: Deployment[]) => {
-  if (deployments && deployments.length > 0) {
-    for (let i = 0; i < deployments.length; i++) {
-      let annotations = deployments[i].template_annotations;
-      if (annotations && annotations['sidecar.istio.io/status']) {
-        return true;
-      }
-    }
+export const hasIstioSidecar = (pods?: Pod[]) => {
+  if (pods) {
+    const hasAny = pods.find(
+      pod => pod.annotations !== undefined && pod.annotations.hasOwnProperty('sidecar.istio.io/status')
+    );
+    return hasAny !== undefined;
   }
   return false;
 };
 
 export interface ServiceDetailsInfo {
-  labels?: Map<string, string>;
+  labels?: { [key: string]: string };
   type: string;
   name: string;
   created_at: string;
@@ -354,11 +361,33 @@ export interface ServiceDetailsInfo {
   ports?: Port[];
   endpoints?: Endpoints[];
   istio_sidecar: boolean;
+  pods?: Pod[];
   deployments?: Deployment[];
   routeRules?: RouteRule[];
   destinationPolicies?: DestinationPolicy[];
   virtualServices?: VirtualService[];
   destinationRules?: DestinationRule[];
+  dependencies?: Map<string, string[]>;
+  health?: Health;
+}
+
+// Temporary interface due to tiny differences between the model from REST API and the ServiceDetailsInfo used above.
+//  They should be cleaned & merged asap
+export interface ServiceDetailsInfoFromAPI {
+  labels?: { [key: string]: string };
+  type: string;
+  name: string;
+  created_at: string;
+  resource_version: string;
+  ip: string;
+  ports?: Port[];
+  endpoints?: Endpoints[];
+  pods?: Pod[];
+  deployments?: Deployment[];
+  route_rules?: RouteRule[];
+  destination_policies?: DestinationPolicy[];
+  virtual_services?: VirtualService[];
+  destination_rules?: DestinationRule[];
   dependencies?: Map<string, string[]>;
   health?: Health;
 }

--- a/src/types/ServiceInfo.ts
+++ b/src/types/ServiceInfo.ts
@@ -19,11 +19,21 @@ export interface Port {
 
 export interface Pod {
   name: string;
-  annotations?: { [key: string]: string };
   labels?: { [key: string]: string };
-  created_at: string;
-  k8sCreatedBy?: any;
-  istioSideCar?: any;
+  createdAt: string;
+  createdBy?: Reference;
+  istioContainers?: ContainerInfo[];
+  istioInitContainers?: ContainerInfo[];
+}
+
+export interface Reference {
+  name: string;
+  kind: string;
+}
+
+export interface ContainerInfo {
+  name: string;
+  image: string;
 }
 
 export interface Deployment {
@@ -343,10 +353,7 @@ export interface DestinationRule {
 
 export const hasIstioSidecar = (pods?: Pod[]) => {
   if (pods) {
-    const hasAny = pods.find(
-      pod => pod.annotations !== undefined && pod.annotations.hasOwnProperty('sidecar.istio.io/status')
-    );
-    return hasAny !== undefined;
+    return pods.find(pod => pod.istioContainers != null) !== undefined;
   }
   return false;
 };


### PR DESCRIPTION
Also now hasIstioSidecar function runs from pods rather than deployments, since not all pods may come from deployments.

Refactoring:
- Create an interface for service details model coming from API. It should be temporary (I'll create a JIRA to merge it with the model class used in ts _[edit: [KIALI-768](https://issues.jboss.org/browse/KIALI-768)]_). It's "ServiceDetailsInfoFromAPI"
- In model coming from the API, replace some "Map" fields with "raw" key-value maps ({ [key: string]: string }). Using Map is incorrect and leads to potential bugs as functions defined in the Map class are not present in runtime, leading to compile-time/runtime mismatch. There was actually a bug where "Map.size" was invoked and never returned the intended result so service labels were never displayed in service details.
- Remove 90% of the state in ServiceInfo component since it was duplicated from props and never modified, so useless as state.