### PR TITLE
KIALI-992 Use public methods instead of the private internal data for…

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "axios": "0.18.0",
     "csstips": "0.3.0",
     "csx": "9.0.0",
-    "cytoscape": "3.2.12",
+    "cytoscape": "3.2.14",
     "cytoscape-canvas": "3.0.1",
     "cytoscape-cola": "2.2.3",
     "cytoscape-cose-bilkent": "4.0.0",

--- a/src/components/CytoscapeGraph/graphs/TrafficRenderer.ts
+++ b/src/components/CytoscapeGraph/graphs/TrafficRenderer.ts
@@ -425,25 +425,11 @@ export default class TrafficRenderer {
 
   private edgeControlPoints(edge: any) {
     const controlPoints: Array<Point> = [edge.sourceEndpoint()];
-    let rawControlPoints = edge.controlPoints();
-    // TODO KIALI-992: remove once this issue is fixed and released https://github.com/cytoscape/cytoscape.js/issues/2139
-    // Loops don't expose the controlPoints, use the internal data for the time being until the bug is solved
-    if (!rawControlPoints && edge.isLoop()) {
-      const internalControlPoints = edge._private.rscratch.ctrlpts;
-      if (internalControlPoints) {
-        rawControlPoints = [];
-        for (let i = 0; i < internalControlPoints.length; i += 2) {
-          rawControlPoints.push({
-            x: internalControlPoints[i],
-            y: internalControlPoints[i + 1]
-          });
-        }
-      }
-    }
+    const rawControlPoints = edge.controlPoints();
     if (rawControlPoints) {
       for (let i = 0; i < rawControlPoints.length; ++i) {
         controlPoints.push(rawControlPoints[i]);
-        // If there is a next point, we are going to use the midpoint for the next control point point
+        // If there is a next point, we are going to use the midpoint for the next point
         if (i + 1 < rawControlPoints.length) {
           controlPoints.push({
             x: (rawControlPoints[i].x + rawControlPoints[i + 1].x) / 2,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2345,9 +2345,9 @@ cytoscape-popper@1.0.1:
   dependencies:
     popper.js "^1.0.0"
 
-cytoscape@3.2.12:
-  version "3.2.12"
-  resolved "https://registry.yarnpkg.com/cytoscape/-/cytoscape-3.2.12.tgz#0b04a334f4e09f27d460c54e8dcfa0c711f69eb2"
+cytoscape@3.2.14:
+  version "3.2.14"
+  resolved "https://registry.yarnpkg.com/cytoscape/-/cytoscape-3.2.14.tgz#78ad92e0195541228b78a6252cea2a0b0b12f59e"
   dependencies:
     heap "^0.2.6"
     lodash.debounce "^4.0.8"


### PR DESCRIPTION
… computing the control points

- Updated cytoscape to 3.2.14
- Removed the use of private methods

![removing-internal-code](https://user-images.githubusercontent.com/3845764/41942105-ddc0daa6-7963-11e8-9bbf-3e7374daa352.gif)
