### PR TITLE
KIALI-1231 Refactors panel to handle metrics by app or workload

### DIFF
--- a/src/pages/ServiceDetails/ServiceMetrics.tsx
+++ b/src/pages/ServiceDetails/ServiceMetrics.tsx
@@ -111,7 +111,7 @@ class ServiceMetrics extends React.Component<ServiceMetricsProps, ServiceMetrics
   };
 
   fetchMetrics = () => {
-    API.getServiceMetrics(authentication(), this.props.namespace, this.props.service, this.options)
+    API.getAppMetrics(authentication(), this.props.namespace, this.props.service, this.options)
       .then(response => {
         const metrics: M.Metrics = response.data;
         this.setState({

--- a/src/pages/ServiceDetails/__tests__/ServiceMetrics.test.tsx
+++ b/src/pages/ServiceDetails/__tests__/ServiceMetrics.test.tsx
@@ -25,7 +25,7 @@ const mockAPIToPromise = (func: keyof typeof API, obj: any): Promise<void> => {
 };
 
 const mockMetrics = (metrics: any): Promise<void> => {
-  return mockAPIToPromise('getServiceMetrics', metrics);
+  return mockAPIToPromise('getAppMetrics', metrics);
 };
 
 const mockGrafanaInfo = (info: any): Promise<any> => {

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -102,13 +102,22 @@ export const getServices = (auth: string, namespace: String): Promise<Response<S
   return newRequest('get', `/api/namespaces/${namespace}/services`, {}, {}, auth);
 };
 
-export const getServiceMetrics = (
+export const getAppMetrics = (
   auth: string,
   namespace: String,
   service: String,
   params: MetricsOptions
 ): Promise<Response<Metrics>> => {
   return newRequest('get', `/api/namespaces/${namespace}/services/${service}/metrics`, params, {}, auth);
+};
+
+export const getWorkloadMetrics = (
+  auth: string,
+  namespace: String,
+  workload: String,
+  params: MetricsOptions
+): Promise<Response<Metrics>> => {
+  return newRequest('get', `/api/namespaces/${namespace}/workloads/${workload}/metrics`, params, {}, auth);
 };
 
 export const getServiceHealth = (

--- a/src/services/__tests__/ApiMethods.test.tsx.ts
+++ b/src/services/__tests__/ApiMethods.test.tsx.ts
@@ -68,8 +68,8 @@ describe('#Test Methods return a Promise', () => {
     evaluatePromise(result);
   });
 
-  it('#getServiceMetrics', () => {
-    const result = API.getServiceMetrics(authentication(), 'istio-system', 'book-info', {});
+  it('#getAppMetrics', () => {
+    const result = API.getAppMetrics(authentication(), 'istio-system', 'book-info', {});
     evaluatePromise(result);
   });
 

--- a/src/types/Graph.ts
+++ b/src/types/Graph.ts
@@ -5,7 +5,7 @@ import Namespace from './Namespace';
 //   summaryTarget: The cytoscape element
 //   summaryType  : one of 'graph', 'node', 'edge', 'group'
 export interface SummaryData {
-  summaryType: string;
+  summaryType: 'graph' | 'node' | 'edge' | 'group';
   summaryTarget: any;
 }
 

--- a/src/types/Metrics.ts
+++ b/src/types/Metrics.ts
@@ -14,8 +14,12 @@ export interface MetricGroup {
   matrix: TimeSeries[];
 }
 
+export type Metric = {
+  [key: string]: string;
+};
+
 export interface TimeSeries {
-  metric: { [key: string]: string };
+  metric: Metric;
   values: Datapoint[];
   name: string;
 }


### PR DESCRIPTION
Refactored the logic to handle the metrics by app(versioned or not) and workload.

Currently it shows the sparklines in the app (versioned and not versioned) when the label app is set. It doesn't (yet) handle when we need to access the workload metrics. 

I'm looking at the server code to create that service or use one if available.

TODO:
- [x] Check old label (source_service)

This requires: https://github.com/kiali/kiali/pull/385