### PR TITLE
KIALI-1277 Do not render badges outside the graph area

### DIFF
--- a/src/components/CytoscapeGraph/graphs/GraphBadge.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphBadge.ts
@@ -84,8 +84,11 @@ class GraphBadge {
         modifiers: {
           inner: { enabled: this.inner },
           preventOverflow: {
-            enabled: true,
+            enabled: false,
             padding: 0
+          },
+          hide: {
+            enabled: false
           },
           flip: {
             enabled: false

--- a/src/components/CytoscapeGraph/graphs/GraphBadge.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphBadge.ts
@@ -40,10 +40,21 @@ class GraphBadge {
     div.style.zIndex = node.css('z-index');
     div.style.position = 'absolute';
 
-    node
-      .cy()
-      .container()
-      .children[0].appendChild(div);
+    const containerNode = Array.prototype.slice
+      .call(node.cy().container().children, 0)
+      .reverse()
+      .find((element: any) => {
+        return element.nodeName === 'DIV';
+      });
+
+    if (containerNode) {
+      containerNode.appendChild(div);
+    } else {
+      node
+        .cy()
+        .container()
+        .children[0].appendChild(div);
+    }
 
     const setScale = () => {
       const zoom = node.cy().zoom();


### PR DESCRIPTION
  - Try to put the badges in the last div of the cy container

Solves KIALI-1277 by putting the badges in the last div container (currently it was putting the badges in container[0]. That was the panzoom container).