### PR TITLE
Fix bad use of Map object on getServiceValidations scenario

### DIFF
--- a/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -106,12 +106,6 @@ class ServiceInfo extends React.Component<ServiceDetailsId, ServiceInfoState> {
     return sorted;
   }
 
-  validationsFor(objectType: string) {
-    return this.state.validations && typeof this.state.validations.get === 'function'
-      ? this.state.validations.get(objectType)
-      : null;
-  }
-
   render() {
     let deployments = this.state.deployments || [];
     let dependencies = this.state.dependencies || new Map();
@@ -177,7 +171,7 @@ class ServiceInfo extends React.Component<ServiceDetailsId, ServiceInfoState> {
                         <ServiceInfoRouteRules
                           routeRules={routeRules}
                           editorLink={editorLink}
-                          validations={this.validationsFor('routerule') || new Map()}
+                          validations={this.state.validations!['routerule']}
                         />
                       )}
                     </TabPane>

--- a/src/pages/ServiceDetails/__tests__/__snapshots__/ServiceInfo.test.tsx.snap
+++ b/src/pages/ServiceDetails/__tests__/__snapshots__/ServiceInfo.test.tsx.snap
@@ -315,7 +315,7 @@ ShallowWrapper {
                             },
                           ]
                         }
-                        validations={Map {}}
+                        validations={undefined}
                       />
                     </TabPane>
                     <TabPane
@@ -542,7 +542,7 @@ ShallowWrapper {
                               },
                             ]
                           }
-                          validations={Map {}}
+                          validations={undefined}
                         />
                       </TabPane>
                       <TabPane
@@ -886,7 +886,7 @@ ShallowWrapper {
                               },
                             ]
                           }
-                          validations={Map {}}
+                          validations={undefined}
                         />
                       </TabPane>
                       <TabPane
@@ -1033,7 +1033,7 @@ ShallowWrapper {
                               },
                             ]
                           }
-                          validations={Map {}}
+                          validations={undefined}
                         />
                       </TabPane>
                       <TabPane
@@ -1177,7 +1177,7 @@ ShallowWrapper {
                               },
                             ]
                           }
-                          validations={Map {}}
+                          validations={undefined}
                         />
                       </TabPane>
                       <TabPane
@@ -1317,7 +1317,7 @@ ShallowWrapper {
                                 },
                               ]
                             }
-                            validations={Map {}}
+                            validations={undefined}
                           />
                         </TabPane>
                         <TabPane
@@ -1545,7 +1545,7 @@ ShallowWrapper {
                                   },
                                 ]
                               }
-                              validations={Map {}}
+                              validations={undefined}
                             />
                           </TabPane>,
                           <TabPane
@@ -1643,7 +1643,7 @@ ShallowWrapper {
                                   },
                                 ]
                               }
-                              validations={Map {}}
+                              validations={undefined}
                             />,
                             "eventKey": 3,
                           },
@@ -1694,7 +1694,7 @@ ShallowWrapper {
                                   ],
                                 },
                               ],
-                              "validations": Map {},
+                              "validations": undefined,
                             },
                             "ref": null,
                             "rendered": null,
@@ -1965,7 +1965,7 @@ ShallowWrapper {
                               },
                             ]
                           }
-                          validations={Map {}}
+                          validations={undefined}
                         />
                       </TabPane>
                       <TabPane
@@ -2192,7 +2192,7 @@ ShallowWrapper {
                                 },
                               ]
                             }
-                            validations={Map {}}
+                            validations={undefined}
                           />
                         </TabPane>
                         <TabPane
@@ -2536,7 +2536,7 @@ ShallowWrapper {
                                 },
                               ]
                             }
-                            validations={Map {}}
+                            validations={undefined}
                           />
                         </TabPane>
                         <TabPane
@@ -2683,7 +2683,7 @@ ShallowWrapper {
                                 },
                               ]
                             }
-                            validations={Map {}}
+                            validations={undefined}
                           />
                         </TabPane>
                         <TabPane
@@ -2827,7 +2827,7 @@ ShallowWrapper {
                                 },
                               ]
                             }
-                            validations={Map {}}
+                            validations={undefined}
                           />
                         </TabPane>
                         <TabPane
@@ -2967,7 +2967,7 @@ ShallowWrapper {
                                   },
                                 ]
                               }
-                              validations={Map {}}
+                              validations={undefined}
                             />
                           </TabPane>
                           <TabPane
@@ -3195,7 +3195,7 @@ ShallowWrapper {
                                     },
                                   ]
                                 }
-                                validations={Map {}}
+                                validations={undefined}
                               />
                             </TabPane>,
                             <TabPane
@@ -3293,7 +3293,7 @@ ShallowWrapper {
                                     },
                                   ]
                                 }
-                                validations={Map {}}
+                                validations={undefined}
                               />,
                               "eventKey": 3,
                             },
@@ -3344,7 +3344,7 @@ ShallowWrapper {
                                     ],
                                   },
                                 ],
-                                "validations": Map {},
+                                "validations": undefined,
                               },
                               "ref": null,
                               "rendered": null,

--- a/src/services/__mockData__/getServiceValidations.json
+++ b/src/services/__mockData__/getServiceValidations.json
@@ -1,0 +1,30 @@
+{
+  "pod": {
+    "reviews-v1-3758685241-z4ppr": {
+      "name": "reviews-v1-3758685241-z4ppr",
+      "object_type": "pod",
+      "valid": true,
+      "checks": null
+    },
+    "reviews-v2-29632839-dsl5c": {
+      "name": "reviews-v2-29632839-dsl5c",
+      "object_type": "pod",
+      "valid": true,
+      "checks": null
+    },
+    "reviews-v3-2285656649-f9qgb": {
+      "name": "reviews-v3-2285656649-f9qgb",
+      "object_type": "pod",
+      "valid": true,
+      "checks": null
+    }
+  },
+  "routerule": {
+    "reviews-default": {
+      "name": "reviews-default",
+      "object_type": "routerule",
+      "valid": true,
+      "checks": null
+    }
+  }
+}

--- a/src/services/__mocks__/Api.ts
+++ b/src/services/__mocks__/Api.ts
@@ -45,6 +45,10 @@ export const getServiceDetail = (namespace: String, service: String) => {
   return mockPromiseFromFile(`./src/services/__mockData__/getServiceDetail.json`);
 };
 
+export const getServiceValidations = (namespace: String, service: String) => {
+  return mockPromiseFromFile(`./src/services/__mockData__/getServiceValidations.json`);
+};
+
 export const getIstioConfig = (namespace: String) => {
   if (namespace === 'bookinfo') {
     return mockPromiseFromFile(`./src/services/__mockData__/getIstioConfigBookinfo.json`);

--- a/src/services/__tests__/Api.test.tsx
+++ b/src/services/__tests__/Api.test.tsx
@@ -91,3 +91,13 @@ describe('#GetIstioConfigDetail using Promises', () => {
     });
   });
 });
+
+describe('#GetServiceValidations using Promises', () => {
+  it('should load istio service validation data', () => {
+    return API.getServiceValidations('bookinfo', 'reviews').then(({ data }) => {
+      expect(data).toBeDefined();
+      expect(data!['pod']).toBeDefined();
+      expect(data!['routerule']).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
PR #360 will refactor Map() object in all scenarios.
This is a continuation of #364 to use a plain js object instead of Map.
Also, added additional tests for getServiceValidations.