### PR TITLE
KIALI-1194 Node and Edge styling per UX

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -42,11 +42,6 @@ export const config = () => {
         'cose-bilkent': 'Cose',
         dagre: 'Dagre'
       }
-    },
-    /** Threshold limits */
-    threshold: {
-      percentErrorSevere: 2.0,
-      percentErrorWarn: 0.1
     }
   });
 };

--- a/src/types/Health.ts
+++ b/src/types/Health.ts
@@ -75,7 +75,7 @@ interface Thresholds {
   unit: string;
 }
 
-const REQUESTS_THRESHOLDS: Thresholds = {
+export const REQUESTS_THRESHOLDS: Thresholds = {
   degraded: 0.1,
   failure: 20,
   unit: '%'


### PR DESCRIPTION
- solve issues with selection hiding health
- use the same thresholds for health and graph

Here is a link to [kiali-1194]https://issues.jboss.org/browse/KIALI-1194) so that you can see the UX color chart.

This PR also solves [kiali-1280](https://issues.jboss.org/browse/KIALI-1280), which is the same issue but for edges.  Also, see this [UX design PR](https://github.com/kiali/kiali-design/pull/29) for more on the edges.
