### PR TITLE
KIALI-385: Link from service graph charts to detailed service page charts

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
-import { BrowserRouter, withRouter } from 'react-router-dom';
+import { Router, withRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import './App.css';
 import Navigation from '../containers/NavigationContainer';
 import store from '../store/ConfigStore';
 import axios from 'axios';
 import { GlobalActionKeys } from '../actions/GlobalActions';
+import history from './History';
 
 // intercept all Axios requests and dispatch the LOADING_SPINNER_ON Action
 axios.interceptors.request.use(
@@ -43,9 +44,9 @@ class App extends React.Component {
     const Sidebar = withRouter(Navigation);
     return (
       <Provider store={store}>
-        <BrowserRouter basename="/console">
+        <Router history={history}>
           <Sidebar />
-        </BrowserRouter>
+        </Router>
       </Provider>
     );
   }

--- a/src/app/History.tsx
+++ b/src/app/History.tsx
@@ -1,0 +1,3 @@
+import { createBrowserHistory } from 'history';
+const history = createBrowserHistory({ basename: '/console' });
+export default history;

--- a/src/components/MetricsOptions/MetricsOptionsBar.tsx
+++ b/src/components/MetricsOptions/MetricsOptionsBar.tsx
@@ -57,13 +57,14 @@ export class MetricsOptionsBar extends React.Component<Props, MetricsOptionsStat
       items: Object.keys(MetricsOptionsBar.GroupByLabelOptions),
       onChange: this.changedGroupByLabel,
       dropdownTitle: 'Group by',
-      resultsTitle: 'Grouping by:'
+      resultsTitle: 'Grouping by:',
+      urlAttrName: 'groupings'
     });
 
     this.state = {
       pollInterval: MetricsOptionsBar.DefaultPollInterval,
       duration: Number(sessionStorage.getItem('appDuration')) || MetricsOptionsBar.DefaultDuration,
-      groupByLabels: []
+      groupByLabels: this.groupByLabelsHelper.selected
     };
   }
 

--- a/src/pages/ServiceDetails/HistogramChart.tsx
+++ b/src/pages/ServiceDetails/HistogramChart.tsx
@@ -1,0 +1,36 @@
+import { Histogram } from '../../types/Metrics';
+import graphUtils from '../../utils/Graphing';
+import MetricsChartBase from './MetricsChartBase';
+
+interface HistogramChartProps {
+  histogram: Histogram;
+  familyName: string;
+}
+
+class HistogramChart extends MetricsChartBase<HistogramChartProps> {
+  protected get controlKey() {
+    if (this.props.histogram.average.matrix.length === 0) {
+      return 'blank';
+    }
+
+    const labelNames = Object.keys(this.props.histogram.average.matrix[0].metric);
+    if (labelNames.length === 0) {
+      return this.props.familyName;
+    }
+
+    return this.props.familyName + '-' + labelNames.join('-');
+  }
+
+  protected get seriesData() {
+    return {
+      x: 'x',
+      columns: graphUtils
+        .toC3Columns(this.nameTimeSeries('[avg]', this.props.histogram.average.matrix))
+        .concat(graphUtils.toC3Columns(this.nameTimeSeries('[med]', this.props.histogram.median.matrix)))
+        .concat(graphUtils.toC3Columns(this.nameTimeSeries('[p95]', this.props.histogram.percentile95.matrix)))
+        .concat(graphUtils.toC3Columns(this.nameTimeSeries('[p99]', this.props.histogram.percentile99.matrix)))
+    };
+  }
+}
+
+export default HistogramChart;

--- a/src/pages/ServiceDetails/MetricChart.tsx
+++ b/src/pages/ServiceDetails/MetricChart.tsx
@@ -1,0 +1,30 @@
+import graphUtils from '../../utils/Graphing';
+import { TimeSeries } from '../../types/Metrics';
+import MetricsChartBase from './MetricsChartBase';
+
+type MetricChartProps = {
+  series: TimeSeries[];
+  familyName: string;
+};
+
+export default class MetricsChart extends MetricsChartBase<MetricChartProps> {
+  protected get controlKey(): string {
+    if (this.props.series.length === 0) {
+      return 'blank';
+    }
+
+    const labelNames = Object.keys(this.props.series[0].metric);
+    if (labelNames.length === 0) {
+      return this.props.familyName;
+    }
+
+    return this.props.familyName + '-' + labelNames.join('-');
+  }
+
+  protected get seriesData() {
+    return {
+      x: 'x',
+      columns: graphUtils.toC3Columns(this.nameTimeSeries('', this.props.series))
+    };
+  }
+}

--- a/src/pages/ServiceDetails/MetricsChartBase.tsx
+++ b/src/pages/ServiceDetails/MetricsChartBase.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react';
+import { LineChart } from 'patternfly-react';
+import { TimeSeries } from '../../types/Metrics';
+
+type MetricsChartBaseProps = {
+  familyName: string;
+};
+
+abstract class MetricsChartBase<Props extends MetricsChartBaseProps> extends React.Component<Props> {
+  protected abstract get controlKey(): string;
+  protected abstract get seriesData(): any;
+
+  protected nameTimeSeries = (groupName: string, matrix: TimeSeries[]): TimeSeries[] => {
+    matrix.forEach(ts => {
+      const labels = Object.keys(ts.metric).map(k => ts.metric[k]);
+
+      ts.name = this.props.familyName + groupName;
+      if (labels.length !== 0) {
+        ts.name += '{' + labels.join(',') + '}';
+      }
+    });
+    return matrix;
+  };
+
+  protected get axisDefinition() {
+    return {
+      x: {
+        type: 'timeseries',
+        tick: {
+          fit: true,
+          count: 15,
+          multiline: false,
+          format: '%H:%M:%S'
+        }
+      },
+      y: {
+        tick: {
+          format: val => {
+            // parseFloat is used to remove trailing zeros
+            return parseFloat(val.toFixed(5));
+          }
+        }
+      }
+    };
+  }
+
+  render() {
+    return (
+      <div key={this.controlKey}>
+        <LineChart
+          id={this.props.familyName}
+          title={{ text: this.props.familyName }}
+          data={this.seriesData}
+          axis={this.axisDefinition}
+          point={{ show: false }}
+        />
+      </div>
+    );
+  }
+}
+
+export default MetricsChartBase;

--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -194,6 +194,7 @@ class ServiceDetails extends React.Component<RouteComponentProps<ServiceId>, Ser
   }
 
   render() {
+    const urlParams = new URLSearchParams(this.props.location.search);
     let parsedSearch = this.parseSearch();
     let editorVisible = parsedSearch.name && parsedSearch.type;
     let to = '/namespaces/' + this.props.match.params.namespace + '/services/' + this.props.match.params.service;
@@ -234,13 +235,13 @@ class ServiceDetails extends React.Component<RouteComponentProps<ServiceId>, Ser
             </Row>
           </div>
         ) : (
-          <TabContainer id="basic-tabs" defaultActiveKey={1}>
+          <TabContainer id="basic-tabs" activeKey={urlParams.get('tab') || 'info'} onSelect={this.mainTabSelectHandler}>
             <div>
               <Nav bsClass="nav nav-tabs nav-tabs-pf">
-                <NavItem eventKey={1}>
+                <NavItem eventKey="info">
                   <div>Info</div>
                 </NavItem>
-                <NavItem eventKey={2}>
+                <NavItem eventKey="metrics">
                   <div>Metrics</div>
                 </NavItem>
                 <NavItem href={this.state.jaegerUri}>
@@ -248,7 +249,7 @@ class ServiceDetails extends React.Component<RouteComponentProps<ServiceId>, Ser
                 </NavItem>
               </Nav>
               <TabContent>
-                <TabPane eventKey={1}>
+                <TabPane eventKey="info">
                   <ServiceInfo
                     namespace={this.props.match.params.namespace}
                     service={this.props.match.params.service}
@@ -256,7 +257,7 @@ class ServiceDetails extends React.Component<RouteComponentProps<ServiceId>, Ser
                     validations={this.state.validations}
                   />
                 </TabPane>
-                <TabPane eventKey={2} mountOnEnter={true} unmountOnExit={true}>
+                <TabPane eventKey="metrics" mountOnEnter={true} unmountOnExit={true}>
                   <ServiceMetrics
                     namespace={this.props.match.params.namespace}
                     service={this.props.match.params.service}
@@ -269,6 +270,17 @@ class ServiceDetails extends React.Component<RouteComponentProps<ServiceId>, Ser
       </div>
     );
   }
+
+  private mainTabSelectHandler = (tabKey?: string) => {
+    if (!tabKey) {
+      return;
+    }
+
+    const urlParams = new URLSearchParams(this.props.location.search);
+    urlParams.set('tab', tabKey);
+
+    this.props.history.push(this.props.location.pathname + '?' + urlParams.toString());
+  };
 }
 
 export default ServiceDetails;

--- a/src/pages/ServiceDetails/__tests__/ServiceMetrics.test.tsx
+++ b/src/pages/ServiceDetails/__tests__/ServiceMetrics.test.tsx
@@ -103,9 +103,7 @@ describe('ServiceMetrics', () => {
           mounted!.update();
           expect(mounted!.find('Spinner').map(div => div.getElement().props.loading)).toEqual([]);
           expect(mounted!.find('.card-pf-body')).toHaveLength(2);
-          mounted!
-            .find('.card-pf-body')
-            .forEach(pfCard => expect(pfCard.children().map(div => div.text())).toEqual(['', '', '', '']));
+          mounted!.find('.card-pf-body').forEach(pfCard => expect(pfCard.children().length === 0));
         })
         .catch(err => done.fail(err)),
       mockGrafanaInfo({

--- a/src/pages/ServiceGraph/SummaryPanelEdge.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelEdge.tsx
@@ -10,6 +10,8 @@ import graphUtils from '../../utils/Graphing';
 import MetricsOptions from '../../types/MetricsOptions';
 import { PfColors } from '../../components/Pf/PfColors';
 import { authentication } from '../../utils/Authentication';
+import { Icon } from 'patternfly-react';
+import { Link } from 'react-router-dom';
 
 type SummaryPanelEdgeState = {
   loading: boolean;
@@ -82,9 +84,9 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
     const rate4xx = this.safeRate(edge.data('rate4XX'));
     const rate5xx = this.safeRate(edge.data('rate5XX'));
     const sourceLink = (
-      <a href={`../namespaces/${sourceNamespace}/services/${sourceServiceName}`}>{sourceServiceName}</a>
+      <Link to={`/namespaces/${sourceNamespace}/services/${sourceServiceName}`}>{sourceServiceName}</Link>
     );
-    const destLink = <a href={`../namespaces/${destNamespace}/services/${destServiceName}`}>{destServiceName}</a>;
+    const destLink = <Link to={`/namespaces/${destNamespace}/services/${destServiceName}`}>{destServiceName}</Link>;
 
     const isUnknown = sourceServiceName === 'unknown';
     return (
@@ -98,6 +100,16 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
           {this.renderLabels(destNamespace, destVersion)}
         </div>
         <div className="panel-body">
+          <p style={{ textAlign: 'right' }}>
+            <Link
+              to={
+                (isUnknown ? destLink.props.to : sourceLink.props.to) +
+                '?tab=metrics&groupings=local+version%2Cremote+service%2Cremote+version%2Cresponse+code'
+              }
+            >
+              View detailed charts <Icon name="angle-double-right" />
+            </Link>
+          </p>
           <RateTable
             title="Traffic (requests per second):"
             rate={rate}

--- a/src/pages/ServiceGraph/SummaryPanelGroup.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelGroup.tsx
@@ -11,6 +11,7 @@ import MetricsOptions from '../../types/MetricsOptions';
 import { PfColors } from '../../components/Pf/PfColors';
 import { Icon } from 'patternfly-react';
 import { authentication } from '../../utils/Authentication';
+import { Link } from 'react-router-dom';
 
 type SummaryPanelGroupState = {
   loading: boolean;
@@ -64,7 +65,7 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
 
     const namespace = group.data('service').split('.')[1];
     const service = group.data('service').split('.')[0];
-    const serviceHotLink = <a href={`../namespaces/${namespace}/services/${service}`}>{service}</a>;
+    const serviceHotLink = <Link to={`/namespaces/${namespace}/services/${service}`}>{service}</Link>;
 
     const incoming = getAccumulatedTrafficRate(group.children());
     const outgoing = getAccumulatedTrafficRate(group.children().edgesTo('*'));
@@ -87,6 +88,13 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
           {this.renderBadgeSummary(group.data('hasRR'))}
         </div>
         <div className="panel-body">
+          <p style={{ textAlign: 'right' }}>
+            <Link
+              to={`/namespaces/${namespace}/services/${service}?tab=metrics&groupings=local+version%2Cresponse+code`}
+            >
+              View detailed charts <Icon name="angle-double-right" />
+            </Link>
+          </p>
           <InOutRateTable
             title="Request Traffic (requests per second):"
             inRate={incoming.rate}

--- a/src/pages/ServiceGraph/SummaryPanelNode.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelNode.tsx
@@ -12,6 +12,7 @@ import { Metrics } from '../../types/Metrics';
 import { PfColors } from '../../components/Pf/PfColors';
 import { Icon } from 'patternfly-react';
 import { authentication } from '../../utils/Authentication';
+import { Link } from 'react-router-dom';
 
 type SummaryPanelStateType = {
   loading: boolean;
@@ -111,7 +112,7 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
     const serviceSplit = node.data('service').split('.');
     const namespace = serviceSplit.length < 2 ? 'unknown' : serviceSplit[1];
     const service = serviceSplit[0];
-    const serviceHotLink = <a href={`../namespaces/${namespace}/services/${service}`}>{service}</a>;
+    const serviceHotLink = <Link to={`/namespaces/${namespace}/services/${service}`}>{service}</Link>;
 
     const incoming = getTrafficRate(node);
     const outgoing = getAccumulatedTrafficRate(this.props.data.summaryTarget.edgesTo('*'));
@@ -134,6 +135,15 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
           {this.renderBadgeSummary(node.data('hasCB'), node.data('hasRR'), node.data('hasMissingSidecars'))}
         </div>
         <div className="panel-body">
+          {!isUnknown && (
+            <p style={{ textAlign: 'right' }}>
+              <Link
+                to={`/namespaces/${namespace}/services/${service}?tab=metrics&groupings=local+version%2Cresponse+code`}
+              >
+                View detailed charts <Icon name="angle-double-right" />
+              </Link>
+            </p>
+          )}
           <InOutRateTable
             title="Request Traffic (requests per second):"
             inRate={incoming.rate}


### PR DESCRIPTION
This covers both KIALI-758 and KIALI-759.

* The metrics tab in the service details page is now
  linkable/bookmarkable.
** As part of this, some cleanup in ServiceDetailsPage.tsx.
** Also, the "group by" options can now be specified in the URL.
* Adding simple links service graph's summary panels to the metrics tab
  of the detailed page.

Also, some refactorings in ServiceMetics.tsx:
* The charts were extracted to its own components, making
  ServiceMetrics.tsx smaller and some unneeded types were removed.