### PR TITLE
KIALI-673 Add 'all' namespace option for graph page

### DIFF
--- a/src/components/NamespaceDropdown.tsx
+++ b/src/components/NamespaceDropdown.tsx
@@ -34,6 +34,9 @@ export class NamespaceDropdown extends React.PureComponent<NamespaceListType, {}
         onSelect={this.onSelectTypesafe}
         onToggle={this.onToggle}
       >
+        <MenuItem key="all" active={'all' === this.props.activeNamespace.name} eventKey="all">
+          all
+        </MenuItem>
         {this.props.items &&
           this.props.items.map(ns => (
             <MenuItem key={ns.name} active={ns.name === this.props.activeNamespace.name} eventKey={ns.name}>

--- a/src/components/Nav/Navigation.tsx
+++ b/src/components/Nav/Navigation.tsx
@@ -17,7 +17,7 @@ import ServiceJaegerPage from '../../pages/ServiceJaeger/ServiceJaegerPage';
 
 const istioConfigPath = '/istio';
 export const istioConfigTitle = 'Istio Config';
-const serviceGraphPath = '/service-graph/istio-system';
+const serviceGraphPath = '/service-graph/all';
 export const serviceGraphTitle = 'Graph';
 const servicesPath = '/services';
 const servicesJaegerPath = '/jaeger';

--- a/src/pages/ServiceGraph/SummaryPanelGraph.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelGraph.tsx
@@ -42,7 +42,11 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
 
   componentDidMount() {
     this._isMounted = true;
-    this.updateRpsChart(this.props);
+    // TODO (maybe) we omit the rps chart when dealing with multiple namespaces. There is no backend
+    // API support to gather the data. The whole-graph chart is of nominal value, it will likely be OK.
+    if (this.props.namespace !== 'all') {
+      this.updateRpsChart(this.props);
+    }
   }
 
   componentWillUnmount() {
@@ -83,10 +87,12 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
               rate4xx={trafficRate.rate4xx}
               rate5xx={trafficRate.rate5xx}
             />
-            <div>
-              <hr />
-              {this.renderRpsChart()}
-            </div>
+            {this.props.namespace !== 'all' && (
+              <div>
+                <hr />
+                {this.renderRpsChart()}
+              </div>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
- This will be the new default.
- The summary sparkline is omitted when 'all' is selected.