### PR TITLE
KIALI-1253 Fix missing warning icon in VS/DR tab

### DIFF
--- a/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -64,14 +64,16 @@ class ServiceInfo extends React.Component<ServiceDetails, ServiceInfoState> {
       virtualService =>
         this.props.validations['virtualservice'] &&
         this.props.validations['virtualservice'][virtualService.name] &&
-        !this.props.validations['virtualservice'][virtualService.name].valid
+        this.props.validations['virtualservice'][virtualService.name].checks !== undefined &&
+        this.props.validations['virtualservice'][virtualService.name].checks!.length > 0
     );
 
     validationChecks.hasDestinationRuleChecks = destinationRules.some(
       destinationRule =>
         this.props.validations['destinationrule'] &&
         this.props.validations['destinationrule'][destinationRule.name] &&
-        !this.props.validations['destinationrule'][destinationRule.name].valid
+        this.props.validations['destinationrule'][destinationRule.name].checks !== undefined &&
+        this.props.validations['destinationrule'][destinationRule.name].checks!.length > 0
     );
 
     return validationChecks;


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/23639005/43921488-8203595a-9be1-11e8-971e-b78ef39b4955.png)


Cheks that issue warnings do not necessarily mark a
VirtualService/DestinationRule as invalid. So, in order to show the icon
in tab headers, presence of any failed check is verified.

Right now, the backend is only returning checks that have 'failed'
either with low or high severity. Checks that pass are not informed. This
makes safe to assume that if the backend has returned something, then at
least, a warning icon can be shown.
