### PR TITLE
KIALI-762 - Force Jest to exit after all tests have completed running

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 script:
   - yarn prettier --list-different &&
     yarn build &&
-    yarn test
+    yarn test --forceExit
   - ./run_itest.sh
 before_deploy:
   - yarn set-snapshot-version $TRAVIS_BUILD_NUMBER


### PR DESCRIPTION
This should help in our stalled builds by forcing jest to exit.

```
  --forceExit               Force Jest to exit after all tests have
                            completed running. This is useful when
                            resources set up by test code cannot be
                            adequately cleaned up.               [boolean]
```