### PR TITLE
Let UI show multiple error/warnings into one DestinationWeight

### DIFF
--- a/src/types/ServiceInfo.ts
+++ b/src/types/ServiceInfo.ts
@@ -394,6 +394,15 @@ export interface ObjectCheck {
   path: string;
 }
 
+const higherThan = [
+  'error-warning',
+  'error-improvement',
+  'error-correct',
+  'warning-improvement',
+  'warning-correct',
+  'improvement-correct'
+];
+
 const IconSeverityMap = new Map<string, string>([
   ['error', 'error-circle-o'],
   ['warning', 'warning-triangle-o'],
@@ -408,6 +417,22 @@ export const severityToIconName = (severity: string): string => {
   }
 
   return iconName;
+};
+
+export const higherSeverity = (a: string, b: string): boolean => {
+  return higherThan.includes(a + '-' + b);
+};
+
+export const highestSeverity = (checks: ObjectCheck[]): string => {
+  let severity = 'correct';
+
+  checks.forEach(check => {
+    if (higherSeverity(check.severity, severity)) {
+      severity = check.severity;
+    }
+  });
+
+  return severity;
 };
 
 export const validationToIconName = (object: ObjectValidation): string => {


### PR DESCRIPTION
Allow weights to have more than one validation per line:

Before hover:

![multiple-errors-destination-weight-2-previous](https://user-images.githubusercontent.com/613814/40795477-82e3101a-6502-11e8-9532-10897a739ebc.png)

On hover:

![multiple-errors-destination-weight-2](https://user-images.githubusercontent.com/613814/40795396-40613a50-6502-11e8-9f8d-0222f7bf33a5.png)

Icon on status column correspond to the validation with the highest severity.

This PR needs [kiali/kiali#239](https://github.com/kiali/kiali/pull/239) to be merged.
