### PR TITLE
KIALI-1283 Correctly link to service details page

### DIFF
--- a/src/pages/ServiceGraph/SummaryPanelCommon.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelCommon.tsx
@@ -1,4 +1,7 @@
-import { SummaryPanelPropType } from '../../types/Graph';
+import { Link } from 'react-router-dom';
+import * as React from 'react';
+
+import { NodeType, SummaryPanelPropType } from '../../types/Graph';
 import { Health, healthNotAvailable } from '../../types/Health';
 
 export const shouldRefreshData = (prevProps: SummaryPanelPropType, nextProps: SummaryPanelPropType) => {
@@ -36,4 +39,50 @@ export const nodeData = (node: any) => {
     version: node.data('version'),
     workload: node.data('workload')
   };
+};
+
+export const nodeTypeToString = (nodeType: string) => {
+  if (nodeType === NodeType.APP) {
+    return 'Application';
+  }
+
+  if (nodeType === NodeType.UNKNOWN) {
+    return 'Service';
+  }
+
+  return nodeType.charAt(0).toUpperCase() + nodeType.slice(1);
+};
+
+export const getServicesLinkList = (cyNodes: any) => {
+  let namespace = '';
+  if (cyNodes.data) {
+    namespace = cyNodes.data('namespace');
+  } else {
+    namespace = cyNodes[0].data('namespace');
+  }
+
+  let services = new Set();
+  let linkList: any[] = [];
+
+  cyNodes.forEach(node => {
+    if (node.data('destServices')) {
+      Object.keys(node.data('destServices')).forEach(k => {
+        services.add(k);
+      });
+    }
+  });
+
+  services.forEach(svc => {
+    linkList.push(
+      <span key={svc}>
+        <Link to={`/namespaces/${namespace}/services/${svc}`}>{svc}</Link>
+      </span>
+    );
+    linkList.push(', ');
+  });
+  if (linkList.length > 0) {
+    linkList.pop();
+  }
+
+  return linkList;
 };

--- a/src/pages/ServiceGraph/SummaryPanelGroup.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelGroup.tsx
@@ -10,7 +10,7 @@ import MetricsOptions from '../../types/MetricsOptions';
 import { Icon } from 'patternfly-react';
 import { authentication } from '../../utils/Authentication';
 import { Link } from 'react-router-dom';
-import { shouldRefreshData, updateHealth, nodeData } from './SummaryPanelCommon';
+import { shouldRefreshData, updateHealth, nodeData, getServicesLinkList } from './SummaryPanelCommon';
 import { DisplayMode, HealthIndicator } from '../../components/Health/HealthIndicator';
 import Label from '../../components/Label/Label';
 import { Health } from '../../types/Health';
@@ -67,10 +67,10 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
   render() {
     const group = this.props.data.summaryTarget;
     const { namespace, app } = nodeData(group);
-    const serviceHotLink = <Link to={`/namespaces/${namespace}/services/${app}`}>{app}</Link>;
 
     const incoming = getAccumulatedTrafficRate(group.children());
     const outgoing = getAccumulatedTrafficRate(group.children().edgesTo('*'));
+    const backedServices = getServicesLinkList(group.children());
 
     return (
       <div className="panel panel-default" style={SummaryPanelGroup.panelStyle}>
@@ -88,7 +88,7 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
               />
             )
           )}
-          <span> Versioned Group: {serviceHotLink}</span>
+          <span> Versioned Group: {app}</span>
           <div className="label-collection" style={{ paddingTop: '3px' }}>
             <Label name="namespace" value={namespace} key={namespace} />
             {this.renderVersionBadges()}
@@ -96,6 +96,13 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
           {this.renderBadgeSummary(group.data('hasVS'))}
         </div>
         <div className="panel-body">
+          {backedServices.length > 0 && (
+            <div>
+              <strong>Backed services: </strong>
+              {backedServices}
+              <hr />
+            </div>
+          )}
           <p style={{ textAlign: 'right' }}>
             <Link to={`/namespaces/${namespace}/services/${app}?tab=metrics&groupings=local+version%2Cresponse+code`}>
               View detailed charts <Icon name="angle-double-right" />


### PR DESCRIPTION
Now, nodes in the graph can be of several types. Nodes will be backing
services, so the old links in the headers of the side panel are no
longer valid.  Links to the backing services are now listed in the body
of the side panel (one node can be backing several services).

This commit is also: removing the link to the detailed charts for the
"edge" version of the side panel, since a link cannot be resolved
reliably; fixing titles-headings of the side panels with the right
legends (app, workload, servce).

For nodes, the panel look like this:
![image](https://user-images.githubusercontent.com/23639005/43781866-8d35b79c-9a23-11e8-8d6f-58704a66d621.png)

For versioned groups, it looks very similar to the previous screenshot. For edges, the look is the following:
![image](https://user-images.githubusercontent.com/23639005/43781922-ac3a90ae-9a23-11e8-825c-7fd69999467e.png)


