### PR TITLE
KIALI-1176 Fixes routes to get the right namespace

### DIFF
--- a/src/components/Nav/Navigation.tsx
+++ b/src/components/Nav/Navigation.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { VerticalNav } from 'patternfly-react';
 import PropTypes from 'prop-types';
-import { routes } from '../../routes';
+import { navItems } from '../../routes';
 import RenderPage from './RenderPage';
 import { matchPath } from 'react-router';
 import _ from 'lodash';
@@ -56,20 +56,20 @@ class Navigation extends React.Component<PropsType> {
 
   renderMenuItems() {
     const { location } = this.props;
-    const activeItem = routes.find(item => {
+    const activeItem = navItems.find(item => {
       let isRoute = matchPath(location.pathname, { path: item.to, exact: true, strict: false }) ? true : false;
       if (!isRoute && item.pathsActive) {
         isRoute = _.filter(item.pathsActive, path => path.test(location.pathname)).length > 0;
       }
       return isRoute;
     });
-    return routes.map(item => {
+    return navItems.map(item => {
       return (
         <VerticalNav.Item
           key={item.to}
           title={item.title}
           iconClass={item.iconClass}
-          active={item === activeItem || (!activeItem && item.redirect)}
+          active={item === activeItem}
           onClick={() => this.context.router.history.push(item.to)}
         />
       );

--- a/src/components/Nav/RenderPage.tsx
+++ b/src/components/Nav/RenderPage.tsx
@@ -1,38 +1,24 @@
 import React from 'react';
 import { Redirect, Route } from 'react-router-dom';
 import SwitchErrorBoundary from '../SwitchErrorBoundary/SwitchErrorBoundary';
-import { routes, pathRoutes } from '../../routes';
+import { pathRoutes, defaultRoute } from '../../routes';
 import PfContainerNavVertical from '../Pf/PfContainerNavVertical';
 
 class RenderPage extends React.Component {
-  renderRoutes() {
-    let redirectRoot: any = undefined;
-
-    return {
-      renderRoutes: routes.map((item, index) => {
-        if (item.redirect === true) {
-          redirectRoot = <Redirect from="/" to={item.to} />;
-        }
-        return <Route key={index} path={item.to} component={item.component} />;
-      }),
-      redirectRoot,
-      renderPaths: pathRoutes.map((item, index) => {
-        return <Route key={index} path={item.path} component={item.component} />;
-      })
-    };
+  renderPaths() {
+    return pathRoutes.map((item, index) => {
+      return <Route key={index} path={item.path} component={item.component} />;
+    });
   }
 
   render() {
-    const { renderRoutes, redirectRoot, renderPaths } = this.renderRoutes();
-
     return (
       <PfContainerNavVertical>
         <SwitchErrorBoundary
           fallBackComponent={() => <h2>Sorry, there was a problem. Try a refresh or navigate to a different page.</h2>}
         >
-          {renderRoutes}
-          {renderPaths}
-          {redirectRoot}
+          {this.renderPaths()}
+          <Redirect from="/" to={defaultRoute} />
         </SwitchErrorBoundary>
       </PfContainerNavVertical>
     );

--- a/src/components/Nav/__tests__/Navigation.test.tsx
+++ b/src/components/Nav/__tests__/Navigation.test.tsx
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 
 import Navigation, { servicesTitle, istioConfigTitle } from '../Navigation';
 import { VerticalNav } from 'patternfly-react';
-import { kialiRoute, routes } from '../../../routes';
+import { kialiRoute } from '../../../routes';
 
 const _tester = (path: string, expectedMenuPath: string) => {
   const wrapper = shallow(
@@ -24,9 +24,5 @@ describe('Navigation test', () => {
   it('should select menu item according to browser url', () => {
     _tester(kialiRoute('/services'), servicesTitle);
     _tester(kialiRoute('/istio'), istioConfigTitle);
-  });
-
-  it('should have only one redirect', () => {
-    expect(routes.filter(path => path.redirect === true)).toHaveLength(1);
   });
 });

--- a/src/pages/ServiceDetails/__tests__/ServiceMetrics.test.tsx
+++ b/src/pages/ServiceDetails/__tests__/ServiceMetrics.test.tsx
@@ -137,31 +137,35 @@ describe('ServiceMetrics', () => {
     mounted = mount(<ServiceMetrics namespace="ns" service="svc" />);
   });
 
-  it('mounts and loads full metrics', done => {
-    const allMocksDone = [
-      mockMetrics({
-        metrics: {
-          request_count_in: createMetric('m1'),
-          request_count_out: createMetric('m2')
-        },
-        histograms: {
-          request_size_in: createHistogram('m3'),
-          request_size_out: createHistogram('m4'),
-          request_duration_in: createHistogram('m5'),
-          request_duration_out: createHistogram('m6'),
-          response_size_in: createHistogram('m7'),
-          response_size_out: createHistogram('m8')
-        }
-      })
-        .then(() => {
-          mounted!.update();
-          expect(mounted!.find('Spinner').map(div => div.getElement().props.loading)).toEqual([]);
-          expect(mounted!.find('LineChart')).toHaveLength(8);
+  it(
+    'mounts and loads full metrics',
+    done => {
+      const allMocksDone = [
+        mockMetrics({
+          metrics: {
+            request_count_in: createMetric('m1'),
+            request_count_out: createMetric('m2')
+          },
+          histograms: {
+            request_size_in: createHistogram('m3'),
+            request_size_out: createHistogram('m4'),
+            request_duration_in: createHistogram('m5'),
+            request_duration_out: createHistogram('m6'),
+            response_size_in: createHistogram('m7'),
+            response_size_out: createHistogram('m8')
+          }
         })
-        .catch(err => done.fail(err)),
-      mockGrafanaInfo({})
-    ];
-    Promise.all(allMocksDone).then(() => done());
-    mounted = mount(<ServiceMetrics namespace="ns" service="svc" />);
-  });
+          .then(() => {
+            mounted!.update();
+            expect(mounted!.find('Spinner').map(div => div.getElement().props.loading)).toEqual([]);
+            expect(mounted!.find('LineChart')).toHaveLength(8);
+          })
+          .catch(err => done.fail(err)),
+        mockGrafanaInfo({})
+      ];
+      Promise.all(allMocksDone).then(() => done());
+      mounted = mount(<ServiceMetrics namespace="ns" service="svc" />);
+    },
+    10000
+  ); // Increase timeout for this test
 });

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -4,7 +4,7 @@ import IstioConfigPage from './pages/IstioConfigList/IstioConfigListPage';
 import ServiceJaegerPage from './pages/ServiceJaeger/ServiceJaegerPage';
 import ServiceDetailsPage from './pages/ServiceDetails/ServiceDetailsPage';
 import IstioConfigDetailsPage from './pages/IstioConfigDetails/IstioConfigDetailsPage';
-import { Route, Path } from './types/Routes';
+import { MenuItem, Path } from './types/Routes';
 
 const baseName = '/console';
 
@@ -13,36 +13,33 @@ export const kialiRoute = (route: string) => baseName + route;
  * Return array of objects that describe vertical menu
  * @return {array}
  */
-const routes: Route[] = [
+const navItems: MenuItem[] = [
   {
     iconClass: 'fa pficon-topology',
     title: 'Graph',
     to: kialiRoute('/service-graph/all'),
-    redirect: true,
-    component: ServiceGraphRouteHandler,
-    pathsActive: [/\/service-graph\/(.*)\//]
+    pathsActive: [/\/service-graph\/(.*)/]
   },
   {
     iconClass: 'fa pficon-service',
     title: 'Services',
     to: kialiRoute('/services'),
-    component: ServiceListPage,
     pathsActive: [/\/namespaces\/(.*)\/services\/(.*)/]
   },
   {
     iconClass: 'fa pficon-template',
     title: 'Istio Config',
     to: kialiRoute('/istio'),
-    component: IstioConfigPage,
     pathsActive: [/\/namespaces\/(.*)\/istio\/(.*)/]
   },
   {
     iconClass: 'fa fa-paw',
     title: 'Distributed Tracing',
-    to: kialiRoute('/jaeger'),
-    component: ServiceJaegerPage
+    to: kialiRoute('/jaeger')
   }
 ];
+
+const defaultRoute = kialiRoute('/service-graph/all');
 
 const pathRoutes: Path[] = [
   {
@@ -56,7 +53,19 @@ const pathRoutes: Path[] = [
   {
     path: kialiRoute('/namespaces/:namespace/istio/:objectType/:object'),
     component: IstioConfigDetailsPage
+  },
+  {
+    path: kialiRoute('/services'),
+    component: ServiceListPage
+  },
+  {
+    path: kialiRoute('/istio'),
+    component: IstioConfigPage
+  },
+  {
+    path: kialiRoute('/jaeger'),
+    component: ServiceJaegerPage
   }
 ];
 
-export { baseName, routes, pathRoutes };
+export { baseName, defaultRoute, navItems, pathRoutes };

--- a/src/types/Routes.ts
+++ b/src/types/Routes.ts
@@ -1,11 +1,9 @@
 import { PropTypes } from 'prop-types';
 
-export interface Route {
+export interface MenuItem {
   iconClass: string;
   title: string;
   to: string;
-  redirect?: boolean;
-  component: PropTypes.object;
   pathsActive?: RegExp[];
 }
 


### PR DESCRIPTION
There were several routes in routes.tsx, and laid out in our VerticalNavigation item.
We can extract data from the routes, e.g. from the route definition `/servicegraph/:namespace` we can extract the value `namespace`.
From the url `/servicegraph/all` we have `namespace=all`, `/servicegraph/default` yields `namespace=default`.

The problem is that we had a route `/servicegraph/all` that matched the url `/servicegraph/all` but didn't had any value for namespace (unlike the route `/servicegraph/:namespace`), routes are matched in order, and `/servicegraph/all` was before `/servicegraph/:namespace`

This namespace value is used [here](https://github.com/kiali/kiali-ui/blob/master/src/pages/ServiceGraph/ServiceGraphRouteHandler.tsx#L59).

Fixed this by adding all the routes to `pathRoutes` and leaving the `routes` as an array for the vertical menu.
