### PR TITLE
[Kiali-850] Configure Redux-Persist

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react-scripts-ts": "2.15.1",
     "redux": "3.7.2",
     "redux-mock-store": "1.5.1",
+    "redux-persist": "5.9.1",
     "redux-thunk": "2.2.0",
     "ssri": "6.0.0",
     "typesafe-actions": "1.1.2",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -3,10 +3,11 @@ import { Router, withRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import './App.css';
 import Navigation from '../containers/NavigationContainer';
-import store from '../store/ConfigStore';
+import { store, persistor } from '../store/ConfigStore';
 import axios from 'axios';
 import { GlobalActionKeys } from '../actions/GlobalActions';
 import history from './History';
+import { PersistGate } from 'redux-persist/lib/integration/react';
 
 // intercept all Axios requests and dispatch the LOADING_SPINNER_ON Action
 axios.interceptors.request.use(
@@ -38,14 +39,20 @@ axios.interceptors.response.use(
   }
 );
 
+const Loading = () => {
+  return <div>Loading</div>;
+};
+
 class App extends React.Component {
   render() {
     const Sidebar = withRouter(Navigation);
     return (
       <Provider store={store}>
-        <Router history={history}>
-          <Sidebar />
-        </Router>
+        <PersistGate loading={<Loading />} persistor={persistor}>
+          <Router history={history}>
+            <Sidebar />
+          </Router>
+        </PersistGate>
       </Provider>
     );
   }

--- a/src/components/Nav/Navigation.tsx
+++ b/src/components/Nav/Navigation.tsx
@@ -16,7 +16,7 @@ import ServiceGraphRouteHandler from '../../pages/ServiceGraph/ServiceGraphRoute
 import ServiceListPage from '../../pages/ServiceList/ServiceListPage';
 import ServiceJaegerPage from '../../pages/ServiceJaeger/ServiceJaegerPage';
 import LoginPage from '../../containers/LoginPageContainer';
-import store from '../../store/ConfigStore';
+import { store } from '../../store/ConfigStore';
 import PfSpinnerContainer from '../../containers/PfSpinnerContainer';
 
 const istioConfigPath = '/istio';

--- a/src/store/ConfigStore.ts
+++ b/src/store/ConfigStore.ts
@@ -11,7 +11,8 @@ declare const window;
 
 const persistConfig = {
   key: 'root',
-  storage: storage
+  storage: storage,
+  whitelist: ['authentication']
 };
 
 const composeEnhancers =

--- a/src/store/ConfigStore.ts
+++ b/src/store/ConfigStore.ts
@@ -1,9 +1,18 @@
 import { createStore, applyMiddleware, compose } from 'redux';
 import { KialiAppState } from './Store';
+import { persistStore, persistReducer } from 'redux-persist';
 import rootReducer from '../reducers';
 import thunk from 'redux-thunk';
 
+// defaults to localStorage for web and AsyncStorage for react-native
+import storage from 'redux-persist/lib/storage';
+
 declare const window;
+
+const persistConfig = {
+  key: 'root',
+  storage: storage
+};
 
 const composeEnhancers =
   (process.env.NODE_ENV === 'development' && window && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) || compose;
@@ -13,12 +22,12 @@ const configureStore = (initialState?: KialiAppState) => {
   const middlewares = [thunk];
   // compose enhancers
   const enhancer = composeEnhancers(applyMiddleware(...middlewares));
+  // persist reducers
+  const persistentReducer = persistReducer(persistConfig, rootReducer);
   // create store
-  return createStore(rootReducer, initialState, enhancer);
+  return createStore(persistentReducer, initialState, enhancer);
 };
 
 // pass an optional param to rehydrate state on app start
-const store = configureStore();
-
-// export store singleton instance
-export default store;
+export const store = configureStore();
+export const persistor = persistStore(store);

--- a/src/utils/Authentication.ts
+++ b/src/utils/Authentication.ts
@@ -1,4 +1,4 @@
-import store from '../store/ConfigStore';
+import { store } from '../store/ConfigStore';
 
 export const authentication = () => {
   const actualState = store.getState() || {};

--- a/src/utils/MessageCenter.ts
+++ b/src/utils/MessageCenter.ts
@@ -1,4 +1,4 @@
-import store from '../store/ConfigStore';
+import { store } from '../store/ConfigStore';
 import { MessageType } from '../types/MessageCenter';
 import { MessageCenterActions } from '../actions/MessageCenterActions';
 

--- a/src/utils/__tests__/Authentication.test.ts
+++ b/src/utils/__tests__/Authentication.test.ts
@@ -1,5 +1,5 @@
 import { authentication } from '../Authentication';
-import store from '../../store/ConfigStore';
+import { store } from '../../store/ConfigStore';
 import { LoginActions } from '../../actions/LoginActions';
 
 const token =

--- a/yarn.lock
+++ b/yarn.lock
@@ -7052,6 +7052,10 @@ redux-mock-store@1.5.1:
   dependencies:
     lodash.isplainobject "^4.0.6"
 
+redux-persist@5.9.1:
+  version "5.9.1"
+  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-5.9.1.tgz#83bd4abd526ef768f63fceee338fa9d8ed6552d6"
+
 redux-thunk@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.2.0.tgz#e615a16e16b47a19a515766133d1e3e99b7852e5"


### PR DESCRIPTION
With this we can persist the state of redux.

**Require**: https://github.com/kiali/kiali-ui/pull/413

- Keep the session and options after refresh app (F5)
- Let puppeter (Itest) navigate to others page for @abonas proposal 
- Fix Bug [Kiali-850](https://issues.jboss.org/browse/KIALI-850)
- Work in the session timeout [KIALI-533](https://issues.jboss.org/browse/KIALI-533) reported by @mtho11 

Documentation : [Redux-persist ](https://github.com/rt2zz/redux-persist) 5582 starts 398 forks

![redux-persist](https://user-images.githubusercontent.com/3019213/40974410-bf30526c-68c7-11e8-8553-8429c89848b2.gif)


Things to improve.

- Select another kind of storage and encrypt this information. Currently there is no sensitive information so we can do this after.

## Storage Engines

- **localStorage** `import storage from 'redux-persist/lib/storage'`
- **sessionStorage** `import storageSession from 'redux-persist/lib/storage/session'`
- **AsyncStorage** react-native `import { AsyncStorage } from 'react-native'`
- **[localForage](https://github.com/mozilla/localForage)** recommended for web
- **[electron storage](https://github.com/psperber/redux-persist-electron-storage)** Electron support via [electron store](https://github.com/sindresorhus/electron-store)
- **[redux-persist-filesystem-storage](https://github.com/robwalkerco/redux-persist-filesystem-storage)** react-native, to mitigate storage size limitations in android ([#199](https://github.com/rt2zz/redux-persist/issues/199), [#284](https://github.com/rt2zz/redux-persist/issues/284))
- **[redux-persist-node-storage](https://github.com/pellejacobs/redux-persist-node-storage)** for use in nodejs environments.
- **[redux-persist-sensitive-storage](https://github.com/CodingZeal/redux-persist-sensitive-storage)** react-native, for sensitive information (uses [react-native-sensitive-storage](https://github.com/mCodex/react-native-sensitive-info)).
- **[redux-persist-expo-securestore](https://github.com/Cretezy/redux-persist-expo-securestore)** react-native, for sensitive information using Expo's SecureStore. Only available if using Expo SDK (Expo, create-react-native-app, standalone).
- **[redux-persist-fs-storage](https://github.com/leethree/redux-persist-fs-storage)** react-native-fs engine
- **[redux-persist-cookie-storage](https://github.com/abersager/redux-persist-cookie-storage)** Cookie storage engine, works in browser and Node.js, for universal / isomorphic apps
- **[redux-persist-weapp-storage](https://github.com/cuijiemmx/redux-casa/tree/master/packages/redux-persist-weapp-storage)** Storage engine for wechat mini program, also compatible with wepy
- **custom** any conforming storage api implementing the following methods: `setItem` `getItem` `removeItem`. (**NB**: These methods must support promises)
