### PR TITLE
KIALI-1307 added namespace query string to Services link

### DIFF
--- a/src/pages/ServiceGraph/SummaryPanelGraph.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelGraph.tsx
@@ -74,7 +74,10 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
     const numEdges = cy.edges().size();
     const trafficRate = getAccumulatedTrafficRate(cy.edges());
     const servicesLink = (
-      <Link to="../services" onClick={this.updateServicesFilter}>
+      <Link
+        to={this.props.namespace === 'all' ? '../services' : `../services?namespace=${this.props.namespace}`}
+        onClick={this.updateServicesFilter}
+      >
         {this.props.namespace}
       </Link>
     );


### PR DESCRIPTION
** Describe the change **
Service Graph sidepanel has a link to Services page without passing along the selected namespace.  The fix simply appends `?namespace=<active namespace>` to the link.

** Issue reference **
KIALI-1307

** Backwards in compatible? **
No

** Screenshot **
![kiali-1307](https://user-images.githubusercontent.com/3805254/43972263-9f220d5e-9c88-11e8-92ed-f6baf28ff345.png)

![image](https://user-images.githubusercontent.com/3805254/43973982-fa63ba00-9c8d-11e8-909d-d6cbdc509ae4.png)
