### PR TITLE
KIALI-1367 Breadcrumb throw an error in console

### DIFF
--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -217,7 +217,7 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
       );
     } else if (parsedRuleParams.type && parsedRuleParams.name) {
       titleBreadcrumb.push(
-        <Breadcrumb.Item key={'breadcrumb_' + this.props.match.params.object}>
+        <Breadcrumb.Item key={'breadcrumb_' + this.props.match.params.object} componentClass={'span'}>
           <Link to={this.props.location.pathname}>Istio Object: {this.props.match.params.object}</Link>
         </Breadcrumb.Item>
       );
@@ -229,17 +229,17 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
     }
     return (
       <Breadcrumb title={true}>
-        <Breadcrumb.Item>
+        <Breadcrumb.Item componentClass={'span'}>
           <Link to="/istio" onClick={this.cleanFilter}>
             Istio Config
           </Link>
         </Breadcrumb.Item>
-        <Breadcrumb.Item>
+        <Breadcrumb.Item componentClass={'span'}>
           <Link to="/istio" onClick={this.updateNamespaceFilter}>
             Namespace: {this.props.match.params.namespace}
           </Link>
         </Breadcrumb.Item>
-        <Breadcrumb.Item>
+        <Breadcrumb.Item componentClass={'span'}>
           <Link to="/istio" onClick={this.updateTypeFilter}>
             Istio Object Type: {dicIstioType[this.props.match.params.objectType]}
           </Link>

--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -166,15 +166,15 @@ class ServiceDetails extends React.Component<RouteComponentProps<ServiceId>, Ser
     const toDetails = to + '?' + parsedSearch.type + '=' + parsedSearch.name;
     return (
       <Breadcrumb title={true}>
-        <Breadcrumb.Item>
+        <Breadcrumb.Item componentClass={'span'}>
           <Link to="/services">Services</Link>
         </Breadcrumb.Item>
-        <Breadcrumb.Item>
+        <Breadcrumb.Item componentClass={'span'}>
           <Link to={`/services?namespace=${encodeURIComponent(this.props.match.params.namespace)}`}>
             Namespace: {this.props.match.params.namespace}
           </Link>
         </Breadcrumb.Item>
-        <Breadcrumb.Item>
+        <Breadcrumb.Item componentClass={'span'}>
           <Link to={to}>Service: {this.props.match.params.service}</Link>
         </Breadcrumb.Item>
         {!showingDetails ? (
@@ -183,10 +183,10 @@ class ServiceDetails extends React.Component<RouteComponentProps<ServiceId>, Ser
           </Breadcrumb.Item>
         ) : (
           <>
-            <Breadcrumb.Item>
+            <Breadcrumb.Item componentClass={'span'}>
               <Link to={to}>Service Info</Link>
             </Breadcrumb.Item>
-            <Breadcrumb.Item>
+            <Breadcrumb.Item componentClass={'span'}>
               <Link to={toDetails}>
                 {parsedSearchTypeHuman}: {parsedSearch.name}
               </Link>


### PR DESCRIPTION
** Describe the change **

Add ` componentClass={'span'}` in `breadcrumb.Item` to avoid the insertion of element `<a>` inside another element `<a>`
To Fix the warning
```java

Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>.
--
in a (created by Link)
in Link (created by ServiceDetails)
in a (created by SafeAnchor)
in SafeAnchor (created by BreadcrumbItem)
in li (created by BreadcrumbItem)
in BreadcrumbItem (created by ServiceDetails)
in ol (created by Breadcrumb)
in Breadcrumb (created by Breadcrumb)
in Breadcrumb (created by ServiceDetails)
in ServiceDetails (created by Route)
in Route (created by RenderPage)
in Switch (created by SwitchErrorBoundary)
in SwitchErrorBoundary (created by RenderPage)
in div (created by PfContainerNavVertical)
in PfContainerNavVertical (created by RenderPage)
in RenderPage (created by Navigation)
in Navigation (created by Connect(Navigation))
in Connect(Navigation) (created by Route)
in Route (created by withRouter(Connect(Navigation)))
in withRouter(Connect(Navigation)) (created by App)
in Router (created by App)
in PersistGate (created by App)
in Provider (created by App)
in App
```
** Issue reference **
[KIALI-1367](https://issues.jboss.org/browse/KIALI-1367)

** Backwards in compatible? **

Yes

** Screenshot **
### Before
![Uploading Screenshot from 2018-08-17 10-18-37.png…]()
![screenshot from 2018-08-17 10-18-23](https://user-images.githubusercontent.com/3019213/44256245-e332de80-a208-11e8-9d6d-f502d7b054fe.png)

### After
![fix_istio_object](https://user-images.githubusercontent.com/3019213/44256229-d9a97680-a208-11e8-8931-7148173adc11.png)
![services_fix](https://user-images.githubusercontent.com/3019213/44256230-d9a97680-a208-11e8-9ff6-89cc63ba9fbd.png)


Add a screenshot of the UI after your changes.
