### PR TITLE
KIALI-1113 Avoid overlap of node labels

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -313,6 +313,9 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
       cy.nodes().forEach(node => {
         node.position({ x: 0, y: 0 });
       });
+      // Enable labels when doing a relayout, layouts can be told to take into account the labels to avoid
+      // overlap, but we need to have them enabled (nodeDimensionsIncludeLabels: true)
+      this.turnNodeLabelsTo(cy, true);
       cy.layout(LayoutDictionary.getLayout(this.props.graphLayout)).run();
       this.updateLayout = false;
     }

--- a/src/components/CytoscapeGraph/graphs/BreadthFirstGraph.ts
+++ b/src/components/CytoscapeGraph/graphs/BreadthFirstGraph.ts
@@ -6,7 +6,8 @@ export class BreadthFirstGraph implements GraphType {
       name: 'breadthfirst',
       directed: 'true',
       maximalAdjustments: 2,
-      spacingFactor: 1
+      spacingFactor: 1,
+      nodeDimensionsIncludeLabels: true
     };
   }
 }

--- a/src/components/CytoscapeGraph/graphs/ColaGraph.ts
+++ b/src/components/CytoscapeGraph/graphs/ColaGraph.ts
@@ -5,7 +5,8 @@ export class ColaGraph implements GraphType {
     return {
       name: 'cola',
       animate: false,
-      flow: { axis: 'y' }
+      flow: { axis: 'y' },
+      nodeDimensionsIncludeLabels: true
     };
   }
 }

--- a/src/components/CytoscapeGraph/graphs/CoseGraph.ts
+++ b/src/components/CytoscapeGraph/graphs/CoseGraph.ts
@@ -4,7 +4,8 @@ export class CoseGraph implements GraphType {
   static getLayout() {
     return {
       name: 'cose',
-      animate: false
+      animate: false,
+      nodeDimensionsIncludeLabels: true
     };
   }
 }

--- a/src/components/CytoscapeGraph/graphs/DagreGraph.ts
+++ b/src/components/CytoscapeGraph/graphs/DagreGraph.ts
@@ -4,7 +4,8 @@ export class DagreGraph implements GraphType {
   static getLayout() {
     return {
       name: 'dagre',
-      rankDir: 'LR'
+      rankDir: 'LR',
+      nodeDimensionsIncludeLabels: true
     };
   }
 }

--- a/src/components/CytoscapeGraph/graphs/KlayGraph.ts
+++ b/src/components/CytoscapeGraph/graphs/KlayGraph.ts
@@ -4,7 +4,8 @@ export class KlayGraph implements GraphType {
   static getLayout() {
     return {
       name: 'klay',
-      animate: false
+      animate: false,
+      nodeDimensionsIncludeLabels: true
     };
   }
 }


### PR DESCRIPTION
Note: Cose still has some sort of overlap, but it seems more related to the overlapping of the group boxes


### Layout cola
Before:
![before-cola](https://user-images.githubusercontent.com/3845764/42520689-821a61ee-842c-11e8-8a79-2e8f6fa38ffe.png)

After:
![after-cola](https://user-images.githubusercontent.com/3845764/42520924-20e76cea-842d-11e8-8e70-9f297b863da8.png)

### Layout Breadthfirst
Before:
![before-breadthfirst](https://user-images.githubusercontent.com/3845764/42520945-355b6532-842d-11e8-92b1-2f57ac4ceaad.png)

After:
![after-breadthfirst](https://user-images.githubusercontent.com/3845764/42520952-3a7b2d22-842d-11e8-84a2-b0425670883c.png)

### Layout Cose
Before:
![before-cose](https://user-images.githubusercontent.com/3845764/42520991-57b96322-842d-11e8-91f5-373cbaf84194.png)

After:
![after-cose-2](https://user-images.githubusercontent.com/3845764/42521007-5e749ace-842d-11e8-9765-a66f1695b395.png)

![after-cose](https://user-images.githubusercontent.com/3845764/42521123-9c5e7d78-842d-11e8-9b5c-3ce2c2e6d7ed.png)
