### PR TITLE
KIALI-1292 Back link in VS/DR Yaml page goes to corresponding list

### DIFF
--- a/src/pages/ServiceDetails/IstioObjectDetails.tsx
+++ b/src/pages/ServiceDetails/IstioObjectDetails.tsx
@@ -86,7 +86,7 @@ export default class IstioObjectDetails extends React.Component<IstioObjectDetai
           <Row className={'card-pf-body'} key={'virtualservice-yaml'}>
             <Col xs={12}>
               <div className={'pull-right'}>
-                <Link to={{ pathname: this.props.servicePageURL }}>Back to Service</Link>{' '}
+                <Link to={this.props.servicePageURL}>Back to Service</Link>{' '}
               </div>
               <AceEditor
                 mode="yaml"

--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -38,8 +38,12 @@ class ServiceDetails extends React.Component<RouteComponentProps<ServiceId>, Ser
     };
   }
 
-  servicePageURL() {
-    return '/namespaces/' + this.props.match.params.namespace + '/services/' + this.props.match.params.service;
+  servicePageURL(parsedSearch?: ParsedSearch) {
+    let url = '/namespaces/' + this.props.match.params.namespace + '/services/' + this.props.match.params.service;
+    if (parsedSearch && parsedSearch.type) {
+      url += `?list=${parsedSearch.type}s`;
+    }
+    return url;
   }
 
   cleanFilter = () => {
@@ -224,7 +228,7 @@ class ServiceDetails extends React.Component<RouteComponentProps<ServiceId>, Ser
             validations={this.searchValidation(parsedSearch)}
             onSelectTab={this.tabSelectHandler}
             activeTab={this.activeTab}
-            servicePageURL={this.servicePageURL()}
+            servicePageURL={this.servicePageURL(parsedSearch)}
           />
         ) : (
           <TabContainer


### PR DESCRIPTION
This avoids the annoyance of re-clicking on the virtualservice/destinationrule tab if the user is browsing the list.
