### PR TITLE
KIALI-998 Don't ignore groups, instead detect if we have child nodes …

### DIFF
--- a/src/components/CytoscapeGraph/graphs/GraphHighlighter.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphHighlighter.ts
@@ -83,9 +83,6 @@ export class GraphHighlighter {
     this.cy
       .elements()
       .difference(toHighlight)
-      .filter((ele: any) => {
-        return !ele.isParent();
-      })
       .addClass(DIM_CLASS);
   };
 
@@ -113,21 +110,30 @@ export class GraphHighlighter {
     return undefined;
   }
 
+  includeParentNodes(nodes: any) {
+    return nodes.reduce((all, current) => {
+      all = all.add(current);
+      if (current.isChild()) {
+        all = all.add(current.parent());
+      }
+      return all;
+    }, this.cy.collection());
+  }
+
   // return the children and children relations, including edges
   getGroupHighlight(groupBox: any) {
-    return groupBox.children().reduce((prev, child) => {
-      if (!prev) {
-        prev = this.cy.collection();
-      }
-      return prev.add(child.closedNeighborhood());
-    });
+    return this.includeParentNodes(
+      groupBox.children().reduce((prev, child) => {
+        return prev.add(child.closedNeighborhood());
+      }, this.cy.collection())
+    );
   }
 
   getNodeHighlight(node: any) {
-    return node.closedNeighborhood();
+    return this.includeParentNodes(node.closedNeighborhood());
   }
 
   getEdgeHighlight(edge: any) {
-    return edge.connectedNodes().add(edge);
+    return this.includeParentNodes(edge.connectedNodes().add(edge));
   }
 }


### PR DESCRIPTION
…to include the group into the collection

If any element of the to-be highlighted collection is a child, include the parent (group) too

![dim](https://user-images.githubusercontent.com/3845764/42004973-fffd8cac-7a37-11e8-922a-6c4386eac058.gif)
