### PR TITLE
KIALI-1322 make istio validation checks never null/undefined

### DIFF
--- a/src/components/ConfigValidation/ConfigIndicator.tsx
+++ b/src/components/ConfigValidation/ConfigIndicator.tsx
@@ -53,7 +53,7 @@ const tooltipListStyle = style({
 });
 
 export class ConfigIndicator extends React.PureComponent<Props, {}> {
-  numberOfChecks = (type: string) => (this.props.validation.checks || []).filter(i => i.severity === type).length;
+  numberOfChecks = (type: string) => this.props.validation.checks.filter(i => i.severity === type).length;
 
   getTypeMessage = (type: string) => {
     const numberType = this.numberOfChecks(type);
@@ -75,7 +75,7 @@ export class ConfigIndicator extends React.PureComponent<Props, {}> {
   }
 
   tooltipContent() {
-    const numChecks = this.props.validation.checks ? this.props.validation.checks.length : 0;
+    const numChecks = this.props.validation.checks.length;
 
     let issuesMessages: string[] = [];
     if (numChecks === 0) {

--- a/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -64,16 +64,14 @@ class ServiceInfo extends React.Component<ServiceDetails, ServiceInfoState> {
       virtualService =>
         this.props.validations['virtualservice'] &&
         this.props.validations['virtualservice'][virtualService.name] &&
-        this.props.validations['virtualservice'][virtualService.name].checks !== undefined &&
-        this.props.validations['virtualservice'][virtualService.name].checks!.length > 0
+        this.props.validations['virtualservice'][virtualService.name].checks.length > 0
     );
 
     validationChecks.hasDestinationRuleChecks = destinationRules.some(
       destinationRule =>
         this.props.validations['destinationrule'] &&
         this.props.validations['destinationrule'][destinationRule.name] &&
-        this.props.validations['destinationrule'][destinationRule.name].checks !== undefined &&
-        this.props.validations['destinationrule'][destinationRule.name].checks!.length > 0
+        this.props.validations['destinationrule'][destinationRule.name].checks.length > 0
     );
 
     return validationChecks;

--- a/src/types/AceValidations.ts
+++ b/src/types/AceValidations.ts
@@ -226,13 +226,11 @@ export const parseAceValidations = (yaml: string, validations?: Validations): Ac
 
   let objectValidations = getObjectValidations(validations);
   objectValidations.forEach(objectValidation => {
-    if (objectValidation.checks) {
-      objectValidation.checks.forEach(check => {
-        let aceCheck = parseCheck(yaml, check);
-        aceValidations.markers.push(aceCheck.marker);
-        aceValidations.annotations.push(aceCheck.annotation);
-      });
-    }
+    objectValidation.checks.forEach(check => {
+      let aceCheck = parseCheck(yaml, check);
+      aceValidations.markers.push(aceCheck.marker);
+      aceValidations.annotations.push(aceCheck.annotation);
+    });
   });
   return aceValidations;
 };

--- a/src/types/IstioConfigListComponent.ts
+++ b/src/types/IstioConfigListComponent.ts
@@ -201,11 +201,7 @@ export const filterByConfigValidation = (unfiltered: IstioConfigItem[], configFi
     if (filterByNotValidated && !item.validation) {
       filtered.push(item);
     }
-    if (
-      filterByWarning &&
-      item.validation &&
-      (item.validation.checks || []).filter(i => i.severity === 'warning').length > 0
-    ) {
+    if (filterByWarning && item.validation && item.validation.checks.filter(i => i.severity === 'warning').length > 0) {
       filtered.push(item);
     }
   });
@@ -288,9 +284,7 @@ export const sortIstioItems = (unsorted: IstioConfigItem[], sortField: SortField
           sortValue = 0;
         }
         if (!a.validation.valid && !b.validation.valid) {
-          let aIssues = a.validation.checks ? a.validation.checks.length : 0;
-          let bIssues = b.validation.checks ? b.validation.checks.length : 0;
-          sortValue = aIssues > bIssues ? -1 : aIssues < bIssues ? 1 : 0;
+          sortValue = b.validation.checks.length - a.validation.checks.length;
         }
       }
     }

--- a/src/types/ServiceInfo.ts
+++ b/src/types/ServiceInfo.ts
@@ -393,7 +393,7 @@ export interface ObjectValidation {
   name: string;
   objectType: string;
   valid: boolean;
-  checks?: ObjectCheck[];
+  checks: ObjectCheck[];
 }
 
 export interface ObjectCheck {
@@ -460,7 +460,7 @@ export const highestSeverity = (checks: ObjectCheck[]): string => {
 };
 
 const numberOfChecks = (type: string, object: ObjectValidation) =>
-  (object ? object.checks || [] : []).filter(i => i.severity === type).length;
+  (object ? object.checks : []).filter(i => i.severity === type).length;
 
 export const validationToSeverity = (object: ObjectValidation): string => {
   const warnChecks = numberOfChecks('warning', object);
@@ -480,7 +480,7 @@ export const validationToIconName = (object: ObjectValidation): string => {
 };
 
 export const checkForPath = (object: ObjectValidation, path: string): ObjectCheck[] => {
-  if (!object || !object.checks) {
+  if (!object) {
     return [];
   }
 


### PR DESCRIPTION
This PR comes with kiali/kiali#425
It's not absolutely mandatory (the server-side PR would be sufficient to fix the bug) but IMO it helps by clarifying what we do expect from the json, now enforcing non-null and non-undefined values.

JIRA: https://issues.jboss.org/browse/KIALI-1322