### PR TITLE
KIALI-822: Show error on service graph when encountered

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -18,6 +18,7 @@ import { ServiceGraphActions } from '../../actions/ServiceGraphActions';
 type CytoscapeGraphType = {
   elements?: any;
   isLoading?: boolean;
+  error?: any;
   edgeLabelMode: EdgeLabelMode;
   showNodeLabels: boolean;
   showCircuitBreakers: boolean;
@@ -64,6 +65,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
     this.newLayout = this.props.graphLayout !== nextProps.graphLayout ? nextProps.graphLayout : '';
     return (
       this.props.isLoading !== nextProps.isLoading ||
+      this.props.error !== nextProps.error ||
       this.props.graphLayout !== nextProps.graphLayout ||
       this.props.edgeLabelMode !== nextProps.edgeLabelMode ||
       this.props.showNodeLabels !== nextProps.showNodeLabels ||
@@ -96,6 +98,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
             elements={this.props.elements}
             namespace={this.props.namespace.name}
             action={this.props.refresh}
+            error={this.props.error}
           >
             <CytoscapeReactWrapper
               ref={e => {

--- a/src/components/CytoscapeGraph/EmptyGraphLayout.tsx
+++ b/src/components/CytoscapeGraph/EmptyGraphLayout.tsx
@@ -1,11 +1,19 @@
 import * as React from 'react';
-import { Button, EmptyState, EmptyStateTitle, EmptyStateInfo, EmptyStateAction } from 'patternfly-react';
+import {
+  Button,
+  EmptyState,
+  EmptyStateIcon,
+  EmptyStateTitle,
+  EmptyStateInfo,
+  EmptyStateAction
+} from 'patternfly-react';
 import { style } from 'typestyle';
 
 type EmptyGraphLayoutProps = {
   elements: any;
   namespace: string;
   action: any;
+  error: any;
 };
 
 const emptyStateStyle = style({
@@ -19,7 +27,15 @@ type EmptyGraphLayoutState = {};
 
 export default class EmptyGraphLayout extends React.Component<EmptyGraphLayoutProps, EmptyGraphLayoutState> {
   render() {
-    if (
+    if (this.props.error) {
+      return (
+        <EmptyState className={emptyStateStyle}>
+          <EmptyStateIcon name="error-circle-o" />
+          <EmptyStateTitle>Error Fetching Service Graph</EmptyStateTitle>
+          <EmptyStateInfo>{this.props.error}</EmptyStateInfo>
+        </EmptyState>
+      );
+    } else if (
       !this.props.elements ||
       this.props.elements.length < 1 ||
       !this.props.elements.nodes ||

--- a/src/containers/ServiceGraphPageContainer.ts
+++ b/src/containers/ServiceGraphPageContainer.ts
@@ -10,6 +10,7 @@ const mapStateToProps = (state: KialiAppState) => ({
   graphTimestamp: state.serviceGraph.graphDataTimestamp,
   graphData: state.serviceGraph.graphData,
   isLoading: state.serviceGraph.isLoading,
+  error: state.serviceGraph.error,
   summaryData: state.serviceGraph.sidePanelInfo
     ? {
         summaryTarget: state.serviceGraph.sidePanelInfo.graphReference,

--- a/src/pages/ServiceGraph/ServiceGraphPage.tsx
+++ b/src/pages/ServiceGraph/ServiceGraphPage.tsx
@@ -21,6 +21,7 @@ type ServiceGraphPageProps = GraphParamsType & {
   graphTimestamp: string;
   graphData: any;
   isLoading: boolean;
+  error: any;
   hideLegend: boolean;
   isReady: boolean;
   fetchGraphData: (namespace: Namespace, graphDuration: Duration) => any;
@@ -87,6 +88,7 @@ export default class ServiceGraphPage extends React.Component<ServiceGraphPagePr
           <CytoscapeGraph
             {...graphParams}
             isLoading={this.props.isLoading}
+            error={this.props.error}
             elements={this.props.graphData}
             refresh={this.handleRefreshClick}
           />

--- a/src/reducers/ServiceGraphDataState.ts
+++ b/src/reducers/ServiceGraphDataState.ts
@@ -5,6 +5,7 @@ import FilterStateReducer from './ServiceGraphFilterState';
 
 const INITIAL_STATE: any = {
   isLoading: false,
+  error: null,
   graphDataTimestamp: 0,
   graphData: {},
   sidePanelInfo: null,
@@ -23,6 +24,7 @@ const serviceGraphDataState = (state: ServiceGraphState = INITIAL_STATE, action)
     case ServiceGraphDataActionKeys.GET_GRAPH_DATA_START:
       console.log('ServiceGraphDataState reducer: graph data is loading...');
       newState.isLoading = true;
+      newState.error = null;
       newState.sidePanelInfo = null;
       break;
     case ServiceGraphDataActionKeys.HANDLE_LEGEND:
@@ -34,13 +36,14 @@ const serviceGraphDataState = (state: ServiceGraphState = INITIAL_STATE, action)
     case ServiceGraphDataActionKeys.GET_GRAPH_DATA_SUCCESS:
       console.log('ServiceGraphDataState reducer: graph data successfully received');
       newState.isLoading = false;
+      newState.error = null;
       newState.graphDataTimestamp = action.timestamp;
       newState.graphData = action.graphData;
       break;
     case ServiceGraphDataActionKeys.GET_GRAPH_DATA_FAILURE:
       console.warn('ServiceGraphDataState reducer: failed to get graph data');
       newState.isLoading = false;
-      // newState.error = action.error; // Already handled in the action.
+      newState.error = action.error;
       break;
     case ServiceGraphActionKeys.SERVICE_GRAPH_SIDE_PANEL_SHOW_INFO:
       newState.sidePanelInfo = {

--- a/src/reducers/__tests__/ServiceGraphDataState.test.ts
+++ b/src/reducers/__tests__/ServiceGraphDataState.test.ts
@@ -8,6 +8,7 @@ describe('ServiceGraphDataState', () => {
     expect(serviceGraphDataState(undefined, {})).toEqual({
       filterState: serviceGraphFilterState(undefined, {}),
       isLoading: false,
+      error: null,
       graphDataTimestamp: 0,
       hideLegend: true,
       graphData: {},

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -27,6 +27,7 @@ export interface MessageCenterState {
 
 export interface ServiceGraphState {
   isLoading: boolean;
+  error: any;
   graphDataTimestamp: number;
   graphData: any;
   filterState: ServiceGraphFilterState;


### PR DESCRIPTION
Current we incorrectly display the empty service graph page even if the reason we don't have results is because we encountered an error.

This updates to the service graph page to display an error message instead, which should make things more clear to the user.