### PR TITLE
KIALI-959 PoC - click a node or edge with the "Control" key pressed to focus on a subset of nodes

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -47,7 +47,9 @@ interface CytoscapeBaseEvent {
   summaryTarget: any; // the cytoscape element that was the target of the event
 }
 
-export interface CytoscapeClickEvent extends CytoscapeBaseEvent {}
+export interface CytoscapeClickEvent extends CytoscapeBaseEvent {
+  ctrlKey?: boolean;
+}
 export interface CytoscapeMouseInEvent extends CytoscapeBaseEvent {}
 export interface CytoscapeMouseOutEvent extends CytoscapeBaseEvent {}
 
@@ -161,7 +163,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
     this.graphHighlighter = new GraphHighlighter(cy);
     this.trafficRenderer = new TrafficRender(cy, cy.edges());
 
-    const getCytoscapeBaseEvent = (event: any): CytoscapeBaseEvent | null => {
+    const getCytoscapeBaseEvent = (event: any): CytoscapeBaseEvent => {
       const target = event.target;
       if (target === cy) {
         return { summaryType: 'graph', summaryTarget: cy };
@@ -174,8 +176,8 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
       } else if (target.isEdge()) {
         return { summaryType: 'edge', summaryTarget: target };
       } else {
-        console.log(`${event.type} UNHANDLED`);
-        return null;
+        console.error(`${event.type} UNHANDLED`);
+        throw Error(`Unhandlable event: ${event.type}`);
       }
     };
 
@@ -203,7 +205,11 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
     cy.on(
       'tap',
       injectDoubleTap((evt: any) => {
-        const cytoscapeEvent = getCytoscapeBaseEvent(evt);
+        const ctrlKey: boolean = evt.originalEvent ? evt.originalEvent.ctrlKey : false;
+        const cytoscapeEvent: CytoscapeClickEvent = {
+          ...getCytoscapeBaseEvent(evt),
+          ctrlKey: ctrlKey
+        };
 
         if (cytoscapeEvent) {
           this.handleTap(cytoscapeEvent);

--- a/src/components/CytoscapeGraph/graphs/GraphBadge.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphBadge.ts
@@ -99,6 +99,7 @@ class GraphBadge {
       // 'mousedim' is the class used by GraphHighlighter.
       // The opacity values are from GraphStyles.
       div.style.opacity = event.target.hasClass('mousedim') ? '0.3' : '1.0';
+      div.style.display = event.target.hasClass('mousehide') ? 'none' : 'inline';
     };
 
     node.on('position', update);

--- a/src/components/CytoscapeGraph/graphs/GraphHighlighter.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphHighlighter.ts
@@ -1,7 +1,8 @@
 import { CytoscapeClickEvent, CytoscapeMouseInEvent, CytoscapeMouseOutEvent } from '../CytoscapeGraph';
-import { DimClass } from './GraphStyles';
+import { DimClass, HideClass } from './GraphStyles';
 
 const DIM_CLASS: string = DimClass;
+const HIDE_CLASS: string = HideClass;
 const HIGHLIGHT_CLASS: string = 'mousehighlight';
 
 export class GraphHighlighter {
@@ -54,6 +55,7 @@ export class GraphHighlighter {
 
   unhighlight = () => {
     this.cy.elements('.' + DIM_CLASS).removeClass(DIM_CLASS);
+    this.cy.elements('.' + HIDE_CLASS).removeClass(HIDE_CLASS);
     this.cy.elements('.' + HIGHLIGHT_CLASS).removeClass(HIGHLIGHT_CLASS);
   };
 
@@ -80,10 +82,18 @@ export class GraphHighlighter {
       })
       .addClass(HIGHLIGHT_CLASS);
 
-    this.cy
-      .elements()
-      .difference(toHighlight)
-      .addClass(DIM_CLASS);
+    if (this.selected.ctrlKey) {
+      this.cy
+        .elements()
+        .difference(toHighlight)
+        .addClass(HIDE_CLASS);
+      this.cy.fit(toHighlight);
+    } else {
+      this.cy
+        .elements()
+        .difference(toHighlight)
+        .addClass(DIM_CLASS);
+    }
   };
 
   // Returns the nodes to highlight depending the selected or hovered summaryType

--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -4,6 +4,7 @@ import { config } from '../../../config';
 import { FAILURE, DEGRADED } from '../../../utils/Health';
 
 export const DimClass = 'mousedim';
+export const HideClass = 'mousehide';
 
 export class GraphStyles {
   static options() {
@@ -189,6 +190,12 @@ export class GraphStyles {
         selector: 'node.' + DimClass,
         style: {
           opacity: '0.3'
+        }
+      },
+      {
+        selector: 'node.' + HideClass,
+        style: {
+          display: 'none'
         }
       },
       {


### PR DESCRIPTION
WARNING! This is ONLY A PoC!  UXD has NOT given any input into this. This is a prototype only -- just to see what kind of behavior we can achieve with cytoscape.

Selecting a node or edge with the control key pressed will show only the related nodes/edges. The rest are hidden. The new graph is then zoomed/panned to fit in the display window. Click outside the graph or anything else without the control key will bring back the graph in its entirety.

![zoom](https://user-images.githubusercontent.com/2029470/42109671-7275699c-7bac-11e8-919f-af5007b73461.gif)
