### PR TITLE
KIALI-1058 Present an error view if the CytoscapeGraph fails

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -64,14 +64,12 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
   private trafficRenderer: TrafficRender;
   private cytoscapeReactWrapperRef: any;
   private updateLayout: boolean;
-  private refit: boolean;
   private resetSelection: boolean;
   private cy: any;
 
   constructor(props: CytoscapeGraphProps) {
     super(props);
     this.updateLayout = false;
-    this.refit = false;
   }
 
   shouldComponentUpdate(nextProps: CytoscapeGraphProps, nextState: CytoscapeGraphState) {
@@ -130,8 +128,6 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
             ref={e => {
               this.setCytoscapeReactWrapperRef(e);
             }}
-            elements={this.props.elements}
-            layout={this.props.graphLayout}
           />
         </EmptyGraphLayout>
       </div>
@@ -179,7 +175,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
       return;
     }
     this.cy = cy;
-    this.refit = true;
+    this.updateLayout = true;
 
     this.graphHighlighter = new GraphHighlighter(cy);
     this.trafficRenderer = new TrafficRender(cy, cy.edges());
@@ -325,8 +321,6 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
       // overlap, but we need to have them enabled (nodeDimensionsIncludeLabels: true)
       this.turnNodeLabelsTo(cy, true);
       cy.layout(LayoutDictionary.getLayout(this.props.graphLayout)).run();
-      this.refit = true;
-      this.updateLayout = false;
     }
 
     // Create and destroy labels
@@ -353,9 +347,9 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
     cy.endBatch();
 
     // We need to fit outside of the batch operation for it to take effect on the new nodes
-    if (this.refit) {
+    if (this.updateLayout) {
       this.safeFit(cy);
-      this.refit = false;
+      this.updateLayout = false;
     }
 
     // We opt-in for manual selection to be able to control when to select a node/edge

--- a/src/components/CytoscapeGraph/CytoscapeReactWrapper.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeReactWrapper.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
 import { GraphStyles } from './graphs/GraphStyles';
-import * as LayoutDictionary from './graphs/LayoutDictionary';
 
 import canvas from 'cytoscape-canvas';
 import cytoscape from 'cytoscape';
@@ -21,10 +20,7 @@ cytoscape.use(klay);
 cytoscape.use(popper);
 panzoom(cytoscape);
 
-type CytoscapeReactWrapperProps = {
-  elements: any;
-  layout: any;
-};
+type CytoscapeReactWrapperProps = {};
 
 type CytoscapeReactWrapperState = {};
 
@@ -84,9 +80,7 @@ export class CytoscapeReactWrapper extends React.Component<CytoscapeReactWrapper
         container: this.divParentRef.current,
         boxSelectionEnabled: false,
         autounselectify: true,
-        style: GraphStyles.styles(),
-        elements: this.props.elements,
-        layout: LayoutDictionary.getLayout(this.props.layout)
+        style: GraphStyles.styles()
       },
       GraphStyles.options()
     );

--- a/src/components/CytoscapeGraph/EmptyGraphLayout.tsx
+++ b/src/components/CytoscapeGraph/EmptyGraphLayout.tsx
@@ -4,10 +4,10 @@ import { style } from 'typestyle';
 import * as MessageCenter from '../../utils/MessageCenter';
 
 type EmptyGraphLayoutProps = {
-  elements: any;
-  namespace: string;
-  action: any;
-  isLoading: boolean;
+  elements?: any;
+  namespace?: string;
+  action?: any;
+  isLoading?: boolean;
   isError: boolean;
 };
 

--- a/src/components/CytoscapeGraph/__tests__/CytoscapeGraph.test.tsx
+++ b/src/components/CytoscapeGraph/__tests__/CytoscapeGraph.test.tsx
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme';
 import { CytoscapeGraph } from '../CytoscapeGraph';
 import * as GRAPH_DATA from '../../../services/__mockData__/getGraphElements';
 import { Duration, Layout, EdgeLabelMode } from '../../../types/GraphFilter';
-import { CytoscapeReactWrapper } from '../CytoscapeReactWrapper';
+import EmptyGraphLayout from '../EmptyGraphLayout';
 
 jest.mock('../../../services/Api');
 
@@ -31,7 +31,7 @@ describe('CytoscapeGraph component test', () => {
     const wrapper = shallow(
       <CytoscapeGraph
         namespace={{ name: testNamespace }}
-        elements={GRAPH_DATA[testNamespace]}
+        elements={GRAPH_DATA[testNamespace].elements}
         graphLayout={myLayout}
         graphDuration={myDuration}
         edgeLabelMode={myEdgeLabelMode}
@@ -48,8 +48,8 @@ describe('CytoscapeGraph component test', () => {
         isError={false}
       />
     );
-    const cytoscapeWrapper = wrapper.find(CytoscapeReactWrapper);
-    expect(cytoscapeWrapper.prop('elements')['elements'].nodes).toEqual(GRAPH_DATA[testNamespace].elements.nodes);
-    expect(cytoscapeWrapper.prop('elements')['elements'].edges).toEqual(GRAPH_DATA[testNamespace].elements.edges);
+    const emptyGraphLayoutWrapper = wrapper.find(EmptyGraphLayout);
+    expect(emptyGraphLayoutWrapper.prop('elements')['nodes']).toEqual(GRAPH_DATA[testNamespace].elements.nodes);
+    expect(emptyGraphLayoutWrapper.prop('elements')['edges']).toEqual(GRAPH_DATA[testNamespace].elements.edges);
   });
 });

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+
+type ErrorHandlerFunction = (error: Error, componentStack: string) => void;
+
+type ErrorBoundaryProps = {
+  fallBackComponent: any;
+  onError?: ErrorHandlerFunction;
+};
+
+type ErrorBoundaryState = {
+  hasError: boolean;
+};
+
+export default class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  componentDidCatch(error: any, info: any) {
+    if (this.props.onError) {
+      this.props.onError(error, info);
+    }
+    this.setState({ hasError: true });
+  }
+
+  cleanError = () => {
+    this.setState((prevState: ErrorBoundaryState) => {
+      if (prevState.hasError === true) {
+        return { hasError: false };
+      }
+      return null;
+    });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallBackComponent;
+    }
+    return this.props.children;
+  }
+}

--- a/src/pages/ServiceGraph/ServiceGraphPage.tsx
+++ b/src/pages/ServiceGraph/ServiceGraphPage.tsx
@@ -7,9 +7,13 @@ import { Duration, PollIntervalInMs } from '../../types/GraphFilter';
 
 import SummaryPanel from './SummaryPanel';
 import CytoscapeGraph from '../../components/CytoscapeGraph/CytoscapeGraph';
+import ErrorBoundary from '../../components/ErrorBoundary/ErrorBoundary';
+import EmptyGraphLayout from '../../components/CytoscapeGraph/EmptyGraphLayout';
 import GraphFilterToolbar from '../../components/GraphFilter/GraphFilterToolbar';
 import { computePrometheusQueryInterval } from '../../services/Prometheus';
 import { style } from 'typestyle';
+
+import * as MessageCenterUtils from '../../utils/MessageCenter';
 
 import GraphLegend from '../../components/GraphFilter/GraphLegend';
 
@@ -51,11 +55,21 @@ const makeCancelablePromise = (promise: Promise<any>) => {
   };
 };
 
+const ServiceGraphErrorBoundaryFallback = () => {
+  return (
+    <div className={cytoscapeGraphContainerStyle}>
+      <EmptyGraphLayout isError={true} />
+    </div>
+  );
+};
+
 export default class ServiceGraphPage extends React.PureComponent<ServiceGraphPageProps> {
   private pollTimeoutRef?: number;
   private pollPromise?;
+  private errorBoundaryRef: any;
   constructor(props: ServiceGraphPageProps) {
     super(props);
+    this.errorBoundaryRef = React.createRef();
   }
 
   componentDidMount() {
@@ -79,6 +93,13 @@ export default class ServiceGraphPage extends React.PureComponent<ServiceGraphPa
       this.scheduleNextPollingInterval(0);
     } else if (pollIntervalChanged) {
       this.scheduleNextPollingIntervalFromProps();
+    }
+    if (
+      prevProps.graphLayout.name !== this.props.graphLayout.name ||
+      prevProps.graphData !== this.props.graphData ||
+      namespaceHasChanged
+    ) {
+      this.errorBoundaryRef.current.cleanError();
     }
   }
 
@@ -106,13 +127,19 @@ export default class ServiceGraphPage extends React.PureComponent<ServiceGraphPa
             />
           </div>
           <FlexView grow={true}>
-            <CytoscapeGraph
-              {...graphParams}
-              isLoading={this.props.isLoading}
-              elements={this.props.graphData}
-              refresh={this.handleRefreshClick}
-              containerClassName={cytoscapeGraphContainerStyle}
-            />
+            <ErrorBoundary
+              ref={this.errorBoundaryRef}
+              onError={this.notifyError}
+              fallBackComponent={<ServiceGraphErrorBoundaryFallback />}
+            >
+              <CytoscapeGraph
+                {...graphParams}
+                isLoading={this.props.isLoading}
+                elements={this.props.graphData}
+                refresh={this.handleRefreshClick}
+                containerClassName={cytoscapeGraphContainerStyle}
+              />
+            </ErrorBoundary>
             {this.props.summaryData ? (
               <SummaryPanel
                 data={this.props.summaryData}
@@ -178,4 +205,8 @@ export default class ServiceGraphPage extends React.PureComponent<ServiceGraphPa
       this.pollPromise = undefined;
     }
   }
+
+  private notifyError = (error: Error, componentStack: string) => {
+    MessageCenterUtils.add('There was an error when rendering the service graph, please try a different layout');
+  };
 }


### PR DESCRIPTION
This won't block the controls, allowing the user to select a different layout if needed

Bonus:
Simplified the refit operation and this maybe fixed the "all nodes appearing on top of each other".
It was a mix of [KIALI-1166](https://issues.jboss.org/browse/KIALI-1166) and the graph not doing an updateLayout as the first operation (only doing the refit)

![kiali-1058](https://user-images.githubusercontent.com/3845764/42601222-88eb865c-852a-11e8-8132-328edf99422d.png)
