### PR TITLE
KIALI-1246 Remove all usages of cyNode.data('service')

### DIFF
--- a/src/pages/ServiceGraph/SummaryPanelCommon.ts
+++ b/src/pages/ServiceGraph/SummaryPanelCommon.ts
@@ -28,3 +28,12 @@ export const updateHealth = (summaryTarget: any, stateSetter: (hs: HealthState) 
     stateSetter({ health: undefined, healthLoading: false });
   }
 };
+
+export const nodeData = (node: any) => {
+  return {
+    namespace: node.data('namespace'),
+    app: node.data('app'),
+    version: node.data('version'),
+    workload: node.data('workload')
+  };
+};

--- a/src/pages/ServiceGraph/SummaryPanelGroup.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelGroup.tsx
@@ -10,7 +10,7 @@ import MetricsOptions from '../../types/MetricsOptions';
 import { Icon } from 'patternfly-react';
 import { authentication } from '../../utils/Authentication';
 import { Link } from 'react-router-dom';
-import { shouldRefreshData, updateHealth } from './SummaryPanelCommon';
+import { shouldRefreshData, updateHealth, nodeData } from './SummaryPanelCommon';
 import { HealthIndicator, DisplayMode } from '../../components/ServiceHealth/HealthIndicator';
 import Label from '../../components/Label/Label';
 import { Health } from '../../types/Health';
@@ -66,10 +66,8 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
 
   render() {
     const group = this.props.data.summaryTarget;
-
-    const namespace = group.data('service').split('.')[1];
-    const service = group.data('service').split('.')[0];
-    const serviceHotLink = <Link to={`/namespaces/${namespace}/services/${service}`}>{service}</Link>;
+    const { namespace, app } = nodeData(group);
+    const serviceHotLink = <Link to={`/namespaces/${namespace}/services/${app}`}>{app}</Link>;
 
     const incoming = getAccumulatedTrafficRate(group.children());
     const outgoing = getAccumulatedTrafficRate(group.children().edgesTo('*'));
@@ -100,9 +98,7 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
         </div>
         <div className="panel-body">
           <p style={{ textAlign: 'right' }}>
-            <Link
-              to={`/namespaces/${namespace}/services/${service}?tab=metrics&groupings=local+version%2Cresponse+code`}
-            >
+            <Link to={`/namespaces/${namespace}/services/${app}?tab=metrics&groupings=local+version%2Cresponse+code`}>
               View detailed charts <Icon name="angle-double-right" />
             </Link>
           </p>
@@ -125,8 +121,7 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
   }
 
   private updateRpsCharts = (props: SummaryPanelPropType) => {
-    const namespace = props.data.summaryTarget.data('service').split('.')[1];
-    const service = props.data.summaryTarget.data('service').split('.')[0];
+    const { namespace, app } = nodeData(props.data.summaryTarget);
     const options: MetricsOptions = {
       queryTime: props.queryTime,
       duration: +props.duration,
@@ -135,7 +130,7 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
       filters: ['request_count', 'request_error_count'],
       includeIstio: props.namespace === 'istio-system'
     };
-    API.getServiceMetrics(authentication(), namespace, service, options)
+    API.getServiceMetrics(authentication(), namespace, app, options)
       .then(response => {
         if (!this._isMounted) {
           console.log('SummaryPanelGroup: Ignore fetch, component not mounted.');


### PR DESCRIPTION
UI is untouched by this PR. 

Most of this is about the sidebar.
I only replaced all the uses of `node.data('service')` by `node.data('app')` (or by `node.data('namespace')` where the actual intend was to get to parse the namespace).

I'm not yet using `workload` anywhere in the sidebar, but we could potentially add that term there 
```
 app: [link to app]
 workload: [link to workload?]
```

Also, still using the term "service":

![kiali-1246-2](https://user-images.githubusercontent.com/3845764/43217633-c647799c-9007-11e8-9efc-b5999d864fe6.png)
![kiali-1246-1](https://user-images.githubusercontent.com/3845764/43217634-c68acc4c-9007-11e8-82c8-a65b2d802304.png)
![kiali-1246-0](https://user-images.githubusercontent.com/3845764/43217635-c6a7755e-9007-11e8-9ba5-cee5b14e5009.png)


