### PR TITLE
KIALI-1323 Filtering homogenization

### DIFF
--- a/src/components/NamespaceFilter/NamespaceFilter.tsx
+++ b/src/components/NamespaceFilter/NamespaceFilter.tsx
@@ -141,7 +141,11 @@ export class NamespaceFilter extends React.Component<NamespaceFilterProps, Names
   filterValueSelected = (filterValue: FilterValue) => {
     const { currentFilterType, currentValue } = this.state;
 
-    if (filterValue && filterValue.id !== currentValue) {
+    if (
+      filterValue &&
+      filterValue.id !== currentValue &&
+      !this.duplicatesFilter(currentFilterType, filterValue.title)
+    ) {
       this.filterAdded(currentFilterType, filterValue);
     }
   };
@@ -153,12 +157,23 @@ export class NamespaceFilter extends React.Component<NamespaceFilterProps, Names
   onValueKeyPress = (keyEvent: any) => {
     const { currentValue, currentFilterType } = this.state;
 
-    if (keyEvent.key === 'Enter' && currentValue && currentValue.length > 0) {
+    if (keyEvent.key === 'Enter') {
+      if (currentValue && currentValue.length > 0 && !this.duplicatesFilter(currentFilterType, currentValue)) {
+        this.filterAdded(currentFilterType, currentValue);
+      }
+
       this.setState({ currentValue: '' });
-      this.filterAdded(currentFilterType, currentValue);
       keyEvent.stopPropagation();
       keyEvent.preventDefault();
     }
+  };
+
+  duplicatesFilter = (filterType: FilterType, filterValue: string): boolean => {
+    const filter = this.state.activeFilters.find(activeFilter => {
+      return filterValue === activeFilter.value && filterType.title === activeFilter.category;
+    });
+
+    return !!filter;
   };
 
   removeFilter = (filter: ActiveFilter) => {

--- a/src/components/NamespaceFilter/NamespaceFilter.tsx
+++ b/src/components/NamespaceFilter/NamespaceFilter.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import { Filter, FormControl, Toolbar } from 'patternfly-react';
 import {
   ActiveFilter,
+  FILTER_ACTION_APPEND,
+  FILTER_ACTION_UPDATE,
   FilterType,
   FilterValue,
   NamespaceFilterProps,
@@ -27,6 +29,7 @@ export const defaultNamespaceFilter = {
   title: 'Namespace',
   placeholder: 'Filter by Namespace',
   filterType: 'select',
+  action: FILTER_ACTION_APPEND,
   filterValues: []
 };
 
@@ -88,6 +91,7 @@ export class NamespaceFilter extends React.Component<NamespaceFilterProps, Names
           title: 'Namespace',
           placeholder: 'Filter by Namespace',
           filterType: 'select',
+          action: FILTER_ACTION_APPEND,
           filterValues: response.data.map(namespace => {
             return { title: namespace.name, id: namespace.name };
           })
@@ -102,7 +106,7 @@ export class NamespaceFilter extends React.Component<NamespaceFilterProps, Names
       });
   }
 
-  filterAdded = (field: any, value: any) => {
+  filterAdded = (field: FilterType, value: string) => {
     let filterText = '';
     const activeFilters = this.state.activeFilters;
     let activeFilter: ActiveFilter = { label: '', category: '', value: '' };
@@ -111,18 +115,23 @@ export class NamespaceFilter extends React.Component<NamespaceFilterProps, Names
       filterText = field.title;
       activeFilter.category = field.title;
     }
-    filterText += ': ';
 
-    if (value.title) {
-      filterText += value.title;
-      activeFilter.value = value.title;
+    filterText += ': ' + value;
+    activeFilter.value = value;
+    activeFilter.label = filterText;
+
+    const typeFilterPresent = activeFilters.filter(filter => filter.category === field.title).length > 0;
+
+    if (field.action === FILTER_ACTION_UPDATE && typeFilterPresent) {
+      activeFilters.forEach(filter => {
+        if (filter.category === field.title) {
+          filter.value = value;
+        }
+      });
     } else {
-      filterText += value;
-      activeFilter.value = value;
+      activeFilters.push(activeFilter);
     }
 
-    activeFilter.label = filterText;
-    activeFilters.push(activeFilter);
     this.setState({ activeFilters: activeFilters });
     NamespaceFilterSelected.setSelected(activeFilters);
     this.props.onFilterChange(activeFilters);
@@ -146,7 +155,7 @@ export class NamespaceFilter extends React.Component<NamespaceFilterProps, Names
       filterValue.id !== currentValue &&
       !this.duplicatesFilter(currentFilterType, filterValue.title)
     ) {
-      this.filterAdded(currentFilterType, filterValue);
+      this.filterAdded(currentFilterType, filterValue.title);
     }
   };
 

--- a/src/pages/AppList/AppListComponent.tsx
+++ b/src/pages/AppList/AppListComponent.tsx
@@ -89,7 +89,7 @@ class AppListComponent extends React.Component<AppListComponentProps, AppListCom
         if (typeof availableFilter === 'undefined') {
           NamespaceFilterSelected.setSelected(
             NamespaceFilterSelected.getSelected().filter(nfs => {
-              return nfs.category === activeFilter.category;
+              return nfs.category !== activeFilter.category;
             })
           );
           return null;

--- a/src/pages/AppList/FiltersAndSorts.ts
+++ b/src/pages/AppList/FiltersAndSorts.ts
@@ -1,4 +1,10 @@
-import { ActiveFilter, FilterType, FilterValue } from '../../types/NamespaceFilter';
+import {
+  ActiveFilter,
+  FILTER_ACTION_APPEND,
+  FILTER_ACTION_UPDATE,
+  FilterType,
+  FilterValue
+} from '../../types/NamespaceFilter';
 import { AppListItem } from '../../types/AppList';
 import { removeDuplicatesArray } from '../../utils/Common';
 
@@ -65,6 +71,7 @@ export namespace AppListFilters {
     title: 'App Name',
     placeholder: 'Filter by App Name',
     filterType: 'text',
+    action: FILTER_ACTION_APPEND,
     filterValues: []
   };
 
@@ -73,6 +80,7 @@ export namespace AppListFilters {
     title: 'Istio Sidecar',
     placeholder: 'Filter by IstioSidecar Validation',
     filterType: 'select',
+    action: FILTER_ACTION_UPDATE,
     filterValues: presenceValues
   };
 

--- a/src/pages/IstioConfigList/IstioConfigListComponent.tsx
+++ b/src/pages/IstioConfigList/IstioConfigListComponent.tsx
@@ -7,7 +7,7 @@ import {
   NamespaceFilterSelected
 } from '../../components/NamespaceFilter/NamespaceFilter';
 import { Paginator } from 'patternfly-react';
-import { ActiveFilter, FilterType } from '../../types/NamespaceFilter';
+import { ActiveFilter, FILTER_ACTION_APPEND, FILTER_ACTION_UPDATE, FilterType } from '../../types/NamespaceFilter';
 import * as API from '../../services/Api';
 import Namespace from '../../types/Namespace';
 import { Pagination } from '../../types/Pagination';
@@ -61,6 +61,7 @@ const istioNameFilter: FilterType = {
   title: 'Istio Name',
   placeholder: 'Filter by Istio Name',
   filterType: 'text',
+  action: FILTER_ACTION_UPDATE,
   filterValues: []
 };
 
@@ -69,6 +70,7 @@ const istioTypeFilter: FilterType = {
   title: 'Istio Type',
   placeholder: 'Filter by Istio Type',
   filterType: 'select',
+  action: FILTER_ACTION_APPEND,
   filterValues: [
     {
       id: 'Gateway',
@@ -106,6 +108,7 @@ const configValidationFilter: FilterType = {
   title: 'Config',
   placeholder: 'Filter by Config Validation',
   filterType: 'select',
+  action: FILTER_ACTION_APPEND,
   filterValues: [
     {
       id: 'valid',

--- a/src/pages/IstioConfigList/IstioConfigListComponent.tsx
+++ b/src/pages/IstioConfigList/IstioConfigListComponent.tsx
@@ -236,7 +236,7 @@ class IstioConfigListComponent extends React.Component<IstioConfigListComponentP
         if (typeof availableFilter === 'undefined') {
           NamespaceFilterSelected.setSelected(
             NamespaceFilterSelected.getSelected().filter(nfs => {
-              return nfs.category === activeFilter.category;
+              return nfs.category !== activeFilter.category;
             })
           );
           return null;

--- a/src/pages/ServiceList/ServiceListComponent.tsx
+++ b/src/pages/ServiceList/ServiceListComponent.tsx
@@ -119,7 +119,7 @@ const istioFilter: FilterType = {
   title: 'Istio Sidecar',
   placeholder: 'Filter by Istio Sidecar',
   filterType: 'select',
-  filterValues: [{ id: 'deployed', title: 'Deployed' }, { id: 'not_deployed', title: 'Not Deployed' }]
+  filterValues: [{ id: 'present', title: 'Present' }, { id: 'not_present', title: 'Not Present' }]
 };
 
 export const availableFilters: FilterType[] = [serviceNameFilter, istioFilter, defaultNamespaceFilter];
@@ -438,10 +438,10 @@ class ServiceListComponent extends React.Component<ServiceListComponentProps, Se
 
     let istioFiltered = true;
     if (istioFilters.length === 1) {
-      if (istioFilters[0] === 'Deployed') {
+      if (istioFilters[0] === 'Present') {
         istioFiltered = service.istioSidecar;
       }
-      if (istioFilters[0] === 'Not Deployed') {
+      if (istioFilters[0] === 'Not Present') {
         istioFiltered = !service.istioSidecar;
       }
     }

--- a/src/pages/ServiceList/ServiceListComponent.tsx
+++ b/src/pages/ServiceList/ServiceListComponent.tsx
@@ -22,7 +22,7 @@ import { PfColors } from '../../components/Pf/PfColors';
 import * as API from '../../services/Api';
 import { getRequestErrorsRatio, ServiceHealth } from '../../types/Health';
 import Namespace from '../../types/Namespace';
-import { ActiveFilter, FilterType } from '../../types/NamespaceFilter';
+import { ActiveFilter, FILTER_ACTION_UPDATE, FilterType } from '../../types/NamespaceFilter';
 import { Pagination } from '../../types/Pagination';
 import { overviewToItem, ServiceItem, ServiceOverview, SortField } from '../../types/ServiceListComponent';
 import { IstioLogo } from '../../config';
@@ -111,6 +111,7 @@ const serviceNameFilter: FilterType = {
   title: 'Service Name',
   placeholder: 'Filter by Service Name',
   filterType: 'text',
+  action: 'append',
   filterValues: []
 };
 
@@ -119,6 +120,7 @@ const istioFilter: FilterType = {
   title: 'Istio Sidecar',
   placeholder: 'Filter by Istio Sidecar',
   filterType: 'select',
+  action: 'update',
   filterValues: [{ id: 'present', title: 'Present' }, { id: 'not_present', title: 'Not Present' }]
 };
 
@@ -272,15 +274,37 @@ class ServiceListComponent extends React.Component<ServiceListComponentProps, Se
         }) || availableFilters[2]
       ).id;
 
-      params.push({
-        name: filterId,
-        value: activeFilter.value
-      });
+      const updateableFilterIds = availableFilters
+        .filter(filter => filter.action === FILTER_ACTION_UPDATE)
+        .map(filter => filter.id);
+
+      if (updateableFilterIds.includes(filterId)) {
+        params = this.updateParams(params, filterId, activeFilter.value);
+      } else {
+        params.push({
+          name: filterId,
+          value: activeFilter.value
+        });
+      }
     });
 
     this.props.onParamChange(params, 'append');
     this.updateServices();
   };
+
+  updateParams(params: URLParameter[], id: string, value: string) {
+    let newParams = params;
+    const index = newParams.findIndex(param => param.name === id && param.value.length > 0);
+    if (index >= 0) {
+      newParams[index].value = value;
+    } else {
+      newParams.push({
+        name: id,
+        value: value
+      });
+    }
+    return newParams;
+  }
 
   handleError = (error: string) => {
     this.props.onError(error);

--- a/src/pages/ServiceList/ServiceListComponent.tsx
+++ b/src/pages/ServiceList/ServiceListComponent.tsx
@@ -229,7 +229,7 @@ class ServiceListComponent extends React.Component<ServiceListComponentProps, Se
         if (typeof availableFilter === 'undefined') {
           NamespaceFilterSelected.setSelected(
             NamespaceFilterSelected.getSelected().filter(nfs => {
-              return nfs.category === activeFilter.category;
+              return nfs.category !== activeFilter.category;
             })
           );
           return null;

--- a/src/pages/WorkloadList/FiltersAndSorts.ts
+++ b/src/pages/WorkloadList/FiltersAndSorts.ts
@@ -1,4 +1,10 @@
-import { ActiveFilter, FilterType, FilterValue } from '../../types/NamespaceFilter';
+import {
+  ActiveFilter,
+  FILTER_ACTION_APPEND,
+  FILTER_ACTION_UPDATE,
+  FilterType,
+  FilterValue
+} from '../../types/NamespaceFilter';
 import { WorkloadListItem, WorkloadType } from '../../types/Workload';
 import { removeDuplicatesArray } from '../../utils/Common';
 
@@ -102,14 +108,16 @@ export namespace WorkloadListFilters {
     title: 'Workload Name',
     placeholder: 'Filter by Workload Name',
     filterType: 'text',
+    action: FILTER_ACTION_APPEND,
     filterValues: []
   };
 
   export const istioSidecarFilter: FilterType = {
-    id: 'istiosidecar',
+    id: 'istio',
     title: 'Istio Sidecar',
     placeholder: 'Filter by IstioSidecar Validation',
     filterType: 'select',
+    action: FILTER_ACTION_UPDATE,
     filterValues: presenceValues
   };
 
@@ -118,6 +126,7 @@ export namespace WorkloadListFilters {
     title: 'App Label',
     placeholder: 'Filter by App Label Validation',
     filterType: 'select',
+    action: FILTER_ACTION_UPDATE,
     filterValues: presenceValues
   };
 
@@ -126,6 +135,7 @@ export namespace WorkloadListFilters {
     title: 'Version Label',
     placeholder: 'Filter by Version Label Validation',
     filterType: 'select',
+    action: FILTER_ACTION_UPDATE,
     filterValues: presenceValues
   };
 
@@ -134,6 +144,7 @@ export namespace WorkloadListFilters {
     title: 'Workload Type',
     placeholder: 'Filter by Workload Type',
     filterType: 'select',
+    action: FILTER_ACTION_APPEND,
     filterValues: [
       {
         id: WorkloadType.Deployment,

--- a/src/pages/WorkloadList/WorkloadListComponent.tsx
+++ b/src/pages/WorkloadList/WorkloadListComponent.tsx
@@ -92,7 +92,7 @@ class WorkloadListComponent extends React.Component<WorkloadListComponentProps, 
         if (typeof availableFilter === 'undefined') {
           NamespaceFilterSelected.setSelected(
             NamespaceFilterSelected.getSelected().filter(nfs => {
-              return nfs.category === activeFilter.category;
+              return nfs.category !== activeFilter.category;
             })
           );
           return null;

--- a/src/pages/WorkloadList/WorkloadListComponent.tsx
+++ b/src/pages/WorkloadList/WorkloadListComponent.tsx
@@ -14,7 +14,7 @@ import {
 import { ListView, Sort, Paginator, ToolbarRightContent, Button, Icon } from 'patternfly-react';
 import { Pagination } from '../../types/Pagination';
 import PropTypes from 'prop-types';
-import { ActiveFilter, FilterType } from '../../types/NamespaceFilter';
+import { ActiveFilter, FILTER_ACTION_UPDATE, FilterType } from '../../types/NamespaceFilter';
 import { removeDuplicatesArray } from '../../utils/Common';
 import { URLParameter } from '../../types/Parameters';
 
@@ -213,9 +213,9 @@ class WorkloadListComponent extends React.Component<WorkloadListComponentProps, 
     console.error(errMsg);
   }
 
-  updateParams(params: URLParameter[], looking: string, id: string, value: string) {
+  updateParams(params: URLParameter[], id: string, value: string) {
     let newParams = params;
-    const index = newParams.findIndex(param => param.name === looking && param.value.length > 0);
+    const index = newParams.findIndex(param => param.name === id && param.value.length > 0);
     if (index >= 0) {
       newParams[index].value = value;
     } else {
@@ -229,34 +229,29 @@ class WorkloadListComponent extends React.Component<WorkloadListComponentProps, 
 
   onFilterChange = (filters: ActiveFilter[]) => {
     let params: URLParameter[] = [];
+
     availableFilters.forEach(availableFilter => {
       params.push({ name: availableFilter.id, value: '' });
     });
+
     filters.forEach(activeFilter => {
       let filterId = (
         availableFilters.find(filter => {
           return filter.title === activeFilter.category;
         }) || availableFilters[2]
       ).id;
-      switch (activeFilter.category) {
-        case 'Istio Sidecar': {
-          params = this.updateParams(params, 'istiosidecar', filterId, activeFilter.value);
-          break;
-        }
-        case 'App Label': {
-          params = this.updateParams(params, 'applabel', filterId, activeFilter.value);
-          break;
-        }
-        case 'Version Label': {
-          params = this.updateParams(params, 'versionlabel', filterId, activeFilter.value);
-          break;
-        }
-        default: {
-          params.push({
-            name: filterId,
-            value: activeFilter.value
-          });
-        }
+
+      const updateableFilterIds = availableFilters
+        .filter(filter => filter.action === FILTER_ACTION_UPDATE)
+        .map(filter => filter.id);
+
+      if (updateableFilterIds.includes(filterId)) {
+        params = this.updateParams(params, filterId, activeFilter.value);
+      } else {
+        params.push({
+          name: filterId,
+          value: activeFilter.value
+        });
       }
     });
     this.props.onParamChange(params, 'append');

--- a/src/types/NamespaceFilter.ts
+++ b/src/types/NamespaceFilter.ts
@@ -10,8 +10,12 @@ export interface FilterType {
   title: string;
   placeholder: string;
   filterType: string;
+  action: string;
   filterValues: FilterValue[];
 }
+
+export const FILTER_ACTION_APPEND = 'append';
+export const FILTER_ACTION_UPDATE = 'update';
 
 export interface ActiveFilter {
   label: string;


### PR DESCRIPTION
** Describe the change **

Bugs fixed:

1. Filter duplication
![screen recording](https://user-images.githubusercontent.com/613814/44411419-c1b65780-a566-11e8-8eff-1b87f20d8c33.gif)

2.  Istio filter is now: Present, Not Present (instead of Deployed/Not Deployed)
![screenshot of kiali console 1](https://user-images.githubusercontent.com/613814/44410750-5ddf5f00-a565-11e8-9fae-9de7b2a683ca.png)

![screenshot of kiali console 2](https://user-images.githubusercontent.com/613814/44410754-6041b900-a565-11e8-9124-173495d55686.png)

3. Let filters be updated or appended: e.g. istio filter is a boolean, so have both filters shouldn't exist. Otherwise, namespace filter can be added several times with different values. (This is done to be consistent with the workload list)
![screen recording 1](https://user-images.githubusercontent.com/613814/44411442-cc70ec80-a566-11e8-92f4-93b3ff190eb5.gif)


4. Before this fix, switching between workload/service/istioconfig list wasn't filtering properly with the filters brought from the previous list.
![screen recording 2](https://user-images.githubusercontent.com/613814/44411447-d0047380-a566-11e8-86a1-82af5aad22f9.gif)


** Issue reference **
[KIALI-1323](https://issues.jboss.org/browse/KIALI-1323)

** Backwards in compatible? **
Yes.

[x] Is your pull-request introducing changes in behaviour?