### PR TITLE
KIALI-840 Hide sidebar on small windows

### DIFF
--- a/src/pages/ServiceGraph/SummaryPanel.tsx
+++ b/src/pages/ServiceGraph/SummaryPanel.tsx
@@ -5,55 +5,68 @@ import SummaryPanelGraph from './SummaryPanelGraph';
 import SummaryPanelGroup from './SummaryPanelGroup';
 import SummaryPanelNode from './SummaryPanelNode';
 
-type SummaryPanelState = {
-  // stateless
-};
+export default class SummaryPanel extends React.Component<SummaryPanelPropType, {}> {
+  updateSummary = () => {
+    this.forceUpdate();
+  };
 
-export default class SummaryPanel extends React.Component<SummaryPanelPropType, SummaryPanelState> {
+  componentDidMount() {
+    window.addEventListener('resize', this.updateSummary);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.updateSummary);
+  }
+
   render() {
-    return (
-      <>
-        {this.props.data.summaryType === 'edge' ? (
-          <SummaryPanelEdge
-            data={this.props.data}
-            namespace={this.props.namespace}
-            queryTime={this.props.queryTime}
-            duration={this.props.duration}
-            step={this.props.step}
-            rateInterval={this.props.rateInterval}
-          />
-        ) : null}
-        {this.props.data.summaryType === 'graph' ? (
-          <SummaryPanelGraph
-            data={this.props.data}
-            namespace={this.props.namespace}
-            queryTime={this.props.queryTime}
-            duration={this.props.duration}
-            step={this.props.step}
-            rateInterval={this.props.rateInterval}
-          />
-        ) : null}
-        {this.props.data.summaryType === 'group' ? (
-          <SummaryPanelGroup
-            data={this.props.data}
-            namespace={this.props.namespace}
-            queryTime={this.props.queryTime}
-            duration={this.props.duration}
-            step={this.props.step}
-            rateInterval={this.props.rateInterval}
-          />
-        ) : null}
-        {this.props.data.summaryType === 'node' ? (
-          <SummaryPanelNode
-            data={this.props.data}
-            queryTime={this.props.queryTime}
-            namespace={this.props.namespace}
-            duration={this.props.duration}
-            step={this.props.step}
-            rateInterval={this.props.rateInterval}
-          />
-        ) : null}
-      </>
-    );
+    if (window.innerWidth > 1024) {
+      return (
+        <>
+          {this.props.data.summaryType === 'edge' ? (
+            <SummaryPanelEdge
+              data={this.props.data}
+              namespace={this.props.namespace}
+              queryTime={this.props.queryTime}
+              duration={this.props.duration}
+              step={this.props.step}
+              rateInterval={this.props.rateInterval}
+            />
+          ) : null}
+          {this.props.data.summaryType === 'graph' ? (
+            <SummaryPanelGraph
+              data={this.props.data}
+              namespace={this.props.namespace}
+              queryTime={this.props.queryTime}
+              duration={this.props.duration}
+              step={this.props.step}
+              rateInterval={this.props.rateInterval}
+            />
+          ) : null}
+          {this.props.data.summaryType === 'group' ? (
+            <SummaryPanelGroup
+              data={this.props.data}
+              namespace={this.props.namespace}
+              queryTime={this.props.queryTime}
+              duration={this.props.duration}
+              step={this.props.step}
+              rateInterval={this.props.rateInterval}
+            />
+          ) : null}
+          {this.props.data.summaryType === 'node' ? (
+            <SummaryPanelNode
+              data={this.props.data}
+              queryTime={this.props.queryTime}
+              namespace={this.props.namespace}
+              duration={this.props.duration}
+              step={this.props.step}
+              rateInterval={this.props.rateInterval}
+            />
+          ) : null}
+        </>
+      );
+    } else {
+      // Just a placeholder, just something that is not going to be rendered.
+      return <span />;
+    }
   }
 }


### PR DESCRIPTION
This is the naivest implementation possible, and might be a good idea to
review or find some other implementation that's smarter.

This aims to fix the following problem: when you resize the window to a
smaller size, the sidebar goes over the graph, so we hide it and
add it back when the windows is bigger.

Before:

![](https://i.imgur.com/SnDIJGJ.png)

After:

![](https://i.imgur.com/aEZgS7u.png)

There are some caveats that I could find:

* Graph dimensions are not responsive, so even removing the sidebar does
not fixes the size of the graph to fill the whole available screen
space. That causes some weird bugs, such as this one:

![](https://i.imgur.com/uJywPnS.png)

Ideas on how to fix this are welcome.