### PR TITLE
KIALI-915 UI must now opt-in for istio traffic

### DIFF
--- a/src/actions/ServiceGraphDataActions.ts
+++ b/src/actions/ServiceGraphDataActions.ts
@@ -85,7 +85,10 @@ export const ServiceGraphDataActions = {
     return dispatch => {
       dispatch(ServiceGraphDataActions.getGraphDataStart());
       const duration = graphDuration.value;
-      const restParams = { duration: duration + 's' };
+      let restParams = { duration: duration + 's' };
+      if (namespace.name === 'istio-system') {
+        restParams['includeIstio'] = true;
+      }
       return API.getGraphElements(authentication(), namespace, restParams).then(
         response => {
           const responseData: any = response['data'];

--- a/src/pages/ServiceGraph/SummaryPanelGroup.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelGroup.tsx
@@ -74,7 +74,7 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
     return (
       <div className="panel panel-default" style={SummaryPanelGroup.panelStyle}>
         <div className="panel-heading">
-          Versioned Group: {serviceHotLink}
+          Versioned Service: {serviceHotLink}
           <div style={{ paddingTop: '3px' }}>
             <Badge
               scale={0.9}
@@ -122,7 +122,8 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
       duration: +props.duration,
       step: props.step,
       rateInterval: props.rateInterval,
-      filters: ['request_count', 'request_error_count']
+      filters: ['request_count', 'request_error_count'],
+      includeIstio: props.namespace === 'istio-system'
     };
     API.getServiceMetrics(authentication(), namespace, service, options)
       .then(response => {

--- a/src/pages/ServiceGraph/SummaryPanelNode.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelNode.tsx
@@ -74,7 +74,8 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
       duration: +props.duration,
       step: props.step,
       rateInterval: props.rateInterval,
-      filters: ['request_count', 'request_error_count']
+      filters: ['request_count', 'request_error_count'],
+      includeIstio: props.namespace === 'istio-system'
     };
     API.getServiceMetrics(authentication(), namespace, service, options)
       .then(response => {

--- a/src/types/MetricsOptions.ts
+++ b/src/types/MetricsOptions.ts
@@ -8,6 +8,7 @@ interface MetricsOptions {
   filters?: string[];
   byLabelsIn?: string[];
   byLabelsOut?: string[];
+  includeIstio?: boolean;
 }
 
 export default MetricsOptions;


### PR DESCRIPTION

This is pending merge of the [server PR](https://github.com/kiali/kiali/pull/287).  

With both PRs in place we won't see istio infra services unless looking specifically at the istio-system namespace, which will not show all services for all namespaces, because all services interact with the istio infra services.
