### PR TITLE
KIALI-1159 FIX Refreshing kiali always redirects to service graph

### DIFF
--- a/src/app/History.tsx
+++ b/src/app/History.tsx
@@ -1,3 +1,5 @@
 import { createBrowserHistory } from 'history';
-const history = createBrowserHistory({ basename: '/console' });
+import { baseName } from '../routes';
+
+const history = createBrowserHistory({ basename: baseName });
 export default history;

--- a/src/components/Nav/RenderPage.tsx
+++ b/src/components/Nav/RenderPage.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Redirect, Route } from 'react-router-dom';
+import SwitchErrorBoundary from '../SwitchErrorBoundary/SwitchErrorBoundary';
+import { routes, pathRoutes } from '../../routes';
+import PfContainerNavVertical from '../Pf/PfContainerNavVertical';
+
+class RenderPage extends React.Component {
+  renderRoutes() {
+    let redirectRoot: any = undefined;
+
+    return {
+      renderRoutes: routes.map((item, index) => {
+        if (item.redirect === true) {
+          redirectRoot = <Redirect from="/" to={item.to} />;
+        }
+
+        return <Route key={index} path={item.to} component={item.component} />;
+      }),
+      redirectRoot,
+      renderPaths: pathRoutes.map((item, index) => {
+        return <Route key={index} path={item.path} component={item.component} />;
+      })
+    };
+  }
+
+  render() {
+    const { renderRoutes, redirectRoot, renderPaths } = this.renderRoutes();
+
+    return (
+      <PfContainerNavVertical>
+        <SwitchErrorBoundary
+          fallBackComponent={() => <h2>Sorry, there was a problem. Try a refresh or navigate to a different page.</h2>}
+        >
+          {renderRoutes}
+          {renderPaths}
+          {redirectRoot}
+        </SwitchErrorBoundary>
+      </PfContainerNavVertical>
+    );
+  }
+}
+
+export default RenderPage;

--- a/src/components/Nav/__tests__/Navigation.test.tsx
+++ b/src/components/Nav/__tests__/Navigation.test.tsx
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme';
 
 import Navigation, { servicesTitle, istioConfigTitle } from '../Navigation';
 import { VerticalNav } from 'patternfly-react';
+import { routes } from '../../../routes';
 
 const _tester = (path: string, expectedMenuPath: string) => {
   const wrapper = shallow(
@@ -14,13 +15,18 @@ const _tester = (path: string, expectedMenuPath: string) => {
       setNavCollapsed={jest.fn()}
     />
   );
-  const navWrapper = wrapper.find(VerticalNav);
-  expect(navWrapper.prop('activePath')).toEqual(`/${expectedMenuPath}/`);
+
+  const navWrapper = wrapper.find(VerticalNav.Item).findWhere(el => el.key() === path);
+  expect(navWrapper.props()['active']).toBeTruthy();
 };
 
 describe('Navigation test', () => {
   it('should select menu item according to browser url', () => {
     _tester('/services', servicesTitle);
     _tester('/istio', istioConfigTitle);
+  });
+
+  it('should have only one redirect', () => {
+    expect(routes.filter(path => path.redirect === true)).toHaveLength(1);
   });
 });

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,0 +1,61 @@
+import ServiceGraphRouteHandler from './pages/ServiceGraph/ServiceGraphRouteHandler';
+import ServiceListPage from './pages/ServiceList/ServiceListPage';
+import IstioConfigPage from './pages/IstioConfigList/IstioConfigListPage';
+import ServiceJaegerPage from './pages/ServiceJaeger/ServiceJaegerPage';
+import ServiceDetailsPage from './pages/ServiceDetails/ServiceDetailsPage';
+import IstioConfigDetailsPage from './pages/IstioConfigDetails/IstioConfigDetailsPage';
+import { Route, Path } from './types/Routes';
+
+const baseName = '/console';
+
+/**
+ * Return array of objects that describe vertical menu
+ * @return {array}
+ */
+const routes: Route[] = [
+  {
+    iconClass: 'fa pficon-topology',
+    title: 'Graph',
+    to: '/service-graph/all',
+    redirect: true,
+    component: ServiceGraphRouteHandler,
+    pathsActive: [/^\/service-graph\/(.*)\//]
+  },
+  {
+    iconClass: 'fa pficon-service',
+    title: 'Services',
+    to: '/services',
+    component: ServiceListPage,
+    pathsActive: [/^\/namespaces\/(.*)\/services\/(.*)/]
+  },
+  {
+    iconClass: 'fa pficon-template',
+    title: 'Istio Config',
+    to: '/istio',
+    component: IstioConfigPage,
+    pathsActive: [/^\/namespaces\/(.*)\/istio\/(.*)/]
+  },
+  {
+    iconClass: 'fa fa-paw',
+    title: 'Distributed Tracing',
+    to: '/jaeger',
+    component: ServiceJaegerPage
+  }
+];
+
+const pathRoutes: Path[] = [
+  {
+    path: '/service-graph/:namespace',
+    component: ServiceGraphRouteHandler
+  },
+  {
+    path: '/namespaces/:namespace/services/:service',
+    component: ServiceDetailsPage
+  },
+  {
+    path: '/namespaces/:namespace/istio/:objectType/:object',
+    component: IstioConfigDetailsPage
+  }
+];
+
+export { baseName, routes, pathRoutes };

--- a/src/types/Routes.ts
+++ b/src/types/Routes.ts
@@ -1,0 +1,15 @@
+import { PropTypes } from 'prop-types';
+
+export interface Route {
+  iconClass: string;
+  title: string;
+  to: string;
+  redirect?: boolean;
+  component: PropTypes.object;
+  pathsActive?: RegExp[];
+}
+
+export interface Path {
+  path: string;
+  component: PropTypes.object;
+}


### PR DESCRIPTION
- Refactor
  - Now you manage the routes in  /src/components/routes
  - Reduce the code and complexity 
- Fix Refresh

![refresh](https://user-images.githubusercontent.com/3019213/42600125-93517192-8561-11e8-8d1d-10a5316970b2.gif)
