### PR TITLE
KIALI-1299: Remove extra spacing around breadcrumb (global)

### DIFF
--- a/src/app/App.scss
+++ b/src/app/App.scss
@@ -37,6 +37,11 @@ a:focus {
   vertical-align: middle;
 }
 
+// Take out extra margin and padding for breadcrumb
+.breadcrumb {
+  margin-bottom: -5px;
+}
+
 // SplitButton looks separated inside a toolbar, fix that
 .toolbar-pf .form-group .btn+.btn {
   margin-left: 0;


### PR DESCRIPTION
** Describe the change **

Remove extra spacing around breadcrumb (global for all pages). See images and design issue below for exact details. This is a simple SCSS fix.

** Issue reference **

Jira: https://issues.jboss.org/browse/KIALI-1299
Design Issue: https://github.com/kiali/kiali-design/issues/26

** Screenshot **

Before: 
![services-space](https://user-images.githubusercontent.com/1312165/44290856-957d9c80-a22f-11e8-9c7b-3d9892d19907.png)

After:
![services-spacing](https://user-images.githubusercontent.com/1312165/44290825-68c98500-a22f-11e8-8e84-22f58ebd00b9.png)

Before:
![graph-extra-spacing](https://user-images.githubusercontent.com/1312165/44290956-3ec49280-a230-11e8-8f33-2d8ed9e1b0a9.png)

After:
![graph-spacing-after](https://user-images.githubusercontent.com/1312165/44290927-0624b900-a230-11e8-85a7-26151d7817a9.png)
