### PR TITLE
KIALI-1015 Add validations to Virtual Services

### DIFF
--- a/src/components/Details/DetailObject.tsx
+++ b/src/components/Details/DetailObject.tsx
@@ -1,11 +1,18 @@
 import * as React from 'react';
 import Label from '../Label/Label';
+import { Icon } from 'patternfly-react';
 
 interface DetailObjectProps {
   name: string;
   detail: any;
   labels?: string[];
   exclude?: string[];
+  validation?: Validation;
+}
+
+interface Validation {
+  message: string;
+  icon: string;
 }
 
 class DetailObject extends React.Component<DetailObjectProps> {
@@ -37,10 +44,12 @@ class DetailObject extends React.Component<DetailObjectProps> {
   }
 
   canDisplay(name: string) {
-    return this.props.exclude && !this.props.exclude.includes(name);
+    return this.props.exclude == null || !this.props.exclude.includes(name);
   }
 
-  buildList(name: string, value: any, isLabel: boolean): any {
+  // buildList returns a recursive list of all items within value. It shows a validation
+  // only for the first iteration (when depth is 0)
+  buildList(name: string, value: any, isLabel: boolean, depth: number): any {
     if (!this.canDisplay(name)) {
       return '';
     }
@@ -70,14 +79,14 @@ class DetailObject extends React.Component<DetailObjectProps> {
           childrenList.push(<li key={listKey + '_i' + i}>{v}</li>);
         } else {
           Object.keys(v).forEach((key, j) => {
-            let childList = this.buildList(key, v[key], checkLabel);
+            let childList = this.buildList(key, v[key], checkLabel, depth + 1);
             childrenList.push(<li key={listKey + '_i' + i + '_j' + j}>{childList}</li>);
           });
         }
       });
     } else {
       Object.keys(value).forEach((key, k) => {
-        let childList = this.buildList(key, value[key], checkLabel);
+        let childList = this.buildList(key, value[key], checkLabel, depth + 1);
         childrenList.push(<li key={listKey + '_k' + k}>{childList}</li>);
       });
     }
@@ -85,6 +94,15 @@ class DetailObject extends React.Component<DetailObjectProps> {
     return (
       <div>
         <strong className="text-capitalize">{name}</strong>
+        {depth === 0 && !!this.props.validation && this.props.validation.message ? (
+          <div>
+            <p style={{ color: 'red' }}>
+              <Icon type="pf" name={this.props.validation.icon} /> {this.props.validation.message}
+            </p>
+          </div>
+        ) : (
+          undefined
+        )}
         <ul style={{ listStyleType: 'none' }}>{childrenList}</ul>
       </div>
     );
@@ -93,7 +111,7 @@ class DetailObject extends React.Component<DetailObjectProps> {
   render() {
     let findLabels = typeof this.props.labels !== 'undefined' && this.props.labels.length > 0;
 
-    let objectList = this.buildList(this.props.name, this.props.detail, findLabels);
+    let objectList = this.buildList(this.props.name, this.props.detail, findLabels, 0);
     return <div>{objectList}</div>;
   }
 }

--- a/src/components/Details/DetailObject.tsx
+++ b/src/components/Details/DetailObject.tsx
@@ -5,6 +5,7 @@ interface DetailObjectProps {
   name: string;
   detail: any;
   labels?: string[];
+  exclude?: string[];
 }
 
 class DetailObject extends React.Component<DetailObjectProps> {
@@ -35,7 +36,15 @@ class DetailObject extends React.Component<DetailObjectProps> {
     return this.props.labels.indexOf(name) > -1;
   }
 
+  canDisplay(name: string) {
+    return this.props.exclude && !this.props.exclude.includes(name);
+  }
+
   buildList(name: string, value: any, isLabel: boolean): any {
+    if (!this.canDisplay(name)) {
+      return '';
+    }
+
     let valueType = typeof value;
     if (valueType === 'string' || valueType === 'number' || valueType === 'boolean') {
       return (

--- a/src/components/Details/__tests__/DetailObject.test.tsx
+++ b/src/components/Details/__tests__/DetailObject.test.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { Icon } from 'patternfly-react';
+import { default as DetailObject } from '../DetailObject';
+import { DestinationWeight } from '../../../types/ServiceInfo';
+
+describe('DetailObject test', () => {
+  const detail: DestinationWeight = {
+    destination: {
+      host: 'reviews',
+      subset: 'v1',
+      port: {
+        number: 22,
+        name: 'ssh'
+      }
+    },
+    weight: 85
+  };
+
+  const mockRandom = () => {
+    const mockMath = Object.create(global.Math);
+    mockMath.random = () => 0.8;
+    global.Math = mockMath;
+  };
+
+  it('prints a nested list with all attributes in the detail', () => {
+    mockRandom();
+
+    const wrapper = shallow(<DetailObject name={name} detail={detail} />);
+
+    expect(wrapper).toBeDefined();
+    expect(wrapper).toMatchSnapshot();
+
+    expect(wrapper.html()).toContain('<span class="text-capitalize">[host]</span>');
+    expect(wrapper.html()).toContain('<span class="text-capitalize">[subset]</span>');
+    expect(wrapper.html()).toContain('<span class="text-capitalize">[weight]</span>');
+
+    expect(wrapper.html()).toContain('<strong class="text-capitalize">port</strong>');
+    expect(wrapper.html()).toContain('<span class="text-capitalize">[number]</span>');
+    expect(wrapper.html()).toContain('<span class="text-capitalize">[name]</span>');
+  });
+
+  it("doesn't print excluded fields", () => {
+    mockRandom();
+
+    const wrapper = shallow(<DetailObject name={name} detail={detail} exclude={['port']} />);
+
+    expect(wrapper).toBeDefined();
+    expect(wrapper).toMatchSnapshot();
+
+    expect(wrapper.html()).toContain('<span class="text-capitalize">[host]</span>');
+    expect(wrapper.html()).toContain('<span class="text-capitalize">[subset]</span>');
+    expect(wrapper.html()).toContain('<span class="text-capitalize">[weight]</span>');
+
+    expect(wrapper.html()).not.toContain('<strong class="text-capitalize">port</strong>');
+    expect(wrapper.html()).not.toContain('<span class="text-capitalize">[number]</span>');
+    expect(wrapper.html()).not.toContain('<span class="text-capitalize">[name]</span>');
+  });
+
+  it('prints an alert message', () => {
+    const validation = {
+      message: 'Not all checks passed',
+      icon: 'error-circle-o'
+    };
+
+    mockRandom();
+
+    const wrapper = shallow(<DetailObject name={name} detail={detail} validation={validation} />);
+
+    expect(wrapper).toBeDefined();
+    expect(wrapper).toMatchSnapshot();
+
+    const iconWrapper = wrapper.find(Icon);
+    expect(iconWrapper.prop('type')).toEqual('pf');
+    expect(iconWrapper.prop('name')).toEqual(validation.icon);
+    expect(iconWrapper.parent().html()).toContain(validation.message);
+  });
+
+  it("doesn't print any alert message", () => {
+    const validation = {
+      message: '',
+      icon: 'error-circle-o'
+    };
+
+    mockRandom();
+
+    const wrapper = shallow(<DetailObject name={name} detail={detail} validation={validation} />);
+
+    expect(wrapper).toBeDefined();
+    expect(wrapper).toMatchSnapshot();
+
+    const iconWrapper = wrapper.find(Icon);
+    expect(iconWrapper.length).toEqual(0);
+  });
+});

--- a/src/components/Details/__tests__/__snapshots__/DetailObject.test.tsx.snap
+++ b/src/components/Details/__tests__/__snapshots__/DetailObject.test.tsx.snap
@@ -1,0 +1,10270 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DetailObject test doesn't print any alert message 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <DetailObject
+    detail={
+      Object {
+        "destination": Object {
+          "host": "reviews",
+          "port": Object {
+            "name": "ssh",
+            "number": 22,
+          },
+          "subset": "v1",
+        },
+        "weight": 85,
+      }
+    }
+    name="nodejs"
+    validation={
+      Object {
+        "icon": "error-circle-o",
+        "message": "",
+      }
+    }
+  />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": <div>
+        <strong
+          className="text-capitalize"
+        >
+          nodejs
+        </strong>
+        <ul
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <li>
+            <div>
+              <strong
+                className="text-capitalize"
+              >
+                destination
+              </strong>
+              <ul
+                style={
+                  Object {
+                    "listStyleType": "none",
+                  }
+                }
+              >
+                <li>
+                  <div
+                    className="label-collection"
+                  >
+                    <span>
+                      <span
+                        className="text-capitalize"
+                      >
+                        [
+                        host
+                        ]
+                      </span>
+                       
+                      reviews
+                    </span>
+                  </div>
+                </li>
+                <li>
+                  <div
+                    className="label-collection"
+                  >
+                    <span>
+                      <span
+                        className="text-capitalize"
+                      >
+                        [
+                        subset
+                        ]
+                      </span>
+                       
+                      v1
+                    </span>
+                  </div>
+                </li>
+                <li>
+                  <div>
+                    <strong
+                      className="text-capitalize"
+                    >
+                      port
+                    </strong>
+                    <ul
+                      style={
+                        Object {
+                          "listStyleType": "none",
+                        }
+                      }
+                    >
+                      <li>
+                        <div
+                          className="label-collection"
+                        >
+                          <span>
+                            <span
+                              className="text-capitalize"
+                            >
+                              [
+                              number
+                              ]
+                            </span>
+                             
+                            22
+                          </span>
+                        </div>
+                      </li>
+                      <li>
+                        <div
+                          className="label-collection"
+                        >
+                          <span>
+                            <span
+                              className="text-capitalize"
+                            >
+                              [
+                              name
+                              ]
+                            </span>
+                             
+                            ssh
+                          </span>
+                        </div>
+                      </li>
+                    </ul>
+                  </div>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li>
+            <div
+              className="label-collection"
+            >
+              <span>
+                <span
+                  className="text-capitalize"
+                >
+                  [
+                  weight
+                  ]
+                </span>
+                 
+                85
+              </span>
+            </div>
+          </li>
+        </ul>
+      </div>,
+    },
+    "ref": null,
+    "rendered": Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <strong
+            className="text-capitalize"
+          >
+            nodejs
+          </strong>,
+          undefined,
+          <ul
+            style={
+              Object {
+                "listStyleType": "none",
+              }
+            }
+          >
+            <li>
+              <div>
+                <strong
+                  className="text-capitalize"
+                >
+                  destination
+                </strong>
+                <ul
+                  style={
+                    Object {
+                      "listStyleType": "none",
+                    }
+                  }
+                >
+                  <li>
+                    <div
+                      className="label-collection"
+                    >
+                      <span>
+                        <span
+                          className="text-capitalize"
+                        >
+                          [
+                          host
+                          ]
+                        </span>
+                         
+                        reviews
+                      </span>
+                    </div>
+                  </li>
+                  <li>
+                    <div
+                      className="label-collection"
+                    >
+                      <span>
+                        <span
+                          className="text-capitalize"
+                        >
+                          [
+                          subset
+                          ]
+                        </span>
+                         
+                        v1
+                      </span>
+                    </div>
+                  </li>
+                  <li>
+                    <div>
+                      <strong
+                        className="text-capitalize"
+                      >
+                        port
+                      </strong>
+                      <ul
+                        style={
+                          Object {
+                            "listStyleType": "none",
+                          }
+                        }
+                      >
+                        <li>
+                          <div
+                            className="label-collection"
+                          >
+                            <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                number
+                                ]
+                              </span>
+                               
+                              22
+                            </span>
+                          </div>
+                        </li>
+                        <li>
+                          <div
+                            className="label-collection"
+                          >
+                            <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                name
+                                ]
+                              </span>
+                               
+                              ssh
+                            </span>
+                          </div>
+                        </li>
+                      </ul>
+                    </div>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li>
+              <div
+                className="label-collection"
+              >
+                <span>
+                  <span
+                    className="text-capitalize"
+                  >
+                    [
+                    weight
+                    ]
+                  </span>
+                   
+                  85
+                </span>
+              </div>
+            </li>
+          </ul>,
+        ],
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": "nodejs",
+            "className": "text-capitalize",
+          },
+          "ref": null,
+          "rendered": "nodejs",
+          "type": "strong",
+        },
+        undefined,
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              <li>
+                <div>
+                  <strong
+                    className="text-capitalize"
+                  >
+                    destination
+                  </strong>
+                  <ul
+                    style={
+                      Object {
+                        "listStyleType": "none",
+                      }
+                    }
+                  >
+                    <li>
+                      <div
+                        className="label-collection"
+                      >
+                        <span>
+                          <span
+                            className="text-capitalize"
+                          >
+                            [
+                            host
+                            ]
+                          </span>
+                           
+                          reviews
+                        </span>
+                      </div>
+                    </li>
+                    <li>
+                      <div
+                        className="label-collection"
+                      >
+                        <span>
+                          <span
+                            className="text-capitalize"
+                          >
+                            [
+                            subset
+                            ]
+                          </span>
+                           
+                          v1
+                        </span>
+                      </div>
+                    </li>
+                    <li>
+                      <div>
+                        <strong
+                          className="text-capitalize"
+                        >
+                          port
+                        </strong>
+                        <ul
+                          style={
+                            Object {
+                              "listStyleType": "none",
+                            }
+                          }
+                        >
+                          <li>
+                            <div
+                              className="label-collection"
+                            >
+                              <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  number
+                                  ]
+                                </span>
+                                 
+                                22
+                              </span>
+                            </div>
+                          </li>
+                          <li>
+                            <div
+                              className="label-collection"
+                            >
+                              <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  name
+                                  ]
+                                </span>
+                                 
+                                ssh
+                              </span>
+                            </div>
+                          </li>
+                        </ul>
+                      </div>
+                    </li>
+                  </ul>
+                </div>
+              </li>,
+              <li>
+                <div
+                  className="label-collection"
+                >
+                  <span>
+                    <span
+                      className="text-capitalize"
+                    >
+                      [
+                      weight
+                      ]
+                    </span>
+                     
+                    85
+                  </span>
+                </div>
+              </li>,
+            ],
+            "style": Object {
+              "listStyleType": "none",
+            },
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": "key_sssssssss_k0",
+              "nodeType": "host",
+              "props": Object {
+                "children": <div>
+                  <strong
+                    className="text-capitalize"
+                  >
+                    destination
+                  </strong>
+                  <ul
+                    style={
+                      Object {
+                        "listStyleType": "none",
+                      }
+                    }
+                  >
+                    <li>
+                      <div
+                        className="label-collection"
+                      >
+                        <span>
+                          <span
+                            className="text-capitalize"
+                          >
+                            [
+                            host
+                            ]
+                          </span>
+                           
+                          reviews
+                        </span>
+                      </div>
+                    </li>
+                    <li>
+                      <div
+                        className="label-collection"
+                      >
+                        <span>
+                          <span
+                            className="text-capitalize"
+                          >
+                            [
+                            subset
+                            ]
+                          </span>
+                           
+                          v1
+                        </span>
+                      </div>
+                    </li>
+                    <li>
+                      <div>
+                        <strong
+                          className="text-capitalize"
+                        >
+                          port
+                        </strong>
+                        <ul
+                          style={
+                            Object {
+                              "listStyleType": "none",
+                            }
+                          }
+                        >
+                          <li>
+                            <div
+                              className="label-collection"
+                            >
+                              <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  number
+                                  ]
+                                </span>
+                                 
+                                22
+                              </span>
+                            </div>
+                          </li>
+                          <li>
+                            <div
+                              className="label-collection"
+                            >
+                              <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  name
+                                  ]
+                                </span>
+                                 
+                                ssh
+                              </span>
+                            </div>
+                          </li>
+                        </ul>
+                      </div>
+                    </li>
+                  </ul>
+                </div>,
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": Array [
+                    <strong
+                      className="text-capitalize"
+                    >
+                      destination
+                    </strong>,
+                    undefined,
+                    <ul
+                      style={
+                        Object {
+                          "listStyleType": "none",
+                        }
+                      }
+                    >
+                      <li>
+                        <div
+                          className="label-collection"
+                        >
+                          <span>
+                            <span
+                              className="text-capitalize"
+                            >
+                              [
+                              host
+                              ]
+                            </span>
+                             
+                            reviews
+                          </span>
+                        </div>
+                      </li>
+                      <li>
+                        <div
+                          className="label-collection"
+                        >
+                          <span>
+                            <span
+                              className="text-capitalize"
+                            >
+                              [
+                              subset
+                              ]
+                            </span>
+                             
+                            v1
+                          </span>
+                        </div>
+                      </li>
+                      <li>
+                        <div>
+                          <strong
+                            className="text-capitalize"
+                          >
+                            port
+                          </strong>
+                          <ul
+                            style={
+                              Object {
+                                "listStyleType": "none",
+                              }
+                            }
+                          >
+                            <li>
+                              <div
+                                className="label-collection"
+                              >
+                                <span>
+                                  <span
+                                    className="text-capitalize"
+                                  >
+                                    [
+                                    number
+                                    ]
+                                  </span>
+                                   
+                                  22
+                                </span>
+                              </div>
+                            </li>
+                            <li>
+                              <div
+                                className="label-collection"
+                              >
+                                <span>
+                                  <span
+                                    className="text-capitalize"
+                                  >
+                                    [
+                                    name
+                                    ]
+                                  </span>
+                                   
+                                  ssh
+                                </span>
+                              </div>
+                            </li>
+                          </ul>
+                        </div>
+                      </li>
+                    </ul>,
+                  ],
+                },
+                "ref": null,
+                "rendered": Array [
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": "destination",
+                      "className": "text-capitalize",
+                    },
+                    "ref": null,
+                    "rendered": "destination",
+                    "type": "strong",
+                  },
+                  undefined,
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": Array [
+                        <li>
+                          <div
+                            className="label-collection"
+                          >
+                            <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                host
+                                ]
+                              </span>
+                               
+                              reviews
+                            </span>
+                          </div>
+                        </li>,
+                        <li>
+                          <div
+                            className="label-collection"
+                          >
+                            <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                subset
+                                ]
+                              </span>
+                               
+                              v1
+                            </span>
+                          </div>
+                        </li>,
+                        <li>
+                          <div>
+                            <strong
+                              className="text-capitalize"
+                            >
+                              port
+                            </strong>
+                            <ul
+                              style={
+                                Object {
+                                  "listStyleType": "none",
+                                }
+                              }
+                            >
+                              <li>
+                                <div
+                                  className="label-collection"
+                                >
+                                  <span>
+                                    <span
+                                      className="text-capitalize"
+                                    >
+                                      [
+                                      number
+                                      ]
+                                    </span>
+                                     
+                                    22
+                                  </span>
+                                </div>
+                              </li>
+                              <li>
+                                <div
+                                  className="label-collection"
+                                >
+                                  <span>
+                                    <span
+                                      className="text-capitalize"
+                                    >
+                                      [
+                                      name
+                                      ]
+                                    </span>
+                                     
+                                    ssh
+                                  </span>
+                                </div>
+                              </li>
+                            </ul>
+                          </div>
+                        </li>,
+                      ],
+                      "style": Object {
+                        "listStyleType": "none",
+                      },
+                    },
+                    "ref": null,
+                    "rendered": Array [
+                      Object {
+                        "instance": null,
+                        "key": "key_sssssssss_k0",
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": <div
+                            className="label-collection"
+                          >
+                            <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                host
+                                ]
+                              </span>
+                               
+                              reviews
+                            </span>
+                          </div>,
+                        },
+                        "ref": null,
+                        "rendered": Object {
+                          "instance": null,
+                          "key": undefined,
+                          "nodeType": "host",
+                          "props": Object {
+                            "children": <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                host
+                                ]
+                              </span>
+                               
+                              reviews
+                            </span>,
+                            "className": "label-collection",
+                          },
+                          "ref": null,
+                          "rendered": Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "host",
+                            "props": Object {
+                              "children": Array [
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  host
+                                  ]
+                                </span>,
+                                " ",
+                                "reviews",
+                              ],
+                            },
+                            "ref": null,
+                            "rendered": Array [
+                              Object {
+                                "instance": null,
+                                "key": undefined,
+                                "nodeType": "host",
+                                "props": Object {
+                                  "children": Array [
+                                    "[",
+                                    "host",
+                                    "]",
+                                  ],
+                                  "className": "text-capitalize",
+                                },
+                                "ref": null,
+                                "rendered": Array [
+                                  "[",
+                                  "host",
+                                  "]",
+                                ],
+                                "type": "span",
+                              },
+                              " ",
+                              "reviews",
+                            ],
+                            "type": "span",
+                          },
+                          "type": "div",
+                        },
+                        "type": "li",
+                      },
+                      Object {
+                        "instance": null,
+                        "key": "key_sssssssss_k1",
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": <div
+                            className="label-collection"
+                          >
+                            <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                subset
+                                ]
+                              </span>
+                               
+                              v1
+                            </span>
+                          </div>,
+                        },
+                        "ref": null,
+                        "rendered": Object {
+                          "instance": null,
+                          "key": undefined,
+                          "nodeType": "host",
+                          "props": Object {
+                            "children": <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                subset
+                                ]
+                              </span>
+                               
+                              v1
+                            </span>,
+                            "className": "label-collection",
+                          },
+                          "ref": null,
+                          "rendered": Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "host",
+                            "props": Object {
+                              "children": Array [
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  subset
+                                  ]
+                                </span>,
+                                " ",
+                                "v1",
+                              ],
+                            },
+                            "ref": null,
+                            "rendered": Array [
+                              Object {
+                                "instance": null,
+                                "key": undefined,
+                                "nodeType": "host",
+                                "props": Object {
+                                  "children": Array [
+                                    "[",
+                                    "subset",
+                                    "]",
+                                  ],
+                                  "className": "text-capitalize",
+                                },
+                                "ref": null,
+                                "rendered": Array [
+                                  "[",
+                                  "subset",
+                                  "]",
+                                ],
+                                "type": "span",
+                              },
+                              " ",
+                              "v1",
+                            ],
+                            "type": "span",
+                          },
+                          "type": "div",
+                        },
+                        "type": "li",
+                      },
+                      Object {
+                        "instance": null,
+                        "key": "key_sssssssss_k2",
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": <div>
+                            <strong
+                              className="text-capitalize"
+                            >
+                              port
+                            </strong>
+                            <ul
+                              style={
+                                Object {
+                                  "listStyleType": "none",
+                                }
+                              }
+                            >
+                              <li>
+                                <div
+                                  className="label-collection"
+                                >
+                                  <span>
+                                    <span
+                                      className="text-capitalize"
+                                    >
+                                      [
+                                      number
+                                      ]
+                                    </span>
+                                     
+                                    22
+                                  </span>
+                                </div>
+                              </li>
+                              <li>
+                                <div
+                                  className="label-collection"
+                                >
+                                  <span>
+                                    <span
+                                      className="text-capitalize"
+                                    >
+                                      [
+                                      name
+                                      ]
+                                    </span>
+                                     
+                                    ssh
+                                  </span>
+                                </div>
+                              </li>
+                            </ul>
+                          </div>,
+                        },
+                        "ref": null,
+                        "rendered": Object {
+                          "instance": null,
+                          "key": undefined,
+                          "nodeType": "host",
+                          "props": Object {
+                            "children": Array [
+                              <strong
+                                className="text-capitalize"
+                              >
+                                port
+                              </strong>,
+                              undefined,
+                              <ul
+                                style={
+                                  Object {
+                                    "listStyleType": "none",
+                                  }
+                                }
+                              >
+                                <li>
+                                  <div
+                                    className="label-collection"
+                                  >
+                                    <span>
+                                      <span
+                                        className="text-capitalize"
+                                      >
+                                        [
+                                        number
+                                        ]
+                                      </span>
+                                       
+                                      22
+                                    </span>
+                                  </div>
+                                </li>
+                                <li>
+                                  <div
+                                    className="label-collection"
+                                  >
+                                    <span>
+                                      <span
+                                        className="text-capitalize"
+                                      >
+                                        [
+                                        name
+                                        ]
+                                      </span>
+                                       
+                                      ssh
+                                    </span>
+                                  </div>
+                                </li>
+                              </ul>,
+                            ],
+                          },
+                          "ref": null,
+                          "rendered": Array [
+                            Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "host",
+                              "props": Object {
+                                "children": "port",
+                                "className": "text-capitalize",
+                              },
+                              "ref": null,
+                              "rendered": "port",
+                              "type": "strong",
+                            },
+                            undefined,
+                            Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "host",
+                              "props": Object {
+                                "children": Array [
+                                  <li>
+                                    <div
+                                      className="label-collection"
+                                    >
+                                      <span>
+                                        <span
+                                          className="text-capitalize"
+                                        >
+                                          [
+                                          number
+                                          ]
+                                        </span>
+                                         
+                                        22
+                                      </span>
+                                    </div>
+                                  </li>,
+                                  <li>
+                                    <div
+                                      className="label-collection"
+                                    >
+                                      <span>
+                                        <span
+                                          className="text-capitalize"
+                                        >
+                                          [
+                                          name
+                                          ]
+                                        </span>
+                                         
+                                        ssh
+                                      </span>
+                                    </div>
+                                  </li>,
+                                ],
+                                "style": Object {
+                                  "listStyleType": "none",
+                                },
+                              },
+                              "ref": null,
+                              "rendered": Array [
+                                Object {
+                                  "instance": null,
+                                  "key": "key_sssssssss_k0",
+                                  "nodeType": "host",
+                                  "props": Object {
+                                    "children": <div
+                                      className="label-collection"
+                                    >
+                                      <span>
+                                        <span
+                                          className="text-capitalize"
+                                        >
+                                          [
+                                          number
+                                          ]
+                                        </span>
+                                         
+                                        22
+                                      </span>
+                                    </div>,
+                                  },
+                                  "ref": null,
+                                  "rendered": Object {
+                                    "instance": null,
+                                    "key": undefined,
+                                    "nodeType": "host",
+                                    "props": Object {
+                                      "children": <span>
+                                        <span
+                                          className="text-capitalize"
+                                        >
+                                          [
+                                          number
+                                          ]
+                                        </span>
+                                         
+                                        22
+                                      </span>,
+                                      "className": "label-collection",
+                                    },
+                                    "ref": null,
+                                    "rendered": Object {
+                                      "instance": null,
+                                      "key": undefined,
+                                      "nodeType": "host",
+                                      "props": Object {
+                                        "children": Array [
+                                          <span
+                                            className="text-capitalize"
+                                          >
+                                            [
+                                            number
+                                            ]
+                                          </span>,
+                                          " ",
+                                          22,
+                                        ],
+                                      },
+                                      "ref": null,
+                                      "rendered": Array [
+                                        Object {
+                                          "instance": null,
+                                          "key": undefined,
+                                          "nodeType": "host",
+                                          "props": Object {
+                                            "children": Array [
+                                              "[",
+                                              "number",
+                                              "]",
+                                            ],
+                                            "className": "text-capitalize",
+                                          },
+                                          "ref": null,
+                                          "rendered": Array [
+                                            "[",
+                                            "number",
+                                            "]",
+                                          ],
+                                          "type": "span",
+                                        },
+                                        " ",
+                                        22,
+                                      ],
+                                      "type": "span",
+                                    },
+                                    "type": "div",
+                                  },
+                                  "type": "li",
+                                },
+                                Object {
+                                  "instance": null,
+                                  "key": "key_sssssssss_k1",
+                                  "nodeType": "host",
+                                  "props": Object {
+                                    "children": <div
+                                      className="label-collection"
+                                    >
+                                      <span>
+                                        <span
+                                          className="text-capitalize"
+                                        >
+                                          [
+                                          name
+                                          ]
+                                        </span>
+                                         
+                                        ssh
+                                      </span>
+                                    </div>,
+                                  },
+                                  "ref": null,
+                                  "rendered": Object {
+                                    "instance": null,
+                                    "key": undefined,
+                                    "nodeType": "host",
+                                    "props": Object {
+                                      "children": <span>
+                                        <span
+                                          className="text-capitalize"
+                                        >
+                                          [
+                                          name
+                                          ]
+                                        </span>
+                                         
+                                        ssh
+                                      </span>,
+                                      "className": "label-collection",
+                                    },
+                                    "ref": null,
+                                    "rendered": Object {
+                                      "instance": null,
+                                      "key": undefined,
+                                      "nodeType": "host",
+                                      "props": Object {
+                                        "children": Array [
+                                          <span
+                                            className="text-capitalize"
+                                          >
+                                            [
+                                            name
+                                            ]
+                                          </span>,
+                                          " ",
+                                          "ssh",
+                                        ],
+                                      },
+                                      "ref": null,
+                                      "rendered": Array [
+                                        Object {
+                                          "instance": null,
+                                          "key": undefined,
+                                          "nodeType": "host",
+                                          "props": Object {
+                                            "children": Array [
+                                              "[",
+                                              "name",
+                                              "]",
+                                            ],
+                                            "className": "text-capitalize",
+                                          },
+                                          "ref": null,
+                                          "rendered": Array [
+                                            "[",
+                                            "name",
+                                            "]",
+                                          ],
+                                          "type": "span",
+                                        },
+                                        " ",
+                                        "ssh",
+                                      ],
+                                      "type": "span",
+                                    },
+                                    "type": "div",
+                                  },
+                                  "type": "li",
+                                },
+                              ],
+                              "type": "ul",
+                            },
+                          ],
+                          "type": "div",
+                        },
+                        "type": "li",
+                      },
+                    ],
+                    "type": "ul",
+                  },
+                ],
+                "type": "div",
+              },
+              "type": "li",
+            },
+            Object {
+              "instance": null,
+              "key": "key_sssssssss_k1",
+              "nodeType": "host",
+              "props": Object {
+                "children": <div
+                  className="label-collection"
+                >
+                  <span>
+                    <span
+                      className="text-capitalize"
+                    >
+                      [
+                      weight
+                      ]
+                    </span>
+                     
+                    85
+                  </span>
+                </div>,
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": <span>
+                    <span
+                      className="text-capitalize"
+                    >
+                      [
+                      weight
+                      ]
+                    </span>
+                     
+                    85
+                  </span>,
+                  "className": "label-collection",
+                },
+                "ref": null,
+                "rendered": Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": Array [
+                      <span
+                        className="text-capitalize"
+                      >
+                        [
+                        weight
+                        ]
+                      </span>,
+                      " ",
+                      85,
+                    ],
+                  },
+                  "ref": null,
+                  "rendered": Array [
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": Array [
+                          "[",
+                          "weight",
+                          "]",
+                        ],
+                        "className": "text-capitalize",
+                      },
+                      "ref": null,
+                      "rendered": Array [
+                        "[",
+                        "weight",
+                        "]",
+                      ],
+                      "type": "span",
+                    },
+                    " ",
+                    85,
+                  ],
+                  "type": "span",
+                },
+                "type": "div",
+              },
+              "type": "li",
+            },
+          ],
+          "type": "ul",
+        },
+      ],
+      "type": "div",
+    },
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": <div>
+          <strong
+            className="text-capitalize"
+          >
+            nodejs
+          </strong>
+          <ul
+            style={
+              Object {
+                "listStyleType": "none",
+              }
+            }
+          >
+            <li>
+              <div>
+                <strong
+                  className="text-capitalize"
+                >
+                  destination
+                </strong>
+                <ul
+                  style={
+                    Object {
+                      "listStyleType": "none",
+                    }
+                  }
+                >
+                  <li>
+                    <div
+                      className="label-collection"
+                    >
+                      <span>
+                        <span
+                          className="text-capitalize"
+                        >
+                          [
+                          host
+                          ]
+                        </span>
+                         
+                        reviews
+                      </span>
+                    </div>
+                  </li>
+                  <li>
+                    <div
+                      className="label-collection"
+                    >
+                      <span>
+                        <span
+                          className="text-capitalize"
+                        >
+                          [
+                          subset
+                          ]
+                        </span>
+                         
+                        v1
+                      </span>
+                    </div>
+                  </li>
+                  <li>
+                    <div>
+                      <strong
+                        className="text-capitalize"
+                      >
+                        port
+                      </strong>
+                      <ul
+                        style={
+                          Object {
+                            "listStyleType": "none",
+                          }
+                        }
+                      >
+                        <li>
+                          <div
+                            className="label-collection"
+                          >
+                            <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                number
+                                ]
+                              </span>
+                               
+                              22
+                            </span>
+                          </div>
+                        </li>
+                        <li>
+                          <div
+                            className="label-collection"
+                          >
+                            <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                name
+                                ]
+                              </span>
+                               
+                              ssh
+                            </span>
+                          </div>
+                        </li>
+                      </ul>
+                    </div>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li>
+              <div
+                className="label-collection"
+              >
+                <span>
+                  <span
+                    className="text-capitalize"
+                  >
+                    [
+                    weight
+                    ]
+                  </span>
+                   
+                  85
+                </span>
+              </div>
+            </li>
+          </ul>
+        </div>,
+      },
+      "ref": null,
+      "rendered": Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            <strong
+              className="text-capitalize"
+            >
+              nodejs
+            </strong>,
+            undefined,
+            <ul
+              style={
+                Object {
+                  "listStyleType": "none",
+                }
+              }
+            >
+              <li>
+                <div>
+                  <strong
+                    className="text-capitalize"
+                  >
+                    destination
+                  </strong>
+                  <ul
+                    style={
+                      Object {
+                        "listStyleType": "none",
+                      }
+                    }
+                  >
+                    <li>
+                      <div
+                        className="label-collection"
+                      >
+                        <span>
+                          <span
+                            className="text-capitalize"
+                          >
+                            [
+                            host
+                            ]
+                          </span>
+                           
+                          reviews
+                        </span>
+                      </div>
+                    </li>
+                    <li>
+                      <div
+                        className="label-collection"
+                      >
+                        <span>
+                          <span
+                            className="text-capitalize"
+                          >
+                            [
+                            subset
+                            ]
+                          </span>
+                           
+                          v1
+                        </span>
+                      </div>
+                    </li>
+                    <li>
+                      <div>
+                        <strong
+                          className="text-capitalize"
+                        >
+                          port
+                        </strong>
+                        <ul
+                          style={
+                            Object {
+                              "listStyleType": "none",
+                            }
+                          }
+                        >
+                          <li>
+                            <div
+                              className="label-collection"
+                            >
+                              <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  number
+                                  ]
+                                </span>
+                                 
+                                22
+                              </span>
+                            </div>
+                          </li>
+                          <li>
+                            <div
+                              className="label-collection"
+                            >
+                              <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  name
+                                  ]
+                                </span>
+                                 
+                                ssh
+                              </span>
+                            </div>
+                          </li>
+                        </ul>
+                      </div>
+                    </li>
+                  </ul>
+                </div>
+              </li>
+              <li>
+                <div
+                  className="label-collection"
+                >
+                  <span>
+                    <span
+                      className="text-capitalize"
+                    >
+                      [
+                      weight
+                      ]
+                    </span>
+                     
+                    85
+                  </span>
+                </div>
+              </li>
+            </ul>,
+          ],
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": "nodejs",
+              "className": "text-capitalize",
+            },
+            "ref": null,
+            "rendered": "nodejs",
+            "type": "strong",
+          },
+          undefined,
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": Array [
+                <li>
+                  <div>
+                    <strong
+                      className="text-capitalize"
+                    >
+                      destination
+                    </strong>
+                    <ul
+                      style={
+                        Object {
+                          "listStyleType": "none",
+                        }
+                      }
+                    >
+                      <li>
+                        <div
+                          className="label-collection"
+                        >
+                          <span>
+                            <span
+                              className="text-capitalize"
+                            >
+                              [
+                              host
+                              ]
+                            </span>
+                             
+                            reviews
+                          </span>
+                        </div>
+                      </li>
+                      <li>
+                        <div
+                          className="label-collection"
+                        >
+                          <span>
+                            <span
+                              className="text-capitalize"
+                            >
+                              [
+                              subset
+                              ]
+                            </span>
+                             
+                            v1
+                          </span>
+                        </div>
+                      </li>
+                      <li>
+                        <div>
+                          <strong
+                            className="text-capitalize"
+                          >
+                            port
+                          </strong>
+                          <ul
+                            style={
+                              Object {
+                                "listStyleType": "none",
+                              }
+                            }
+                          >
+                            <li>
+                              <div
+                                className="label-collection"
+                              >
+                                <span>
+                                  <span
+                                    className="text-capitalize"
+                                  >
+                                    [
+                                    number
+                                    ]
+                                  </span>
+                                   
+                                  22
+                                </span>
+                              </div>
+                            </li>
+                            <li>
+                              <div
+                                className="label-collection"
+                              >
+                                <span>
+                                  <span
+                                    className="text-capitalize"
+                                  >
+                                    [
+                                    name
+                                    ]
+                                  </span>
+                                   
+                                  ssh
+                                </span>
+                              </div>
+                            </li>
+                          </ul>
+                        </div>
+                      </li>
+                    </ul>
+                  </div>
+                </li>,
+                <li>
+                  <div
+                    className="label-collection"
+                  >
+                    <span>
+                      <span
+                        className="text-capitalize"
+                      >
+                        [
+                        weight
+                        ]
+                      </span>
+                       
+                      85
+                    </span>
+                  </div>
+                </li>,
+              ],
+              "style": Object {
+                "listStyleType": "none",
+              },
+            },
+            "ref": null,
+            "rendered": Array [
+              Object {
+                "instance": null,
+                "key": "key_sssssssss_k0",
+                "nodeType": "host",
+                "props": Object {
+                  "children": <div>
+                    <strong
+                      className="text-capitalize"
+                    >
+                      destination
+                    </strong>
+                    <ul
+                      style={
+                        Object {
+                          "listStyleType": "none",
+                        }
+                      }
+                    >
+                      <li>
+                        <div
+                          className="label-collection"
+                        >
+                          <span>
+                            <span
+                              className="text-capitalize"
+                            >
+                              [
+                              host
+                              ]
+                            </span>
+                             
+                            reviews
+                          </span>
+                        </div>
+                      </li>
+                      <li>
+                        <div
+                          className="label-collection"
+                        >
+                          <span>
+                            <span
+                              className="text-capitalize"
+                            >
+                              [
+                              subset
+                              ]
+                            </span>
+                             
+                            v1
+                          </span>
+                        </div>
+                      </li>
+                      <li>
+                        <div>
+                          <strong
+                            className="text-capitalize"
+                          >
+                            port
+                          </strong>
+                          <ul
+                            style={
+                              Object {
+                                "listStyleType": "none",
+                              }
+                            }
+                          >
+                            <li>
+                              <div
+                                className="label-collection"
+                              >
+                                <span>
+                                  <span
+                                    className="text-capitalize"
+                                  >
+                                    [
+                                    number
+                                    ]
+                                  </span>
+                                   
+                                  22
+                                </span>
+                              </div>
+                            </li>
+                            <li>
+                              <div
+                                className="label-collection"
+                              >
+                                <span>
+                                  <span
+                                    className="text-capitalize"
+                                  >
+                                    [
+                                    name
+                                    ]
+                                  </span>
+                                   
+                                  ssh
+                                </span>
+                              </div>
+                            </li>
+                          </ul>
+                        </div>
+                      </li>
+                    </ul>
+                  </div>,
+                },
+                "ref": null,
+                "rendered": Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": Array [
+                      <strong
+                        className="text-capitalize"
+                      >
+                        destination
+                      </strong>,
+                      undefined,
+                      <ul
+                        style={
+                          Object {
+                            "listStyleType": "none",
+                          }
+                        }
+                      >
+                        <li>
+                          <div
+                            className="label-collection"
+                          >
+                            <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                host
+                                ]
+                              </span>
+                               
+                              reviews
+                            </span>
+                          </div>
+                        </li>
+                        <li>
+                          <div
+                            className="label-collection"
+                          >
+                            <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                subset
+                                ]
+                              </span>
+                               
+                              v1
+                            </span>
+                          </div>
+                        </li>
+                        <li>
+                          <div>
+                            <strong
+                              className="text-capitalize"
+                            >
+                              port
+                            </strong>
+                            <ul
+                              style={
+                                Object {
+                                  "listStyleType": "none",
+                                }
+                              }
+                            >
+                              <li>
+                                <div
+                                  className="label-collection"
+                                >
+                                  <span>
+                                    <span
+                                      className="text-capitalize"
+                                    >
+                                      [
+                                      number
+                                      ]
+                                    </span>
+                                     
+                                    22
+                                  </span>
+                                </div>
+                              </li>
+                              <li>
+                                <div
+                                  className="label-collection"
+                                >
+                                  <span>
+                                    <span
+                                      className="text-capitalize"
+                                    >
+                                      [
+                                      name
+                                      ]
+                                    </span>
+                                     
+                                    ssh
+                                  </span>
+                                </div>
+                              </li>
+                            </ul>
+                          </div>
+                        </li>
+                      </ul>,
+                    ],
+                  },
+                  "ref": null,
+                  "rendered": Array [
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": "destination",
+                        "className": "text-capitalize",
+                      },
+                      "ref": null,
+                      "rendered": "destination",
+                      "type": "strong",
+                    },
+                    undefined,
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": Array [
+                          <li>
+                            <div
+                              className="label-collection"
+                            >
+                              <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  host
+                                  ]
+                                </span>
+                                 
+                                reviews
+                              </span>
+                            </div>
+                          </li>,
+                          <li>
+                            <div
+                              className="label-collection"
+                            >
+                              <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  subset
+                                  ]
+                                </span>
+                                 
+                                v1
+                              </span>
+                            </div>
+                          </li>,
+                          <li>
+                            <div>
+                              <strong
+                                className="text-capitalize"
+                              >
+                                port
+                              </strong>
+                              <ul
+                                style={
+                                  Object {
+                                    "listStyleType": "none",
+                                  }
+                                }
+                              >
+                                <li>
+                                  <div
+                                    className="label-collection"
+                                  >
+                                    <span>
+                                      <span
+                                        className="text-capitalize"
+                                      >
+                                        [
+                                        number
+                                        ]
+                                      </span>
+                                       
+                                      22
+                                    </span>
+                                  </div>
+                                </li>
+                                <li>
+                                  <div
+                                    className="label-collection"
+                                  >
+                                    <span>
+                                      <span
+                                        className="text-capitalize"
+                                      >
+                                        [
+                                        name
+                                        ]
+                                      </span>
+                                       
+                                      ssh
+                                    </span>
+                                  </div>
+                                </li>
+                              </ul>
+                            </div>
+                          </li>,
+                        ],
+                        "style": Object {
+                          "listStyleType": "none",
+                        },
+                      },
+                      "ref": null,
+                      "rendered": Array [
+                        Object {
+                          "instance": null,
+                          "key": "key_sssssssss_k0",
+                          "nodeType": "host",
+                          "props": Object {
+                            "children": <div
+                              className="label-collection"
+                            >
+                              <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  host
+                                  ]
+                                </span>
+                                 
+                                reviews
+                              </span>
+                            </div>,
+                          },
+                          "ref": null,
+                          "rendered": Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "host",
+                            "props": Object {
+                              "children": <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  host
+                                  ]
+                                </span>
+                                 
+                                reviews
+                              </span>,
+                              "className": "label-collection",
+                            },
+                            "ref": null,
+                            "rendered": Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "host",
+                              "props": Object {
+                                "children": Array [
+                                  <span
+                                    className="text-capitalize"
+                                  >
+                                    [
+                                    host
+                                    ]
+                                  </span>,
+                                  " ",
+                                  "reviews",
+                                ],
+                              },
+                              "ref": null,
+                              "rendered": Array [
+                                Object {
+                                  "instance": null,
+                                  "key": undefined,
+                                  "nodeType": "host",
+                                  "props": Object {
+                                    "children": Array [
+                                      "[",
+                                      "host",
+                                      "]",
+                                    ],
+                                    "className": "text-capitalize",
+                                  },
+                                  "ref": null,
+                                  "rendered": Array [
+                                    "[",
+                                    "host",
+                                    "]",
+                                  ],
+                                  "type": "span",
+                                },
+                                " ",
+                                "reviews",
+                              ],
+                              "type": "span",
+                            },
+                            "type": "div",
+                          },
+                          "type": "li",
+                        },
+                        Object {
+                          "instance": null,
+                          "key": "key_sssssssss_k1",
+                          "nodeType": "host",
+                          "props": Object {
+                            "children": <div
+                              className="label-collection"
+                            >
+                              <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  subset
+                                  ]
+                                </span>
+                                 
+                                v1
+                              </span>
+                            </div>,
+                          },
+                          "ref": null,
+                          "rendered": Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "host",
+                            "props": Object {
+                              "children": <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  subset
+                                  ]
+                                </span>
+                                 
+                                v1
+                              </span>,
+                              "className": "label-collection",
+                            },
+                            "ref": null,
+                            "rendered": Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "host",
+                              "props": Object {
+                                "children": Array [
+                                  <span
+                                    className="text-capitalize"
+                                  >
+                                    [
+                                    subset
+                                    ]
+                                  </span>,
+                                  " ",
+                                  "v1",
+                                ],
+                              },
+                              "ref": null,
+                              "rendered": Array [
+                                Object {
+                                  "instance": null,
+                                  "key": undefined,
+                                  "nodeType": "host",
+                                  "props": Object {
+                                    "children": Array [
+                                      "[",
+                                      "subset",
+                                      "]",
+                                    ],
+                                    "className": "text-capitalize",
+                                  },
+                                  "ref": null,
+                                  "rendered": Array [
+                                    "[",
+                                    "subset",
+                                    "]",
+                                  ],
+                                  "type": "span",
+                                },
+                                " ",
+                                "v1",
+                              ],
+                              "type": "span",
+                            },
+                            "type": "div",
+                          },
+                          "type": "li",
+                        },
+                        Object {
+                          "instance": null,
+                          "key": "key_sssssssss_k2",
+                          "nodeType": "host",
+                          "props": Object {
+                            "children": <div>
+                              <strong
+                                className="text-capitalize"
+                              >
+                                port
+                              </strong>
+                              <ul
+                                style={
+                                  Object {
+                                    "listStyleType": "none",
+                                  }
+                                }
+                              >
+                                <li>
+                                  <div
+                                    className="label-collection"
+                                  >
+                                    <span>
+                                      <span
+                                        className="text-capitalize"
+                                      >
+                                        [
+                                        number
+                                        ]
+                                      </span>
+                                       
+                                      22
+                                    </span>
+                                  </div>
+                                </li>
+                                <li>
+                                  <div
+                                    className="label-collection"
+                                  >
+                                    <span>
+                                      <span
+                                        className="text-capitalize"
+                                      >
+                                        [
+                                        name
+                                        ]
+                                      </span>
+                                       
+                                      ssh
+                                    </span>
+                                  </div>
+                                </li>
+                              </ul>
+                            </div>,
+                          },
+                          "ref": null,
+                          "rendered": Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "host",
+                            "props": Object {
+                              "children": Array [
+                                <strong
+                                  className="text-capitalize"
+                                >
+                                  port
+                                </strong>,
+                                undefined,
+                                <ul
+                                  style={
+                                    Object {
+                                      "listStyleType": "none",
+                                    }
+                                  }
+                                >
+                                  <li>
+                                    <div
+                                      className="label-collection"
+                                    >
+                                      <span>
+                                        <span
+                                          className="text-capitalize"
+                                        >
+                                          [
+                                          number
+                                          ]
+                                        </span>
+                                         
+                                        22
+                                      </span>
+                                    </div>
+                                  </li>
+                                  <li>
+                                    <div
+                                      className="label-collection"
+                                    >
+                                      <span>
+                                        <span
+                                          className="text-capitalize"
+                                        >
+                                          [
+                                          name
+                                          ]
+                                        </span>
+                                         
+                                        ssh
+                                      </span>
+                                    </div>
+                                  </li>
+                                </ul>,
+                              ],
+                            },
+                            "ref": null,
+                            "rendered": Array [
+                              Object {
+                                "instance": null,
+                                "key": undefined,
+                                "nodeType": "host",
+                                "props": Object {
+                                  "children": "port",
+                                  "className": "text-capitalize",
+                                },
+                                "ref": null,
+                                "rendered": "port",
+                                "type": "strong",
+                              },
+                              undefined,
+                              Object {
+                                "instance": null,
+                                "key": undefined,
+                                "nodeType": "host",
+                                "props": Object {
+                                  "children": Array [
+                                    <li>
+                                      <div
+                                        className="label-collection"
+                                      >
+                                        <span>
+                                          <span
+                                            className="text-capitalize"
+                                          >
+                                            [
+                                            number
+                                            ]
+                                          </span>
+                                           
+                                          22
+                                        </span>
+                                      </div>
+                                    </li>,
+                                    <li>
+                                      <div
+                                        className="label-collection"
+                                      >
+                                        <span>
+                                          <span
+                                            className="text-capitalize"
+                                          >
+                                            [
+                                            name
+                                            ]
+                                          </span>
+                                           
+                                          ssh
+                                        </span>
+                                      </div>
+                                    </li>,
+                                  ],
+                                  "style": Object {
+                                    "listStyleType": "none",
+                                  },
+                                },
+                                "ref": null,
+                                "rendered": Array [
+                                  Object {
+                                    "instance": null,
+                                    "key": "key_sssssssss_k0",
+                                    "nodeType": "host",
+                                    "props": Object {
+                                      "children": <div
+                                        className="label-collection"
+                                      >
+                                        <span>
+                                          <span
+                                            className="text-capitalize"
+                                          >
+                                            [
+                                            number
+                                            ]
+                                          </span>
+                                           
+                                          22
+                                        </span>
+                                      </div>,
+                                    },
+                                    "ref": null,
+                                    "rendered": Object {
+                                      "instance": null,
+                                      "key": undefined,
+                                      "nodeType": "host",
+                                      "props": Object {
+                                        "children": <span>
+                                          <span
+                                            className="text-capitalize"
+                                          >
+                                            [
+                                            number
+                                            ]
+                                          </span>
+                                           
+                                          22
+                                        </span>,
+                                        "className": "label-collection",
+                                      },
+                                      "ref": null,
+                                      "rendered": Object {
+                                        "instance": null,
+                                        "key": undefined,
+                                        "nodeType": "host",
+                                        "props": Object {
+                                          "children": Array [
+                                            <span
+                                              className="text-capitalize"
+                                            >
+                                              [
+                                              number
+                                              ]
+                                            </span>,
+                                            " ",
+                                            22,
+                                          ],
+                                        },
+                                        "ref": null,
+                                        "rendered": Array [
+                                          Object {
+                                            "instance": null,
+                                            "key": undefined,
+                                            "nodeType": "host",
+                                            "props": Object {
+                                              "children": Array [
+                                                "[",
+                                                "number",
+                                                "]",
+                                              ],
+                                              "className": "text-capitalize",
+                                            },
+                                            "ref": null,
+                                            "rendered": Array [
+                                              "[",
+                                              "number",
+                                              "]",
+                                            ],
+                                            "type": "span",
+                                          },
+                                          " ",
+                                          22,
+                                        ],
+                                        "type": "span",
+                                      },
+                                      "type": "div",
+                                    },
+                                    "type": "li",
+                                  },
+                                  Object {
+                                    "instance": null,
+                                    "key": "key_sssssssss_k1",
+                                    "nodeType": "host",
+                                    "props": Object {
+                                      "children": <div
+                                        className="label-collection"
+                                      >
+                                        <span>
+                                          <span
+                                            className="text-capitalize"
+                                          >
+                                            [
+                                            name
+                                            ]
+                                          </span>
+                                           
+                                          ssh
+                                        </span>
+                                      </div>,
+                                    },
+                                    "ref": null,
+                                    "rendered": Object {
+                                      "instance": null,
+                                      "key": undefined,
+                                      "nodeType": "host",
+                                      "props": Object {
+                                        "children": <span>
+                                          <span
+                                            className="text-capitalize"
+                                          >
+                                            [
+                                            name
+                                            ]
+                                          </span>
+                                           
+                                          ssh
+                                        </span>,
+                                        "className": "label-collection",
+                                      },
+                                      "ref": null,
+                                      "rendered": Object {
+                                        "instance": null,
+                                        "key": undefined,
+                                        "nodeType": "host",
+                                        "props": Object {
+                                          "children": Array [
+                                            <span
+                                              className="text-capitalize"
+                                            >
+                                              [
+                                              name
+                                              ]
+                                            </span>,
+                                            " ",
+                                            "ssh",
+                                          ],
+                                        },
+                                        "ref": null,
+                                        "rendered": Array [
+                                          Object {
+                                            "instance": null,
+                                            "key": undefined,
+                                            "nodeType": "host",
+                                            "props": Object {
+                                              "children": Array [
+                                                "[",
+                                                "name",
+                                                "]",
+                                              ],
+                                              "className": "text-capitalize",
+                                            },
+                                            "ref": null,
+                                            "rendered": Array [
+                                              "[",
+                                              "name",
+                                              "]",
+                                            ],
+                                            "type": "span",
+                                          },
+                                          " ",
+                                          "ssh",
+                                        ],
+                                        "type": "span",
+                                      },
+                                      "type": "div",
+                                    },
+                                    "type": "li",
+                                  },
+                                ],
+                                "type": "ul",
+                              },
+                            ],
+                            "type": "div",
+                          },
+                          "type": "li",
+                        },
+                      ],
+                      "type": "ul",
+                    },
+                  ],
+                  "type": "div",
+                },
+                "type": "li",
+              },
+              Object {
+                "instance": null,
+                "key": "key_sssssssss_k1",
+                "nodeType": "host",
+                "props": Object {
+                  "children": <div
+                    className="label-collection"
+                  >
+                    <span>
+                      <span
+                        className="text-capitalize"
+                      >
+                        [
+                        weight
+                        ]
+                      </span>
+                       
+                      85
+                    </span>
+                  </div>,
+                },
+                "ref": null,
+                "rendered": Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": <span>
+                      <span
+                        className="text-capitalize"
+                      >
+                        [
+                        weight
+                        ]
+                      </span>
+                       
+                      85
+                    </span>,
+                    "className": "label-collection",
+                  },
+                  "ref": null,
+                  "rendered": Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": Array [
+                        <span
+                          className="text-capitalize"
+                        >
+                          [
+                          weight
+                          ]
+                        </span>,
+                        " ",
+                        85,
+                      ],
+                    },
+                    "ref": null,
+                    "rendered": Array [
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": Array [
+                            "[",
+                            "weight",
+                            "]",
+                          ],
+                          "className": "text-capitalize",
+                        },
+                        "ref": null,
+                        "rendered": Array [
+                          "[",
+                          "weight",
+                          "]",
+                        ],
+                        "type": "span",
+                      },
+                      " ",
+                      85,
+                    ],
+                    "type": "span",
+                  },
+                  "type": "div",
+                },
+                "type": "li",
+              },
+            ],
+            "type": "ul",
+          },
+        ],
+        "type": "div",
+      },
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;
+
+exports[`DetailObject test doesn't print excluded fields 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <DetailObject
+    detail={
+      Object {
+        "destination": Object {
+          "host": "reviews",
+          "port": Object {
+            "name": "ssh",
+            "number": 22,
+          },
+          "subset": "v1",
+        },
+        "weight": 85,
+      }
+    }
+    exclude={
+      Array [
+        "port",
+      ]
+    }
+    name="nodejs"
+  />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": <div>
+        <strong
+          className="text-capitalize"
+        >
+          nodejs
+        </strong>
+        <ul
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <li>
+            <div>
+              <strong
+                className="text-capitalize"
+              >
+                destination
+              </strong>
+              <ul
+                style={
+                  Object {
+                    "listStyleType": "none",
+                  }
+                }
+              >
+                <li>
+                  <div
+                    className="label-collection"
+                  >
+                    <span>
+                      <span
+                        className="text-capitalize"
+                      >
+                        [
+                        host
+                        ]
+                      </span>
+                       
+                      reviews
+                    </span>
+                  </div>
+                </li>
+                <li>
+                  <div
+                    className="label-collection"
+                  >
+                    <span>
+                      <span
+                        className="text-capitalize"
+                      >
+                        [
+                        subset
+                        ]
+                      </span>
+                       
+                      v1
+                    </span>
+                  </div>
+                </li>
+                <li>
+                  
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li>
+            <div
+              className="label-collection"
+            >
+              <span>
+                <span
+                  className="text-capitalize"
+                >
+                  [
+                  weight
+                  ]
+                </span>
+                 
+                85
+              </span>
+            </div>
+          </li>
+        </ul>
+      </div>,
+    },
+    "ref": null,
+    "rendered": Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <strong
+            className="text-capitalize"
+          >
+            nodejs
+          </strong>,
+          undefined,
+          <ul
+            style={
+              Object {
+                "listStyleType": "none",
+              }
+            }
+          >
+            <li>
+              <div>
+                <strong
+                  className="text-capitalize"
+                >
+                  destination
+                </strong>
+                <ul
+                  style={
+                    Object {
+                      "listStyleType": "none",
+                    }
+                  }
+                >
+                  <li>
+                    <div
+                      className="label-collection"
+                    >
+                      <span>
+                        <span
+                          className="text-capitalize"
+                        >
+                          [
+                          host
+                          ]
+                        </span>
+                         
+                        reviews
+                      </span>
+                    </div>
+                  </li>
+                  <li>
+                    <div
+                      className="label-collection"
+                    >
+                      <span>
+                        <span
+                          className="text-capitalize"
+                        >
+                          [
+                          subset
+                          ]
+                        </span>
+                         
+                        v1
+                      </span>
+                    </div>
+                  </li>
+                  <li>
+                    
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li>
+              <div
+                className="label-collection"
+              >
+                <span>
+                  <span
+                    className="text-capitalize"
+                  >
+                    [
+                    weight
+                    ]
+                  </span>
+                   
+                  85
+                </span>
+              </div>
+            </li>
+          </ul>,
+        ],
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": "nodejs",
+            "className": "text-capitalize",
+          },
+          "ref": null,
+          "rendered": "nodejs",
+          "type": "strong",
+        },
+        undefined,
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              <li>
+                <div>
+                  <strong
+                    className="text-capitalize"
+                  >
+                    destination
+                  </strong>
+                  <ul
+                    style={
+                      Object {
+                        "listStyleType": "none",
+                      }
+                    }
+                  >
+                    <li>
+                      <div
+                        className="label-collection"
+                      >
+                        <span>
+                          <span
+                            className="text-capitalize"
+                          >
+                            [
+                            host
+                            ]
+                          </span>
+                           
+                          reviews
+                        </span>
+                      </div>
+                    </li>
+                    <li>
+                      <div
+                        className="label-collection"
+                      >
+                        <span>
+                          <span
+                            className="text-capitalize"
+                          >
+                            [
+                            subset
+                            ]
+                          </span>
+                           
+                          v1
+                        </span>
+                      </div>
+                    </li>
+                    <li>
+                      
+                    </li>
+                  </ul>
+                </div>
+              </li>,
+              <li>
+                <div
+                  className="label-collection"
+                >
+                  <span>
+                    <span
+                      className="text-capitalize"
+                    >
+                      [
+                      weight
+                      ]
+                    </span>
+                     
+                    85
+                  </span>
+                </div>
+              </li>,
+            ],
+            "style": Object {
+              "listStyleType": "none",
+            },
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": "key_sssssssss_k0",
+              "nodeType": "host",
+              "props": Object {
+                "children": <div>
+                  <strong
+                    className="text-capitalize"
+                  >
+                    destination
+                  </strong>
+                  <ul
+                    style={
+                      Object {
+                        "listStyleType": "none",
+                      }
+                    }
+                  >
+                    <li>
+                      <div
+                        className="label-collection"
+                      >
+                        <span>
+                          <span
+                            className="text-capitalize"
+                          >
+                            [
+                            host
+                            ]
+                          </span>
+                           
+                          reviews
+                        </span>
+                      </div>
+                    </li>
+                    <li>
+                      <div
+                        className="label-collection"
+                      >
+                        <span>
+                          <span
+                            className="text-capitalize"
+                          >
+                            [
+                            subset
+                            ]
+                          </span>
+                           
+                          v1
+                        </span>
+                      </div>
+                    </li>
+                    <li>
+                      
+                    </li>
+                  </ul>
+                </div>,
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": Array [
+                    <strong
+                      className="text-capitalize"
+                    >
+                      destination
+                    </strong>,
+                    undefined,
+                    <ul
+                      style={
+                        Object {
+                          "listStyleType": "none",
+                        }
+                      }
+                    >
+                      <li>
+                        <div
+                          className="label-collection"
+                        >
+                          <span>
+                            <span
+                              className="text-capitalize"
+                            >
+                              [
+                              host
+                              ]
+                            </span>
+                             
+                            reviews
+                          </span>
+                        </div>
+                      </li>
+                      <li>
+                        <div
+                          className="label-collection"
+                        >
+                          <span>
+                            <span
+                              className="text-capitalize"
+                            >
+                              [
+                              subset
+                              ]
+                            </span>
+                             
+                            v1
+                          </span>
+                        </div>
+                      </li>
+                      <li>
+                        
+                      </li>
+                    </ul>,
+                  ],
+                },
+                "ref": null,
+                "rendered": Array [
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": "destination",
+                      "className": "text-capitalize",
+                    },
+                    "ref": null,
+                    "rendered": "destination",
+                    "type": "strong",
+                  },
+                  undefined,
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": Array [
+                        <li>
+                          <div
+                            className="label-collection"
+                          >
+                            <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                host
+                                ]
+                              </span>
+                               
+                              reviews
+                            </span>
+                          </div>
+                        </li>,
+                        <li>
+                          <div
+                            className="label-collection"
+                          >
+                            <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                subset
+                                ]
+                              </span>
+                               
+                              v1
+                            </span>
+                          </div>
+                        </li>,
+                        <li>
+                          
+                        </li>,
+                      ],
+                      "style": Object {
+                        "listStyleType": "none",
+                      },
+                    },
+                    "ref": null,
+                    "rendered": Array [
+                      Object {
+                        "instance": null,
+                        "key": "key_sssssssss_k0",
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": <div
+                            className="label-collection"
+                          >
+                            <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                host
+                                ]
+                              </span>
+                               
+                              reviews
+                            </span>
+                          </div>,
+                        },
+                        "ref": null,
+                        "rendered": Object {
+                          "instance": null,
+                          "key": undefined,
+                          "nodeType": "host",
+                          "props": Object {
+                            "children": <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                host
+                                ]
+                              </span>
+                               
+                              reviews
+                            </span>,
+                            "className": "label-collection",
+                          },
+                          "ref": null,
+                          "rendered": Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "host",
+                            "props": Object {
+                              "children": Array [
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  host
+                                  ]
+                                </span>,
+                                " ",
+                                "reviews",
+                              ],
+                            },
+                            "ref": null,
+                            "rendered": Array [
+                              Object {
+                                "instance": null,
+                                "key": undefined,
+                                "nodeType": "host",
+                                "props": Object {
+                                  "children": Array [
+                                    "[",
+                                    "host",
+                                    "]",
+                                  ],
+                                  "className": "text-capitalize",
+                                },
+                                "ref": null,
+                                "rendered": Array [
+                                  "[",
+                                  "host",
+                                  "]",
+                                ],
+                                "type": "span",
+                              },
+                              " ",
+                              "reviews",
+                            ],
+                            "type": "span",
+                          },
+                          "type": "div",
+                        },
+                        "type": "li",
+                      },
+                      Object {
+                        "instance": null,
+                        "key": "key_sssssssss_k1",
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": <div
+                            className="label-collection"
+                          >
+                            <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                subset
+                                ]
+                              </span>
+                               
+                              v1
+                            </span>
+                          </div>,
+                        },
+                        "ref": null,
+                        "rendered": Object {
+                          "instance": null,
+                          "key": undefined,
+                          "nodeType": "host",
+                          "props": Object {
+                            "children": <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                subset
+                                ]
+                              </span>
+                               
+                              v1
+                            </span>,
+                            "className": "label-collection",
+                          },
+                          "ref": null,
+                          "rendered": Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "host",
+                            "props": Object {
+                              "children": Array [
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  subset
+                                  ]
+                                </span>,
+                                " ",
+                                "v1",
+                              ],
+                            },
+                            "ref": null,
+                            "rendered": Array [
+                              Object {
+                                "instance": null,
+                                "key": undefined,
+                                "nodeType": "host",
+                                "props": Object {
+                                  "children": Array [
+                                    "[",
+                                    "subset",
+                                    "]",
+                                  ],
+                                  "className": "text-capitalize",
+                                },
+                                "ref": null,
+                                "rendered": Array [
+                                  "[",
+                                  "subset",
+                                  "]",
+                                ],
+                                "type": "span",
+                              },
+                              " ",
+                              "v1",
+                            ],
+                            "type": "span",
+                          },
+                          "type": "div",
+                        },
+                        "type": "li",
+                      },
+                      Object {
+                        "instance": null,
+                        "key": "key_sssssssss_k2",
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": "",
+                        },
+                        "ref": null,
+                        "rendered": "",
+                        "type": "li",
+                      },
+                    ],
+                    "type": "ul",
+                  },
+                ],
+                "type": "div",
+              },
+              "type": "li",
+            },
+            Object {
+              "instance": null,
+              "key": "key_sssssssss_k1",
+              "nodeType": "host",
+              "props": Object {
+                "children": <div
+                  className="label-collection"
+                >
+                  <span>
+                    <span
+                      className="text-capitalize"
+                    >
+                      [
+                      weight
+                      ]
+                    </span>
+                     
+                    85
+                  </span>
+                </div>,
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": <span>
+                    <span
+                      className="text-capitalize"
+                    >
+                      [
+                      weight
+                      ]
+                    </span>
+                     
+                    85
+                  </span>,
+                  "className": "label-collection",
+                },
+                "ref": null,
+                "rendered": Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": Array [
+                      <span
+                        className="text-capitalize"
+                      >
+                        [
+                        weight
+                        ]
+                      </span>,
+                      " ",
+                      85,
+                    ],
+                  },
+                  "ref": null,
+                  "rendered": Array [
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": Array [
+                          "[",
+                          "weight",
+                          "]",
+                        ],
+                        "className": "text-capitalize",
+                      },
+                      "ref": null,
+                      "rendered": Array [
+                        "[",
+                        "weight",
+                        "]",
+                      ],
+                      "type": "span",
+                    },
+                    " ",
+                    85,
+                  ],
+                  "type": "span",
+                },
+                "type": "div",
+              },
+              "type": "li",
+            },
+          ],
+          "type": "ul",
+        },
+      ],
+      "type": "div",
+    },
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": <div>
+          <strong
+            className="text-capitalize"
+          >
+            nodejs
+          </strong>
+          <ul
+            style={
+              Object {
+                "listStyleType": "none",
+              }
+            }
+          >
+            <li>
+              <div>
+                <strong
+                  className="text-capitalize"
+                >
+                  destination
+                </strong>
+                <ul
+                  style={
+                    Object {
+                      "listStyleType": "none",
+                    }
+                  }
+                >
+                  <li>
+                    <div
+                      className="label-collection"
+                    >
+                      <span>
+                        <span
+                          className="text-capitalize"
+                        >
+                          [
+                          host
+                          ]
+                        </span>
+                         
+                        reviews
+                      </span>
+                    </div>
+                  </li>
+                  <li>
+                    <div
+                      className="label-collection"
+                    >
+                      <span>
+                        <span
+                          className="text-capitalize"
+                        >
+                          [
+                          subset
+                          ]
+                        </span>
+                         
+                        v1
+                      </span>
+                    </div>
+                  </li>
+                  <li>
+                    
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li>
+              <div
+                className="label-collection"
+              >
+                <span>
+                  <span
+                    className="text-capitalize"
+                  >
+                    [
+                    weight
+                    ]
+                  </span>
+                   
+                  85
+                </span>
+              </div>
+            </li>
+          </ul>
+        </div>,
+      },
+      "ref": null,
+      "rendered": Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            <strong
+              className="text-capitalize"
+            >
+              nodejs
+            </strong>,
+            undefined,
+            <ul
+              style={
+                Object {
+                  "listStyleType": "none",
+                }
+              }
+            >
+              <li>
+                <div>
+                  <strong
+                    className="text-capitalize"
+                  >
+                    destination
+                  </strong>
+                  <ul
+                    style={
+                      Object {
+                        "listStyleType": "none",
+                      }
+                    }
+                  >
+                    <li>
+                      <div
+                        className="label-collection"
+                      >
+                        <span>
+                          <span
+                            className="text-capitalize"
+                          >
+                            [
+                            host
+                            ]
+                          </span>
+                           
+                          reviews
+                        </span>
+                      </div>
+                    </li>
+                    <li>
+                      <div
+                        className="label-collection"
+                      >
+                        <span>
+                          <span
+                            className="text-capitalize"
+                          >
+                            [
+                            subset
+                            ]
+                          </span>
+                           
+                          v1
+                        </span>
+                      </div>
+                    </li>
+                    <li>
+                      
+                    </li>
+                  </ul>
+                </div>
+              </li>
+              <li>
+                <div
+                  className="label-collection"
+                >
+                  <span>
+                    <span
+                      className="text-capitalize"
+                    >
+                      [
+                      weight
+                      ]
+                    </span>
+                     
+                    85
+                  </span>
+                </div>
+              </li>
+            </ul>,
+          ],
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": "nodejs",
+              "className": "text-capitalize",
+            },
+            "ref": null,
+            "rendered": "nodejs",
+            "type": "strong",
+          },
+          undefined,
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": Array [
+                <li>
+                  <div>
+                    <strong
+                      className="text-capitalize"
+                    >
+                      destination
+                    </strong>
+                    <ul
+                      style={
+                        Object {
+                          "listStyleType": "none",
+                        }
+                      }
+                    >
+                      <li>
+                        <div
+                          className="label-collection"
+                        >
+                          <span>
+                            <span
+                              className="text-capitalize"
+                            >
+                              [
+                              host
+                              ]
+                            </span>
+                             
+                            reviews
+                          </span>
+                        </div>
+                      </li>
+                      <li>
+                        <div
+                          className="label-collection"
+                        >
+                          <span>
+                            <span
+                              className="text-capitalize"
+                            >
+                              [
+                              subset
+                              ]
+                            </span>
+                             
+                            v1
+                          </span>
+                        </div>
+                      </li>
+                      <li>
+                        
+                      </li>
+                    </ul>
+                  </div>
+                </li>,
+                <li>
+                  <div
+                    className="label-collection"
+                  >
+                    <span>
+                      <span
+                        className="text-capitalize"
+                      >
+                        [
+                        weight
+                        ]
+                      </span>
+                       
+                      85
+                    </span>
+                  </div>
+                </li>,
+              ],
+              "style": Object {
+                "listStyleType": "none",
+              },
+            },
+            "ref": null,
+            "rendered": Array [
+              Object {
+                "instance": null,
+                "key": "key_sssssssss_k0",
+                "nodeType": "host",
+                "props": Object {
+                  "children": <div>
+                    <strong
+                      className="text-capitalize"
+                    >
+                      destination
+                    </strong>
+                    <ul
+                      style={
+                        Object {
+                          "listStyleType": "none",
+                        }
+                      }
+                    >
+                      <li>
+                        <div
+                          className="label-collection"
+                        >
+                          <span>
+                            <span
+                              className="text-capitalize"
+                            >
+                              [
+                              host
+                              ]
+                            </span>
+                             
+                            reviews
+                          </span>
+                        </div>
+                      </li>
+                      <li>
+                        <div
+                          className="label-collection"
+                        >
+                          <span>
+                            <span
+                              className="text-capitalize"
+                            >
+                              [
+                              subset
+                              ]
+                            </span>
+                             
+                            v1
+                          </span>
+                        </div>
+                      </li>
+                      <li>
+                        
+                      </li>
+                    </ul>
+                  </div>,
+                },
+                "ref": null,
+                "rendered": Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": Array [
+                      <strong
+                        className="text-capitalize"
+                      >
+                        destination
+                      </strong>,
+                      undefined,
+                      <ul
+                        style={
+                          Object {
+                            "listStyleType": "none",
+                          }
+                        }
+                      >
+                        <li>
+                          <div
+                            className="label-collection"
+                          >
+                            <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                host
+                                ]
+                              </span>
+                               
+                              reviews
+                            </span>
+                          </div>
+                        </li>
+                        <li>
+                          <div
+                            className="label-collection"
+                          >
+                            <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                subset
+                                ]
+                              </span>
+                               
+                              v1
+                            </span>
+                          </div>
+                        </li>
+                        <li>
+                          
+                        </li>
+                      </ul>,
+                    ],
+                  },
+                  "ref": null,
+                  "rendered": Array [
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": "destination",
+                        "className": "text-capitalize",
+                      },
+                      "ref": null,
+                      "rendered": "destination",
+                      "type": "strong",
+                    },
+                    undefined,
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": Array [
+                          <li>
+                            <div
+                              className="label-collection"
+                            >
+                              <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  host
+                                  ]
+                                </span>
+                                 
+                                reviews
+                              </span>
+                            </div>
+                          </li>,
+                          <li>
+                            <div
+                              className="label-collection"
+                            >
+                              <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  subset
+                                  ]
+                                </span>
+                                 
+                                v1
+                              </span>
+                            </div>
+                          </li>,
+                          <li>
+                            
+                          </li>,
+                        ],
+                        "style": Object {
+                          "listStyleType": "none",
+                        },
+                      },
+                      "ref": null,
+                      "rendered": Array [
+                        Object {
+                          "instance": null,
+                          "key": "key_sssssssss_k0",
+                          "nodeType": "host",
+                          "props": Object {
+                            "children": <div
+                              className="label-collection"
+                            >
+                              <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  host
+                                  ]
+                                </span>
+                                 
+                                reviews
+                              </span>
+                            </div>,
+                          },
+                          "ref": null,
+                          "rendered": Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "host",
+                            "props": Object {
+                              "children": <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  host
+                                  ]
+                                </span>
+                                 
+                                reviews
+                              </span>,
+                              "className": "label-collection",
+                            },
+                            "ref": null,
+                            "rendered": Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "host",
+                              "props": Object {
+                                "children": Array [
+                                  <span
+                                    className="text-capitalize"
+                                  >
+                                    [
+                                    host
+                                    ]
+                                  </span>,
+                                  " ",
+                                  "reviews",
+                                ],
+                              },
+                              "ref": null,
+                              "rendered": Array [
+                                Object {
+                                  "instance": null,
+                                  "key": undefined,
+                                  "nodeType": "host",
+                                  "props": Object {
+                                    "children": Array [
+                                      "[",
+                                      "host",
+                                      "]",
+                                    ],
+                                    "className": "text-capitalize",
+                                  },
+                                  "ref": null,
+                                  "rendered": Array [
+                                    "[",
+                                    "host",
+                                    "]",
+                                  ],
+                                  "type": "span",
+                                },
+                                " ",
+                                "reviews",
+                              ],
+                              "type": "span",
+                            },
+                            "type": "div",
+                          },
+                          "type": "li",
+                        },
+                        Object {
+                          "instance": null,
+                          "key": "key_sssssssss_k1",
+                          "nodeType": "host",
+                          "props": Object {
+                            "children": <div
+                              className="label-collection"
+                            >
+                              <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  subset
+                                  ]
+                                </span>
+                                 
+                                v1
+                              </span>
+                            </div>,
+                          },
+                          "ref": null,
+                          "rendered": Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "host",
+                            "props": Object {
+                              "children": <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  subset
+                                  ]
+                                </span>
+                                 
+                                v1
+                              </span>,
+                              "className": "label-collection",
+                            },
+                            "ref": null,
+                            "rendered": Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "host",
+                              "props": Object {
+                                "children": Array [
+                                  <span
+                                    className="text-capitalize"
+                                  >
+                                    [
+                                    subset
+                                    ]
+                                  </span>,
+                                  " ",
+                                  "v1",
+                                ],
+                              },
+                              "ref": null,
+                              "rendered": Array [
+                                Object {
+                                  "instance": null,
+                                  "key": undefined,
+                                  "nodeType": "host",
+                                  "props": Object {
+                                    "children": Array [
+                                      "[",
+                                      "subset",
+                                      "]",
+                                    ],
+                                    "className": "text-capitalize",
+                                  },
+                                  "ref": null,
+                                  "rendered": Array [
+                                    "[",
+                                    "subset",
+                                    "]",
+                                  ],
+                                  "type": "span",
+                                },
+                                " ",
+                                "v1",
+                              ],
+                              "type": "span",
+                            },
+                            "type": "div",
+                          },
+                          "type": "li",
+                        },
+                        Object {
+                          "instance": null,
+                          "key": "key_sssssssss_k2",
+                          "nodeType": "host",
+                          "props": Object {
+                            "children": "",
+                          },
+                          "ref": null,
+                          "rendered": "",
+                          "type": "li",
+                        },
+                      ],
+                      "type": "ul",
+                    },
+                  ],
+                  "type": "div",
+                },
+                "type": "li",
+              },
+              Object {
+                "instance": null,
+                "key": "key_sssssssss_k1",
+                "nodeType": "host",
+                "props": Object {
+                  "children": <div
+                    className="label-collection"
+                  >
+                    <span>
+                      <span
+                        className="text-capitalize"
+                      >
+                        [
+                        weight
+                        ]
+                      </span>
+                       
+                      85
+                    </span>
+                  </div>,
+                },
+                "ref": null,
+                "rendered": Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": <span>
+                      <span
+                        className="text-capitalize"
+                      >
+                        [
+                        weight
+                        ]
+                      </span>
+                       
+                      85
+                    </span>,
+                    "className": "label-collection",
+                  },
+                  "ref": null,
+                  "rendered": Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": Array [
+                        <span
+                          className="text-capitalize"
+                        >
+                          [
+                          weight
+                          ]
+                        </span>,
+                        " ",
+                        85,
+                      ],
+                    },
+                    "ref": null,
+                    "rendered": Array [
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": Array [
+                            "[",
+                            "weight",
+                            "]",
+                          ],
+                          "className": "text-capitalize",
+                        },
+                        "ref": null,
+                        "rendered": Array [
+                          "[",
+                          "weight",
+                          "]",
+                        ],
+                        "type": "span",
+                      },
+                      " ",
+                      85,
+                    ],
+                    "type": "span",
+                  },
+                  "type": "div",
+                },
+                "type": "li",
+              },
+            ],
+            "type": "ul",
+          },
+        ],
+        "type": "div",
+      },
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;
+
+exports[`DetailObject test prints a nested list with all attributes in the detail 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <DetailObject
+    detail={
+      Object {
+        "destination": Object {
+          "host": "reviews",
+          "port": Object {
+            "name": "ssh",
+            "number": 22,
+          },
+          "subset": "v1",
+        },
+        "weight": 85,
+      }
+    }
+    name="nodejs"
+  />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": <div>
+        <strong
+          className="text-capitalize"
+        >
+          nodejs
+        </strong>
+        <ul
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <li>
+            <div>
+              <strong
+                className="text-capitalize"
+              >
+                destination
+              </strong>
+              <ul
+                style={
+                  Object {
+                    "listStyleType": "none",
+                  }
+                }
+              >
+                <li>
+                  <div
+                    className="label-collection"
+                  >
+                    <span>
+                      <span
+                        className="text-capitalize"
+                      >
+                        [
+                        host
+                        ]
+                      </span>
+                       
+                      reviews
+                    </span>
+                  </div>
+                </li>
+                <li>
+                  <div
+                    className="label-collection"
+                  >
+                    <span>
+                      <span
+                        className="text-capitalize"
+                      >
+                        [
+                        subset
+                        ]
+                      </span>
+                       
+                      v1
+                    </span>
+                  </div>
+                </li>
+                <li>
+                  <div>
+                    <strong
+                      className="text-capitalize"
+                    >
+                      port
+                    </strong>
+                    <ul
+                      style={
+                        Object {
+                          "listStyleType": "none",
+                        }
+                      }
+                    >
+                      <li>
+                        <div
+                          className="label-collection"
+                        >
+                          <span>
+                            <span
+                              className="text-capitalize"
+                            >
+                              [
+                              number
+                              ]
+                            </span>
+                             
+                            22
+                          </span>
+                        </div>
+                      </li>
+                      <li>
+                        <div
+                          className="label-collection"
+                        >
+                          <span>
+                            <span
+                              className="text-capitalize"
+                            >
+                              [
+                              name
+                              ]
+                            </span>
+                             
+                            ssh
+                          </span>
+                        </div>
+                      </li>
+                    </ul>
+                  </div>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li>
+            <div
+              className="label-collection"
+            >
+              <span>
+                <span
+                  className="text-capitalize"
+                >
+                  [
+                  weight
+                  ]
+                </span>
+                 
+                85
+              </span>
+            </div>
+          </li>
+        </ul>
+      </div>,
+    },
+    "ref": null,
+    "rendered": Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <strong
+            className="text-capitalize"
+          >
+            nodejs
+          </strong>,
+          undefined,
+          <ul
+            style={
+              Object {
+                "listStyleType": "none",
+              }
+            }
+          >
+            <li>
+              <div>
+                <strong
+                  className="text-capitalize"
+                >
+                  destination
+                </strong>
+                <ul
+                  style={
+                    Object {
+                      "listStyleType": "none",
+                    }
+                  }
+                >
+                  <li>
+                    <div
+                      className="label-collection"
+                    >
+                      <span>
+                        <span
+                          className="text-capitalize"
+                        >
+                          [
+                          host
+                          ]
+                        </span>
+                         
+                        reviews
+                      </span>
+                    </div>
+                  </li>
+                  <li>
+                    <div
+                      className="label-collection"
+                    >
+                      <span>
+                        <span
+                          className="text-capitalize"
+                        >
+                          [
+                          subset
+                          ]
+                        </span>
+                         
+                        v1
+                      </span>
+                    </div>
+                  </li>
+                  <li>
+                    <div>
+                      <strong
+                        className="text-capitalize"
+                      >
+                        port
+                      </strong>
+                      <ul
+                        style={
+                          Object {
+                            "listStyleType": "none",
+                          }
+                        }
+                      >
+                        <li>
+                          <div
+                            className="label-collection"
+                          >
+                            <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                number
+                                ]
+                              </span>
+                               
+                              22
+                            </span>
+                          </div>
+                        </li>
+                        <li>
+                          <div
+                            className="label-collection"
+                          >
+                            <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                name
+                                ]
+                              </span>
+                               
+                              ssh
+                            </span>
+                          </div>
+                        </li>
+                      </ul>
+                    </div>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li>
+              <div
+                className="label-collection"
+              >
+                <span>
+                  <span
+                    className="text-capitalize"
+                  >
+                    [
+                    weight
+                    ]
+                  </span>
+                   
+                  85
+                </span>
+              </div>
+            </li>
+          </ul>,
+        ],
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": "nodejs",
+            "className": "text-capitalize",
+          },
+          "ref": null,
+          "rendered": "nodejs",
+          "type": "strong",
+        },
+        undefined,
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              <li>
+                <div>
+                  <strong
+                    className="text-capitalize"
+                  >
+                    destination
+                  </strong>
+                  <ul
+                    style={
+                      Object {
+                        "listStyleType": "none",
+                      }
+                    }
+                  >
+                    <li>
+                      <div
+                        className="label-collection"
+                      >
+                        <span>
+                          <span
+                            className="text-capitalize"
+                          >
+                            [
+                            host
+                            ]
+                          </span>
+                           
+                          reviews
+                        </span>
+                      </div>
+                    </li>
+                    <li>
+                      <div
+                        className="label-collection"
+                      >
+                        <span>
+                          <span
+                            className="text-capitalize"
+                          >
+                            [
+                            subset
+                            ]
+                          </span>
+                           
+                          v1
+                        </span>
+                      </div>
+                    </li>
+                    <li>
+                      <div>
+                        <strong
+                          className="text-capitalize"
+                        >
+                          port
+                        </strong>
+                        <ul
+                          style={
+                            Object {
+                              "listStyleType": "none",
+                            }
+                          }
+                        >
+                          <li>
+                            <div
+                              className="label-collection"
+                            >
+                              <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  number
+                                  ]
+                                </span>
+                                 
+                                22
+                              </span>
+                            </div>
+                          </li>
+                          <li>
+                            <div
+                              className="label-collection"
+                            >
+                              <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  name
+                                  ]
+                                </span>
+                                 
+                                ssh
+                              </span>
+                            </div>
+                          </li>
+                        </ul>
+                      </div>
+                    </li>
+                  </ul>
+                </div>
+              </li>,
+              <li>
+                <div
+                  className="label-collection"
+                >
+                  <span>
+                    <span
+                      className="text-capitalize"
+                    >
+                      [
+                      weight
+                      ]
+                    </span>
+                     
+                    85
+                  </span>
+                </div>
+              </li>,
+            ],
+            "style": Object {
+              "listStyleType": "none",
+            },
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": "key_sssssssss_k0",
+              "nodeType": "host",
+              "props": Object {
+                "children": <div>
+                  <strong
+                    className="text-capitalize"
+                  >
+                    destination
+                  </strong>
+                  <ul
+                    style={
+                      Object {
+                        "listStyleType": "none",
+                      }
+                    }
+                  >
+                    <li>
+                      <div
+                        className="label-collection"
+                      >
+                        <span>
+                          <span
+                            className="text-capitalize"
+                          >
+                            [
+                            host
+                            ]
+                          </span>
+                           
+                          reviews
+                        </span>
+                      </div>
+                    </li>
+                    <li>
+                      <div
+                        className="label-collection"
+                      >
+                        <span>
+                          <span
+                            className="text-capitalize"
+                          >
+                            [
+                            subset
+                            ]
+                          </span>
+                           
+                          v1
+                        </span>
+                      </div>
+                    </li>
+                    <li>
+                      <div>
+                        <strong
+                          className="text-capitalize"
+                        >
+                          port
+                        </strong>
+                        <ul
+                          style={
+                            Object {
+                              "listStyleType": "none",
+                            }
+                          }
+                        >
+                          <li>
+                            <div
+                              className="label-collection"
+                            >
+                              <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  number
+                                  ]
+                                </span>
+                                 
+                                22
+                              </span>
+                            </div>
+                          </li>
+                          <li>
+                            <div
+                              className="label-collection"
+                            >
+                              <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  name
+                                  ]
+                                </span>
+                                 
+                                ssh
+                              </span>
+                            </div>
+                          </li>
+                        </ul>
+                      </div>
+                    </li>
+                  </ul>
+                </div>,
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": Array [
+                    <strong
+                      className="text-capitalize"
+                    >
+                      destination
+                    </strong>,
+                    undefined,
+                    <ul
+                      style={
+                        Object {
+                          "listStyleType": "none",
+                        }
+                      }
+                    >
+                      <li>
+                        <div
+                          className="label-collection"
+                        >
+                          <span>
+                            <span
+                              className="text-capitalize"
+                            >
+                              [
+                              host
+                              ]
+                            </span>
+                             
+                            reviews
+                          </span>
+                        </div>
+                      </li>
+                      <li>
+                        <div
+                          className="label-collection"
+                        >
+                          <span>
+                            <span
+                              className="text-capitalize"
+                            >
+                              [
+                              subset
+                              ]
+                            </span>
+                             
+                            v1
+                          </span>
+                        </div>
+                      </li>
+                      <li>
+                        <div>
+                          <strong
+                            className="text-capitalize"
+                          >
+                            port
+                          </strong>
+                          <ul
+                            style={
+                              Object {
+                                "listStyleType": "none",
+                              }
+                            }
+                          >
+                            <li>
+                              <div
+                                className="label-collection"
+                              >
+                                <span>
+                                  <span
+                                    className="text-capitalize"
+                                  >
+                                    [
+                                    number
+                                    ]
+                                  </span>
+                                   
+                                  22
+                                </span>
+                              </div>
+                            </li>
+                            <li>
+                              <div
+                                className="label-collection"
+                              >
+                                <span>
+                                  <span
+                                    className="text-capitalize"
+                                  >
+                                    [
+                                    name
+                                    ]
+                                  </span>
+                                   
+                                  ssh
+                                </span>
+                              </div>
+                            </li>
+                          </ul>
+                        </div>
+                      </li>
+                    </ul>,
+                  ],
+                },
+                "ref": null,
+                "rendered": Array [
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": "destination",
+                      "className": "text-capitalize",
+                    },
+                    "ref": null,
+                    "rendered": "destination",
+                    "type": "strong",
+                  },
+                  undefined,
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": Array [
+                        <li>
+                          <div
+                            className="label-collection"
+                          >
+                            <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                host
+                                ]
+                              </span>
+                               
+                              reviews
+                            </span>
+                          </div>
+                        </li>,
+                        <li>
+                          <div
+                            className="label-collection"
+                          >
+                            <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                subset
+                                ]
+                              </span>
+                               
+                              v1
+                            </span>
+                          </div>
+                        </li>,
+                        <li>
+                          <div>
+                            <strong
+                              className="text-capitalize"
+                            >
+                              port
+                            </strong>
+                            <ul
+                              style={
+                                Object {
+                                  "listStyleType": "none",
+                                }
+                              }
+                            >
+                              <li>
+                                <div
+                                  className="label-collection"
+                                >
+                                  <span>
+                                    <span
+                                      className="text-capitalize"
+                                    >
+                                      [
+                                      number
+                                      ]
+                                    </span>
+                                     
+                                    22
+                                  </span>
+                                </div>
+                              </li>
+                              <li>
+                                <div
+                                  className="label-collection"
+                                >
+                                  <span>
+                                    <span
+                                      className="text-capitalize"
+                                    >
+                                      [
+                                      name
+                                      ]
+                                    </span>
+                                     
+                                    ssh
+                                  </span>
+                                </div>
+                              </li>
+                            </ul>
+                          </div>
+                        </li>,
+                      ],
+                      "style": Object {
+                        "listStyleType": "none",
+                      },
+                    },
+                    "ref": null,
+                    "rendered": Array [
+                      Object {
+                        "instance": null,
+                        "key": "key_sssssssss_k0",
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": <div
+                            className="label-collection"
+                          >
+                            <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                host
+                                ]
+                              </span>
+                               
+                              reviews
+                            </span>
+                          </div>,
+                        },
+                        "ref": null,
+                        "rendered": Object {
+                          "instance": null,
+                          "key": undefined,
+                          "nodeType": "host",
+                          "props": Object {
+                            "children": <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                host
+                                ]
+                              </span>
+                               
+                              reviews
+                            </span>,
+                            "className": "label-collection",
+                          },
+                          "ref": null,
+                          "rendered": Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "host",
+                            "props": Object {
+                              "children": Array [
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  host
+                                  ]
+                                </span>,
+                                " ",
+                                "reviews",
+                              ],
+                            },
+                            "ref": null,
+                            "rendered": Array [
+                              Object {
+                                "instance": null,
+                                "key": undefined,
+                                "nodeType": "host",
+                                "props": Object {
+                                  "children": Array [
+                                    "[",
+                                    "host",
+                                    "]",
+                                  ],
+                                  "className": "text-capitalize",
+                                },
+                                "ref": null,
+                                "rendered": Array [
+                                  "[",
+                                  "host",
+                                  "]",
+                                ],
+                                "type": "span",
+                              },
+                              " ",
+                              "reviews",
+                            ],
+                            "type": "span",
+                          },
+                          "type": "div",
+                        },
+                        "type": "li",
+                      },
+                      Object {
+                        "instance": null,
+                        "key": "key_sssssssss_k1",
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": <div
+                            className="label-collection"
+                          >
+                            <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                subset
+                                ]
+                              </span>
+                               
+                              v1
+                            </span>
+                          </div>,
+                        },
+                        "ref": null,
+                        "rendered": Object {
+                          "instance": null,
+                          "key": undefined,
+                          "nodeType": "host",
+                          "props": Object {
+                            "children": <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                subset
+                                ]
+                              </span>
+                               
+                              v1
+                            </span>,
+                            "className": "label-collection",
+                          },
+                          "ref": null,
+                          "rendered": Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "host",
+                            "props": Object {
+                              "children": Array [
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  subset
+                                  ]
+                                </span>,
+                                " ",
+                                "v1",
+                              ],
+                            },
+                            "ref": null,
+                            "rendered": Array [
+                              Object {
+                                "instance": null,
+                                "key": undefined,
+                                "nodeType": "host",
+                                "props": Object {
+                                  "children": Array [
+                                    "[",
+                                    "subset",
+                                    "]",
+                                  ],
+                                  "className": "text-capitalize",
+                                },
+                                "ref": null,
+                                "rendered": Array [
+                                  "[",
+                                  "subset",
+                                  "]",
+                                ],
+                                "type": "span",
+                              },
+                              " ",
+                              "v1",
+                            ],
+                            "type": "span",
+                          },
+                          "type": "div",
+                        },
+                        "type": "li",
+                      },
+                      Object {
+                        "instance": null,
+                        "key": "key_sssssssss_k2",
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": <div>
+                            <strong
+                              className="text-capitalize"
+                            >
+                              port
+                            </strong>
+                            <ul
+                              style={
+                                Object {
+                                  "listStyleType": "none",
+                                }
+                              }
+                            >
+                              <li>
+                                <div
+                                  className="label-collection"
+                                >
+                                  <span>
+                                    <span
+                                      className="text-capitalize"
+                                    >
+                                      [
+                                      number
+                                      ]
+                                    </span>
+                                     
+                                    22
+                                  </span>
+                                </div>
+                              </li>
+                              <li>
+                                <div
+                                  className="label-collection"
+                                >
+                                  <span>
+                                    <span
+                                      className="text-capitalize"
+                                    >
+                                      [
+                                      name
+                                      ]
+                                    </span>
+                                     
+                                    ssh
+                                  </span>
+                                </div>
+                              </li>
+                            </ul>
+                          </div>,
+                        },
+                        "ref": null,
+                        "rendered": Object {
+                          "instance": null,
+                          "key": undefined,
+                          "nodeType": "host",
+                          "props": Object {
+                            "children": Array [
+                              <strong
+                                className="text-capitalize"
+                              >
+                                port
+                              </strong>,
+                              undefined,
+                              <ul
+                                style={
+                                  Object {
+                                    "listStyleType": "none",
+                                  }
+                                }
+                              >
+                                <li>
+                                  <div
+                                    className="label-collection"
+                                  >
+                                    <span>
+                                      <span
+                                        className="text-capitalize"
+                                      >
+                                        [
+                                        number
+                                        ]
+                                      </span>
+                                       
+                                      22
+                                    </span>
+                                  </div>
+                                </li>
+                                <li>
+                                  <div
+                                    className="label-collection"
+                                  >
+                                    <span>
+                                      <span
+                                        className="text-capitalize"
+                                      >
+                                        [
+                                        name
+                                        ]
+                                      </span>
+                                       
+                                      ssh
+                                    </span>
+                                  </div>
+                                </li>
+                              </ul>,
+                            ],
+                          },
+                          "ref": null,
+                          "rendered": Array [
+                            Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "host",
+                              "props": Object {
+                                "children": "port",
+                                "className": "text-capitalize",
+                              },
+                              "ref": null,
+                              "rendered": "port",
+                              "type": "strong",
+                            },
+                            undefined,
+                            Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "host",
+                              "props": Object {
+                                "children": Array [
+                                  <li>
+                                    <div
+                                      className="label-collection"
+                                    >
+                                      <span>
+                                        <span
+                                          className="text-capitalize"
+                                        >
+                                          [
+                                          number
+                                          ]
+                                        </span>
+                                         
+                                        22
+                                      </span>
+                                    </div>
+                                  </li>,
+                                  <li>
+                                    <div
+                                      className="label-collection"
+                                    >
+                                      <span>
+                                        <span
+                                          className="text-capitalize"
+                                        >
+                                          [
+                                          name
+                                          ]
+                                        </span>
+                                         
+                                        ssh
+                                      </span>
+                                    </div>
+                                  </li>,
+                                ],
+                                "style": Object {
+                                  "listStyleType": "none",
+                                },
+                              },
+                              "ref": null,
+                              "rendered": Array [
+                                Object {
+                                  "instance": null,
+                                  "key": "key_sssssssss_k0",
+                                  "nodeType": "host",
+                                  "props": Object {
+                                    "children": <div
+                                      className="label-collection"
+                                    >
+                                      <span>
+                                        <span
+                                          className="text-capitalize"
+                                        >
+                                          [
+                                          number
+                                          ]
+                                        </span>
+                                         
+                                        22
+                                      </span>
+                                    </div>,
+                                  },
+                                  "ref": null,
+                                  "rendered": Object {
+                                    "instance": null,
+                                    "key": undefined,
+                                    "nodeType": "host",
+                                    "props": Object {
+                                      "children": <span>
+                                        <span
+                                          className="text-capitalize"
+                                        >
+                                          [
+                                          number
+                                          ]
+                                        </span>
+                                         
+                                        22
+                                      </span>,
+                                      "className": "label-collection",
+                                    },
+                                    "ref": null,
+                                    "rendered": Object {
+                                      "instance": null,
+                                      "key": undefined,
+                                      "nodeType": "host",
+                                      "props": Object {
+                                        "children": Array [
+                                          <span
+                                            className="text-capitalize"
+                                          >
+                                            [
+                                            number
+                                            ]
+                                          </span>,
+                                          " ",
+                                          22,
+                                        ],
+                                      },
+                                      "ref": null,
+                                      "rendered": Array [
+                                        Object {
+                                          "instance": null,
+                                          "key": undefined,
+                                          "nodeType": "host",
+                                          "props": Object {
+                                            "children": Array [
+                                              "[",
+                                              "number",
+                                              "]",
+                                            ],
+                                            "className": "text-capitalize",
+                                          },
+                                          "ref": null,
+                                          "rendered": Array [
+                                            "[",
+                                            "number",
+                                            "]",
+                                          ],
+                                          "type": "span",
+                                        },
+                                        " ",
+                                        22,
+                                      ],
+                                      "type": "span",
+                                    },
+                                    "type": "div",
+                                  },
+                                  "type": "li",
+                                },
+                                Object {
+                                  "instance": null,
+                                  "key": "key_sssssssss_k1",
+                                  "nodeType": "host",
+                                  "props": Object {
+                                    "children": <div
+                                      className="label-collection"
+                                    >
+                                      <span>
+                                        <span
+                                          className="text-capitalize"
+                                        >
+                                          [
+                                          name
+                                          ]
+                                        </span>
+                                         
+                                        ssh
+                                      </span>
+                                    </div>,
+                                  },
+                                  "ref": null,
+                                  "rendered": Object {
+                                    "instance": null,
+                                    "key": undefined,
+                                    "nodeType": "host",
+                                    "props": Object {
+                                      "children": <span>
+                                        <span
+                                          className="text-capitalize"
+                                        >
+                                          [
+                                          name
+                                          ]
+                                        </span>
+                                         
+                                        ssh
+                                      </span>,
+                                      "className": "label-collection",
+                                    },
+                                    "ref": null,
+                                    "rendered": Object {
+                                      "instance": null,
+                                      "key": undefined,
+                                      "nodeType": "host",
+                                      "props": Object {
+                                        "children": Array [
+                                          <span
+                                            className="text-capitalize"
+                                          >
+                                            [
+                                            name
+                                            ]
+                                          </span>,
+                                          " ",
+                                          "ssh",
+                                        ],
+                                      },
+                                      "ref": null,
+                                      "rendered": Array [
+                                        Object {
+                                          "instance": null,
+                                          "key": undefined,
+                                          "nodeType": "host",
+                                          "props": Object {
+                                            "children": Array [
+                                              "[",
+                                              "name",
+                                              "]",
+                                            ],
+                                            "className": "text-capitalize",
+                                          },
+                                          "ref": null,
+                                          "rendered": Array [
+                                            "[",
+                                            "name",
+                                            "]",
+                                          ],
+                                          "type": "span",
+                                        },
+                                        " ",
+                                        "ssh",
+                                      ],
+                                      "type": "span",
+                                    },
+                                    "type": "div",
+                                  },
+                                  "type": "li",
+                                },
+                              ],
+                              "type": "ul",
+                            },
+                          ],
+                          "type": "div",
+                        },
+                        "type": "li",
+                      },
+                    ],
+                    "type": "ul",
+                  },
+                ],
+                "type": "div",
+              },
+              "type": "li",
+            },
+            Object {
+              "instance": null,
+              "key": "key_sssssssss_k1",
+              "nodeType": "host",
+              "props": Object {
+                "children": <div
+                  className="label-collection"
+                >
+                  <span>
+                    <span
+                      className="text-capitalize"
+                    >
+                      [
+                      weight
+                      ]
+                    </span>
+                     
+                    85
+                  </span>
+                </div>,
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": <span>
+                    <span
+                      className="text-capitalize"
+                    >
+                      [
+                      weight
+                      ]
+                    </span>
+                     
+                    85
+                  </span>,
+                  "className": "label-collection",
+                },
+                "ref": null,
+                "rendered": Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": Array [
+                      <span
+                        className="text-capitalize"
+                      >
+                        [
+                        weight
+                        ]
+                      </span>,
+                      " ",
+                      85,
+                    ],
+                  },
+                  "ref": null,
+                  "rendered": Array [
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": Array [
+                          "[",
+                          "weight",
+                          "]",
+                        ],
+                        "className": "text-capitalize",
+                      },
+                      "ref": null,
+                      "rendered": Array [
+                        "[",
+                        "weight",
+                        "]",
+                      ],
+                      "type": "span",
+                    },
+                    " ",
+                    85,
+                  ],
+                  "type": "span",
+                },
+                "type": "div",
+              },
+              "type": "li",
+            },
+          ],
+          "type": "ul",
+        },
+      ],
+      "type": "div",
+    },
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": <div>
+          <strong
+            className="text-capitalize"
+          >
+            nodejs
+          </strong>
+          <ul
+            style={
+              Object {
+                "listStyleType": "none",
+              }
+            }
+          >
+            <li>
+              <div>
+                <strong
+                  className="text-capitalize"
+                >
+                  destination
+                </strong>
+                <ul
+                  style={
+                    Object {
+                      "listStyleType": "none",
+                    }
+                  }
+                >
+                  <li>
+                    <div
+                      className="label-collection"
+                    >
+                      <span>
+                        <span
+                          className="text-capitalize"
+                        >
+                          [
+                          host
+                          ]
+                        </span>
+                         
+                        reviews
+                      </span>
+                    </div>
+                  </li>
+                  <li>
+                    <div
+                      className="label-collection"
+                    >
+                      <span>
+                        <span
+                          className="text-capitalize"
+                        >
+                          [
+                          subset
+                          ]
+                        </span>
+                         
+                        v1
+                      </span>
+                    </div>
+                  </li>
+                  <li>
+                    <div>
+                      <strong
+                        className="text-capitalize"
+                      >
+                        port
+                      </strong>
+                      <ul
+                        style={
+                          Object {
+                            "listStyleType": "none",
+                          }
+                        }
+                      >
+                        <li>
+                          <div
+                            className="label-collection"
+                          >
+                            <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                number
+                                ]
+                              </span>
+                               
+                              22
+                            </span>
+                          </div>
+                        </li>
+                        <li>
+                          <div
+                            className="label-collection"
+                          >
+                            <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                name
+                                ]
+                              </span>
+                               
+                              ssh
+                            </span>
+                          </div>
+                        </li>
+                      </ul>
+                    </div>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li>
+              <div
+                className="label-collection"
+              >
+                <span>
+                  <span
+                    className="text-capitalize"
+                  >
+                    [
+                    weight
+                    ]
+                  </span>
+                   
+                  85
+                </span>
+              </div>
+            </li>
+          </ul>
+        </div>,
+      },
+      "ref": null,
+      "rendered": Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            <strong
+              className="text-capitalize"
+            >
+              nodejs
+            </strong>,
+            undefined,
+            <ul
+              style={
+                Object {
+                  "listStyleType": "none",
+                }
+              }
+            >
+              <li>
+                <div>
+                  <strong
+                    className="text-capitalize"
+                  >
+                    destination
+                  </strong>
+                  <ul
+                    style={
+                      Object {
+                        "listStyleType": "none",
+                      }
+                    }
+                  >
+                    <li>
+                      <div
+                        className="label-collection"
+                      >
+                        <span>
+                          <span
+                            className="text-capitalize"
+                          >
+                            [
+                            host
+                            ]
+                          </span>
+                           
+                          reviews
+                        </span>
+                      </div>
+                    </li>
+                    <li>
+                      <div
+                        className="label-collection"
+                      >
+                        <span>
+                          <span
+                            className="text-capitalize"
+                          >
+                            [
+                            subset
+                            ]
+                          </span>
+                           
+                          v1
+                        </span>
+                      </div>
+                    </li>
+                    <li>
+                      <div>
+                        <strong
+                          className="text-capitalize"
+                        >
+                          port
+                        </strong>
+                        <ul
+                          style={
+                            Object {
+                              "listStyleType": "none",
+                            }
+                          }
+                        >
+                          <li>
+                            <div
+                              className="label-collection"
+                            >
+                              <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  number
+                                  ]
+                                </span>
+                                 
+                                22
+                              </span>
+                            </div>
+                          </li>
+                          <li>
+                            <div
+                              className="label-collection"
+                            >
+                              <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  name
+                                  ]
+                                </span>
+                                 
+                                ssh
+                              </span>
+                            </div>
+                          </li>
+                        </ul>
+                      </div>
+                    </li>
+                  </ul>
+                </div>
+              </li>
+              <li>
+                <div
+                  className="label-collection"
+                >
+                  <span>
+                    <span
+                      className="text-capitalize"
+                    >
+                      [
+                      weight
+                      ]
+                    </span>
+                     
+                    85
+                  </span>
+                </div>
+              </li>
+            </ul>,
+          ],
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": "nodejs",
+              "className": "text-capitalize",
+            },
+            "ref": null,
+            "rendered": "nodejs",
+            "type": "strong",
+          },
+          undefined,
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": Array [
+                <li>
+                  <div>
+                    <strong
+                      className="text-capitalize"
+                    >
+                      destination
+                    </strong>
+                    <ul
+                      style={
+                        Object {
+                          "listStyleType": "none",
+                        }
+                      }
+                    >
+                      <li>
+                        <div
+                          className="label-collection"
+                        >
+                          <span>
+                            <span
+                              className="text-capitalize"
+                            >
+                              [
+                              host
+                              ]
+                            </span>
+                             
+                            reviews
+                          </span>
+                        </div>
+                      </li>
+                      <li>
+                        <div
+                          className="label-collection"
+                        >
+                          <span>
+                            <span
+                              className="text-capitalize"
+                            >
+                              [
+                              subset
+                              ]
+                            </span>
+                             
+                            v1
+                          </span>
+                        </div>
+                      </li>
+                      <li>
+                        <div>
+                          <strong
+                            className="text-capitalize"
+                          >
+                            port
+                          </strong>
+                          <ul
+                            style={
+                              Object {
+                                "listStyleType": "none",
+                              }
+                            }
+                          >
+                            <li>
+                              <div
+                                className="label-collection"
+                              >
+                                <span>
+                                  <span
+                                    className="text-capitalize"
+                                  >
+                                    [
+                                    number
+                                    ]
+                                  </span>
+                                   
+                                  22
+                                </span>
+                              </div>
+                            </li>
+                            <li>
+                              <div
+                                className="label-collection"
+                              >
+                                <span>
+                                  <span
+                                    className="text-capitalize"
+                                  >
+                                    [
+                                    name
+                                    ]
+                                  </span>
+                                   
+                                  ssh
+                                </span>
+                              </div>
+                            </li>
+                          </ul>
+                        </div>
+                      </li>
+                    </ul>
+                  </div>
+                </li>,
+                <li>
+                  <div
+                    className="label-collection"
+                  >
+                    <span>
+                      <span
+                        className="text-capitalize"
+                      >
+                        [
+                        weight
+                        ]
+                      </span>
+                       
+                      85
+                    </span>
+                  </div>
+                </li>,
+              ],
+              "style": Object {
+                "listStyleType": "none",
+              },
+            },
+            "ref": null,
+            "rendered": Array [
+              Object {
+                "instance": null,
+                "key": "key_sssssssss_k0",
+                "nodeType": "host",
+                "props": Object {
+                  "children": <div>
+                    <strong
+                      className="text-capitalize"
+                    >
+                      destination
+                    </strong>
+                    <ul
+                      style={
+                        Object {
+                          "listStyleType": "none",
+                        }
+                      }
+                    >
+                      <li>
+                        <div
+                          className="label-collection"
+                        >
+                          <span>
+                            <span
+                              className="text-capitalize"
+                            >
+                              [
+                              host
+                              ]
+                            </span>
+                             
+                            reviews
+                          </span>
+                        </div>
+                      </li>
+                      <li>
+                        <div
+                          className="label-collection"
+                        >
+                          <span>
+                            <span
+                              className="text-capitalize"
+                            >
+                              [
+                              subset
+                              ]
+                            </span>
+                             
+                            v1
+                          </span>
+                        </div>
+                      </li>
+                      <li>
+                        <div>
+                          <strong
+                            className="text-capitalize"
+                          >
+                            port
+                          </strong>
+                          <ul
+                            style={
+                              Object {
+                                "listStyleType": "none",
+                              }
+                            }
+                          >
+                            <li>
+                              <div
+                                className="label-collection"
+                              >
+                                <span>
+                                  <span
+                                    className="text-capitalize"
+                                  >
+                                    [
+                                    number
+                                    ]
+                                  </span>
+                                   
+                                  22
+                                </span>
+                              </div>
+                            </li>
+                            <li>
+                              <div
+                                className="label-collection"
+                              >
+                                <span>
+                                  <span
+                                    className="text-capitalize"
+                                  >
+                                    [
+                                    name
+                                    ]
+                                  </span>
+                                   
+                                  ssh
+                                </span>
+                              </div>
+                            </li>
+                          </ul>
+                        </div>
+                      </li>
+                    </ul>
+                  </div>,
+                },
+                "ref": null,
+                "rendered": Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": Array [
+                      <strong
+                        className="text-capitalize"
+                      >
+                        destination
+                      </strong>,
+                      undefined,
+                      <ul
+                        style={
+                          Object {
+                            "listStyleType": "none",
+                          }
+                        }
+                      >
+                        <li>
+                          <div
+                            className="label-collection"
+                          >
+                            <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                host
+                                ]
+                              </span>
+                               
+                              reviews
+                            </span>
+                          </div>
+                        </li>
+                        <li>
+                          <div
+                            className="label-collection"
+                          >
+                            <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                subset
+                                ]
+                              </span>
+                               
+                              v1
+                            </span>
+                          </div>
+                        </li>
+                        <li>
+                          <div>
+                            <strong
+                              className="text-capitalize"
+                            >
+                              port
+                            </strong>
+                            <ul
+                              style={
+                                Object {
+                                  "listStyleType": "none",
+                                }
+                              }
+                            >
+                              <li>
+                                <div
+                                  className="label-collection"
+                                >
+                                  <span>
+                                    <span
+                                      className="text-capitalize"
+                                    >
+                                      [
+                                      number
+                                      ]
+                                    </span>
+                                     
+                                    22
+                                  </span>
+                                </div>
+                              </li>
+                              <li>
+                                <div
+                                  className="label-collection"
+                                >
+                                  <span>
+                                    <span
+                                      className="text-capitalize"
+                                    >
+                                      [
+                                      name
+                                      ]
+                                    </span>
+                                     
+                                    ssh
+                                  </span>
+                                </div>
+                              </li>
+                            </ul>
+                          </div>
+                        </li>
+                      </ul>,
+                    ],
+                  },
+                  "ref": null,
+                  "rendered": Array [
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": "destination",
+                        "className": "text-capitalize",
+                      },
+                      "ref": null,
+                      "rendered": "destination",
+                      "type": "strong",
+                    },
+                    undefined,
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": Array [
+                          <li>
+                            <div
+                              className="label-collection"
+                            >
+                              <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  host
+                                  ]
+                                </span>
+                                 
+                                reviews
+                              </span>
+                            </div>
+                          </li>,
+                          <li>
+                            <div
+                              className="label-collection"
+                            >
+                              <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  subset
+                                  ]
+                                </span>
+                                 
+                                v1
+                              </span>
+                            </div>
+                          </li>,
+                          <li>
+                            <div>
+                              <strong
+                                className="text-capitalize"
+                              >
+                                port
+                              </strong>
+                              <ul
+                                style={
+                                  Object {
+                                    "listStyleType": "none",
+                                  }
+                                }
+                              >
+                                <li>
+                                  <div
+                                    className="label-collection"
+                                  >
+                                    <span>
+                                      <span
+                                        className="text-capitalize"
+                                      >
+                                        [
+                                        number
+                                        ]
+                                      </span>
+                                       
+                                      22
+                                    </span>
+                                  </div>
+                                </li>
+                                <li>
+                                  <div
+                                    className="label-collection"
+                                  >
+                                    <span>
+                                      <span
+                                        className="text-capitalize"
+                                      >
+                                        [
+                                        name
+                                        ]
+                                      </span>
+                                       
+                                      ssh
+                                    </span>
+                                  </div>
+                                </li>
+                              </ul>
+                            </div>
+                          </li>,
+                        ],
+                        "style": Object {
+                          "listStyleType": "none",
+                        },
+                      },
+                      "ref": null,
+                      "rendered": Array [
+                        Object {
+                          "instance": null,
+                          "key": "key_sssssssss_k0",
+                          "nodeType": "host",
+                          "props": Object {
+                            "children": <div
+                              className="label-collection"
+                            >
+                              <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  host
+                                  ]
+                                </span>
+                                 
+                                reviews
+                              </span>
+                            </div>,
+                          },
+                          "ref": null,
+                          "rendered": Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "host",
+                            "props": Object {
+                              "children": <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  host
+                                  ]
+                                </span>
+                                 
+                                reviews
+                              </span>,
+                              "className": "label-collection",
+                            },
+                            "ref": null,
+                            "rendered": Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "host",
+                              "props": Object {
+                                "children": Array [
+                                  <span
+                                    className="text-capitalize"
+                                  >
+                                    [
+                                    host
+                                    ]
+                                  </span>,
+                                  " ",
+                                  "reviews",
+                                ],
+                              },
+                              "ref": null,
+                              "rendered": Array [
+                                Object {
+                                  "instance": null,
+                                  "key": undefined,
+                                  "nodeType": "host",
+                                  "props": Object {
+                                    "children": Array [
+                                      "[",
+                                      "host",
+                                      "]",
+                                    ],
+                                    "className": "text-capitalize",
+                                  },
+                                  "ref": null,
+                                  "rendered": Array [
+                                    "[",
+                                    "host",
+                                    "]",
+                                  ],
+                                  "type": "span",
+                                },
+                                " ",
+                                "reviews",
+                              ],
+                              "type": "span",
+                            },
+                            "type": "div",
+                          },
+                          "type": "li",
+                        },
+                        Object {
+                          "instance": null,
+                          "key": "key_sssssssss_k1",
+                          "nodeType": "host",
+                          "props": Object {
+                            "children": <div
+                              className="label-collection"
+                            >
+                              <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  subset
+                                  ]
+                                </span>
+                                 
+                                v1
+                              </span>
+                            </div>,
+                          },
+                          "ref": null,
+                          "rendered": Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "host",
+                            "props": Object {
+                              "children": <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  subset
+                                  ]
+                                </span>
+                                 
+                                v1
+                              </span>,
+                              "className": "label-collection",
+                            },
+                            "ref": null,
+                            "rendered": Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "host",
+                              "props": Object {
+                                "children": Array [
+                                  <span
+                                    className="text-capitalize"
+                                  >
+                                    [
+                                    subset
+                                    ]
+                                  </span>,
+                                  " ",
+                                  "v1",
+                                ],
+                              },
+                              "ref": null,
+                              "rendered": Array [
+                                Object {
+                                  "instance": null,
+                                  "key": undefined,
+                                  "nodeType": "host",
+                                  "props": Object {
+                                    "children": Array [
+                                      "[",
+                                      "subset",
+                                      "]",
+                                    ],
+                                    "className": "text-capitalize",
+                                  },
+                                  "ref": null,
+                                  "rendered": Array [
+                                    "[",
+                                    "subset",
+                                    "]",
+                                  ],
+                                  "type": "span",
+                                },
+                                " ",
+                                "v1",
+                              ],
+                              "type": "span",
+                            },
+                            "type": "div",
+                          },
+                          "type": "li",
+                        },
+                        Object {
+                          "instance": null,
+                          "key": "key_sssssssss_k2",
+                          "nodeType": "host",
+                          "props": Object {
+                            "children": <div>
+                              <strong
+                                className="text-capitalize"
+                              >
+                                port
+                              </strong>
+                              <ul
+                                style={
+                                  Object {
+                                    "listStyleType": "none",
+                                  }
+                                }
+                              >
+                                <li>
+                                  <div
+                                    className="label-collection"
+                                  >
+                                    <span>
+                                      <span
+                                        className="text-capitalize"
+                                      >
+                                        [
+                                        number
+                                        ]
+                                      </span>
+                                       
+                                      22
+                                    </span>
+                                  </div>
+                                </li>
+                                <li>
+                                  <div
+                                    className="label-collection"
+                                  >
+                                    <span>
+                                      <span
+                                        className="text-capitalize"
+                                      >
+                                        [
+                                        name
+                                        ]
+                                      </span>
+                                       
+                                      ssh
+                                    </span>
+                                  </div>
+                                </li>
+                              </ul>
+                            </div>,
+                          },
+                          "ref": null,
+                          "rendered": Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "host",
+                            "props": Object {
+                              "children": Array [
+                                <strong
+                                  className="text-capitalize"
+                                >
+                                  port
+                                </strong>,
+                                undefined,
+                                <ul
+                                  style={
+                                    Object {
+                                      "listStyleType": "none",
+                                    }
+                                  }
+                                >
+                                  <li>
+                                    <div
+                                      className="label-collection"
+                                    >
+                                      <span>
+                                        <span
+                                          className="text-capitalize"
+                                        >
+                                          [
+                                          number
+                                          ]
+                                        </span>
+                                         
+                                        22
+                                      </span>
+                                    </div>
+                                  </li>
+                                  <li>
+                                    <div
+                                      className="label-collection"
+                                    >
+                                      <span>
+                                        <span
+                                          className="text-capitalize"
+                                        >
+                                          [
+                                          name
+                                          ]
+                                        </span>
+                                         
+                                        ssh
+                                      </span>
+                                    </div>
+                                  </li>
+                                </ul>,
+                              ],
+                            },
+                            "ref": null,
+                            "rendered": Array [
+                              Object {
+                                "instance": null,
+                                "key": undefined,
+                                "nodeType": "host",
+                                "props": Object {
+                                  "children": "port",
+                                  "className": "text-capitalize",
+                                },
+                                "ref": null,
+                                "rendered": "port",
+                                "type": "strong",
+                              },
+                              undefined,
+                              Object {
+                                "instance": null,
+                                "key": undefined,
+                                "nodeType": "host",
+                                "props": Object {
+                                  "children": Array [
+                                    <li>
+                                      <div
+                                        className="label-collection"
+                                      >
+                                        <span>
+                                          <span
+                                            className="text-capitalize"
+                                          >
+                                            [
+                                            number
+                                            ]
+                                          </span>
+                                           
+                                          22
+                                        </span>
+                                      </div>
+                                    </li>,
+                                    <li>
+                                      <div
+                                        className="label-collection"
+                                      >
+                                        <span>
+                                          <span
+                                            className="text-capitalize"
+                                          >
+                                            [
+                                            name
+                                            ]
+                                          </span>
+                                           
+                                          ssh
+                                        </span>
+                                      </div>
+                                    </li>,
+                                  ],
+                                  "style": Object {
+                                    "listStyleType": "none",
+                                  },
+                                },
+                                "ref": null,
+                                "rendered": Array [
+                                  Object {
+                                    "instance": null,
+                                    "key": "key_sssssssss_k0",
+                                    "nodeType": "host",
+                                    "props": Object {
+                                      "children": <div
+                                        className="label-collection"
+                                      >
+                                        <span>
+                                          <span
+                                            className="text-capitalize"
+                                          >
+                                            [
+                                            number
+                                            ]
+                                          </span>
+                                           
+                                          22
+                                        </span>
+                                      </div>,
+                                    },
+                                    "ref": null,
+                                    "rendered": Object {
+                                      "instance": null,
+                                      "key": undefined,
+                                      "nodeType": "host",
+                                      "props": Object {
+                                        "children": <span>
+                                          <span
+                                            className="text-capitalize"
+                                          >
+                                            [
+                                            number
+                                            ]
+                                          </span>
+                                           
+                                          22
+                                        </span>,
+                                        "className": "label-collection",
+                                      },
+                                      "ref": null,
+                                      "rendered": Object {
+                                        "instance": null,
+                                        "key": undefined,
+                                        "nodeType": "host",
+                                        "props": Object {
+                                          "children": Array [
+                                            <span
+                                              className="text-capitalize"
+                                            >
+                                              [
+                                              number
+                                              ]
+                                            </span>,
+                                            " ",
+                                            22,
+                                          ],
+                                        },
+                                        "ref": null,
+                                        "rendered": Array [
+                                          Object {
+                                            "instance": null,
+                                            "key": undefined,
+                                            "nodeType": "host",
+                                            "props": Object {
+                                              "children": Array [
+                                                "[",
+                                                "number",
+                                                "]",
+                                              ],
+                                              "className": "text-capitalize",
+                                            },
+                                            "ref": null,
+                                            "rendered": Array [
+                                              "[",
+                                              "number",
+                                              "]",
+                                            ],
+                                            "type": "span",
+                                          },
+                                          " ",
+                                          22,
+                                        ],
+                                        "type": "span",
+                                      },
+                                      "type": "div",
+                                    },
+                                    "type": "li",
+                                  },
+                                  Object {
+                                    "instance": null,
+                                    "key": "key_sssssssss_k1",
+                                    "nodeType": "host",
+                                    "props": Object {
+                                      "children": <div
+                                        className="label-collection"
+                                      >
+                                        <span>
+                                          <span
+                                            className="text-capitalize"
+                                          >
+                                            [
+                                            name
+                                            ]
+                                          </span>
+                                           
+                                          ssh
+                                        </span>
+                                      </div>,
+                                    },
+                                    "ref": null,
+                                    "rendered": Object {
+                                      "instance": null,
+                                      "key": undefined,
+                                      "nodeType": "host",
+                                      "props": Object {
+                                        "children": <span>
+                                          <span
+                                            className="text-capitalize"
+                                          >
+                                            [
+                                            name
+                                            ]
+                                          </span>
+                                           
+                                          ssh
+                                        </span>,
+                                        "className": "label-collection",
+                                      },
+                                      "ref": null,
+                                      "rendered": Object {
+                                        "instance": null,
+                                        "key": undefined,
+                                        "nodeType": "host",
+                                        "props": Object {
+                                          "children": Array [
+                                            <span
+                                              className="text-capitalize"
+                                            >
+                                              [
+                                              name
+                                              ]
+                                            </span>,
+                                            " ",
+                                            "ssh",
+                                          ],
+                                        },
+                                        "ref": null,
+                                        "rendered": Array [
+                                          Object {
+                                            "instance": null,
+                                            "key": undefined,
+                                            "nodeType": "host",
+                                            "props": Object {
+                                              "children": Array [
+                                                "[",
+                                                "name",
+                                                "]",
+                                              ],
+                                              "className": "text-capitalize",
+                                            },
+                                            "ref": null,
+                                            "rendered": Array [
+                                              "[",
+                                              "name",
+                                              "]",
+                                            ],
+                                            "type": "span",
+                                          },
+                                          " ",
+                                          "ssh",
+                                        ],
+                                        "type": "span",
+                                      },
+                                      "type": "div",
+                                    },
+                                    "type": "li",
+                                  },
+                                ],
+                                "type": "ul",
+                              },
+                            ],
+                            "type": "div",
+                          },
+                          "type": "li",
+                        },
+                      ],
+                      "type": "ul",
+                    },
+                  ],
+                  "type": "div",
+                },
+                "type": "li",
+              },
+              Object {
+                "instance": null,
+                "key": "key_sssssssss_k1",
+                "nodeType": "host",
+                "props": Object {
+                  "children": <div
+                    className="label-collection"
+                  >
+                    <span>
+                      <span
+                        className="text-capitalize"
+                      >
+                        [
+                        weight
+                        ]
+                      </span>
+                       
+                      85
+                    </span>
+                  </div>,
+                },
+                "ref": null,
+                "rendered": Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": <span>
+                      <span
+                        className="text-capitalize"
+                      >
+                        [
+                        weight
+                        ]
+                      </span>
+                       
+                      85
+                    </span>,
+                    "className": "label-collection",
+                  },
+                  "ref": null,
+                  "rendered": Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": Array [
+                        <span
+                          className="text-capitalize"
+                        >
+                          [
+                          weight
+                          ]
+                        </span>,
+                        " ",
+                        85,
+                      ],
+                    },
+                    "ref": null,
+                    "rendered": Array [
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": Array [
+                            "[",
+                            "weight",
+                            "]",
+                          ],
+                          "className": "text-capitalize",
+                        },
+                        "ref": null,
+                        "rendered": Array [
+                          "[",
+                          "weight",
+                          "]",
+                        ],
+                        "type": "span",
+                      },
+                      " ",
+                      85,
+                    ],
+                    "type": "span",
+                  },
+                  "type": "div",
+                },
+                "type": "li",
+              },
+            ],
+            "type": "ul",
+          },
+        ],
+        "type": "div",
+      },
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;
+
+exports[`DetailObject test prints an alert message 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <DetailObject
+    detail={
+      Object {
+        "destination": Object {
+          "host": "reviews",
+          "port": Object {
+            "name": "ssh",
+            "number": 22,
+          },
+          "subset": "v1",
+        },
+        "weight": 85,
+      }
+    }
+    name="nodejs"
+    validation={
+      Object {
+        "icon": "error-circle-o",
+        "message": "Not all checks passed",
+      }
+    }
+  />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": <div>
+        <strong
+          className="text-capitalize"
+        >
+          nodejs
+        </strong>
+        <div>
+          <p
+            style={
+              Object {
+                "color": "red",
+              }
+            }
+          >
+            <Icon
+              name="error-circle-o"
+              type="pf"
+            />
+             
+            Not all checks passed
+          </p>
+        </div>
+        <ul
+          style={
+            Object {
+              "listStyleType": "none",
+            }
+          }
+        >
+          <li>
+            <div>
+              <strong
+                className="text-capitalize"
+              >
+                destination
+              </strong>
+              <ul
+                style={
+                  Object {
+                    "listStyleType": "none",
+                  }
+                }
+              >
+                <li>
+                  <div
+                    className="label-collection"
+                  >
+                    <span>
+                      <span
+                        className="text-capitalize"
+                      >
+                        [
+                        host
+                        ]
+                      </span>
+                       
+                      reviews
+                    </span>
+                  </div>
+                </li>
+                <li>
+                  <div
+                    className="label-collection"
+                  >
+                    <span>
+                      <span
+                        className="text-capitalize"
+                      >
+                        [
+                        subset
+                        ]
+                      </span>
+                       
+                      v1
+                    </span>
+                  </div>
+                </li>
+                <li>
+                  <div>
+                    <strong
+                      className="text-capitalize"
+                    >
+                      port
+                    </strong>
+                    <ul
+                      style={
+                        Object {
+                          "listStyleType": "none",
+                        }
+                      }
+                    >
+                      <li>
+                        <div
+                          className="label-collection"
+                        >
+                          <span>
+                            <span
+                              className="text-capitalize"
+                            >
+                              [
+                              number
+                              ]
+                            </span>
+                             
+                            22
+                          </span>
+                        </div>
+                      </li>
+                      <li>
+                        <div
+                          className="label-collection"
+                        >
+                          <span>
+                            <span
+                              className="text-capitalize"
+                            >
+                              [
+                              name
+                              ]
+                            </span>
+                             
+                            ssh
+                          </span>
+                        </div>
+                      </li>
+                    </ul>
+                  </div>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li>
+            <div
+              className="label-collection"
+            >
+              <span>
+                <span
+                  className="text-capitalize"
+                >
+                  [
+                  weight
+                  ]
+                </span>
+                 
+                85
+              </span>
+            </div>
+          </li>
+        </ul>
+      </div>,
+    },
+    "ref": null,
+    "rendered": Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <strong
+            className="text-capitalize"
+          >
+            nodejs
+          </strong>,
+          <div>
+            <p
+              style={
+                Object {
+                  "color": "red",
+                }
+              }
+            >
+              <Icon
+                name="error-circle-o"
+                type="pf"
+              />
+               
+              Not all checks passed
+            </p>
+          </div>,
+          <ul
+            style={
+              Object {
+                "listStyleType": "none",
+              }
+            }
+          >
+            <li>
+              <div>
+                <strong
+                  className="text-capitalize"
+                >
+                  destination
+                </strong>
+                <ul
+                  style={
+                    Object {
+                      "listStyleType": "none",
+                    }
+                  }
+                >
+                  <li>
+                    <div
+                      className="label-collection"
+                    >
+                      <span>
+                        <span
+                          className="text-capitalize"
+                        >
+                          [
+                          host
+                          ]
+                        </span>
+                         
+                        reviews
+                      </span>
+                    </div>
+                  </li>
+                  <li>
+                    <div
+                      className="label-collection"
+                    >
+                      <span>
+                        <span
+                          className="text-capitalize"
+                        >
+                          [
+                          subset
+                          ]
+                        </span>
+                         
+                        v1
+                      </span>
+                    </div>
+                  </li>
+                  <li>
+                    <div>
+                      <strong
+                        className="text-capitalize"
+                      >
+                        port
+                      </strong>
+                      <ul
+                        style={
+                          Object {
+                            "listStyleType": "none",
+                          }
+                        }
+                      >
+                        <li>
+                          <div
+                            className="label-collection"
+                          >
+                            <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                number
+                                ]
+                              </span>
+                               
+                              22
+                            </span>
+                          </div>
+                        </li>
+                        <li>
+                          <div
+                            className="label-collection"
+                          >
+                            <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                name
+                                ]
+                              </span>
+                               
+                              ssh
+                            </span>
+                          </div>
+                        </li>
+                      </ul>
+                    </div>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li>
+              <div
+                className="label-collection"
+              >
+                <span>
+                  <span
+                    className="text-capitalize"
+                  >
+                    [
+                    weight
+                    ]
+                  </span>
+                   
+                  85
+                </span>
+              </div>
+            </li>
+          </ul>,
+        ],
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": "nodejs",
+            "className": "text-capitalize",
+          },
+          "ref": null,
+          "rendered": "nodejs",
+          "type": "strong",
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": <p
+              style={
+                Object {
+                  "color": "red",
+                }
+              }
+            >
+              <Icon
+                name="error-circle-o"
+                type="pf"
+              />
+               
+              Not all checks passed
+            </p>,
+          },
+          "ref": null,
+          "rendered": Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": Array [
+                <Icon
+                  name="error-circle-o"
+                  type="pf"
+                />,
+                " ",
+                "Not all checks passed",
+              ],
+              "style": Object {
+                "color": "red",
+              },
+            },
+            "ref": null,
+            "rendered": Array [
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "function",
+                "props": Object {
+                  "name": "error-circle-o",
+                  "type": "pf",
+                },
+                "ref": null,
+                "rendered": null,
+                "type": [Function],
+              },
+              " ",
+              "Not all checks passed",
+            ],
+            "type": "p",
+          },
+          "type": "div",
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              <li>
+                <div>
+                  <strong
+                    className="text-capitalize"
+                  >
+                    destination
+                  </strong>
+                  <ul
+                    style={
+                      Object {
+                        "listStyleType": "none",
+                      }
+                    }
+                  >
+                    <li>
+                      <div
+                        className="label-collection"
+                      >
+                        <span>
+                          <span
+                            className="text-capitalize"
+                          >
+                            [
+                            host
+                            ]
+                          </span>
+                           
+                          reviews
+                        </span>
+                      </div>
+                    </li>
+                    <li>
+                      <div
+                        className="label-collection"
+                      >
+                        <span>
+                          <span
+                            className="text-capitalize"
+                          >
+                            [
+                            subset
+                            ]
+                          </span>
+                           
+                          v1
+                        </span>
+                      </div>
+                    </li>
+                    <li>
+                      <div>
+                        <strong
+                          className="text-capitalize"
+                        >
+                          port
+                        </strong>
+                        <ul
+                          style={
+                            Object {
+                              "listStyleType": "none",
+                            }
+                          }
+                        >
+                          <li>
+                            <div
+                              className="label-collection"
+                            >
+                              <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  number
+                                  ]
+                                </span>
+                                 
+                                22
+                              </span>
+                            </div>
+                          </li>
+                          <li>
+                            <div
+                              className="label-collection"
+                            >
+                              <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  name
+                                  ]
+                                </span>
+                                 
+                                ssh
+                              </span>
+                            </div>
+                          </li>
+                        </ul>
+                      </div>
+                    </li>
+                  </ul>
+                </div>
+              </li>,
+              <li>
+                <div
+                  className="label-collection"
+                >
+                  <span>
+                    <span
+                      className="text-capitalize"
+                    >
+                      [
+                      weight
+                      ]
+                    </span>
+                     
+                    85
+                  </span>
+                </div>
+              </li>,
+            ],
+            "style": Object {
+              "listStyleType": "none",
+            },
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": "key_sssssssss_k0",
+              "nodeType": "host",
+              "props": Object {
+                "children": <div>
+                  <strong
+                    className="text-capitalize"
+                  >
+                    destination
+                  </strong>
+                  <ul
+                    style={
+                      Object {
+                        "listStyleType": "none",
+                      }
+                    }
+                  >
+                    <li>
+                      <div
+                        className="label-collection"
+                      >
+                        <span>
+                          <span
+                            className="text-capitalize"
+                          >
+                            [
+                            host
+                            ]
+                          </span>
+                           
+                          reviews
+                        </span>
+                      </div>
+                    </li>
+                    <li>
+                      <div
+                        className="label-collection"
+                      >
+                        <span>
+                          <span
+                            className="text-capitalize"
+                          >
+                            [
+                            subset
+                            ]
+                          </span>
+                           
+                          v1
+                        </span>
+                      </div>
+                    </li>
+                    <li>
+                      <div>
+                        <strong
+                          className="text-capitalize"
+                        >
+                          port
+                        </strong>
+                        <ul
+                          style={
+                            Object {
+                              "listStyleType": "none",
+                            }
+                          }
+                        >
+                          <li>
+                            <div
+                              className="label-collection"
+                            >
+                              <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  number
+                                  ]
+                                </span>
+                                 
+                                22
+                              </span>
+                            </div>
+                          </li>
+                          <li>
+                            <div
+                              className="label-collection"
+                            >
+                              <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  name
+                                  ]
+                                </span>
+                                 
+                                ssh
+                              </span>
+                            </div>
+                          </li>
+                        </ul>
+                      </div>
+                    </li>
+                  </ul>
+                </div>,
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": Array [
+                    <strong
+                      className="text-capitalize"
+                    >
+                      destination
+                    </strong>,
+                    undefined,
+                    <ul
+                      style={
+                        Object {
+                          "listStyleType": "none",
+                        }
+                      }
+                    >
+                      <li>
+                        <div
+                          className="label-collection"
+                        >
+                          <span>
+                            <span
+                              className="text-capitalize"
+                            >
+                              [
+                              host
+                              ]
+                            </span>
+                             
+                            reviews
+                          </span>
+                        </div>
+                      </li>
+                      <li>
+                        <div
+                          className="label-collection"
+                        >
+                          <span>
+                            <span
+                              className="text-capitalize"
+                            >
+                              [
+                              subset
+                              ]
+                            </span>
+                             
+                            v1
+                          </span>
+                        </div>
+                      </li>
+                      <li>
+                        <div>
+                          <strong
+                            className="text-capitalize"
+                          >
+                            port
+                          </strong>
+                          <ul
+                            style={
+                              Object {
+                                "listStyleType": "none",
+                              }
+                            }
+                          >
+                            <li>
+                              <div
+                                className="label-collection"
+                              >
+                                <span>
+                                  <span
+                                    className="text-capitalize"
+                                  >
+                                    [
+                                    number
+                                    ]
+                                  </span>
+                                   
+                                  22
+                                </span>
+                              </div>
+                            </li>
+                            <li>
+                              <div
+                                className="label-collection"
+                              >
+                                <span>
+                                  <span
+                                    className="text-capitalize"
+                                  >
+                                    [
+                                    name
+                                    ]
+                                  </span>
+                                   
+                                  ssh
+                                </span>
+                              </div>
+                            </li>
+                          </ul>
+                        </div>
+                      </li>
+                    </ul>,
+                  ],
+                },
+                "ref": null,
+                "rendered": Array [
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": "destination",
+                      "className": "text-capitalize",
+                    },
+                    "ref": null,
+                    "rendered": "destination",
+                    "type": "strong",
+                  },
+                  undefined,
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": Array [
+                        <li>
+                          <div
+                            className="label-collection"
+                          >
+                            <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                host
+                                ]
+                              </span>
+                               
+                              reviews
+                            </span>
+                          </div>
+                        </li>,
+                        <li>
+                          <div
+                            className="label-collection"
+                          >
+                            <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                subset
+                                ]
+                              </span>
+                               
+                              v1
+                            </span>
+                          </div>
+                        </li>,
+                        <li>
+                          <div>
+                            <strong
+                              className="text-capitalize"
+                            >
+                              port
+                            </strong>
+                            <ul
+                              style={
+                                Object {
+                                  "listStyleType": "none",
+                                }
+                              }
+                            >
+                              <li>
+                                <div
+                                  className="label-collection"
+                                >
+                                  <span>
+                                    <span
+                                      className="text-capitalize"
+                                    >
+                                      [
+                                      number
+                                      ]
+                                    </span>
+                                     
+                                    22
+                                  </span>
+                                </div>
+                              </li>
+                              <li>
+                                <div
+                                  className="label-collection"
+                                >
+                                  <span>
+                                    <span
+                                      className="text-capitalize"
+                                    >
+                                      [
+                                      name
+                                      ]
+                                    </span>
+                                     
+                                    ssh
+                                  </span>
+                                </div>
+                              </li>
+                            </ul>
+                          </div>
+                        </li>,
+                      ],
+                      "style": Object {
+                        "listStyleType": "none",
+                      },
+                    },
+                    "ref": null,
+                    "rendered": Array [
+                      Object {
+                        "instance": null,
+                        "key": "key_sssssssss_k0",
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": <div
+                            className="label-collection"
+                          >
+                            <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                host
+                                ]
+                              </span>
+                               
+                              reviews
+                            </span>
+                          </div>,
+                        },
+                        "ref": null,
+                        "rendered": Object {
+                          "instance": null,
+                          "key": undefined,
+                          "nodeType": "host",
+                          "props": Object {
+                            "children": <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                host
+                                ]
+                              </span>
+                               
+                              reviews
+                            </span>,
+                            "className": "label-collection",
+                          },
+                          "ref": null,
+                          "rendered": Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "host",
+                            "props": Object {
+                              "children": Array [
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  host
+                                  ]
+                                </span>,
+                                " ",
+                                "reviews",
+                              ],
+                            },
+                            "ref": null,
+                            "rendered": Array [
+                              Object {
+                                "instance": null,
+                                "key": undefined,
+                                "nodeType": "host",
+                                "props": Object {
+                                  "children": Array [
+                                    "[",
+                                    "host",
+                                    "]",
+                                  ],
+                                  "className": "text-capitalize",
+                                },
+                                "ref": null,
+                                "rendered": Array [
+                                  "[",
+                                  "host",
+                                  "]",
+                                ],
+                                "type": "span",
+                              },
+                              " ",
+                              "reviews",
+                            ],
+                            "type": "span",
+                          },
+                          "type": "div",
+                        },
+                        "type": "li",
+                      },
+                      Object {
+                        "instance": null,
+                        "key": "key_sssssssss_k1",
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": <div
+                            className="label-collection"
+                          >
+                            <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                subset
+                                ]
+                              </span>
+                               
+                              v1
+                            </span>
+                          </div>,
+                        },
+                        "ref": null,
+                        "rendered": Object {
+                          "instance": null,
+                          "key": undefined,
+                          "nodeType": "host",
+                          "props": Object {
+                            "children": <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                subset
+                                ]
+                              </span>
+                               
+                              v1
+                            </span>,
+                            "className": "label-collection",
+                          },
+                          "ref": null,
+                          "rendered": Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "host",
+                            "props": Object {
+                              "children": Array [
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  subset
+                                  ]
+                                </span>,
+                                " ",
+                                "v1",
+                              ],
+                            },
+                            "ref": null,
+                            "rendered": Array [
+                              Object {
+                                "instance": null,
+                                "key": undefined,
+                                "nodeType": "host",
+                                "props": Object {
+                                  "children": Array [
+                                    "[",
+                                    "subset",
+                                    "]",
+                                  ],
+                                  "className": "text-capitalize",
+                                },
+                                "ref": null,
+                                "rendered": Array [
+                                  "[",
+                                  "subset",
+                                  "]",
+                                ],
+                                "type": "span",
+                              },
+                              " ",
+                              "v1",
+                            ],
+                            "type": "span",
+                          },
+                          "type": "div",
+                        },
+                        "type": "li",
+                      },
+                      Object {
+                        "instance": null,
+                        "key": "key_sssssssss_k2",
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": <div>
+                            <strong
+                              className="text-capitalize"
+                            >
+                              port
+                            </strong>
+                            <ul
+                              style={
+                                Object {
+                                  "listStyleType": "none",
+                                }
+                              }
+                            >
+                              <li>
+                                <div
+                                  className="label-collection"
+                                >
+                                  <span>
+                                    <span
+                                      className="text-capitalize"
+                                    >
+                                      [
+                                      number
+                                      ]
+                                    </span>
+                                     
+                                    22
+                                  </span>
+                                </div>
+                              </li>
+                              <li>
+                                <div
+                                  className="label-collection"
+                                >
+                                  <span>
+                                    <span
+                                      className="text-capitalize"
+                                    >
+                                      [
+                                      name
+                                      ]
+                                    </span>
+                                     
+                                    ssh
+                                  </span>
+                                </div>
+                              </li>
+                            </ul>
+                          </div>,
+                        },
+                        "ref": null,
+                        "rendered": Object {
+                          "instance": null,
+                          "key": undefined,
+                          "nodeType": "host",
+                          "props": Object {
+                            "children": Array [
+                              <strong
+                                className="text-capitalize"
+                              >
+                                port
+                              </strong>,
+                              undefined,
+                              <ul
+                                style={
+                                  Object {
+                                    "listStyleType": "none",
+                                  }
+                                }
+                              >
+                                <li>
+                                  <div
+                                    className="label-collection"
+                                  >
+                                    <span>
+                                      <span
+                                        className="text-capitalize"
+                                      >
+                                        [
+                                        number
+                                        ]
+                                      </span>
+                                       
+                                      22
+                                    </span>
+                                  </div>
+                                </li>
+                                <li>
+                                  <div
+                                    className="label-collection"
+                                  >
+                                    <span>
+                                      <span
+                                        className="text-capitalize"
+                                      >
+                                        [
+                                        name
+                                        ]
+                                      </span>
+                                       
+                                      ssh
+                                    </span>
+                                  </div>
+                                </li>
+                              </ul>,
+                            ],
+                          },
+                          "ref": null,
+                          "rendered": Array [
+                            Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "host",
+                              "props": Object {
+                                "children": "port",
+                                "className": "text-capitalize",
+                              },
+                              "ref": null,
+                              "rendered": "port",
+                              "type": "strong",
+                            },
+                            undefined,
+                            Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "host",
+                              "props": Object {
+                                "children": Array [
+                                  <li>
+                                    <div
+                                      className="label-collection"
+                                    >
+                                      <span>
+                                        <span
+                                          className="text-capitalize"
+                                        >
+                                          [
+                                          number
+                                          ]
+                                        </span>
+                                         
+                                        22
+                                      </span>
+                                    </div>
+                                  </li>,
+                                  <li>
+                                    <div
+                                      className="label-collection"
+                                    >
+                                      <span>
+                                        <span
+                                          className="text-capitalize"
+                                        >
+                                          [
+                                          name
+                                          ]
+                                        </span>
+                                         
+                                        ssh
+                                      </span>
+                                    </div>
+                                  </li>,
+                                ],
+                                "style": Object {
+                                  "listStyleType": "none",
+                                },
+                              },
+                              "ref": null,
+                              "rendered": Array [
+                                Object {
+                                  "instance": null,
+                                  "key": "key_sssssssss_k0",
+                                  "nodeType": "host",
+                                  "props": Object {
+                                    "children": <div
+                                      className="label-collection"
+                                    >
+                                      <span>
+                                        <span
+                                          className="text-capitalize"
+                                        >
+                                          [
+                                          number
+                                          ]
+                                        </span>
+                                         
+                                        22
+                                      </span>
+                                    </div>,
+                                  },
+                                  "ref": null,
+                                  "rendered": Object {
+                                    "instance": null,
+                                    "key": undefined,
+                                    "nodeType": "host",
+                                    "props": Object {
+                                      "children": <span>
+                                        <span
+                                          className="text-capitalize"
+                                        >
+                                          [
+                                          number
+                                          ]
+                                        </span>
+                                         
+                                        22
+                                      </span>,
+                                      "className": "label-collection",
+                                    },
+                                    "ref": null,
+                                    "rendered": Object {
+                                      "instance": null,
+                                      "key": undefined,
+                                      "nodeType": "host",
+                                      "props": Object {
+                                        "children": Array [
+                                          <span
+                                            className="text-capitalize"
+                                          >
+                                            [
+                                            number
+                                            ]
+                                          </span>,
+                                          " ",
+                                          22,
+                                        ],
+                                      },
+                                      "ref": null,
+                                      "rendered": Array [
+                                        Object {
+                                          "instance": null,
+                                          "key": undefined,
+                                          "nodeType": "host",
+                                          "props": Object {
+                                            "children": Array [
+                                              "[",
+                                              "number",
+                                              "]",
+                                            ],
+                                            "className": "text-capitalize",
+                                          },
+                                          "ref": null,
+                                          "rendered": Array [
+                                            "[",
+                                            "number",
+                                            "]",
+                                          ],
+                                          "type": "span",
+                                        },
+                                        " ",
+                                        22,
+                                      ],
+                                      "type": "span",
+                                    },
+                                    "type": "div",
+                                  },
+                                  "type": "li",
+                                },
+                                Object {
+                                  "instance": null,
+                                  "key": "key_sssssssss_k1",
+                                  "nodeType": "host",
+                                  "props": Object {
+                                    "children": <div
+                                      className="label-collection"
+                                    >
+                                      <span>
+                                        <span
+                                          className="text-capitalize"
+                                        >
+                                          [
+                                          name
+                                          ]
+                                        </span>
+                                         
+                                        ssh
+                                      </span>
+                                    </div>,
+                                  },
+                                  "ref": null,
+                                  "rendered": Object {
+                                    "instance": null,
+                                    "key": undefined,
+                                    "nodeType": "host",
+                                    "props": Object {
+                                      "children": <span>
+                                        <span
+                                          className="text-capitalize"
+                                        >
+                                          [
+                                          name
+                                          ]
+                                        </span>
+                                         
+                                        ssh
+                                      </span>,
+                                      "className": "label-collection",
+                                    },
+                                    "ref": null,
+                                    "rendered": Object {
+                                      "instance": null,
+                                      "key": undefined,
+                                      "nodeType": "host",
+                                      "props": Object {
+                                        "children": Array [
+                                          <span
+                                            className="text-capitalize"
+                                          >
+                                            [
+                                            name
+                                            ]
+                                          </span>,
+                                          " ",
+                                          "ssh",
+                                        ],
+                                      },
+                                      "ref": null,
+                                      "rendered": Array [
+                                        Object {
+                                          "instance": null,
+                                          "key": undefined,
+                                          "nodeType": "host",
+                                          "props": Object {
+                                            "children": Array [
+                                              "[",
+                                              "name",
+                                              "]",
+                                            ],
+                                            "className": "text-capitalize",
+                                          },
+                                          "ref": null,
+                                          "rendered": Array [
+                                            "[",
+                                            "name",
+                                            "]",
+                                          ],
+                                          "type": "span",
+                                        },
+                                        " ",
+                                        "ssh",
+                                      ],
+                                      "type": "span",
+                                    },
+                                    "type": "div",
+                                  },
+                                  "type": "li",
+                                },
+                              ],
+                              "type": "ul",
+                            },
+                          ],
+                          "type": "div",
+                        },
+                        "type": "li",
+                      },
+                    ],
+                    "type": "ul",
+                  },
+                ],
+                "type": "div",
+              },
+              "type": "li",
+            },
+            Object {
+              "instance": null,
+              "key": "key_sssssssss_k1",
+              "nodeType": "host",
+              "props": Object {
+                "children": <div
+                  className="label-collection"
+                >
+                  <span>
+                    <span
+                      className="text-capitalize"
+                    >
+                      [
+                      weight
+                      ]
+                    </span>
+                     
+                    85
+                  </span>
+                </div>,
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": <span>
+                    <span
+                      className="text-capitalize"
+                    >
+                      [
+                      weight
+                      ]
+                    </span>
+                     
+                    85
+                  </span>,
+                  "className": "label-collection",
+                },
+                "ref": null,
+                "rendered": Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": Array [
+                      <span
+                        className="text-capitalize"
+                      >
+                        [
+                        weight
+                        ]
+                      </span>,
+                      " ",
+                      85,
+                    ],
+                  },
+                  "ref": null,
+                  "rendered": Array [
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": Array [
+                          "[",
+                          "weight",
+                          "]",
+                        ],
+                        "className": "text-capitalize",
+                      },
+                      "ref": null,
+                      "rendered": Array [
+                        "[",
+                        "weight",
+                        "]",
+                      ],
+                      "type": "span",
+                    },
+                    " ",
+                    85,
+                  ],
+                  "type": "span",
+                },
+                "type": "div",
+              },
+              "type": "li",
+            },
+          ],
+          "type": "ul",
+        },
+      ],
+      "type": "div",
+    },
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": <div>
+          <strong
+            className="text-capitalize"
+          >
+            nodejs
+          </strong>
+          <div>
+            <p
+              style={
+                Object {
+                  "color": "red",
+                }
+              }
+            >
+              <Icon
+                name="error-circle-o"
+                type="pf"
+              />
+               
+              Not all checks passed
+            </p>
+          </div>
+          <ul
+            style={
+              Object {
+                "listStyleType": "none",
+              }
+            }
+          >
+            <li>
+              <div>
+                <strong
+                  className="text-capitalize"
+                >
+                  destination
+                </strong>
+                <ul
+                  style={
+                    Object {
+                      "listStyleType": "none",
+                    }
+                  }
+                >
+                  <li>
+                    <div
+                      className="label-collection"
+                    >
+                      <span>
+                        <span
+                          className="text-capitalize"
+                        >
+                          [
+                          host
+                          ]
+                        </span>
+                         
+                        reviews
+                      </span>
+                    </div>
+                  </li>
+                  <li>
+                    <div
+                      className="label-collection"
+                    >
+                      <span>
+                        <span
+                          className="text-capitalize"
+                        >
+                          [
+                          subset
+                          ]
+                        </span>
+                         
+                        v1
+                      </span>
+                    </div>
+                  </li>
+                  <li>
+                    <div>
+                      <strong
+                        className="text-capitalize"
+                      >
+                        port
+                      </strong>
+                      <ul
+                        style={
+                          Object {
+                            "listStyleType": "none",
+                          }
+                        }
+                      >
+                        <li>
+                          <div
+                            className="label-collection"
+                          >
+                            <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                number
+                                ]
+                              </span>
+                               
+                              22
+                            </span>
+                          </div>
+                        </li>
+                        <li>
+                          <div
+                            className="label-collection"
+                          >
+                            <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                name
+                                ]
+                              </span>
+                               
+                              ssh
+                            </span>
+                          </div>
+                        </li>
+                      </ul>
+                    </div>
+                  </li>
+                </ul>
+              </div>
+            </li>
+            <li>
+              <div
+                className="label-collection"
+              >
+                <span>
+                  <span
+                    className="text-capitalize"
+                  >
+                    [
+                    weight
+                    ]
+                  </span>
+                   
+                  85
+                </span>
+              </div>
+            </li>
+          </ul>
+        </div>,
+      },
+      "ref": null,
+      "rendered": Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            <strong
+              className="text-capitalize"
+            >
+              nodejs
+            </strong>,
+            <div>
+              <p
+                style={
+                  Object {
+                    "color": "red",
+                  }
+                }
+              >
+                <Icon
+                  name="error-circle-o"
+                  type="pf"
+                />
+                 
+                Not all checks passed
+              </p>
+            </div>,
+            <ul
+              style={
+                Object {
+                  "listStyleType": "none",
+                }
+              }
+            >
+              <li>
+                <div>
+                  <strong
+                    className="text-capitalize"
+                  >
+                    destination
+                  </strong>
+                  <ul
+                    style={
+                      Object {
+                        "listStyleType": "none",
+                      }
+                    }
+                  >
+                    <li>
+                      <div
+                        className="label-collection"
+                      >
+                        <span>
+                          <span
+                            className="text-capitalize"
+                          >
+                            [
+                            host
+                            ]
+                          </span>
+                           
+                          reviews
+                        </span>
+                      </div>
+                    </li>
+                    <li>
+                      <div
+                        className="label-collection"
+                      >
+                        <span>
+                          <span
+                            className="text-capitalize"
+                          >
+                            [
+                            subset
+                            ]
+                          </span>
+                           
+                          v1
+                        </span>
+                      </div>
+                    </li>
+                    <li>
+                      <div>
+                        <strong
+                          className="text-capitalize"
+                        >
+                          port
+                        </strong>
+                        <ul
+                          style={
+                            Object {
+                              "listStyleType": "none",
+                            }
+                          }
+                        >
+                          <li>
+                            <div
+                              className="label-collection"
+                            >
+                              <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  number
+                                  ]
+                                </span>
+                                 
+                                22
+                              </span>
+                            </div>
+                          </li>
+                          <li>
+                            <div
+                              className="label-collection"
+                            >
+                              <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  name
+                                  ]
+                                </span>
+                                 
+                                ssh
+                              </span>
+                            </div>
+                          </li>
+                        </ul>
+                      </div>
+                    </li>
+                  </ul>
+                </div>
+              </li>
+              <li>
+                <div
+                  className="label-collection"
+                >
+                  <span>
+                    <span
+                      className="text-capitalize"
+                    >
+                      [
+                      weight
+                      ]
+                    </span>
+                     
+                    85
+                  </span>
+                </div>
+              </li>
+            </ul>,
+          ],
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": "nodejs",
+              "className": "text-capitalize",
+            },
+            "ref": null,
+            "rendered": "nodejs",
+            "type": "strong",
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": <p
+                style={
+                  Object {
+                    "color": "red",
+                  }
+                }
+              >
+                <Icon
+                  name="error-circle-o"
+                  type="pf"
+                />
+                 
+                Not all checks passed
+              </p>,
+            },
+            "ref": null,
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": Array [
+                  <Icon
+                    name="error-circle-o"
+                    type="pf"
+                  />,
+                  " ",
+                  "Not all checks passed",
+                ],
+                "style": Object {
+                  "color": "red",
+                },
+              },
+              "ref": null,
+              "rendered": Array [
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "function",
+                  "props": Object {
+                    "name": "error-circle-o",
+                    "type": "pf",
+                  },
+                  "ref": null,
+                  "rendered": null,
+                  "type": [Function],
+                },
+                " ",
+                "Not all checks passed",
+              ],
+              "type": "p",
+            },
+            "type": "div",
+          },
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": Array [
+                <li>
+                  <div>
+                    <strong
+                      className="text-capitalize"
+                    >
+                      destination
+                    </strong>
+                    <ul
+                      style={
+                        Object {
+                          "listStyleType": "none",
+                        }
+                      }
+                    >
+                      <li>
+                        <div
+                          className="label-collection"
+                        >
+                          <span>
+                            <span
+                              className="text-capitalize"
+                            >
+                              [
+                              host
+                              ]
+                            </span>
+                             
+                            reviews
+                          </span>
+                        </div>
+                      </li>
+                      <li>
+                        <div
+                          className="label-collection"
+                        >
+                          <span>
+                            <span
+                              className="text-capitalize"
+                            >
+                              [
+                              subset
+                              ]
+                            </span>
+                             
+                            v1
+                          </span>
+                        </div>
+                      </li>
+                      <li>
+                        <div>
+                          <strong
+                            className="text-capitalize"
+                          >
+                            port
+                          </strong>
+                          <ul
+                            style={
+                              Object {
+                                "listStyleType": "none",
+                              }
+                            }
+                          >
+                            <li>
+                              <div
+                                className="label-collection"
+                              >
+                                <span>
+                                  <span
+                                    className="text-capitalize"
+                                  >
+                                    [
+                                    number
+                                    ]
+                                  </span>
+                                   
+                                  22
+                                </span>
+                              </div>
+                            </li>
+                            <li>
+                              <div
+                                className="label-collection"
+                              >
+                                <span>
+                                  <span
+                                    className="text-capitalize"
+                                  >
+                                    [
+                                    name
+                                    ]
+                                  </span>
+                                   
+                                  ssh
+                                </span>
+                              </div>
+                            </li>
+                          </ul>
+                        </div>
+                      </li>
+                    </ul>
+                  </div>
+                </li>,
+                <li>
+                  <div
+                    className="label-collection"
+                  >
+                    <span>
+                      <span
+                        className="text-capitalize"
+                      >
+                        [
+                        weight
+                        ]
+                      </span>
+                       
+                      85
+                    </span>
+                  </div>
+                </li>,
+              ],
+              "style": Object {
+                "listStyleType": "none",
+              },
+            },
+            "ref": null,
+            "rendered": Array [
+              Object {
+                "instance": null,
+                "key": "key_sssssssss_k0",
+                "nodeType": "host",
+                "props": Object {
+                  "children": <div>
+                    <strong
+                      className="text-capitalize"
+                    >
+                      destination
+                    </strong>
+                    <ul
+                      style={
+                        Object {
+                          "listStyleType": "none",
+                        }
+                      }
+                    >
+                      <li>
+                        <div
+                          className="label-collection"
+                        >
+                          <span>
+                            <span
+                              className="text-capitalize"
+                            >
+                              [
+                              host
+                              ]
+                            </span>
+                             
+                            reviews
+                          </span>
+                        </div>
+                      </li>
+                      <li>
+                        <div
+                          className="label-collection"
+                        >
+                          <span>
+                            <span
+                              className="text-capitalize"
+                            >
+                              [
+                              subset
+                              ]
+                            </span>
+                             
+                            v1
+                          </span>
+                        </div>
+                      </li>
+                      <li>
+                        <div>
+                          <strong
+                            className="text-capitalize"
+                          >
+                            port
+                          </strong>
+                          <ul
+                            style={
+                              Object {
+                                "listStyleType": "none",
+                              }
+                            }
+                          >
+                            <li>
+                              <div
+                                className="label-collection"
+                              >
+                                <span>
+                                  <span
+                                    className="text-capitalize"
+                                  >
+                                    [
+                                    number
+                                    ]
+                                  </span>
+                                   
+                                  22
+                                </span>
+                              </div>
+                            </li>
+                            <li>
+                              <div
+                                className="label-collection"
+                              >
+                                <span>
+                                  <span
+                                    className="text-capitalize"
+                                  >
+                                    [
+                                    name
+                                    ]
+                                  </span>
+                                   
+                                  ssh
+                                </span>
+                              </div>
+                            </li>
+                          </ul>
+                        </div>
+                      </li>
+                    </ul>
+                  </div>,
+                },
+                "ref": null,
+                "rendered": Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": Array [
+                      <strong
+                        className="text-capitalize"
+                      >
+                        destination
+                      </strong>,
+                      undefined,
+                      <ul
+                        style={
+                          Object {
+                            "listStyleType": "none",
+                          }
+                        }
+                      >
+                        <li>
+                          <div
+                            className="label-collection"
+                          >
+                            <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                host
+                                ]
+                              </span>
+                               
+                              reviews
+                            </span>
+                          </div>
+                        </li>
+                        <li>
+                          <div
+                            className="label-collection"
+                          >
+                            <span>
+                              <span
+                                className="text-capitalize"
+                              >
+                                [
+                                subset
+                                ]
+                              </span>
+                               
+                              v1
+                            </span>
+                          </div>
+                        </li>
+                        <li>
+                          <div>
+                            <strong
+                              className="text-capitalize"
+                            >
+                              port
+                            </strong>
+                            <ul
+                              style={
+                                Object {
+                                  "listStyleType": "none",
+                                }
+                              }
+                            >
+                              <li>
+                                <div
+                                  className="label-collection"
+                                >
+                                  <span>
+                                    <span
+                                      className="text-capitalize"
+                                    >
+                                      [
+                                      number
+                                      ]
+                                    </span>
+                                     
+                                    22
+                                  </span>
+                                </div>
+                              </li>
+                              <li>
+                                <div
+                                  className="label-collection"
+                                >
+                                  <span>
+                                    <span
+                                      className="text-capitalize"
+                                    >
+                                      [
+                                      name
+                                      ]
+                                    </span>
+                                     
+                                    ssh
+                                  </span>
+                                </div>
+                              </li>
+                            </ul>
+                          </div>
+                        </li>
+                      </ul>,
+                    ],
+                  },
+                  "ref": null,
+                  "rendered": Array [
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": "destination",
+                        "className": "text-capitalize",
+                      },
+                      "ref": null,
+                      "rendered": "destination",
+                      "type": "strong",
+                    },
+                    undefined,
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": Array [
+                          <li>
+                            <div
+                              className="label-collection"
+                            >
+                              <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  host
+                                  ]
+                                </span>
+                                 
+                                reviews
+                              </span>
+                            </div>
+                          </li>,
+                          <li>
+                            <div
+                              className="label-collection"
+                            >
+                              <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  subset
+                                  ]
+                                </span>
+                                 
+                                v1
+                              </span>
+                            </div>
+                          </li>,
+                          <li>
+                            <div>
+                              <strong
+                                className="text-capitalize"
+                              >
+                                port
+                              </strong>
+                              <ul
+                                style={
+                                  Object {
+                                    "listStyleType": "none",
+                                  }
+                                }
+                              >
+                                <li>
+                                  <div
+                                    className="label-collection"
+                                  >
+                                    <span>
+                                      <span
+                                        className="text-capitalize"
+                                      >
+                                        [
+                                        number
+                                        ]
+                                      </span>
+                                       
+                                      22
+                                    </span>
+                                  </div>
+                                </li>
+                                <li>
+                                  <div
+                                    className="label-collection"
+                                  >
+                                    <span>
+                                      <span
+                                        className="text-capitalize"
+                                      >
+                                        [
+                                        name
+                                        ]
+                                      </span>
+                                       
+                                      ssh
+                                    </span>
+                                  </div>
+                                </li>
+                              </ul>
+                            </div>
+                          </li>,
+                        ],
+                        "style": Object {
+                          "listStyleType": "none",
+                        },
+                      },
+                      "ref": null,
+                      "rendered": Array [
+                        Object {
+                          "instance": null,
+                          "key": "key_sssssssss_k0",
+                          "nodeType": "host",
+                          "props": Object {
+                            "children": <div
+                              className="label-collection"
+                            >
+                              <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  host
+                                  ]
+                                </span>
+                                 
+                                reviews
+                              </span>
+                            </div>,
+                          },
+                          "ref": null,
+                          "rendered": Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "host",
+                            "props": Object {
+                              "children": <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  host
+                                  ]
+                                </span>
+                                 
+                                reviews
+                              </span>,
+                              "className": "label-collection",
+                            },
+                            "ref": null,
+                            "rendered": Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "host",
+                              "props": Object {
+                                "children": Array [
+                                  <span
+                                    className="text-capitalize"
+                                  >
+                                    [
+                                    host
+                                    ]
+                                  </span>,
+                                  " ",
+                                  "reviews",
+                                ],
+                              },
+                              "ref": null,
+                              "rendered": Array [
+                                Object {
+                                  "instance": null,
+                                  "key": undefined,
+                                  "nodeType": "host",
+                                  "props": Object {
+                                    "children": Array [
+                                      "[",
+                                      "host",
+                                      "]",
+                                    ],
+                                    "className": "text-capitalize",
+                                  },
+                                  "ref": null,
+                                  "rendered": Array [
+                                    "[",
+                                    "host",
+                                    "]",
+                                  ],
+                                  "type": "span",
+                                },
+                                " ",
+                                "reviews",
+                              ],
+                              "type": "span",
+                            },
+                            "type": "div",
+                          },
+                          "type": "li",
+                        },
+                        Object {
+                          "instance": null,
+                          "key": "key_sssssssss_k1",
+                          "nodeType": "host",
+                          "props": Object {
+                            "children": <div
+                              className="label-collection"
+                            >
+                              <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  subset
+                                  ]
+                                </span>
+                                 
+                                v1
+                              </span>
+                            </div>,
+                          },
+                          "ref": null,
+                          "rendered": Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "host",
+                            "props": Object {
+                              "children": <span>
+                                <span
+                                  className="text-capitalize"
+                                >
+                                  [
+                                  subset
+                                  ]
+                                </span>
+                                 
+                                v1
+                              </span>,
+                              "className": "label-collection",
+                            },
+                            "ref": null,
+                            "rendered": Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "host",
+                              "props": Object {
+                                "children": Array [
+                                  <span
+                                    className="text-capitalize"
+                                  >
+                                    [
+                                    subset
+                                    ]
+                                  </span>,
+                                  " ",
+                                  "v1",
+                                ],
+                              },
+                              "ref": null,
+                              "rendered": Array [
+                                Object {
+                                  "instance": null,
+                                  "key": undefined,
+                                  "nodeType": "host",
+                                  "props": Object {
+                                    "children": Array [
+                                      "[",
+                                      "subset",
+                                      "]",
+                                    ],
+                                    "className": "text-capitalize",
+                                  },
+                                  "ref": null,
+                                  "rendered": Array [
+                                    "[",
+                                    "subset",
+                                    "]",
+                                  ],
+                                  "type": "span",
+                                },
+                                " ",
+                                "v1",
+                              ],
+                              "type": "span",
+                            },
+                            "type": "div",
+                          },
+                          "type": "li",
+                        },
+                        Object {
+                          "instance": null,
+                          "key": "key_sssssssss_k2",
+                          "nodeType": "host",
+                          "props": Object {
+                            "children": <div>
+                              <strong
+                                className="text-capitalize"
+                              >
+                                port
+                              </strong>
+                              <ul
+                                style={
+                                  Object {
+                                    "listStyleType": "none",
+                                  }
+                                }
+                              >
+                                <li>
+                                  <div
+                                    className="label-collection"
+                                  >
+                                    <span>
+                                      <span
+                                        className="text-capitalize"
+                                      >
+                                        [
+                                        number
+                                        ]
+                                      </span>
+                                       
+                                      22
+                                    </span>
+                                  </div>
+                                </li>
+                                <li>
+                                  <div
+                                    className="label-collection"
+                                  >
+                                    <span>
+                                      <span
+                                        className="text-capitalize"
+                                      >
+                                        [
+                                        name
+                                        ]
+                                      </span>
+                                       
+                                      ssh
+                                    </span>
+                                  </div>
+                                </li>
+                              </ul>
+                            </div>,
+                          },
+                          "ref": null,
+                          "rendered": Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "host",
+                            "props": Object {
+                              "children": Array [
+                                <strong
+                                  className="text-capitalize"
+                                >
+                                  port
+                                </strong>,
+                                undefined,
+                                <ul
+                                  style={
+                                    Object {
+                                      "listStyleType": "none",
+                                    }
+                                  }
+                                >
+                                  <li>
+                                    <div
+                                      className="label-collection"
+                                    >
+                                      <span>
+                                        <span
+                                          className="text-capitalize"
+                                        >
+                                          [
+                                          number
+                                          ]
+                                        </span>
+                                         
+                                        22
+                                      </span>
+                                    </div>
+                                  </li>
+                                  <li>
+                                    <div
+                                      className="label-collection"
+                                    >
+                                      <span>
+                                        <span
+                                          className="text-capitalize"
+                                        >
+                                          [
+                                          name
+                                          ]
+                                        </span>
+                                         
+                                        ssh
+                                      </span>
+                                    </div>
+                                  </li>
+                                </ul>,
+                              ],
+                            },
+                            "ref": null,
+                            "rendered": Array [
+                              Object {
+                                "instance": null,
+                                "key": undefined,
+                                "nodeType": "host",
+                                "props": Object {
+                                  "children": "port",
+                                  "className": "text-capitalize",
+                                },
+                                "ref": null,
+                                "rendered": "port",
+                                "type": "strong",
+                              },
+                              undefined,
+                              Object {
+                                "instance": null,
+                                "key": undefined,
+                                "nodeType": "host",
+                                "props": Object {
+                                  "children": Array [
+                                    <li>
+                                      <div
+                                        className="label-collection"
+                                      >
+                                        <span>
+                                          <span
+                                            className="text-capitalize"
+                                          >
+                                            [
+                                            number
+                                            ]
+                                          </span>
+                                           
+                                          22
+                                        </span>
+                                      </div>
+                                    </li>,
+                                    <li>
+                                      <div
+                                        className="label-collection"
+                                      >
+                                        <span>
+                                          <span
+                                            className="text-capitalize"
+                                          >
+                                            [
+                                            name
+                                            ]
+                                          </span>
+                                           
+                                          ssh
+                                        </span>
+                                      </div>
+                                    </li>,
+                                  ],
+                                  "style": Object {
+                                    "listStyleType": "none",
+                                  },
+                                },
+                                "ref": null,
+                                "rendered": Array [
+                                  Object {
+                                    "instance": null,
+                                    "key": "key_sssssssss_k0",
+                                    "nodeType": "host",
+                                    "props": Object {
+                                      "children": <div
+                                        className="label-collection"
+                                      >
+                                        <span>
+                                          <span
+                                            className="text-capitalize"
+                                          >
+                                            [
+                                            number
+                                            ]
+                                          </span>
+                                           
+                                          22
+                                        </span>
+                                      </div>,
+                                    },
+                                    "ref": null,
+                                    "rendered": Object {
+                                      "instance": null,
+                                      "key": undefined,
+                                      "nodeType": "host",
+                                      "props": Object {
+                                        "children": <span>
+                                          <span
+                                            className="text-capitalize"
+                                          >
+                                            [
+                                            number
+                                            ]
+                                          </span>
+                                           
+                                          22
+                                        </span>,
+                                        "className": "label-collection",
+                                      },
+                                      "ref": null,
+                                      "rendered": Object {
+                                        "instance": null,
+                                        "key": undefined,
+                                        "nodeType": "host",
+                                        "props": Object {
+                                          "children": Array [
+                                            <span
+                                              className="text-capitalize"
+                                            >
+                                              [
+                                              number
+                                              ]
+                                            </span>,
+                                            " ",
+                                            22,
+                                          ],
+                                        },
+                                        "ref": null,
+                                        "rendered": Array [
+                                          Object {
+                                            "instance": null,
+                                            "key": undefined,
+                                            "nodeType": "host",
+                                            "props": Object {
+                                              "children": Array [
+                                                "[",
+                                                "number",
+                                                "]",
+                                              ],
+                                              "className": "text-capitalize",
+                                            },
+                                            "ref": null,
+                                            "rendered": Array [
+                                              "[",
+                                              "number",
+                                              "]",
+                                            ],
+                                            "type": "span",
+                                          },
+                                          " ",
+                                          22,
+                                        ],
+                                        "type": "span",
+                                      },
+                                      "type": "div",
+                                    },
+                                    "type": "li",
+                                  },
+                                  Object {
+                                    "instance": null,
+                                    "key": "key_sssssssss_k1",
+                                    "nodeType": "host",
+                                    "props": Object {
+                                      "children": <div
+                                        className="label-collection"
+                                      >
+                                        <span>
+                                          <span
+                                            className="text-capitalize"
+                                          >
+                                            [
+                                            name
+                                            ]
+                                          </span>
+                                           
+                                          ssh
+                                        </span>
+                                      </div>,
+                                    },
+                                    "ref": null,
+                                    "rendered": Object {
+                                      "instance": null,
+                                      "key": undefined,
+                                      "nodeType": "host",
+                                      "props": Object {
+                                        "children": <span>
+                                          <span
+                                            className="text-capitalize"
+                                          >
+                                            [
+                                            name
+                                            ]
+                                          </span>
+                                           
+                                          ssh
+                                        </span>,
+                                        "className": "label-collection",
+                                      },
+                                      "ref": null,
+                                      "rendered": Object {
+                                        "instance": null,
+                                        "key": undefined,
+                                        "nodeType": "host",
+                                        "props": Object {
+                                          "children": Array [
+                                            <span
+                                              className="text-capitalize"
+                                            >
+                                              [
+                                              name
+                                              ]
+                                            </span>,
+                                            " ",
+                                            "ssh",
+                                          ],
+                                        },
+                                        "ref": null,
+                                        "rendered": Array [
+                                          Object {
+                                            "instance": null,
+                                            "key": undefined,
+                                            "nodeType": "host",
+                                            "props": Object {
+                                              "children": Array [
+                                                "[",
+                                                "name",
+                                                "]",
+                                              ],
+                                              "className": "text-capitalize",
+                                            },
+                                            "ref": null,
+                                            "rendered": Array [
+                                              "[",
+                                              "name",
+                                              "]",
+                                            ],
+                                            "type": "span",
+                                          },
+                                          " ",
+                                          "ssh",
+                                        ],
+                                        "type": "span",
+                                      },
+                                      "type": "div",
+                                    },
+                                    "type": "li",
+                                  },
+                                ],
+                                "type": "ul",
+                              },
+                            ],
+                            "type": "div",
+                          },
+                          "type": "li",
+                        },
+                      ],
+                      "type": "ul",
+                    },
+                  ],
+                  "type": "div",
+                },
+                "type": "li",
+              },
+              Object {
+                "instance": null,
+                "key": "key_sssssssss_k1",
+                "nodeType": "host",
+                "props": Object {
+                  "children": <div
+                    className="label-collection"
+                  >
+                    <span>
+                      <span
+                        className="text-capitalize"
+                      >
+                        [
+                        weight
+                        ]
+                      </span>
+                       
+                      85
+                    </span>
+                  </div>,
+                },
+                "ref": null,
+                "rendered": Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": <span>
+                      <span
+                        className="text-capitalize"
+                      >
+                        [
+                        weight
+                        ]
+                      </span>
+                       
+                      85
+                    </span>,
+                    "className": "label-collection",
+                  },
+                  "ref": null,
+                  "rendered": Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": Array [
+                        <span
+                          className="text-capitalize"
+                        >
+                          [
+                          weight
+                          ]
+                        </span>,
+                        " ",
+                        85,
+                      ],
+                    },
+                    "ref": null,
+                    "rendered": Array [
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": Array [
+                            "[",
+                            "weight",
+                            "]",
+                          ],
+                          "className": "text-capitalize",
+                        },
+                        "ref": null,
+                        "rendered": Array [
+                          "[",
+                          "weight",
+                          "]",
+                        ],
+                        "type": "span",
+                      },
+                      " ",
+                      85,
+                    ],
+                    "type": "span",
+                  },
+                  "type": "div",
+                },
+                "type": "li",
+              },
+            ],
+            "type": "ul",
+          },
+        ],
+        "type": "div",
+      },
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;

--- a/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -216,7 +216,11 @@ class ServiceInfo extends React.Component<ServiceDetails, ServiceInfoState> {
                     </TabPane>
                     <TabPane eventKey={5}>
                       {(virtualServices.length > 0 || this.props.serviceDetails.istioSidecar) && (
-                        <ServiceInfoVirtualServices virtualServices={virtualServices} editorLink={editorLink} />
+                        <ServiceInfoVirtualServices
+                          virtualServices={virtualServices}
+                          editorLink={editorLink}
+                          validations={this.props.validations!['virtualservice']}
+                        />
                       )}
                     </TabPane>
                     <TabPane eventKey={6}>

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoRouteRules/RouteRuleRoute.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoRouteRules/RouteRuleRoute.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as resolve from 'table-resolver';
 import {
   checkForPath,
-  DestinationWeight,
+  DestinationWeightV1Alpha1,
   highestSeverity,
   ObjectValidation,
   severityToIconName,
@@ -16,7 +16,7 @@ import Label from '../../../../components/Label/Label';
 
 interface RouteRuleRouteProps {
   name: string;
-  route: DestinationWeight[];
+  route: DestinationWeightV1Alpha1[];
   validations: { [key: string]: ObjectValidation };
 }
 
@@ -101,7 +101,7 @@ class RouteRuleRoute extends React.Component<RouteRuleRouteProps> {
   validation(): ObjectValidation {
     return this.props.validations[this.props.name];
   }
-  statusFrom(validation: ObjectValidation, routeItem: DestinationWeight, index: number) {
+  statusFrom(validation: ObjectValidation, routeItem: DestinationWeightV1Alpha1, index: number) {
     let checks = checkForPath(validation, 'spec/route[' + index + ']/weight/' + routeItem.weight);
     checks.push(...checkForPath(validation, 'spec/route[' + index + ']/labels'));
     let severity = highestSeverity(checks);

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoVirtualServices.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoVirtualServices.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { Col, Row, Icon } from 'patternfly-react';
-import { EditorLink, VirtualService } from '../../../types/ServiceInfo';
+import { Col, Icon, Row } from 'patternfly-react';
+import { EditorLink, ObjectValidation, VirtualService } from '../../../types/ServiceInfo';
 import LocalTime from '../../../components/Time/LocalTime';
 import DetailObject from '../../../components/Details/DetailObject';
 import { Link } from 'react-router-dom';
@@ -8,6 +8,7 @@ import VirtualServiceRoute from './ServiceInfoVirtualServices/VirtualServiceRout
 
 interface ServiceInfoVirtualServicesProps extends EditorLink {
   virtualServices?: VirtualService[];
+  validations: { [key: string]: ObjectValidation };
 }
 
 class ServiceInfoVirtualServices extends React.Component<ServiceInfoVirtualServicesProps> {
@@ -17,10 +18,8 @@ class ServiceInfoVirtualServices extends React.Component<ServiceInfoVirtualServi
 
   rawConfig(virtualService: VirtualService, i: number) {
     return (
-      <div className="card-pf-body" key={'virtualService' + i}>
-        <div>
-          <h3>{virtualService.name}</h3>
-        </div>
+      <div className="card-pf-body" key={'virtualServiceConfig' + i}>
+        <h3>{virtualService.name}</h3>
         <div>
           <Link to={this.props.editorLink + '?virtualservice=' + virtualService.name}>
             Show Yaml <Icon name="angle-double-right" />
@@ -46,9 +45,9 @@ class ServiceInfoVirtualServices extends React.Component<ServiceInfoVirtualServi
     );
   }
 
-  weights(virtualService: VirtualService) {
+  weights(virtualService: VirtualService, i: number) {
     return (
-      <Row>
+      <Row className="card-pf-body" key={'virtualServiceWeights' + i}>
         <Col>
           {virtualService.http && virtualService.http.length > 0 ? (
             <Row>
@@ -56,14 +55,20 @@ class ServiceInfoVirtualServices extends React.Component<ServiceInfoVirtualServi
                 name={virtualService.name}
                 kind="HTTP"
                 routes={virtualService.http}
-                validations={{}}
-              /> </Row>
+                validations={this.props.validations}
+              />
+            </Row>
           ) : (
             undefined
           )}
           {virtualService.tcp && virtualService.tcp.length > 0 ? (
             <Row>
-              <VirtualServiceRoute name={virtualService.name} kind="TCP" routes={virtualService.tcp} validations={{}} />
+              <VirtualServiceRoute
+                name={virtualService.name}
+                kind="TCP"
+                routes={virtualService.tcp}
+                validations={this.props.validations}
+              />
             </Row>
           ) : (
             undefined
@@ -77,13 +82,15 @@ class ServiceInfoVirtualServices extends React.Component<ServiceInfoVirtualServi
     return (
       <div className="card-pf">
         {(this.props.virtualServices || []).map((virtualService, i) => (
-          <Row key={'virtualservice' + i} className="row-cards-pf">
-            <Col xs={12} sm={12} md={3} lg={3}>
-              {this.rawConfig(virtualService, i)}
-            </Col>
-            <Col xs={12} sm={12} md={9} lg={9}>
-              {this.weights(virtualService)}
-            </Col>
+          <Row className={'row-cards-pf'} key={'virtualservice' + i}>
+            <Row className="row-cards-pf">
+              <Col xs={12} sm={12} md={3} lg={3}>
+                {this.rawConfig(virtualService, i)}
+              </Col>
+              <Col xs={12} sm={12} md={9} lg={9}>
+                {this.weights(virtualService, i)}
+              </Col>
+            </Row>
           </Row>
         ))}
       </div>

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoVirtualServices.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoVirtualServices.tsx
@@ -4,6 +4,7 @@ import { EditorLink, VirtualService } from '../../../types/ServiceInfo';
 import LocalTime from '../../../components/Time/LocalTime';
 import DetailObject from '../../../components/Details/DetailObject';
 import { Link } from 'react-router-dom';
+import VirtualServiceRoute from './ServiceInfoVirtualServices/VirtualServiceRoute';
 
 interface ServiceInfoVirtualServicesProps extends EditorLink {
   virtualServices?: VirtualService[];
@@ -14,52 +15,77 @@ class ServiceInfoVirtualServices extends React.Component<ServiceInfoVirtualServi
     super(props);
   }
 
+  rawConfig(virtualService: VirtualService, i: number) {
+    return (
+      <div className="card-pf-body" key={'virtualService' + i}>
+        <div>
+          <h3>{virtualService.name}</h3>
+        </div>
+        <div>
+          <Link to={this.props.editorLink + '?virtualservice=' + virtualService.name}>
+            Show Yaml <Icon name="angle-double-right" />
+          </Link>
+        </div>
+        <div>
+          <strong>Created at</strong>: <LocalTime time={virtualService.createdAt} />
+        </div>
+        <div>
+          <strong>Resource Version</strong>: {virtualService.resourceVersion}
+        </div>
+        {virtualService.hosts && virtualService.hosts.length > 0 ? (
+          <DetailObject name="Hosts" detail={virtualService.hosts} />
+        ) : (
+          undefined
+        )}
+        {virtualService.gateways && virtualService.gateways.length > 0 ? (
+          <DetailObject name="Gateways" detail={virtualService.gateways} />
+        ) : (
+          undefined
+        )}
+      </div>
+    );
+  }
+
+  weights(virtualService: VirtualService) {
+    return (
+      <Row>
+        <Col>
+          {virtualService.http && virtualService.http.length > 0 ? (
+            <Row>
+              <VirtualServiceRoute
+                name={virtualService.name}
+                kind="HTTP"
+                routes={virtualService.http}
+                validations={{}}
+              /> </Row>
+          ) : (
+            undefined
+          )}
+          {virtualService.tcp && virtualService.tcp.length > 0 ? (
+            <Row>
+              <VirtualServiceRoute name={virtualService.name} kind="TCP" routes={virtualService.tcp} validations={{}} />
+            </Row>
+          ) : (
+            undefined
+          )}
+        </Col>
+      </Row>
+    );
+  }
+
   render() {
     return (
       <div className="card-pf">
-        <Row className="row-cards-pf">
-          <Col xs={12} sm={12} md={12} lg={12}>
-            {(this.props.virtualServices || []).map((virtualService, i) => (
-              <div className="card-pf-body" key={'virtualService' + i}>
-                <div>
-                  <h3>{virtualService.name}</h3>
-                </div>
-                <div>
-                  <Link to={this.props.editorLink + '?virtualservice=' + virtualService.name}>
-                    Show Yaml <Icon name="angle-double-right" />
-                  </Link>
-                </div>
-                <div>
-                  <strong>Created at</strong>: <LocalTime time={virtualService.createdAt} />
-                </div>
-                <div>
-                  <strong>Resource Version</strong>: {virtualService.resourceVersion}
-                </div>
-                {virtualService.hosts && virtualService.hosts.length > 0 ? (
-                  <DetailObject name="Hosts" detail={virtualService.hosts} />
-                ) : (
-                  undefined
-                )}
-                {virtualService.gateways && virtualService.gateways.length > 0 ? (
-                  <DetailObject name="Gateways" detail={virtualService.gateways} />
-                ) : (
-                  undefined
-                )}
-                {virtualService.http && virtualService.http.length > 0 ? (
-                  <DetailObject name="Http Routes" detail={virtualService.http} />
-                ) : (
-                  undefined
-                )}
-                {virtualService.tcp && virtualService.tcp.length > 0 ? (
-                  <DetailObject name="Tcp Routes" detail={virtualService.tcp} />
-                ) : (
-                  undefined
-                )}
-                <hr />
-              </div>
-            ))}
-          </Col>
-        </Row>
+        {(this.props.virtualServices || []).map((virtualService, i) => (
+          <Row key={'virtualservice' + i} className="row-cards-pf">
+            <Col xs={12} sm={12} md={3} lg={3}>
+              {this.rawConfig(virtualService, i)}
+            </Col>
+            <Col xs={12} sm={12} md={9} lg={9}>
+              {this.weights(virtualService)}
+            </Col>
+          </Row>
+        ))}
       </div>
     );
   }

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoVirtualServices/VirtualServiceRoute.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoVirtualServices/VirtualServiceRoute.tsx
@@ -1,0 +1,291 @@
+import * as React from 'react';
+import * as resolve from 'table-resolver';
+import {
+  checkForPath,
+  Destination,
+  DestinationWeight,
+  highestSeverity,
+  HTTPRoute,
+  ObjectCheck,
+  ObjectValidation,
+  severityToIconName,
+  TCPRoute
+} from '../../../../types/ServiceInfo';
+import { BulletChart, Col, Icon, OverlayTrigger, Popover, Row, Table, Tooltip } from 'patternfly-react';
+import DetailObject from '../../../../components/Details/DetailObject';
+import { PfColors } from '../../../../components/Pf/PfColors';
+
+interface VirtualServiceRouteProps {
+  name: string;
+  kind: string;
+  routes: any[];
+  validations: { [key: string]: ObjectValidation };
+}
+
+const PFBlueColors = [
+  PfColors.Blue,
+  PfColors.Blue500,
+  PfColors.Blue600,
+  PfColors.Blue300,
+  PfColors.Blue200,
+  PfColors.Blue100
+];
+
+class VirtualServiceRoute extends React.Component<VirtualServiceRouteProps> {
+  cellFormat = value => <Table.Cell>{value}</Table.Cell>;
+  headerFormat = (label, { column }) => {
+    let className = column.property || column.header.label.toLowerCase();
+    let colSpan = column.header && column.header.props ? column.header.props.colSpan || '' : '';
+
+    return (
+      <Table.Heading colSpan={colSpan} className={className}>
+        {label}
+      </Table.Heading>
+    );
+  };
+
+  constructor(props: VirtualServiceRouteProps) {
+    super(props);
+  }
+
+  columns() {
+    return {
+      columns: [
+        {
+          header: {
+            label: 'Status',
+            formatters: [this.headerFormat],
+            props: {
+              colSpan: 1
+            }
+          },
+          cell: {
+            formatters: [this.cellFormat]
+          },
+          children: [
+            {
+              property: 'status.value',
+              header: {
+                label: '',
+                formatters: [this.headerFormat]
+              },
+              cell: {
+                formatters: [this.cellFormat]
+              }
+            }
+          ]
+        },
+        {
+          header: {
+            label: 'Destination',
+            formatters: [this.headerFormat],
+            props: {
+              colSpan: 3
+            }
+          },
+          cell: {
+            formatters: [this.cellFormat]
+          },
+          children: [
+            {
+              property: 'destination.host',
+              header: {
+                label: 'Host',
+                formatters: [this.headerFormat]
+              },
+              cell: {
+                formatters: [this.cellFormat]
+              }
+            },
+            {
+              property: 'destination.subset',
+              header: {
+                label: 'Subset',
+                formatters: [this.headerFormat]
+              },
+              cell: {
+                formatters: [this.cellFormat]
+              }
+            },
+            {
+              property: 'destination.port',
+              header: {
+                label: 'Port',
+                formatters: [this.headerFormat]
+              },
+              cell: {
+                formatters: [this.cellFormat]
+              }
+            }
+          ]
+        },
+        {
+          header: {
+            label: 'Weights',
+            formatters: [this.headerFormat],
+            props: {
+              colSpan: 1
+            }
+          },
+          cell: {
+            formatters: [this.cellFormat]
+          },
+          children: [
+            {
+              property: 'weight.value',
+              header: {
+                label: '',
+                formatters: [this.headerFormat]
+              },
+              cell: {
+                formatters: [this.cellFormat]
+              }
+            }
+          ]
+        }
+      ]
+    };
+  }
+
+  rows(route: any) {
+    return (route.route || []).map((routeItem, u) => ({
+      id: u,
+      status: { value: this.statusFrom(this.validation(), routeItem, u) },
+      weight: { value: routeItem.weight ? routeItem.weight : '-' },
+      destination: this.destinationFrom(routeItem, u)
+    }));
+  }
+
+  validation(): ObjectValidation {
+    return this.props.validations[this.props.name];
+  }
+
+  statusFrom(validation: ObjectValidation, routeItem: DestinationWeight, index: number) {
+    let checks = checkForPath(validation, 'spec/route[' + index + ']/weight/' + routeItem.weight);
+    checks.push(...checkForPath(validation, 'spec/route[' + index + ']/labels'));
+    let severity = highestSeverity(checks);
+    let iconName = severity ? severityToIconName(severity) : 'ok';
+    if (iconName !== 'ok') {
+      return (
+        <OverlayTrigger
+          placement={'right'}
+          overlay={this.infotipContent(checks)}
+          trigger={['hover', 'focus']}
+          rootClose={false}
+        >
+          <Icon type="pf" name={iconName} />
+        </OverlayTrigger>
+      );
+    } else {
+      return '';
+    }
+  }
+
+  destinationFrom(destinationWeight: DestinationWeight, i: number) {
+    let destination = destinationWeight.destination;
+    return {
+      host: destination.host || '-',
+      subset: destination.subset || '-',
+      port: destination.port ? destination.port.number || '-' : '-'
+    };
+  }
+
+  infotipContent(checks: ObjectCheck[]) {
+    return (
+      <Popover id={this.props.name + '-weight-tooltip'}>
+        {checks.map(check => {
+          return this.objectCheckToHtml(check);
+        })}
+      </Popover>
+    );
+  }
+
+  objectCheckToHtml(object: ObjectCheck) {
+    return (
+      <Row>
+        <Col xs={1}>
+          <Icon type="pf" name={severityToIconName(object.severity)} />
+        </Col>
+        <Col xs={10} style={{ marginLeft: '-20px' }}>
+          {object.message}
+        </Col>
+      </Row>
+    );
+  }
+
+  bulletChartValues(routes: TCPRoute | HTTPRoute) {
+    return (routes.route || []).map((destinationWeight, u) => ({
+      value: routes.route.length === 1 ? 100 : destinationWeight.weight,
+      title: `${u}_${destinationWeight.weight}`,
+      color: PFBlueColors[u % PFBlueColors.length],
+      tooltipFunction: () => {
+        const badges = this.renderDestination(destinationWeight.destination);
+        return (
+          <Tooltip id={`${u}_${destinationWeight.weight}`} key={`${u}_${destinationWeight.weight}`}>
+            <div className="label-collection">{badges}</div>
+          </Tooltip>
+        );
+      }
+    }));
+  }
+
+  renderDestination(destination: Destination) {
+    return (
+      <ul style={{ listStyleType: 'none', paddingLeft: '15px' }}>
+        <li>Host: {destination.host || '-'} </li>
+        <li>Subset: {destination.subset || '-'} </li>
+        <li>Port: {destination.port ? destination.port.number : '-'} </li>
+      </ul>
+    );
+  }
+
+  renderTable(route: any, i: number) {
+    const resolvedColumns = resolve.columnChildren(this.columns());
+    const resolvedRows = resolve.resolve({
+      columns: resolvedColumns,
+      method: resolve.nested
+    })(this.rows(route));
+
+    return (
+      <div key={'bulletchart-wrapper-' + i} style={{ marginTop: '30px' }}>
+        <div>
+          <BulletChart
+            key={'bullet-chart-' + i}
+            label="Weight sum"
+            stacked={true}
+            thresholdWarning={-1}
+            thresholdError={-1}
+            values={this.bulletChartValues(route)}
+            ranges={[{ value: 100 }]}
+          />
+        </div>
+        <Table.PfProvider columns={resolvedColumns} striped={true} bordered={true} hover={true} dataTable={true}>
+          <Table.Header headerRows={resolve.headerRows(this.columns())} />
+          <Table.Body rows={resolvedRows} rowKey="id" />
+        </Table.PfProvider>
+      </div>
+    );
+  }
+
+  render() {
+    return (
+      <div>
+        {(this.props.routes || []).map((route, i) => (
+          <div key={'virtualservice-rule' + i} className="row-cards-pf">
+            <Row>
+              <Col xs={12} sm={12} md={3} lg={3}>
+                <DetailObject name={this.props.kind + ' Route'} detail={route} exclude={['route']} />
+              </Col>
+              <Col xs={12} sm={12} md={5} lg={5}>
+                {this.renderTable(route, i)}
+              </Col>
+            </Row>
+            <hr />
+          </div>
+        ))}
+      </div>
+    );
+  }
+}
+
+export default VirtualServiceRoute;

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/ServiceInfoRouteVirtualServices.test.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/ServiceInfoRouteVirtualServices.test.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { VirtualService } from '../../../../types/ServiceInfo';
+import ServiceInfoVirtualServices from '../ServiceInfoVirtualServices';
+
+const virtualServices: VirtualService[] = [
+  {
+    name: 'reviews-default',
+    createdAt: '2018-03-14T10:17:52Z',
+    resourceVersion: '1234',
+    hosts: ['rewiews'],
+    gateways: ['reviews'],
+    http: [
+      {
+        route: [
+          {
+            destination: {
+              subset: 'v1',
+              host: 'reviews'
+            },
+            weight: 55
+          },
+          {
+            destination: {
+              subset: 'v3',
+              host: 'reviews'
+            },
+            weight: 55
+          }
+        ]
+      }
+    ],
+    tcp: [
+      {
+        match: [],
+        route: [
+          {
+            destination: {
+              subset: 'v1',
+              host: 'reviews'
+            },
+            weight: 55
+          },
+          {
+            destination: {
+              subset: 'v2',
+              host: 'reviews'
+            },
+            weight: 55
+          }
+        ]
+      }
+    ]
+  }
+];
+
+describe('#ServiceInfoVirtualServices render correctly with data', () => {
+  it('should render service virtual services', () => {
+    const wrapper = shallow(
+      <ServiceInfoVirtualServices
+        virtualServices={virtualServices}
+        editorLink={'/namespaces/test_namespace/services/test_services'}
+        validations={{}}
+      />
+    );
+    expect(wrapper).toBeDefined();
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoRouteVirtualServices.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoRouteVirtualServices.test.tsx.snap
@@ -1,0 +1,2452 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`#ServiceInfoVirtualServices render correctly with data should render service virtual services 1`] = `
+ShallowWrapper {
+  "length": 1,
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <ServiceInfoVirtualServices
+    editorLink="/namespaces/test_namespace/services/test_services"
+    validations={Object {}}
+    virtualServices={
+      Array [
+        Object {
+          "createdAt": "2018-03-14T10:17:52Z",
+          "gateways": Array [
+            "reviews",
+          ],
+          "hosts": Array [
+            "rewiews",
+          ],
+          "http": Array [
+            Object {
+              "route": Array [
+                Object {
+                  "destination": Object {
+                    "host": "reviews",
+                    "subset": "v1",
+                  },
+                  "weight": 55,
+                },
+                Object {
+                  "destination": Object {
+                    "host": "reviews",
+                    "subset": "v3",
+                  },
+                  "weight": 55,
+                },
+              ],
+            },
+          ],
+          "name": "reviews-default",
+          "resourceVersion": "1234",
+          "tcp": Array [
+            Object {
+              "match": Array [],
+              "route": Array [
+                Object {
+                  "destination": Object {
+                    "host": "reviews",
+                    "subset": "v1",
+                  },
+                  "weight": 55,
+                },
+                Object {
+                  "destination": Object {
+                    "host": "reviews",
+                    "subset": "v2",
+                  },
+                  "weight": 55,
+                },
+              ],
+            },
+          ],
+        },
+      ]
+    }
+  />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "children": Array [
+        <Row
+          bsClass="row"
+          className="row-cards-pf"
+          componentClass="div"
+        >
+          <Row
+            bsClass="row"
+            className="row-cards-pf"
+            componentClass="div"
+          >
+            <Col
+              bsClass="col"
+              componentClass="div"
+              lg={3}
+              md={3}
+              sm={12}
+              xs={12}
+            >
+              <div
+                className="card-pf-body"
+              >
+                <h3>
+                  reviews-default
+                </h3>
+                <div>
+                  <Link
+                    replace={false}
+                    to="/namespaces/test_namespace/services/test_services?virtualservice=reviews-default"
+                  >
+                    Show Yaml 
+                    <Icon
+                      name="angle-double-right"
+                      type="fa"
+                    />
+                  </Link>
+                </div>
+                <div>
+                  <strong>
+                    Created at
+                  </strong>
+                  : 
+                  <LocalTime
+                    time="2018-03-14T10:17:52Z"
+                  />
+                </div>
+                <div>
+                  <strong>
+                    Resource Version
+                  </strong>
+                  : 
+                  1234
+                </div>
+                <DetailObject
+                  detail={
+                    Array [
+                      "rewiews",
+                    ]
+                  }
+                  name="Hosts"
+                />
+                <DetailObject
+                  detail={
+                    Array [
+                      "reviews",
+                    ]
+                  }
+                  name="Gateways"
+                />
+              </div>
+            </Col>
+            <Col
+              bsClass="col"
+              componentClass="div"
+              lg={9}
+              md={9}
+              sm={12}
+              xs={12}
+            >
+              <Row
+                bsClass="row"
+                className="card-pf-body"
+                componentClass="div"
+              >
+                <Col
+                  bsClass="col"
+                  componentClass="div"
+                >
+                  <Row
+                    bsClass="row"
+                    componentClass="div"
+                  >
+                    <VirtualServiceRoute
+                      kind="HTTP"
+                      name="reviews-default"
+                      routes={
+                        Array [
+                          Object {
+                            "route": Array [
+                              Object {
+                                "destination": Object {
+                                  "host": "reviews",
+                                  "subset": "v1",
+                                },
+                                "weight": 55,
+                              },
+                              Object {
+                                "destination": Object {
+                                  "host": "reviews",
+                                  "subset": "v3",
+                                },
+                                "weight": 55,
+                              },
+                            ],
+                          },
+                        ]
+                      }
+                      validations={Object {}}
+                    />
+                  </Row>
+                  <Row
+                    bsClass="row"
+                    componentClass="div"
+                  >
+                    <VirtualServiceRoute
+                      kind="TCP"
+                      name="reviews-default"
+                      routes={
+                        Array [
+                          Object {
+                            "match": Array [],
+                            "route": Array [
+                              Object {
+                                "destination": Object {
+                                  "host": "reviews",
+                                  "subset": "v1",
+                                },
+                                "weight": 55,
+                              },
+                              Object {
+                                "destination": Object {
+                                  "host": "reviews",
+                                  "subset": "v2",
+                                },
+                                "weight": 55,
+                              },
+                            ],
+                          },
+                        ]
+                      }
+                      validations={Object {}}
+                    />
+                  </Row>
+                </Col>
+              </Row>
+            </Col>
+          </Row>
+        </Row>,
+      ],
+      "className": "card-pf",
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": "virtualservice0",
+        "nodeType": "class",
+        "props": Object {
+          "bsClass": "row",
+          "children": <Row
+            bsClass="row"
+            className="row-cards-pf"
+            componentClass="div"
+          >
+            <Col
+              bsClass="col"
+              componentClass="div"
+              lg={3}
+              md={3}
+              sm={12}
+              xs={12}
+            >
+              <div
+                className="card-pf-body"
+              >
+                <h3>
+                  reviews-default
+                </h3>
+                <div>
+                  <Link
+                    replace={false}
+                    to="/namespaces/test_namespace/services/test_services?virtualservice=reviews-default"
+                  >
+                    Show Yaml 
+                    <Icon
+                      name="angle-double-right"
+                      type="fa"
+                    />
+                  </Link>
+                </div>
+                <div>
+                  <strong>
+                    Created at
+                  </strong>
+                  : 
+                  <LocalTime
+                    time="2018-03-14T10:17:52Z"
+                  />
+                </div>
+                <div>
+                  <strong>
+                    Resource Version
+                  </strong>
+                  : 
+                  1234
+                </div>
+                <DetailObject
+                  detail={
+                    Array [
+                      "rewiews",
+                    ]
+                  }
+                  name="Hosts"
+                />
+                <DetailObject
+                  detail={
+                    Array [
+                      "reviews",
+                    ]
+                  }
+                  name="Gateways"
+                />
+              </div>
+            </Col>
+            <Col
+              bsClass="col"
+              componentClass="div"
+              lg={9}
+              md={9}
+              sm={12}
+              xs={12}
+            >
+              <Row
+                bsClass="row"
+                className="card-pf-body"
+                componentClass="div"
+              >
+                <Col
+                  bsClass="col"
+                  componentClass="div"
+                >
+                  <Row
+                    bsClass="row"
+                    componentClass="div"
+                  >
+                    <VirtualServiceRoute
+                      kind="HTTP"
+                      name="reviews-default"
+                      routes={
+                        Array [
+                          Object {
+                            "route": Array [
+                              Object {
+                                "destination": Object {
+                                  "host": "reviews",
+                                  "subset": "v1",
+                                },
+                                "weight": 55,
+                              },
+                              Object {
+                                "destination": Object {
+                                  "host": "reviews",
+                                  "subset": "v3",
+                                },
+                                "weight": 55,
+                              },
+                            ],
+                          },
+                        ]
+                      }
+                      validations={Object {}}
+                    />
+                  </Row>
+                  <Row
+                    bsClass="row"
+                    componentClass="div"
+                  >
+                    <VirtualServiceRoute
+                      kind="TCP"
+                      name="reviews-default"
+                      routes={
+                        Array [
+                          Object {
+                            "match": Array [],
+                            "route": Array [
+                              Object {
+                                "destination": Object {
+                                  "host": "reviews",
+                                  "subset": "v1",
+                                },
+                                "weight": 55,
+                              },
+                              Object {
+                                "destination": Object {
+                                  "host": "reviews",
+                                  "subset": "v2",
+                                },
+                                "weight": 55,
+                              },
+                            ],
+                          },
+                        ]
+                      }
+                      validations={Object {}}
+                    />
+                  </Row>
+                </Col>
+              </Row>
+            </Col>
+          </Row>,
+          "className": "row-cards-pf",
+          "componentClass": "div",
+        },
+        "ref": null,
+        "rendered": Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "bsClass": "row",
+            "children": Array [
+              <Col
+                bsClass="col"
+                componentClass="div"
+                lg={3}
+                md={3}
+                sm={12}
+                xs={12}
+              >
+                <div
+                  className="card-pf-body"
+                >
+                  <h3>
+                    reviews-default
+                  </h3>
+                  <div>
+                    <Link
+                      replace={false}
+                      to="/namespaces/test_namespace/services/test_services?virtualservice=reviews-default"
+                    >
+                      Show Yaml 
+                      <Icon
+                        name="angle-double-right"
+                        type="fa"
+                      />
+                    </Link>
+                  </div>
+                  <div>
+                    <strong>
+                      Created at
+                    </strong>
+                    : 
+                    <LocalTime
+                      time="2018-03-14T10:17:52Z"
+                    />
+                  </div>
+                  <div>
+                    <strong>
+                      Resource Version
+                    </strong>
+                    : 
+                    1234
+                  </div>
+                  <DetailObject
+                    detail={
+                      Array [
+                        "rewiews",
+                      ]
+                    }
+                    name="Hosts"
+                  />
+                  <DetailObject
+                    detail={
+                      Array [
+                        "reviews",
+                      ]
+                    }
+                    name="Gateways"
+                  />
+                </div>
+              </Col>,
+              <Col
+                bsClass="col"
+                componentClass="div"
+                lg={9}
+                md={9}
+                sm={12}
+                xs={12}
+              >
+                <Row
+                  bsClass="row"
+                  className="card-pf-body"
+                  componentClass="div"
+                >
+                  <Col
+                    bsClass="col"
+                    componentClass="div"
+                  >
+                    <Row
+                      bsClass="row"
+                      componentClass="div"
+                    >
+                      <VirtualServiceRoute
+                        kind="HTTP"
+                        name="reviews-default"
+                        routes={
+                          Array [
+                            Object {
+                              "route": Array [
+                                Object {
+                                  "destination": Object {
+                                    "host": "reviews",
+                                    "subset": "v1",
+                                  },
+                                  "weight": 55,
+                                },
+                                Object {
+                                  "destination": Object {
+                                    "host": "reviews",
+                                    "subset": "v3",
+                                  },
+                                  "weight": 55,
+                                },
+                              ],
+                            },
+                          ]
+                        }
+                        validations={Object {}}
+                      />
+                    </Row>
+                    <Row
+                      bsClass="row"
+                      componentClass="div"
+                    >
+                      <VirtualServiceRoute
+                        kind="TCP"
+                        name="reviews-default"
+                        routes={
+                          Array [
+                            Object {
+                              "match": Array [],
+                              "route": Array [
+                                Object {
+                                  "destination": Object {
+                                    "host": "reviews",
+                                    "subset": "v1",
+                                  },
+                                  "weight": 55,
+                                },
+                                Object {
+                                  "destination": Object {
+                                    "host": "reviews",
+                                    "subset": "v2",
+                                  },
+                                  "weight": 55,
+                                },
+                              ],
+                            },
+                          ]
+                        }
+                        validations={Object {}}
+                      />
+                    </Row>
+                  </Col>
+                </Row>
+              </Col>,
+            ],
+            "className": "row-cards-pf",
+            "componentClass": "div",
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "bsClass": "col",
+                "children": <div
+                  className="card-pf-body"
+                >
+                  <h3>
+                    reviews-default
+                  </h3>
+                  <div>
+                    <Link
+                      replace={false}
+                      to="/namespaces/test_namespace/services/test_services?virtualservice=reviews-default"
+                    >
+                      Show Yaml 
+                      <Icon
+                        name="angle-double-right"
+                        type="fa"
+                      />
+                    </Link>
+                  </div>
+                  <div>
+                    <strong>
+                      Created at
+                    </strong>
+                    : 
+                    <LocalTime
+                      time="2018-03-14T10:17:52Z"
+                    />
+                  </div>
+                  <div>
+                    <strong>
+                      Resource Version
+                    </strong>
+                    : 
+                    1234
+                  </div>
+                  <DetailObject
+                    detail={
+                      Array [
+                        "rewiews",
+                      ]
+                    }
+                    name="Hosts"
+                  />
+                  <DetailObject
+                    detail={
+                      Array [
+                        "reviews",
+                      ]
+                    }
+                    name="Gateways"
+                  />
+                </div>,
+                "componentClass": "div",
+                "lg": 3,
+                "md": 3,
+                "sm": 12,
+                "xs": 12,
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": "virtualServiceConfig0",
+                "nodeType": "host",
+                "props": Object {
+                  "children": Array [
+                    <h3>
+                      reviews-default
+                    </h3>,
+                    <div>
+                      <Link
+                        replace={false}
+                        to="/namespaces/test_namespace/services/test_services?virtualservice=reviews-default"
+                      >
+                        Show Yaml 
+                        <Icon
+                          name="angle-double-right"
+                          type="fa"
+                        />
+                      </Link>
+                    </div>,
+                    <div>
+                      <strong>
+                        Created at
+                      </strong>
+                      : 
+                      <LocalTime
+                        time="2018-03-14T10:17:52Z"
+                      />
+                    </div>,
+                    <div>
+                      <strong>
+                        Resource Version
+                      </strong>
+                      : 
+                      1234
+                    </div>,
+                    <DetailObject
+                      detail={
+                        Array [
+                          "rewiews",
+                        ]
+                      }
+                      name="Hosts"
+                    />,
+                    <DetailObject
+                      detail={
+                        Array [
+                          "reviews",
+                        ]
+                      }
+                      name="Gateways"
+                    />,
+                  ],
+                  "className": "card-pf-body",
+                },
+                "ref": null,
+                "rendered": Array [
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": "reviews-default",
+                    },
+                    "ref": null,
+                    "rendered": "reviews-default",
+                    "type": "h3",
+                  },
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": <Link
+                        replace={false}
+                        to="/namespaces/test_namespace/services/test_services?virtualservice=reviews-default"
+                      >
+                        Show Yaml 
+                        <Icon
+                          name="angle-double-right"
+                          type="fa"
+                        />
+                      </Link>,
+                    },
+                    "ref": null,
+                    "rendered": Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "class",
+                      "props": Object {
+                        "children": Array [
+                          "Show Yaml ",
+                          <Icon
+                            name="angle-double-right"
+                            type="fa"
+                          />,
+                        ],
+                        "replace": false,
+                        "to": "/namespaces/test_namespace/services/test_services?virtualservice=reviews-default",
+                      },
+                      "ref": null,
+                      "rendered": Array [
+                        "Show Yaml ",
+                        Object {
+                          "instance": null,
+                          "key": undefined,
+                          "nodeType": "function",
+                          "props": Object {
+                            "name": "angle-double-right",
+                            "type": "fa",
+                          },
+                          "ref": null,
+                          "rendered": null,
+                          "type": [Function],
+                        },
+                      ],
+                      "type": [Function],
+                    },
+                    "type": "div",
+                  },
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": Array [
+                        <strong>
+                          Created at
+                        </strong>,
+                        ": ",
+                        <LocalTime
+                          time="2018-03-14T10:17:52Z"
+                        />,
+                      ],
+                    },
+                    "ref": null,
+                    "rendered": Array [
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": "Created at",
+                        },
+                        "ref": null,
+                        "rendered": "Created at",
+                        "type": "strong",
+                      },
+                      ": ",
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "class",
+                        "props": Object {
+                          "time": "2018-03-14T10:17:52Z",
+                        },
+                        "ref": null,
+                        "rendered": null,
+                        "type": [Function],
+                      },
+                    ],
+                    "type": "div",
+                  },
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": Array [
+                        <strong>
+                          Resource Version
+                        </strong>,
+                        ": ",
+                        "1234",
+                      ],
+                    },
+                    "ref": null,
+                    "rendered": Array [
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": "Resource Version",
+                        },
+                        "ref": null,
+                        "rendered": "Resource Version",
+                        "type": "strong",
+                      },
+                      ": ",
+                      "1234",
+                    ],
+                    "type": "div",
+                  },
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "class",
+                    "props": Object {
+                      "detail": Array [
+                        "rewiews",
+                      ],
+                      "name": "Hosts",
+                    },
+                    "ref": null,
+                    "rendered": null,
+                    "type": [Function],
+                  },
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "class",
+                    "props": Object {
+                      "detail": Array [
+                        "reviews",
+                      ],
+                      "name": "Gateways",
+                    },
+                    "ref": null,
+                    "rendered": null,
+                    "type": [Function],
+                  },
+                ],
+                "type": "div",
+              },
+              "type": [Function],
+            },
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "bsClass": "col",
+                "children": <Row
+                  bsClass="row"
+                  className="card-pf-body"
+                  componentClass="div"
+                >
+                  <Col
+                    bsClass="col"
+                    componentClass="div"
+                  >
+                    <Row
+                      bsClass="row"
+                      componentClass="div"
+                    >
+                      <VirtualServiceRoute
+                        kind="HTTP"
+                        name="reviews-default"
+                        routes={
+                          Array [
+                            Object {
+                              "route": Array [
+                                Object {
+                                  "destination": Object {
+                                    "host": "reviews",
+                                    "subset": "v1",
+                                  },
+                                  "weight": 55,
+                                },
+                                Object {
+                                  "destination": Object {
+                                    "host": "reviews",
+                                    "subset": "v3",
+                                  },
+                                  "weight": 55,
+                                },
+                              ],
+                            },
+                          ]
+                        }
+                        validations={Object {}}
+                      />
+                    </Row>
+                    <Row
+                      bsClass="row"
+                      componentClass="div"
+                    >
+                      <VirtualServiceRoute
+                        kind="TCP"
+                        name="reviews-default"
+                        routes={
+                          Array [
+                            Object {
+                              "match": Array [],
+                              "route": Array [
+                                Object {
+                                  "destination": Object {
+                                    "host": "reviews",
+                                    "subset": "v1",
+                                  },
+                                  "weight": 55,
+                                },
+                                Object {
+                                  "destination": Object {
+                                    "host": "reviews",
+                                    "subset": "v2",
+                                  },
+                                  "weight": 55,
+                                },
+                              ],
+                            },
+                          ]
+                        }
+                        validations={Object {}}
+                      />
+                    </Row>
+                  </Col>
+                </Row>,
+                "componentClass": "div",
+                "lg": 9,
+                "md": 9,
+                "sm": 12,
+                "xs": 12,
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": "virtualServiceWeights0",
+                "nodeType": "class",
+                "props": Object {
+                  "bsClass": "row",
+                  "children": <Col
+                    bsClass="col"
+                    componentClass="div"
+                  >
+                    <Row
+                      bsClass="row"
+                      componentClass="div"
+                    >
+                      <VirtualServiceRoute
+                        kind="HTTP"
+                        name="reviews-default"
+                        routes={
+                          Array [
+                            Object {
+                              "route": Array [
+                                Object {
+                                  "destination": Object {
+                                    "host": "reviews",
+                                    "subset": "v1",
+                                  },
+                                  "weight": 55,
+                                },
+                                Object {
+                                  "destination": Object {
+                                    "host": "reviews",
+                                    "subset": "v3",
+                                  },
+                                  "weight": 55,
+                                },
+                              ],
+                            },
+                          ]
+                        }
+                        validations={Object {}}
+                      />
+                    </Row>
+                    <Row
+                      bsClass="row"
+                      componentClass="div"
+                    >
+                      <VirtualServiceRoute
+                        kind="TCP"
+                        name="reviews-default"
+                        routes={
+                          Array [
+                            Object {
+                              "match": Array [],
+                              "route": Array [
+                                Object {
+                                  "destination": Object {
+                                    "host": "reviews",
+                                    "subset": "v1",
+                                  },
+                                  "weight": 55,
+                                },
+                                Object {
+                                  "destination": Object {
+                                    "host": "reviews",
+                                    "subset": "v2",
+                                  },
+                                  "weight": 55,
+                                },
+                              ],
+                            },
+                          ]
+                        }
+                        validations={Object {}}
+                      />
+                    </Row>
+                  </Col>,
+                  "className": "card-pf-body",
+                  "componentClass": "div",
+                },
+                "ref": null,
+                "rendered": Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "class",
+                  "props": Object {
+                    "bsClass": "col",
+                    "children": Array [
+                      <Row
+                        bsClass="row"
+                        componentClass="div"
+                      >
+                        <VirtualServiceRoute
+                          kind="HTTP"
+                          name="reviews-default"
+                          routes={
+                            Array [
+                              Object {
+                                "route": Array [
+                                  Object {
+                                    "destination": Object {
+                                      "host": "reviews",
+                                      "subset": "v1",
+                                    },
+                                    "weight": 55,
+                                  },
+                                  Object {
+                                    "destination": Object {
+                                      "host": "reviews",
+                                      "subset": "v3",
+                                    },
+                                    "weight": 55,
+                                  },
+                                ],
+                              },
+                            ]
+                          }
+                          validations={Object {}}
+                        />
+                      </Row>,
+                      <Row
+                        bsClass="row"
+                        componentClass="div"
+                      >
+                        <VirtualServiceRoute
+                          kind="TCP"
+                          name="reviews-default"
+                          routes={
+                            Array [
+                              Object {
+                                "match": Array [],
+                                "route": Array [
+                                  Object {
+                                    "destination": Object {
+                                      "host": "reviews",
+                                      "subset": "v1",
+                                    },
+                                    "weight": 55,
+                                  },
+                                  Object {
+                                    "destination": Object {
+                                      "host": "reviews",
+                                      "subset": "v2",
+                                    },
+                                    "weight": 55,
+                                  },
+                                ],
+                              },
+                            ]
+                          }
+                          validations={Object {}}
+                        />
+                      </Row>,
+                    ],
+                    "componentClass": "div",
+                  },
+                  "ref": null,
+                  "rendered": Array [
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "class",
+                      "props": Object {
+                        "bsClass": "row",
+                        "children": <VirtualServiceRoute
+                          kind="HTTP"
+                          name="reviews-default"
+                          routes={
+                            Array [
+                              Object {
+                                "route": Array [
+                                  Object {
+                                    "destination": Object {
+                                      "host": "reviews",
+                                      "subset": "v1",
+                                    },
+                                    "weight": 55,
+                                  },
+                                  Object {
+                                    "destination": Object {
+                                      "host": "reviews",
+                                      "subset": "v3",
+                                    },
+                                    "weight": 55,
+                                  },
+                                ],
+                              },
+                            ]
+                          }
+                          validations={Object {}}
+                        />,
+                        "componentClass": "div",
+                      },
+                      "ref": null,
+                      "rendered": Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "class",
+                        "props": Object {
+                          "kind": "HTTP",
+                          "name": "reviews-default",
+                          "routes": Array [
+                            Object {
+                              "route": Array [
+                                Object {
+                                  "destination": Object {
+                                    "host": "reviews",
+                                    "subset": "v1",
+                                  },
+                                  "weight": 55,
+                                },
+                                Object {
+                                  "destination": Object {
+                                    "host": "reviews",
+                                    "subset": "v3",
+                                  },
+                                  "weight": 55,
+                                },
+                              ],
+                            },
+                          ],
+                          "validations": Object {},
+                        },
+                        "ref": null,
+                        "rendered": null,
+                        "type": [Function],
+                      },
+                      "type": [Function],
+                    },
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "class",
+                      "props": Object {
+                        "bsClass": "row",
+                        "children": <VirtualServiceRoute
+                          kind="TCP"
+                          name="reviews-default"
+                          routes={
+                            Array [
+                              Object {
+                                "match": Array [],
+                                "route": Array [
+                                  Object {
+                                    "destination": Object {
+                                      "host": "reviews",
+                                      "subset": "v1",
+                                    },
+                                    "weight": 55,
+                                  },
+                                  Object {
+                                    "destination": Object {
+                                      "host": "reviews",
+                                      "subset": "v2",
+                                    },
+                                    "weight": 55,
+                                  },
+                                ],
+                              },
+                            ]
+                          }
+                          validations={Object {}}
+                        />,
+                        "componentClass": "div",
+                      },
+                      "ref": null,
+                      "rendered": Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "class",
+                        "props": Object {
+                          "kind": "TCP",
+                          "name": "reviews-default",
+                          "routes": Array [
+                            Object {
+                              "match": Array [],
+                              "route": Array [
+                                Object {
+                                  "destination": Object {
+                                    "host": "reviews",
+                                    "subset": "v1",
+                                  },
+                                  "weight": 55,
+                                },
+                                Object {
+                                  "destination": Object {
+                                    "host": "reviews",
+                                    "subset": "v2",
+                                  },
+                                  "weight": 55,
+                                },
+                              ],
+                            },
+                          ],
+                          "validations": Object {},
+                        },
+                        "ref": null,
+                        "rendered": null,
+                        "type": [Function],
+                      },
+                      "type": [Function],
+                    },
+                  ],
+                  "type": [Function],
+                },
+                "type": [Function],
+              },
+              "type": [Function],
+            },
+          ],
+          "type": [Function],
+        },
+        "type": [Function],
+      },
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <Row
+            bsClass="row"
+            className="row-cards-pf"
+            componentClass="div"
+          >
+            <Row
+              bsClass="row"
+              className="row-cards-pf"
+              componentClass="div"
+            >
+              <Col
+                bsClass="col"
+                componentClass="div"
+                lg={3}
+                md={3}
+                sm={12}
+                xs={12}
+              >
+                <div
+                  className="card-pf-body"
+                >
+                  <h3>
+                    reviews-default
+                  </h3>
+                  <div>
+                    <Link
+                      replace={false}
+                      to="/namespaces/test_namespace/services/test_services?virtualservice=reviews-default"
+                    >
+                      Show Yaml 
+                      <Icon
+                        name="angle-double-right"
+                        type="fa"
+                      />
+                    </Link>
+                  </div>
+                  <div>
+                    <strong>
+                      Created at
+                    </strong>
+                    : 
+                    <LocalTime
+                      time="2018-03-14T10:17:52Z"
+                    />
+                  </div>
+                  <div>
+                    <strong>
+                      Resource Version
+                    </strong>
+                    : 
+                    1234
+                  </div>
+                  <DetailObject
+                    detail={
+                      Array [
+                        "rewiews",
+                      ]
+                    }
+                    name="Hosts"
+                  />
+                  <DetailObject
+                    detail={
+                      Array [
+                        "reviews",
+                      ]
+                    }
+                    name="Gateways"
+                  />
+                </div>
+              </Col>
+              <Col
+                bsClass="col"
+                componentClass="div"
+                lg={9}
+                md={9}
+                sm={12}
+                xs={12}
+              >
+                <Row
+                  bsClass="row"
+                  className="card-pf-body"
+                  componentClass="div"
+                >
+                  <Col
+                    bsClass="col"
+                    componentClass="div"
+                  >
+                    <Row
+                      bsClass="row"
+                      componentClass="div"
+                    >
+                      <VirtualServiceRoute
+                        kind="HTTP"
+                        name="reviews-default"
+                        routes={
+                          Array [
+                            Object {
+                              "route": Array [
+                                Object {
+                                  "destination": Object {
+                                    "host": "reviews",
+                                    "subset": "v1",
+                                  },
+                                  "weight": 55,
+                                },
+                                Object {
+                                  "destination": Object {
+                                    "host": "reviews",
+                                    "subset": "v3",
+                                  },
+                                  "weight": 55,
+                                },
+                              ],
+                            },
+                          ]
+                        }
+                        validations={Object {}}
+                      />
+                    </Row>
+                    <Row
+                      bsClass="row"
+                      componentClass="div"
+                    >
+                      <VirtualServiceRoute
+                        kind="TCP"
+                        name="reviews-default"
+                        routes={
+                          Array [
+                            Object {
+                              "match": Array [],
+                              "route": Array [
+                                Object {
+                                  "destination": Object {
+                                    "host": "reviews",
+                                    "subset": "v1",
+                                  },
+                                  "weight": 55,
+                                },
+                                Object {
+                                  "destination": Object {
+                                    "host": "reviews",
+                                    "subset": "v2",
+                                  },
+                                  "weight": 55,
+                                },
+                              ],
+                            },
+                          ]
+                        }
+                        validations={Object {}}
+                      />
+                    </Row>
+                  </Col>
+                </Row>
+              </Col>
+            </Row>
+          </Row>,
+        ],
+        "className": "card-pf",
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": "virtualservice0",
+          "nodeType": "class",
+          "props": Object {
+            "bsClass": "row",
+            "children": <Row
+              bsClass="row"
+              className="row-cards-pf"
+              componentClass="div"
+            >
+              <Col
+                bsClass="col"
+                componentClass="div"
+                lg={3}
+                md={3}
+                sm={12}
+                xs={12}
+              >
+                <div
+                  className="card-pf-body"
+                >
+                  <h3>
+                    reviews-default
+                  </h3>
+                  <div>
+                    <Link
+                      replace={false}
+                      to="/namespaces/test_namespace/services/test_services?virtualservice=reviews-default"
+                    >
+                      Show Yaml 
+                      <Icon
+                        name="angle-double-right"
+                        type="fa"
+                      />
+                    </Link>
+                  </div>
+                  <div>
+                    <strong>
+                      Created at
+                    </strong>
+                    : 
+                    <LocalTime
+                      time="2018-03-14T10:17:52Z"
+                    />
+                  </div>
+                  <div>
+                    <strong>
+                      Resource Version
+                    </strong>
+                    : 
+                    1234
+                  </div>
+                  <DetailObject
+                    detail={
+                      Array [
+                        "rewiews",
+                      ]
+                    }
+                    name="Hosts"
+                  />
+                  <DetailObject
+                    detail={
+                      Array [
+                        "reviews",
+                      ]
+                    }
+                    name="Gateways"
+                  />
+                </div>
+              </Col>
+              <Col
+                bsClass="col"
+                componentClass="div"
+                lg={9}
+                md={9}
+                sm={12}
+                xs={12}
+              >
+                <Row
+                  bsClass="row"
+                  className="card-pf-body"
+                  componentClass="div"
+                >
+                  <Col
+                    bsClass="col"
+                    componentClass="div"
+                  >
+                    <Row
+                      bsClass="row"
+                      componentClass="div"
+                    >
+                      <VirtualServiceRoute
+                        kind="HTTP"
+                        name="reviews-default"
+                        routes={
+                          Array [
+                            Object {
+                              "route": Array [
+                                Object {
+                                  "destination": Object {
+                                    "host": "reviews",
+                                    "subset": "v1",
+                                  },
+                                  "weight": 55,
+                                },
+                                Object {
+                                  "destination": Object {
+                                    "host": "reviews",
+                                    "subset": "v3",
+                                  },
+                                  "weight": 55,
+                                },
+                              ],
+                            },
+                          ]
+                        }
+                        validations={Object {}}
+                      />
+                    </Row>
+                    <Row
+                      bsClass="row"
+                      componentClass="div"
+                    >
+                      <VirtualServiceRoute
+                        kind="TCP"
+                        name="reviews-default"
+                        routes={
+                          Array [
+                            Object {
+                              "match": Array [],
+                              "route": Array [
+                                Object {
+                                  "destination": Object {
+                                    "host": "reviews",
+                                    "subset": "v1",
+                                  },
+                                  "weight": 55,
+                                },
+                                Object {
+                                  "destination": Object {
+                                    "host": "reviews",
+                                    "subset": "v2",
+                                  },
+                                  "weight": 55,
+                                },
+                              ],
+                            },
+                          ]
+                        }
+                        validations={Object {}}
+                      />
+                    </Row>
+                  </Col>
+                </Row>
+              </Col>
+            </Row>,
+            "className": "row-cards-pf",
+            "componentClass": "div",
+          },
+          "ref": null,
+          "rendered": Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "bsClass": "row",
+              "children": Array [
+                <Col
+                  bsClass="col"
+                  componentClass="div"
+                  lg={3}
+                  md={3}
+                  sm={12}
+                  xs={12}
+                >
+                  <div
+                    className="card-pf-body"
+                  >
+                    <h3>
+                      reviews-default
+                    </h3>
+                    <div>
+                      <Link
+                        replace={false}
+                        to="/namespaces/test_namespace/services/test_services?virtualservice=reviews-default"
+                      >
+                        Show Yaml 
+                        <Icon
+                          name="angle-double-right"
+                          type="fa"
+                        />
+                      </Link>
+                    </div>
+                    <div>
+                      <strong>
+                        Created at
+                      </strong>
+                      : 
+                      <LocalTime
+                        time="2018-03-14T10:17:52Z"
+                      />
+                    </div>
+                    <div>
+                      <strong>
+                        Resource Version
+                      </strong>
+                      : 
+                      1234
+                    </div>
+                    <DetailObject
+                      detail={
+                        Array [
+                          "rewiews",
+                        ]
+                      }
+                      name="Hosts"
+                    />
+                    <DetailObject
+                      detail={
+                        Array [
+                          "reviews",
+                        ]
+                      }
+                      name="Gateways"
+                    />
+                  </div>
+                </Col>,
+                <Col
+                  bsClass="col"
+                  componentClass="div"
+                  lg={9}
+                  md={9}
+                  sm={12}
+                  xs={12}
+                >
+                  <Row
+                    bsClass="row"
+                    className="card-pf-body"
+                    componentClass="div"
+                  >
+                    <Col
+                      bsClass="col"
+                      componentClass="div"
+                    >
+                      <Row
+                        bsClass="row"
+                        componentClass="div"
+                      >
+                        <VirtualServiceRoute
+                          kind="HTTP"
+                          name="reviews-default"
+                          routes={
+                            Array [
+                              Object {
+                                "route": Array [
+                                  Object {
+                                    "destination": Object {
+                                      "host": "reviews",
+                                      "subset": "v1",
+                                    },
+                                    "weight": 55,
+                                  },
+                                  Object {
+                                    "destination": Object {
+                                      "host": "reviews",
+                                      "subset": "v3",
+                                    },
+                                    "weight": 55,
+                                  },
+                                ],
+                              },
+                            ]
+                          }
+                          validations={Object {}}
+                        />
+                      </Row>
+                      <Row
+                        bsClass="row"
+                        componentClass="div"
+                      >
+                        <VirtualServiceRoute
+                          kind="TCP"
+                          name="reviews-default"
+                          routes={
+                            Array [
+                              Object {
+                                "match": Array [],
+                                "route": Array [
+                                  Object {
+                                    "destination": Object {
+                                      "host": "reviews",
+                                      "subset": "v1",
+                                    },
+                                    "weight": 55,
+                                  },
+                                  Object {
+                                    "destination": Object {
+                                      "host": "reviews",
+                                      "subset": "v2",
+                                    },
+                                    "weight": 55,
+                                  },
+                                ],
+                              },
+                            ]
+                          }
+                          validations={Object {}}
+                        />
+                      </Row>
+                    </Col>
+                  </Row>
+                </Col>,
+              ],
+              "className": "row-cards-pf",
+              "componentClass": "div",
+            },
+            "ref": null,
+            "rendered": Array [
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "class",
+                "props": Object {
+                  "bsClass": "col",
+                  "children": <div
+                    className="card-pf-body"
+                  >
+                    <h3>
+                      reviews-default
+                    </h3>
+                    <div>
+                      <Link
+                        replace={false}
+                        to="/namespaces/test_namespace/services/test_services?virtualservice=reviews-default"
+                      >
+                        Show Yaml 
+                        <Icon
+                          name="angle-double-right"
+                          type="fa"
+                        />
+                      </Link>
+                    </div>
+                    <div>
+                      <strong>
+                        Created at
+                      </strong>
+                      : 
+                      <LocalTime
+                        time="2018-03-14T10:17:52Z"
+                      />
+                    </div>
+                    <div>
+                      <strong>
+                        Resource Version
+                      </strong>
+                      : 
+                      1234
+                    </div>
+                    <DetailObject
+                      detail={
+                        Array [
+                          "rewiews",
+                        ]
+                      }
+                      name="Hosts"
+                    />
+                    <DetailObject
+                      detail={
+                        Array [
+                          "reviews",
+                        ]
+                      }
+                      name="Gateways"
+                    />
+                  </div>,
+                  "componentClass": "div",
+                  "lg": 3,
+                  "md": 3,
+                  "sm": 12,
+                  "xs": 12,
+                },
+                "ref": null,
+                "rendered": Object {
+                  "instance": null,
+                  "key": "virtualServiceConfig0",
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": Array [
+                      <h3>
+                        reviews-default
+                      </h3>,
+                      <div>
+                        <Link
+                          replace={false}
+                          to="/namespaces/test_namespace/services/test_services?virtualservice=reviews-default"
+                        >
+                          Show Yaml 
+                          <Icon
+                            name="angle-double-right"
+                            type="fa"
+                          />
+                        </Link>
+                      </div>,
+                      <div>
+                        <strong>
+                          Created at
+                        </strong>
+                        : 
+                        <LocalTime
+                          time="2018-03-14T10:17:52Z"
+                        />
+                      </div>,
+                      <div>
+                        <strong>
+                          Resource Version
+                        </strong>
+                        : 
+                        1234
+                      </div>,
+                      <DetailObject
+                        detail={
+                          Array [
+                            "rewiews",
+                          ]
+                        }
+                        name="Hosts"
+                      />,
+                      <DetailObject
+                        detail={
+                          Array [
+                            "reviews",
+                          ]
+                        }
+                        name="Gateways"
+                      />,
+                    ],
+                    "className": "card-pf-body",
+                  },
+                  "ref": null,
+                  "rendered": Array [
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": "reviews-default",
+                      },
+                      "ref": null,
+                      "rendered": "reviews-default",
+                      "type": "h3",
+                    },
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": <Link
+                          replace={false}
+                          to="/namespaces/test_namespace/services/test_services?virtualservice=reviews-default"
+                        >
+                          Show Yaml 
+                          <Icon
+                            name="angle-double-right"
+                            type="fa"
+                          />
+                        </Link>,
+                      },
+                      "ref": null,
+                      "rendered": Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "class",
+                        "props": Object {
+                          "children": Array [
+                            "Show Yaml ",
+                            <Icon
+                              name="angle-double-right"
+                              type="fa"
+                            />,
+                          ],
+                          "replace": false,
+                          "to": "/namespaces/test_namespace/services/test_services?virtualservice=reviews-default",
+                        },
+                        "ref": null,
+                        "rendered": Array [
+                          "Show Yaml ",
+                          Object {
+                            "instance": null,
+                            "key": undefined,
+                            "nodeType": "function",
+                            "props": Object {
+                              "name": "angle-double-right",
+                              "type": "fa",
+                            },
+                            "ref": null,
+                            "rendered": null,
+                            "type": [Function],
+                          },
+                        ],
+                        "type": [Function],
+                      },
+                      "type": "div",
+                    },
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": Array [
+                          <strong>
+                            Created at
+                          </strong>,
+                          ": ",
+                          <LocalTime
+                            time="2018-03-14T10:17:52Z"
+                          />,
+                        ],
+                      },
+                      "ref": null,
+                      "rendered": Array [
+                        Object {
+                          "instance": null,
+                          "key": undefined,
+                          "nodeType": "host",
+                          "props": Object {
+                            "children": "Created at",
+                          },
+                          "ref": null,
+                          "rendered": "Created at",
+                          "type": "strong",
+                        },
+                        ": ",
+                        Object {
+                          "instance": null,
+                          "key": undefined,
+                          "nodeType": "class",
+                          "props": Object {
+                            "time": "2018-03-14T10:17:52Z",
+                          },
+                          "ref": null,
+                          "rendered": null,
+                          "type": [Function],
+                        },
+                      ],
+                      "type": "div",
+                    },
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": Array [
+                          <strong>
+                            Resource Version
+                          </strong>,
+                          ": ",
+                          "1234",
+                        ],
+                      },
+                      "ref": null,
+                      "rendered": Array [
+                        Object {
+                          "instance": null,
+                          "key": undefined,
+                          "nodeType": "host",
+                          "props": Object {
+                            "children": "Resource Version",
+                          },
+                          "ref": null,
+                          "rendered": "Resource Version",
+                          "type": "strong",
+                        },
+                        ": ",
+                        "1234",
+                      ],
+                      "type": "div",
+                    },
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "class",
+                      "props": Object {
+                        "detail": Array [
+                          "rewiews",
+                        ],
+                        "name": "Hosts",
+                      },
+                      "ref": null,
+                      "rendered": null,
+                      "type": [Function],
+                    },
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "class",
+                      "props": Object {
+                        "detail": Array [
+                          "reviews",
+                        ],
+                        "name": "Gateways",
+                      },
+                      "ref": null,
+                      "rendered": null,
+                      "type": [Function],
+                    },
+                  ],
+                  "type": "div",
+                },
+                "type": [Function],
+              },
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "class",
+                "props": Object {
+                  "bsClass": "col",
+                  "children": <Row
+                    bsClass="row"
+                    className="card-pf-body"
+                    componentClass="div"
+                  >
+                    <Col
+                      bsClass="col"
+                      componentClass="div"
+                    >
+                      <Row
+                        bsClass="row"
+                        componentClass="div"
+                      >
+                        <VirtualServiceRoute
+                          kind="HTTP"
+                          name="reviews-default"
+                          routes={
+                            Array [
+                              Object {
+                                "route": Array [
+                                  Object {
+                                    "destination": Object {
+                                      "host": "reviews",
+                                      "subset": "v1",
+                                    },
+                                    "weight": 55,
+                                  },
+                                  Object {
+                                    "destination": Object {
+                                      "host": "reviews",
+                                      "subset": "v3",
+                                    },
+                                    "weight": 55,
+                                  },
+                                ],
+                              },
+                            ]
+                          }
+                          validations={Object {}}
+                        />
+                      </Row>
+                      <Row
+                        bsClass="row"
+                        componentClass="div"
+                      >
+                        <VirtualServiceRoute
+                          kind="TCP"
+                          name="reviews-default"
+                          routes={
+                            Array [
+                              Object {
+                                "match": Array [],
+                                "route": Array [
+                                  Object {
+                                    "destination": Object {
+                                      "host": "reviews",
+                                      "subset": "v1",
+                                    },
+                                    "weight": 55,
+                                  },
+                                  Object {
+                                    "destination": Object {
+                                      "host": "reviews",
+                                      "subset": "v2",
+                                    },
+                                    "weight": 55,
+                                  },
+                                ],
+                              },
+                            ]
+                          }
+                          validations={Object {}}
+                        />
+                      </Row>
+                    </Col>
+                  </Row>,
+                  "componentClass": "div",
+                  "lg": 9,
+                  "md": 9,
+                  "sm": 12,
+                  "xs": 12,
+                },
+                "ref": null,
+                "rendered": Object {
+                  "instance": null,
+                  "key": "virtualServiceWeights0",
+                  "nodeType": "class",
+                  "props": Object {
+                    "bsClass": "row",
+                    "children": <Col
+                      bsClass="col"
+                      componentClass="div"
+                    >
+                      <Row
+                        bsClass="row"
+                        componentClass="div"
+                      >
+                        <VirtualServiceRoute
+                          kind="HTTP"
+                          name="reviews-default"
+                          routes={
+                            Array [
+                              Object {
+                                "route": Array [
+                                  Object {
+                                    "destination": Object {
+                                      "host": "reviews",
+                                      "subset": "v1",
+                                    },
+                                    "weight": 55,
+                                  },
+                                  Object {
+                                    "destination": Object {
+                                      "host": "reviews",
+                                      "subset": "v3",
+                                    },
+                                    "weight": 55,
+                                  },
+                                ],
+                              },
+                            ]
+                          }
+                          validations={Object {}}
+                        />
+                      </Row>
+                      <Row
+                        bsClass="row"
+                        componentClass="div"
+                      >
+                        <VirtualServiceRoute
+                          kind="TCP"
+                          name="reviews-default"
+                          routes={
+                            Array [
+                              Object {
+                                "match": Array [],
+                                "route": Array [
+                                  Object {
+                                    "destination": Object {
+                                      "host": "reviews",
+                                      "subset": "v1",
+                                    },
+                                    "weight": 55,
+                                  },
+                                  Object {
+                                    "destination": Object {
+                                      "host": "reviews",
+                                      "subset": "v2",
+                                    },
+                                    "weight": 55,
+                                  },
+                                ],
+                              },
+                            ]
+                          }
+                          validations={Object {}}
+                        />
+                      </Row>
+                    </Col>,
+                    "className": "card-pf-body",
+                    "componentClass": "div",
+                  },
+                  "ref": null,
+                  "rendered": Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "class",
+                    "props": Object {
+                      "bsClass": "col",
+                      "children": Array [
+                        <Row
+                          bsClass="row"
+                          componentClass="div"
+                        >
+                          <VirtualServiceRoute
+                            kind="HTTP"
+                            name="reviews-default"
+                            routes={
+                              Array [
+                                Object {
+                                  "route": Array [
+                                    Object {
+                                      "destination": Object {
+                                        "host": "reviews",
+                                        "subset": "v1",
+                                      },
+                                      "weight": 55,
+                                    },
+                                    Object {
+                                      "destination": Object {
+                                        "host": "reviews",
+                                        "subset": "v3",
+                                      },
+                                      "weight": 55,
+                                    },
+                                  ],
+                                },
+                              ]
+                            }
+                            validations={Object {}}
+                          />
+                        </Row>,
+                        <Row
+                          bsClass="row"
+                          componentClass="div"
+                        >
+                          <VirtualServiceRoute
+                            kind="TCP"
+                            name="reviews-default"
+                            routes={
+                              Array [
+                                Object {
+                                  "match": Array [],
+                                  "route": Array [
+                                    Object {
+                                      "destination": Object {
+                                        "host": "reviews",
+                                        "subset": "v1",
+                                      },
+                                      "weight": 55,
+                                    },
+                                    Object {
+                                      "destination": Object {
+                                        "host": "reviews",
+                                        "subset": "v2",
+                                      },
+                                      "weight": 55,
+                                    },
+                                  ],
+                                },
+                              ]
+                            }
+                            validations={Object {}}
+                          />
+                        </Row>,
+                      ],
+                      "componentClass": "div",
+                    },
+                    "ref": null,
+                    "rendered": Array [
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "class",
+                        "props": Object {
+                          "bsClass": "row",
+                          "children": <VirtualServiceRoute
+                            kind="HTTP"
+                            name="reviews-default"
+                            routes={
+                              Array [
+                                Object {
+                                  "route": Array [
+                                    Object {
+                                      "destination": Object {
+                                        "host": "reviews",
+                                        "subset": "v1",
+                                      },
+                                      "weight": 55,
+                                    },
+                                    Object {
+                                      "destination": Object {
+                                        "host": "reviews",
+                                        "subset": "v3",
+                                      },
+                                      "weight": 55,
+                                    },
+                                  ],
+                                },
+                              ]
+                            }
+                            validations={Object {}}
+                          />,
+                          "componentClass": "div",
+                        },
+                        "ref": null,
+                        "rendered": Object {
+                          "instance": null,
+                          "key": undefined,
+                          "nodeType": "class",
+                          "props": Object {
+                            "kind": "HTTP",
+                            "name": "reviews-default",
+                            "routes": Array [
+                              Object {
+                                "route": Array [
+                                  Object {
+                                    "destination": Object {
+                                      "host": "reviews",
+                                      "subset": "v1",
+                                    },
+                                    "weight": 55,
+                                  },
+                                  Object {
+                                    "destination": Object {
+                                      "host": "reviews",
+                                      "subset": "v3",
+                                    },
+                                    "weight": 55,
+                                  },
+                                ],
+                              },
+                            ],
+                            "validations": Object {},
+                          },
+                          "ref": null,
+                          "rendered": null,
+                          "type": [Function],
+                        },
+                        "type": [Function],
+                      },
+                      Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "class",
+                        "props": Object {
+                          "bsClass": "row",
+                          "children": <VirtualServiceRoute
+                            kind="TCP"
+                            name="reviews-default"
+                            routes={
+                              Array [
+                                Object {
+                                  "match": Array [],
+                                  "route": Array [
+                                    Object {
+                                      "destination": Object {
+                                        "host": "reviews",
+                                        "subset": "v1",
+                                      },
+                                      "weight": 55,
+                                    },
+                                    Object {
+                                      "destination": Object {
+                                        "host": "reviews",
+                                        "subset": "v2",
+                                      },
+                                      "weight": 55,
+                                    },
+                                  ],
+                                },
+                              ]
+                            }
+                            validations={Object {}}
+                          />,
+                          "componentClass": "div",
+                        },
+                        "ref": null,
+                        "rendered": Object {
+                          "instance": null,
+                          "key": undefined,
+                          "nodeType": "class",
+                          "props": Object {
+                            "kind": "TCP",
+                            "name": "reviews-default",
+                            "routes": Array [
+                              Object {
+                                "match": Array [],
+                                "route": Array [
+                                  Object {
+                                    "destination": Object {
+                                      "host": "reviews",
+                                      "subset": "v1",
+                                    },
+                                    "weight": 55,
+                                  },
+                                  Object {
+                                    "destination": Object {
+                                      "host": "reviews",
+                                      "subset": "v2",
+                                    },
+                                    "weight": 55,
+                                  },
+                                ],
+                              },
+                            ],
+                            "validations": Object {},
+                          },
+                          "ref": null,
+                          "rendered": null,
+                          "type": [Function],
+                        },
+                        "type": [Function],
+                      },
+                    ],
+                    "type": [Function],
+                  },
+                  "type": [Function],
+                },
+                "type": [Function],
+              },
+            ],
+            "type": [Function],
+          },
+          "type": [Function],
+        },
+      ],
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+      },
+    },
+  },
+}
+`;

--- a/src/types/ServiceInfo.ts
+++ b/src/types/ServiceInfo.ts
@@ -67,7 +67,7 @@ export interface RouteRule {
   destination?: IstioService;
   precedence?: number;
   match?: MatchCondition;
-  route?: DestinationWeight[];
+  route?: DestinationWeightV1Alpha1[];
   redirect?: HTTPRedirect;
   rewrite?: HTTPRewrite;
   websocketUpgrade?: string;
@@ -110,8 +110,13 @@ export interface StringMatch {
   regex?: string;
 }
 
-export interface DestinationWeight {
+export interface DestinationWeightV1Alpha1 {
   labels: { [key: string]: string };
+  weight?: number;
+}
+
+export interface DestinationWeight {
+  destination: Destination;
   weight?: number;
 }
 
@@ -235,9 +240,9 @@ export interface PortSelector {
 }
 
 export interface Destination {
-  name: string;
-  subset: string;
-  port: PortSelector;
+  host: string;
+  subset?: string;
+  port?: PortSelector;
 }
 
 export interface HTTPMatchRequest {
@@ -252,21 +257,21 @@ export interface HTTPMatchRequest {
 }
 
 export interface HTTPRoute {
-  match: HTTPMatchRequest[];
-  route: DestinationWeight[];
-  redirect: HTTPRedirect;
-  rewrite: HTTPRewrite;
-  websocketUpgrade: boolean;
-  timeout: string;
-  retries: HTTPRetry;
-  mirror: Destination;
-  corsPolicy: CorsPolicy;
-  appendHeaders: { [key: string]: string };
+  match?: HTTPMatchRequest[];
+  route?: DestinationWeight[];
+  redirect?: HTTPRedirect;
+  rewrite?: HTTPRewrite;
+  websocketUpgrade?: boolean;
+  timeout?: string;
+  retries?: HTTPRetry;
+  mirror?: Destination;
+  corsPolicy?: CorsPolicy;
+  appendHeaders?: { [key: string]: string };
 }
 
 export interface TCPRoute {
-  match: L4MatchAttributes[];
-  route: DestinationWeight[];
+  match?: L4MatchAttributes[];
+  route?: DestinationWeight[];
 }
 
 export interface VirtualService {


### PR DESCRIPTION
The main goal of this PR is move all the visuals from RouteRules tab to Virtual Services. Here the result of this PR changes:

![virtual-service-ui-migration-2](https://user-images.githubusercontent.com/613814/42031350-426897be-7ad6-11e8-8056-a0bb945a6160.png)

This PR needs kiali/kiali#319 to be merged.