### PR TITLE
KIALI-1325: Remove the sparkline graphs for service nodes

### DIFF
--- a/src/pages/ServiceGraph/SummaryPanelCommon.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelCommon.tsx
@@ -18,7 +18,8 @@ export interface NodeData {
 
 export enum NodeMetricType {
   APP = 1,
-  WORKLOAD = 2
+  WORKLOAD = 2,
+  SERVICE = 3
 }
 
 export const shouldRefreshData = (prevProps: SummaryPanelPropType, nextProps: SummaryPanelPropType) => {
@@ -109,6 +110,8 @@ export const getNodeMetricType = (node: any) => {
     return NodeMetricType.WORKLOAD;
   } else if (data.nodeType === NodeType.APP) {
     return NodeMetricType.APP;
+  } else if (data.nodeType === NodeType.SERVICE) {
+    return NodeMetricType.SERVICE;
   }
   return undefined;
 };

--- a/src/pages/ServiceGraph/SummaryPanelNode.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelNode.tsx
@@ -14,7 +14,8 @@ import {
   getNodeMetrics,
   getNodeMetricType,
   getServicesLinkList,
-  renderPanelTitle
+  renderPanelTitle,
+  NodeMetricType
 } from './SummaryPanelCommon';
 import { HealthIndicator, DisplayMode } from '../../components/Health/HealthIndicator';
 import Label from '../../components/Label/Label';
@@ -28,6 +29,7 @@ type SummaryPanelStateType = {
   errorCountOut: [string, number][];
   healthLoading: boolean;
   health?: Health;
+  rpsMetrics: boolean;
 };
 
 export default class SummaryPanelNode extends React.Component<SummaryPanelPropType, SummaryPanelStateType> {
@@ -50,7 +52,8 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
       requestCountOut: [],
       errorCountIn: [],
       errorCountOut: [],
-      healthLoading: false
+      healthLoading: false,
+      rpsMetrics: true
     };
   }
 
@@ -82,24 +85,31 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
     const filters = ['request_count', 'request_error_count'];
     const includeIstio = props.namespace === 'istio-system';
 
-    getNodeMetrics(nodeMetricType, target, props, filters, includeIstio)
-      .then(response => {
-        if (!this._isMounted) {
-          console.log('SummaryPanelNode: Ignore fetch, component not mounted.');
-          return;
-        }
-        this.showRequestCountMetrics(response.data);
-      })
-      .catch(error => {
-        if (!this._isMounted) {
-          console.log('SummaryPanelNode: Ignore fetch error, component not mounted.');
-          return;
-        }
-        this.setState({ loading: false });
-        console.error(error);
-      });
+    // For service nodes we need to handle metrics a bit differently
+    // The don't have the normal incoming and outgoing metrics, so we don't display them
+    if (nodeMetricType === NodeMetricType.SERVICE) {
+      this.setState({ loading: false });
+      this.setState({ rpsMetrics: false });
+    } else {
+      getNodeMetrics(nodeMetricType, target, props, filters, includeIstio)
+        .then(response => {
+          if (!this._isMounted) {
+            console.log('SummaryPanelNode: Ignore fetch, component not mounted.');
+            return;
+          }
+          this.showRequestCountMetrics(response.data);
+        })
+        .catch(error => {
+          if (!this._isMounted) {
+            console.log('SummaryPanelNode: Ignore fetch error, component not mounted.');
+            return;
+          }
+          this.setState({ loading: false });
+          console.error(error);
+        });
 
-    this.setState({ loading: true });
+      this.setState({ loading: true });
+    }
   }
 
   showRequestCountMetrics(all: Metrics) {
@@ -187,6 +197,8 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
   private renderRpsCharts = () => {
     if (this.state.loading) {
       return <strong>loading charts...</strong>;
+    } else if (!this.state.rpsMetrics) {
+      return;
     }
     return (
       <>


### PR DESCRIPTION
** Describe the change **

Removes the sparkline graphs for the service nodes. Service nodes don't have both incoming and outgoing metrics, so we can't display then in the same way as the other node types.

For now we should remove the sparkline graphs for service nodes. But eventually we will need to introduce in single sparkline graph for them.

** Issue reference **

https://issues.jboss.org/browse/KIALI-1325

** Backwards in compatible? **

Removes the sparkline graph for service nodes. Previously these would be stuck with 'loading graph'

** Screenshot **

![screenshot from 2018-08-10 19-08-30](https://user-images.githubusercontent.com/691166/43984794-e1f04de2-9cd0-11e8-9fee-f62ebb987871.png)
