### PR TITLE
KIALI-750 Add istio mTLS support into service graph

### DIFF
--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -25,6 +25,14 @@ export class GraphStyles {
       return PfColors.Green400;
     };
 
+    const getTLSValue = (ele: any, tlsValue: string, nonTlsValue: string): string => {
+      if (ele.data('enabledmTLS') && ele.data('edgeLabelMode') === EdgeLabelMode.MTLS_ENABLED) {
+        return tlsValue;
+      } else {
+        return nonTlsValue;
+      }
+    };
+
     return [
       {
         selector: 'node',
@@ -116,13 +124,19 @@ export class GraphStyles {
                 return percentRate > 0 ? percentRate.toFixed(0) + '%' : '';
               }
               case EdgeLabelMode.MTLS_ENABLED: {
-                return ele.data('enabledmTLS') ? 'mTLS' : '';
+                return ele.data('enabledmTLS') ? '\ue923' : '';
               }
               default:
                 return '';
             }
           },
           'curve-style': 'bezier',
+          'font-family': (ele: any) => {
+            return getTLSValue(ele, 'PatternFlyIcons-webfont', 'inherit');
+          },
+          'text-rotation': (ele: any) => {
+            return getTLSValue(ele, '0deg', 'autorotate');
+          },
           'font-size': '7px',
           'line-color': (ele: any) => {
             return getEdgeColor(ele);
@@ -135,7 +149,6 @@ export class GraphStyles {
             return getEdgeColor(ele);
           },
           'text-margin-x': '6px',
-          'text-rotation': 'autorotate',
           width: 1
         }
       },

--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -115,6 +115,9 @@ export class GraphStyles {
                 const percentRate = ele.data('percentRate') ? parseFloat(ele.data('percentRate')) : 0;
                 return percentRate > 0 ? percentRate.toFixed(0) + '%' : '';
               }
+              case EdgeLabelMode.MTLS_ENABLED: {
+                return ele.data('enabledmTLS') ? 'mTLS' : '';
+              }
               default:
                 return '';
             }

--- a/src/types/GraphFilter.ts
+++ b/src/types/GraphFilter.ts
@@ -12,7 +12,8 @@ export enum EdgeLabelMode {
   HIDE = 'hide',
   REQUESTS_PER_SECOND = 'requestsPerSecond',
   REQUESTS_PERCENT_OF_TOTAL = 'requestsPercentOfTotal',
-  LATENCY_95TH_PERCENTILE = 'latency95thPercentile'
+  LATENCY_95TH_PERCENTILE = 'latency95thPercentile',
+  MTLS_ENABLED = 'security'
 }
 
 export namespace EdgeLabelMode {


### PR DESCRIPTION
The aim of this PR is to display which communications are being handled using the istio mutual TLS.

![edge-mtls-with-rates](https://user-images.githubusercontent.com/613814/41284138-bf6d718a-6e38-11e8-9f6b-7657d7ff8330.png)

[kiali/kiali#269](https://github.com/kiali/kiali/pull/269) needs to be merged at the same time.

Connected to this PR, I have created a UI JIRA for allowing edges to display icons. This would help us to make this feature fancier: https://issues.jboss.org/browse/KIALI-935