### PR TITLE
KIALI-1279 Avoid Kiali lock-up by multiple chart refreshes when page …

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "ssri": "6.0.0",
     "typesafe-actions": "1.1.2",
     "typestyle": "2.0.1",
-    "url-search-params": "0.10.0"
+    "url-search-params": "0.10.0",
+    "visibilityjs": "2.0.1"
   },
   "script-comments": [
     "When adding new scripts, please be careful to using `npm run` instead of `yarn` for the tasks.",

--- a/src/actions/GlobalActions.ts
+++ b/src/actions/GlobalActions.ts
@@ -3,10 +3,14 @@ import { createAction } from 'typesafe-actions';
 
 export enum GlobalActionKeys {
   INCREMENT_LOADING_COUNTER = 'INCREMENT_LOADING_COUNTER',
-  DECREMENT_LOADING_COUNTER = 'DECREMENT_LOADING_COUNTER'
+  DECREMENT_LOADING_COUNTER = 'DECREMENT_LOADING_COUNTER',
+  SET_PAGE_VISIBILITY_HIDDEN = 'SET_PAGE_VISIBILITY_HIDDEN',
+  SET_PAGE_VISIBILITY_VISIBLE = 'SET_PAGE_VISIBILITY_VISIBLE'
 }
 
-export const globalActions = {
+export const GlobalActions = {
   incrementLoadingCounter: createAction(GlobalActionKeys.INCREMENT_LOADING_COUNTER),
-  decrementLoadingCounter: createAction(GlobalActionKeys.DECREMENT_LOADING_COUNTER)
+  decrementLoadingCounter: createAction(GlobalActionKeys.DECREMENT_LOADING_COUNTER),
+  setPageVisibilityHidden: createAction(GlobalActionKeys.SET_PAGE_VISIBILITY_HIDDEN),
+  setPageVisibilityVisible: createAction(GlobalActionKeys.SET_PAGE_VISIBILITY_VISIBLE)
 };

--- a/src/actions/__tests__/GlobalActions.test.ts
+++ b/src/actions/__tests__/GlobalActions.test.ts
@@ -1,0 +1,24 @@
+import { GlobalActionKeys, GlobalActions } from '../GlobalActions';
+
+describe('GlobalActions', () => {
+  it('should increment Loading counter', () => {
+    expect(GlobalActions.incrementLoadingCounter()).toEqual({
+      type: GlobalActionKeys.INCREMENT_LOADING_COUNTER
+    });
+  });
+  it('should decrement Loading counter', () => {
+    expect(GlobalActions.decrementLoadingCounter()).toEqual({
+      type: GlobalActionKeys.DECREMENT_LOADING_COUNTER
+    });
+  });
+  it('should set page visibility to hidden', () => {
+    expect(GlobalActions.setPageVisibilityHidden()).toEqual({
+      type: GlobalActionKeys.SET_PAGE_VISIBILITY_HIDDEN
+    });
+  });
+  it('should set page visibility to visible', () => {
+    expect(GlobalActions.setPageVisibilityVisible()).toEqual({
+      type: GlobalActionKeys.SET_PAGE_VISIBILITY_VISIBLE
+    });
+  });
+});

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -5,9 +5,25 @@ import './App.css';
 import Navigation from '../containers/NavigationContainer';
 import { store, persistor } from '../store/ConfigStore';
 import axios from 'axios';
-import { globalActions } from '../actions/GlobalActions';
+import { GlobalActions } from '../actions/GlobalActions';
 import history from './History';
 import { PersistGate } from 'redux-persist/lib/integration/react';
+import * as Visibility from 'visibilityjs';
+
+Visibility.change((e, state) => {
+  // There are 3 states, visible, hidden and prerender, consider prerender as hidden.
+  // https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilityState
+  if (state === 'visible') {
+    store.dispatch(GlobalActions.setPageVisibilityVisible());
+  } else {
+    store.dispatch(GlobalActions.setPageVisibilityHidden());
+  }
+});
+if (Visibility.hidden()) {
+  store.dispatch(GlobalActions.setPageVisibilityHidden);
+} else {
+  store.dispatch(GlobalActions.setPageVisibilityVisible);
+}
 
 const getIsLoadingState = () => {
   const state = store.getState();
@@ -16,7 +32,7 @@ const getIsLoadingState = () => {
 
 const decrementLoadingCounter = () => {
   if (getIsLoadingState()) {
-    store.dispatch(globalActions.decrementLoadingCounter());
+    store.dispatch(GlobalActions.decrementLoadingCounter());
   }
 };
 
@@ -24,7 +40,7 @@ const decrementLoadingCounter = () => {
 axios.interceptors.request.use(
   request => {
     // dispatch an action to turn spinner on
-    store.dispatch(globalActions.incrementLoadingCounter());
+    store.dispatch(GlobalActions.incrementLoadingCounter());
     return request;
   },
   error => {

--- a/src/containers/ServiceGraphPageContainer.ts
+++ b/src/containers/ServiceGraphPageContainer.ts
@@ -20,7 +20,8 @@ const mapStateToProps = (state: KialiAppState) => ({
       }
     : null,
   showLegend: state.serviceGraph.filterState.showLegend,
-  pollInterval: state.serviceGraph.filterState.refreshRate
+  pollInterval: state.serviceGraph.filterState.refreshRate,
+  isPageVisible: state.globalState.isPageVisible
 });
 
 const mapDispatchToProps = (dispatch: any) => ({

--- a/src/pages/ServiceGraph/ServiceGraphPage.tsx
+++ b/src/pages/ServiceGraph/ServiceGraphPage.tsx
@@ -29,6 +29,7 @@ type ServiceGraphPageProps = GraphParamsType & {
   toggleLegend: () => void;
   summaryData: SummaryData | null;
   pollInterval: PollIntervalInMs;
+  isPageVisible: boolean;
 };
 const NUMBER_OF_DATAPOINTS = 30;
 
@@ -152,6 +153,7 @@ export default class ServiceGraphPage extends React.PureComponent<ServiceGraphPa
                 namespace={this.props.namespace.name}
                 queryTime={this.props.graphTimestamp}
                 duration={this.props.graphDuration.value}
+                isPageVisible={this.props.isPageVisible}
                 {...computePrometheusQueryInterval(this.props.graphDuration.value, NUMBER_OF_DATAPOINTS)}
               />
             ) : null}

--- a/src/pages/ServiceGraph/SummaryPanel.tsx
+++ b/src/pages/ServiceGraph/SummaryPanel.tsx
@@ -9,8 +9,15 @@ type SummaryPanelState = {
   // stateless
 };
 
-export default class SummaryPanel extends React.Component<SummaryPanelPropType, SummaryPanelState> {
+type MainSummaryPanelPropType = SummaryPanelPropType & {
+  isPageVisible: boolean;
+};
+
+export default class SummaryPanel extends React.Component<MainSummaryPanelPropType, SummaryPanelState> {
   render() {
+    if (!this.props.isPageVisible) {
+      return null;
+    }
     return (
       <>
         {this.props.data.summaryType === 'edge' ? (

--- a/src/reducers/GlobalState.ts
+++ b/src/reducers/GlobalState.ts
@@ -3,7 +3,8 @@ import { updateState } from '../utils/Reducer';
 import { GlobalActionKeys } from '../actions/GlobalActions';
 
 const INITIAL_GLOBAL_STATE: GlobalState = {
-  loadingCounter: 0
+  loadingCounter: 0,
+  isPageVisible: true
 };
 
 // This Reducer allows changes to the 'globalState' portion of Redux Store
@@ -13,6 +14,10 @@ const globalState = (state: GlobalState = INITIAL_GLOBAL_STATE, action) => {
       return updateState(state, { loadingCounter: state.loadingCounter + 1 });
     case GlobalActionKeys.DECREMENT_LOADING_COUNTER:
       return updateState(state, { loadingCounter: Math.max(0, state.loadingCounter - 1) });
+    case GlobalActionKeys.SET_PAGE_VISIBILITY_HIDDEN:
+      return updateState(state, { isPageVisible: false });
+    case GlobalActionKeys.SET_PAGE_VISIBILITY_VISIBLE:
+      return updateState(state, { isPageVisible: true });
     default:
       return state;
   }

--- a/src/reducers/__tests__/GlobalStateReducer.test.ts
+++ b/src/reducers/__tests__/GlobalStateReducer.test.ts
@@ -4,7 +4,8 @@ import { GlobalActionKeys } from '../../actions/GlobalActions';
 describe('GlobalState reducer', () => {
   it('should return the initial state', () => {
     expect(globalState(undefined, {})).toEqual({
-      loadingCounter: 0
+      loadingCounter: 0,
+      isPageVisible: true
     });
   });
 
@@ -12,14 +13,16 @@ describe('GlobalState reducer', () => {
     expect(
       globalState(
         {
-          loadingCounter: 0
+          loadingCounter: 0,
+          isPageVisible: true
         },
         {
           type: GlobalActionKeys.INCREMENT_LOADING_COUNTER
         }
       )
     ).toEqual({
-      loadingCounter: 1
+      loadingCounter: 1,
+      isPageVisible: true
     });
   });
 
@@ -27,14 +30,16 @@ describe('GlobalState reducer', () => {
     expect(
       globalState(
         {
-          loadingCounter: 1
+          loadingCounter: 1,
+          isPageVisible: true
         },
         {
           type: GlobalActionKeys.DECREMENT_LOADING_COUNTER
         }
       )
     ).toEqual({
-      loadingCounter: 0
+      loadingCounter: 0,
+      isPageVisible: true
     });
   });
 
@@ -42,14 +47,16 @@ describe('GlobalState reducer', () => {
     expect(
       globalState(
         {
-          loadingCounter: 1
+          loadingCounter: 1,
+          isPageVisible: true
         },
         {
           type: GlobalActionKeys.INCREMENT_LOADING_COUNTER
         }
       )
     ).toEqual({
-      loadingCounter: 2
+      loadingCounter: 2,
+      isPageVisible: true
     });
   });
 
@@ -57,14 +64,48 @@ describe('GlobalState reducer', () => {
     expect(
       globalState(
         {
-          loadingCounter: 2
+          loadingCounter: 2,
+          isPageVisible: true
         },
         {
           type: GlobalActionKeys.DECREMENT_LOADING_COUNTER
         }
       )
     ).toEqual({
-      loadingCounter: 1
+      loadingCounter: 1,
+      isPageVisible: true
+    });
+  });
+  it('should turn on page visibility status', () => {
+    expect(
+      globalState(
+        {
+          loadingCounter: 0,
+          isPageVisible: false
+        },
+        {
+          type: GlobalActionKeys.SET_PAGE_VISIBILITY_VISIBLE
+        }
+      )
+    ).toEqual({
+      loadingCounter: 0,
+      isPageVisible: true
+    });
+  });
+  it('should turn off page visibility status', () => {
+    expect(
+      globalState(
+        {
+          loadingCounter: 0,
+          isPageVisible: true
+        },
+        {
+          type: GlobalActionKeys.SET_PAGE_VISIBILITY_HIDDEN
+        }
+      )
+    ).toEqual({
+      loadingCounter: 0,
+      isPageVisible: false
     });
   });
 });

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -4,6 +4,7 @@ import { PollIntervalInMs } from '../types/GraphFilter';
 
 export interface GlobalState {
   readonly loadingCounter: number;
+  readonly isPageVisible: boolean;
 }
 
 // Various pages are described here with their various sections

--- a/yarn.lock
+++ b/yarn.lock
@@ -8840,6 +8840,10 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
+visibilityjs@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/visibilityjs/-/visibilityjs-2.0.1.tgz#64f58c789828a170306e5a7e5b394526b2ec3832"
+
 vm-browserify@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-0.0.4.tgz#5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73"


### PR DESCRIPTION
…is hidden

** Describe the change **

 - There seems to be an issue with the C3Charts, when refreshing multiple times
   when the page is hidden, it doesn't seem to be processed right away and they
   build up over time. When the page is visible again, they start processing
   (taking 100% cpu) and the page becomes unresponsive. After all the processing
   is done the page becomes responsive again. The more time the page is in
   background, the more time it takes to become responsive.

   Using Visibility API to detect if page is hidden to hide the C3Charts.