### PR TITLE
KIALI-1232 Explicitly set L -> R flow for graph

### DIFF
--- a/src/components/CytoscapeGraph/graphs/ColaGraph.ts
+++ b/src/components/CytoscapeGraph/graphs/ColaGraph.ts
@@ -5,7 +5,7 @@ export class ColaGraph implements GraphType {
     return {
       name: 'cola',
       animate: false,
-      flow: { axis: 'y' },
+      flow: { axis: 'x' },
       nodeDimensionsIncludeLabels: true
     };
   }


### PR DESCRIPTION
** Describe the change **
KIALI-1232 Set Left to Right flow for graph.

Note: "Flow" direction option is different for each graph type.

- Dadre: already displays L->R as expected
- Cola: changed flow axis from y to x
- Cose: no flow options available.  API [link](https://github.com/cytoscape/cytoscape.js-cose-bilkent#api). 

** Backwards in compatible? **
No
[ ] Is your pull-request introducing changes in behaviour?

** Screenshot **

Dagre Before (already flowing L-R by with `rankDir: 'LR'` option)
![dagre-before](https://user-images.githubusercontent.com/3805254/44495369-909c5c80-a624-11e8-826d-c94e9ca09d24.png)
Dagre After
![dagre-after](https://user-images.githubusercontent.com/3805254/44495370-909c5c80-a624-11e8-9503-1b7764d89ba4.png)

Cola Before
![cola-before](https://user-images.githubusercontent.com/3805254/44495404-ad389480-a624-11e8-97b2-caef1230d5f0.png)
Cola After
![cola-after](https://user-images.githubusercontent.com/3805254/44495403-ad389480-a624-11e8-9651-65bf55b575de.png)

Cose: no flow option available

