### PR TITLE
[POC] KIALI-756 New Overview Page

### DIFF
--- a/src/actions/ServiceGraphDataActions.ts
+++ b/src/actions/ServiceGraphDataActions.ts
@@ -4,6 +4,7 @@ import { Duration } from '../types/GraphFilter';
 import * as API from '../services/Api';
 import * as MessageCenter from '../utils/MessageCenter';
 import { authentication } from '../utils/Authentication';
+import * as H from '../utils/Health';
 
 const EMPTY_GRAPH_DATA = { nodes: [], edges: [] };
 
@@ -11,6 +12,11 @@ export enum ServiceGraphDataActionKeys {
   GET_GRAPH_DATA_START = 'GET_GRAPH_DATA_START',
   GET_GRAPH_DATA_SUCCESS = 'GET_GRAPH_DATA_SUCCESS',
   GET_GRAPH_DATA_FAILURE = 'GET_GRAPH_DATA_FAILURE',
+  CLEANUP_GRAPH_DATA = 'CLEANUP_GRAPH_DATA',
+  GET_OVERVIEW_GRAPH_DATA_START = 'GET_OVERVIEW_GRAPH_DATA_START',
+  GET_OVERVIEW_GRAPH_DATA_SUCCESS = 'GET_OVERVIEW_GRAPH_DATA_SUCCESS',
+  GET_OVERVIEW_GRAPH_DATA_FAILURE = 'GET_OVERVIEW_GRAPH_DATA_FAILURE',
+  CLEANUP_OVERVIEW_GRAPH_DATA = 'CLEANUP_OVERVIEW_GRAPH_DATA',
   HANDLE_LEGEND = 'HANDLE_LEGEND'
 }
 
@@ -36,13 +42,14 @@ const decorateGraphData = (graphData: any) => {
       rate4XX: undefined,
       rate5XX: undefined,
       rateSelfInvoke: undefined,
+      globalStatus: undefined,
       hasCB: undefined,
+      hasMissingSidecars: undefined,
       hasRR: undefined,
       isDead: undefined,
       isGroup: undefined,
       isRoot: undefined,
-      isUnused: undefined,
-      hasMissingSidecars: undefined
+      isUnused: undefined
     }
   };
   if (graphData) {
@@ -79,6 +86,24 @@ export const ServiceGraphDataActions = {
     type: ServiceGraphDataActionKeys.GET_GRAPH_DATA_FAILURE,
     error: error
   })),
+  cleanupGraphData: createAction(ServiceGraphDataActionKeys.CLEANUP_GRAPH_DATA),
+  getOverviewGraphDataStart: createAction(ServiceGraphDataActionKeys.GET_OVERVIEW_GRAPH_DATA_START),
+  getOverviewGraphDataSuccess: createAction(
+    ServiceGraphDataActionKeys.GET_OVERVIEW_GRAPH_DATA_SUCCESS,
+    (timestamp: number, graphData: any) => ({
+      type: ServiceGraphDataActionKeys.GET_OVERVIEW_GRAPH_DATA_SUCCESS,
+      timestamp: timestamp,
+      graphData: decorateGraphData(graphData)
+    })
+  ),
+  getOverviewGraphDataFailure: createAction(
+    ServiceGraphDataActionKeys.GET_OVERVIEW_GRAPH_DATA_FAILURE,
+    (error: any) => ({
+      type: ServiceGraphDataActionKeys.GET_OVERVIEW_GRAPH_DATA_FAILURE,
+      error: error
+    })
+  ),
+  cleanupOverviewGraphData: createAction(ServiceGraphDataActionKeys.CLEANUP_OVERVIEW_GRAPH_DATA),
   handleLegend: createAction(ServiceGraphDataActionKeys.HANDLE_LEGEND),
 
   // action creator that performs the async request
@@ -103,6 +128,39 @@ export const ServiceGraphDataActions = {
           }
           MessageCenter.add(emsg);
           dispatch(ServiceGraphDataActions.getGraphDataFailure(emsg));
+        }
+      );
+    };
+  },
+  // action creator that performs the async request
+  fetchOverviewGraphData: (graphDuration: Duration) => {
+    return dispatch => {
+      dispatch(ServiceGraphDataActions.getOverviewGraphDataStart());
+      const duration = graphDuration.value;
+      const restParams = { duration: duration + 's' };
+      API.getOverviewGraphElements(authentication(), restParams).then(
+        response => {
+          const responseData: any = response['data'];
+          const graphData = responseData && responseData.elements ? responseData.elements : EMPTY_GRAPH_DATA;
+          graphData.nodes.forEach(n => {
+            const health = n.data.health;
+            if (health) {
+              n.data.globalStatus = H.computeAggregatedHealth(health);
+            }
+          });
+          const timestamp = responseData && responseData.timestamp ? responseData.timestamp : 0;
+          dispatch(ServiceGraphDataActions.getOverviewGraphDataSuccess(timestamp, graphData));
+        },
+        error => {
+          let emsg: string;
+          if (error.response && error.response.data && error.response.data.error) {
+            emsg = 'Cannot load the graph: ' + error.response.data.error;
+          } else {
+            emsg = 'Cannot load the graph: ' + error.toString();
+          }
+          console.log('OverviewGraphDataActions: ', emsg);
+          MessageCenter.add(emsg);
+          dispatch(ServiceGraphDataActions.getOverviewGraphDataFailure(emsg));
         }
       );
     };

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -84,6 +84,11 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
     this.processGraphUpdate(this.getCy());
   }
 
+  // private getCy() {
+  getCy() {
+    return this.cytoscapeReactWrapperRef ? this.cytoscapeReactWrapperRef.getCy() : null;
+  }
+
   render() {
     return (
       <div id="cytoscape-container" style={{ marginRight: '25em', height: '100%' }}>
@@ -104,23 +109,19 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
     );
   }
 
-  private getCy() {
-    return this.cytoscapeReactWrapperRef ? this.cytoscapeReactWrapperRef.getCy() : null;
-  }
-
   private setCytoscapeReactWrapperRef(cyRef: any) {
     this.cytoscapeReactWrapperRef = cyRef;
     this.cyInitialization(this.getCy());
   }
 
-  private turnEdgeLabelsTo = (value: EdgeLabelMode) => {
-    this.cy.edges().forEach(edge => {
+  private turnEdgeLabelsTo = (cy: any, value: EdgeLabelMode) => {
+    cy.edges().forEach(edge => {
       edge.data('edgeLabelMode', value);
     });
   };
 
-  private turnNodeLabelsTo = (value: boolean) => {
-    this.cy.nodes().forEach(node => {
+  private turnNodeLabelsTo = (cy: any, value: boolean) => {
+    cy.nodes().forEach(node => {
       node.data('showNodeLabels', value);
     });
   };
@@ -231,8 +232,8 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
     }
 
     // Create and destroy labels
-    this.turnEdgeLabelsTo(this.props.edgeLabelMode);
-    this.turnNodeLabelsTo(this.props.showNodeLabels);
+    this.turnEdgeLabelsTo(cy, this.props.edgeLabelMode);
+    this.turnNodeLabelsTo(cy, this.props.showNodeLabels);
 
     // Create badges
     cy.nodes().forEach(ele => {

--- a/src/components/CytoscapeGraph/CytoscapeReactWrapper.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeReactWrapper.tsx
@@ -26,7 +26,7 @@ type CytoscapeReactWrapperProps = {
 type CytoscapeReactWrapperState = {};
 
 /**
- * The purpose of this wrapper is very simple and minimal - to provide a long-lived <div> element that can be used
+ * The purpose of this wrapper is minimal; it provides a long-lived <div> element that can be used
  * as the parent container for the cy graph (cy.container). Because cy does not provide the ability to re-parent an
  * existing graph (e.g. there is no API such as "cy.setContainer(div)"), the only way to be able to re-use a
  * graph (without re-creating and re-rendering it all the time) is to have it inside a wrapper like this one
@@ -37,8 +37,8 @@ type CytoscapeReactWrapperState = {};
  * It is the job of the parent component to manipulate and update the cy graph during runtime.
  */
 export class CytoscapeReactWrapper extends React.Component<CytoscapeReactWrapperProps, CytoscapeReactWrapperState> {
-  cy: any;
-  divParentRef: any;
+  private divParentRef: any;
+  private cy: any;
 
   constructor(props: CytoscapeReactWrapperProps) {
     super(props);
@@ -46,7 +46,7 @@ export class CytoscapeReactWrapper extends React.Component<CytoscapeReactWrapper
     this.divParentRef = React.createRef();
   }
 
-  // For other components to be able to maniuplate the cy graph.
+  // For other components to be able to manipulate the cy graph.
   getCy() {
     return this.cy;
   }
@@ -67,7 +67,7 @@ export class CytoscapeReactWrapper extends React.Component<CytoscapeReactWrapper
 
   render() {
     const styleContainer = { height: '100%', width: '100%', display: 'block' };
-    return <div id="cy" className="graph" style={styleContainer} ref={this.divParentRef} />;
+    return <div id="graph" className="graph" style={styleContainer} ref={this.divParentRef} />;
   }
 
   build() {

--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -13,12 +13,11 @@ export class GraphStyles {
       {
         selector: 'node',
         css: {
-          // color: PfColors.Black,
           content: (ele: any) => {
-            const version = ele.data('version');
             if (!ele.data('showNodeLabels')) {
               return '';
             }
+            const version = ele.data('version');
             if (ele.data('parent')) {
               return version;
             }
@@ -52,6 +51,30 @@ export class GraphStyles {
         selector: 'node[isRoot]',
         style: {
           shape: 'diamond'
+        }
+      },
+      {
+        selector: 'node[globalStatus]',
+        style: {
+          content: (ele: any) => {
+            if (!ele.data('showNodeLabels')) {
+              return '';
+            }
+            let version = ele.data('version');
+            if (ele.data('parent')) {
+              return version;
+            }
+            const name = ele.data('service') || ele.data('id');
+            const split = name.split('.');
+            const namespace = split.length > 0 ? '[ ' + split[1] + ' ]\n' : '';
+            const service = split[0] + '\n';
+            version = version === 'unknown' ? '' : version + '\n';
+            const status = ele.data('globalStatus').name;
+            return namespace + service + version + status;
+          },
+          'background-color': (ele: any) => {
+            return ele.data('globalStatus').color;
+          }
         }
       },
       {

--- a/src/components/GraphFilter/GraphFilter.tsx
+++ b/src/components/GraphFilter/GraphFilter.tsx
@@ -80,14 +80,16 @@ export default class GraphFilter extends React.PureComponent<GraphFilterProps> {
     return (
       <>
         <Toolbar>
-          <FormGroup className={zeroPaddingLeft}>
-            <label className={labelPaddingRight}>Namespace:</label>
-            <NamespaceDropdownContainer
-              disabled={this.props.disabled}
-              activeNamespace={this.props.namespace}
-              onSelect={this.props.onNamespaceChange}
-            />
-          </FormGroup>
+          {this.props.namespace.name !== '' ? (
+            <FormGroup className={zeroPaddingLeft}>
+              <label className={labelPaddingRight}>Namespace:</label>
+              <NamespaceDropdownContainer
+                disabled={this.props.disabled}
+                activeNamespace={this.props.namespace}
+                onSelect={this.props.onNamespaceChange}
+              />
+            </FormGroup>
+          ) : null}
           <ToolbarDropdown
             id={'graph_filter_interval_duration'}
             disabled={this.props.disabled}

--- a/src/components/GraphFilter/OverviewGraphFilterToolbar.tsx
+++ b/src/components/GraphFilter/OverviewGraphFilterToolbar.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+import { PropTypes } from 'prop-types';
+
+import { GraphParamsType } from '../../types/Graph';
+import { Duration, Layout, EdgeLabelMode } from '../../types/GraphFilter';
+import GraphFilterToolbarType from '../../types/GraphFilterToolbar';
+
+import { makeOverviewURLFromParams } from '../../components/Nav/NavUtils';
+
+import GraphFilter from './GraphFilter';
+
+export default class OverviewGraphFilterToolbar extends React.PureComponent<GraphFilterToolbarType, {}> {
+  static contextTypes = {
+    router: PropTypes.object
+  };
+
+  render() {
+    const graphParams: GraphParamsType = {
+      graphLayout: this.props.graphLayout,
+      graphDuration: this.props.graphDuration,
+      edgeLabelMode: this.props.edgeLabelMode,
+      namespace: { name: '' }
+    };
+
+    return (
+      <GraphFilter
+        disabled={this.props.isLoading}
+        onLayoutChange={this.handleOverviewLayoutChange}
+        onDurationChange={this.handleOverviewDurationChange}
+        onNamespaceChange={this.handleOverviewNamespaceChange}
+        onEdgeLabelModeChange={this.handleOverviewEdgeLabelModeChange}
+        onRefresh={this.props.handleRefreshClick}
+        {...graphParams}
+      />
+    );
+  }
+
+  handleOverviewLayoutChange = (graphLayout: Layout) => {
+    const { namespace, graphDuration, edgeLabelMode } = this.getGraphParams();
+    this.handleOverviewFilterChange({
+      graphDuration,
+      namespace,
+      graphLayout,
+      edgeLabelMode
+    });
+  };
+
+  handleOverviewDurationChange = (graphDuration: Duration) => {
+    const { namespace, graphLayout, edgeLabelMode } = this.getGraphParams();
+    this.handleOverviewFilterChange({
+      graphDuration,
+      namespace,
+      graphLayout,
+      edgeLabelMode
+    });
+  };
+
+  handleOverviewNamespaceChange = () => {
+    // dummy
+  };
+
+  handleOverviewEdgeLabelModeChange = (edgeLabelMode: EdgeLabelMode) => {
+    const { namespace, graphDuration, graphLayout } = this.getGraphParams();
+    this.handleOverviewFilterChange({
+      namespace,
+      graphDuration,
+      graphLayout,
+      edgeLabelMode
+    });
+  };
+
+  handleOverviewFilterChange = (params: GraphParamsType) => {
+    this.context.router.history.push(makeOverviewURLFromParams(params));
+  };
+
+  private getGraphParams: () => GraphParamsType = () => {
+    return {
+      namespace: this.props.namespace,
+      graphDuration: this.props.graphDuration,
+      graphLayout: this.props.graphLayout,
+      edgeLabelMode: this.props.edgeLabelMode
+    };
+  };
+}

--- a/src/components/Nav/NavUtils.tsx
+++ b/src/components/Nav/NavUtils.tsx
@@ -4,3 +4,8 @@ export const makeURLFromParams = (params: GraphParamsType) =>
   `/service-graph/${params.namespace.name}?layout=${params.graphLayout.name}&duration=${
     params.graphDuration.value
   }&edges=${params.edgeLabelMode}`;
+
+export const makeOverviewURLFromParams = (params: GraphParamsType) =>
+  `/overview-graph?layout=${params.graphLayout.name}&duration=${params.graphDuration.value}&edges=${
+    params.edgeLabelMode
+  }`;

--- a/src/components/Nav/Navigation.tsx
+++ b/src/components/Nav/Navigation.tsx
@@ -11,6 +11,7 @@ import IstioConfigPage from '../../pages/IstioConfigList/IstioConfigListPage';
 import IstioConfigDetailsPage from '../../pages/IstioConfigDetails/IstioConfigDetailsPage';
 import HelpDropdown from './HelpDropdown';
 import UserDropdown from '../../containers/UserDropdownContainer';
+import OverviewGraphRouteHandler from '../../pages/ServiceGraph/OverviewGraphRouteHandler';
 import ServiceDetailsPage from '../../pages/ServiceDetails/ServiceDetailsPage';
 import ServiceGraphRouteHandler from '../../pages/ServiceGraph/ServiceGraphRouteHandler';
 import ServiceListPage from '../../pages/ServiceList/ServiceListPage';
@@ -23,6 +24,8 @@ const istioConfigPath = '/istio';
 export const istioConfigTitle = 'Istio Config';
 const serviceGraphPath = '/service-graph/all';
 export const serviceGraphTitle = 'Graph';
+const overviewGraphPath = '/overview-graph';
+export const overviewGraphTitle = 'Overview';
 const servicesPath = '/services';
 const servicesJaegerPath = '/jaeger';
 export const servicesTitle = 'Services';
@@ -78,7 +81,7 @@ class Navigation extends React.Component<PropsType, StateType> {
         selected = istioConfigTitle;
       }
     } else {
-      selected = serviceGraphTitle;
+      selected = overviewGraphTitle;
     }
     return selected;
   };
@@ -133,6 +136,7 @@ class Navigation extends React.Component<PropsType, StateType> {
             </VerticalNav.IconBar>
             <MessageCenter drawerTitle="Message Center" />
           </VerticalNav.Masthead>
+          <VerticalNav.Item title={overviewGraphTitle} iconClass="fa fa-dashboard" onClick={this.navigateTo} />
           <VerticalNav.Item title={serviceGraphTitle} iconClass="fa pficon-topology" onClick={this.navigateTo} />
           <VerticalNav.Item title={servicesTitle} iconClass="fa pficon-service" onClick={this.navigateTo} />
           <VerticalNav.Item title={istioConfigTitle} iconClass="fa pficon-template" onClick={this.navigateTo} />
@@ -145,6 +149,7 @@ class Navigation extends React.Component<PropsType, StateType> {
             </PfContainerNavVertical>
           )}
         >
+          <Route path="/overview-graph" component={OverviewGraphRouteHandler} />
           <Route path="/service-graph/:namespace" component={ServiceGraphRouteHandler} />
           <Route path={servicesPath} component={ServiceListPage} />
           <Route path={servicesJaegerPath} component={ServiceJaegerPage} />
@@ -166,8 +171,10 @@ class Navigation extends React.Component<PropsType, StateType> {
       this.context.router.history.push(istioConfigPath);
     } else if (e.title === servicesJaeger) {
       this.context.router.history.push(servicesJaegerPath);
-    } else {
+    } else if (e.title === serviceGraphTitle) {
       this.context.router.history.push(serviceGraphPath);
+    } else {
+      this.context.router.history.push(overviewGraphPath);
     }
   };
 }

--- a/src/containers/OverviewGraphPageContainer.ts
+++ b/src/containers/OverviewGraphPageContainer.ts
@@ -1,0 +1,28 @@
+import { KialiAppState } from '../store/Store';
+import { connect } from 'react-redux';
+import { Duration } from '../types/GraphFilter';
+import OverviewGraphPage from '../pages/ServiceGraph/OverviewGraphPage';
+
+import { ServiceGraphDataActions } from '../actions/ServiceGraphDataActions';
+
+const mapStateToProps = (state: KialiAppState) => ({
+  graphTimestamp: state.serviceGraph.graphDataTimestamp,
+  graphData: state.serviceGraph.graphData,
+  isLoading: state.serviceGraph.isLoading,
+  summaryData: state.serviceGraph.sidePanelInfo
+    ? {
+        summaryTarget: state.serviceGraph.sidePanelInfo.graphReference,
+        summaryType: state.serviceGraph.sidePanelInfo.kind
+      }
+    : null,
+  hideLegend: state.serviceGraph.hideLegend
+});
+
+const mapDispatchToProps = (dispatch: any) => ({
+  fetchGraphData: (graphDuration: Duration) => dispatch(ServiceGraphDataActions.fetchOverviewGraphData(graphDuration)),
+  cleanupGraphData: () => dispatch(ServiceGraphDataActions.cleanupOverviewGraphData()),
+  handleLegend: () => dispatch(ServiceGraphDataActions.handleLegend())
+});
+
+const OverviewGraphPageConnected = connect(mapStateToProps, mapDispatchToProps)(OverviewGraphPage);
+export default OverviewGraphPageConnected;

--- a/src/containers/ServiceGraphPageContainer.ts
+++ b/src/containers/ServiceGraphPageContainer.ts
@@ -24,6 +24,7 @@ const mapStateToProps = (state: KialiAppState) => ({
 const mapDispatchToProps = (dispatch: any) => ({
   fetchGraphData: (namespace: Namespace, graphDuration: Duration) =>
     dispatch(ServiceGraphDataActions.fetchGraphData(namespace, graphDuration)),
+  cleanupGraphData: () => dispatch(ServiceGraphDataActions.cleanupGraphData()),
   toggleLegend: () => bindActionCreators(serviceGraphFilterActions.toggleLegend, dispatch)
 });
 

--- a/src/pages/ServiceGraph/OverviewGraphRouteHandler.tsx
+++ b/src/pages/ServiceGraph/OverviewGraphRouteHandler.tsx
@@ -1,0 +1,90 @@
+import * as React from 'react';
+import { RouteComponentProps } from 'react-router-dom';
+import { PropTypes } from 'prop-types';
+
+import { GraphParamsType } from '../../types/Graph';
+import { EdgeLabelMode } from '../../types/GraphFilter';
+import * as LayoutDictionary from '../../components/CytoscapeGraph/graphs/LayoutDictionary';
+import OverviewGraphPage from '../../containers/OverviewGraphPageContainer';
+import { makeOverviewURLFromParams } from '../../components/Nav/NavUtils';
+import { config } from '../../config';
+
+const URLSearchParams = require('url-search-params');
+
+const SESSION_KEY = 'overview-graph-params';
+
+type OverviewGraphURLProps = {
+  // @todo: redo this manual params with Redux-Router
+  // @todo: add back in circuit-breaker, route-rules params to Redux-Router for URL-params
+  duration: string;
+  layout: string;
+};
+
+/**
+ * Handle URL parameters for OverviewGraph page
+ */
+export default class OverviewGraphRouteHandler extends React.Component<
+  RouteComponentProps<OverviewGraphURLProps>,
+  GraphParamsType
+> {
+  static contextTypes = {
+    router: PropTypes.object
+  };
+
+  constructor(routeProps: RouteComponentProps<OverviewGraphURLProps>) {
+    super(routeProps);
+    const previousParamsStr = sessionStorage.getItem(SESSION_KEY);
+    const graphParams: GraphParamsType = previousParamsStr
+      ? JSON.parse(previousParamsStr)
+      : {
+          namespace: { name: '' },
+          ...this.parseProps(routeProps.location.search)
+        };
+    this.state = graphParams;
+  }
+
+  parseProps = (queryString: string) => {
+    const urlParams = new URLSearchParams(queryString);
+    // TODO: [KIALI-357] validate `duration`
+    const _duration = urlParams.get('duration');
+    const _hideCBs = urlParams.get('hideCBs') ? urlParams.get('hideCBs') === 'true' : false;
+    const _hideRRs = urlParams.get('hideRRs') ? urlParams.get('hideRRs') === 'true' : false;
+    const _edgeLabelMode = EdgeLabelMode.fromString(urlParams.get('edges'), EdgeLabelMode.HIDE);
+    return {
+      graphDuration: _duration ? { value: _duration } : { value: config().toolbar.defaultDuration },
+      graphLayout: LayoutDictionary.getLayout({ name: urlParams.get('layout') }),
+      badgeStatus: { hideCBs: _hideCBs, hideRRs: _hideRRs },
+      edgeLabelMode: _edgeLabelMode
+    };
+  };
+
+  componentDidMount() {
+    // Note: `history.replace` simply changes the address bar text, not re-navigation
+    this.context.router.history.replace(makeOverviewURLFromParams(this.state));
+  }
+
+  componentWillReceiveProps(nextProps: RouteComponentProps<OverviewGraphURLProps>) {
+    const { graphDuration: nextDuration, graphLayout: nextLayout, edgeLabelMode: nextEdgeLabelMode } = this.parseProps(
+      nextProps.location.search
+    );
+
+    const layoutHasChanged = nextLayout.name !== this.state.graphLayout.name;
+    const durationHasChanged = nextDuration.value !== this.state.graphDuration.value;
+    const edgeLabelModeChanged = nextEdgeLabelMode !== this.state.edgeLabelMode;
+
+    if (layoutHasChanged || durationHasChanged || edgeLabelModeChanged) {
+      const newParams: GraphParamsType = {
+        graphDuration: nextDuration,
+        graphLayout: nextLayout,
+        edgeLabelMode: nextEdgeLabelMode,
+        namespace: { name: '' }
+      };
+      sessionStorage.setItem(SESSION_KEY, JSON.stringify(newParams));
+      this.setState({ ...newParams });
+    }
+  }
+
+  render() {
+    return <OverviewGraphPage {...this.state} />;
+  }
+}

--- a/src/reducers/ServiceGraphDataState.ts
+++ b/src/reducers/ServiceGraphDataState.ts
@@ -3,10 +3,12 @@ import { ServiceGraphDataActionKeys } from '../actions/ServiceGraphDataActions';
 import { ServiceGraphActionKeys } from '../actions/ServiceGraphActions';
 import FilterStateReducer from './ServiceGraphFilterState';
 
+const EMPTY_GRAPH_DATA = { nodes: [], edges: [] };
+
 const INITIAL_STATE: any = {
   isLoading: false,
   graphDataTimestamp: 0,
-  graphData: {},
+  graphData: EMPTY_GRAPH_DATA,
   sidePanelInfo: null,
   hideLegend: true
 };
@@ -21,6 +23,7 @@ const serviceGraphDataState = (state: ServiceGraphState = INITIAL_STATE, action)
 
   switch (action.type) {
     case ServiceGraphDataActionKeys.GET_GRAPH_DATA_START:
+    case ServiceGraphDataActionKeys.GET_OVERVIEW_GRAPH_DATA_START:
       newState.isLoading = true;
       break;
     case ServiceGraphDataActionKeys.HANDLE_LEGEND:
@@ -29,11 +32,13 @@ const serviceGraphDataState = (state: ServiceGraphState = INITIAL_STATE, action)
         hideLegend: !state.hideLegend
       };
     case ServiceGraphDataActionKeys.GET_GRAPH_DATA_SUCCESS:
+    case ServiceGraphDataActionKeys.GET_OVERVIEW_GRAPH_DATA_SUCCESS:
       newState.isLoading = false;
       newState.graphDataTimestamp = action.timestamp;
       newState.graphData = action.graphData;
       break;
     case ServiceGraphDataActionKeys.GET_GRAPH_DATA_FAILURE:
+    case ServiceGraphDataActionKeys.GET_OVERVIEW_GRAPH_DATA_FAILURE:
       console.warn('ServiceGraphDataState reducer: failed to get graph data');
       newState.isLoading = false;
       // newState.error = action.error; // Already handled in the action.
@@ -43,6 +48,11 @@ const serviceGraphDataState = (state: ServiceGraphState = INITIAL_STATE, action)
         kind: action.summaryType,
         graphReference: action.summaryTarget
       };
+      break;
+    case ServiceGraphDataActionKeys.CLEANUP_GRAPH_DATA:
+    case ServiceGraphDataActionKeys.CLEANUP_OVERVIEW_GRAPH_DATA:
+      newState.graphData = EMPTY_GRAPH_DATA;
+      newState.graphDataTimestamp = 0;
       break;
     default:
       break;

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -111,6 +111,10 @@ export const getGraphElements = (auth: any, namespace: Namespace, params: any) =
   return newRequest('get', `/api/namespaces/${namespace.name}/graph`, params, {}, auth);
 };
 
+export const getOverviewGraphElements = (auth: any, params: any) => {
+  return newRequest('get', `/api/overview/graph`, params, {}, auth);
+};
+
 export const getServiceDetail = (
   auth: any,
   namespace: String,


### PR DESCRIPTION
This creates a new Overview page that is currently defined to be the new default.  The goal is to provide an initial "traffic light" view for overall "App" health.  Initially an "App" is basically a namespace.  And it is represented by the service[s] from that namespace which handle external requests.  Initially that is constrained to "istio-ingress" and "unknown".  That may need to be expanded if we want to see services called only from other services.  The view also does not look for orphan services (dotted line services). This is currently by design but I'm not sure if it is correct (note, adding it in may not be completely trivial).

The service nodes reflect health both by their coloring and via a text label.  By clicking the service you get the familiar service node summary with the addition of the standard health icon and standard popover.

This relies on the server additions in https://github.com/kiali/kiali/pull/247.

Here is an example (a bit dull with only green bookinfo traffic):

![screenshot](https://user-images.githubusercontent.com/2104052/40940672-81cee00c-6816-11e8-8ee7-1f7e028b8c42.jpg)
