### PR TITLE
KIALI-1025 Set isFetching to false if an error happens

### DIFF
--- a/src/actions/NamespaceAction.ts
+++ b/src/actions/NamespaceAction.ts
@@ -3,7 +3,8 @@ import * as Api from '../services/Api';
 export enum NamespaceActionKeys {
   NAMESPACE_RELOAD = 'NAMESPACE_RELOAD',
   NAMESPACE_START = 'NAMESPACE_START',
-  NAMESPACE_SUCCESS = 'NAMESPACE_SUCCESS'
+  NAMESPACE_SUCCESS = 'NAMESPACE_SUCCESS',
+  NAMESPACE_FAILED = 'NAMESPACE_FAILED'
 }
 
 export const reload = () => {
@@ -26,12 +27,19 @@ export const apiReceiveList = newList => {
   };
 };
 
+export const apiRequestFailed = () => {
+  return {
+    type: NamespaceActionKeys.NAMESPACE_FAILED
+  };
+};
+
 export const asyncFetchNamespaces = (auth: any) => {
   return dispatch => {
     dispatch(apiInitiateRequest());
     return Api.getNamespaces(auth)
       .then(response => response['data'])
-      .then(data => dispatch(apiReceiveList(data)));
+      .then(data => dispatch(apiReceiveList(data)))
+      .catch(() => dispatch(apiRequestFailed()));
   };
 };
 

--- a/src/actions/NamespaceAction.ts
+++ b/src/actions/NamespaceAction.ts
@@ -1,47 +1,11 @@
 import * as Api from '../services/Api';
+import { createAction } from 'typesafe-actions';
 
 export enum NamespaceActionKeys {
-  NAMESPACE_RELOAD = 'NAMESPACE_RELOAD',
-  NAMESPACE_START = 'NAMESPACE_START',
+  NAMESPACE_REQUEST_STARTED = 'NAMESPACE_REQUEST_STARTED',
   NAMESPACE_SUCCESS = 'NAMESPACE_SUCCESS',
   NAMESPACE_FAILED = 'NAMESPACE_FAILED'
 }
-
-export const reload = () => {
-  return {
-    type: NamespaceActionKeys.NAMESPACE_RELOAD
-  };
-};
-
-export const apiInitiateRequest = () => {
-  return {
-    type: NamespaceActionKeys.NAMESPACE_START
-  };
-};
-
-export const apiReceiveList = newList => {
-  return {
-    type: NamespaceActionKeys.NAMESPACE_SUCCESS,
-    list: newList,
-    receivedAt: Date.now()
-  };
-};
-
-export const apiRequestFailed = () => {
-  return {
-    type: NamespaceActionKeys.NAMESPACE_FAILED
-  };
-};
-
-export const asyncFetchNamespaces = (auth: any) => {
-  return dispatch => {
-    dispatch(apiInitiateRequest());
-    return Api.getNamespaces(auth)
-      .then(response => response['data'])
-      .then(data => dispatch(apiReceiveList(data)))
-      .catch(() => dispatch(apiRequestFailed()));
-  };
-};
 
 const shouldFetchNamespaces = state => {
   if (!state) {
@@ -51,22 +15,41 @@ const shouldFetchNamespaces = state => {
   }
 };
 
-export const fetchNamespacesIfNeeded = () => {
-  // Note that the function also receives getState()
-  // which lets you choose what to dispatch next.
-  // This is useful for avoiding a network request if
-  // a cached value is already available.
-  return (dispatch, getState) => {
-    if (shouldFetchNamespaces(getState())) {
-      // Dispatch a thunk from thunk!
-      if (getState()['authentication']['token'] === undefined) {
+export const NamespaceActions = {
+  requestStarted: createAction(NamespaceActionKeys.NAMESPACE_REQUEST_STARTED),
+  requestFailed: createAction(NamespaceActionKeys.NAMESPACE_FAILED),
+  receiveList: createAction(NamespaceActionKeys.NAMESPACE_SUCCESS, (newList: any, receivedAt: Date) => ({
+    type: NamespaceActionKeys.NAMESPACE_SUCCESS,
+    list: newList,
+    receivedAt: receivedAt
+  })),
+  asyncFetchNamespaces: (auth: any) => {
+    return dispatch => {
+      dispatch(NamespaceActions.requestStarted());
+      return Api.getNamespaces(auth)
+        .then(response => response['data'])
+        .then(data => dispatch(NamespaceActions.receiveList(data, new Date())))
+        .catch(() => dispatch(NamespaceActions.requestFailed()));
+    };
+  },
+
+  fetchNamespacesIfNeeded: () => {
+    // Note that the function also receives getState()
+    // which lets you choose what to dispatch next.
+    // This is useful for avoiding a network request if
+    // a cached value is already available.
+    return (dispatch, getState) => {
+      if (shouldFetchNamespaces(getState())) {
+        if (getState()['authentication']['token'] === undefined) {
+          return Promise.resolve();
+        }
+        const auth = 'Bearer ' + getState().authentication.token.token;
+        // Dispatch a thunk from thunk!
+        return dispatch(NamespaceActions.asyncFetchNamespaces(auth));
+      } else {
+        // Let the calling code know there's nothing to wait for.
         return Promise.resolve();
       }
-      const auth = 'Bearer ' + getState().authentication.token.token;
-      return dispatch(asyncFetchNamespaces(auth));
-    } else {
-      // Let the calling code know there's nothing to wait for.
-      return Promise.resolve();
-    }
-  };
+    };
+  }
 };

--- a/src/actions/__tests__/NamespaceAction.test.ts
+++ b/src/actions/__tests__/NamespaceAction.test.ts
@@ -1,0 +1,94 @@
+import { NamespaceActions, NamespaceActionKeys } from '../NamespaceAction';
+
+import thunk from 'redux-thunk';
+import configureMockStore from 'redux-mock-store';
+import axios from 'axios';
+import axiosMockAdapter from 'axios-mock-adapter';
+
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
+
+describe('NamespaceActions', () => {
+  const RealDate = Date;
+
+  const mockDate = date => {
+    global.Date = jest.fn(() => date) as any;
+    return date;
+  };
+
+  afterEach(() => {
+    global.Date = RealDate;
+  });
+
+  it('should start request', () => {
+    const expectedAction = {
+      type: NamespaceActionKeys.NAMESPACE_REQUEST_STARTED
+    };
+    expect(NamespaceActions.requestStarted()).toEqual(expectedAction);
+  });
+  it('request is success', () => {
+    const currentDate = new Date();
+    const expectedAction = {
+      type: NamespaceActionKeys.NAMESPACE_SUCCESS,
+      list: ['a', 'b'],
+      receivedAt: currentDate
+    };
+    expect(NamespaceActions.receiveList(['a', 'b'], currentDate)).toEqual(expectedAction);
+  });
+  it('request failed', () => {
+    const expectedAction = {
+      type: NamespaceActionKeys.NAMESPACE_FAILED
+    };
+    expect(NamespaceActions.requestFailed()).toEqual(expectedAction);
+  });
+  it('should success if api request success', () => {
+    const currentDate = new Date();
+    mockDate(currentDate);
+    const expectedActions = [
+      {
+        type: NamespaceActionKeys.NAMESPACE_REQUEST_STARTED
+      },
+      {
+        type: NamespaceActionKeys.NAMESPACE_SUCCESS,
+        list: ['a', 'b', 'c'],
+        receivedAt: currentDate
+      }
+    ];
+    const axiosMock = new axiosMockAdapter(axios);
+    axiosMock.onGet('/api/namespaces').reply(200, ['a', 'b', 'c']);
+
+    const store = mockStore({});
+    return store.dispatch(NamespaceActions.asyncFetchNamespaces('dummy-token')).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+  it('should fail if api request fails', () => {
+    const expectedActions = [
+      {
+        type: NamespaceActionKeys.NAMESPACE_REQUEST_STARTED
+      },
+      {
+        type: NamespaceActionKeys.NAMESPACE_FAILED
+      }
+    ];
+    const axiosMock = new axiosMockAdapter(axios);
+    axiosMock.onGet('/api/namespaces').reply(404);
+
+    const store = mockStore({});
+    return store.dispatch(NamespaceActions.asyncFetchNamespaces('dummy-token')).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+  it("it won't fetch a namespace if one is loading", () => {
+    const expectedActions = [];
+    const store = mockStore({
+      authentication: { token: { token: 'dummy-token' } },
+      namespaces: {
+        isFetching: true
+      }
+    });
+    return store.dispatch(NamespaceActions.fetchNamespacesIfNeeded()).then(() => {
+      expect(store.getActions()).toEqual(expectedActions);
+    });
+  });
+});

--- a/src/containers/NamespaceDropdownContainer.tsx
+++ b/src/containers/NamespaceDropdownContainer.tsx
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 
-import { fetchNamespacesIfNeeded } from '../actions/NamespaceAction';
+import { NamespaceActions } from '../actions/NamespaceAction';
 import { NamespaceDropdown } from '../components/NamespaceDropdown';
 
 const mapStateToProps = state => {
@@ -12,7 +12,7 @@ const mapStateToProps = state => {
 const mapDispatchToProps = dispatch => {
   return {
     refresh: () => {
-      dispatch(fetchNamespacesIfNeeded());
+      dispatch(NamespaceActions.fetchNamespacesIfNeeded());
     }
   };
 };

--- a/src/reducers/Namespaces.ts
+++ b/src/reducers/Namespaces.ts
@@ -2,34 +2,25 @@ import { NamespaceActionKeys } from '../actions/NamespaceAction';
 
 const INITIAL_STATE = {
   isFetching: false,
-  didInvalidate: false,
-  items: []
+  items: [] as Array<string>
 };
 
 const namespaces = (state = INITIAL_STATE, action) => {
   switch (action.type) {
-    case NamespaceActionKeys.NAMESPACE_RELOAD:
+    case NamespaceActionKeys.NAMESPACE_REQUEST_STARTED:
       return Object.assign({}, state, {
-        didInvalidate: true
-      });
-
-    case NamespaceActionKeys.NAMESPACE_START:
-      return Object.assign({}, state, {
-        isFetching: true,
-        didInvalidate: false
+        isFetching: true
       });
 
     case NamespaceActionKeys.NAMESPACE_SUCCESS:
       return Object.assign({}, state, {
         isFetching: false,
-        didInvalidate: false,
         items: action.list,
         lastUpdated: action.receivedAt
       });
     case NamespaceActionKeys.NAMESPACE_FAILED:
       return Object.assign({}, state, {
-        isFetching: false,
-        didInvalidate: true
+        isFetching: false
       });
     default:
       return state;

--- a/src/reducers/Namespaces.ts
+++ b/src/reducers/Namespaces.ts
@@ -26,7 +26,11 @@ const namespaces = (state = INITIAL_STATE, action) => {
         items: action.list,
         lastUpdated: action.receivedAt
       });
-
+    case NamespaceActionKeys.NAMESPACE_FAILED:
+      return Object.assign({}, state, {
+        isFetching: false,
+        didInvalidate: true
+      });
     default:
       return state;
   }

--- a/src/reducers/__tests__/NamespacesReducer.test.ts
+++ b/src/reducers/__tests__/NamespacesReducer.test.ts
@@ -1,0 +1,57 @@
+import Namespace from '../Namespaces';
+import { NamespaceActionKeys } from '../../actions/NamespaceAction';
+
+describe('Namespaces reducer', () => {
+  it('should return the initial state', () => {
+    expect(Namespace(undefined, {})).toEqual({
+      isFetching: false,
+      items: []
+    });
+  });
+  it('should handle NAMESPACE_REQUEST_STARTED', () => {
+    const currentState = {
+      isFetching: false,
+      items: []
+    };
+    const requestStartedAction = {
+      type: NamespaceActionKeys.NAMESPACE_REQUEST_STARTED
+    };
+    const expectedState = {
+      isFetching: true,
+      items: []
+    };
+    expect(Namespace(currentState, requestStartedAction)).toEqual(expectedState);
+  });
+  it('should handle NAMESPACE_FAILED', () => {
+    const currentState = {
+      isFetching: true,
+      items: []
+    };
+    const requestStartedAction = {
+      type: NamespaceActionKeys.NAMESPACE_FAILED
+    };
+    const expectedState = {
+      isFetching: false,
+      items: []
+    };
+    expect(Namespace(currentState, requestStartedAction)).toEqual(expectedState);
+  });
+  it('should handle NAMESPACE_SUCCESS', () => {
+    const currentDate = new Date();
+    const currentState = {
+      isFetching: true,
+      items: ['old', 'namespace']
+    };
+    const requestStartedAction = {
+      type: NamespaceActionKeys.NAMESPACE_SUCCESS,
+      list: ['a', 'b', 'c'],
+      receivedAt: currentDate
+    };
+    const expectedState = {
+      isFetching: false,
+      items: ['a', 'b', 'c'],
+      lastUpdated: currentDate
+    };
+    expect(Namespace(currentState, requestStartedAction)).toEqual(expectedState);
+  });
+});


### PR DESCRIPTION
I couldn't consistently reproduce this bug, it happened to me once, but I suspect the issue is that the namespace request fails [1] and `isFetching` remains `true`, blocking the next refresh [2]


[1] https://github.com/kiali/kiali-ui/blob/master/src/actions/NamespaceAction.ts#L34
[2] https://github.com/kiali/kiali-ui/blob/master/src/actions/NamespaceAction.ts#L42