### PR TITLE
KIALI-1119 Nodes from other namespaces now show their version

### DIFF
--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -54,15 +54,20 @@ export class GraphStyles {
               return '';
             }
 
-            if (ele.data('isOutside')) {
-              return `${service}\n${namespace}`;
-            }
-
             if (ele.data('parent')) {
               return version;
             }
 
-            return version && version !== 'unknown' ? service + '\n' + version : service;
+            let content = service;
+            if (version && version !== 'unknown') {
+              content += `\n${version}`;
+            }
+
+            if (ele.data('isOutside')) {
+              content += `\n${namespace}`;
+            }
+
+            return content;
           },
           'background-color': PfColors.Black200,
           'border-color': PfColors.Black400,


### PR DESCRIPTION
Service name and namespace are now grouped into the box and single nodes have their version appended (if any)

![kiali-1119-box](https://user-images.githubusercontent.com/3845764/42526804-81e5c9ce-843c-11e8-9d40-be3edb3bf3c2.png)

![kiali-1119-services](https://user-images.githubusercontent.com/3845764/42526806-8419bb2e-843c-11e8-9528-834803ee2d29.png)

Depends on https://github.com/kiali/kiali/pull/347