### PR TITLE
KIALI-269 Warning Message when the Istio version is not supported

### DIFF
--- a/src/actions/HelpDropdownActions.ts
+++ b/src/actions/HelpDropdownActions.ts
@@ -1,0 +1,50 @@
+import { createAction } from 'typesafe-actions';
+import * as API from '../services/Api';
+import { Component } from '../store/Store';
+import { MessageType } from '../types/MessageCenter';
+import { MessageCenterActions } from './MessageCenterActions';
+
+export enum HelpDropdownActionKeys {
+  STATUS_REFRESH = 'STATUS_REFRESH'
+}
+
+export const HelpDropdownActions = {
+  statusRefresh: createAction(
+    HelpDropdownActionKeys.STATUS_REFRESH,
+    (status: { [key: string]: string }, components: Component[], warningMessages: string[]) => ({
+      type: HelpDropdownActionKeys.STATUS_REFRESH,
+      status: status,
+      components: components,
+      warningMessages: warningMessages
+    })
+  ),
+  refresh: () => {
+    return (dispatch, getState) => {
+      const state = getState();
+
+      API.getStatus('Bearer ' + state.authentication.token.token).then(
+        status => {
+          dispatch(
+            HelpDropdownActions.statusRefresh(
+              status['data']['status'],
+              status['data']['externalServices'],
+              status['data']['warningMessages']
+            )
+          );
+          status['data']['warningMessages'].forEach(wMsg => {
+            dispatch(MessageCenterActions.addMessage(wMsg, 'default', MessageType.WARNING));
+          });
+        },
+        error => {
+          dispatch(
+            MessageCenterActions.addMessage(
+              API.getErrorMsg('Error fetching status.', error),
+              'default',
+              MessageType.WARNING
+            )
+          );
+        }
+      );
+    };
+  }
+};

--- a/src/actions/LoginActions.ts
+++ b/src/actions/LoginActions.ts
@@ -2,6 +2,7 @@ import { createAction } from 'typesafe-actions';
 import * as API from '../services/Api';
 import { Token } from '../store/Store';
 import { HTTP_CODES } from '../types/Common';
+import { HelpDropdownActions } from './HelpDropdownActions';
 
 export enum LoginActionKeys {
   LOGIN_REQUEST = 'LOGIN_REQUEST',
@@ -56,6 +57,7 @@ export const LoginActions = {
       API.login(username, password).then(
         token => {
           dispatch(LoginActions.loginSuccess(token['data'], username));
+          dispatch(HelpDropdownActions.refresh());
         },
         error => {
           dispatch(LoginActions.loginFailure(error));

--- a/src/components/About/AboutUIModal.tsx
+++ b/src/components/About/AboutUIModal.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { AboutModal, Spinner } from 'patternfly-react';
-import * as API from '../../services/Api';
-import { authentication } from '../../utils/Authentication';
+import { AboutModal } from 'patternfly-react';
+import { Component } from '../../store/Store';
 
 const pfLogo = require('../../img/logo-alt.svg');
 const KIALI_CORE_COMMIT_HASH = 'Kiali core commit hash';
@@ -9,67 +8,21 @@ const KIALI_CORE_VERSION = 'Kiali core version';
 
 type AboutUIModalState = {
   showModal: boolean;
-  loadingVersions: boolean;
-  versions: Array<AboutUIModalService>;
-  externalServices: Array<AboutUIModalProduct>;
 };
 
-type AboutUIModalService = {
-  name: string;
-  version: string;
+type AboutUIModalProps = {
+  status: { [key: string]: string };
+  components: Component[];
 };
 
-type AboutUIModalProduct = {
-  name: string;
-  version: string;
-  full_version: string;
-};
-
-const getStatus = () => {
-  return API.getStatus(authentication()).then(response => {
-    const rawStatus = response['data'];
-    return {
-      kiali: [
-        {
-          name: 'kiali',
-          version: `${rawStatus['status'][KIALI_CORE_VERSION]} (${rawStatus['status'][KIALI_CORE_COMMIT_HASH]})`
-        }
-      ],
-      externalServices: rawStatus['externalServices']
-    };
-  });
-};
-
-class AboutUIModal extends React.Component<Object, AboutUIModalState> {
-  constructor(props: any) {
+class AboutUIModal extends React.Component<AboutUIModalProps, AboutUIModalState> {
+  constructor(props: AboutUIModalProps) {
     super(props);
-    this.state = { showModal: false, loadingVersions: false, versions: [], externalServices: [] };
+    this.state = { showModal: false };
   }
 
   open = () => {
-    this.setState(state => {
-      if (!state.loadingVersions) {
-        getStatus().then(
-          status => {
-            this.setState({
-              loadingVersions: false,
-              versions: status['kiali'],
-              externalServices: status['externalServices']
-            });
-          },
-          error => {
-            console.log(error);
-            this.setState({
-              loadingVersions: false,
-              versions: [],
-              externalServices: []
-            });
-          }
-        );
-        return { showModal: true, loadingVersions: true, versions: [], externalServices: [] };
-      }
-      return state;
-    });
+    this.setState({ showModal: true });
   };
 
   close = () => {
@@ -84,22 +37,20 @@ class AboutUIModal extends React.Component<Object, AboutUIModalState> {
         productTitle="Kiali"
         logo={pfLogo}
         altLogo="Kiali Logo"
-        trademarkText="Trademark Text"
       >
         <AboutModal.Versions>
           <AboutModal.VersionItem
             label="kiali-ui"
             versionText={`${process.env.REACT_APP_VERSION} (${process.env.REACT_APP_GIT_HASH})`}
           />
-          <Spinner style={{ marginTop: '15px' }} loading={this.state.loadingVersions} size="lg" inverse={true}>
-            {this.state.versions.map(service => (
-              <AboutModal.VersionItem key={service.name} label={service.name} versionText={service.version} />
-            ))}
-            <h3>Esternal Services </h3>
-            {this.state.externalServices.map(extServ => (
-              <AboutModal.VersionItem key={extServ.name} label={extServ.name} versionText={extServ.version} />
-            ))}
-          </Spinner>
+          <AboutModal.VersionItem
+            label="kiali"
+            versionText={`${this.props.status[KIALI_CORE_VERSION]} (${this.props.status[KIALI_CORE_COMMIT_HASH]})`}
+          />
+          <h3>Components </h3>
+          {this.props.components.map(component => (
+            <AboutModal.VersionItem key={component.name} label={component.name} versionText={component.version} />
+          ))}
         </AboutModal.Versions>
       </AboutModal>
     );

--- a/src/components/MessageCenter/MessageCenterTrigger.tsx
+++ b/src/components/MessageCenter/MessageCenterTrigger.tsx
@@ -10,15 +10,20 @@ type PropsType = {
 
 export default class MessageCenterTrigger extends React.PureComponent<PropsType, StateType> {
   render() {
+    let icon;
+    if (this.props.newMessagesCount > 0) {
+      icon = (
+        <div>
+          <PfReact.Icon name="warning-triangle-o" type="pf" /> {this.props.newMessagesCount} open issues
+        </div>
+      );
+    } else {
+      icon = <PfReact.Icon name="bell" />;
+    }
     return (
       <li className="drawer-pf-trigger">
         <a className="nav-item-iconic" onClick={this.props.toggleMessageCenter}>
-          <PfReact.Icon name="bell" />
-          {this.props.newMessagesCount > 0 && (
-            <PfReact.Badge className={'pf-badge-bodered' + (this.props.badgeDanger ? ' badge-danger' : '')}>
-              {this.props.newMessagesCount}
-            </PfReact.Badge>
-          )}
+          {icon}
         </a>
       </li>
     );

--- a/src/components/Nav/HelpDropdown.tsx
+++ b/src/components/Nav/HelpDropdown.tsx
@@ -2,9 +2,21 @@ import * as React from 'react';
 import { Dropdown, Icon, MenuItem } from 'patternfly-react';
 
 import AboutUIModal from '../About/AboutUIModal';
+import { Component } from '../../store/Store';
 
-class HelpDropdown extends React.Component {
+type HelpDropdownProps = {
+  status: { [key: string]: string };
+  components: Component[];
+  warningMessages: string[];
+};
+type HelpDropdownState = {};
+
+class HelpDropdown extends React.Component<HelpDropdownProps, HelpDropdownState> {
   about: any;
+
+  constructor(props: HelpDropdownProps) {
+    super(props);
+  }
 
   render() {
     return (
@@ -13,6 +25,8 @@ class HelpDropdown extends React.Component {
           ref={about => {
             this.about = about;
           }}
+          status={this.props.status}
+          components={this.props.components}
         />
         <Dropdown componentClass="li" id="help">
           <Dropdown.Toggle useAnchor={true} className="nav-item-iconic">

--- a/src/components/Nav/Navigation.tsx
+++ b/src/components/Nav/Navigation.tsx
@@ -9,7 +9,7 @@ import MessageCenter from '../../containers/MessageCenterContainer';
 
 import IstioConfigPage from '../../pages/IstioConfigList/IstioConfigListPage';
 import IstioConfigDetailsPage from '../../pages/IstioConfigDetails/IstioConfigDetailsPage';
-import HelpDropdown from './HelpDropdown';
+import HelpDropdown from '../../containers/HelpDropdownContainer';
 import UserDropdown from '../../containers/UserDropdownContainer';
 import ServiceDetailsPage from '../../pages/ServiceDetails/ServiceDetailsPage';
 import ServiceGraphRouteHandler from '../../pages/ServiceGraph/ServiceGraphRouteHandler';

--- a/src/containers/HelpDropdownContainer.ts
+++ b/src/containers/HelpDropdownContainer.ts
@@ -1,0 +1,21 @@
+import { KialiAppState } from '../store/Store';
+import { connect } from 'react-redux';
+import HelpDropdown from '../components/Nav/HelpDropdown';
+
+import { HelpDropdownActions } from '../actions/HelpDropdownActions';
+
+const mapStateToProps = (state: KialiAppState) => ({
+  status: state.statusState.status,
+  components: state.statusState.components,
+  warningMessages: state.statusState.warningMessages
+});
+
+const mapDispatchToProps = (dispatch: any) => ({
+  refresh: () => dispatch(HelpDropdownActions.refresh())
+});
+
+const HelpDropdownConnected = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(HelpDropdown);
+export default HelpDropdownConnected;

--- a/src/reducers/HelpDropdownState.ts
+++ b/src/reducers/HelpDropdownState.ts
@@ -1,0 +1,24 @@
+import { StatusState } from '../store/Store';
+import { HelpDropdownActionKeys } from '../actions/HelpDropdownActions';
+
+const INITIAL_STATE: StatusState = {
+  status: {},
+  components: [],
+  warningMessages: []
+};
+
+// This Reducer allows changes to the 'serviceGraphDataState' portion of Redux Store
+const HelpDropdownState = (state: StatusState = INITIAL_STATE, action) => {
+  switch (action.type) {
+    case HelpDropdownActionKeys.STATUS_REFRESH:
+      return Object.assign({}, INITIAL_STATE, {
+        status: action.status,
+        components: action.components,
+        warningMessages: action.warningMessages
+      });
+    default:
+      return state;
+  }
+};
+
+export default HelpDropdownState;

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -4,11 +4,13 @@ import namespaces from './Namespaces';
 import { KialiAppState } from '../store/Store';
 import messageCenter from './MessageCenter';
 import LoginState from './LoginState';
+import HelpDropdownState from './HelpDropdownState';
 import serviceGraphDataState from './ServiceGraphDataState';
 import globalState from './GlobalState';
 
 const rootReducer = combineReducers<KialiAppState>({
   authentication: LoginState,
+  statusState: HelpDropdownState,
   messageCenter,
   namespaces,
   globalState: globalState,

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -56,6 +56,17 @@ export interface LoginState {
   logged: boolean;
   logging: boolean;
 }
+
+export interface Component {
+  name: string;
+  version: string;
+}
+
+export interface StatusState {
+  status: { [key: string]: string };
+  components: Component[];
+  warningMessages: string[];
+}
 // @todo: Add namespaces interface
 
 // This defines the Kiali Global Application State
@@ -63,6 +74,7 @@ export interface KialiAppState {
   // Global state === across multiple pages
   // could also be session state
   globalState: GlobalState;
+  statusState: StatusState;
   // page settings
   authentication: LoginState;
   messageCenter: MessageCenterState;


### PR DESCRIPTION
Show a warning message when the Istio version is not supported.
JIRA: [KIALI-269](https://issues.jboss.org/browse/KIALI-269)

**Require**: https://github.com/kiali/kiali/pull/248

- About Modal Refactored
- Now when the user do login an getStatus action is executed and get versions, products and warningMessages (The application no longer asks for a request each time ithe users go to aboutmodal). This trigger to MessageCenter if there is a warningMessage.

_Example with Istio installed 0.7.1 and the Istio required is >= 0.8_

![error_version](https://user-images.githubusercontent.com/3019213/40909847-eee11376-67ea-11e8-827b-ca2d12881fe3.gif)


@abonas I don't know if it is better to show a message in the navigation bar between the spinner and the bell icon or it's ok with this. Should we ask to @serenamarie125 ?