### PR TITLE
KIALI-1300: Change to cose layout to cose-bilkent

### DIFF
--- a/src/components/CytoscapeGraph/graphs/CoseGraph.ts
+++ b/src/components/CytoscapeGraph/graphs/CoseGraph.ts
@@ -3,7 +3,7 @@ import { GraphType } from './GraphType';
 export class CoseGraph implements GraphType {
   static getLayout() {
     return {
-      name: 'cose',
+      name: 'cose-bilkent',
       animate: false,
       nodeDimensionsIncludeLabels: true
     };

--- a/src/components/CytoscapeGraph/graphs/LayoutDictionary.ts
+++ b/src/components/CytoscapeGraph/graphs/LayoutDictionary.ts
@@ -6,7 +6,7 @@ import { Layout } from '../../../types/GraphFilter';
 const LayoutMap = {
   cola: ColaGraph.getLayout(),
   dagre: DagreGraph.getLayout(),
-  cose: CoseGraph.getLayout()
+  'cose-bilkent': CoseGraph.getLayout()
 };
 
 const getLayout = (layout: Layout) =>

--- a/src/components/ToolbarDropdown/__tests__/__snapshots__/ToolbarDropdown.test.tsx.snap
+++ b/src/components/ToolbarDropdown/__tests__/__snapshots__/ToolbarDropdown.test.tsx.snap
@@ -1670,7 +1670,7 @@ ShallowWrapper {
     options={
       Object {
         "cola": "Cola",
-        "cose": "Cose",
+        "cose-bilkent": "Cose",
         "dagre": "Dagre",
       }
     }
@@ -1717,7 +1717,7 @@ ShallowWrapper {
             bsClass="dropdown"
             disabled={false}
             divider={false}
-            eventKey="cose"
+            eventKey="cose-bilkent"
             header={false}
           >
             Cose
@@ -1773,7 +1773,7 @@ ShallowWrapper {
               bsClass="dropdown"
               disabled={false}
               divider={false}
-              eventKey="cose"
+              eventKey="cose-bilkent"
               header={false}
             >
               Cose
@@ -1814,7 +1814,7 @@ ShallowWrapper {
           },
           Object {
             "instance": null,
-            "key": "cose",
+            "key": "cose-bilkent",
             "nodeType": "class",
             "props": Object {
               "active": false,
@@ -1822,7 +1822,7 @@ ShallowWrapper {
               "children": "Cose",
               "disabled": false,
               "divider": false,
-              "eventKey": "cose",
+              "eventKey": "cose-bilkent",
               "header": false,
             },
             "ref": null,
@@ -1888,7 +1888,7 @@ ShallowWrapper {
               bsClass="dropdown"
               disabled={false}
               divider={false}
-              eventKey="cose"
+              eventKey="cose-bilkent"
               header={false}
             >
               Cose
@@ -1944,7 +1944,7 @@ ShallowWrapper {
                 bsClass="dropdown"
                 disabled={false}
                 divider={false}
-                eventKey="cose"
+                eventKey="cose-bilkent"
                 header={false}
               >
                 Cose
@@ -1985,7 +1985,7 @@ ShallowWrapper {
             },
             Object {
               "instance": null,
-              "key": "cose",
+              "key": "cose-bilkent",
               "nodeType": "class",
               "props": Object {
                 "active": false,
@@ -1993,7 +1993,7 @@ ShallowWrapper {
                 "children": "Cose",
                 "disabled": false,
                 "divider": false,
-                "eventKey": "cose",
+                "eventKey": "cose-bilkent",
                 "header": false,
               },
               "ref": null,
@@ -3703,7 +3703,7 @@ ShallowWrapper {
     options={
       Object {
         "cola": "Cola",
-        "cose": "Cose",
+        "cose-bilkent": "Cose",
         "dagre": "Dagre",
       }
     }
@@ -3751,7 +3751,7 @@ ShallowWrapper {
             bsClass="dropdown"
             disabled={false}
             divider={false}
-            eventKey="cose"
+            eventKey="cose-bilkent"
             header={false}
           >
             Cose
@@ -3807,7 +3807,7 @@ ShallowWrapper {
               bsClass="dropdown"
               disabled={false}
               divider={false}
-              eventKey="cose"
+              eventKey="cose-bilkent"
               header={false}
             >
               Cose
@@ -3848,7 +3848,7 @@ ShallowWrapper {
           },
           Object {
             "instance": null,
-            "key": "cose",
+            "key": "cose-bilkent",
             "nodeType": "class",
             "props": Object {
               "active": false,
@@ -3856,7 +3856,7 @@ ShallowWrapper {
               "children": "Cose",
               "disabled": false,
               "divider": false,
-              "eventKey": "cose",
+              "eventKey": "cose-bilkent",
               "header": false,
             },
             "ref": null,
@@ -3922,7 +3922,7 @@ ShallowWrapper {
               bsClass="dropdown"
               disabled={false}
               divider={false}
-              eventKey="cose"
+              eventKey="cose-bilkent"
               header={false}
             >
               Cose
@@ -3978,7 +3978,7 @@ ShallowWrapper {
                 bsClass="dropdown"
                 disabled={false}
                 divider={false}
-                eventKey="cose"
+                eventKey="cose-bilkent"
                 header={false}
               >
                 Cose
@@ -4019,7 +4019,7 @@ ShallowWrapper {
             },
             Object {
               "instance": null,
-              "key": "cose",
+              "key": "cose-bilkent",
               "nodeType": "class",
               "props": Object {
                 "active": false,
@@ -4027,7 +4027,7 @@ ShallowWrapper {
                 "children": "Cose",
                 "disabled": false,
                 "divider": false,
-                "eventKey": "cose",
+                "eventKey": "cose-bilkent",
                 "header": false,
               },
               "ref": null,

--- a/src/config.ts
+++ b/src/config.ts
@@ -39,7 +39,7 @@ export const config = () => {
       /** Graphs layouts types */
       graphLayouts: {
         cola: 'Cola',
-        cose: 'Cose',
+        'cose-bilkent': 'Cose',
         dagre: 'Dagre'
       }
     },


### PR DESCRIPTION
** Describe the change **

Change the layout for 'cose' to 'cose-bilkent'.

Whatever the 'cose' layout is, it doesn't seem to be working properly. We can't find a lot of information about it online, nothing of the configuration options listed here seem to have an affect on it: https://github.com/cytoscape/cytoscape.js/blob/master/documentation/demos/cose-layout/code.js


** Issue reference **

This fixes both

https://issues.jboss.org/browse/KIALI-1300
https://issues.jboss.org/browse/KIALI-1297

** Backwards in compatible? **

The url changes from displaying 'cose' to 'cose-bilkent'. Anyone with an old bookmark may have to update it.


** Screenshot **

![screenshot from 2018-08-10 10-46-45](https://user-images.githubusercontent.com/691166/43964384-c17f76be-9c8a-11e8-95ec-407e6f28ca67.png)
