### PR TITLE
Trivial - Brings back the behavior of the precommit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "itest": "export CI=true && react-scripts-ts test  __itests__",
     "eject": "react-scripts-ts eject",
     "set-snapshot-version": "npm-snapshot",
-    "precommit": "npm run prettier --list-different || (echo 'Above file(s) were modified by prettier, check them before commiting' && false)"
+    "precommit": "npm run prettier -- --list-different || (echo 'Above file(s) were modified by prettier, check them before commiting' && false)"
   },
   "devDependencies": {
     "@types/enzyme": "3.1.10",


### PR DESCRIPTION
 - It cancels the commit and warns when trying to commit
   "non-pretty" files

`npm run` needs a `--` at the end to signal that we are passing arguments.