### PR TITLE
KIALI-731: Add button to show YAML of route rules, etc.

### DIFF
--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDestinationPolicies.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDestinationPolicies.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Col, Row } from 'patternfly-react';
+import { Col, Row, Icon } from 'patternfly-react';
 import { DestinationPolicy, EditorLink } from '../../../types/ServiceInfo';
 import LocalTime from '../../../components/Time/LocalTime';
 import DetailObject from '../../../components/Details/DetailObject';
@@ -23,9 +23,12 @@ class ServiceInfoDestinationPolicies extends React.Component<ServiceInfoDestinat
               return (
                 <div className="card-pf-body" key={'rule' + i}>
                   <div>
-                    <h3>
-                      <Link to={this.props.editorLink + '?destinationpolicy=' + dPolicy.name}>{dPolicy.name}</Link>
-                    </h3>
+                    <h3>{dPolicy.name}</h3>
+                  </div>
+                  <div>
+                    <Link to={this.props.editorLink + '?destinationpolicy=' + dPolicy.name}>
+                      Show Yaml <Icon name="angle-double-right" />
+                    </Link>
                   </div>
                   <div>
                     <strong>Created at</strong>

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDestinationRules.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDestinationRules.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { DestinationRule, EditorLink } from '../../../types/ServiceInfo';
-import { Col, Row } from 'patternfly-react';
+import { Col, Row, Icon } from 'patternfly-react';
 import LocalTime from '../../../components/Time/LocalTime';
 import DetailObject from '../../../components/Details/DetailObject';
 import { Link } from 'react-router-dom';
@@ -21,11 +21,12 @@ class ServiceInfoDestinationRules extends React.Component<ServiceInfoDestination
           <Col xs={12} sm={12} md={12} lg={12}>
             {(this.props.destinationRules || []).map((destinationRule, i) => (
               <div className="card-pf-body" key={'destinationRule' + i}>
-                <h3>
+                <h3>{destinationRule.name}</h3>
+                <div>
                   <Link to={this.props.editorLink + '?destinationrule=' + destinationRule.name}>
-                    {destinationRule.name}
+                    Show Yaml <Icon name="angle-double-right" />
                   </Link>
-                </h3>
+                </div>
                 <div>
                   <strong>Created at</strong>: <LocalTime time={destinationRule.createdAt} />
                 </div>

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoRouteRules.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoRouteRules.tsx
@@ -25,9 +25,12 @@ class ServiceInfoRouteRules extends React.Component<ServiceInfoRouteRulesProps> 
   rawConfig(rule: RouteRule, i: number) {
     return (
       <div className="card-pf-body" key={'ruleconfig' + i}>
-        <h3>
-          <Link to={this.props.editorLink + '?routerule=' + rule.name}>{rule.name}</Link>
-        </h3>
+        <h3>{rule.name}</h3>
+        <div>
+          <Link to={this.props.editorLink + '?routerule=' + rule.name}>
+            Show Yaml <Icon name="angle-double-right" />
+          </Link>
+        </div>
         {this.globalStatus(rule)}
         <div>
           <strong>Created at</strong>: <LocalTime time={rule.createdAt} />

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoVirtualServices.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoVirtualServices.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Col, Row } from 'patternfly-react';
+import { Col, Row, Icon } from 'patternfly-react';
 import { EditorLink, VirtualService } from '../../../types/ServiceInfo';
 import LocalTime from '../../../components/Time/LocalTime';
 import DetailObject from '../../../components/Details/DetailObject';
@@ -22,11 +22,12 @@ class ServiceInfoVirtualServices extends React.Component<ServiceInfoVirtualServi
             {(this.props.virtualServices || []).map((virtualService, i) => (
               <div className="card-pf-body" key={'virtualService' + i}>
                 <div>
-                  <h3>
-                    <Link to={this.props.editorLink + '?virtualservice=' + virtualService.name}>
-                      {virtualService.name}
-                    </Link>
-                  </h3>
+                  <h3>{virtualService.name}</h3>
+                </div>
+                <div>
+                  <Link to={this.props.editorLink + '?virtualservice=' + virtualService.name}>
+                    Show Yaml <Icon name="angle-double-right" />
+                  </Link>
                 </div>
                 <div>
                   <strong>Created at</strong>: <LocalTime time={virtualService.createdAt} />

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoRouteRules.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoRouteRules.test.tsx.snap
@@ -88,13 +88,20 @@ ShallowWrapper {
                 className="card-pf-body"
               >
                 <h3>
+                  reviews-default
+                </h3>
+                <div>
                   <Link
                     replace={false}
                     to="/namespaces/test_namespace/services/test_services?routerule=reviews-default"
                   >
-                    reviews-default
+                    Show Yaml 
+                    <Icon
+                      name="angle-double-right"
+                      type="fa"
+                    />
                   </Link>
-                </h3>
+                </div>
                 
                 <div>
                   <strong>
@@ -161,13 +168,20 @@ ShallowWrapper {
                 className="card-pf-body"
               >
                 <h3>
+                  reviews-test-v2
+                </h3>
+                <div>
                   <Link
                     replace={false}
                     to="/namespaces/test_namespace/services/test_services?routerule=reviews-test-v2"
                   >
-                    reviews-test-v2
+                    Show Yaml 
+                    <Icon
+                      name="angle-double-right"
+                      type="fa"
+                    />
                   </Link>
-                </h3>
+                </div>
                 
                 <div>
                   <strong>
@@ -253,13 +267,20 @@ ShallowWrapper {
                 className="card-pf-body"
               >
                 <h3>
+                  reviews-default
+                </h3>
+                <div>
                   <Link
                     replace={false}
                     to="/namespaces/test_namespace/services/test_services?routerule=reviews-default"
                   >
-                    reviews-default
+                    Show Yaml 
+                    <Icon
+                      name="angle-double-right"
+                      type="fa"
+                    />
                   </Link>
-                </h3>
+                </div>
                 
                 <div>
                   <strong>
@@ -326,13 +347,20 @@ ShallowWrapper {
                 className="card-pf-body"
               >
                 <h3>
+                  reviews-test-v2
+                </h3>
+                <div>
                   <Link
                     replace={false}
                     to="/namespaces/test_namespace/services/test_services?routerule=reviews-test-v2"
                   >
-                    reviews-test-v2
+                    Show Yaml 
+                    <Icon
+                      name="angle-double-right"
+                      type="fa"
+                    />
                   </Link>
-                </h3>
+                </div>
                 
                 <div>
                   <strong>
@@ -411,13 +439,20 @@ ShallowWrapper {
                   className="card-pf-body"
                 >
                   <h3>
+                    reviews-default
+                  </h3>
+                  <div>
                     <Link
                       replace={false}
                       to="/namespaces/test_namespace/services/test_services?routerule=reviews-default"
                     >
-                      reviews-default
+                      Show Yaml 
+                      <Icon
+                        name="angle-double-right"
+                        type="fa"
+                      />
                     </Link>
-                  </h3>
+                  </div>
                   
                   <div>
                     <strong>
@@ -484,13 +519,20 @@ ShallowWrapper {
                   className="card-pf-body"
                 >
                   <h3>
+                    reviews-test-v2
+                  </h3>
+                  <div>
                     <Link
                       replace={false}
                       to="/namespaces/test_namespace/services/test_services?routerule=reviews-test-v2"
                     >
-                      reviews-test-v2
+                      Show Yaml 
+                      <Icon
+                        name="angle-double-right"
+                        type="fa"
+                      />
                     </Link>
-                  </h3>
+                  </div>
                   
                   <div>
                     <strong>
@@ -568,13 +610,20 @@ ShallowWrapper {
                     className="card-pf-body"
                   >
                     <h3>
+                      reviews-default
+                    </h3>
+                    <div>
                       <Link
                         replace={false}
                         to="/namespaces/test_namespace/services/test_services?routerule=reviews-default"
                       >
-                        reviews-default
+                        Show Yaml 
+                        <Icon
+                          name="angle-double-right"
+                          type="fa"
+                        />
                       </Link>
-                    </h3>
+                    </div>
                     
                     <div>
                       <strong>
@@ -639,13 +688,20 @@ ShallowWrapper {
                     className="card-pf-body"
                   >
                     <h3>
+                      reviews-default
+                    </h3>
+                    <div>
                       <Link
                         replace={false}
                         to="/namespaces/test_namespace/services/test_services?routerule=reviews-default"
                       >
-                        reviews-default
+                        Show Yaml 
+                        <Icon
+                          name="angle-double-right"
+                          type="fa"
+                        />
                       </Link>
-                    </h3>
+                    </div>
                     
                     <div>
                       <strong>
@@ -685,13 +741,20 @@ ShallowWrapper {
                   "props": Object {
                     "children": Array [
                       <h3>
+                        reviews-default
+                      </h3>,
+                      <div>
                         <Link
                           replace={false}
                           to="/namespaces/test_namespace/services/test_services?routerule=reviews-default"
                         >
-                          reviews-default
+                          Show Yaml 
+                          <Icon
+                            name="angle-double-right"
+                            type="fa"
+                          />
                         </Link>
-                      </h3>,
+                      </div>,
                       "",
                       <div>
                         <strong>
@@ -735,11 +798,26 @@ ShallowWrapper {
                       "key": undefined,
                       "nodeType": "host",
                       "props": Object {
+                        "children": "reviews-default",
+                      },
+                      "ref": null,
+                      "rendered": "reviews-default",
+                      "type": "h3",
+                    },
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
                         "children": <Link
                           replace={false}
                           to="/namespaces/test_namespace/services/test_services?routerule=reviews-default"
                         >
-                          reviews-default
+                          Show Yaml 
+                          <Icon
+                            name="angle-double-right"
+                            type="fa"
+                          />
                         </Link>,
                       },
                       "ref": null,
@@ -748,15 +826,35 @@ ShallowWrapper {
                         "key": undefined,
                         "nodeType": "class",
                         "props": Object {
-                          "children": "reviews-default",
+                          "children": Array [
+                            "Show Yaml ",
+                            <Icon
+                              name="angle-double-right"
+                              type="fa"
+                            />,
+                          ],
                           "replace": false,
                           "to": "/namespaces/test_namespace/services/test_services?routerule=reviews-default",
                         },
                         "ref": null,
-                        "rendered": "reviews-default",
+                        "rendered": Array [
+                          "Show Yaml ",
+                          Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "function",
+                            "props": Object {
+                              "name": "angle-double-right",
+                              "type": "fa",
+                            },
+                            "ref": null,
+                            "rendered": null,
+                            "type": [Function],
+                          },
+                        ],
                         "type": [Function],
                       },
-                      "type": "h3",
+                      "type": "div",
                     },
                     "",
                     Object {
@@ -947,13 +1045,20 @@ ShallowWrapper {
                     className="card-pf-body"
                   >
                     <h3>
+                      reviews-test-v2
+                    </h3>
+                    <div>
                       <Link
                         replace={false}
                         to="/namespaces/test_namespace/services/test_services?routerule=reviews-test-v2"
                       >
-                        reviews-test-v2
+                        Show Yaml 
+                        <Icon
+                          name="angle-double-right"
+                          type="fa"
+                        />
                       </Link>
-                    </h3>
+                    </div>
                     
                     <div>
                       <strong>
@@ -1018,13 +1123,20 @@ ShallowWrapper {
                     className="card-pf-body"
                   >
                     <h3>
+                      reviews-test-v2
+                    </h3>
+                    <div>
                       <Link
                         replace={false}
                         to="/namespaces/test_namespace/services/test_services?routerule=reviews-test-v2"
                       >
-                        reviews-test-v2
+                        Show Yaml 
+                        <Icon
+                          name="angle-double-right"
+                          type="fa"
+                        />
                       </Link>
-                    </h3>
+                    </div>
                     
                     <div>
                       <strong>
@@ -1064,13 +1176,20 @@ ShallowWrapper {
                   "props": Object {
                     "children": Array [
                       <h3>
+                        reviews-test-v2
+                      </h3>,
+                      <div>
                         <Link
                           replace={false}
                           to="/namespaces/test_namespace/services/test_services?routerule=reviews-test-v2"
                         >
-                          reviews-test-v2
+                          Show Yaml 
+                          <Icon
+                            name="angle-double-right"
+                            type="fa"
+                          />
                         </Link>
-                      </h3>,
+                      </div>,
                       "",
                       <div>
                         <strong>
@@ -1114,11 +1233,26 @@ ShallowWrapper {
                       "key": undefined,
                       "nodeType": "host",
                       "props": Object {
+                        "children": "reviews-test-v2",
+                      },
+                      "ref": null,
+                      "rendered": "reviews-test-v2",
+                      "type": "h3",
+                    },
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
                         "children": <Link
                           replace={false}
                           to="/namespaces/test_namespace/services/test_services?routerule=reviews-test-v2"
                         >
-                          reviews-test-v2
+                          Show Yaml 
+                          <Icon
+                            name="angle-double-right"
+                            type="fa"
+                          />
                         </Link>,
                       },
                       "ref": null,
@@ -1127,15 +1261,35 @@ ShallowWrapper {
                         "key": undefined,
                         "nodeType": "class",
                         "props": Object {
-                          "children": "reviews-test-v2",
+                          "children": Array [
+                            "Show Yaml ",
+                            <Icon
+                              name="angle-double-right"
+                              type="fa"
+                            />,
+                          ],
                           "replace": false,
                           "to": "/namespaces/test_namespace/services/test_services?routerule=reviews-test-v2",
                         },
                         "ref": null,
-                        "rendered": "reviews-test-v2",
+                        "rendered": Array [
+                          "Show Yaml ",
+                          Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "function",
+                            "props": Object {
+                              "name": "angle-double-right",
+                              "type": "fa",
+                            },
+                            "ref": null,
+                            "rendered": null,
+                            "type": [Function],
+                          },
+                        ],
                         "type": [Function],
                       },
-                      "type": "h3",
+                      "type": "div",
                     },
                     "",
                     Object {
@@ -1350,13 +1504,20 @@ ShallowWrapper {
                   className="card-pf-body"
                 >
                   <h3>
+                    reviews-default
+                  </h3>
+                  <div>
                     <Link
                       replace={false}
                       to="/namespaces/test_namespace/services/test_services?routerule=reviews-default"
                     >
-                      reviews-default
+                      Show Yaml 
+                      <Icon
+                        name="angle-double-right"
+                        type="fa"
+                      />
                     </Link>
-                  </h3>
+                  </div>
                   
                   <div>
                     <strong>
@@ -1423,13 +1584,20 @@ ShallowWrapper {
                   className="card-pf-body"
                 >
                   <h3>
+                    reviews-test-v2
+                  </h3>
+                  <div>
                     <Link
                       replace={false}
                       to="/namespaces/test_namespace/services/test_services?routerule=reviews-test-v2"
                     >
-                      reviews-test-v2
+                      Show Yaml 
+                      <Icon
+                        name="angle-double-right"
+                        type="fa"
+                      />
                     </Link>
-                  </h3>
+                  </div>
                   
                   <div>
                     <strong>
@@ -1515,13 +1683,20 @@ ShallowWrapper {
                   className="card-pf-body"
                 >
                   <h3>
+                    reviews-default
+                  </h3>
+                  <div>
                     <Link
                       replace={false}
                       to="/namespaces/test_namespace/services/test_services?routerule=reviews-default"
                     >
-                      reviews-default
+                      Show Yaml 
+                      <Icon
+                        name="angle-double-right"
+                        type="fa"
+                      />
                     </Link>
-                  </h3>
+                  </div>
                   
                   <div>
                     <strong>
@@ -1588,13 +1763,20 @@ ShallowWrapper {
                   className="card-pf-body"
                 >
                   <h3>
+                    reviews-test-v2
+                  </h3>
+                  <div>
                     <Link
                       replace={false}
                       to="/namespaces/test_namespace/services/test_services?routerule=reviews-test-v2"
                     >
-                      reviews-test-v2
+                      Show Yaml 
+                      <Icon
+                        name="angle-double-right"
+                        type="fa"
+                      />
                     </Link>
-                  </h3>
+                  </div>
                   
                   <div>
                     <strong>
@@ -1673,13 +1855,20 @@ ShallowWrapper {
                     className="card-pf-body"
                   >
                     <h3>
+                      reviews-default
+                    </h3>
+                    <div>
                       <Link
                         replace={false}
                         to="/namespaces/test_namespace/services/test_services?routerule=reviews-default"
                       >
-                        reviews-default
+                        Show Yaml 
+                        <Icon
+                          name="angle-double-right"
+                          type="fa"
+                        />
                       </Link>
-                    </h3>
+                    </div>
                     
                     <div>
                       <strong>
@@ -1746,13 +1935,20 @@ ShallowWrapper {
                     className="card-pf-body"
                   >
                     <h3>
+                      reviews-test-v2
+                    </h3>
+                    <div>
                       <Link
                         replace={false}
                         to="/namespaces/test_namespace/services/test_services?routerule=reviews-test-v2"
                       >
-                        reviews-test-v2
+                        Show Yaml 
+                        <Icon
+                          name="angle-double-right"
+                          type="fa"
+                        />
                       </Link>
-                    </h3>
+                    </div>
                     
                     <div>
                       <strong>
@@ -1830,13 +2026,20 @@ ShallowWrapper {
                       className="card-pf-body"
                     >
                       <h3>
+                        reviews-default
+                      </h3>
+                      <div>
                         <Link
                           replace={false}
                           to="/namespaces/test_namespace/services/test_services?routerule=reviews-default"
                         >
-                          reviews-default
+                          Show Yaml 
+                          <Icon
+                            name="angle-double-right"
+                            type="fa"
+                          />
                         </Link>
-                      </h3>
+                      </div>
                       
                       <div>
                         <strong>
@@ -1901,13 +2104,20 @@ ShallowWrapper {
                       className="card-pf-body"
                     >
                       <h3>
+                        reviews-default
+                      </h3>
+                      <div>
                         <Link
                           replace={false}
                           to="/namespaces/test_namespace/services/test_services?routerule=reviews-default"
                         >
-                          reviews-default
+                          Show Yaml 
+                          <Icon
+                            name="angle-double-right"
+                            type="fa"
+                          />
                         </Link>
-                      </h3>
+                      </div>
                       
                       <div>
                         <strong>
@@ -1947,13 +2157,20 @@ ShallowWrapper {
                     "props": Object {
                       "children": Array [
                         <h3>
+                          reviews-default
+                        </h3>,
+                        <div>
                           <Link
                             replace={false}
                             to="/namespaces/test_namespace/services/test_services?routerule=reviews-default"
                           >
-                            reviews-default
+                            Show Yaml 
+                            <Icon
+                              name="angle-double-right"
+                              type="fa"
+                            />
                           </Link>
-                        </h3>,
+                        </div>,
                         "",
                         <div>
                           <strong>
@@ -1997,11 +2214,26 @@ ShallowWrapper {
                         "key": undefined,
                         "nodeType": "host",
                         "props": Object {
+                          "children": "reviews-default",
+                        },
+                        "ref": null,
+                        "rendered": "reviews-default",
+                        "type": "h3",
+                      },
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
                           "children": <Link
                             replace={false}
                             to="/namespaces/test_namespace/services/test_services?routerule=reviews-default"
                           >
-                            reviews-default
+                            Show Yaml 
+                            <Icon
+                              name="angle-double-right"
+                              type="fa"
+                            />
                           </Link>,
                         },
                         "ref": null,
@@ -2010,15 +2242,35 @@ ShallowWrapper {
                           "key": undefined,
                           "nodeType": "class",
                           "props": Object {
-                            "children": "reviews-default",
+                            "children": Array [
+                              "Show Yaml ",
+                              <Icon
+                                name="angle-double-right"
+                                type="fa"
+                              />,
+                            ],
                             "replace": false,
                             "to": "/namespaces/test_namespace/services/test_services?routerule=reviews-default",
                           },
                           "ref": null,
-                          "rendered": "reviews-default",
+                          "rendered": Array [
+                            "Show Yaml ",
+                            Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "function",
+                              "props": Object {
+                                "name": "angle-double-right",
+                                "type": "fa",
+                              },
+                              "ref": null,
+                              "rendered": null,
+                              "type": [Function],
+                            },
+                          ],
                           "type": [Function],
                         },
-                        "type": "h3",
+                        "type": "div",
                       },
                       "",
                       Object {
@@ -2209,13 +2461,20 @@ ShallowWrapper {
                       className="card-pf-body"
                     >
                       <h3>
+                        reviews-test-v2
+                      </h3>
+                      <div>
                         <Link
                           replace={false}
                           to="/namespaces/test_namespace/services/test_services?routerule=reviews-test-v2"
                         >
-                          reviews-test-v2
+                          Show Yaml 
+                          <Icon
+                            name="angle-double-right"
+                            type="fa"
+                          />
                         </Link>
-                      </h3>
+                      </div>
                       
                       <div>
                         <strong>
@@ -2280,13 +2539,20 @@ ShallowWrapper {
                       className="card-pf-body"
                     >
                       <h3>
+                        reviews-test-v2
+                      </h3>
+                      <div>
                         <Link
                           replace={false}
                           to="/namespaces/test_namespace/services/test_services?routerule=reviews-test-v2"
                         >
-                          reviews-test-v2
+                          Show Yaml 
+                          <Icon
+                            name="angle-double-right"
+                            type="fa"
+                          />
                         </Link>
-                      </h3>
+                      </div>
                       
                       <div>
                         <strong>
@@ -2326,13 +2592,20 @@ ShallowWrapper {
                     "props": Object {
                       "children": Array [
                         <h3>
+                          reviews-test-v2
+                        </h3>,
+                        <div>
                           <Link
                             replace={false}
                             to="/namespaces/test_namespace/services/test_services?routerule=reviews-test-v2"
                           >
-                            reviews-test-v2
+                            Show Yaml 
+                            <Icon
+                              name="angle-double-right"
+                              type="fa"
+                            />
                           </Link>
-                        </h3>,
+                        </div>,
                         "",
                         <div>
                           <strong>
@@ -2376,11 +2649,26 @@ ShallowWrapper {
                         "key": undefined,
                         "nodeType": "host",
                         "props": Object {
+                          "children": "reviews-test-v2",
+                        },
+                        "ref": null,
+                        "rendered": "reviews-test-v2",
+                        "type": "h3",
+                      },
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
                           "children": <Link
                             replace={false}
                             to="/namespaces/test_namespace/services/test_services?routerule=reviews-test-v2"
                           >
-                            reviews-test-v2
+                            Show Yaml 
+                            <Icon
+                              name="angle-double-right"
+                              type="fa"
+                            />
                           </Link>,
                         },
                         "ref": null,
@@ -2389,15 +2677,35 @@ ShallowWrapper {
                           "key": undefined,
                           "nodeType": "class",
                           "props": Object {
-                            "children": "reviews-test-v2",
+                            "children": Array [
+                              "Show Yaml ",
+                              <Icon
+                                name="angle-double-right"
+                                type="fa"
+                              />,
+                            ],
                             "replace": false,
                             "to": "/namespaces/test_namespace/services/test_services?routerule=reviews-test-v2",
                           },
                           "ref": null,
-                          "rendered": "reviews-test-v2",
+                          "rendered": Array [
+                            "Show Yaml ",
+                            Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "function",
+                              "props": Object {
+                                "name": "angle-double-right",
+                                "type": "fa",
+                              },
+                              "ref": null,
+                              "rendered": null,
+                              "type": [Function],
+                            },
+                          ],
                           "type": [Function],
                         },
-                        "type": "h3",
+                        "type": "div",
                       },
                       "",
                       Object {


### PR DESCRIPTION
For route rules, destination policies, destination rules and virtual
services.

This is how it looks for route rules:
![image](https://user-images.githubusercontent.com/23639005/41245661-36da30ee-6d6e-11e8-9934-9941e41a997f.png)




For destination policies, virtual services and destination rules, it looks like this:
![image](https://user-images.githubusercontent.com/23639005/41245676-4acdc9a8-6d6e-11e8-9195-4b947bfe88b4.png)

