### PR TITLE
KIALI-1061 Make disabled legends more readable

### DIFF
--- a/src/app/App.scss
+++ b/src/app/App.scss
@@ -77,3 +77,7 @@ a:focus {
   padding-top: 100px;
   text-align: center;
 }
+
+.c3-legend-item-hidden {
+  opacity: 0.4;
+}


### PR DESCRIPTION
...by increasing opacity.
This will impact all legends of the whole app.

Before:
![image](https://user-images.githubusercontent.com/23639005/42289860-a619726e-7f87-11e8-88cb-765e0228d08a.png)

After:
![image](https://user-images.githubusercontent.com/23639005/42289800-283322d2-7f87-11e8-9997-56eb0c34b763.png)
