### PR TITLE
KIALI-910 Show colored borders to represent health in graph

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -86,7 +86,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
   componentDidUpdate(prevProps: CytoscapeGraphProps, prevState: CytoscapeGraphState) {
     const cy = this.getCy();
     this.processGraphUpdate(cy);
-    if (this.props.elements !== prevProps.elements && this.props.namespace.name !== 'all') {
+    if (this.props.elements !== prevProps.elements) {
       this.updateHealth(cy);
     }
   }
@@ -330,8 +330,10 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
     cy.nodes().forEach(ele => {
       const fqService = ele.data('service');
       if (fqService && (ele.data('isGroup') || !ele.data('parent'))) {
-        const service = fqService.split('.')[0];
-        API.getServiceHealth(authentication(), this.props.namespace.name, service, duration).then(r => {
+        const serviceParts = fqService.split('.');
+        const service = serviceParts[0];
+        const namespace = serviceParts[1];
+        API.getServiceHealth(authentication(), namespace, service, duration).then(r => {
           const health = r.data;
           ele.data('health', health);
           const status = H.computeAggregatedHealth(health);

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -330,6 +330,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
   }
 
   private updateHealth(h: Health, ele: any) {
+    ele.data('health', h);
     const status = H.computeAggregatedHealth(h);
     ele.removeClass(H.DEGRADED.name + ' ' + H.FAILURE.name);
     if (status === H.DEGRADED || status === H.FAILURE) {

--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -1,6 +1,7 @@
 import { PfColors } from '../../../components/Pf/PfColors';
 import { EdgeLabelMode } from '../../../types/GraphFilter';
 import { config } from '../../../config';
+import { FAILURE, DEGRADED } from '../../../utils/Health';
 
 export const DimClass = 'mousedim';
 
@@ -157,6 +158,20 @@ export class GraphStyles {
         selector: 'node.' + DimClass,
         style: {
           opacity: '0.3'
+        }
+      },
+      {
+        selector: 'node.' + DEGRADED.name,
+        style: {
+          'border-color': DEGRADED.color,
+          'border-width': '2px'
+        }
+      },
+      {
+        selector: 'node.' + FAILURE.name,
+        style: {
+          'border-color': FAILURE.color,
+          'border-width': '2px'
         }
       },
       {

--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -164,14 +164,14 @@ export class GraphStyles {
         selector: 'node.' + DEGRADED.name,
         style: {
           'border-color': DEGRADED.color,
-          'border-width': '2px'
+          'border-width': '3px'
         }
       },
       {
         selector: 'node.' + FAILURE.name,
         style: {
           'border-color': FAILURE.color,
-          'border-width': '2px'
+          'border-width': '3px'
         }
       },
       {

--- a/src/components/ServiceHealth/HealthDetails.tsx
+++ b/src/components/ServiceHealth/HealthDetails.tsx
@@ -10,7 +10,7 @@ interface Props {
   health: Health;
   headline: string;
   placement?: string;
-  rateInterval: string;
+  rateInterval: number;
 }
 
 export class HealthDetails extends React.PureComponent<Props, {}> {
@@ -65,7 +65,7 @@ export class HealthDetails extends React.PureComponent<Props, {}> {
           {this.renderStatus(reqErrorsRatio.status)}
           {' Error Rate:'}
         </strong>
-        {' ' + reqErrorsText + ' over last ' + getName(this.props.rateInterval)}
+        {' ' + reqErrorsText + ' over ' + getName(this.props.rateInterval).toLowerCase()}
       </Popover>
     );
   }

--- a/src/components/ServiceHealth/HealthIndicator.tsx
+++ b/src/components/ServiceHealth/HealthIndicator.tsx
@@ -15,7 +15,7 @@ interface Props {
   health?: Health;
   mode: DisplayMode;
   tooltipPlacement?: string;
-  rateInterval: string;
+  rateInterval: number;
 }
 
 export class HealthIndicator extends React.PureComponent<Props, {}> {

--- a/src/components/ServiceHealth/__tests__/HealthDetails.test.tsx
+++ b/src/components/ServiceHealth/__tests__/HealthDetails.test.tsx
@@ -12,7 +12,7 @@ describe('HealthDetails', () => {
       requests: { requestCount: 0, requestErrorCount: 0 }
     };
 
-    let wrapper = shallow(<HealthDetails id="svc" health={health} headline="" rateInterval="" />);
+    let wrapper = shallow(<HealthDetails id="svc" health={health} headline="" rateInterval={600} />);
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -23,7 +23,7 @@ describe('HealthDetails', () => {
       requests: { requestCount: 0, requestErrorCount: 0 }
     };
 
-    let wrapper = shallow(<HealthDetails id="svc" health={health} headline="" rateInterval="" />);
+    let wrapper = shallow(<HealthDetails id="svc" health={health} headline="" rateInterval={600} />);
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -34,7 +34,7 @@ describe('HealthDetails', () => {
       requests: { requestCount: 0, requestErrorCount: 0 }
     };
 
-    let wrapper = shallow(<HealthDetails id="svc" health={health} headline="" rateInterval="" />);
+    let wrapper = shallow(<HealthDetails id="svc" health={health} headline="" rateInterval={600} />);
     expect(wrapper).toMatchSnapshot();
   });
 });

--- a/src/components/ServiceHealth/__tests__/HealthIndicator.test.tsx
+++ b/src/components/ServiceHealth/__tests__/HealthIndicator.test.tsx
@@ -7,11 +7,11 @@ import { Health } from '../../../types/Health';
 describe('HealthIndicator', () => {
   it('renders when empty', () => {
     // SMALL
-    let wrapper = shallow(<HealthIndicator id="svc" mode={DisplayMode.SMALL} rateInterval="" />);
+    let wrapper = shallow(<HealthIndicator id="svc" mode={DisplayMode.SMALL} rateInterval={600} />);
     expect(wrapper.html()).not.toContain('pficon');
 
     // LARGE
-    wrapper = shallow(<HealthIndicator id="svc" mode={DisplayMode.LARGE} rateInterval="" />);
+    wrapper = shallow(<HealthIndicator id="svc" mode={DisplayMode.LARGE} rateInterval={600} />);
     expect(wrapper.html()).not.toContain('pficon');
   });
 
@@ -23,13 +23,13 @@ describe('HealthIndicator', () => {
     };
 
     // SMALL
-    let wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.SMALL} rateInterval="" />);
+    let wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.SMALL} rateInterval={600} />);
     expect(wrapper).toMatchSnapshot();
     let html = wrapper.html();
     expect(html).toContain('pficon-ok');
 
     // LARGE
-    wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} rateInterval="" />);
+    wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} rateInterval={600} />);
     expect(wrapper).toMatchSnapshot();
     html = wrapper.html();
     expect(html).toContain('pficon-ok');
@@ -43,13 +43,13 @@ describe('HealthIndicator', () => {
     };
 
     // SMALL
-    let wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.SMALL} rateInterval="" />);
+    let wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.SMALL} rateInterval={600} />);
     expect(wrapper).toMatchSnapshot();
     let html = wrapper.html();
     expect(html).toContain('pficon-warning');
 
     // LARGE
-    wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} rateInterval="" />);
+    wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} rateInterval={600} />);
     expect(wrapper).toMatchSnapshot();
     html = wrapper.html();
     expect(html).toContain('pficon-warning');
@@ -64,13 +64,13 @@ describe('HealthIndicator', () => {
     };
 
     // SMALL
-    let wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.SMALL} rateInterval="" />);
+    let wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.SMALL} rateInterval={600} />);
     expect(wrapper).toMatchSnapshot();
     let html = wrapper.html();
     expect(html).toContain('pficon-warning');
 
     // LARGE
-    wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} rateInterval="" />);
+    wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} rateInterval={600} />);
     expect(wrapper).toMatchSnapshot();
     html = wrapper.html();
     expect(html).toContain('pficon-warning');
@@ -85,13 +85,13 @@ describe('HealthIndicator', () => {
     };
 
     // SMALL
-    let wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.SMALL} rateInterval="" />);
+    let wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.SMALL} rateInterval={600} />);
     expect(wrapper).toMatchSnapshot();
     let html = wrapper.html();
     expect(html).toContain('pficon-warning');
 
     // LARGE
-    wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} rateInterval="" />);
+    wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} rateInterval={600} />);
     expect(wrapper).toMatchSnapshot();
     html = wrapper.html();
     expect(html).toContain('pficon-warning');
@@ -107,13 +107,13 @@ describe('HealthIndicator', () => {
     };
 
     // SMALL
-    let wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.SMALL} rateInterval="" />);
+    let wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.SMALL} rateInterval={600} />);
     expect(wrapper).toMatchSnapshot();
     let html = wrapper.html();
     expect(html).toContain('pficon-error');
 
     // LARGE
-    wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} rateInterval="" />);
+    wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} rateInterval={600} />);
     expect(wrapper).toMatchSnapshot();
     html = wrapper.html();
     expect(html).toContain('pficon-error');
@@ -129,13 +129,13 @@ describe('HealthIndicator', () => {
     };
 
     // SMALL
-    let wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.SMALL} rateInterval="" />);
+    let wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.SMALL} rateInterval={600} />);
     expect(wrapper).toMatchSnapshot();
     let html = wrapper.html();
     expect(html).toContain('pficon-error');
 
     // LARGE
-    wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} rateInterval="" />);
+    wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} rateInterval={600} />);
     expect(wrapper).toMatchSnapshot();
     html = wrapper.html();
     expect(html).toContain('pficon-error');
@@ -151,13 +151,13 @@ describe('HealthIndicator', () => {
     };
 
     // SMALL
-    let wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.SMALL} rateInterval="" />);
+    let wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.SMALL} rateInterval={600} />);
     expect(wrapper).toMatchSnapshot();
     let html = wrapper.html();
     expect(html).toContain('pficon-ok');
 
     // LARGE
-    wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} rateInterval="" />);
+    wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} rateInterval={600} />);
     expect(wrapper).toMatchSnapshot();
     html = wrapper.html();
     expect(html).toContain('pficon-ok');
@@ -172,13 +172,13 @@ describe('HealthIndicator', () => {
     };
 
     // SMALL
-    let wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.SMALL} rateInterval="" />);
+    let wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.SMALL} rateInterval={600} />);
     expect(wrapper).toMatchSnapshot();
     let html = wrapper.html();
     expect(html).toContain('pficon-error');
 
     // LARGE
-    wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} rateInterval="" />);
+    wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} rateInterval={600} />);
     expect(wrapper).toMatchSnapshot();
     html = wrapper.html();
     expect(html).toContain('pficon-error');
@@ -193,13 +193,13 @@ describe('HealthIndicator', () => {
     };
 
     // SMALL
-    let wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.SMALL} rateInterval="" />);
+    let wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.SMALL} rateInterval={600} />);
     expect(wrapper).toMatchSnapshot();
     let html = wrapper.html();
     expect(html).toContain('pficon-warning');
 
     // LARGE
-    wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} rateInterval="" />);
+    wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} rateInterval={600} />);
     expect(wrapper).toMatchSnapshot();
     html = wrapper.html();
     expect(html).toContain('pficon-warning');
@@ -214,13 +214,13 @@ describe('HealthIndicator', () => {
     };
 
     // SMALL
-    let wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.SMALL} rateInterval="" />);
+    let wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.SMALL} rateInterval={600} />);
     expect(wrapper).toMatchSnapshot();
     let html = wrapper.html();
     expect(html).toContain('pficon-error');
 
     // LARGE
-    wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} rateInterval="" />);
+    wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} rateInterval={600} />);
     expect(wrapper).toMatchSnapshot();
     html = wrapper.html();
     expect(html).toContain('pficon-error');

--- a/src/components/ServiceHealth/__tests__/__snapshots__/HealthDetails.test.tsx.snap
+++ b/src/components/ServiceHealth/__tests__/__snapshots__/HealthDetails.test.tsx.snap
@@ -31,7 +31,7 @@ ShallowWrapper {
       }
     }
     id="svc"
-    rateInterval=""
+    rateInterval={600}
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -114,7 +114,7 @@ ShallowWrapper {
           </span>
            Error Rate:
         </strong>
-         No requests over last undefined
+         No requests over last 10 minutes
       </Popover>,
       "placement": "right",
       "rootClose": false,
@@ -202,7 +202,7 @@ ShallowWrapper {
             </span>
              Error Rate:
           </strong>
-           No requests over last undefined
+           No requests over last 10 minutes
         </Popover>,
         "placement": "right",
         "rootClose": false,
@@ -257,7 +257,7 @@ ShallowWrapper {
       }
     }
     id="svc"
-    rateInterval=""
+    rateInterval={600}
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -340,7 +340,7 @@ ShallowWrapper {
           </span>
            Error Rate:
         </strong>
-         No requests over last undefined
+         No requests over last 10 minutes
       </Popover>,
       "placement": "right",
       "rootClose": false,
@@ -428,7 +428,7 @@ ShallowWrapper {
             </span>
              Error Rate:
           </strong>
-           No requests over last undefined
+           No requests over last 10 minutes
         </Popover>,
         "placement": "right",
         "rootClose": false,
@@ -483,7 +483,7 @@ ShallowWrapper {
       }
     }
     id="svc"
-    rateInterval=""
+    rateInterval={600}
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -566,7 +566,7 @@ ShallowWrapper {
           </span>
            Error Rate:
         </strong>
-         No requests over last undefined
+         No requests over last 10 minutes
       </Popover>,
       "placement": "right",
       "rootClose": false,
@@ -654,7 +654,7 @@ ShallowWrapper {
             </span>
              Error Rate:
           </strong>
-           No requests over last undefined
+           No requests over last 10 minutes
         </Popover>,
         "placement": "right",
         "rootClose": false,

--- a/src/components/ServiceHealth/__tests__/__snapshots__/HealthIndicator.test.tsx.snap
+++ b/src/components/ServiceHealth/__tests__/__snapshots__/HealthIndicator.test.tsx.snap
@@ -31,7 +31,7 @@ ShallowWrapper {
     }
     id="svc"
     mode={1}
-    rateInterval=""
+    rateInterval={600}
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -73,7 +73,7 @@ ShallowWrapper {
         }
         id="svc"
         placement={undefined}
-        rateInterval=""
+        rateInterval={600}
       >
         <Icon
           className="health-icon"
@@ -130,7 +130,7 @@ ShallowWrapper {
         },
         "id": "svc",
         "placement": undefined,
-        "rateInterval": "",
+        "rateInterval": 600,
       },
       "ref": null,
       "rendered": Object {
@@ -188,7 +188,7 @@ ShallowWrapper {
           }
           id="svc"
           placement={undefined}
-          rateInterval=""
+          rateInterval={600}
         >
           <Icon
             className="health-icon"
@@ -245,7 +245,7 @@ ShallowWrapper {
           },
           "id": "svc",
           "placement": undefined,
-          "rateInterval": "",
+          "rateInterval": 600,
         },
         "ref": null,
         "rendered": Object {
@@ -311,7 +311,7 @@ ShallowWrapper {
     }
     id="svc"
     mode={0}
-    rateInterval=""
+    rateInterval={600}
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -354,7 +354,7 @@ ShallowWrapper {
           }
           id="svc"
           placement={undefined}
-          rateInterval=""
+          rateInterval={600}
         >
           <Icon
             className="health-icon"
@@ -419,7 +419,7 @@ ShallowWrapper {
           },
           "id": "svc",
           "placement": undefined,
-          "rateInterval": "",
+          "rateInterval": 600,
         },
         "ref": null,
         "rendered": Object {
@@ -490,7 +490,7 @@ ShallowWrapper {
             }
             id="svc"
             placement={undefined}
-            rateInterval=""
+            rateInterval={600}
           >
             <Icon
               className="health-icon"
@@ -555,7 +555,7 @@ ShallowWrapper {
             },
             "id": "svc",
             "placement": undefined,
-            "rateInterval": "",
+            "rateInterval": 600,
           },
           "ref": null,
           "rendered": Object {
@@ -633,7 +633,7 @@ ShallowWrapper {
     }
     id="svc"
     mode={1}
-    rateInterval=""
+    rateInterval={600}
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -675,7 +675,7 @@ ShallowWrapper {
         }
         id="svc"
         placement={undefined}
-        rateInterval=""
+        rateInterval={600}
       >
         <Icon
           className="health-icon"
@@ -732,7 +732,7 @@ ShallowWrapper {
         },
         "id": "svc",
         "placement": undefined,
-        "rateInterval": "",
+        "rateInterval": 600,
       },
       "ref": null,
       "rendered": Object {
@@ -790,7 +790,7 @@ ShallowWrapper {
           }
           id="svc"
           placement={undefined}
-          rateInterval=""
+          rateInterval={600}
         >
           <Icon
             className="health-icon"
@@ -847,7 +847,7 @@ ShallowWrapper {
           },
           "id": "svc",
           "placement": undefined,
-          "rateInterval": "",
+          "rateInterval": 600,
         },
         "ref": null,
         "rendered": Object {
@@ -913,7 +913,7 @@ ShallowWrapper {
     }
     id="svc"
     mode={0}
-    rateInterval=""
+    rateInterval={600}
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -956,7 +956,7 @@ ShallowWrapper {
           }
           id="svc"
           placement={undefined}
-          rateInterval=""
+          rateInterval={600}
         >
           <Icon
             className="health-icon"
@@ -1037,7 +1037,7 @@ ShallowWrapper {
           },
           "id": "svc",
           "placement": undefined,
-          "rateInterval": "",
+          "rateInterval": 600,
         },
         "ref": null,
         "rendered": Object {
@@ -1165,7 +1165,7 @@ ShallowWrapper {
             }
             id="svc"
             placement={undefined}
-            rateInterval=""
+            rateInterval={600}
           >
             <Icon
               className="health-icon"
@@ -1246,7 +1246,7 @@ ShallowWrapper {
             },
             "id": "svc",
             "placement": undefined,
-            "rateInterval": "",
+            "rateInterval": 600,
           },
           "ref": null,
           "rendered": Object {
@@ -1381,7 +1381,7 @@ ShallowWrapper {
     }
     id="svc"
     mode={1}
-    rateInterval=""
+    rateInterval={600}
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -1423,7 +1423,7 @@ ShallowWrapper {
         }
         id="svc"
         placement={undefined}
-        rateInterval=""
+        rateInterval={600}
       >
         <Icon
           className="health-icon"
@@ -1480,7 +1480,7 @@ ShallowWrapper {
         },
         "id": "svc",
         "placement": undefined,
-        "rateInterval": "",
+        "rateInterval": 600,
       },
       "ref": null,
       "rendered": Object {
@@ -1538,7 +1538,7 @@ ShallowWrapper {
           }
           id="svc"
           placement={undefined}
-          rateInterval=""
+          rateInterval={600}
         >
           <Icon
             className="health-icon"
@@ -1595,7 +1595,7 @@ ShallowWrapper {
           },
           "id": "svc",
           "placement": undefined,
-          "rateInterval": "",
+          "rateInterval": 600,
         },
         "ref": null,
         "rendered": Object {
@@ -1661,7 +1661,7 @@ ShallowWrapper {
     }
     id="svc"
     mode={0}
-    rateInterval=""
+    rateInterval={600}
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -1704,7 +1704,7 @@ ShallowWrapper {
           }
           id="svc"
           placement={undefined}
-          rateInterval=""
+          rateInterval={600}
         >
           <Icon
             className="health-icon"
@@ -1769,7 +1769,7 @@ ShallowWrapper {
           },
           "id": "svc",
           "placement": undefined,
-          "rateInterval": "",
+          "rateInterval": 600,
         },
         "ref": null,
         "rendered": Object {
@@ -1840,7 +1840,7 @@ ShallowWrapper {
             }
             id="svc"
             placement={undefined}
-            rateInterval=""
+            rateInterval={600}
           >
             <Icon
               className="health-icon"
@@ -1905,7 +1905,7 @@ ShallowWrapper {
             },
             "id": "svc",
             "placement": undefined,
-            "rateInterval": "",
+            "rateInterval": 600,
           },
           "ref": null,
           "rendered": Object {
@@ -1983,7 +1983,7 @@ ShallowWrapper {
     }
     id="svc"
     mode={1}
-    rateInterval=""
+    rateInterval={600}
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -2025,7 +2025,7 @@ ShallowWrapper {
         }
         id="svc"
         placement={undefined}
-        rateInterval=""
+        rateInterval={600}
       >
         <Icon
           className="health-icon"
@@ -2082,7 +2082,7 @@ ShallowWrapper {
         },
         "id": "svc",
         "placement": undefined,
-        "rateInterval": "",
+        "rateInterval": 600,
       },
       "ref": null,
       "rendered": Object {
@@ -2140,7 +2140,7 @@ ShallowWrapper {
           }
           id="svc"
           placement={undefined}
-          rateInterval=""
+          rateInterval={600}
         >
           <Icon
             className="health-icon"
@@ -2197,7 +2197,7 @@ ShallowWrapper {
           },
           "id": "svc",
           "placement": undefined,
-          "rateInterval": "",
+          "rateInterval": 600,
         },
         "ref": null,
         "rendered": Object {
@@ -2263,7 +2263,7 @@ ShallowWrapper {
     }
     id="svc"
     mode={0}
-    rateInterval=""
+    rateInterval={600}
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -2306,7 +2306,7 @@ ShallowWrapper {
           }
           id="svc"
           placement={undefined}
-          rateInterval=""
+          rateInterval={600}
         >
           <Icon
             className="health-icon"
@@ -2384,7 +2384,7 @@ ShallowWrapper {
           },
           "id": "svc",
           "placement": undefined,
-          "rateInterval": "",
+          "rateInterval": 600,
         },
         "ref": null,
         "rendered": Object {
@@ -2498,7 +2498,7 @@ ShallowWrapper {
             }
             id="svc"
             placement={undefined}
-            rateInterval=""
+            rateInterval={600}
           >
             <Icon
               className="health-icon"
@@ -2576,7 +2576,7 @@ ShallowWrapper {
             },
             "id": "svc",
             "placement": undefined,
-            "rateInterval": "",
+            "rateInterval": 600,
           },
           "ref": null,
           "rendered": Object {
@@ -2697,7 +2697,7 @@ ShallowWrapper {
     }
     id="svc"
     mode={1}
-    rateInterval=""
+    rateInterval={600}
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -2739,7 +2739,7 @@ ShallowWrapper {
         }
         id="svc"
         placement={undefined}
-        rateInterval=""
+        rateInterval={600}
       >
         <Icon
           className="health-icon"
@@ -2796,7 +2796,7 @@ ShallowWrapper {
         },
         "id": "svc",
         "placement": undefined,
-        "rateInterval": "",
+        "rateInterval": 600,
       },
       "ref": null,
       "rendered": Object {
@@ -2854,7 +2854,7 @@ ShallowWrapper {
           }
           id="svc"
           placement={undefined}
-          rateInterval=""
+          rateInterval={600}
         >
           <Icon
             className="health-icon"
@@ -2911,7 +2911,7 @@ ShallowWrapper {
           },
           "id": "svc",
           "placement": undefined,
-          "rateInterval": "",
+          "rateInterval": 600,
         },
         "ref": null,
         "rendered": Object {
@@ -2977,7 +2977,7 @@ ShallowWrapper {
     }
     id="svc"
     mode={0}
-    rateInterval=""
+    rateInterval={600}
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -3020,7 +3020,7 @@ ShallowWrapper {
           }
           id="svc"
           placement={undefined}
-          rateInterval=""
+          rateInterval={600}
         >
           <Icon
             className="health-icon"
@@ -3085,7 +3085,7 @@ ShallowWrapper {
           },
           "id": "svc",
           "placement": undefined,
-          "rateInterval": "",
+          "rateInterval": 600,
         },
         "ref": null,
         "rendered": Object {
@@ -3156,7 +3156,7 @@ ShallowWrapper {
             }
             id="svc"
             placement={undefined}
-            rateInterval=""
+            rateInterval={600}
           >
             <Icon
               className="health-icon"
@@ -3221,7 +3221,7 @@ ShallowWrapper {
             },
             "id": "svc",
             "placement": undefined,
-            "rateInterval": "",
+            "rateInterval": 600,
           },
           "ref": null,
           "rendered": Object {
@@ -3299,7 +3299,7 @@ ShallowWrapper {
     }
     id="svc"
     mode={1}
-    rateInterval=""
+    rateInterval={600}
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -3341,7 +3341,7 @@ ShallowWrapper {
         }
         id="svc"
         placement={undefined}
-        rateInterval=""
+        rateInterval={600}
       >
         <Icon
           className="health-icon"
@@ -3398,7 +3398,7 @@ ShallowWrapper {
         },
         "id": "svc",
         "placement": undefined,
-        "rateInterval": "",
+        "rateInterval": 600,
       },
       "ref": null,
       "rendered": Object {
@@ -3456,7 +3456,7 @@ ShallowWrapper {
           }
           id="svc"
           placement={undefined}
-          rateInterval=""
+          rateInterval={600}
         >
           <Icon
             className="health-icon"
@@ -3513,7 +3513,7 @@ ShallowWrapper {
           },
           "id": "svc",
           "placement": undefined,
-          "rateInterval": "",
+          "rateInterval": 600,
         },
         "ref": null,
         "rendered": Object {
@@ -3579,7 +3579,7 @@ ShallowWrapper {
     }
     id="svc"
     mode={0}
-    rateInterval=""
+    rateInterval={600}
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -3622,7 +3622,7 @@ ShallowWrapper {
           }
           id="svc"
           placement={undefined}
-          rateInterval=""
+          rateInterval={600}
         >
           <Icon
             className="health-icon"
@@ -3700,7 +3700,7 @@ ShallowWrapper {
           },
           "id": "svc",
           "placement": undefined,
-          "rateInterval": "",
+          "rateInterval": 600,
         },
         "ref": null,
         "rendered": Object {
@@ -3814,7 +3814,7 @@ ShallowWrapper {
             }
             id="svc"
             placement={undefined}
-            rateInterval=""
+            rateInterval={600}
           >
             <Icon
               className="health-icon"
@@ -3892,7 +3892,7 @@ ShallowWrapper {
             },
             "id": "svc",
             "placement": undefined,
-            "rateInterval": "",
+            "rateInterval": 600,
           },
           "ref": null,
           "rendered": Object {
@@ -4008,7 +4008,7 @@ ShallowWrapper {
     }
     id="svc"
     mode={1}
-    rateInterval=""
+    rateInterval={600}
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -4045,7 +4045,7 @@ ShallowWrapper {
         }
         id="svc"
         placement={undefined}
-        rateInterval=""
+        rateInterval={600}
       >
         <Icon
           className="health-icon"
@@ -4097,7 +4097,7 @@ ShallowWrapper {
         },
         "id": "svc",
         "placement": undefined,
-        "rateInterval": "",
+        "rateInterval": 600,
       },
       "ref": null,
       "rendered": Object {
@@ -4150,7 +4150,7 @@ ShallowWrapper {
           }
           id="svc"
           placement={undefined}
-          rateInterval=""
+          rateInterval={600}
         >
           <Icon
             className="health-icon"
@@ -4202,7 +4202,7 @@ ShallowWrapper {
           },
           "id": "svc",
           "placement": undefined,
-          "rateInterval": "",
+          "rateInterval": 600,
         },
         "ref": null,
         "rendered": Object {
@@ -4263,7 +4263,7 @@ ShallowWrapper {
     }
     id="svc"
     mode={0}
-    rateInterval=""
+    rateInterval={600}
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -4301,7 +4301,7 @@ ShallowWrapper {
           }
           id="svc"
           placement={undefined}
-          rateInterval=""
+          rateInterval={600}
         >
           <Icon
             className="health-icon"
@@ -4374,7 +4374,7 @@ ShallowWrapper {
           },
           "id": "svc",
           "placement": undefined,
-          "rateInterval": "",
+          "rateInterval": 600,
         },
         "ref": null,
         "rendered": Object {
@@ -4483,7 +4483,7 @@ ShallowWrapper {
             }
             id="svc"
             placement={undefined}
-            rateInterval=""
+            rateInterval={600}
           >
             <Icon
               className="health-icon"
@@ -4556,7 +4556,7 @@ ShallowWrapper {
             },
             "id": "svc",
             "placement": undefined,
-            "rateInterval": "",
+            "rateInterval": 600,
           },
           "ref": null,
           "rendered": Object {
@@ -4672,7 +4672,7 @@ ShallowWrapper {
     }
     id="svc"
     mode={1}
-    rateInterval=""
+    rateInterval={600}
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -4709,7 +4709,7 @@ ShallowWrapper {
         }
         id="svc"
         placement={undefined}
-        rateInterval=""
+        rateInterval={600}
       >
         <Icon
           className="health-icon"
@@ -4761,7 +4761,7 @@ ShallowWrapper {
         },
         "id": "svc",
         "placement": undefined,
-        "rateInterval": "",
+        "rateInterval": 600,
       },
       "ref": null,
       "rendered": Object {
@@ -4814,7 +4814,7 @@ ShallowWrapper {
           }
           id="svc"
           placement={undefined}
-          rateInterval=""
+          rateInterval={600}
         >
           <Icon
             className="health-icon"
@@ -4866,7 +4866,7 @@ ShallowWrapper {
           },
           "id": "svc",
           "placement": undefined,
-          "rateInterval": "",
+          "rateInterval": 600,
         },
         "ref": null,
         "rendered": Object {
@@ -4927,7 +4927,7 @@ ShallowWrapper {
     }
     id="svc"
     mode={0}
-    rateInterval=""
+    rateInterval={600}
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -4965,7 +4965,7 @@ ShallowWrapper {
           }
           id="svc"
           placement={undefined}
-          rateInterval=""
+          rateInterval={600}
         >
           <Icon
             className="health-icon"
@@ -5038,7 +5038,7 @@ ShallowWrapper {
           },
           "id": "svc",
           "placement": undefined,
-          "rateInterval": "",
+          "rateInterval": 600,
         },
         "ref": null,
         "rendered": Object {
@@ -5147,7 +5147,7 @@ ShallowWrapper {
             }
             id="svc"
             placement={undefined}
-            rateInterval=""
+            rateInterval={600}
           >
             <Icon
               className="health-icon"
@@ -5220,7 +5220,7 @@ ShallowWrapper {
             },
             "id": "svc",
             "placement": undefined,
-            "rateInterval": "",
+            "rateInterval": 600,
           },
           "ref": null,
           "rendered": Object {
@@ -5341,7 +5341,7 @@ ShallowWrapper {
     }
     id="svc"
     mode={1}
-    rateInterval=""
+    rateInterval={600}
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -5383,7 +5383,7 @@ ShallowWrapper {
         }
         id="svc"
         placement={undefined}
-        rateInterval=""
+        rateInterval={600}
       >
         <Icon
           className="health-icon"
@@ -5440,7 +5440,7 @@ ShallowWrapper {
         },
         "id": "svc",
         "placement": undefined,
-        "rateInterval": "",
+        "rateInterval": 600,
       },
       "ref": null,
       "rendered": Object {
@@ -5498,7 +5498,7 @@ ShallowWrapper {
           }
           id="svc"
           placement={undefined}
-          rateInterval=""
+          rateInterval={600}
         >
           <Icon
             className="health-icon"
@@ -5555,7 +5555,7 @@ ShallowWrapper {
           },
           "id": "svc",
           "placement": undefined,
-          "rateInterval": "",
+          "rateInterval": 600,
         },
         "ref": null,
         "rendered": Object {
@@ -5621,7 +5621,7 @@ ShallowWrapper {
     }
     id="svc"
     mode={0}
-    rateInterval=""
+    rateInterval={600}
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -5664,7 +5664,7 @@ ShallowWrapper {
           }
           id="svc"
           placement={undefined}
-          rateInterval=""
+          rateInterval={600}
         >
           <Icon
             className="health-icon"
@@ -5729,7 +5729,7 @@ ShallowWrapper {
           },
           "id": "svc",
           "placement": undefined,
-          "rateInterval": "",
+          "rateInterval": 600,
         },
         "ref": null,
         "rendered": Object {
@@ -5800,7 +5800,7 @@ ShallowWrapper {
             }
             id="svc"
             placement={undefined}
-            rateInterval=""
+            rateInterval={600}
           >
             <Icon
               className="health-icon"
@@ -5865,7 +5865,7 @@ ShallowWrapper {
             },
             "id": "svc",
             "placement": undefined,
-            "rateInterval": "",
+            "rateInterval": 600,
           },
           "ref": null,
           "rendered": Object {
@@ -5943,7 +5943,7 @@ ShallowWrapper {
     }
     id="svc"
     mode={1}
-    rateInterval=""
+    rateInterval={600}
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -5985,7 +5985,7 @@ ShallowWrapper {
         }
         id="svc"
         placement={undefined}
-        rateInterval=""
+        rateInterval={600}
       >
         <Icon
           className="health-icon"
@@ -6042,7 +6042,7 @@ ShallowWrapper {
         },
         "id": "svc",
         "placement": undefined,
-        "rateInterval": "",
+        "rateInterval": 600,
       },
       "ref": null,
       "rendered": Object {
@@ -6100,7 +6100,7 @@ ShallowWrapper {
           }
           id="svc"
           placement={undefined}
-          rateInterval=""
+          rateInterval={600}
         >
           <Icon
             className="health-icon"
@@ -6157,7 +6157,7 @@ ShallowWrapper {
           },
           "id": "svc",
           "placement": undefined,
-          "rateInterval": "",
+          "rateInterval": 600,
         },
         "ref": null,
         "rendered": Object {
@@ -6223,7 +6223,7 @@ ShallowWrapper {
     }
     id="svc"
     mode={0}
-    rateInterval=""
+    rateInterval={600}
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -6266,7 +6266,7 @@ ShallowWrapper {
           }
           id="svc"
           placement={undefined}
-          rateInterval=""
+          rateInterval={600}
         >
           <Icon
             className="health-icon"
@@ -6331,7 +6331,7 @@ ShallowWrapper {
           },
           "id": "svc",
           "placement": undefined,
-          "rateInterval": "",
+          "rateInterval": 600,
         },
         "ref": null,
         "rendered": Object {
@@ -6402,7 +6402,7 @@ ShallowWrapper {
             }
             id="svc"
             placement={undefined}
-            rateInterval=""
+            rateInterval={600}
           >
             <Icon
               className="health-icon"
@@ -6467,7 +6467,7 @@ ShallowWrapper {
             },
             "id": "svc",
             "placement": undefined,
-            "rateInterval": "",
+            "rateInterval": 600,
           },
           "ref": null,
           "rendered": Object {

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
@@ -116,7 +116,7 @@ class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps
                 health={this.props.health}
                 mode={DisplayMode.LARGE}
                 tooltipPlacement="left"
-                rateInterval="10m"
+                rateInterval={600}
               />
             </Col>
           </Row>

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
@@ -229,7 +229,7 @@ ShallowWrapper {
             health={undefined}
             id="reviews"
             mode={0}
-            rateInterval="10m"
+            rateInterval={600}
             tooltipPlacement="left"
           />
         </Col>
@@ -417,7 +417,7 @@ ShallowWrapper {
               health={undefined}
               id="reviews"
               mode={0}
-              rateInterval="10m"
+              rateInterval={600}
               tooltipPlacement="left"
             />
           </Col>

--- a/src/pages/ServiceGraph/SummaryPanelGroup.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelGroup.tsx
@@ -13,6 +13,7 @@ import { Icon } from 'patternfly-react';
 import { authentication } from '../../utils/Authentication';
 import { Link } from 'react-router-dom';
 import { shouldRefreshData } from './SummaryPanelCommon';
+import { HealthIndicator, DisplayMode } from '../../components/ServiceHealth/HealthIndicator';
 
 type SummaryPanelGroupState = {
   loading: boolean;
@@ -67,6 +68,7 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
     const namespace = group.data('service').split('.')[1];
     const service = group.data('service').split('.')[0];
     const serviceHotLink = <Link to={`/namespaces/${namespace}/services/${service}`}>{service}</Link>;
+    const health = group.data('health');
 
     const incoming = getAccumulatedTrafficRate(group.children());
     const outgoing = getAccumulatedTrafficRate(group.children().edgesTo('*'));
@@ -74,7 +76,16 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
     return (
       <div className="panel panel-default" style={SummaryPanelGroup.panelStyle}>
         <div className="panel-heading">
-          Versioned Group: {serviceHotLink}
+          {health && (
+            <HealthIndicator
+              id="graph-health-indicator"
+              mode={DisplayMode.SMALL}
+              health={health}
+              tooltipPlacement="left"
+              rateInterval="10m"
+            />
+          )}
+          <span> Versioned Group: {serviceHotLink}</span>
           <div style={{ paddingTop: '3px' }}>
             <Badge
               scale={0.9}

--- a/src/pages/ServiceGraph/SummaryPanelGroup.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelGroup.tsx
@@ -82,7 +82,7 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
               mode={DisplayMode.SMALL}
               health={health}
               tooltipPlacement="left"
-              rateInterval="10m"
+              rateInterval={this.props.duration}
             />
           )}
           <span> Versioned Group: {serviceHotLink}</span>

--- a/src/pages/ServiceGraph/SummaryPanelNode.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelNode.tsx
@@ -14,6 +14,7 @@ import { Icon } from 'patternfly-react';
 import { authentication } from '../../utils/Authentication';
 import { Link } from 'react-router-dom';
 import { shouldRefreshData } from './SummaryPanelCommon';
+import { HealthIndicator, DisplayMode } from '../../components/ServiceHealth/HealthIndicator';
 
 type SummaryPanelStateType = {
   loading: boolean;
@@ -119,10 +120,20 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
     const outgoing = getAccumulatedTrafficRate(this.props.data.summaryTarget.edgesTo('*'));
 
     const isUnknown = service === 'unknown';
+    const health = node.data('health');
     return (
       <div className="panel panel-default" style={SummaryPanelNode.panelStyle}>
         <div className="panel-heading">
-          Service: {isUnknown ? 'unknown' : serviceHotLink}
+          {health && (
+            <HealthIndicator
+              id="graph-health-indicator"
+              mode={DisplayMode.SMALL}
+              health={health}
+              tooltipPlacement="left"
+              rateInterval="10m"
+            />
+          )}
+          <span> Service: {isUnknown ? 'unknown' : serviceHotLink}</span>
           <div style={{ paddingTop: '3px' }}>
             <Badge scale={0.9} style="plastic" leftText="namespace" rightText={namespace} color={PfColors.Green400} />
             <Badge

--- a/src/pages/ServiceGraph/SummaryPanelNode.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelNode.tsx
@@ -130,7 +130,7 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
               mode={DisplayMode.SMALL}
               health={health}
               tooltipPlacement="left"
-              rateInterval="10m"
+              rateInterval={this.props.duration}
             />
           )}
           <span> Service: {isUnknown ? 'unknown' : serviceHotLink}</span>

--- a/src/pages/ServiceList/RateIntervalToolbarItem.tsx
+++ b/src/pages/ServiceList/RateIntervalToolbarItem.tsx
@@ -1,29 +1,23 @@
 import * as React from 'react';
 import { DropdownButton, MenuItem } from 'patternfly-react';
-import RateIntervals from '../../types/RateIntervals';
+import * as RateIntervals from '../../types/RateIntervals';
 
 type RateIntervalToolbarItemProps = {
-  rateIntervalSelected: string;
-  onRateIntervalChanged?: (key: string) => void;
+  rateIntervalSelected: number;
+  onRateIntervalChanged?: (key: number) => void;
 };
 
 export default class RateIntervalToolbarItem extends React.Component<RateIntervalToolbarItemProps> {
   render() {
-    const rateIntervalSelected = RateIntervals.find(el => {
-      return el[0] === this.props.rateIntervalSelected;
-    });
+    const rateIntervalName = RateIntervals.getName(this.props.rateIntervalSelected);
 
     return (
       <div className="form-group">
         <label style={{ paddingRight: '0.5em' }}>Rate Interval:</label>
-        <DropdownButton
-          title={'Last ' + rateIntervalSelected![1]}
-          onSelect={this.props.onRateIntervalChanged}
-          id="rateIntervalDropDown"
-        >
-          {RateIntervals.map(r => (
+        <DropdownButton title={rateIntervalName} onSelect={this.props.onRateIntervalChanged} id="rateIntervalDropDown">
+          {RateIntervals.tuples.map(r => (
             <MenuItem key={r[0]} active={r[0] === this.props.rateIntervalSelected} eventKey={r[0]}>
-              Last {r[1]}
+              {r[1]}
             </MenuItem>
           ))}
         </DropdownButton>

--- a/src/pages/ServiceList/ServiceListComponent.tsx
+++ b/src/pages/ServiceList/ServiceListComponent.tsx
@@ -87,7 +87,7 @@ type ServiceListComponentState = {
   pagination: Pagination;
   currentSortField: SortField;
   isSortAscending: boolean;
-  rateInterval: string;
+  rateInterval: number;
 };
 
 type ServiceListComponentProps = {
@@ -95,7 +95,7 @@ type ServiceListComponentProps = {
 };
 
 const perPageOptions: number[] = [5, 10, 15];
-const defaultRateInterval = '10m';
+const defaultRateInterval = 600;
 
 class ServiceListComponent extends React.Component<ServiceListComponentProps, ServiceListComponentState> {
   constructor(props: ServiceListComponentProps) {
@@ -178,7 +178,7 @@ class ServiceListComponent extends React.Component<ServiceListComponentProps, Se
     });
   };
 
-  updateServices(rateInterval: string = defaultRateInterval) {
+  updateServices(rateInterval: number = defaultRateInterval) {
     const activeFilters: ActiveFilter[] = NamespaceFilterSelected.getSelected();
     let namespacesSelected: string[] = activeFilters
       .filter(activeFilter => activeFilter.category === 'Namespace')
@@ -199,7 +199,7 @@ class ServiceListComponent extends React.Component<ServiceListComponentProps, Se
             namespaces.map(namespace => namespace.name),
             servicenameFilters,
             istioFilters,
-            rateInterval
+            rateInterval + 's'
           );
         })
         .catch(namespacesError => this.handleAxiosError('Could not fetch namespace list.', namespacesError));
@@ -380,7 +380,7 @@ class ServiceListComponent extends React.Component<ServiceListComponentProps, Se
     return <div>{serviceListComponent}</div>;
   }
 
-  private rateIntervalChangedHandler = (key: string) => {
+  private rateIntervalChangedHandler = (key: number) => {
     this.setState({
       rateInterval: key,
       loading: true

--- a/src/pages/ServiceList/__tests__/RateIntervalToolbarItem.test.tsx
+++ b/src/pages/ServiceList/__tests__/RateIntervalToolbarItem.test.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import RateIntervalToolbarItem from '../RateIntervalToolbarItem';
-import RateIntervals from '../../../types/RateIntervals';
+import * as RateIntervals from '../../../types/RateIntervals';
 
 describe('RateIntervalToolbarItem', () => {
   it('renders correctly', () => {
-    const wrapper = shallow(<RateIntervalToolbarItem rateIntervalSelected="10m" />);
+    const wrapper = shallow(<RateIntervalToolbarItem rateIntervalSelected={600} />);
     expect(wrapper).toBeDefined();
     expect(wrapper).toMatchSnapshot();
-    expect(wrapper.find('MenuItem').length).toBe(RateIntervals.length);
+    expect(wrapper.find('MenuItem').length).toBe(RateIntervals.tuples.length);
   });
 });

--- a/src/pages/ServiceList/__tests__/__snapshots__/RateIntervalToolbarItem.test.tsx.snap
+++ b/src/pages/ServiceList/__tests__/__snapshots__/RateIntervalToolbarItem.test.tsx.snap
@@ -5,7 +5,7 @@ ShallowWrapper {
   "length": 1,
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <RateIntervalToolbarItem
-    rateIntervalSelected="10m"
+    rateIntervalSelected={600}
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -39,44 +39,110 @@ ShallowWrapper {
             bsClass="dropdown"
             disabled={false}
             divider={false}
-            eventKey="1m"
+            eventKey={60}
             header={false}
           >
-            Last 
-            1 minute
+            Last minute
           </MenuItem>
           <MenuItem
             active={false}
             bsClass="dropdown"
             disabled={false}
             divider={false}
-            eventKey="5m"
+            eventKey={300}
             header={false}
           >
-            Last 
-            5 minutes
+            Last 5 minutes
           </MenuItem>
           <MenuItem
             active={true}
             bsClass="dropdown"
             disabled={false}
             divider={false}
-            eventKey="10m"
+            eventKey={600}
             header={false}
           >
-            Last 
-            10 minutes
+            Last 10 minutes
           </MenuItem>
           <MenuItem
             active={false}
             bsClass="dropdown"
             disabled={false}
             divider={false}
-            eventKey="30m"
+            eventKey={1800}
             header={false}
           >
-            Last 
-            30 minutes
+            Last 30 minutes
+          </MenuItem>
+          <MenuItem
+            active={false}
+            bsClass="dropdown"
+            disabled={false}
+            divider={false}
+            eventKey={3600}
+            header={false}
+          >
+            Last hour
+          </MenuItem>
+          <MenuItem
+            active={false}
+            bsClass="dropdown"
+            disabled={false}
+            divider={false}
+            eventKey={10800}
+            header={false}
+          >
+            Last 3 hours
+          </MenuItem>
+          <MenuItem
+            active={false}
+            bsClass="dropdown"
+            disabled={false}
+            divider={false}
+            eventKey={21600}
+            header={false}
+          >
+            Last 6 hours
+          </MenuItem>
+          <MenuItem
+            active={false}
+            bsClass="dropdown"
+            disabled={false}
+            divider={false}
+            eventKey={43200}
+            header={false}
+          >
+            Last 12 hours
+          </MenuItem>
+          <MenuItem
+            active={false}
+            bsClass="dropdown"
+            disabled={false}
+            divider={false}
+            eventKey={86400}
+            header={false}
+          >
+            Last day
+          </MenuItem>
+          <MenuItem
+            active={false}
+            bsClass="dropdown"
+            disabled={false}
+            divider={false}
+            eventKey={604800}
+            header={false}
+          >
+            Last 7 days
+          </MenuItem>
+          <MenuItem
+            active={false}
+            bsClass="dropdown"
+            disabled={false}
+            divider={false}
+            eventKey={2592000}
+            header={false}
+          >
+            Last 30 days
           </MenuItem>
         </DropdownButton>,
       ],
@@ -109,44 +175,110 @@ ShallowWrapper {
               bsClass="dropdown"
               disabled={false}
               divider={false}
-              eventKey="1m"
+              eventKey={60}
               header={false}
             >
-              Last 
-              1 minute
+              Last minute
             </MenuItem>,
             <MenuItem
               active={false}
               bsClass="dropdown"
               disabled={false}
               divider={false}
-              eventKey="5m"
+              eventKey={300}
               header={false}
             >
-              Last 
-              5 minutes
+              Last 5 minutes
             </MenuItem>,
             <MenuItem
               active={true}
               bsClass="dropdown"
               disabled={false}
               divider={false}
-              eventKey="10m"
+              eventKey={600}
               header={false}
             >
-              Last 
-              10 minutes
+              Last 10 minutes
             </MenuItem>,
             <MenuItem
               active={false}
               bsClass="dropdown"
               disabled={false}
               divider={false}
-              eventKey="30m"
+              eventKey={1800}
               header={false}
             >
-              Last 
-              30 minutes
+              Last 30 minutes
+            </MenuItem>,
+            <MenuItem
+              active={false}
+              bsClass="dropdown"
+              disabled={false}
+              divider={false}
+              eventKey={3600}
+              header={false}
+            >
+              Last hour
+            </MenuItem>,
+            <MenuItem
+              active={false}
+              bsClass="dropdown"
+              disabled={false}
+              divider={false}
+              eventKey={10800}
+              header={false}
+            >
+              Last 3 hours
+            </MenuItem>,
+            <MenuItem
+              active={false}
+              bsClass="dropdown"
+              disabled={false}
+              divider={false}
+              eventKey={21600}
+              header={false}
+            >
+              Last 6 hours
+            </MenuItem>,
+            <MenuItem
+              active={false}
+              bsClass="dropdown"
+              disabled={false}
+              divider={false}
+              eventKey={43200}
+              header={false}
+            >
+              Last 12 hours
+            </MenuItem>,
+            <MenuItem
+              active={false}
+              bsClass="dropdown"
+              disabled={false}
+              divider={false}
+              eventKey={86400}
+              header={false}
+            >
+              Last day
+            </MenuItem>,
+            <MenuItem
+              active={false}
+              bsClass="dropdown"
+              disabled={false}
+              divider={false}
+              eventKey={604800}
+              header={false}
+            >
+              Last 7 days
+            </MenuItem>,
+            <MenuItem
+              active={false}
+              bsClass="dropdown"
+              disabled={false}
+              divider={false}
+              eventKey={2592000}
+              header={false}
+            >
+              Last 30 days
             </MenuItem>,
           ],
           "id": "rateIntervalDropDown",
@@ -157,94 +289,189 @@ ShallowWrapper {
         "rendered": Array [
           Object {
             "instance": null,
-            "key": "1m",
+            "key": "60",
             "nodeType": "class",
             "props": Object {
               "active": false,
               "bsClass": "dropdown",
-              "children": Array [
-                "Last ",
-                "1 minute",
-              ],
+              "children": "Last minute",
               "disabled": false,
               "divider": false,
-              "eventKey": "1m",
+              "eventKey": 60,
               "header": false,
             },
             "ref": null,
-            "rendered": Array [
-              "Last ",
-              "1 minute",
-            ],
+            "rendered": "Last minute",
             "type": [Function],
           },
           Object {
             "instance": null,
-            "key": "5m",
+            "key": "300",
             "nodeType": "class",
             "props": Object {
               "active": false,
               "bsClass": "dropdown",
-              "children": Array [
-                "Last ",
-                "5 minutes",
-              ],
+              "children": "Last 5 minutes",
               "disabled": false,
               "divider": false,
-              "eventKey": "5m",
+              "eventKey": 300,
               "header": false,
             },
             "ref": null,
-            "rendered": Array [
-              "Last ",
-              "5 minutes",
-            ],
+            "rendered": "Last 5 minutes",
             "type": [Function],
           },
           Object {
             "instance": null,
-            "key": "10m",
+            "key": "600",
             "nodeType": "class",
             "props": Object {
               "active": true,
               "bsClass": "dropdown",
-              "children": Array [
-                "Last ",
-                "10 minutes",
-              ],
+              "children": "Last 10 minutes",
               "disabled": false,
               "divider": false,
-              "eventKey": "10m",
+              "eventKey": 600,
               "header": false,
             },
             "ref": null,
-            "rendered": Array [
-              "Last ",
-              "10 minutes",
-            ],
+            "rendered": "Last 10 minutes",
             "type": [Function],
           },
           Object {
             "instance": null,
-            "key": "30m",
+            "key": "1800",
             "nodeType": "class",
             "props": Object {
               "active": false,
               "bsClass": "dropdown",
-              "children": Array [
-                "Last ",
-                "30 minutes",
-              ],
+              "children": "Last 30 minutes",
               "disabled": false,
               "divider": false,
-              "eventKey": "30m",
+              "eventKey": 1800,
               "header": false,
             },
             "ref": null,
-            "rendered": Array [
-              "Last ",
-              "30 minutes",
-            ],
+            "rendered": "Last 30 minutes",
+            "type": [Function],
+          },
+          Object {
+            "instance": null,
+            "key": "3600",
+            "nodeType": "class",
+            "props": Object {
+              "active": false,
+              "bsClass": "dropdown",
+              "children": "Last hour",
+              "disabled": false,
+              "divider": false,
+              "eventKey": 3600,
+              "header": false,
+            },
+            "ref": null,
+            "rendered": "Last hour",
+            "type": [Function],
+          },
+          Object {
+            "instance": null,
+            "key": "10800",
+            "nodeType": "class",
+            "props": Object {
+              "active": false,
+              "bsClass": "dropdown",
+              "children": "Last 3 hours",
+              "disabled": false,
+              "divider": false,
+              "eventKey": 10800,
+              "header": false,
+            },
+            "ref": null,
+            "rendered": "Last 3 hours",
+            "type": [Function],
+          },
+          Object {
+            "instance": null,
+            "key": "21600",
+            "nodeType": "class",
+            "props": Object {
+              "active": false,
+              "bsClass": "dropdown",
+              "children": "Last 6 hours",
+              "disabled": false,
+              "divider": false,
+              "eventKey": 21600,
+              "header": false,
+            },
+            "ref": null,
+            "rendered": "Last 6 hours",
+            "type": [Function],
+          },
+          Object {
+            "instance": null,
+            "key": "43200",
+            "nodeType": "class",
+            "props": Object {
+              "active": false,
+              "bsClass": "dropdown",
+              "children": "Last 12 hours",
+              "disabled": false,
+              "divider": false,
+              "eventKey": 43200,
+              "header": false,
+            },
+            "ref": null,
+            "rendered": "Last 12 hours",
+            "type": [Function],
+          },
+          Object {
+            "instance": null,
+            "key": "86400",
+            "nodeType": "class",
+            "props": Object {
+              "active": false,
+              "bsClass": "dropdown",
+              "children": "Last day",
+              "disabled": false,
+              "divider": false,
+              "eventKey": 86400,
+              "header": false,
+            },
+            "ref": null,
+            "rendered": "Last day",
+            "type": [Function],
+          },
+          Object {
+            "instance": null,
+            "key": "604800",
+            "nodeType": "class",
+            "props": Object {
+              "active": false,
+              "bsClass": "dropdown",
+              "children": "Last 7 days",
+              "disabled": false,
+              "divider": false,
+              "eventKey": 604800,
+              "header": false,
+            },
+            "ref": null,
+            "rendered": "Last 7 days",
+            "type": [Function],
+          },
+          Object {
+            "instance": null,
+            "key": "2592000",
+            "nodeType": "class",
+            "props": Object {
+              "active": false,
+              "bsClass": "dropdown",
+              "children": "Last 30 days",
+              "disabled": false,
+              "divider": false,
+              "eventKey": 2592000,
+              "header": false,
+            },
+            "ref": null,
+            "rendered": "Last 30 days",
             "type": [Function],
           },
         ],
@@ -279,44 +506,110 @@ ShallowWrapper {
               bsClass="dropdown"
               disabled={false}
               divider={false}
-              eventKey="1m"
+              eventKey={60}
               header={false}
             >
-              Last 
-              1 minute
+              Last minute
             </MenuItem>
             <MenuItem
               active={false}
               bsClass="dropdown"
               disabled={false}
               divider={false}
-              eventKey="5m"
+              eventKey={300}
               header={false}
             >
-              Last 
-              5 minutes
+              Last 5 minutes
             </MenuItem>
             <MenuItem
               active={true}
               bsClass="dropdown"
               disabled={false}
               divider={false}
-              eventKey="10m"
+              eventKey={600}
               header={false}
             >
-              Last 
-              10 minutes
+              Last 10 minutes
             </MenuItem>
             <MenuItem
               active={false}
               bsClass="dropdown"
               disabled={false}
               divider={false}
-              eventKey="30m"
+              eventKey={1800}
               header={false}
             >
-              Last 
-              30 minutes
+              Last 30 minutes
+            </MenuItem>
+            <MenuItem
+              active={false}
+              bsClass="dropdown"
+              disabled={false}
+              divider={false}
+              eventKey={3600}
+              header={false}
+            >
+              Last hour
+            </MenuItem>
+            <MenuItem
+              active={false}
+              bsClass="dropdown"
+              disabled={false}
+              divider={false}
+              eventKey={10800}
+              header={false}
+            >
+              Last 3 hours
+            </MenuItem>
+            <MenuItem
+              active={false}
+              bsClass="dropdown"
+              disabled={false}
+              divider={false}
+              eventKey={21600}
+              header={false}
+            >
+              Last 6 hours
+            </MenuItem>
+            <MenuItem
+              active={false}
+              bsClass="dropdown"
+              disabled={false}
+              divider={false}
+              eventKey={43200}
+              header={false}
+            >
+              Last 12 hours
+            </MenuItem>
+            <MenuItem
+              active={false}
+              bsClass="dropdown"
+              disabled={false}
+              divider={false}
+              eventKey={86400}
+              header={false}
+            >
+              Last day
+            </MenuItem>
+            <MenuItem
+              active={false}
+              bsClass="dropdown"
+              disabled={false}
+              divider={false}
+              eventKey={604800}
+              header={false}
+            >
+              Last 7 days
+            </MenuItem>
+            <MenuItem
+              active={false}
+              bsClass="dropdown"
+              disabled={false}
+              divider={false}
+              eventKey={2592000}
+              header={false}
+            >
+              Last 30 days
             </MenuItem>
           </DropdownButton>,
         ],
@@ -349,44 +642,110 @@ ShallowWrapper {
                 bsClass="dropdown"
                 disabled={false}
                 divider={false}
-                eventKey="1m"
+                eventKey={60}
                 header={false}
               >
-                Last 
-                1 minute
+                Last minute
               </MenuItem>,
               <MenuItem
                 active={false}
                 bsClass="dropdown"
                 disabled={false}
                 divider={false}
-                eventKey="5m"
+                eventKey={300}
                 header={false}
               >
-                Last 
-                5 minutes
+                Last 5 minutes
               </MenuItem>,
               <MenuItem
                 active={true}
                 bsClass="dropdown"
                 disabled={false}
                 divider={false}
-                eventKey="10m"
+                eventKey={600}
                 header={false}
               >
-                Last 
-                10 minutes
+                Last 10 minutes
               </MenuItem>,
               <MenuItem
                 active={false}
                 bsClass="dropdown"
                 disabled={false}
                 divider={false}
-                eventKey="30m"
+                eventKey={1800}
                 header={false}
               >
-                Last 
-                30 minutes
+                Last 30 minutes
+              </MenuItem>,
+              <MenuItem
+                active={false}
+                bsClass="dropdown"
+                disabled={false}
+                divider={false}
+                eventKey={3600}
+                header={false}
+              >
+                Last hour
+              </MenuItem>,
+              <MenuItem
+                active={false}
+                bsClass="dropdown"
+                disabled={false}
+                divider={false}
+                eventKey={10800}
+                header={false}
+              >
+                Last 3 hours
+              </MenuItem>,
+              <MenuItem
+                active={false}
+                bsClass="dropdown"
+                disabled={false}
+                divider={false}
+                eventKey={21600}
+                header={false}
+              >
+                Last 6 hours
+              </MenuItem>,
+              <MenuItem
+                active={false}
+                bsClass="dropdown"
+                disabled={false}
+                divider={false}
+                eventKey={43200}
+                header={false}
+              >
+                Last 12 hours
+              </MenuItem>,
+              <MenuItem
+                active={false}
+                bsClass="dropdown"
+                disabled={false}
+                divider={false}
+                eventKey={86400}
+                header={false}
+              >
+                Last day
+              </MenuItem>,
+              <MenuItem
+                active={false}
+                bsClass="dropdown"
+                disabled={false}
+                divider={false}
+                eventKey={604800}
+                header={false}
+              >
+                Last 7 days
+              </MenuItem>,
+              <MenuItem
+                active={false}
+                bsClass="dropdown"
+                disabled={false}
+                divider={false}
+                eventKey={2592000}
+                header={false}
+              >
+                Last 30 days
               </MenuItem>,
             ],
             "id": "rateIntervalDropDown",
@@ -397,94 +756,189 @@ ShallowWrapper {
           "rendered": Array [
             Object {
               "instance": null,
-              "key": "1m",
+              "key": "60",
               "nodeType": "class",
               "props": Object {
                 "active": false,
                 "bsClass": "dropdown",
-                "children": Array [
-                  "Last ",
-                  "1 minute",
-                ],
+                "children": "Last minute",
                 "disabled": false,
                 "divider": false,
-                "eventKey": "1m",
+                "eventKey": 60,
                 "header": false,
               },
               "ref": null,
-              "rendered": Array [
-                "Last ",
-                "1 minute",
-              ],
+              "rendered": "Last minute",
               "type": [Function],
             },
             Object {
               "instance": null,
-              "key": "5m",
+              "key": "300",
               "nodeType": "class",
               "props": Object {
                 "active": false,
                 "bsClass": "dropdown",
-                "children": Array [
-                  "Last ",
-                  "5 minutes",
-                ],
+                "children": "Last 5 minutes",
                 "disabled": false,
                 "divider": false,
-                "eventKey": "5m",
+                "eventKey": 300,
                 "header": false,
               },
               "ref": null,
-              "rendered": Array [
-                "Last ",
-                "5 minutes",
-              ],
+              "rendered": "Last 5 minutes",
               "type": [Function],
             },
             Object {
               "instance": null,
-              "key": "10m",
+              "key": "600",
               "nodeType": "class",
               "props": Object {
                 "active": true,
                 "bsClass": "dropdown",
-                "children": Array [
-                  "Last ",
-                  "10 minutes",
-                ],
+                "children": "Last 10 minutes",
                 "disabled": false,
                 "divider": false,
-                "eventKey": "10m",
+                "eventKey": 600,
                 "header": false,
               },
               "ref": null,
-              "rendered": Array [
-                "Last ",
-                "10 minutes",
-              ],
+              "rendered": "Last 10 minutes",
               "type": [Function],
             },
             Object {
               "instance": null,
-              "key": "30m",
+              "key": "1800",
               "nodeType": "class",
               "props": Object {
                 "active": false,
                 "bsClass": "dropdown",
-                "children": Array [
-                  "Last ",
-                  "30 minutes",
-                ],
+                "children": "Last 30 minutes",
                 "disabled": false,
                 "divider": false,
-                "eventKey": "30m",
+                "eventKey": 1800,
                 "header": false,
               },
               "ref": null,
-              "rendered": Array [
-                "Last ",
-                "30 minutes",
-              ],
+              "rendered": "Last 30 minutes",
+              "type": [Function],
+            },
+            Object {
+              "instance": null,
+              "key": "3600",
+              "nodeType": "class",
+              "props": Object {
+                "active": false,
+                "bsClass": "dropdown",
+                "children": "Last hour",
+                "disabled": false,
+                "divider": false,
+                "eventKey": 3600,
+                "header": false,
+              },
+              "ref": null,
+              "rendered": "Last hour",
+              "type": [Function],
+            },
+            Object {
+              "instance": null,
+              "key": "10800",
+              "nodeType": "class",
+              "props": Object {
+                "active": false,
+                "bsClass": "dropdown",
+                "children": "Last 3 hours",
+                "disabled": false,
+                "divider": false,
+                "eventKey": 10800,
+                "header": false,
+              },
+              "ref": null,
+              "rendered": "Last 3 hours",
+              "type": [Function],
+            },
+            Object {
+              "instance": null,
+              "key": "21600",
+              "nodeType": "class",
+              "props": Object {
+                "active": false,
+                "bsClass": "dropdown",
+                "children": "Last 6 hours",
+                "disabled": false,
+                "divider": false,
+                "eventKey": 21600,
+                "header": false,
+              },
+              "ref": null,
+              "rendered": "Last 6 hours",
+              "type": [Function],
+            },
+            Object {
+              "instance": null,
+              "key": "43200",
+              "nodeType": "class",
+              "props": Object {
+                "active": false,
+                "bsClass": "dropdown",
+                "children": "Last 12 hours",
+                "disabled": false,
+                "divider": false,
+                "eventKey": 43200,
+                "header": false,
+              },
+              "ref": null,
+              "rendered": "Last 12 hours",
+              "type": [Function],
+            },
+            Object {
+              "instance": null,
+              "key": "86400",
+              "nodeType": "class",
+              "props": Object {
+                "active": false,
+                "bsClass": "dropdown",
+                "children": "Last day",
+                "disabled": false,
+                "divider": false,
+                "eventKey": 86400,
+                "header": false,
+              },
+              "ref": null,
+              "rendered": "Last day",
+              "type": [Function],
+            },
+            Object {
+              "instance": null,
+              "key": "604800",
+              "nodeType": "class",
+              "props": Object {
+                "active": false,
+                "bsClass": "dropdown",
+                "children": "Last 7 days",
+                "disabled": false,
+                "divider": false,
+                "eventKey": 604800,
+                "header": false,
+              },
+              "ref": null,
+              "rendered": "Last 7 days",
+              "type": [Function],
+            },
+            Object {
+              "instance": null,
+              "key": "2592000",
+              "nodeType": "class",
+              "props": Object {
+                "active": false,
+                "bsClass": "dropdown",
+                "children": "Last 30 days",
+                "disabled": false,
+                "divider": false,
+                "eventKey": 2592000,
+                "header": false,
+              },
+              "ref": null,
+              "rendered": "Last 30 days",
               "type": [Function],
             },
           ],

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -101,8 +101,18 @@ export const getServiceMetrics = (
   return newRequest('get', `/api/namespaces/${namespace}/services/${service}/metrics`, params, {}, auth);
 };
 
-export const getServiceHealth = (auth: any, namespace: String, service: String): Promise<Response<Health>> => {
-  return newRequest('get', `/api/namespaces/${namespace}/services/${service}/health`, {}, {}, auth);
+export const getServiceHealth = (
+  auth: any,
+  namespace: String,
+  service: String,
+  durationSeconds?: number
+): Promise<Response<Health>> => {
+  const params = durationSeconds
+    ? {
+        rateInterval: String(durationSeconds) + 's'
+      }
+    : {};
+  return newRequest('get', `/api/namespaces/${namespace}/services/${service}/health`, params, {}, auth);
 };
 
 export const getGrafanaInfo = (auth: any): Promise<Response<GrafanaInfo>> => {

--- a/src/types/RateIntervals.ts
+++ b/src/types/RateIntervals.ts
@@ -1,8 +1,15 @@
-const RateIntervals = [['1m', '1 minute'], ['5m', '5 minutes'], ['10m', '10 minutes'], ['30m', '30 minutes']];
+import { config } from '../config';
 
-const mapIntervals: { [key: string]: string } = {};
-RateIntervals.forEach(pair => (mapIntervals[pair[0]] = pair[1]));
+const mapIntervals: { [key: number]: string } = config().toolbar.intervalDuration;
+export const tuples: [number, string][] = Object.keys(mapIntervals).map(key => {
+  const tuple: [number, string] = [+key, mapIntervals[key]];
+  return tuple;
+});
 
-export const getName = (key: string): string => mapIntervals[key];
-
-export default RateIntervals;
+export const getName = (durationSeconds: number): string => {
+  const name = mapIntervals[durationSeconds];
+  if (name) {
+    return name;
+  }
+  return 'Last ' + durationSeconds + ' seconds';
+};


### PR DESCRIPTION
Since this is my first incursion in Graph code maybe I haven't done things as you would have expected, so I'm all ears about comments.

This shows colored borders on nodes for each _service_ (and not _version_).

Example:
![health in graph](https://screenshotscdn.firefoxusercontent.com/images/d936c92b-495f-4548-a330-7fb4f9c9ac4e.png)

This is a first step but maybe discussions can lead to other subtasks being created. Like improving performances, reducing number of calls or showing more information or per-version health maybe.

Currently if performs one backend api call per service, asynchronously from the main graph fetching.
I think it has advantages (graph can be displayed without having to wait for all health information being collected) and drawbacks (many http calls), so probably an optimization will be to fetch health information for all services within a namespace at once.

Then, there is also what @jshaughn suggested: restraining health checking to services that are suspected to not perform well (regarding their error rates).