### PR TITLE
kiali-1059 support custom context path

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,13 +120,9 @@
   ],
   "author": "Red Hat",
   "license": "Apache-2.0",
-  "homepage-comment": [
-    "By default, Create React App produces a build assuming your app is hosted at the server root.",
-    "To override this, specify the homepage in your package.json:",
-    "We don't want this, so don't touch homepage.",
-    "https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#building-for-relative-paths"
-  ],
-  "homepage": "/",
+  "homepage-comment": ["*Do not* change this setting if you wish run Kiali under different server root.",
+                       "Instead update 'web_root' in Kaili config map in OpenShift console."],
+  "homepage": "./",
   "publishConfig": {
     "access": "public"
   },

--- a/public/env.js
+++ b/public/env.js
@@ -1,0 +1,2 @@
+// This file is intentionally left bank.
+// Kiali server may re-generate this file with configuration variables.

--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="theme-color" content="#000000">
+    <base href="/">
+    <script type="text/javascript" src="./env.js"></script>
     <!--
       manifest.json provides metadata used when your web app is added to the
       homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/

--- a/src/app/History.tsx
+++ b/src/app/History.tsx
@@ -1,5 +1,7 @@
 import { createBrowserHistory } from 'history';
 
-const baseName = '/console';
+const webRoot = (window as any).WEB_ROOT ? (window as any).WEB_ROOT : undefined;
+const baseName = webRoot && webRoot !== '/' ? webRoot + '/console' : '/console';
 const history = createBrowserHistory({ basename: baseName });
+
 export default history;

--- a/src/components/About/AboutUIModal.tsx
+++ b/src/components/About/AboutUIModal.tsx
@@ -39,12 +39,17 @@ class AboutUIModal extends React.Component<AboutUIModalProps, AboutUIModalState>
           />
           <AboutModal.VersionItem
             label="kiali"
-            versionText={`${this.props.status[KIALI_CORE_VERSION]} (${this.props.status[KIALI_CORE_COMMIT_HASH]})`}
+            versionText={
+              this.props.status
+                ? `${this.props.status[KIALI_CORE_VERSION]} (${this.props.status[KIALI_CORE_COMMIT_HASH]})`
+                : 'Unknown'
+            }
           />
           <h3>Components </h3>
-          {this.props.components.map(component => (
-            <AboutModal.VersionItem key={component.name} label={component.name} versionText={component.version} />
-          ))}
+          {this.props.components &&
+            this.props.components.map(component => (
+              <AboutModal.VersionItem key={component.name} label={component.name} versionText={component.version} />
+            ))}
         </AboutModal.Versions>
         {this.renderWebsiteLink()}
         {this.renderProjectLink()}

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -59,7 +59,7 @@ export const login = (username: string, password: string) => {
   return new Promise((resolve, reject) => {
     axios({
       method: 'get',
-      url: '/api/token',
+      url: 'api/token',
       headers: getHeaders(),
       auth: basicAuth(username, password)
     })
@@ -73,15 +73,15 @@ export const login = (username: string, password: string) => {
 };
 
 export const getStatus = () => {
-  return newRequest('get', '/api/status', {}, {});
+  return newRequest('get', 'api/status', {}, {});
 };
 
 export const getNamespaces = (auth: string): Promise<Response<Namespace[]>> => {
-  return newRequest('get', `/api/namespaces`, {}, {}, auth);
+  return newRequest('get', `api/namespaces`, {}, {}, auth);
 };
 
 export const getNamespaceMetrics = (auth: string, namespace: String, params: any): Promise<Response<Metrics>> => {
-  return newRequest('get', `/api/namespaces/${namespace}/metrics`, params, {}, auth);
+  return newRequest('get', `api/namespaces/${namespace}/metrics`, params, {}, auth);
 };
 
 export const getIstioConfig = (
@@ -90,7 +90,7 @@ export const getIstioConfig = (
   objects: String[]
 ): Promise<Response<IstioConfigList>> => {
   let params = objects && objects.length > 0 ? { objects: objects.join(',') } : {};
-  return newRequest('get', `/api/namespaces/${namespace}/istio`, params, {}, auth);
+  return newRequest('get', `api/namespaces/${namespace}/istio`, params, {}, auth);
 };
 
 export const getIstioConfigDetail = (
@@ -99,11 +99,11 @@ export const getIstioConfigDetail = (
   objectType: String,
   object: String
 ): Promise<Response<IstioConfigDetails>> => {
-  return newRequest('get', `/api/namespaces/${namespace}/istio/${objectType}/${object}`, {}, {}, auth);
+  return newRequest('get', `api/namespaces/${namespace}/istio/${objectType}/${object}`, {}, {}, auth);
 };
 
 export const getServices = (auth: string, namespace: String): Promise<Response<ServiceList>> => {
-  return newRequest('get', `/api/namespaces/${namespace}/services`, {}, {}, auth);
+  return newRequest('get', `api/namespaces/${namespace}/services`, {}, {}, auth);
 };
 
 export const getServiceMetrics = (
@@ -112,15 +112,15 @@ export const getServiceMetrics = (
   service: String,
   params: MetricsOptions
 ): Promise<Response<Metrics>> => {
-  return newRequest('get', `/api/namespaces/${namespace}/services/${service}/metrics`, params, {}, auth);
+  return newRequest('get', `api/namespaces/${namespace}/services/${service}/metrics`, params, {}, auth);
 };
 
 export const getApp = (auth: string, namespace: String, app: String): Promise<Response<App>> => {
-  return newRequest('get', `/api/namespaces/${namespace}/apps/${app}`, {}, {}, auth);
+  return newRequest('get', `api/namespaces/${namespace}/apps/${app}`, {}, {}, auth);
 };
 
 export const getApps = (auth: string, namespace: String): Promise<Response<AppList>> => {
-  return newRequest('get', `/api/namespaces/${namespace}/apps`, {}, {}, auth);
+  return newRequest('get', `api/namespaces/${namespace}/apps`, {}, {}, auth);
 };
 
 export const getAppMetrics = (
@@ -129,7 +129,7 @@ export const getAppMetrics = (
   app: String,
   params: MetricsOptions
 ): Promise<Response<Metrics>> => {
-  return newRequest('get', `/api/namespaces/${namespace}/apps/${app}/metrics`, params, {}, auth);
+  return newRequest('get', `api/namespaces/${namespace}/apps/${app}/metrics`, params, {}, auth);
 };
 
 export const getWorkloadMetrics = (
@@ -138,7 +138,7 @@ export const getWorkloadMetrics = (
   workload: String,
   params: MetricsOptions
 ): Promise<Response<Metrics>> => {
-  return newRequest('get', `/api/namespaces/${namespace}/workloads/${workload}/metrics`, params, {}, auth);
+  return newRequest('get', `api/namespaces/${namespace}/workloads/${workload}/metrics`, params, {}, auth);
 };
 
 export const getServiceHealth = (
@@ -148,14 +148,14 @@ export const getServiceHealth = (
   durationSec: number
 ): Promise<ServiceHealth> => {
   const params = durationSec ? { rateInterval: String(durationSec) + 's' } : {};
-  return newRequest('get', `/api/namespaces/${namespace}/services/${service}/health`, params, {}, auth).then(response =>
+  return newRequest('get', `api/namespaces/${namespace}/services/${service}/health`, params, {}, auth).then(response =>
     ServiceHealth.fromJson(response.data, durationSec)
   );
 };
 
 export const getAppHealth = (auth: string, namespace: String, app: String, durationSec: number): Promise<AppHealth> => {
   const params = durationSec ? { rateInterval: String(durationSec) + 's' } : {};
-  return newRequest('get', `/api/namespaces/${namespace}/apps/${app}/health`, params, {}, auth).then(response =>
+  return newRequest('get', `api/namespaces/${namespace}/apps/${app}/health`, params, {}, auth).then(response =>
     AppHealth.fromJson(response.data, durationSec)
   );
 };
@@ -167,7 +167,7 @@ export const getWorkloadHealth = (
   durationSec: number
 ): Promise<WorkloadHealth> => {
   const params = durationSec ? { rateInterval: String(durationSec) + 's' } : {};
-  return newRequest('get', `/api/namespaces/${namespace}/workloads/${workload}/health`, params, {}, auth).then(
+  return newRequest('get', `api/namespaces/${namespace}/workloads/${workload}/health`, params, {}, auth).then(
     response => WorkloadHealth.fromJson(response.data, durationSec)
   );
 };
@@ -183,7 +183,7 @@ export const getNamespaceAppHealth = (
   if (durationSec) {
     params.rateInterval = String(durationSec) + 's';
   }
-  return newRequest('get', `/api/namespaces/${namespace}/health`, params, {}, auth).then(response => {
+  return newRequest('get', `api/namespaces/${namespace}/health`, params, {}, auth).then(response => {
     const ret: NamespaceAppHealth = {};
     Object.keys(response.data).forEach(k => {
       ret[k] = AppHealth.fromJson(response.data[k], durationSec);
@@ -203,7 +203,7 @@ export const getNamespaceWorkloadHealth = (
   if (durationSec) {
     params.rateInterval = String(durationSec) + 's';
   }
-  return newRequest('get', `/api/namespaces/${namespace}/health`, params, {}, auth).then(response => {
+  return newRequest('get', `api/namespaces/${namespace}/health`, params, {}, auth).then(response => {
     const ret: NamespaceWorkloadHealth = {};
     Object.keys(response.data).forEach(k => {
       ret[k] = WorkloadHealth.fromJson(response.data[k], durationSec);
@@ -213,19 +213,19 @@ export const getNamespaceWorkloadHealth = (
 };
 
 export const getGrafanaInfo = (auth: string): Promise<Response<GrafanaInfo>> => {
-  return newRequest('get', `/api/grafana`, {}, {}, auth);
+  return newRequest('get', `api/grafana`, {}, {}, auth);
 };
 
 export const getJaegerInfo = (auth: string): Promise<Response<JaegerInfo>> => {
-  return newRequest('get', `/api/jaeger`, {}, {}, auth);
+  return newRequest('get', `api/jaeger`, {}, {}, auth);
 };
 
 export const getGraphElements = (auth: string, namespace: Namespace, params: any) => {
-  return newRequest('get', `/api/namespaces/${namespace.name}/graph`, params, {}, auth);
+  return newRequest('get', `api/namespaces/${namespace.name}/graph`, params, {}, auth);
 };
 
 export const getServiceDetail = (auth: string, namespace: String, service: String): Promise<ServiceDetailsInfo> => {
-  return newRequest('get', `/api/namespaces/${namespace}/services/${service}`, {}, {}, auth).then(
+  return newRequest('get', `api/namespaces/${namespace}/services/${service}`, {}, {}, auth).then(
     (r: Response<ServiceDetailsInfo>) => {
       const info: ServiceDetailsInfo = r.data;
       info.istioSidecar = info.istioSidecar;
@@ -243,11 +243,11 @@ export const getServiceValidations = (
   namespace: String,
   service: String
 ): Promise<Response<Validations>> => {
-  return newRequest('get', `/api/namespaces/${namespace}/services/${service}/istio_validations`, {}, {}, auth);
+  return newRequest('get', `api/namespaces/${namespace}/services/${service}/istio_validations`, {}, {}, auth);
 };
 
 export const getNamespaceValidations = (auth: string, namespace: String): Promise<Response<NamespaceValidations>> => {
-  return newRequest('get', `/api/namespaces/${namespace}/istio_validations`, {}, {}, auth);
+  return newRequest('get', `api/namespaces/${namespace}/istio_validations`, {}, {}, auth);
 };
 
 export const getIstioConfigValidations = (
@@ -256,21 +256,15 @@ export const getIstioConfigValidations = (
   objectType: String,
   object: String
 ): Promise<Response<Validations>> => {
-  return newRequest(
-    'get',
-    `/api/namespaces/${namespace}/istio/${objectType}/${object}/istio_validations`,
-    {},
-    {},
-    auth
-  );
+  return newRequest('get', `api/namespaces/${namespace}/istio/${objectType}/${object}/istio_validations`, {}, {}, auth);
 };
 
 export const getWorkloads = (auth: string, namespace: String): Promise<Response<WorkloadNamespaceResponse>> => {
-  return newRequest('get', `/api/namespaces/${namespace}/workloads`, {}, {}, auth);
+  return newRequest('get', `api/namespaces/${namespace}/workloads`, {}, {}, auth);
 };
 
 export const getWorkload = (auth: string, namespace: String, name: String): Promise<Response<Deployment>> => {
-  return newRequest('get', `/api/namespaces/${namespace}/workloads/${name}`, {}, {}, auth);
+  return newRequest('get', `api/namespaces/${namespace}/workloads/${name}`, {}, {}, auth);
 };
 
 export const getWorkloadValidations = (
@@ -278,7 +272,7 @@ export const getWorkloadValidations = (
   namespace: String,
   workload: String
 ): Promise<Response<Validations>> => {
-  return newRequest('get', `/api/namespaces/${namespace}/workloads/${workload}/istio_validations`, {}, {}, auth);
+  return newRequest('get', `api/namespaces/${namespace}/workloads/${workload}/istio_validations`, {}, {}, auth);
 };
 
 export const getErrorMsg = (msg: string, error: AxiosError) => {


### PR DESCRIPTION

** Describe the change **
- Frontend changes to support custom context path such as *myapp.com/**kiali***
- By default the app is still served under / unless you specify otherwise during deployment on K8s and OpenShift. (By changing SERVER_WEB_ROOT env variable)
- Please avoid using *absolute* path to reference static assets or API endpoints.  Everything should be relative from `<SERVER_WEB_ROOT>/`  (which can also be "/" ).   
- Adding undefined guards to `AboutUIModal` component to prevent JS error when backend queries fail
- Backend PR https://github.com/kiali/kiali/pull/409

** Issue reference **
- KIALI-1059
- https://github.com/kiali/kiali/issues/321

** Backwards compatible? **
Yes

** Screenshot **
With /kiali

![kiali-1059-login](https://user-images.githubusercontent.com/3805254/43914865-dbab6e44-9bbd-11e8-95d2-4e03668c0df6.png)

![kiali-1059-with-path](https://user-images.githubusercontent.com/3805254/43920249-3d737338-9bcd-11e8-90db-9c78cf142723.png)

404

![kiali-1059-404](https://user-images.githubusercontent.com/3805254/43914866-dbc34370-9bbd-11e8-8e11-fb3ba115258c.png)