### PR TITLE
KIALI-986 Long edges no longer make the animation faster than short edges

### DIFF
--- a/src/utils/MathUtils.ts
+++ b/src/utils/MathUtils.ts
@@ -1,7 +1,7 @@
-type Point = {
+export interface Point {
   x: number;
   y: number;
-};
+}
 
 // Restricts value x to [min, max], if outside, moves to the nearest available value.
 export const clamp = (x, min, max) => {
@@ -25,4 +25,35 @@ export const linearInterpolation = (p0: Point, p1: Point, t: number) => {
     x: p0.x + t * (p1.x - p0.x),
     y: p0.y + t * (p1.y - p0.y)
   };
+};
+
+// Computes the length of a bezier path
+// https://stackoverflow.com/questions/11854907/calculate-the-length-of-a-segment-of-a-quadratic-bezier
+// http://www.malczak.linuxpl.com/blog/quadratic-bezier-curve-length/
+export const bezierLength = (p0: Point, p1: Point, p2: Point) => {
+  const a: Point = {
+    x: p0.x - 2 * p1.x + p2.x,
+    y: p0.y - 2 * p1.y + p2.y
+  };
+  const b: Point = {
+    x: 2 * p1.x - 2 * p0.x,
+    y: 2 * p1.y - 2 * p0.y
+  };
+  const A = 4 * (a.x * a.x + a.y * a.y);
+  const B = 4 * (a.x * b.x + a.y * b.y);
+  const C = b.x * b.x + b.y * b.y;
+
+  const Sabc = 2 * Math.sqrt(A + B + C);
+  const A_2 = Math.sqrt(A);
+  const A_32 = 2 * A * A_2;
+  const C_2 = 2 * Math.sqrt(C);
+  const BA = B / A_2;
+  return (
+    (A_32 * Sabc + A_2 * B * (Sabc - C_2) + (4 * C * A - B * B) * Math.log((2 * A_2 + BA + Sabc) / (BA + C_2))) /
+    (4 * A_32)
+  );
+};
+
+export const distance = (p0: Point, p1: Point) => {
+  return Math.sqrt(Math.pow(p0.x - p1.x, 2) + Math.pow(p0.y - p1.y, 2));
 };


### PR DESCRIPTION
Notice the long edges and loops

Before:
![animation-curves-2](https://user-images.githubusercontent.com/3845764/41622903-b9fbaad4-73d6-11e8-85ea-8d14f66ae523.gif)

After:
![length-of-edge](https://user-images.githubusercontent.com/3845764/41673432-87806840-7482-11e8-87ea-e129be914d33.gif)
