### PR TITLE
KIALI-1350 Avoid displaying 'Invalid Date' in Service Details page

### DIFF
--- a/src/components/Time/LocalTime.tsx
+++ b/src/components/Time/LocalTime.tsx
@@ -6,6 +6,14 @@ interface TimeProps {
 
 export default class LocalTime extends React.Component<TimeProps> {
   render() {
-    return new Date(this.props.time).toLocaleString();
+    let renderedTime: string;
+
+    if (this.props.time) {
+      renderedTime = new Date(this.props.time).toLocaleString();
+    } else {
+      renderedTime = '-';
+    }
+
+    return renderedTime;
   }
 }


### PR DESCRIPTION
** Describe the change **

In Service Details page, avoid showing 'Invalid date' as it follows:
![bildschirmfoto 2018-08-15 um 12 56 56](https://user-images.githubusercontent.com/613814/44587624-cc196100-a7b3-11e8-9ba7-e1c4c8ea0052.png)

and show this:
![screenshot of kiali console](https://user-images.githubusercontent.com/613814/44587630-d20f4200-a7b3-11e8-9e0d-34d8e48ec244.png)

The hyphen is shown when time is empty or has invalid format.

** Issue reference **
https://issues.jboss.org/browse/KIALI-1350

** Backwards in compatible? **
Yes.
