### PR TITLE
 KIALI-1311 Avoid pushing browser history when arriving to any ListPage

### DIFF
--- a/src/components/NamespaceFilter/NamespaceFilter.tsx
+++ b/src/components/NamespaceFilter/NamespaceFilter.tsx
@@ -109,7 +109,7 @@ export class NamespaceFilter extends React.Component<NamespaceFilterProps, Names
   filterAdded = (field: FilterType, value: string) => {
     let filterText = '';
     const activeFilters = this.state.activeFilters;
-    let activeFilter: ActiveFilter = { label: '', category: '', value: '' };
+    let activeFilter: ActiveFilter = { label: '', category: '', value: '', param: '' };
 
     if (field.title) {
       filterText = field.title;
@@ -119,6 +119,7 @@ export class NamespaceFilter extends React.Component<NamespaceFilterProps, Names
     filterText += ': ' + value;
     activeFilter.value = value;
     activeFilter.label = filterText;
+    activeFilter.param = field.id;
 
     const typeFilterPresent = activeFilters.filter(filter => filter.category === field.title).length > 0;
 

--- a/src/pages/AppList/AppListComponent.tsx
+++ b/src/pages/AppList/AppListComponent.tsx
@@ -79,13 +79,35 @@ class AppListComponent extends React.Component<AppListComponentProps, AppListCom
     }
   };
 
+  currentURLParams(): URLParameter[] {
+    let currentURLParams: URLParameter[] = [];
+
+    const selectedFilters = NamespaceFilterSelected.getSelected();
+    const filterParams = selectedFilters
+      .map(filter => filter.param)
+      .filter((param, index, self) => index === self.indexOf(param));
+
+    filterParams.forEach(filterName => {
+      this.props.queryParam(filterName, []).forEach(param => {
+        currentURLParams = currentURLParams.concat({
+          name: filterName,
+          value: param
+        });
+      });
+    });
+
+    return currentURLParams;
+  }
+
   setActiveFiltersToURL() {
-    const params = NamespaceFilterSelected.getSelected()
+    // @ts-ignore
+    const params: URLParameter[] = NamespaceFilterSelected.getSelected()
       .map(activeFilter => {
         const availableFilter = availableFilters.find(filter => {
           return filter.title === activeFilter.category;
         });
 
+        // Remove filter that doesn't apply to the ServiceList
         if (typeof availableFilter === 'undefined') {
           NamespaceFilterSelected.setSelected(
             NamespaceFilterSelected.getSelected().filter(nfs => {
@@ -102,7 +124,19 @@ class AppListComponent extends React.Component<AppListComponentProps, AppListCom
       })
       .filter(filter => filter !== null);
 
-    this.props.onParamChange(params, 'append');
+    // Only change the url + update browser history in case the URL changes
+    const currentURLParams = this.currentURLParams();
+    let equalParams = currentURLParams.every(currentParam => {
+      return params.some(param => {
+        return param.name === currentParam.name && param.value === currentParam.value;
+      });
+    });
+
+    equalParams = equalParams && currentURLParams.length === NamespaceFilterSelected.getSelected().length;
+
+    if (!equalParams) {
+      this.props.onParamChange(params, 'append');
+    }
   }
 
   fetchApps(namespaces: string[], filters: ActiveFilter[]) {
@@ -168,7 +202,8 @@ class AppListComponent extends React.Component<AppListComponentProps, AppListCom
         activeFilters.push({
           label: filter.title + ': ' + value,
           category: filter.title,
-          value: value
+          value: value,
+          param: filter.id
         });
       });
     });

--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -43,14 +43,16 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
     let namespaceFilter: ActiveFilter = {
       label: 'Namespace: ' + this.props.match.params.namespace,
       category: 'Namespace',
-      value: this.props.match.params.namespace.toString()
+      value: this.props.match.params.namespace.toString(),
+      param: 'namespace'
     };
     activeFilters.push(namespaceFilter);
     if (addObjectTypeFilter) {
       let objectTypeFilter: ActiveFilter = {
         label: 'Istio Type: ' + dicIstioType[this.props.match.params.objectType],
         category: 'Istio Type',
-        value: dicIstioType[this.props.match.params.objectType]
+        value: dicIstioType[this.props.match.params.objectType],
+        param: 'istio'
       };
       activeFilters.push(objectTypeFilter);
     }

--- a/src/pages/IstioConfigList/IstioConfigListComponent.tsx
+++ b/src/pages/IstioConfigList/IstioConfigListComponent.tsx
@@ -226,13 +226,35 @@ class IstioConfigListComponent extends React.Component<IstioConfigListComponentP
     return selectedFilters.size === urlParams.size && equalFilters;
   }
 
+  currentURLParams(): URLParameter[] {
+    let currentURLParams: URLParameter[] = [];
+
+    const selectedFilters = NamespaceFilterSelected.getSelected();
+    const filterParams = selectedFilters
+      .map(filter => filter.param)
+      .filter((param, index, self) => index === self.indexOf(param));
+
+    filterParams.forEach(filterName => {
+      this.props.queryParam(filterName, []).forEach(param => {
+        currentURLParams = currentURLParams.concat({
+          name: filterName,
+          value: param
+        });
+      });
+    });
+
+    return currentURLParams;
+  }
+
   setActiveFiltersToURL() {
-    const params = NamespaceFilterSelected.getSelected()
+    // @ts-ignore
+    const params: URLParameter[] = NamespaceFilterSelected.getSelected()
       .map(activeFilter => {
         const availableFilter = availableFilters.find(filter => {
           return filter.title === activeFilter.category;
         });
 
+        // Remove filter that doesn't apply to the ServiceList
         if (typeof availableFilter === 'undefined') {
           NamespaceFilterSelected.setSelected(
             NamespaceFilterSelected.getSelected().filter(nfs => {
@@ -249,7 +271,19 @@ class IstioConfigListComponent extends React.Component<IstioConfigListComponentP
       })
       .filter(filter => filter !== null);
 
-    this.props.onParamChange(params, 'append');
+    // Only change the url + update browser history in case the URL changes
+    const currentURLParams = this.currentURLParams();
+    let equalParams = currentURLParams.every(currentParam => {
+      return params.some(param => {
+        return param.name === currentParam.name && param.value === currentParam.value;
+      });
+    });
+
+    equalParams = equalParams && currentURLParams.length === NamespaceFilterSelected.getSelected().length;
+
+    if (!equalParams) {
+      this.props.onParamChange(params, 'append');
+    }
   }
 
   selectedFilters() {
@@ -259,7 +293,8 @@ class IstioConfigListComponent extends React.Component<IstioConfigListComponentP
         activeFilters.push({
           label: filter.title + ': ' + value,
           category: filter.title,
-          value: value
+          value: value,
+          param: filter.id
         });
       });
     });

--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -10,6 +10,7 @@ import { authentication } from '../../utils/Authentication';
 import IstioObjectDetails from './IstioObjectDetails';
 import ServiceMetricsContainer from '../../containers/ServiceMetricsContainer';
 import ServiceInfo from './ServiceInfo';
+import { NamespaceFilterSelected } from '../../components/NamespaceFilter/NamespaceFilter';
 
 type ServiceDetailsState = {
   serviceDetailsInfo: ServiceDetailsInfo;
@@ -160,6 +161,10 @@ class ServiceDetails extends React.Component<RouteComponentProps<ServiceId>, Ser
       });
   };
 
+  clearFilters = () => {
+    NamespaceFilterSelected.setSelected([]);
+  };
+
   renderBreadcrumbs = (parsedSearch: ParsedSearch, showingDetails: boolean) => {
     const urlParams = new URLSearchParams(this.props.location.search);
     const parsedSearchTypeHuman = parsedSearch.type === 'virtualservice' ? 'Virtual Service' : 'Destination Rule';
@@ -168,7 +173,9 @@ class ServiceDetails extends React.Component<RouteComponentProps<ServiceId>, Ser
     return (
       <Breadcrumb title={true}>
         <Breadcrumb.Item componentClass={'span'}>
-          <Link to="/services">Services</Link>
+          <Link to="/services" onClick={this.clearFilters}>
+            Services
+          </Link>
         </Breadcrumb.Item>
         <Breadcrumb.Item componentClass={'span'}>
           <Link to={`/services?namespace=${encodeURIComponent(this.props.match.params.namespace)}`}>

--- a/src/pages/ServiceGraph/SummaryPanelGraph.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelGraph.tsx
@@ -178,7 +178,8 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
       let activeFilter: ActiveFilter = {
         label: 'Namespace: ' + this.props.namespace,
         category: 'Namespace',
-        value: this.props.namespace.toString()
+        value: this.props.namespace.toString(),
+        param: 'namespace'
       };
       filters = [activeFilter];
     }

--- a/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -8,6 +8,7 @@ import { Breadcrumb, TabContainer, Nav, NavItem, TabContent, TabPane } from 'pat
 import WorkloadInfo from './WorkloadInfo';
 import * as MessageCenter from '../../utils/MessageCenter';
 import WorkloadMetricsContainer from '../../containers/WorkloadMetricsContainer';
+import { NamespaceFilterSelected } from '../../components/NamespaceFilter/NamespaceFilter';
 
 type WorkloadDetailsState = {
   workload: Deployment;
@@ -86,6 +87,10 @@ class WorkloadDetails extends React.Component<RouteComponentProps<WorkloadId>, W
     return istioEnabled;
   };
 
+  clearFilters = () => {
+    NamespaceFilterSelected.setSelected([]);
+  };
+
   renderBreadcrumbs = () => {
     const urlParams = new URLSearchParams(this.props.location.search);
     const to = this.workloadPageURL();
@@ -106,7 +111,9 @@ class WorkloadDetails extends React.Component<RouteComponentProps<WorkloadId>, W
     return (
       <Breadcrumb title={true}>
         <Breadcrumb.Item componentClass="span">
-          <Link to="/workloads">Workloads</Link>
+          <Link to="/workloads" onClick={this.clearFilters}>
+            Workloads
+          </Link>
         </Breadcrumb.Item>
         <Breadcrumb.Item componentClass="span">
           <Link to={`/workloads?namespace=${encodeURIComponent(this.props.match.params.namespace)}`}>

--- a/src/types/NamespaceFilter.ts
+++ b/src/types/NamespaceFilter.ts
@@ -21,6 +21,7 @@ export interface ActiveFilter {
   label: string;
   category: string;
   value: string;
+  param: string;
 }
 
 export interface NamespaceFilterProps {


### PR DESCRIPTION
** Describe the change **

Fixing a bug about browser history.
Problem found: whenever you arrive to a ListPage (workoads, services, and so on) the console mistakenly pushed an entry into the browser history. So, if you hit 'goback' into your browser to get any ListPage, the console would have pushed an entry in the history and therefore it would have removed that previous page.

** Issue reference **

[KIALI-1311](https://issues.jboss.org/browse/KIALI-1311)

** Backwards in compatible? **
yes.

[ ] Is your pull-request introducing changes in behaviour?

** Screenshot **

![screen recording 8](https://user-images.githubusercontent.com/613814/44476056-f2fe5880-a636-11e8-9e90-7b7a8a250966.gif)

![screen recording 9](https://user-images.githubusercontent.com/613814/44476049-eb3eb400-a636-11e8-8bf2-fd5314c761cb.gif)

Adding a DNM label. Something wrong in WorkloadList.