### PR TITLE
KIALI-741 fix chart height issue due to large legend

### DIFF
--- a/src/pages/ServiceDetails/HistogramChart.tsx
+++ b/src/pages/ServiceDetails/HistogramChart.tsx
@@ -26,9 +26,9 @@ class HistogramChart extends MetricsChartBase<HistogramChartProps> {
       x: 'x',
       columns: graphUtils
         .toC3Columns(this.nameTimeSeries('[avg]', this.props.histogram.average.matrix))
-        .concat(graphUtils.toC3Columns(this.nameTimeSeries('[med]', this.props.histogram.median.matrix)))
-        .concat(graphUtils.toC3Columns(this.nameTimeSeries('[p95]', this.props.histogram.percentile95.matrix)))
-        .concat(graphUtils.toC3Columns(this.nameTimeSeries('[p99]', this.props.histogram.percentile99.matrix)))
+        .concat(graphUtils.toC3ValueColumns(this.nameTimeSeries('[med]', this.props.histogram.median.matrix)))
+        .concat(graphUtils.toC3ValueColumns(this.nameTimeSeries('[p95]', this.props.histogram.percentile95.matrix)))
+        .concat(graphUtils.toC3ValueColumns(this.nameTimeSeries('[p99]', this.props.histogram.percentile99.matrix)))
     };
   }
 }

--- a/src/pages/ServiceDetails/MetricsChartBase.tsx
+++ b/src/pages/ServiceDetails/MetricsChartBase.tsx
@@ -44,13 +44,21 @@ abstract class MetricsChartBase<Props extends MetricsChartBaseProps> extends Rea
     };
   }
 
+  adjustHeight(columns: any[]): number {
+    const series = columns.length - 1;
+    return 350 + series * 23;
+  }
+
   render() {
+    const data = this.seriesData;
+    const height = this.adjustHeight(data.columns);
     return (
       <div key={this.controlKey}>
         <LineChart
+          style={{ height: height }}
           id={this.props.familyName}
           title={{ text: this.props.familyName }}
-          data={this.seriesData}
+          data={data}
           axis={this.axisDefinition}
           point={{ show: false }}
         />

--- a/src/utils/Graphing.ts
+++ b/src/utils/Graphing.ts
@@ -6,16 +6,19 @@ export default {
       return [['x'], [title || '']];
     }
 
-    return matrix
-      .map(mat => {
-        let xseries: any = ['x'];
-        return xseries.concat(mat.values.map(dp => dp[0] * 1000));
+    let xseries: any = ['x'];
+    return [xseries.concat(matrix[0].values.map(dp => dp[0] * 1000))].concat(
+      matrix.map(mat => {
+        let yseries: any = [title || mat.name];
+        return yseries.concat(mat.values.map(dp => dp[1]));
       })
-      .concat(
-        matrix.map(mat => {
-          let yseries: any = [title || mat.name];
-          return yseries.concat(mat.values.map(dp => dp[1]));
-        })
-      );
+    );
+  },
+
+  toC3ValueColumns(matrix: TimeSeries[], title?: string) {
+    return matrix.map(mat => {
+      let yseries: any = [title || mat.name];
+      return yseries.concat(mat.values.map(dp => dp[1]));
+    });
   }
 };


### PR DESCRIPTION
Note, this is certainly not a perfect patch. Charts still appear somewhat inconsistent because they may have different heights - which makes them not always aligned. I'm pretty sure we'll get some complains about that :)

However this is IMO still much better than the current state as described in the jira issue ( https://issues.jboss.org/browse/KIALI-741 ), having charts completely unreadable. And I do not have a better solution so far, but if anyone has ideas please let me know.