### PR TITLE
KIALI-1193 Re-fits the graph on every resize if we are on the "initial" pan/zoom level

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -50,6 +50,16 @@ type CytoscapeGraphProps = CytoscapeGraphType &
 
 type CytoscapeGraphState = {};
 
+type Position = {
+  x: number;
+  y: number;
+};
+
+type InitialValues = {
+  position?: Position;
+  zoom?: number;
+};
+
 // @todo: Move this class to 'containers' folder -- but it effects many other things
 // exporting this class for testing
 export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, CytoscapeGraphState> {
@@ -62,11 +72,16 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
   private cytoscapeReactWrapperRef: any;
   private updateLayout: boolean;
   private resetSelection: boolean;
+  private initialValues: InitialValues;
   private cy: any;
 
   constructor(props: CytoscapeGraphProps) {
     super(props);
     this.updateLayout = false;
+    this.initialValues = {
+      position: undefined,
+      zoom: undefined
+    };
   }
 
   shouldComponentUpdate(nextProps: CytoscapeGraphProps, nextState: CytoscapeGraphState) {
@@ -106,14 +121,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
   render() {
     return (
       <div id="cytoscape-container" className={this.props.containerClassName}>
-        <ReactResizeDetector
-          handleWidth={true}
-          handleHeight={true}
-          skipOnMount={true}
-          refreshMode={'throttle'}
-          refreshRate={100}
-          onResize={this.onResize}
-        />
+        <ReactResizeDetector handleWidth={true} handleHeight={true} skipOnMount={true} onResize={this.onResize} />
         <EmptyGraphLayout
           elements={this.props.elements}
           namespace={this.props.namespace.name}
@@ -143,6 +151,17 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
   private onResize = () => {
     if (this.cy) {
       this.cy.resize();
+      const currentPosition = this.cy.pan();
+      const currentZoom = this.cy.zoom();
+      if (
+        this.initialValues.position &&
+        this.initialValues.position.x === currentPosition.x &&
+        this.initialValues.position.y === currentPosition.y &&
+        this.initialValues.zoom === currentZoom
+      ) {
+        // There was a resize, but we are in the initial pan/zoom state, we can fit again.
+        this.safeFit(this.cy);
+      }
     }
   };
 
@@ -271,6 +290,8 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
       cy.zoom(2.5);
       cy.center();
     }
+    this.initialValues.position = { ...cy.pan() };
+    this.initialValues.zoom = cy.zoom();
   }
 
   private processGraphUpdate(cy: any) {

--- a/src/pages/ServiceGraph/ServiceGraphPage.tsx
+++ b/src/pages/ServiceGraph/ServiceGraphPage.tsx
@@ -37,7 +37,7 @@ const containerStyle = style({
   height: 'calc(100vh - 60px)' // View height minus top bar height
 });
 
-const cytoscapeGraphContainerStyle = style({ flex: '1', minWidth: '350px', zIndex: 0 });
+const cytoscapeGraphContainerStyle = style({ flex: '1', minWidth: '350px', zIndex: 0, paddingRight: '5px' });
 
 const makeCancelablePromise = (promise: Promise<any>) => {
   let hasCanceled = false;


### PR DESCRIPTION
This is one of the 3 ways I think we can solve this issue, by doing a `fit` if we are in the "initial" position

If we move away (pan or zoom) of that initial position, it won't do a `fit` again

Other ways to solve this would be to provide an [Empty State](https://www.patternfly.org/pattern-library/communication/empty-state/) side panel that says something like "Load a graph to show its information".

![kiali-1193](https://user-images.githubusercontent.com/3845764/42909923-42d629b6-8aab-11e8-954d-6a092f6e8f5d.gif)
note: There is "Hello world" on the top right of this gif when the graph is "Loading", this is a quick test of the "Empty State side panel" that forgot to remove previous to recording the gif

