### PR TITLE
KIALI-1147 [UX] Change the term 'Undeployed' to 'Not deployed' for Istio sidecars indication

### DIFF
--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
@@ -61,7 +61,7 @@ class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps
                     <img className="IstioLogo" src={IstioLogo} alt="Istio sidecar" />
                   </span>
                 ) : (
-                  ' Undeployed'
+                  ' Not deployed'
                 )}
               </div>
               <div>

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
@@ -107,7 +107,7 @@ ShallowWrapper {
             <strong>
               Istio Sidecar
             </strong>
-             Undeployed
+             Not deployed
           </div>
           <div>
             <strong>
@@ -296,7 +296,7 @@ ShallowWrapper {
               <strong>
                 Istio Sidecar
               </strong>
-               Undeployed
+               Not deployed
             </div>
             <div>
               <strong>

--- a/src/pages/ServiceList/ServiceListComponent.tsx
+++ b/src/pages/ServiceList/ServiceListComponent.tsx
@@ -110,7 +110,7 @@ const istioFilter: FilterType = {
   title: 'Istio Sidecar',
   placeholder: 'Filter by Istio Sidecar',
   filterType: 'select',
-  filterValues: [{ id: 'deployed', title: 'Deployed' }, { id: 'undeployed', title: 'Undeployed' }]
+  filterValues: [{ id: 'deployed', title: 'Deployed' }, { id: 'not_deployed', title: 'Not Deployed' }]
 };
 
 type ServiceListComponentState = {
@@ -294,7 +294,7 @@ class ServiceListComponent extends React.Component<ServiceListComponentProps, Se
       if (istioFilters[0] === 'Deployed') {
         istioFiltered = service.istioSidecar;
       }
-      if (istioFilters[0] === 'Undeployed') {
+      if (istioFilters[0] === 'Not Deployed') {
         istioFiltered = !service.istioSidecar;
       }
     }


### PR DESCRIPTION
[UX] Change the term 'Undeployed' to 'Not deployed' for Istio sidecars indication

![peek 2018-07-11 10-04](https://user-images.githubusercontent.com/3019213/42558541-da04ca64-84f1-11e8-96c3-775d292aef32.gif)
