### PR TITLE
fix the if-stmt when not workload graph

### DIFF
--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -72,7 +72,7 @@ export class GraphStyles {
 
             // use the workload name unless app label was defined
             let content = workload;
-            if (getCyGlobalData(ele).graphType !== GraphType.WORKLOAD && (app || app !== 'unknown')) {
+            if (getCyGlobalData(ele).graphType !== GraphType.WORKLOAD && app && app !== 'unknown') {
               content = app;
               if (version && version !== 'unknown') {
                 content += `\n${version}`;


### PR DESCRIPTION
@jshaughn this fixes some of those unknown nodes (most of them anyway). I still see one odd one that I think is this one:

```
      {
        "data": {
          "id": "ad921d60486366258809553a3db49a4a",
          "namespace": "istio-system",
          "workload": "unknown",
          "app": "unknown",
          "version": "unknown",
          "service": "unknown",
          "serviceName": "istio-policy",
          "hasMissingSC": true,
          "isGroup": "version"
        }
      }
```