### PR TITLE
KIALI-1339: Temporarily remove the spark charts

### DIFF
--- a/src/pages/ServiceGraph/SummaryPanelEdge.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelEdge.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import RateTable from '../../components/SummaryPanel/RateTable';
-import RpsChart from '../../components/SummaryPanel/RpsChart';
-import ResponseTimeChart from '../../components/SummaryPanel/ResponseTimeChart';
+// import RpsChart from '../../components/SummaryPanel/RpsChart';
+// import ResponseTimeChart from '../../components/SummaryPanel/ResponseTimeChart';
 import { SummaryPanelPropType } from '../../types/Graph';
 import * as M from '../../types/Metrics';
 import graphUtils from '../../utils/Graphing';
@@ -221,23 +221,25 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
   );
 
   private renderCharts = () => {
-    if (this.state.loading) {
-      return <strong>loading charts...</strong>;
-    }
-
-    return (
-      <>
-        <RpsChart label="Request Traffic" dataRps={this.state.reqRates} dataErrors={this.state.errRates} />
-        <hr />
-        <ResponseTimeChart
-          label="Request Response Time (ms)"
-          rtAvg={this.state.rtAvg}
-          rtMed={this.state.rtMed}
-          rt95={this.state.rt95}
-          rt99={this.state.rt99}
-        />
-      </>
-    );
+    // Temporarily remove charts: KIALI-1339
+    return;
+    //    if (this.state.loading) {
+    //      return <strong>loading charts...</strong>;
+    //    }
+    //
+    //    return (
+    //      <>
+    //        <RpsChart label="Request Traffic" dataRps={this.state.reqRates} dataErrors={this.state.errRates} />
+    //        <hr />
+    //        <ResponseTimeChart
+    //          label="Request Response Time (ms)"
+    //          rtAvg={this.state.rtAvg}
+    //          rtMed={this.state.rtMed}
+    //          rt95={this.state.rt95}
+    //          rt99={this.state.rt99}
+    //        />
+    //      </>
+    //    );
   };
 
   private getDatapoints = (

--- a/src/pages/ServiceGraph/SummaryPanelGroup.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelGroup.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import InOutRateTable from '../../components/SummaryPanel/InOutRateTable';
-import RpsChart from '../../components/SummaryPanel/RpsChart';
+// import RpsChart from '../../components/SummaryPanel/RpsChart';
 import { SummaryPanelPropType } from '../../types/Graph';
 import * as M from '../../types/Metrics';
 import graphUtils from '../../utils/Graphing';
@@ -117,7 +117,6 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
             outRate5xx={outgoing.rate5xx}
           />
           <hr />
-          <div>{this.renderRpsCharts()}</div>
         </div>
       </div>
     );
@@ -185,25 +184,27 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
     );
   };
 
-  private renderRpsCharts = () => {
-    if (this.state.loading) {
-      return <strong>loading charts...</strong>;
-    }
-    return (
-      <>
-        <RpsChart
-          label="Incoming Request Traffic"
-          dataRps={this.state.requestCountIn}
-          dataErrors={this.state.errorCountIn}
-        />
-        <RpsChart
-          label="Outgoing Request Traffic"
-          dataRps={this.state.requestCountOut}
-          dataErrors={this.state.errorCountOut}
-        />
-      </>
-    );
-  };
+  // Temporarily remove charts: KIALI-1339
+  //  private renderRpsCharts = () => {
+  //    return;
+  //    if (this.state.loading) {
+  //      return <strong>loading charts...</strong>;
+  //    }
+  //    return (
+  //      <>
+  //        <RpsChart
+  //          label="Incoming Request Traffic"
+  //          dataRps={this.state.requestCountIn}
+  //          dataErrors={this.state.errorCountIn}
+  //        />
+  //        <RpsChart
+  //          label="Outgoing Request Traffic"
+  //          dataRps={this.state.requestCountOut}
+  //          dataErrors={this.state.errorCountOut}
+  //        />
+  //      </>
+  //    );
+  //  };
 
   private renderWorkloadList = (group): any[] => {
     let workloadList: any[] = [];

--- a/src/pages/ServiceGraph/SummaryPanelNode.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelNode.tsx
@@ -11,11 +11,11 @@ import {
   shouldRefreshData,
   updateHealth,
   nodeData,
-  getNodeMetrics,
+  //  getNodeMetrics,
   getNodeMetricType,
   getServicesLinkList,
-  renderPanelTitle,
-  NodeMetricType
+  renderPanelTitle
+  //  NodeMetricType
 } from './SummaryPanelCommon';
 import { HealthIndicator, DisplayMode } from '../../components/Health/HealthIndicator';
 import Label from '../../components/Label/Label';
@@ -53,7 +53,7 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
       errorCountIn: [],
       errorCountOut: [],
       healthLoading: false,
-      rpsMetrics: true
+      rpsMetrics: false
     };
   }
 
@@ -82,34 +82,37 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
       return;
     }
 
-    const filters = ['request_count', 'request_error_count'];
-    const includeIstio = props.namespace === 'istio-system';
+    // const filters = ['request_count', 'request_error_count'];
+    // const includeIstio = props.namespace === 'istio-system';
 
+    // KIALI-1339 - Temporarily Remove the sparkgraphs
+    this.setState({ loading: false });
+    this.setState({ rpsMetrics: false });
     // For service nodes we need to handle metrics a bit differently
     // The don't have the normal incoming and outgoing metrics, so we don't display them
-    if (nodeMetricType === NodeMetricType.SERVICE) {
-      this.setState({ loading: false });
-      this.setState({ rpsMetrics: false });
-    } else {
-      getNodeMetrics(nodeMetricType, target, props, filters, includeIstio)
-        .then(response => {
-          if (!this._isMounted) {
-            console.log('SummaryPanelNode: Ignore fetch, component not mounted.');
-            return;
-          }
-          this.showRequestCountMetrics(response.data);
-        })
-        .catch(error => {
-          if (!this._isMounted) {
-            console.log('SummaryPanelNode: Ignore fetch error, component not mounted.');
-            return;
-          }
-          this.setState({ loading: false });
-          console.error(error);
-        });
-
-      this.setState({ loading: true });
-    }
+    // if (nodeMetricType === NodeMetricType.SERVICE) {
+    //  this.setState({ loading: false });
+    //  this.setState({ rpsMetrics: false });
+    // } else {
+    //  getNodeMetrics(nodeMetricType, target, props, filters, includeIstio)
+    //    .then(response => {
+    //      if (!this._isMounted) {
+    //        console.log('SummaryPanelNode: Ignore fetch, component not mounted.');
+    //        return;
+    //      }
+    //      this.showRequestCountMetrics(response.data);
+    //    })
+    //    .catch(error => {
+    //      if (!this._isMounted) {
+    //        console.log('SummaryPanelNode: Ignore fetch error, component not mounted.');
+    //        return;
+    //      }
+    //      this.setState({ loading: false });
+    //      console.error(error);
+    //    });
+    //
+    //  this.setState({ loading: true });
+    // }
   }
 
   showRequestCountMetrics(all: Metrics) {


### PR DESCRIPTION
Removes the sparkline charts from the graph page.

Temporary until we can figure out and fix all the sparkline graph issues.
