### PR TITLE
KIALI-1288 Fix Services Overview issue with DetailObject Undefined

### DIFF
--- a/src/components/Details/DetailObject.tsx
+++ b/src/components/Details/DetailObject.tsx
@@ -86,7 +86,7 @@ class DetailObject extends React.Component<DetailObjectProps> {
         }
       });
     } else {
-      Object.keys(value).forEach((key, k) => {
+      Object.keys(value || {}).forEach((key, k) => {
         let childList = this.buildList(key, value[key], checkLabel, depth + 1);
         childrenList.push(<li key={listKey + '_k' + k}>{childList}</li>);
       });


### PR DESCRIPTION
** Describe the change **

Fix issue Service Details when you try to access to the Service Overview with Destination Tule or Virtual Services, DetailObject has an error here when the object is undefined/null in the values.

** Issue reference **
[KIALI-1288](https://issues.jboss.org/browse/KIALI-1288)

** Backwards in compatible? **

Yes

![peek 2018-08-06 10-19](https://user-images.githubusercontent.com/3019213/43705253-4f42b5f0-9962-11e8-98f5-94e1119281fb.gif)


