### PR TITLE
 KIALI-745 Autoupdate the service graph

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -16,7 +16,6 @@ import { ServiceGraphActions } from '../../actions/ServiceGraphActions';
 
 type CytoscapeGraphType = {
   elements?: any;
-  isLoading?: boolean;
   edgeLabelMode: EdgeLabelMode;
   showNodeLabels: boolean;
   showCircuitBreakers: boolean;
@@ -62,7 +61,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
   shouldComponentUpdate(nextProps: any, nextState: any) {
     this.newLayout = this.props.graphLayout !== nextProps.graphLayout ? nextProps.graphLayout : '';
     return (
-      this.props.isLoading !== nextProps.isLoading ||
+      this.props.namespace.name !== nextProps.namespace.name ||
       this.props.graphLayout !== nextProps.graphLayout ||
       this.props.edgeLabelMode !== nextProps.edgeLabelMode ||
       this.props.showNodeLabels !== nextProps.showNodeLabels ||
@@ -203,31 +202,31 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
 
     this.trafficRenderer.stop();
 
-    cy.startBatch();
-
-    // update the entire set of nodes and edges to keep the graph up-to-date
-    cy.json({ elements: this.props.elements });
-
-    // update the layout if it changed
-    if (this.newLayout) {
-      cy.layout(LayoutDictionary.getLayout(this.newLayout)).run();
-      this.newLayout = '';
-    }
-
-    // Create and destroy labels
-    this.turnEdgeLabelsTo(this.props.edgeLabelMode);
-    this.turnNodeLabelsTo(this.props.showNodeLabels);
-
     // Create and destroy badges
+    // We must destroy all badges before updating the json, or else we will lose all the
+    // references to removed nodes
     const cbBadge = new GraphBadge.CircuitBreakerBadge();
     const rrBadge = new GraphBadge.RouteRuleBadge();
     const rrGroupBadge = new GraphBadge.RouteRuleGroupBadge();
     const msBadge = new GraphBadge.MissingSidecarsBadge();
     cy.nodes().forEach(ele => {
+      cbBadge.destroyBadge(ele);
+      rrBadge.destroyBadge(ele);
+      rrGroupBadge.destroyBadge(ele);
+      msBadge.destroyBadge(ele);
+    });
+
+    cy.startBatch();
+    // update the entire set of nodes and edges to keep the graph up-to-date
+    cy.json({ elements: this.props.elements });
+
+    // Create and destroy labels
+    this.turnEdgeLabelsTo(this.props.edgeLabelMode);
+    this.turnNodeLabelsTo(this.props.showNodeLabels);
+
+    cy.nodes().forEach(ele => {
       if (this.props.showCircuitBreakers && ele.data('hasCB') === 'true') {
         cbBadge.buildBadge(ele);
-      } else {
-        cbBadge.destroyBadge(ele);
       }
       if (this.props.showRouteRules && ele.data('hasRR') === 'true') {
         if (ele.data('isGroup')) {
@@ -235,13 +234,9 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
         } else {
           rrBadge.buildBadge(ele);
         }
-      } else {
-        rrBadge.destroyBadge(ele);
       }
       if (this.props.showMissingSidecars && ele.data('hasMissingSidecars') && !ele.data('isGroup')) {
         msBadge.buildBadge(ele);
-      } else {
-        msBadge.destroyBadge(ele);
       }
     });
 
@@ -250,6 +245,11 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
     if (cy.zoom() > 2.5) {
       cy.zoom(2.5);
       cy.center();
+    }
+
+    if (this.newLayout) {
+      cy.layout(LayoutDictionary.getLayout(this.newLayout)).run();
+      this.newLayout = '';
     }
 
     cy.endBatch();

--- a/src/components/CytoscapeGraph/__tests__/CytoscapeGraph.test.tsx
+++ b/src/components/CytoscapeGraph/__tests__/CytoscapeGraph.test.tsx
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 
 import { CytoscapeGraph } from '../CytoscapeGraph';
 import * as GRAPH_DATA from '../../../services/__mockData__/getGraphElements';
-import { Duration, Layout, EdgeLabelMode } from '../../../types/GraphFilter';
+import { Duration, Layout, EdgeLabelMode, PollInterval } from '../../../types/GraphFilter';
 import { CytoscapeReactWrapper } from '../CytoscapeReactWrapper';
 
 jest.mock('../../../services/Api');
@@ -22,6 +22,7 @@ describe('CytoscapeGraph component test', () => {
   it('should set correct elements data', () => {
     const myLayout: Layout = { name: 'breadthfirst' };
     const myDuration: Duration = { value: 300 };
+    const myPollInterval: PollInterval = { value: 5 };
     const myEdgeLabelMode: EdgeLabelMode = EdgeLabelMode.HIDE;
 
     const wrapper = shallow(
@@ -31,6 +32,7 @@ describe('CytoscapeGraph component test', () => {
         graphLayout={myLayout}
         graphDuration={myDuration}
         edgeLabelMode={myEdgeLabelMode}
+        pollInterval={myPollInterval}
         onClick={testClickHandler}
         onReady={testReadyHandler}
         refresh={testClickHandler}

--- a/src/components/Filters/PollIntervalFilter.tsx
+++ b/src/components/Filters/PollIntervalFilter.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+
+import { config } from '../../config';
+import { ToolbarDropdown } from '../ToolbarDropdown/ToolbarDropdown';
+import { PollInterval } from '../../types/GraphFilter';
+
+type PollIntervalFilterProps = {
+  id: string;
+  disabled: boolean;
+  onPollIntervalChanged: (interval: number) => void;
+  selected?: PollInterval;
+};
+
+const PollIntervals = config().toolbar.pollInterval;
+const DefaultPollInterval = config().toolbar.defaultPollInterval;
+
+const PollIntervalFilter: React.SFC<PollIntervalFilterProps> = props => {
+  const selectedLabel = PollIntervals[props.selected!.value]
+    ? PollIntervals[props.selected!.value]
+    : `${props.selected!.value} ms`;
+  return (
+    <ToolbarDropdown
+      id={props.id}
+      disabled={props.disabled}
+      handleSelect={props.onPollIntervalChanged}
+      nameDropdown="Poll Interval"
+      initialValue={props.selected!.value}
+      initialLabel={selectedLabel}
+      options={PollIntervals}
+    />
+  );
+};
+
+PollIntervalFilter.defaultProps = {
+  selected: { value: DefaultPollInterval }
+};
+
+export default PollIntervalFilter;

--- a/src/components/GraphFilter/GraphFilter.tsx
+++ b/src/components/GraphFilter/GraphFilter.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Toolbar, Button, Icon, FormGroup } from 'patternfly-react';
 
-import { Duration, Layout, EdgeLabelMode } from '../../types/GraphFilter';
+import { Duration, Layout, EdgeLabelMode, PollInterval } from '../../types/GraphFilter';
 import { ToolbarDropdown } from '../ToolbarDropdown/ToolbarDropdown';
 import NamespaceDropdownContainer from '../../containers/NamespaceDropdownContainer';
 import { config } from '../../config';
@@ -9,6 +9,7 @@ import GraphLayersContainer from '../../containers/GraphLayersContainer';
 import { style } from 'typestyle';
 import { GraphParamsType } from '../../types/Graph';
 import Namespace from '../../types/Namespace';
+import PollIntervalFilter from '../Filters/PollIntervalFilter';
 
 import * as _ from 'lodash';
 
@@ -18,9 +19,11 @@ export interface GraphFilterProps extends GraphParamsType {
   onDurationChange: (newDuration: Duration) => void;
   onNamespaceChange: (newValue: Namespace) => void;
   onEdgeLabelModeChange: (newEdges: EdgeLabelMode) => void;
+  onPollIntervalChanged: (newPollInterval: PollInterval) => void;
   onRefresh: () => void;
   onLegend: () => void;
   hideLegend: boolean;
+  isLoading: boolean;
 }
 
 export interface GraphFilterState {
@@ -79,6 +82,12 @@ export default class GraphFilter extends React.Component<GraphFilterProps, Graph
     }
   };
 
+  pollInterval = (selected: number) => {
+    if (this.props.pollInterval.value !== selected) {
+      this.props.onPollIntervalChanged({ value: selected });
+    }
+  };
+
   handleRefresh = (e: any) => {
     this.props.onRefresh();
   };
@@ -121,6 +130,12 @@ export default class GraphFilter extends React.Component<GraphFilterProps, Graph
             initialValue={this.props.edgeLabelMode}
             initialLabel={GraphFilter.EDGE_LABEL_MODES[this.props.edgeLabelMode]}
             options={GraphFilter.EDGE_LABEL_MODES}
+          />
+          <PollIntervalFilter
+            id={'metrics_filter_poll_interval'}
+            disabled={false}
+            onPollIntervalChanged={this.pollInterval}
+            selected={this.props.pollInterval}
           />
           <FormGroup className={zeroPaddingLeft}>
             <label className={labelPaddingRight}>Filters:</label>

--- a/src/components/GraphFilter/GraphFilterToolbar.tsx
+++ b/src/components/GraphFilter/GraphFilterToolbar.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { PropTypes } from 'prop-types';
 
 import { GraphParamsType } from '../../types/Graph';
-import { Duration, Layout, EdgeLabelMode } from '../../types/GraphFilter';
+import { Duration, Layout, EdgeLabelMode, PollInterval } from '../../types/GraphFilter';
 import Namespace from '../../types/Namespace';
 import GraphFilterToolbarType from '../../types/GraphFilterToolbar';
 
@@ -20,7 +20,8 @@ export default class GraphFilterToolbar extends React.PureComponent<GraphFilterT
       namespace: this.props.namespace,
       graphLayout: this.props.graphLayout,
       graphDuration: this.props.graphDuration,
-      edgeLabelMode: this.props.edgeLabelMode
+      edgeLabelMode: this.props.edgeLabelMode,
+      pollInterval: this.props.pollInterval
     };
 
     return (
@@ -31,50 +32,44 @@ export default class GraphFilterToolbar extends React.PureComponent<GraphFilterT
         onNamespaceChange={this.handleNamespaceChange}
         onEdgeLabelModeChange={this.handleEdgeLabelModeChange}
         onRefresh={this.props.handleRefreshClick}
+        onPollIntervalChanged={this.handlePollIntervalChanged}
         onLegend={this.props.handleLegendClick}
         hideLegend={this.props.hideLegend}
+        isLoading={this.props.isLoading}
         {...graphParams}
       />
     );
   }
 
   handleLayoutChange = (graphLayout: Layout) => {
-    const { namespace, graphDuration, edgeLabelMode } = this.getGraphParams();
     this.handleFilterChange({
-      graphDuration,
-      namespace,
-      graphLayout,
-      edgeLabelMode
+      ...this.getGraphParams(),
+      graphLayout
     });
   };
 
   handleDurationChange = (graphDuration: Duration) => {
-    const { namespace, graphLayout, edgeLabelMode } = this.getGraphParams();
     this.handleFilterChange({
-      graphDuration,
-      namespace,
-      graphLayout,
-      edgeLabelMode
+      ...this.getGraphParams(),
+      graphDuration
     });
   };
 
   handleNamespaceChange = (namespace: Namespace) => {
-    const { graphDuration, graphLayout, edgeLabelMode } = this.getGraphParams();
     this.handleFilterChange({
-      namespace,
-      graphDuration,
-      graphLayout,
-      edgeLabelMode
+      ...this.getGraphParams(),
+      namespace
     });
   };
 
   handleEdgeLabelModeChange = (edgeLabelMode: EdgeLabelMode) => {
-    const { namespace, graphDuration, graphLayout } = this.getGraphParams();
+    this.handleFilterChange({ ...this.getGraphParams(), edgeLabelMode });
+  };
+
+  handlePollIntervalChanged = (pollInterval: PollInterval) => {
     this.handleFilterChange({
-      namespace,
-      graphDuration,
-      graphLayout,
-      edgeLabelMode
+      ...this.getGraphParams(),
+      pollInterval
     });
   };
 
@@ -87,7 +82,8 @@ export default class GraphFilterToolbar extends React.PureComponent<GraphFilterT
       namespace: this.props.namespace,
       graphDuration: this.props.graphDuration,
       graphLayout: this.props.graphLayout,
-      edgeLabelMode: this.props.edgeLabelMode
+      edgeLabelMode: this.props.edgeLabelMode,
+      pollInterval: this.props.pollInterval
     };
   };
 }

--- a/src/components/GraphFilter/__tests__/GraphFilterToolbar.test.tsx
+++ b/src/components/GraphFilter/__tests__/GraphFilterToolbar.test.tsx
@@ -11,7 +11,8 @@ const PARAMS: GraphParamsType = {
   namespace: { name: 'itsio-system' },
   graphDuration: { value: 60 },
   graphLayout: { name: 'Cose' },
-  edgeLabelMode: EdgeLabelMode.HIDE
+  edgeLabelMode: EdgeLabelMode.HIDE,
+  pollInterval: { value: 5 }
 };
 
 describe('ServiceGraphPage test', () => {

--- a/src/components/MetricsOptions/MetricsOptionsBar.tsx
+++ b/src/components/MetricsOptions/MetricsOptionsBar.tsx
@@ -4,6 +4,7 @@ import { config } from '../../config';
 import ValueSelectHelper from './ValueSelectHelper';
 import MetricsOptions from '../../types/MetricsOptions';
 import { ToolbarDropdown } from '../ToolbarDropdown/ToolbarDropdown';
+import PollIntervalFilter from '../Filters/PollIntervalFilter';
 
 interface Props {
   onOptionsChanged: (opts: MetricsOptions) => void;
@@ -122,14 +123,10 @@ export class MetricsOptionsBar extends React.Component<Props, MetricsOptionsStat
           )}
           options={MetricsOptionsBar.Durations}
         />
-        <ToolbarDropdown
+        <PollIntervalFilter
           id={'metrics_filter_poll_interval'}
           disabled={false}
-          handleSelect={this.onPollIntervalChanged}
-          nameDropdown={'Poll Interval'}
-          initialValue={MetricsOptionsBar.DefaultPollInterval}
-          initialLabel={String(MetricsOptionsBar.PollIntervals[MetricsOptionsBar.DefaultPollInterval])}
-          options={MetricsOptionsBar.PollIntervals}
+          onPollIntervalChanged={this.onPollIntervalChanged}
         />
 
         <ToolbarRightContent>

--- a/src/components/MetricsOptions/__tests__/__snapshots__/MetricsOptionsBar.test.tsx.snap
+++ b/src/components/MetricsOptions/__tests__/__snapshots__/MetricsOptionsBar.test.tsx.snap
@@ -82,21 +82,13 @@ ShallowWrapper {
             }
           }
         />,
-        <ToolbarDropdown
+        <PollIntervalFilter
           disabled={false}
-          handleSelect={[Function]}
           id="metrics_filter_poll_interval"
-          initialLabel="5 seconds"
-          initialValue={5000}
-          nameDropdown="Poll Interval"
-          options={
+          onPollIntervalChanged={[Function]}
+          selected={
             Object {
-              "0": "Pause",
-              "10000": "10 seconds",
-              "30000": "30 seconds",
-              "300000": "5 minutes",
-              "5000": "5 seconds",
-              "60000": "1 minute",
+              "value": 5000,
             }
           }
         />,
@@ -199,21 +191,13 @@ ShallowWrapper {
       Object {
         "instance": null,
         "key": undefined,
-        "nodeType": "class",
+        "nodeType": "function",
         "props": Object {
           "disabled": false,
-          "handleSelect": [Function],
           "id": "metrics_filter_poll_interval",
-          "initialLabel": "5 seconds",
-          "initialValue": 5000,
-          "nameDropdown": "Poll Interval",
-          "options": Object {
-            "0": "Pause",
-            "10000": "10 seconds",
-            "30000": "30 seconds",
-            "300000": "5 minutes",
-            "5000": "5 seconds",
-            "60000": "1 minute",
+          "onPollIntervalChanged": [Function],
+          "selected": Object {
+            "value": 5000,
           },
         },
         "ref": null,
@@ -331,21 +315,13 @@ ShallowWrapper {
               }
             }
           />,
-          <ToolbarDropdown
+          <PollIntervalFilter
             disabled={false}
-            handleSelect={[Function]}
             id="metrics_filter_poll_interval"
-            initialLabel="5 seconds"
-            initialValue={5000}
-            nameDropdown="Poll Interval"
-            options={
+            onPollIntervalChanged={[Function]}
+            selected={
               Object {
-                "0": "Pause",
-                "10000": "10 seconds",
-                "30000": "30 seconds",
-                "300000": "5 minutes",
-                "5000": "5 seconds",
-                "60000": "1 minute",
+                "value": 5000,
               }
             }
           />,
@@ -448,21 +424,13 @@ ShallowWrapper {
         Object {
           "instance": null,
           "key": undefined,
-          "nodeType": "class",
+          "nodeType": "function",
           "props": Object {
             "disabled": false,
-            "handleSelect": [Function],
             "id": "metrics_filter_poll_interval",
-            "initialLabel": "5 seconds",
-            "initialValue": 5000,
-            "nameDropdown": "Poll Interval",
-            "options": Object {
-              "0": "Pause",
-              "10000": "10 seconds",
-              "30000": "30 seconds",
-              "300000": "5 minutes",
-              "5000": "5 seconds",
-              "60000": "1 minute",
+            "onPollIntervalChanged": [Function],
+            "selected": Object {
+              "value": 5000,
             },
           },
           "ref": null,

--- a/src/components/Nav/NavUtils.tsx
+++ b/src/components/Nav/NavUtils.tsx
@@ -3,4 +3,4 @@ import { GraphParamsType } from '../../types/Graph';
 export const makeURLFromParams = (params: GraphParamsType) =>
   `/service-graph/${params.namespace.name}?layout=${params.graphLayout.name}&duration=${
     params.graphDuration.value
-  }&edges=${params.edgeLabelMode}`;
+  }&edges=${params.edgeLabelMode}&pollInterval=${params.pollInterval.value}`;

--- a/src/pages/ServiceGraph/ServiceGraphRouteHandler.tsx
+++ b/src/pages/ServiceGraph/ServiceGraphRouteHandler.tsx
@@ -19,6 +19,7 @@ type ServiceGraphURLProps = {
   duration: string;
   namespace: string;
   layout: string;
+  pollInterval: string;
 };
 
 /**
@@ -51,11 +52,13 @@ export default class ServiceGraphRouteHandler extends React.Component<
     const _hideCBs = urlParams.get('hideCBs') ? urlParams.get('hideCBs') === 'true' : false;
     const _hideRRs = urlParams.get('hideRRs') ? urlParams.get('hideRRs') === 'true' : false;
     const _edgeLabelMode = EdgeLabelMode.fromString(urlParams.get('edges'), EdgeLabelMode.HIDE);
+    const _pollInterval = urlParams.get('pollInterval');
     return {
       graphDuration: _duration ? { value: _duration } : { value: config().toolbar.defaultDuration },
       graphLayout: LayoutDictionary.getLayout({ name: urlParams.get('layout') }),
       badgeStatus: { hideCBs: _hideCBs, hideRRs: _hideRRs },
-      edgeLabelMode: _edgeLabelMode
+      edgeLabelMode: _edgeLabelMode,
+      pollInterval: _pollInterval ? { value: _pollInterval } : { value: config().toolbar.defaultPollInterval }
     };
   };
 
@@ -66,21 +69,26 @@ export default class ServiceGraphRouteHandler extends React.Component<
 
   componentWillReceiveProps(nextProps: RouteComponentProps<ServiceGraphURLProps>) {
     const nextNamespace = { name: nextProps.match.params.namespace };
-    const { graphDuration: nextDuration, graphLayout: nextLayout, edgeLabelMode: nextEdgeLabelMode } = this.parseProps(
-      nextProps.location.search
-    );
+    const {
+      graphDuration: nextDuration,
+      graphLayout: nextLayout,
+      edgeLabelMode: nextEdgeLabelMode,
+      pollInterval: nextPollInverval
+    } = this.parseProps(nextProps.location.search);
 
     const layoutHasChanged = nextLayout.name !== this.state.graphLayout.name;
     const namespaceHasChanged = nextNamespace.name !== this.state.namespace.name;
     const durationHasChanged = nextDuration.value !== this.state.graphDuration.value;
     const edgeLabelModeChanged = nextEdgeLabelMode !== this.state.edgeLabelMode;
+    const pollIntervalChanged = nextPollInverval !== this.state.pollInterval;
 
-    if (layoutHasChanged || namespaceHasChanged || durationHasChanged || edgeLabelModeChanged) {
+    if (layoutHasChanged || namespaceHasChanged || durationHasChanged || edgeLabelModeChanged || pollIntervalChanged) {
       const newParams: GraphParamsType = {
         namespace: nextNamespace,
         graphDuration: nextDuration,
         graphLayout: nextLayout,
-        edgeLabelMode: nextEdgeLabelMode
+        edgeLabelMode: nextEdgeLabelMode,
+        pollInterval: nextPollInverval
       };
       sessionStorage.setItem(SESSION_KEY, JSON.stringify(newParams));
       this.setState({ ...newParams });

--- a/src/reducers/ServiceGraphDataState.ts
+++ b/src/reducers/ServiceGraphDataState.ts
@@ -22,7 +22,6 @@ const serviceGraphDataState = (state: ServiceGraphState = INITIAL_STATE, action)
   switch (action.type) {
     case ServiceGraphDataActionKeys.GET_GRAPH_DATA_START:
       newState.isLoading = true;
-      newState.sidePanelInfo = null;
       break;
     case ServiceGraphDataActionKeys.HANDLE_LEGEND:
       return {

--- a/src/types/Graph.ts
+++ b/src/types/Graph.ts
@@ -1,4 +1,4 @@
-import { Duration, Layout, EdgeLabelMode } from './GraphFilter';
+import { Duration, Layout, EdgeLabelMode, PollInterval } from './GraphFilter';
 import Namespace from './Namespace';
 
 // SummaryData will have two fields:
@@ -23,4 +23,5 @@ export interface GraphParamsType {
   graphDuration: Duration;
   graphLayout: Layout;
   edgeLabelMode: EdgeLabelMode;
+  pollInterval: PollInterval;
 }

--- a/src/types/GraphFilter.ts
+++ b/src/types/GraphFilter.ts
@@ -6,6 +6,10 @@ export interface Duration {
   value: number;
 }
 
+export interface PollInterval {
+  value: number;
+}
+
 export enum EdgeLabelMode {
   HIDE = 'hide',
   REQUESTS_PER_SECOND = 'requestsPerSecond',


### PR DESCRIPTION
The main concern of this PR is to add the polling interval to the Service Graph, however other issues happened when removing the "loading" spinner that made the graph "jump" when loading the data.

#382 Also did the same (removed the loading spinner) so this fixes some issues after that.

- Edges not being up to date after refreshes
  - This was was caused because the `cy.json` only diffs the values received, it doesn't replace data and the backend doesn't return empty data (so the empty data is never replaced)
- Badges not being removed between namespace changes
  - Badges were removed AFTER updating the json, if we had any badge on an element that would be removed, it would stay there (because we remove the element first and the badge later)

Issues not fixed:
- If going from a one-node layout to a multiple-node namespace, the nodes look all stacked on top of each other. Manually triggering a new layout fixes this. Tried to force the relayout in code, but didn't fixed it (however, if forcing the relayout and going from `istio-system` to `bookinfo` (looks stacked) then to `all` it looks good, there must be some re-render issue (tried `cy.forceRender`) I assume i'm doing something wrong
- Need to reload the sidepanel after each refresh of the graph (Todo)

It might be an option to merge this PR and fix the issues on a separate PR (because current graph is sort of buggy)
