### PR TITLE
KIALI-1335 Omit 'unknown' version from app node text

### DIFF
--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -72,7 +72,7 @@ export class GraphStyles {
             let content = '';
             switch (nodeType) {
               case NodeType.APP:
-                if (getCyGlobalData(ele).graphType === GraphType.APP || ele.data('isGroup')) {
+                if (getCyGlobalData(ele).graphType === GraphType.APP || ele.data('isGroup') || version === 'unknown') {
                   content = app;
                 } else {
                   content = app + `\n${version}`;


### PR DESCRIPTION
- this is just to make the node more visually pleasing. The unknown label
  value is still visible in the side panel.  This helps make istio ingress
  and some other infra-nodes look better and can better reflect an unset
  version label.
