### PR TITLE
KIALI-1131 Use RCUE for productized Patternfly UI

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -93,6 +93,21 @@ yarn build-css
 Note:
 Only static assets which are `import` 'ed into your application will be included in your resulting build output.
 
+=== RCUE Styling
+To use the https://redhat-rcue.github.io/[RCUE] styled css instead of normal Patternfly
+
+For development run:
+[source,shell]
+----
+env REACT_APP_RCUE=true yarn start
+----
+
+For production build run:
+[source,shell]
+----
+env REACT_APP_RCUE=true yarn build
+----
+
 === Style Code Guide
 
 See the link:./STYLE_GUIDE.adoc[STYLE CODE GUIDE file].

--- a/src/app/App.scss
+++ b/src/app/App.scss
@@ -21,6 +21,12 @@ $icon-font-path: "~bootstrap-sass/assets/fonts/bootstrap/";
   }
 }
 
+// Override RCUE style: https://redhat-rcue.github.io/
+// otherwise we get a 35px height for title which is distorted
+.navbar-pf-vertical .navbar-brand .navbar-brand-name {
+  height: 12px !important;
+}
+
 .navbar-pf-vertical .nav .nav-item-iconic .badge-danger {
   background-color: #cc0000; // Red100
 }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -10,6 +10,20 @@ import history from './History';
 import { PersistGate } from 'redux-persist/lib/integration/react';
 import * as Visibility from 'visibilityjs';
 
+/**
+ * Use the Patternfly RCUE productized css styles if set by the environment
+ * @example 'env REACT_APP_RCUE=true yarn start'
+ */
+const loadRcueCssIfNeeded = async (): Promise<void> => {
+  // get the flag from command line if set: env REACT_APP_RCUE=true yarn start
+  const useRcue = process.env.REACT_APP_RCUE;
+  if (useRcue === 'true') {
+    console.debug('REACT_APP_RCUE set to true');
+    Promise.all([require('patternfly/dist/css/rcue.css'), require('patternfly/dist/css/rcue-additions.css')]);
+    console.debug('Loaded RCUE css libraries loaded');
+  }
+};
+
 Visibility.change((e, state) => {
   // There are 3 states, visible, hidden and prerender, consider prerender as hidden.
   // https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilityState
@@ -68,6 +82,7 @@ const Loading = () => {
 
 class App extends React.Component {
   render() {
+    loadRcueCssIfNeeded();
     const Sidebar = withRouter(Navigation);
     return (
       <Provider store={store}>


### PR DESCRIPTION
** Describe the change **
Enable selectively building with Patternfly or RCUE(RH productization) based on CLI settings.
This PR dynamically loads the RCUE css stylesheets if specified on the CLI.

By adding a React parameter to the build, we can build using different css libraries (RCUE vs Patternfly).

So to build for RCUE just pass the additional parameter to the build:
```
env REACT_APP_RCUE=true yarn build
```
Or for development:
```
env REACT_APP_RCUE=true yarn start
```

** Issue reference **

https://issues.jboss.org/browse/KIALI-1131

** Backwards compatible? **
Yes

** Screenshot **
Before (Patternfly):
![pf-login](https://user-images.githubusercontent.com/1312165/44179185-7275b000-a0aa-11e8-9f1f-c47d79c5cacb.png)

After(RCUE):
![rcue-login](https://user-images.githubusercontent.com/1312165/44179037-db105d00-a0a9-11e8-84ce-ddb59e55d813.png)

QE Instructions:
Visually, the above can be seen to tell the difference between Patternfly and RCUE.
However, if you open the JS console you will find a *debug* level message telling you that the RCUE css has loaded:
![rcue-message](https://user-images.githubusercontent.com/1312165/44179147-46f2c580-a0aa-11e8-99da-149d103d14f9.png)
