### PR TITLE
KIALI-1312 Avoid history push when initializing list pages

### DIFF
--- a/src/components/ListPage/ListPage.ts
+++ b/src/components/ListPage/ListPage.ts
@@ -12,10 +12,10 @@ export namespace ListPage {
       MessageCenter.add(error);
     };
 
-    onParamChange = (params: URLParameter[], action?: string) => {
+    onParamChange = (params: URLParameter[], paramAction: string, historyAction: string) => {
       const urlParams = new URLSearchParams(this.props.location.search);
 
-      if (params.length > 0 && action === ACTION_APPEND) {
+      if (params.length > 0 && paramAction === ACTION_APPEND) {
         params.forEach(param => {
           urlParams.delete(param.name);
         });
@@ -25,15 +25,19 @@ export namespace ListPage {
         if (param.value === '') {
           urlParams.delete(param.name);
         } else {
-          if (action === ACTION_APPEND) {
+          if (paramAction === ACTION_APPEND) {
             urlParams.append(param.name, param.value);
-          } else if (!action || action === ACTION_SET) {
+          } else if (!paramAction || paramAction === ACTION_SET) {
             urlParams.set(param.name, param.value);
           }
         }
       });
 
-      this.props.history.push(this.props.location.pathname + '?' + urlParams.toString());
+      if (historyAction === 'replace') {
+        this.props.history.replace(this.props.location.pathname + '?' + urlParams.toString());
+      } else {
+        this.props.history.push(this.props.location.pathname + '?' + urlParams.toString());
+      }
     };
 
     onParamDelete = (params: string[]) => {

--- a/src/pages/AppList/AppListComponent.tsx
+++ b/src/pages/AppList/AppListComponent.tsx
@@ -102,7 +102,7 @@ class AppListComponent extends React.Component<AppListComponentProps, AppListCom
       })
       .filter(filter => filter !== null);
 
-    this.props.onParamChange(params, 'append');
+    this.props.onParamChange(params, 'append', 'replace');
   }
 
   fetchApps(namespaces: string[], filters: ActiveFilter[]) {

--- a/src/pages/IstioConfigList/IstioConfigListComponent.tsx
+++ b/src/pages/IstioConfigList/IstioConfigListComponent.tsx
@@ -249,7 +249,7 @@ class IstioConfigListComponent extends React.Component<IstioConfigListComponentP
       })
       .filter(filter => filter !== null);
 
-    this.props.onParamChange(params, 'append');
+    this.props.onParamChange(params, 'append', 'replace');
   }
 
   selectedFilters() {

--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -10,6 +10,7 @@ import { authentication } from '../../utils/Authentication';
 import IstioObjectDetails from './IstioObjectDetails';
 import ServiceMetricsContainer from '../../containers/ServiceMetricsContainer';
 import ServiceInfo from './ServiceInfo';
+import { NamespaceFilterSelected } from '../../components/NamespaceFilter/NamespaceFilter';
 
 type ServiceDetailsState = {
   serviceDetailsInfo: ServiceDetailsInfo;
@@ -160,6 +161,10 @@ class ServiceDetails extends React.Component<RouteComponentProps<ServiceId>, Ser
       });
   };
 
+  clearFilters() {
+    NamespaceFilterSelected.setSelected([]);
+  }
+
   renderBreadcrumbs = (parsedSearch: ParsedSearch, showingDetails: boolean) => {
     const urlParams = new URLSearchParams(this.props.location.search);
     const parsedSearchTypeHuman = parsedSearch.type === 'virtualservice' ? 'Virtual Service' : 'Destination Rule';
@@ -168,7 +173,9 @@ class ServiceDetails extends React.Component<RouteComponentProps<ServiceId>, Ser
     return (
       <Breadcrumb title={true}>
         <Breadcrumb.Item componentClass={'span'}>
-          <Link to="/services">Services</Link>
+          <Link to="/services" onClick={this.clearFilters}>
+            Services
+          </Link>
         </Breadcrumb.Item>
         <Breadcrumb.Item componentClass={'span'}>
           <Link to={`/services?namespace=${encodeURIComponent(this.props.match.params.namespace)}`}>

--- a/src/pages/ServiceList/ServiceListComponent.tsx
+++ b/src/pages/ServiceList/ServiceListComponent.tsx
@@ -242,7 +242,7 @@ class ServiceListComponent extends React.Component<ServiceListComponentProps, Se
       })
       .filter(filter => filter !== null);
 
-    this.props.onParamChange(params, 'append');
+    this.props.onParamChange(params, 'append', 'replace');
   }
 
   selectedFilters() {

--- a/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -9,6 +9,7 @@ import WorkloadInfo from './WorkloadInfo';
 import * as MessageCenter from '../../utils/MessageCenter';
 import WorkloadMetricsContainer from '../../containers/WorkloadMetricsContainer';
 import { WorkloadHealth } from '../../types/Health';
+import { NamespaceFilterSelected } from '../../components/NamespaceFilter/NamespaceFilter';
 
 type WorkloadDetailsState = {
   workload: Deployment;
@@ -96,6 +97,10 @@ class WorkloadDetails extends React.Component<RouteComponentProps<WorkloadId>, W
     return istioEnabled;
   };
 
+  clearFilters() {
+    NamespaceFilterSelected.setSelected([]);
+  }
+
   renderBreadcrumbs = () => {
     const urlParams = new URLSearchParams(this.props.location.search);
     const to = this.workloadPageURL();
@@ -116,7 +121,9 @@ class WorkloadDetails extends React.Component<RouteComponentProps<WorkloadId>, W
     return (
       <Breadcrumb title={true}>
         <Breadcrumb.Item componentClass="span">
-          <Link to="/workloads">Workloads</Link>
+          <Link to="/workloads" onClick={this.clearFilters}>
+            Workloads
+          </Link>
         </Breadcrumb.Item>
         <Breadcrumb.Item componentClass="span">
           <Link to={`/workloads?namespace=${encodeURIComponent(this.props.match.params.namespace)}`}>

--- a/src/pages/WorkloadList/WorkloadListComponent.tsx
+++ b/src/pages/WorkloadList/WorkloadListComponent.tsx
@@ -109,7 +109,7 @@ class WorkloadListComponent extends React.Component<WorkloadListComponentProps, 
       })
       .filter(filter => filter !== null);
 
-    this.props.onParamChange(params, 'append');
+    this.props.onParamChange(params, 'append', 'replace');
   }
 
   getDeploymentItems = (data: WorkloadNamespaceResponse): WorkloadListItem[] => {


### PR DESCRIPTION
** Describe the change **

Fixes 'Go Forward' block after arriving to any list page (app, service, workload, config)

** Issue reference **

[KIALI-1311](https://issues.jboss.org/browse/KIALI-1311): Service list and Istio config list disabling browser "forward" button

** Backwards in compatible? **
Yes.

** Screenshot **

![screen recording 10 1](https://user-images.githubusercontent.com/613814/44576099-0243ea00-a78e-11e8-8747-6f8a2850a377.gif)

