### PR TITLE
KIALI-988 Query the API with the right namespace for the unknown node

### DIFF
--- a/src/components/SummaryPanel/RpsChart.tsx
+++ b/src/components/SummaryPanel/RpsChart.tsx
@@ -46,7 +46,12 @@ export default class RpsChart extends React.Component<RpsChartTypeProp, {}> {
   }
 
   private thereIsTrafficData = () => {
-    return this.props.dataRps.length > 0 && this.props.dataRps[0].length > 1;
+    const dataRps: any = this.props.dataRps;
+    return (
+      dataRps.length > 0 &&
+      dataRps[0].length > 1 &&
+      dataRps[1].slice(1).reduce((accum, val) => accum + parseFloat(val), 0) > 0
+    );
   };
 
   private renderMinMaxStats = () => {

--- a/src/pages/ServiceGraph/SummaryPanelNode.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelNode.tsx
@@ -65,7 +65,7 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
   }
 
   fetchRequestCountMetrics(props: SummaryPanelPropType) {
-    const namespace = props.data.summaryTarget.data('service').split('.')[1];
+    const namespace = props.data.summaryTarget.data('namespace');
     const service = props.data.summaryTarget.data('service').split('.')[0];
     const version = props.data.summaryTarget.data('version');
     const options: MetricsOptions = {


### PR DESCRIPTION
The unknown node cannot be broken down to {service name, namespace}
data. But the summary panel received the namespace in its properties.
So, if the namespace is not available in the cytoscape node, use the
namespace provided in the properties of the component.

I'm also adding a small fix to the "No traffic legend" that I saw while testing.