### PR TITLE
Kiali-841 Standardize the isLoading Spinner to Header

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -13,7 +13,6 @@ import { KialiAppState } from '../../store/Store';
 import * as GraphBadge from './graphs/GraphBadge';
 import TrafficRender from './graphs/TrafficRenderer';
 import { ServiceGraphActions } from '../../actions/ServiceGraphActions';
-import PfSpinnerContainer from '../../containers/PfSpinnerContainer';
 
 type CytoscapeGraphType = {
   elements?: any;
@@ -87,7 +86,6 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
   render() {
     return (
       <div id="cytoscape-container" style={{ marginRight: '25em', height: '100%' }}>
-        <PfSpinnerContainer />
         <EmptyGraphLayout
           elements={this.props.elements}
           namespace={this.props.namespace.name}

--- a/src/components/Nav/Navigation.tsx
+++ b/src/components/Nav/Navigation.tsx
@@ -14,6 +14,7 @@ import ServiceDetailsPage from '../../pages/ServiceDetails/ServiceDetailsPage';
 import ServiceGraphRouteHandler from '../../pages/ServiceGraph/ServiceGraphRouteHandler';
 import ServiceListPage from '../../pages/ServiceList/ServiceListPage';
 import ServiceJaegerPage from '../../pages/ServiceJaeger/ServiceJaegerPage';
+import PfSpinnerContainer from '../../containers/PfSpinnerContainer';
 
 const istioConfigPath = '/istio';
 export const istioConfigTitle = 'Istio Config';
@@ -108,6 +109,7 @@ class Navigation extends React.Component<PropsType, StateType> {
         >
           <VerticalNav.Masthead title="Kiali">
             <VerticalNav.Brand iconImg={pfLogo} titleImg={pfBrand} />
+            <PfSpinnerContainer />
             <VerticalNav.IconBar>
               <MessageCenter.Trigger />
               <HelpDropdown />

--- a/src/containers/PfSpinnerContainer.tsx
+++ b/src/containers/PfSpinnerContainer.tsx
@@ -1,19 +1,28 @@
 import React from 'react';
 import { KialiAppState } from '../store/Store';
 import { connect } from 'react-redux';
+import { Spinner } from 'patternfly-react';
+import { style } from 'typestyle';
 
 type PfSpinnerProps = {
   isLoading: boolean;
 };
 
+const spinnerStyle = style({
+  position: 'absolute',
+  left: 450,
+  top: 15
+});
+
 const mapStateToProps = (state: KialiAppState) => ({
   isLoading: state.globalState.isLoading
 });
+
 export const PfSpinner: React.SFC<PfSpinnerProps> = props => {
   const { isLoading } = props;
   // It is more than likely it won't have any children; but it could.
   // @todo: Patternfly Spinner is not working here
-  return isLoading ? <div className="spinner spinner-sm left-spinner">{props.children} </div> : null;
+  return <Spinner className={spinnerStyle} loading={isLoading} inverse={true} />;
 };
 
 // hook up to Redux for our State to be mapped to props

--- a/src/pages/IstioConfigList/IstioConfigListComponent.tsx
+++ b/src/pages/IstioConfigList/IstioConfigListComponent.tsx
@@ -18,7 +18,6 @@ import PropTypes from 'prop-types';
 // import IstioRuleListDescription from './IstioRuleListDescription';
 import { Link } from 'react-router-dom';
 import { PfColors } from '../../components/Pf/PfColors';
-import PfSpinnerContainer from '../../containers/PfSpinnerContainer';
 
 const sortFields: SortField[] = [
   {
@@ -287,7 +286,6 @@ class IstioConfigListComponent extends React.Component<IstioConfigListComponentP
     let ruleListComponent;
     ruleListComponent = (
       <>
-        <PfSpinnerContainer />
         <NamespaceFilter
           initialFilters={[istioTypeFilter, istioNameFilter]}
           onFilterChange={this.filterChange}

--- a/src/pages/ServiceList/ServiceListComponent.tsx
+++ b/src/pages/ServiceList/ServiceListComponent.tsx
@@ -16,7 +16,6 @@ import RateIntervalToolbarItem from './RateIntervalToolbarItem';
 import { PfColors } from '../../components/Pf/PfColors';
 
 import './ServiceListComponent.css';
-import PfSpinnerContainer from '../../containers/PfSpinnerContainer';
 
 // Exported for test
 export const sortFields: SortField[] = [
@@ -344,8 +343,7 @@ class ServiceListComponent extends React.Component<ServiceListComponentProps, Se
 
     let serviceListComponent;
     serviceListComponent = (
-      <div>
-        <PfSpinnerContainer />
+      <>
         <NamespaceFilter
           initialFilters={[serviceNameFilter, istioFilter]}
           onFilterChange={this.filterChange}
@@ -376,7 +374,7 @@ class ServiceListComponent extends React.Component<ServiceListComponentProps, Se
           onPageSet={this.pageSet}
           onPerPageSelect={this.pageSelect}
         />
-      </div>
+      </>
     );
     return <div>{serviceListComponent}</div>;
   }


### PR DESCRIPTION
Consolidate the spinners in each of the pages into one spinner located in the header.
![spinner](https://user-images.githubusercontent.com/1312165/40735758-d98a1eee-63f0-11e8-845d-341cb20d946f.jpg)
Latest working spinner in the header:
![spinner-header-new](https://user-images.githubusercontent.com/1312165/40736696-945308c4-63f3-11e8-8f0c-d0d2d8561737.gif)




This fixes the problem with the page shifting downward when the spinner was engaged.

https://issues.jboss.org/browse/KIALI-841