### PR TITLE
KIALI-762 Fix builds failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,8 @@ before_install:
 script:
   - yarn prettier --list-different &&
     yarn build &&
-    yarn test --coverage
+    yarn test
   - ./run_itest.sh
-after_success:
-  - cat ./coverage/lcov.info | coveralls
 before_deploy:
   - yarn set-snapshot-version $TRAVIS_BUILD_NUMBER
 deploy:

--- a/README.adoc
+++ b/README.adoc
@@ -3,7 +3,6 @@
 
 toc::[]
 = Kiali UI
-image:https://coveralls.io/repos/github/kiali/kiali-ui/badge.svg?branch=master[Coverage Status, link=https://coveralls.io/github/kiali/kiali-ui?branch=master]
 
 == Introduction
 


### PR DESCRIPTION
 Travis builds are getting stuck on "yarn test --coverage"
 --coverage flags makes the test [slower](https://github.com/wmonk/create-react-app-typescript/blob/master/packages/react-scripts/template/README.md#coverage-reporting) there might be something wrong with our tests that sometimes makes travis unhappy

 Disable for now while we check what is really affecting our tests, this should run without errors and i'll restart the test a few times to confirm no errors are there.

