### PR TITLE
KIALI-897 Fast fail travis build if yarn.lock is not in sync with pac…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,7 @@ cache:
   yarn: true
   directories:
     - node_modules
-before_install:
-  yarn --frozen-lockfile --non-interactive || true
-  # Above is a candidate to test if package.json is in sync with yarn.lock
-  # if out of sync, it will fail. This can be moved to the "install" phase
+install: yarn --frozen-lockfile --non-interactive || (echo 'package.json is not in sync with yarn.lock, check that you include yarn.lock' && false)
 script:
   - yarn prettier --list-different &&
     yarn build &&


### PR DESCRIPTION
…kage.json

I have been checking some PRs and all are passing this test, I think its time to promote as part of the install phase (instead of just `yarn`)

This should fail like [this](https://travis-ci.org/kiali/kiali-ui/builds/388931032?utm_source=github_status&utm_medium=notification) in case package.json is not in sync with yarn.lock

![screenshot_2018-06-06_14-21-32](https://user-images.githubusercontent.com/3845764/41060344-f9a82082-6994-11e8-94a5-71da8fdf6917.png)
