### PR TITLE
KIALI-1117 Create a Dialog Box to warn user about session Timeout

### DIFF
--- a/src/actions/LoginActions.ts
+++ b/src/actions/LoginActions.ts
@@ -7,6 +7,7 @@ import { config } from '../config';
 
 export enum LoginActionKeys {
   LOGIN_REQUEST = 'LOGIN_REQUEST',
+  LOGIN_EXTEND = 'LOGIN_EXTEND',
   LOGIN_SUCCESS = 'LOGIN_SUCCESS',
   LOGIN_FAILURE = 'LOGIN_FAILURE',
   LOGOUT_SUCCESS = 'LOGOUT_SUCCESS'
@@ -15,12 +16,18 @@ export enum LoginActionKeys {
 // synchronous action creators
 export const LoginActions = {
   loginRequest: createAction(LoginActionKeys.LOGIN_REQUEST),
+  loginExtend: createAction(LoginActionKeys.LOGIN_EXTEND, (token: Token, username: string, actualTimeOut: number) => ({
+    type: LoginActionKeys.LOGIN_EXTEND,
+    token: token,
+    username: username,
+    sessionTimeOut: actualTimeOut + config().session.extendedSessionTimeOut
+  })),
   loginSuccess: createAction(LoginActionKeys.LOGIN_SUCCESS, (token: Token, username: string) => ({
     type: LoginActionKeys.LOGIN_SUCCESS,
     token: token,
     username: username,
     logged: true,
-    sessionTimeOut: new Date().getTime() + config().sessionTimeOut
+    sessionTimeOut: new Date().getTime() + config().session.sessionTimeOut
   })),
   loginFailure: createAction(LoginActionKeys.LOGIN_FAILURE, (error: any) => ({
     type: LoginActionKeys.LOGIN_FAILURE,
@@ -32,6 +39,18 @@ export const LoginActions = {
     username: undefined,
     logged: false
   })),
+  extendSession: () => {
+    return (dispatch, getState) => {
+      const actualState = getState() || {};
+      dispatch(
+        LoginActions.loginExtend(
+          actualState.authentication.token,
+          actualState.authentication.username,
+          actualState.authentication.sessionTimeOut
+        )
+      );
+    };
+  },
   checkCredentials: () => {
     return (dispatch, getState) => {
       const actualState = getState() || {};

--- a/src/components/Nav/UserDropdown.tsx
+++ b/src/components/Nav/UserDropdown.tsx
@@ -1,21 +1,69 @@
 import * as React from 'react';
 import { Dropdown, Icon, MenuItem } from 'patternfly-react';
+import { SessionTimeout } from '../SessionTimeout/SessionTimeout';
+import { config } from '../../config';
+import { MILLISECONDS } from '../../types/Common';
+
 type UserProps = {
   username: string;
   logout: () => void;
+  extendSession: () => void;
+  sessionTimeOut: number;
 };
 
-type UserState = {};
+type UserState = {
+  showSessionTimeOut: boolean;
+  timeCountDownSeconds: number;
+};
 
 class UserDropdown extends React.Component<UserProps, UserState> {
+  constructor(props: UserProps) {
+    super(props);
+    this.state = {
+      showSessionTimeOut: false,
+      timeCountDownSeconds: this.timeLeft() / MILLISECONDS
+    };
+  }
+  componentDidMount() {
+    setInterval(() => {
+      this.checkSession();
+    }, 3000);
+
+    setInterval(() => {
+      this.setState({ timeCountDownSeconds: this.timeLeft() / MILLISECONDS });
+    }, 1000);
+  }
+
+  timeLeft = (): number => {
+    const nowDate = new Date().getTime();
+    return this.props.sessionTimeOut - nowDate;
+  };
+
+  checkSession = () => {
+    if (this.timeLeft() < config().session.timeOutforWarningUser) {
+      this.setState({ showSessionTimeOut: true });
+    }
+  };
+
   handleLogout() {
     this.props.logout();
     document.documentElement.className = 'login-pf';
   }
 
+  extendSession = () => {
+    this.props.extendSession();
+    this.setState({ showSessionTimeOut: false });
+  };
+
   render() {
     return (
       <>
+        <SessionTimeout
+          logout={this.props.logout}
+          extendSession={this.extendSession}
+          show={this.state.showSessionTimeOut}
+          timeOutCountDown={this.state.timeCountDownSeconds}
+        />
         <Dropdown componentClass="li" id="user">
           <Dropdown.Toggle useAnchor={true} className="nav-item-iconic">
             <Icon type="pf" name="user" /> {this.props.username}

--- a/src/components/SessionTimeout/SessionTimeout.tsx
+++ b/src/components/SessionTimeout/SessionTimeout.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import { Modal, Button, Icon, Row, Col } from 'patternfly-react';
+import { config } from '../../config';
+import { UNIT_TIME, MILLISECONDS } from '../../types/Common';
+
+type SessionTimeoutProps = {
+  logout: () => void;
+  extendSession: () => void;
+  show: boolean;
+  timeOutCountDown: number;
+};
+
+export class SessionTimeout extends React.Component<SessionTimeoutProps, {}> {
+  constructor(props: SessionTimeoutProps) {
+    super(props);
+  }
+
+  render() {
+    const extendedTime = config().session.extendedSessionTimeOut
+      ? config().session.extendedSessionTimeOut / (MILLISECONDS * UNIT_TIME.MINUTE)
+      : 30;
+    return (
+      <Modal
+        className={'message-dialog-pf'}
+        show={this.props.show}
+        onHide={this.props.logout}
+        enforceFocus={true}
+        aria-modal={true}
+      >
+        <Modal.Body>
+          <Row style={{ paddingTop: '25px' }}>
+            <Col xs={12} sm={1} md={1} lg={1} />
+            <Col xs={12} sm={1} md={1} lg={1} style={{ paddingLeft: '10px' }}>
+              <Icon name="warning-triangle-o" type="pf" style={{ fontSize: '48px' }} />
+            </Col>
+            <Col xs={12} sm={10} md={10} lg={10}>
+              <p className={'lead'}>
+                Your session will timeout in {this.props.timeOutCountDown.toFixed()} seconds.<br />Would you like to
+                extend your session for another {extendedTime} minutes?
+              </p>
+            </Col>
+          </Row>
+        </Modal.Body>
+        <Modal.Footer>
+          <React.Fragment>
+            <Button bsStyle={'default'} onClick={this.props.logout}>
+              Log Out
+            </Button>
+            <Button autoFocus={true} bsStyle={'primary'} onClick={this.props.extendSession}>
+              Continue Session
+            </Button>
+          </React.Fragment>
+        </Modal.Footer>
+      </Modal>
+    );
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,8 +4,15 @@ import { UNIT_TIME, MILLISECONDS } from './types/Common';
 export const config = () => {
   return deepFreeze({
     version: '0.1',
-    /** TimeOut in Minutes default 30 minutes */
-    sessionTimeOut: 30 * UNIT_TIME.MINUTE * MILLISECONDS,
+    /** Configuration related with session */
+    session: {
+      /** TimeOut in Minutes default 24 hours */
+      sessionTimeOut: 24 * UNIT_TIME.HOUR * MILLISECONDS,
+      /** Extended Session in Minutes default 30 minutes */
+      extendedSessionTimeOut: 30 * UNIT_TIME.MINUTE * MILLISECONDS,
+      /** TimeOut Session remain for warning user default 1 minute */
+      timeOutforWarningUser: 1 * UNIT_TIME.MINUTE * MILLISECONDS
+    },
     /** Toolbar Configuration */
     toolbar: {
       /** Duration default in 1 minute */

--- a/src/containers/UserDropdownContainer.ts
+++ b/src/containers/UserDropdownContainer.ts
@@ -5,11 +5,13 @@ import UserDropdown from '../components/Nav/UserDropdown';
 import { LoginActions } from '../actions/LoginActions';
 
 const mapStateToProps = (state: KialiAppState) => ({
-  username: state.authentication.username
+  username: state.authentication.username,
+  sessionTimeOut: state.authentication.sessionTimeOut
 });
 
 const mapDispatchToProps = (dispatch: any) => ({
-  logout: () => dispatch(LoginActions.logoutSuccess())
+  logout: () => dispatch(LoginActions.logoutSuccess()),
+  extendSession: () => dispatch(LoginActions.extendSession())
 });
 
 const UserDropdownConnected = connect(

--- a/src/reducers/LoginState.ts
+++ b/src/reducers/LoginState.ts
@@ -25,6 +25,13 @@ const LoginState = (state: LoginState = INITIAL_STATE, action) => {
         username: action.username,
         sessionTimeOut: action.sessionTimeOut
       });
+    case LoginActionKeys.LOGIN_EXTEND:
+      return Object.assign({}, INITIAL_STATE, {
+        logged: true,
+        token: action.token,
+        username: action.username,
+        sessionTimeOut: action.sessionTimeOut
+      });
     case LoginActionKeys.LOGIN_FAILURE:
       let message = 'Error connecting to Kiali';
       if (action.error.request.status === 401) {


### PR DESCRIPTION
** Describe the change **

Add a Dialog Box to warn user about session Timeout

All parameters are configurable
```json
   /** Configuration related with session */
    session: {
      /** TimeOut in Minutes default 24 hours */
      sessionTimeOut: 24 * UNIT_TIME.HOUR * MILLISECONDS,
      /** Extended Session in Minutes default 30 minutes */
      extendedSessionTimeOut: 30 * UNIT_TIME.MINUTE * MILLISECONDS,
      /** TimeOut Session remain for warning user default 1 minute */
      timeOutforWarningUser: 1 * UNIT_TIME.MINUTE * MILLISECONDS
    }
```
Changed time session to 24 hours like in openshift console.
See [auth opensihift file](https://github.com/openshift/console/blob/7fad08d27843c8d8e008f3d79d068c374e8dde94/auth/auth_openshift.go#L75) in the line 75 the token for console auth is `expiresIn := (time.Hour * 24).Seconds()` 24 hours

** Issue reference **

[KIALI-117](https://issues.jboss.org/browse/KIALI-1117)

How works?  **Mocked times to see how works**

- In Continue Session the sessiontimeOut will be increased by 30 minutes ( default value in **extendedSessionTimeOut** )
- When the sessiontimeOut is below 1 minute (default value in **timeOutforWarningUser**) the MessageDialog will be shown. 
- If the sessiontimeOut is 0 Kiali will logout you.

![how_works](https://user-images.githubusercontent.com/3019213/44519430-5044e900-a6cd-11e8-9183-6d6af7564ed8.gif)


How do you see it ? **Force show MessageDialog** Normal behaviour is show this when you will logout in 60 seconds with the countdown, now show 1794/60 = 29,9 minutes, value by default in **sessionTimeOut**
![screenshot from 2018-08-23 12-05-30](https://user-images.githubusercontent.com/3019213/44519423-4d49f880-a6cd-11e8-9708-0c7cca14d0f8.png)




