### PR TITLE
Trivial: Remove eject script from package.json. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "kiali": "node  ./src/__itests__/Kiali.app.standalone.ts",
     "test": "npm run prettier && react-scripts-ts test --env=jsdom __tests__",
     "itest": "export CI=true && react-scripts-ts test  __itests__",
-    "eject": "react-scripts-ts eject",
     "set-snapshot-version": "npm-snapshot",
     "precommit": "npm run prettier -- --list-different || (echo 'Above file(s) were modified by prettier, check them before commiting' && false)"
   },


### PR DESCRIPTION
This just removes the convenience command from package.json that 'create-react-app' creates.
We don't ever want to encourage this because then we will have to deal directly with all the webpack stuff and manage it ourselves.

