### PR TITLE
KIALI-1289 NameSpaceFilter is not working when the initialFilters is []

### DIFF
--- a/src/components/NamespaceFilter/NamespaceFilter.tsx
+++ b/src/components/NamespaceFilter/NamespaceFilter.tsx
@@ -93,7 +93,7 @@ export class NamespaceFilter extends React.Component<NamespaceFilterProps, Names
           })
         };
         const initialFilters = this.initialFilterList(namespaceFilter);
-        this.setState({ filterTypeList: initialFilters });
+        this.setState({ filterTypeList: initialFilters, currentFilterType: namespaceFilter });
       })
       .catch(error => {
         const errMsg = API.getErrorMsg('Error fetching namespace list.', error);
@@ -184,7 +184,6 @@ export class NamespaceFilter extends React.Component<NamespaceFilterProps, Names
     if (!currentFilterType) {
       return null;
     }
-
     if (currentFilterType.filterType === 'select') {
       return (
         <Filter.ValueSelector


### PR DESCRIPTION
** Describe the change **
When initialFilters is an empty [] NamespaceFilter should show the Namespacefilter only.

This is not working well because the currentFilterType.filterValues is empty, we need to set the currentFilterType after the method updateNamespaces()

** Issue reference **

[KIALI-1289](https://issues.jboss.org/browse/KIALI-1289)

This blocks to [KIALI-1209](https://issues.jboss.org/browse/KIALI-1209)


### Before
![before](https://user-images.githubusercontent.com/3019213/43732414-f9cc61e8-99b1-11e8-80e9-9b9f77f53e78.gif)

### After
![after](https://user-images.githubusercontent.com/3019213/43732409-f78e9f2c-99b1-11e8-8f46-e516d77096fc.gif)


