### PR TITLE
KIALI-861 Prepare service graph for refreshing

### DIFF
--- a/src/actions/ServiceGraphDataActions.ts
+++ b/src/actions/ServiceGraphDataActions.ts
@@ -45,12 +45,20 @@ const decorateGraphData = (graphData: any) => {
       hasMissingSidecars: undefined
     }
   };
-  if (graphData && graphData.elements) {
-    if (graphData.elements.nodes) {
-      graphData.elements.nodes = graphData.elements.nodes.map(node => ({ ...elementsDefaults.nodes, ...node }));
+  if (graphData) {
+    if (graphData.nodes) {
+      graphData.nodes = graphData.nodes.map(node => {
+        const decoratedNode = { ...node };
+        decoratedNode.data = { ...elementsDefaults.nodes, ...decoratedNode.data };
+        return decoratedNode;
+      });
     }
-    if (graphData.elements.edges) {
-      graphData.elements.edges = graphData.elements.edges.map(edge => ({ ...elementsDefaults.edges, ...edge }));
+    if (graphData.edges) {
+      graphData.edges = graphData.edges.map(edge => {
+        const decoratedEdge = { ...edge };
+        decoratedEdge.data = { ...elementsDefaults.edges, ...decoratedEdge.data };
+        return decoratedEdge;
+      });
     }
   }
   return graphData;

--- a/src/actions/ServiceGraphDataActions.ts
+++ b/src/actions/ServiceGraphDataActions.ts
@@ -14,6 +14,48 @@ export enum ServiceGraphDataActionKeys {
   HANDLE_LEGEND = 'HANDLE_LEGEND'
 }
 
+// When updating the cytoscape graph, the element data expects to have all the changes
+// non provided values are taken as "this didn't change", similar as setState does.
+// Put default values for all fields that are ommited.
+const decorateGraphData = (graphData: any) => {
+  const elementsDefaults = {
+    edges: {
+      rate: undefined,
+      rate3XX: undefined,
+      rate4XX: undefined,
+      rate5XX: undefined,
+      percentErr: undefined,
+      percentRate: undefined,
+      latency: undefined,
+      isUnused: undefined
+    },
+    nodes: {
+      version: undefined,
+      rate: undefined,
+      rate3XX: undefined,
+      rate4XX: undefined,
+      rate5XX: undefined,
+      rateSelfInvoke: undefined,
+      hasCB: undefined,
+      hasRR: undefined,
+      isDead: undefined,
+      isGroup: undefined,
+      isRoot: undefined,
+      isUnused: undefined,
+      hasMissingSidecars: undefined
+    }
+  };
+  if (graphData && graphData.elements) {
+    if (graphData.elements.nodes) {
+      graphData.elements.nodes = graphData.elements.nodes.map(node => ({ ...elementsDefaults.nodes, ...node }));
+    }
+    if (graphData.elements.edges) {
+      graphData.elements.edges = graphData.elements.edges.map(edge => ({ ...elementsDefaults.edges, ...edge }));
+    }
+  }
+  return graphData;
+};
+
 // synchronous action creators
 export const ServiceGraphDataActions = {
   getGraphDataStart: createAction(ServiceGraphDataActionKeys.GET_GRAPH_DATA_START),
@@ -22,7 +64,7 @@ export const ServiceGraphDataActions = {
     (timestamp: number, graphData: any) => ({
       type: ServiceGraphDataActionKeys.GET_GRAPH_DATA_SUCCESS,
       timestamp: timestamp,
-      graphData: graphData
+      graphData: decorateGraphData(graphData)
     })
   ),
   getGraphDataFailure: createAction(ServiceGraphDataActionKeys.GET_GRAPH_DATA_FAILURE, (error: any) => ({

--- a/src/actions/ServiceGraphDataActions.ts
+++ b/src/actions/ServiceGraphDataActions.ts
@@ -16,7 +16,7 @@ export enum ServiceGraphDataActionKeys {
 
 // When updating the cytoscape graph, the element data expects to have all the changes
 // non provided values are taken as "this didn't change", similar as setState does.
-// Put default values for all fields that are ommited.
+// Put default values for all fields that are omitted.
 const decorateGraphData = (graphData: any) => {
   const elementsDefaults = {
     edges: {

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -204,7 +204,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
 
     this.trafficRenderer.stop();
 
-    const isTheGraphSelectd = this.cy.$(':selected').length === 0;
+    const isTheGraphSelected = this.cy.$(':selected').length === 0;
 
     cy.startBatch();
 
@@ -260,7 +260,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
     cy.endBatch();
 
     // Verify our current selection is still valid, if not, select the graph
-    if (!isTheGraphSelectd && this.cy.$(':selected').length === 0) {
+    if (!isTheGraphSelected && this.cy.$(':selected').length === 0) {
       this.props.onReady(this.cy);
     }
 

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -13,11 +13,9 @@ import { KialiAppState } from '../../store/Store';
 import * as GraphBadge from './graphs/GraphBadge';
 import TrafficRender from './graphs/TrafficRenderer';
 import { ServiceGraphActions } from '../../actions/ServiceGraphActions';
-import { Spinner } from 'patternfly-react';
 
 type CytoscapeGraphType = {
   elements?: any;
-  isLoading?: boolean;
   edgeLabelMode: EdgeLabelMode;
   showNodeLabels: boolean;
   showCircuitBreakers: boolean;
@@ -52,18 +50,20 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
   private graphHighlighter: GraphHighlighter;
   private trafficRenderer: TrafficRender;
   private cytoscapeReactWrapperRef: any;
-  private newLayout: any;
+  private updateLayout: boolean;
   private cy: any;
 
   constructor(props: CytoscapeGraphProps) {
     super(props);
-    this.newLayout = '';
+    this.updateLayout = false;
   }
 
   shouldComponentUpdate(nextProps: any, nextState: any) {
-    this.newLayout = this.props.graphLayout !== nextProps.graphLayout ? nextProps.graphLayout : '';
+    this.updateLayout =
+      this.props.graphLayout !== nextProps.graphLayout ||
+      (this.props.elements !== nextProps.elements &&
+        this.elementsNeedRelayout(this.props.elements, nextProps.elements));
     return (
-      this.props.isLoading !== nextProps.isLoading ||
       this.props.graphLayout !== nextProps.graphLayout ||
       this.props.edgeLabelMode !== nextProps.edgeLabelMode ||
       this.props.showNodeLabels !== nextProps.showNodeLabels ||
@@ -87,21 +87,19 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
   render() {
     return (
       <div id="cytoscape-container" style={{ marginRight: '25em', height: '100%' }}>
-        <Spinner loading={this.props.isLoading}>
-          <EmptyGraphLayout
+        <EmptyGraphLayout
+          elements={this.props.elements}
+          namespace={this.props.namespace.name}
+          action={this.props.refresh}
+        >
+          <CytoscapeReactWrapper
+            ref={e => {
+              this.setCytoscapeReactWrapperRef(e);
+            }}
             elements={this.props.elements}
-            namespace={this.props.namespace.name}
-            action={this.props.refresh}
-          >
-            <CytoscapeReactWrapper
-              ref={e => {
-                this.setCytoscapeReactWrapperRef(e);
-              }}
-              elements={this.props.elements}
-              layout={this.props.graphLayout}
-            />
-          </EmptyGraphLayout>
-        </Spinner>
+            layout={this.props.graphLayout}
+          />
+        </EmptyGraphLayout>
       </div>
     );
   }
@@ -206,31 +204,46 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
 
     this.trafficRenderer.stop();
 
+    const isTheGraphSelectd = this.cy.$(':selected').length === 0;
+
     cy.startBatch();
+
+    // Destroy badges
+    // We must destroy all badges before updating the json, or else we will lose all the
+    // references to removed nodes
+    const cbBadge = new GraphBadge.CircuitBreakerBadge();
+    const rrBadge = new GraphBadge.RouteRuleBadge();
+    const rrGroupBadge = new GraphBadge.RouteRuleGroupBadge();
+    const msBadge = new GraphBadge.MissingSidecarsBadge();
+    cy.nodes().forEach(ele => {
+      cbBadge.destroyBadge(ele);
+      rrBadge.destroyBadge(ele);
+      rrGroupBadge.destroyBadge(ele);
+      msBadge.destroyBadge(ele);
+    });
 
     // update the entire set of nodes and edges to keep the graph up-to-date
     cy.json({ elements: this.props.elements });
 
-    // update the layout if it changed
-    if (this.newLayout) {
-      cy.layout(LayoutDictionary.getLayout(this.newLayout)).run();
-      this.newLayout = '';
+    // update the layout if needed
+    if (this.updateLayout) {
+      cy.layout(LayoutDictionary.getLayout(this.props.graphLayout)).run();
+      // Don't allow a large zoom if the graph has a few nodes (nodes would look too big).
+      if (cy.zoom() > 2.5) {
+        cy.zoom(2.5);
+        cy.center();
+      }
+      this.updateLayout = false;
     }
 
     // Create and destroy labels
     this.turnEdgeLabelsTo(this.props.edgeLabelMode);
     this.turnNodeLabelsTo(this.props.showNodeLabels);
 
-    // Create and destroy badges
-    const cbBadge = new GraphBadge.CircuitBreakerBadge();
-    const rrBadge = new GraphBadge.RouteRuleBadge();
-    const rrGroupBadge = new GraphBadge.RouteRuleGroupBadge();
-    const msBadge = new GraphBadge.MissingSidecarsBadge();
+    // Create badges
     cy.nodes().forEach(ele => {
       if (this.props.showCircuitBreakers && ele.data('hasCB') === 'true') {
         cbBadge.buildBadge(ele);
-      } else {
-        cbBadge.destroyBadge(ele);
       }
       if (this.props.showRouteRules && ele.data('hasRR') === 'true') {
         if (ele.data('isGroup')) {
@@ -238,24 +251,18 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
         } else {
           rrBadge.buildBadge(ele);
         }
-      } else {
-        rrBadge.destroyBadge(ele);
       }
       if (this.props.showMissingSidecars && ele.data('hasMissingSidecars') && !ele.data('isGroup')) {
         msBadge.buildBadge(ele);
-      } else {
-        msBadge.destroyBadge(ele);
       }
     });
 
-    // Don't allow a large zoom if the graph has a few nodes (nodes would look too big).
-    // TODO: only do this if there is a small number of nodes - let the user zoom in large graphs
-    if (cy.zoom() > 2.5) {
-      cy.zoom(2.5);
-      cy.center();
-    }
-
     cy.endBatch();
+
+    // Verify our current selection is still valid, if not, select the graph
+    if (!isTheGraphSelectd && this.cy.$(':selected').length === 0) {
+      this.props.onReady(this.cy);
+    }
 
     // Update TrafficRenderer
     this.trafficRenderer.setEdges(cy.edges());
@@ -276,6 +283,40 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
   private handleMouseOut = (event: CytoscapeMouseOutEvent) => {
     this.graphHighlighter.onMouseOut(event);
   };
+
+  // To know if we should re-layout, we need to know if any element changed
+  // Do a quick round by comparing the number of nodes and edges, if different
+  // a change is expected.
+  // If we have the same number of elements, compare the ids, if we find one that isn't
+  // in the other, we can be sure that there are changes.
+  // Worst case is when they are the same, avoid that.
+  private elementsNeedRelayout(prevElements: any, nextElements: any) {
+    if (
+      !prevElements ||
+      !nextElements ||
+      !prevElements.nodes ||
+      !prevElements.edges ||
+      !nextElements.nodes ||
+      !nextElements.edges ||
+      prevElements.nodes.length !== nextElements.nodes.length ||
+      prevElements.edges.length !== nextElements.edges.length
+    ) {
+      return true;
+    }
+    // If both have the same ids, we don't need to relayout
+    return !(
+      this.nodeOrEdgeArrayHasSameIds(nextElements.nodes, prevElements.nodes) &&
+      this.nodeOrEdgeArrayHasSameIds(nextElements.edges, prevElements.edges)
+    );
+  }
+
+  private nodeOrEdgeArrayHasSameIds(a: Array<any>, b: Array<any>) {
+    const aIds = a.map(e => e.id).sort();
+    return b
+      .map(e => e.id)
+      .sort()
+      .every((eId, index) => eId === aIds[index]);
+  }
 }
 
 const mapStateToProps = (state: KialiAppState) => ({

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -114,21 +114,15 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
   }
 
   private turnEdgeLabelsTo = (value: EdgeLabelMode) => {
-    let elements = this.props.elements;
-    if (elements && elements.edges) {
-      elements.edges.forEach(edge => {
-        edge.data.edgeLabelMode = value;
-      });
-    }
+    this.cy.edges().forEach(edge => {
+      edge.data('edgeLabelMode', value);
+    });
   };
 
   private turnNodeLabelsTo = (value: boolean) => {
-    let elements = this.props.elements;
-    if (elements && elements.nodes) {
-      elements.nodes.forEach(node => {
-        node.data.showNodeLabels = value;
-      });
-    }
+    this.cy.nodes().forEach(node => {
+      node.data('showNodeLabels', value);
+    });
   };
 
   private cyInitialization(cy: any) {

--- a/src/components/GraphFilter/GraphFilter.tsx
+++ b/src/components/GraphFilter/GraphFilter.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Toolbar, Button, Icon, FormGroup } from 'patternfly-react';
+import { Toolbar, Button, Icon, FormGroup, Spinner } from 'patternfly-react';
 
 import { Duration, Layout, EdgeLabelMode } from '../../types/GraphFilter';
 import { ToolbarDropdown } from '../ToolbarDropdown/ToolbarDropdown';
@@ -131,9 +131,11 @@ export default class GraphFilter extends React.Component<GraphFilterProps, Graph
               <Button onClick={this.props.onLegend}>{this.props.hideLegend ? 'Show' : 'Hide'} Legend</Button>
             </div>
             <div className="form-group">
-              <Button disabled={this.props.disabled} onClick={this.handleRefresh}>
-                <Icon name="refresh" />
-              </Button>
+              <Spinner loading={this.props.disabled}>
+                <Button disabled={this.props.disabled} onClick={this.handleRefresh}>
+                  <Icon name="refresh" />
+                </Button>
+              </Spinner>
             </div>
           </Toolbar.RightContent>
         </Toolbar>

--- a/src/pages/ServiceGraph/SummaryPanelCommon.ts
+++ b/src/pages/ServiceGraph/SummaryPanelCommon.ts
@@ -1,0 +1,12 @@
+import { SummaryPanelPropType } from '../../types/Graph';
+
+export const shouldRefreshData = (prevProps: SummaryPanelPropType, nextProps: SummaryPanelPropType) => {
+  return (
+    // Verify the time of the last request
+    prevProps.queryTime !== nextProps.queryTime ||
+    // Check if going from no data to data
+    (!prevProps.data.summaryTarget && nextProps.data.summaryTarget) ||
+    // Check if the target changed
+    prevProps.data.summaryTarget !== nextProps.data.summaryTarget
+  );
+};

--- a/src/pages/ServiceGraph/SummaryPanelEdge.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelEdge.tsx
@@ -12,6 +12,7 @@ import { PfColors } from '../../components/Pf/PfColors';
 import { authentication } from '../../utils/Authentication';
 import { Icon } from 'patternfly-react';
 import { Link } from 'react-router-dom';
+import { shouldRefreshData } from './SummaryPanelCommon';
 
 type SummaryPanelEdgeState = {
   loading: boolean;
@@ -55,9 +56,9 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
     this.updateCharts(this.props);
   }
 
-  componentWillReceiveProps(nextProps: SummaryPanelPropType) {
-    if (nextProps.data.summaryTarget && nextProps.data.summaryTarget !== this.props.data.summaryTarget) {
-      this.updateCharts(nextProps);
+  componentDidUpdate(prevProps: SummaryPanelPropType) {
+    if (shouldRefreshData(prevProps, this.props)) {
+      this.updateCharts(this.props);
     }
   }
 

--- a/src/pages/ServiceGraph/SummaryPanelGraph.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelGraph.tsx
@@ -11,6 +11,7 @@ import { ActiveFilter } from '../../types/NamespaceFilter';
 import * as M from '../../types/Metrics';
 import { Icon } from 'patternfly-react';
 import { authentication } from '../../utils/Authentication';
+import { shouldRefreshData } from './SummaryPanelCommon';
 
 type SummaryPanelGraphState = {
   loading: boolean;
@@ -43,10 +44,18 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
 
   componentDidMount() {
     this._isMounted = true;
-    // TODO (maybe) we omit the rps chart when dealing with multiple namespaces. There is no backend
-    // API support to gather the data. The whole-graph chart is of nominal value, it will likely be OK.
     if (this.props.namespace !== 'all') {
       this.updateRpsChart(this.props);
+    }
+  }
+
+  componentDidUpdate(prevProps: SummaryPanelPropType) {
+    if (shouldRefreshData(prevProps, this.props)) {
+      // TODO (maybe) we omit the rps chart when dealing with multiple namespaces. There is no backend
+      // API support to gather the data. The whole-graph chart is of nominal value, it will likely be OK.
+      if (this.props.namespace !== 'all') {
+        this.updateRpsChart(this.props);
+      }
     }
   }
 

--- a/src/pages/ServiceGraph/SummaryPanelGroup.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelGroup.tsx
@@ -12,6 +12,7 @@ import { PfColors } from '../../components/Pf/PfColors';
 import { Icon } from 'patternfly-react';
 import { authentication } from '../../utils/Authentication';
 import { Link } from 'react-router-dom';
+import { shouldRefreshData } from './SummaryPanelCommon';
 
 type SummaryPanelGroupState = {
   loading: boolean;
@@ -50,9 +51,9 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
     this.updateRpsCharts(this.props);
   }
 
-  componentWillReceiveProps(nextProps: SummaryPanelPropType) {
-    if (nextProps.data.summaryTarget && nextProps.data.summaryTarget !== this.props.data.summaryTarget) {
-      this.updateRpsCharts(nextProps);
+  componentDidUpdate(prevProps: SummaryPanelPropType) {
+    if (shouldRefreshData(prevProps, this.props)) {
+      this.updateRpsCharts(this.props);
     }
   }
 

--- a/src/pages/ServiceGraph/SummaryPanelNode.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelNode.tsx
@@ -13,6 +13,7 @@ import { PfColors } from '../../components/Pf/PfColors';
 import { Icon } from 'patternfly-react';
 import { authentication } from '../../utils/Authentication';
 import { Link } from 'react-router-dom';
+import { shouldRefreshData } from './SummaryPanelCommon';
 
 type SummaryPanelStateType = {
   loading: boolean;
@@ -53,9 +54,9 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
     this.fetchRequestCountMetrics(this.props);
   }
 
-  componentWillReceiveProps(nextProps: SummaryPanelPropType) {
-    if (nextProps.data.summaryTarget && nextProps.data.summaryTarget !== this.props.data.summaryTarget) {
-      this.fetchRequestCountMetrics(nextProps);
+  componentDidUpdate(prevProps: SummaryPanelPropType) {
+    if (shouldRefreshData(prevProps, this.props)) {
+      this.fetchRequestCountMetrics(this.props);
     }
   }
 

--- a/src/reducers/ServiceGraphDataState.ts
+++ b/src/reducers/ServiceGraphDataState.ts
@@ -22,7 +22,6 @@ const serviceGraphDataState = (state: ServiceGraphState = INITIAL_STATE, action)
   switch (action.type) {
     case ServiceGraphDataActionKeys.GET_GRAPH_DATA_START:
       newState.isLoading = true;
-      newState.sidePanelInfo = null;
       break;
     case ServiceGraphDataActionKeys.HANDLE_LEGEND:
       return {


### PR DESCRIPTION
This should fix the following issues:

- When changing from namespace (all nodes on top of each other)
- When receiving rates/latencies, they are not updated accurately and sometimes it shows a different one nor they are removed when the rate/latency is empty.
- Edge labels are not loaded accurately, if selecting one when the metrics don't have rate or latency in place
- Refresh side panel info with the current graph
- Badges are not removed when changing from namespace
