### PR TITLE
KIALI-1366 Add handling for edges showing TCP traffic

### DIFF
--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -216,6 +216,13 @@ export class GraphStyles {
               case EdgeLabelMode.MTLS_ENABLED: {
                 return ele.data('isMTLS') ? '\ue923' : '';
               }
+              case EdgeLabelMode.TCP_SENT: {
+                const tcpRate = ele.data('tcpSentRate') ? parseFloat(ele.data('tcpSentRate')) : 0;
+                if (tcpRate > 0) {
+                  return `${tcpRate.toFixed(2)}`;
+                }
+                return '';
+              }
               default:
                 return '';
             }
@@ -234,7 +241,7 @@ export class GraphStyles {
           'line-style': (ele: any) => {
             return ele.data('isUnused') ? 'dotted' : 'solid';
           },
-          'target-arrow-shape': 'vee',
+          'target-arrow-shape': 'triangle',
           'target-arrow-color': (ele: any) => {
             return getEdgeColor(ele);
           },
@@ -246,6 +253,14 @@ export class GraphStyles {
         selector: 'edge:selected',
         css: {
           width: EdgeWidthSelected
+        }
+      },
+      {
+        selector: 'edge[tcpSentRate]',
+        css: {
+          'target-arrow-shape': 'triangle-cross',
+          'line-color': PfColors.Blue600,
+          'target-arrow-color': PfColors.Blue600
         }
       },
       // When you mouse over a node, all nodes other than the moused over node

--- a/src/types/GraphFilter.ts
+++ b/src/types/GraphFilter.ts
@@ -13,6 +13,7 @@ export enum EdgeLabelMode {
   REQUESTS_PER_SECOND = 'requestsPerSecond',
   REQUESTS_PERCENT_OF_TOTAL = 'requestsPercentOfTotal',
   RESPONSE_TIME_95TH_PERCENTILE = 'responseTime95thPercentile',
+  TCP_SENT = 'tcpSentBytes',
   MTLS_ENABLED = 'security'
 }
 


### PR DESCRIPTION
A new option is added to the "Graph Settings" dropdown to be able to
show TCP traffic in the edges.

Edges with TCP traffic have a cue to be differentiated from those with
HTTP traffic. Coloring for TCP edges is PfBlue-600.

**Backwards in compatible?** It's compatible

![image](https://user-images.githubusercontent.com/23639005/44369948-c9f69000-a49d-11e8-8bce-6a0813892b71.png)


