### PR TITLE
KIALI-1407 Add links to workloads in the graph side panels

### DIFF
--- a/src/pages/ServiceGraph/SummaryPanelCommon.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelCommon.tsx
@@ -178,17 +178,23 @@ export const getDatapoints = (
 
 export const renderPanelTitle = node => {
   const { namespace, service, app, workload, nodeType } = nodeData(node);
-  const displayName: string = nodeType === NodeType.UNKNOWN ? 'unknown' : app || workload || service;
+  let displayName: string = 'unknown';
   let link: string | undefined;
   let displaySpan: any;
 
   switch (nodeType) {
+    case NodeType.APP:
+      // Not available yet
+      // link = `/namespaces/${encodeURIComponent(namespace)}/services/${encodeURIComponent(service)}`;
+      displayName = app;
+      break;
     case NodeType.SERVICE:
-      link = `/namespaces/${namespace}/services/${service}`;
+      link = `/namespaces/${encodeURIComponent(namespace)}/services/${encodeURIComponent(service)}`;
+      displayName = service;
       break;
     case NodeType.WORKLOAD:
-      // Not available yet.
-      // link = `/namespaces/${namespace}/workloads/${service}`;
+      link = `/namespaces/${encodeURIComponent(namespace)}/workloads/${encodeURIComponent(workload)}`;
+      displayName = workload;
       break;
     default:
       // NOOP

--- a/src/pages/ServiceGraph/SummaryPanelGroup.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelGroup.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { Icon } from 'patternfly-react';
+
 import InOutRateTable from '../../components/SummaryPanel/InOutRateTable';
 import RpsChart from '../../components/SummaryPanel/RpsChart';
 import { SummaryPanelPropType } from '../../types/Graph';
 import graphUtils from '../../utils/Graphing';
 import { getAccumulatedTrafficRate } from '../../utils/TrafficRate';
-import { Icon } from 'patternfly-react';
 import { shouldRefreshData, updateHealth, nodeData, getNodeMetrics, getNodeMetricType } from './SummaryPanelCommon';
 import { DisplayMode, HealthIndicator } from '../../components/Health/HealthIndicator';
 import Label from '../../components/Label/Label';
@@ -212,10 +214,14 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
     let workloadList: any[] = [];
 
     group.children().forEach(node => {
-      let workload = node.data('workload');
+      let { namespace, workload } = nodeData(node);
 
       if (workload) {
-        workloadList.push(workload);
+        workloadList.push(
+          <Link to={`/namespaces/${encodeURIComponent(namespace)}/workloads/${encodeURIComponent(workload)}`}>
+            {workload}
+          </Link>
+        );
         workloadList.push(', ');
       }
     });

--- a/src/pages/ServiceGraph/SummaryPanelNode.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelNode.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { Icon } from 'patternfly-react';
+
 import { getTrafficRate, getAccumulatedTrafficRate } from '../../utils/TrafficRate';
 import InOutRateTable from '../../components/SummaryPanel/InOutRateTable';
 import RpsChart from '../../components/SummaryPanel/RpsChart';
 import { NodeType, SummaryPanelPropType } from '../../types/Graph';
 import { Metrics, Metric } from '../../types/Metrics';
-import { Icon } from 'patternfly-react';
 import {
   shouldRefreshData,
   updateHealth,
@@ -192,7 +194,9 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
           {shouldRenderWorkload && (
             <div>
               <strong>Workload: </strong>
-              {workload}
+              <Link to={`/namespaces/${encodeURIComponent(namespace)}/workloads/${encodeURIComponent(workload)}`}>
+                {workload}
+              </Link>
             </div>
           )}
           {(shouldRenderSvcList || shouldRenderWorkload) && <hr />}


### PR DESCRIPTION
* In the header of the panels, if a workload is being referred, diplay the workload name as a link to the details page.
* In the body of the panels, in the workloads list, also workload names as links to the details page.

![image](https://user-images.githubusercontent.com/23639005/44551717-927e2280-a6ed-11e8-99f3-2e1373e5ced9.png)
