### PR TITLE
KIALI-845: Fix badge positioning when there are browser scrollbars

### DIFF
--- a/src/components/CytoscapeGraph/graphs/GraphBadge.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphBadge.ts
@@ -60,7 +60,10 @@ class GraphBadge {
           .getBoundingClientRect();
         const position = node.renderedPosition();
         const zoom = node.cy().zoom();
-        return { x: position.x - offset.left + 4 * zoom, y: position.y - offset.top - 15 * zoom };
+        return {
+          x: position.x - offset.left + 4 * zoom - 2 * window.pageXOffset,
+          y: position.y - offset.top - 15 * zoom - 2 * window.pageYOffset
+        };
       },
       popper: {
         positionFixed: false,


### PR DESCRIPTION
this is the same as edgar's PR #398, but rebased on master to see if travis is fixed