### PR TITLE
KIALI-1173 [BUGFIX] Wrong filter renaming + wrong filter removal

### DIFF
--- a/src/components/ListPage/ListPage.ts
+++ b/src/components/ListPage/ListPage.ts
@@ -22,10 +22,14 @@ export namespace ListPage {
       }
 
       params.forEach((param: URLParameter) => {
-        if (action === ACTION_APPEND) {
-          urlParams.append(param.name, param.value);
-        } else if (!action || action === ACTION_SET) {
-          urlParams.set(param.name, param.value);
+        if (param.value === '') {
+          urlParams.delete(param.name);
+        } else {
+          if (action === ACTION_APPEND) {
+            urlParams.append(param.name, param.value);
+          } else if (!action || action === ACTION_SET) {
+            urlParams.set(param.name, param.value);
+          }
         }
       });
 

--- a/src/components/NamespaceFilter/NamespaceFilter.tsx
+++ b/src/components/NamespaceFilter/NamespaceFilter.tsx
@@ -36,7 +36,7 @@ export class NamespaceFilter extends React.Component<NamespaceFilterProps, Names
 
     let initialFilters = this.initialFilterList(defaultNamespaceFilter);
 
-    if (this.props.initialActiveFilters && this.props.initialActiveFilters.length > 0) {
+    if (!!this.props.initialActiveFilters) {
       NamespaceFilterSelected.setSelected(this.props.initialActiveFilters);
     }
 

--- a/src/pages/IstioConfigList/IstioConfigListComponent.tsx
+++ b/src/pages/IstioConfigList/IstioConfigListComponent.tsx
@@ -27,6 +27,7 @@ import { authentication } from '../../utils/Authentication';
 import { NamespaceValidations } from '../../types/ServiceInfo';
 import { ConfigIndicator } from '../../components/ConfigValidation/ConfigIndicator';
 import { removeDuplicatesArray } from '../../utils/Common';
+import { URLParameter } from '../../types/Parameters';
 
 export const sortFields: SortField[] = [
   {
@@ -264,28 +265,26 @@ class IstioConfigListComponent extends React.Component<IstioConfigListComponentP
   }
 
   onFilterChange = (filters: ActiveFilter[]) => {
-    if (filters.length > 0) {
-      let params = filters.map(activeFilter => {
-        let filterId = (
-          availableFilters.find(filter => {
-            return filter.title === activeFilter.category;
-          }) || availableFilters[2]
-        ).id;
+    let params: URLParameter[] = [];
 
-        return {
-          name: filterId,
-          value: activeFilter.value
-        };
+    availableFilters.forEach(availableFilter => {
+      params.push({ name: availableFilter.id, value: '' });
+    });
+
+    filters.forEach(activeFilter => {
+      let filterId = (
+        availableFilters.find(filter => {
+          return filter.title === activeFilter.category;
+        }) || availableFilters[2]
+      ).id;
+
+      params.push({
+        name: filterId,
+        value: activeFilter.value
       });
+    });
 
-      this.props.onParamChange(params, 'append');
-    } else {
-      this.props.onParamDelete(
-        availableFilters.map(filter => {
-          return filter.id;
-        })
-      );
-    }
+    this.props.onParamChange(params, 'append');
 
     this.updateIstioConfig();
   };

--- a/src/pages/IstioConfigList/IstioConfigListComponent.tsx
+++ b/src/pages/IstioConfigList/IstioConfigListComponent.tsx
@@ -223,18 +223,27 @@ class IstioConfigListComponent extends React.Component<IstioConfigListComponentP
   }
 
   setActiveFiltersToURL() {
-    const params = NamespaceFilterSelected.getSelected().map(activeFilter => {
-      let filterId = (
-        availableFilters.find(filter => {
+    const params = NamespaceFilterSelected.getSelected()
+      .map(activeFilter => {
+        const availableFilter = availableFilters.find(filter => {
           return filter.title === activeFilter.category;
-        }) || availableFilters[2]
-      ).id;
+        });
 
-      return {
-        name: filterId,
-        value: activeFilter.value
-      };
-    });
+        if (typeof availableFilter === 'undefined') {
+          NamespaceFilterSelected.setSelected(
+            NamespaceFilterSelected.getSelected().filter(nfs => {
+              return nfs.category === activeFilter.category;
+            })
+          );
+          return null;
+        }
+
+        return {
+          name: availableFilter.id,
+          value: activeFilter.value
+        };
+      })
+      .filter(filter => filter !== null);
 
     this.props.onParamChange(params, 'append');
   }

--- a/src/pages/ServiceList/ServiceListComponent.tsx
+++ b/src/pages/ServiceList/ServiceListComponent.tsx
@@ -31,6 +31,7 @@ import { removeDuplicatesArray } from '../../utils/Common';
 import RateIntervalToolbarItem from './RateIntervalToolbarItem';
 import ItemDescription from './ItemDescription';
 import './ServiceListComponent.css';
+import { URLParameter } from '../../types/Parameters';
 
 type ServiceItemHealth = ServiceItem & { health: Health };
 
@@ -258,28 +259,26 @@ class ServiceListComponent extends React.Component<ServiceListComponentProps, Se
   }
 
   onFilterChange = (filters: ActiveFilter[]) => {
-    if (filters.length > 0) {
-      let params = filters.map(activeFilter => {
-        let filterId = (
-          availableFilters.find(filter => {
-            return filter.title === activeFilter.category;
-          }) || availableFilters[2]
-        ).id;
+    let params: URLParameter[] = [];
 
-        return {
-          name: filterId,
-          value: activeFilter.value
-        };
+    availableFilters.forEach(availableFilter => {
+      params.push({ name: availableFilter.id, value: '' });
+    });
+
+    filters.forEach(activeFilter => {
+      let filterId = (
+        availableFilters.find(filter => {
+          return filter.title === activeFilter.category;
+        }) || availableFilters[2]
+      ).id;
+
+      params.push({
+        name: filterId,
+        value: activeFilter.value
       });
-      this.props.onParamChange(params, 'append');
-    } else {
-      this.props.onParamDelete(
-        availableFilters.map(filter => {
-          return filter.id;
-        })
-      );
-    }
+    });
 
+    this.props.onParamChange(params, 'append');
     this.updateServices();
   };
 

--- a/src/pages/ServiceList/ServiceListComponent.tsx
+++ b/src/pages/ServiceList/ServiceListComponent.tsx
@@ -217,18 +217,27 @@ class ServiceListComponent extends React.Component<ServiceListComponentProps, Se
   }
 
   setActiveFiltersToURL() {
-    const params = NamespaceFilterSelected.getSelected().map(activeFilter => {
-      let filterId = (
-        availableFilters.find(filter => {
+    const params = NamespaceFilterSelected.getSelected()
+      .map(activeFilter => {
+        const availableFilter = availableFilters.find(filter => {
           return filter.title === activeFilter.category;
-        }) || availableFilters[2]
-      ).id;
+        });
 
-      return {
-        name: filterId,
-        value: activeFilter.value
-      };
-    });
+        if (typeof availableFilter === 'undefined') {
+          NamespaceFilterSelected.setSelected(
+            NamespaceFilterSelected.getSelected().filter(nfs => {
+              return nfs.category === activeFilter.category;
+            })
+          );
+          return null;
+        }
+
+        return {
+          name: availableFilter.id,
+          value: activeFilter.value
+        };
+      })
+      .filter(filter => filter !== null);
 
     this.props.onParamChange(params, 'append');
   }


### PR DESCRIPTION
** Describe the change **

This PR addresses the bugs found by QE into KIALI-1173:

1. Switching from ServiceList to IstioConfig changes filter names
2. When removing first filter of a type it got not removed from url

** Issue reference **

[KIALI-1173](https://issues.jboss.org/browse/KIALI-1173?focusedCommentId=13613114&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-13613114)

** Backwards in compatible? **

yes.

** Screenshot **

First bug:
![screen recording 1](https://user-images.githubusercontent.com/613814/43646714-eed5889c-9735-11e8-8cbf-439e897a2df6.gif)

Second one:
![screen recording 2](https://user-images.githubusercontent.com/613814/43646725-fa8f18e2-9735-11e8-8446-f7efa54778cc.gif)
