### PR TITLE
Remove some warnings that appear on serviceinfo page

### DIFF
--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -248,16 +248,14 @@ class ServiceDetails extends React.Component<RouteComponentProps<ServiceId>, Ser
             <div>
               <Nav bsClass="nav nav-tabs nav-tabs-pf">
                 <NavItem eventKey={1}>
-                  <div dangerouslySetInnerHTML={{ __html: 'Info' }} />
+                  <div>Info</div>
                 </NavItem>
                 <NavItem eventKey={2}>
-                  <div dangerouslySetInnerHTML={{ __html: 'Metrics' }} />
+                  <div>Metrics</div>
                 </NavItem>
-                <li role="presentation">
-                  <a href={this.state.jaegerUri} target="_blank">
-                    <div dangerouslySetInnerHTML={{ __html: 'Traces' }} />
-                  </a>
-                </li>
+                <NavItem href={this.state.jaegerUri}>
+                  <div>Traces</div>
+                </NavItem>
               </Nav>
               <TabContent>
                 <TabPane eventKey={1}>

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoRoutes.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoRoutes.tsx
@@ -30,7 +30,7 @@ class ServiceInfoRoutes extends React.Component<ServiceInfoRoutesProps> {
                     if (servicename.length > 0 && namespace.length > 0) {
                       let to = '/namespaces/' + namespace + '/services/' + servicename;
                       return (
-                        <Link key={to} to={to}>
+                        <Link key={to + key + dependency} to={to}>
                           <li key={'dependencies_' + u + '_dependency_' + i}>{dependency}</li>
                         </Link>
                       );


### PR DESCRIPTION
 - Non unique key for Link (two services pointing to same service triggered it)
 - activeHref, activeKey set to <li>, Nav can only hold <NavItem> [1]

I also removed the `dangerouslySetInnerHTML` not sure if is needed for something else.

[1] https://github.com/react-bootstrap/react-bootstrap/issues/2199#issuecomment-245167620