### PR TITLE
KIALI-1298 Fix side panel terminology

### DIFF
--- a/src/pages/ServiceGraph/SummaryPanelCommon.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelCommon.tsx
@@ -11,6 +11,7 @@ export interface NodeData {
   app: string;
   version: string;
   workload: string;
+  service: string;
   nodeType: NodeType;
   hasParent: boolean;
 }
@@ -55,20 +56,17 @@ export const nodeData = (node: any): NodeData => {
     version: node.data('version'),
     workload: node.data('workload'),
     nodeType: node.data('nodeType'),
-    hasParent: !!node.data('parent')
+    hasParent: !!node.data('parent'),
+    service: node.data('service')
   };
 };
 
 export const nodeTypeToString = (nodeType: string) => {
-  if (nodeType === NodeType.APP) {
-    return 'Application';
-  }
-
   if (nodeType === NodeType.UNKNOWN) {
-    return 'Service';
+    return 'service';
   }
 
-  return nodeType.charAt(0).toUpperCase() + nodeType.slice(1);
+  return nodeType;
 };
 
 export const getServicesLinkList = (cyNodes: any) => {
@@ -146,4 +144,36 @@ export const getNodeMetrics = (
       // https://github.com/palantir/tslint/issues/696
       return Promise.reject(new Error(`Unknown NodeMetricType: ${nodeMetricType}`));
   }
+};
+
+export const renderPanelTitle = node => {
+  const { namespace, service, app, workload, nodeType } = nodeData(node);
+  const displayName: string = nodeType === NodeType.UNKNOWN ? 'unknown' : app || workload || service;
+  let link: string | undefined;
+  let displaySpan: any;
+
+  switch (nodeType) {
+    case NodeType.SERVICE:
+      link = `/namespaces/${namespace}/services/${service}`;
+      break;
+    case NodeType.WORKLOAD:
+      // Not available yet.
+      // link = `/namespaces/${namespace}/workloads/${service}`;
+      break;
+    default:
+      // NOOP
+      break;
+  }
+
+  if (link) {
+    displaySpan = <Link to={link}>{displayName}</Link>;
+  } else {
+    displaySpan = displayName;
+  }
+
+  return (
+    <>
+      {nodeTypeToString(nodeType)}: {displaySpan}
+    </>
+  );
 };

--- a/src/pages/ServiceGraph/SummaryPanelEdge.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelEdge.tsx
@@ -2,16 +2,16 @@ import * as React from 'react';
 import RateTable from '../../components/SummaryPanel/RateTable';
 import RpsChart from '../../components/SummaryPanel/RpsChart';
 import ResponseTimeChart from '../../components/SummaryPanel/ResponseTimeChart';
-import { NodeType, SummaryPanelPropType } from '../../types/Graph';
+import { SummaryPanelPropType } from '../../types/Graph';
 import * as M from '../../types/Metrics';
 import graphUtils from '../../utils/Graphing';
 import {
   shouldRefreshData,
   nodeData,
-  getServicesLinkList,
   getNodeMetrics,
   NodeMetricType,
-  getNodeMetricType
+  getNodeMetricType,
+  renderPanelTitle
 } from './SummaryPanelCommon';
 import Label from '../../components/Label/Label';
 import { MetricGroup, Metric } from '../../types/Metrics';
@@ -75,38 +75,21 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
     const rate5xx = this.safeRate(edge.data('rate5XX'));
 
     const HeadingBlock = ({ prefix, node }) => {
-      const isAppUnknown = node.data('nodeType') === NodeType.UNKNOWN;
-      const { namespace, version, app, workload } = nodeData(node);
+      const { namespace, version } = nodeData(node);
       return (
         <div className="panel-heading label-collection">
-          {prefix}: {isAppUnknown ? 'unknown' : app || workload || node.data('service')}
+          {prefix} {renderPanelTitle(node)}
           <br />
           {this.renderLabels(namespace, version)}
         </div>
       );
     };
 
-    const sourceServices = getServicesLinkList([source]);
-    const destinationServices = getServicesLinkList([dest]);
-
     return (
       <div className="panel panel-default" style={SummaryPanelEdge.panelStyle}>
         <HeadingBlock prefix="Source" node={source} />
         <HeadingBlock prefix="Destination" node={dest} />
         <div className="panel-body">
-          {sourceServices.length > 0 && (
-            <div>
-              <strong>Source services: </strong>
-              {sourceServices}
-            </div>
-          )}
-          {destinationServices.length > 0 && (
-            <div>
-              <strong>Destination services: </strong>
-              {destinationServices}
-            </div>
-          )}
-          {(destinationServices || sourceServices) && <hr />}
           <RateTable
             title="Traffic (requests per second):"
             rate={rate}

--- a/src/pages/ServiceGraph/SummaryPanelGroup.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelGroup.tsx
@@ -7,14 +7,7 @@ import graphUtils from '../../utils/Graphing';
 import { getAccumulatedTrafficRate } from '../../utils/TrafficRate';
 import { Icon } from 'patternfly-react';
 import { Link } from 'react-router-dom';
-import {
-  shouldRefreshData,
-  updateHealth,
-  nodeData,
-  getServicesLinkList,
-  getNodeMetrics,
-  getNodeMetricType
-} from './SummaryPanelCommon';
+import { shouldRefreshData, updateHealth, nodeData, getNodeMetrics, getNodeMetricType } from './SummaryPanelCommon';
 import { DisplayMode, HealthIndicator } from '../../components/Health/HealthIndicator';
 import Label from '../../components/Label/Label';
 import { Health } from '../../types/Health';
@@ -74,7 +67,7 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
 
     const incoming = getAccumulatedTrafficRate(group.children());
     const outgoing = getAccumulatedTrafficRate(group.children().edgesTo('*'));
-    const backedServices = getServicesLinkList(group.children());
+    const workloadList = this.renderWorkloadList(group);
 
     return (
       <div className="panel panel-default" style={SummaryPanelGroup.panelStyle}>
@@ -92,7 +85,7 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
               />
             )
           )}
-          <span> Versioned Group: {app}</span>
+          <span> app: {app}</span>
           <div className="label-collection" style={{ paddingTop: '3px' }}>
             <Label name="namespace" value={namespace} key={namespace} />
             {this.renderVersionBadges()}
@@ -100,10 +93,10 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
           {this.renderBadgeSummary(group.data('hasVS'))}
         </div>
         <div className="panel-body">
-          {backedServices.length > 0 && (
+          {workloadList.length > 0 && (
             <div>
-              <strong>Backed services: </strong>
-              {backedServices}
+              <strong>Workloads: </strong>
+              {workloadList}
               <hr />
             </div>
           )}
@@ -210,5 +203,24 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
         />
       </>
     );
+  };
+
+  private renderWorkloadList = (group): any[] => {
+    let workloadList: any[] = [];
+
+    group.children().forEach(node => {
+      let workload = node.data('workload');
+
+      if (workload) {
+        workloadList.push(workload);
+        workloadList.push(', ');
+      }
+    });
+
+    if (workloadList.length > 0) {
+      workloadList.pop();
+    }
+
+    return workloadList;
   };
 }


### PR DESCRIPTION
* Show only "services" instead of "backed services"
* Show "services" list only if relevant/applicable
* Uses "app" instead of "application"
* Using lowercase for the type of the node
* Show the type of destination/source node for edges
* Don't show services/workload list for edges
* For group nodes, show list of workloads instead of services

Nodes:
![image](https://user-images.githubusercontent.com/23639005/43885410-6c349b92-9b7e-11e8-8944-83b604fa8c16.png)

Group nodes:
![image](https://user-images.githubusercontent.com/23639005/43885444-83a03c6e-9b7e-11e8-9663-14137147773c.png)


Edges:
![image](https://user-images.githubusercontent.com/23639005/43885463-98a5d1dc-9b7e-11e8-993b-9d876efde9f9.png)
