### PR TITLE
Kiali-852 Fix Toolbar

### DIFF
--- a/src/actions/ServiceGraphFilterActions.ts
+++ b/src/actions/ServiceGraphFilterActions.ts
@@ -4,6 +4,7 @@ import { EdgeLabelMode } from '../types/GraphFilter';
 
 export enum ServiceGraphFilterActionKeys {
   // Toggle Actions
+  TOGGLE_LEGEND = 'TOGGLE_LEGEND',
   TOGGLE_GRAPH_NODE_LABEL = 'TOGGLE_GRAPH_NODE_LABEL',
   TOGGLE_GRAPH_CIRCUIT_BREAKERS = 'TOGGLE_GRAPH_CIRCUIT_BREAKERS',
   TOGGLE_GRAPH_ROUTE_RULES = 'TOGGLE_GRAPH_ROUTE_RULES',
@@ -17,6 +18,7 @@ export enum ServiceGraphFilterActionKeys {
 export const serviceGraphFilterActions = {
   // Toggle actions
   toggleGraphNodeLabel: createAction(ServiceGraphFilterActionKeys.TOGGLE_GRAPH_NODE_LABEL),
+  toggleLegend: createAction(ServiceGraphFilterActionKeys.TOGGLE_LEGEND),
   setGraphEdgeLabelMode: createAction(
     ServiceGraphFilterActionKeys.SET_GRAPH_EDGE_LABEL_MODE,
     (edgeLabelMode: EdgeLabelMode) => ({

--- a/src/actions/__tests__/GraphFilterAction.test.tsx
+++ b/src/actions/__tests__/GraphFilterAction.test.tsx
@@ -13,6 +13,13 @@ describe('GraphFilterActions', () => {
     );
   });
 
+  it('should toggle the legend ', () => {
+    const expectedAction = {
+      type: ServiceGraphFilterActionKeys.TOGGLE_LEGEND
+    };
+    expect(serviceGraphFilterActions.toggleLegend()).toEqual(expectedAction);
+  });
+
   it('should toggle a node label ', () => {
     const expectedAction = {
       type: ServiceGraphFilterActionKeys.TOGGLE_GRAPH_NODE_LABEL

--- a/src/components/GraphFilter/GraphFilter.tsx
+++ b/src/components/GraphFilter/GraphFilter.tsx
@@ -19,12 +19,8 @@ export interface GraphFilterProps extends GraphParamsType {
   onNamespaceChange: (newValue: Namespace) => void;
   onEdgeLabelModeChange: (newEdges: EdgeLabelMode) => void;
   onRefresh: () => void;
-  onLegend: () => void;
-  hideLegend: boolean;
-}
-
-export interface GraphFilterState {
-  legend: boolean;
+  // onLegend: () => void;
+  // hideLegend: boolean;
 }
 
 const zeroPaddingLeft = style({
@@ -34,7 +30,7 @@ const labelPaddingRight = style({
   paddingRight: '0.5em'
 });
 
-export default class GraphFilter extends React.Component<GraphFilterProps, GraphFilterState> {
+export default class GraphFilter extends React.PureComponent<GraphFilterProps> {
   // TODO:  We should keep these mappings with their corresponding filtering components.
   // GraphFilter should be minimal and used for assembling those filtering components.
   static readonly INTERVAL_DURATION = config().toolbar.intervalDuration;
@@ -46,9 +42,6 @@ export default class GraphFilter extends React.Component<GraphFilterProps, Graph
 
   constructor(props: GraphFilterProps) {
     super(props);
-    this.state = {
-      legend: false
-    };
   }
 
   updateDuration = (value: number) => {
@@ -127,14 +120,11 @@ export default class GraphFilter extends React.Component<GraphFilterProps, Graph
             <GraphLayersContainer />
           </FormGroup>
           <Toolbar.RightContent>
-            <div className="form-group">
-              <Button onClick={this.props.onLegend}>{this.props.hideLegend ? 'Show' : 'Hide'} Legend</Button>
-            </div>
-            <div className="form-group">
+            <FormGroup className={zeroPaddingLeft}>
               <Button disabled={this.props.disabled} onClick={this.handleRefresh}>
                 <Icon name="refresh" />
               </Button>
-            </div>
+            </FormGroup>
           </Toolbar.RightContent>
         </Toolbar>
       </>

--- a/src/components/GraphFilter/GraphFilterToolbar.tsx
+++ b/src/components/GraphFilter/GraphFilterToolbar.tsx
@@ -10,7 +10,7 @@ import { makeURLFromParams } from '../../components/Nav/NavUtils';
 
 import GraphFilter from './GraphFilter';
 
-export default class GraphFilterToolbar extends React.PureComponent<GraphFilterToolbarType, {}> {
+export default class GraphFilterToolbar extends React.PureComponent<GraphFilterToolbarType> {
   static contextTypes = {
     router: PropTypes.object
   };
@@ -31,8 +31,6 @@ export default class GraphFilterToolbar extends React.PureComponent<GraphFilterT
         onNamespaceChange={this.handleNamespaceChange}
         onEdgeLabelModeChange={this.handleEdgeLabelModeChange}
         onRefresh={this.props.handleRefreshClick}
-        onLegend={this.props.handleLegendClick}
-        hideLegend={this.props.hideLegend}
         {...graphParams}
       />
     );

--- a/src/components/GraphFilter/__tests__/GraphFilterToolbar.test.tsx
+++ b/src/components/GraphFilter/__tests__/GraphFilterToolbar.test.tsx
@@ -17,15 +17,7 @@ const PARAMS: GraphParamsType = {
 describe('ServiceGraphPage test', () => {
   it('should propagate filter params change with correct value', () => {
     const onParamsChangeMockFn = jest.fn();
-    const wrapper = shallow(
-      <GraphFilterToolbar
-        {...PARAMS}
-        isLoading={false}
-        handleRefreshClick={jest.fn()}
-        handleLegendClick={jest.fn()}
-        hideLegend={true}
-      />
-    );
+    const wrapper = shallow(<GraphFilterToolbar {...PARAMS} isLoading={false} handleRefreshClick={jest.fn()} />);
 
     const toolbar = wrapper.instance() as GraphFilterToolbar;
     toolbar.handleFilterChange = onParamsChangeMockFn;

--- a/src/containers/GraphLayersContainer.tsx
+++ b/src/containers/GraphLayersContainer.tsx
@@ -4,9 +4,11 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { serviceGraphFilterActions } from '../actions/ServiceGraphFilterActions';
 import { KialiAppState, ServiceGraphFilterState } from '../store/Store';
+import { style } from 'typestyle';
 
 interface ServiceGraphDispatch {
   // Dispatch methods
+  toggleLegend(): void;
   toggleGraphNodeLabels(): void;
   toggleGraphCircuitBreakers(): void;
   toggleGraphRouteRules(): void;
@@ -19,6 +21,7 @@ type GraphLayersProps = ServiceGraphDispatch & ServiceGraphFilterState;
 
 // Allow Redux to map sections of our global app state to our props
 const mapStateToProps = (state: KialiAppState) => ({
+  showLegend: state.serviceGraph.filterState.showLegend,
   showNodeLabels: state.serviceGraph.filterState.showNodeLabels,
   showCircuitBreakers: state.serviceGraph.filterState.showCircuitBreakers,
   showRouteRules: state.serviceGraph.filterState.showRouteRules,
@@ -29,6 +32,7 @@ const mapStateToProps = (state: KialiAppState) => ({
 // Map our actions to Redux
 const mapDispatchToProps = (dispatch: any) => {
   return {
+    toggleLegend: bindActionCreators(serviceGraphFilterActions.toggleLegend, dispatch),
     toggleGraphNodeLabels: bindActionCreators(serviceGraphFilterActions.toggleGraphNodeLabel, dispatch),
     setGraphEdgeLabelMode: bindActionCreators(serviceGraphFilterActions.setGraphEdgeLabelMode, dispatch),
     toggleGraphCircuitBreakers: bindActionCreators(serviceGraphFilterActions.toggleGraphCircuitBreakers, dispatch),
@@ -49,9 +53,17 @@ interface VisibilityLayersType {
 // Right now it is a toolbar with Switch Buttons -- this will change once with UXD input
 export const GraphLayers: React.SFC<GraphLayersProps> = props => {
   // map our attributes from redux
-  const { showCircuitBreakers, showRouteRules, showNodeLabels, showMissingSidecars, showTrafficAnimation } = props;
+  const {
+    showLegend,
+    showCircuitBreakers,
+    showRouteRules,
+    showNodeLabels,
+    showMissingSidecars,
+    showTrafficAnimation
+  } = props;
   // // map or dispatchers for redux
   const {
+    toggleLegend,
     toggleGraphCircuitBreakers,
     toggleGraphRouteRules,
     toggleGraphNodeLabels,
@@ -60,6 +72,12 @@ export const GraphLayers: React.SFC<GraphLayersProps> = props => {
   } = props;
 
   const visibilityLayers: VisibilityLayersType[] = [
+    {
+      id: 'toggleLegend',
+      labelText: 'Legend',
+      value: showLegend,
+      onChange: toggleLegend
+    },
     {
       id: 'filterCB',
       labelText: 'Circuit Breakers',
@@ -92,11 +110,12 @@ export const GraphLayers: React.SFC<GraphLayersProps> = props => {
     }
   ];
 
+  const checkboxStyle = style({ marginLeft: 5 });
   const toggleItems = visibilityLayers.map((item: VisibilityLayersType) => (
     <div id={item.id} key={item.id}>
       <label>
-        <input name="isGoing" type="checkbox" checked={item.value} onChange={() => item.onChange()} />
-        {item.labelText}
+        <input type="checkbox" checked={item.value} onChange={() => item.onChange()} />
+        <span className={checkboxStyle}>{item.labelText}</span>
       </label>
     </div>
   ));

--- a/src/containers/ServiceGraphPageContainer.ts
+++ b/src/containers/ServiceGraphPageContainer.ts
@@ -5,6 +5,8 @@ import { Duration } from '../types/GraphFilter';
 import ServiceGraphPage from '../pages/ServiceGraph/ServiceGraphPage';
 
 import { ServiceGraphDataActions } from '../actions/ServiceGraphDataActions';
+import { serviceGraphFilterActions } from '../actions/ServiceGraphFilterActions';
+import { bindActionCreators } from 'redux';
 
 const mapStateToProps = (state: KialiAppState) => ({
   graphTimestamp: state.serviceGraph.graphDataTimestamp,
@@ -16,13 +18,13 @@ const mapStateToProps = (state: KialiAppState) => ({
         summaryType: state.serviceGraph.sidePanelInfo.kind
       }
     : null,
-  hideLegend: state.serviceGraph.hideLegend
+  showLegend: state.serviceGraph.filterState.showLegend
 });
 
 const mapDispatchToProps = (dispatch: any) => ({
   fetchGraphData: (namespace: Namespace, graphDuration: Duration) =>
     dispatch(ServiceGraphDataActions.fetchGraphData(namespace, graphDuration)),
-  handleLegend: () => dispatch(ServiceGraphDataActions.handleLegend())
+  toggleLegend: () => bindActionCreators(serviceGraphFilterActions.toggleLegend, dispatch)
 });
 
 const ServiceGraphPageConnected = connect(mapStateToProps, mapDispatchToProps)(ServiceGraphPage);

--- a/src/pages/ServiceGraph/ServiceGraphPage.tsx
+++ b/src/pages/ServiceGraph/ServiceGraphPage.tsx
@@ -13,19 +13,15 @@ import { style } from 'typestyle';
 
 import GraphLegend from '../../components/GraphFilter/GraphLegend';
 
-type ServiceGraphPageState = {
-  // stateless
-};
-
 type ServiceGraphPageProps = GraphParamsType & {
   graphTimestamp: string;
   graphData: any;
   isLoading: boolean;
-  hideLegend: boolean;
+  showLegend: boolean;
   isReady: boolean;
   fetchGraphData: (namespace: Namespace, graphDuration: Duration) => any;
+  toggleLegend: () => void;
   summaryData: SummaryData | null;
-  handleLegend: () => void;
 };
 const NUMBER_OF_DATAPOINTS = 30;
 
@@ -37,7 +33,7 @@ const cytscapeGraphStyle = style({
   left: 220
 });
 
-export default class ServiceGraphPage extends React.Component<ServiceGraphPageProps, ServiceGraphPageState> {
+export default class ServiceGraphPage extends React.PureComponent<ServiceGraphPageProps> {
   constructor(props: ServiceGraphPageProps) {
     super(props);
 
@@ -79,8 +75,6 @@ export default class ServiceGraphPage extends React.Component<ServiceGraphPagePr
         <GraphFilterToolbar
           isLoading={this.props.isLoading}
           handleRefreshClick={this.handleRefreshClick}
-          handleLegendClick={this.props.handleLegend}
-          hideLegend={this.props.hideLegend}
           {...graphParams}
         />
         <div className={cytscapeGraphStyle}>
@@ -100,13 +94,13 @@ export default class ServiceGraphPage extends React.Component<ServiceGraphPagePr
             />
           ) : null}
         </div>
-        {!this.props.hideLegend && <GraphLegend closeLegend={this.props.handleLegend} />}
+        {this.props.showLegend && <GraphLegend closeLegend={this.props.toggleLegend} />}
       </PfContainerNavVertical>
     );
   }
 
   /** Fetch graph data */
-  loadGraphDataFromBackend = (namespace?: Namespace, graphDuration?: Duration) => {
+  private loadGraphDataFromBackend = (namespace?: Namespace, graphDuration?: Duration) => {
     namespace = namespace ? namespace : this.props.namespace;
     graphDuration = graphDuration ? graphDuration : this.props.graphDuration;
     this.props.fetchGraphData(namespace, graphDuration);

--- a/src/reducers/ServiceGraphFilterState.ts
+++ b/src/reducers/ServiceGraphFilterState.ts
@@ -4,6 +4,7 @@ import { updateState } from '../utils/Reducer';
 import { EdgeLabelMode } from '../types/GraphFilter';
 
 const INITIAL_STATE: ServiceGraphFilterState = {
+  showLegend: false,
   showNodeLabels: true,
   showCircuitBreakers: false,
   showRouteRules: true,
@@ -17,6 +18,8 @@ const INITIAL_STATE: ServiceGraphFilterState = {
 // This Reducer allows changes to the 'serviceGraphFilterState' portion of Redux Store
 const serviceGraphFilterState = (state: ServiceGraphFilterState = INITIAL_STATE, action) => {
   switch (action.type) {
+    case ServiceGraphFilterActionKeys.TOGGLE_LEGEND:
+      return updateState(state, { showLegend: !state.showLegend });
     case ServiceGraphFilterActionKeys.TOGGLE_GRAPH_NODE_LABEL:
       return updateState(state, { showNodeLabels: !state.showNodeLabels });
     case ServiceGraphFilterActionKeys.SET_GRAPH_EDGE_LABEL_MODE:

--- a/src/reducers/__tests__/ServiceGraphFilterStateReducer.test.ts
+++ b/src/reducers/__tests__/ServiceGraphFilterStateReducer.test.ts
@@ -5,6 +5,34 @@ import { EdgeLabelMode } from '../../types/GraphFilter';
 describe('ServiceGraphFilterState reducer', () => {
   it('should return the initial state', () => {
     expect(serviceGraphFilterState(undefined, {})).toEqual({
+      showLegend: false,
+      showNodeLabels: true,
+      edgeLabelMode: EdgeLabelMode.HIDE,
+      showCircuitBreakers: false,
+      showRouteRules: true,
+      showMissingSidecars: true,
+      showTrafficAnimation: false
+    });
+  });
+
+  it('should handle TOGGLE_LEGEND', () => {
+    expect(
+      serviceGraphFilterState(
+        {
+          showLegend: false,
+          showNodeLabels: true,
+          edgeLabelMode: EdgeLabelMode.HIDE,
+          showCircuitBreakers: false,
+          showRouteRules: true,
+          showMissingSidecars: true,
+          showTrafficAnimation: false
+        },
+        {
+          type: ServiceGraphFilterActionKeys.TOGGLE_LEGEND
+        }
+      )
+    ).toEqual({
+      showLegend: true,
       showNodeLabels: true,
       edgeLabelMode: EdgeLabelMode.HIDE,
       showCircuitBreakers: false,
@@ -18,6 +46,7 @@ describe('ServiceGraphFilterState reducer', () => {
     expect(
       serviceGraphFilterState(
         {
+          showLegend: false,
           showNodeLabels: true,
           edgeLabelMode: EdgeLabelMode.HIDE,
           showCircuitBreakers: false,
@@ -30,6 +59,7 @@ describe('ServiceGraphFilterState reducer', () => {
         }
       )
     ).toEqual({
+      showLegend: false,
       showNodeLabels: false,
       edgeLabelMode: EdgeLabelMode.HIDE,
       showCircuitBreakers: false,
@@ -43,6 +73,7 @@ describe('ServiceGraphFilterState reducer', () => {
     expect(
       serviceGraphFilterState(
         {
+          showLegend: false,
           showNodeLabels: true,
           edgeLabelMode: EdgeLabelMode.HIDE,
           showCircuitBreakers: false,
@@ -56,6 +87,7 @@ describe('ServiceGraphFilterState reducer', () => {
         }
       )
     ).toEqual({
+      showLegend: false,
       showNodeLabels: true,
       edgeLabelMode: EdgeLabelMode.LATENCY_95TH_PERCENTILE,
       showCircuitBreakers: false,
@@ -68,6 +100,7 @@ describe('ServiceGraphFilterState reducer', () => {
     expect(
       serviceGraphFilterState(
         {
+          showLegend: false,
           showNodeLabels: true,
           edgeLabelMode: EdgeLabelMode.HIDE,
           showCircuitBreakers: false,
@@ -80,6 +113,7 @@ describe('ServiceGraphFilterState reducer', () => {
         }
       )
     ).toEqual({
+      showLegend: false,
       showNodeLabels: true,
       edgeLabelMode: EdgeLabelMode.HIDE,
       showCircuitBreakers: true,
@@ -92,6 +126,7 @@ describe('ServiceGraphFilterState reducer', () => {
     expect(
       serviceGraphFilterState(
         {
+          showLegend: false,
           showNodeLabels: true,
           edgeLabelMode: EdgeLabelMode.HIDE,
           showCircuitBreakers: false,
@@ -104,6 +139,7 @@ describe('ServiceGraphFilterState reducer', () => {
         }
       )
     ).toEqual({
+      showLegend: false,
       showNodeLabels: true,
       edgeLabelMode: EdgeLabelMode.HIDE,
       showCircuitBreakers: false,
@@ -116,6 +152,7 @@ describe('ServiceGraphFilterState reducer', () => {
     expect(
       serviceGraphFilterState(
         {
+          showLegend: false,
           showNodeLabels: true,
           showCircuitBreakers: false,
           showRouteRules: true,
@@ -128,6 +165,7 @@ describe('ServiceGraphFilterState reducer', () => {
         }
       )
     ).toEqual({
+      showLegend: false,
       showNodeLabels: true,
       showCircuitBreakers: false,
       showRouteRules: true,
@@ -140,6 +178,7 @@ describe('ServiceGraphFilterState reducer', () => {
     expect(
       serviceGraphFilterState(
         {
+          showLegend: false,
           showNodeLabels: true,
           showCircuitBreakers: false,
           showRouteRules: true,
@@ -152,6 +191,7 @@ describe('ServiceGraphFilterState reducer', () => {
         }
       )
     ).toEqual({
+      showLegend: false,
       showNodeLabels: true,
       showCircuitBreakers: false,
       showRouteRules: true,

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -9,6 +9,7 @@ export interface GlobalState {
 // Various pages are described here with their various sections
 export interface ServiceGraphFilterState {
   // Toggle props
+  readonly showLegend: boolean;
   readonly showNodeLabels: boolean;
   readonly showCircuitBreakers: boolean;
   readonly showRouteRules: boolean;

--- a/src/types/GraphFilterToolbar.ts
+++ b/src/types/GraphFilterToolbar.ts
@@ -3,6 +3,4 @@ import { GraphParamsType } from './Graph';
 export default interface GraphFilterToolbarType extends GraphParamsType {
   isLoading: boolean;
   handleRefreshClick: () => void;
-  handleLegendClick: () => void;
-  hideLegend: boolean;
 }


### PR DESCRIPTION
Cleanup the toolbar. There are too many items in it now so it has started overlapping into the next line and doesn't look good. This PR moves the **Show Legend** to a Filter submenu (popover) to conserve space.

![legend](https://user-images.githubusercontent.com/1312165/40861655-a6ecfde4-659e-11e8-861b-6cc69ce78d39.gif)



https://issues.jboss.org/browse/KIALI-852