### PR TITLE
Ignore .css.map files from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ package-lock.json
 
 # compiled patternfly assets
 src/**/*.css
+src/**/*.css.map
 !src/index.css
 !src/css/.gitkeep
 src/img/*


### PR DESCRIPTION
do you think this is a good idea?
Perhaps I am not using project properly, but I found myself committing one .css.map file.