### PR TITLE
Kiali-848 Remove Redux Logger (too verbose)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "react-router-dom": "4.2.2",
     "react-scripts-ts": "2.15.1",
     "redux": "3.7.2",
-    "redux-logger": "3.0.6",
     "redux-mock-store": "1.5.1",
     "redux-thunk": "2.2.0",
     "ssri": "6.0.0",

--- a/src/store/ConfigStore.ts
+++ b/src/store/ConfigStore.ts
@@ -1,7 +1,6 @@
 import { createStore, applyMiddleware, compose } from 'redux';
 import { KialiAppState } from './Store';
 import rootReducer from '../reducers';
-import logger from 'redux-logger';
 import thunk from 'redux-thunk';
 
 declare const window;
@@ -11,7 +10,7 @@ const composeEnhancers =
 
 const configureStore = (initialState?: KialiAppState) => {
   // configure middlewares
-  const middlewares = [thunk, logger];
+  const middlewares = [thunk];
   // compose enhancers
   const enhancer = composeEnhancers(applyMiddleware(...middlewares));
   // create store

--- a/yarn.lock
+++ b/yarn.lock
@@ -2254,10 +2254,6 @@ decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
 
-deep-diff@^0.3.5:
-  version "0.3.8"
-  resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-0.3.8.tgz#c01de63efb0eec9798801d40c7e0dae25b582c84"
-
 deep-equal@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
@@ -7049,12 +7045,6 @@ reduce-function-call@^1.0.1:
   resolved "https://registry.yarnpkg.com/reduce-function-call/-/reduce-function-call-1.0.2.tgz#5a200bf92e0e37751752fe45b0ab330fd4b6be99"
   dependencies:
     balanced-match "^0.4.2"
-
-redux-logger@3.0.6:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-3.0.6.tgz#f7555966f3098f3c88604c449cf0baf5778274bf"
-  dependencies:
-    deep-diff "^0.3.5"
 
 redux-mock-store@1.5.1:
   version "1.5.1"


### PR DESCRIPTION
Remove the redux logger since it is too verbose.
We always have Redux Dev tools which does soo much more.

https://issues.jboss.org/browse/KIALI-848