### PR TITLE
KIALI-1090 Increase opacity on dim node/edges to make them easier to …

### DIFF
--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -186,7 +186,7 @@ export class GraphStyles {
       {
         selector: 'node.' + DimClass,
         style: {
-          opacity: '0.3'
+          opacity: '0.6'
         }
       },
       {


### PR DESCRIPTION
…read

Before:
![kiali-1090-before](https://user-images.githubusercontent.com/3845764/42188276-d8eae206-7e18-11e8-94c6-097bb728f176.png)

After (**updated 2018-07-04**):
![kiali-1090-after-updated](https://user-images.githubusercontent.com/3845764/42293525-945693fe-7fa0-11e8-9b1b-181372c6bdca.png)

Using pf-black-500:
![kiali-1090-pfblack500](https://user-images.githubusercontent.com/3845764/42335863-603fc322-8047-11e8-9a3f-5c591b669bdc.png)