### PR TITLE
KIALI-1305 end the graph update batch before creating the badges

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -348,6 +348,8 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
     // Create and destroy labels
     this.turnNodeLabelsTo(cy, this.props.showNodeLabels);
 
+    cy.endBatch();
+
     // Create badges
     cy.nodes().forEach(ele => {
       if (this.props.showCircuitBreakers && ele.data('hasCB')) {
@@ -364,8 +366,6 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
         msBadge.buildBadge(ele);
       }
     });
-
-    cy.endBatch();
 
     // We need to fit outside of the batch operation for it to take effect on the new nodes
     if (updateLayout) {


### PR DESCRIPTION
** Describe the change **

Allows the graph to pick the styles before creating the badges.
Before we had zIndex with 0 on the first draw, and the next draws it picked the zIndex of 10 (the one that is defined in the [GraphStyles](https://github.com/josejulio/swsui/blob/1e52bceba5a5b8320607b85157156e6055213f41/src/components/CytoscapeGraph/graphs/GraphStyles.ts#L146))

** Screenshot **

Before:
![kiali-1305-before](https://user-images.githubusercontent.com/3845764/44380581-c5e46580-a4d1-11e8-941d-dcf06fa65683.gif)

After:
![kiali-1305-after](https://user-images.githubusercontent.com/3845764/44380584-cb41b000-a4d1-11e8-89e4-5428aca8929c.gif)

