### PR TITLE
KIALI-1342 Fixing wrong fiter apply

### DIFF
--- a/src/components/NamespaceFilter/NamespaceFilter.tsx
+++ b/src/components/NamespaceFilter/NamespaceFilter.tsx
@@ -36,7 +36,7 @@ export class NamespaceFilter extends React.Component<NamespaceFilterProps, Names
 
     let initialFilters = this.initialFilterList(defaultNamespaceFilter);
 
-    if (!!this.props.initialActiveFilters) {
+    if (!!this.props.initialActiveFilters && this.props.initialActiveFilters.length > 0) {
       NamespaceFilterSelected.setSelected(this.props.initialActiveFilters);
     }
 


### PR DESCRIPTION
WARNING: this fix has to be in pre-release. It is tagged as critical/blocker bug.

** Describe the change **
Fixing the following bug:

1. Go to Services page.
2. Filter by "namespace: bookinfo".
3. You will see that it filters and shows the "bookinfo" namespace, then loads all services.
4. Go to Istio Config page. (keeping filter)
5. You will see that it loads all configs from all namespaces, even though 'bookinfo' is in filters.

** Reference **
https://issues.jboss.org/browse/KIALI-1342

** Backwards in compatible? **
yes.

** Screenshot **
![screen recording 5](https://user-images.githubusercontent.com/613814/44083319-f3d893b2-9fb3-11e8-824b-57f12ab23e59.gif)
