### PR TITLE
KIALI-1198: Add error icon and message to service graph

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -7,7 +7,7 @@ import { GraphHighlighter } from './graphs/GraphHighlighter';
 import * as LayoutDictionary from './graphs/LayoutDictionary';
 import * as GraphBadge from './graphs/GraphBadge';
 import TrafficRender from './graphs/TrafficRenderer';
-import EmptyGraphLayout from './EmptyGraphLayout';
+import EmptyGraphLayout from '../../containers/EmptyGraphLayoutContainer';
 import { CytoscapeReactWrapper, PanZoomOptions } from './CytoscapeReactWrapper';
 
 import { ServiceGraphActions } from '../../actions/ServiceGraphActions';

--- a/src/components/CytoscapeGraph/__tests__/CytoscapeGraph.test.tsx
+++ b/src/components/CytoscapeGraph/__tests__/CytoscapeGraph.test.tsx
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme';
 import { CytoscapeGraph } from '../CytoscapeGraph';
 import * as GRAPH_DATA from '../../../services/__mockData__/getGraphElements';
 import { Duration, Layout, EdgeLabelMode } from '../../../types/GraphFilter';
-import EmptyGraphLayout from '../EmptyGraphLayout';
+import EmptyGraphLayout from '../../../containers/EmptyGraphLayoutContainer';
 import { GraphType } from '../../../types/Graph';
 
 jest.mock('../../../services/Api');

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -17,7 +17,7 @@ export default class ErrorBoundary extends React.Component<ErrorBoundaryProps, E
     this.state = { hasError: false };
   }
 
-  componentDidCatch(error: any, info: any) {
+  componentDidCatch(error: Error, info: any) {
     if (this.props.onError) {
       this.props.onError(error, info);
     }
@@ -26,7 +26,7 @@ export default class ErrorBoundary extends React.Component<ErrorBoundaryProps, E
 
   cleanError = () => {
     this.setState((prevState: ErrorBoundaryState) => {
-      if (prevState.hasError === true) {
+      if (prevState.hasError) {
         return { hasError: false };
       }
       return null;

--- a/src/components/SwitchErrorBoundary/SwitchErrorBoundary.tsx
+++ b/src/components/SwitchErrorBoundary/SwitchErrorBoundary.tsx
@@ -30,7 +30,7 @@ export default class SwitchErrorBoundary extends React.Component<SwitchErrorBoun
 
   componentDidUpdate() {
     if (this.state.hasError) {
-      if (this.show === true) {
+      if (this.show) {
         this.setState({ hasError: false });
       }
       this.show = !this.show;

--- a/src/containers/EmptyGraphLayoutContainer.tsx
+++ b/src/containers/EmptyGraphLayoutContainer.tsx
@@ -1,8 +1,23 @@
 import * as React from 'react';
-import { Button, EmptyState, EmptyStateTitle, EmptyStateInfo, EmptyStateAction } from 'patternfly-react';
+import { connect } from 'react-redux';
+import {
+  Button,
+  EmptyState,
+  EmptyStateTitle,
+  EmptyStateIcon,
+  EmptyStateInfo,
+  EmptyStateAction
+} from 'patternfly-react';
 import { style } from 'typestyle';
-import * as MessageCenter from '../../utils/MessageCenter';
+import * as MessageCenter from '../utils/MessageCenter';
 import * as _ from 'lodash';
+import { KialiAppState } from '../store/Store';
+
+const mapStateToProps = (state: KialiAppState) => {
+  return {
+    error: state.serviceGraph.error
+  };
+};
 
 type EmptyGraphLayoutProps = {
   elements?: any;
@@ -10,6 +25,7 @@ type EmptyGraphLayoutProps = {
   action?: any;
   isLoading?: boolean;
   isError: boolean;
+  error?: string;
 };
 
 const emptyStateStyle = style({
@@ -21,8 +37,8 @@ const emptyStateStyle = style({
 
 type EmptyGraphLayoutState = {};
 
-export default class EmptyGraphLayout extends React.Component<EmptyGraphLayoutProps, EmptyGraphLayoutState> {
-  toogleMessageCenter = () => {
+export class EmptyGraphLayout extends React.Component<EmptyGraphLayoutProps, EmptyGraphLayoutState> {
+  toggleMessageCenter = () => {
     MessageCenter.toggleMessageCenter();
   };
 
@@ -31,7 +47,7 @@ export default class EmptyGraphLayout extends React.Component<EmptyGraphLayoutPr
     const nextIsEmpty = _.isEmpty(nextProps.elements.nodes);
 
     // Update if we have elements and we are not loading
-    if (nextProps.isLoading === false && !nextIsEmpty) {
+    if (!nextProps.isLoading && !nextIsEmpty) {
       return true;
     }
 
@@ -40,21 +56,18 @@ export default class EmptyGraphLayout extends React.Component<EmptyGraphLayoutPr
       return true;
     }
     // Do not update if we have elements and the namespace didn't change, as this means we are refreshing
-    if (!nextIsEmpty && this.props.namespace === nextProps.namespace) {
-      return false;
-    }
-
-    return true;
+    return !(!nextIsEmpty && this.props.namespace === nextProps.namespace);
   }
 
   render() {
     if (this.props.isError) {
       return (
         <EmptyState className={emptyStateStyle}>
+          <EmptyStateIcon name="error-circle-o" />
           <EmptyStateTitle>Error loading Graph</EmptyStateTitle>
-          <EmptyStateInfo>Graph cannot be loaded. Please access to the Message Center for more details.</EmptyStateInfo>
+          <EmptyStateInfo>{this.props.error}</EmptyStateInfo>
           <EmptyStateAction>
-            <Button bsStyle="primary" bsSize="large" onClick={this.toogleMessageCenter}>
+            <Button bsStyle="primary" bsSize="large" onClick={this.toggleMessageCenter}>
               Message Center
             </Button>
           </EmptyStateAction>
@@ -68,12 +81,14 @@ export default class EmptyGraphLayout extends React.Component<EmptyGraphLayoutPr
         </EmptyState>
       );
     }
-    if (
+
+    const isGraphEmpty =
       !this.props.elements ||
       this.props.elements.length < 1 ||
       !this.props.elements.nodes ||
-      this.props.elements.nodes.length < 1
-    ) {
+      this.props.elements.nodes.length < 1;
+
+    if (isGraphEmpty) {
       return (
         <EmptyState className={emptyStateStyle}>
           <EmptyStateTitle>Empty Graph</EmptyStateTitle>
@@ -94,3 +109,9 @@ export default class EmptyGraphLayout extends React.Component<EmptyGraphLayoutPr
     }
   }
 }
+
+const EmptyGraphLayoutContainer = connect(
+  mapStateToProps,
+  null
+)(EmptyGraphLayout);
+export default EmptyGraphLayoutContainer;

--- a/src/pages/ServiceGraph/ServiceGraphPage.tsx
+++ b/src/pages/ServiceGraph/ServiceGraphPage.tsx
@@ -10,7 +10,6 @@ import { Duration, PollIntervalInMs } from '../../types/GraphFilter';
 import SummaryPanel from './SummaryPanel';
 import CytoscapeGraph from '../../components/CytoscapeGraph/CytoscapeGraph';
 import ErrorBoundary from '../../components/ErrorBoundary/ErrorBoundary';
-import EmptyGraphLayout from '../../components/CytoscapeGraph/EmptyGraphLayout';
 import GraphFilterToolbar from '../../components/GraphFilter/GraphFilterToolbar';
 import { computePrometheusQueryInterval } from '../../services/Prometheus';
 import { style } from 'typestyle';
@@ -18,6 +17,7 @@ import { style } from 'typestyle';
 import * as MessageCenterUtils from '../../utils/MessageCenter';
 
 import GraphLegend from '../../components/GraphFilter/GraphLegend';
+import EmptyGraphLayoutContainer from '../../containers/EmptyGraphLayoutContainer';
 
 type ServiceGraphPageProps = GraphParamsType & {
   graphTimestamp: string;
@@ -61,7 +61,7 @@ const makeCancelablePromise = (promise: Promise<any>) => {
 const ServiceGraphErrorBoundaryFallback = () => {
   return (
     <div className={cytoscapeGraphContainerStyle}>
-      <EmptyGraphLayout isError={true} />
+      <EmptyGraphLayoutContainer isError={true} />
     </div>
   );
 };
@@ -69,7 +69,7 @@ const ServiceGraphErrorBoundaryFallback = () => {
 export default class ServiceGraphPage extends React.PureComponent<ServiceGraphPageProps> {
   private pollTimeoutRef?: number;
   private pollPromise?;
-  private errorBoundaryRef: any;
+  private readonly errorBoundaryRef: any;
   constructor(props: ServiceGraphPageProps) {
     super(props);
     this.errorBoundaryRef = React.createRef();
@@ -163,7 +163,6 @@ export default class ServiceGraphPage extends React.PureComponent<ServiceGraphPa
     );
   }
 
-  /** Fetch graph data */
   private loadGraphDataFromBackend = () => {
     return this.props.fetchGraphData(this.props.namespace, this.props.graphDuration, this.props.graphType);
   };
@@ -211,7 +210,9 @@ export default class ServiceGraphPage extends React.PureComponent<ServiceGraphPa
     }
   }
 
-  private notifyError = (error: Error, componentStack: string) => {
-    MessageCenterUtils.add('There was an error when rendering the graph, please try a different layout');
+  private notifyError = (error: Error, _componentStack: string) => {
+    MessageCenterUtils.add(
+      `There was an error when rendering the graph: ${error.message}, please try a different layout`
+    );
   };
 }

--- a/src/reducers/ServiceGraphDataState.ts
+++ b/src/reducers/ServiceGraphDataState.ts
@@ -2,13 +2,25 @@ import { ServiceGraphState } from '../store/Store';
 import { ServiceGraphDataActionKeys } from '../actions/ServiceGraphDataActionKeys';
 import { ServiceGraphActionKeys } from '../actions/ServiceGraphActions';
 import FilterStateReducer from './ServiceGraphFilterState';
+import { MILLISECONDS } from '../types/Common';
 
-const INITIAL_STATE: any = {
+const INITIAL_STATE: ServiceGraphState = {
   isLoading: false,
+  isError: false,
+  error: undefined,
   graphDataTimestamp: 0,
   graphData: {},
   sidePanelInfo: null,
-  hideLegend: true
+  hideLegend: true,
+  filterState: {
+    showLegend: false,
+    showNodeLabels: true,
+    showCircuitBreakers: true,
+    showVirtualServices: true,
+    showMissingSidecars: true,
+    showTrafficAnimation: false,
+    refreshRate: 15 * MILLISECONDS
+  }
 };
 
 // This Reducer allows changes to the 'serviceGraphDataState' portion of Redux Store
@@ -36,10 +48,9 @@ const serviceGraphDataState = (state: ServiceGraphState = INITIAL_STATE, action)
       newState.graphData = action.graphData;
       break;
     case ServiceGraphDataActionKeys.GET_GRAPH_DATA_FAILURE:
-      console.warn('ServiceGraphDataState reducer: failed to get graph data');
       newState.isLoading = false;
       newState.isError = true;
-      // newState.error = action.error; // Already handled in the action.
+      newState.error = action.error;
       break;
     case ServiceGraphActionKeys.SERVICE_GRAPH_SIDE_PANEL_SHOW_INFO:
       newState.sidePanelInfo = {

--- a/src/reducers/__tests__/ServiceGraphDataState.test.ts
+++ b/src/reducers/__tests__/ServiceGraphDataState.test.ts
@@ -8,6 +8,8 @@ describe('ServiceGraphDataState', () => {
     expect(serviceGraphDataState(undefined, {})).toEqual({
       filterState: serviceGraphFilterState(undefined, {}),
       isLoading: false,
+      isError: false,
+      error: undefined,
       graphDataTimestamp: 0,
       hideLegend: true,
       graphData: {},
@@ -27,6 +29,9 @@ describe('ServiceGraphDataState', () => {
     const action = ServiceGraphDataActions.getGraphDataSuccess(100, []);
     const updatedState = serviceGraphDataState(undefined, action);
 
+    expect(updatedState.isLoading).toBeFalsy();
+    expect(updatedState.isError).toBeFalsy();
+    expect(updatedState.error).toBeUndefined();
     expect(updatedState).toMatchObject({ isLoading: false, graphDataTimestamp: 100, graphData: [] });
   });
 
@@ -35,6 +40,8 @@ describe('ServiceGraphDataState', () => {
     const updatedState = serviceGraphDataState(undefined, action);
 
     expect(updatedState.isLoading).toBeFalsy();
+    expect(updatedState.isError).toBeTruthy();
+    expect(updatedState.error).toBeDefined();
   });
 
   it('should handle SERVICE_GRAPH_SIDE_PANEL_SHOW_INFO', () => {

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -30,6 +30,7 @@ export interface MessageCenterState {
 export interface ServiceGraphState {
   isLoading: boolean;
   isError: boolean;
+  error?: string; // the error message to show from loading service graph
   graphDataTimestamp: number;
   graphData: any;
   filterState: ServiceGraphFilterState;


### PR DESCRIPTION
** Describe the change **
Adds the error icon and error message to the service graph page when an error occurs.


** Issue reference **
Jira: https://issues.jboss.org/browse/KIALI-1198


** Backwards in compatible? **
Compatible yes

** Screenshot **
Before:
![before](https://user-images.githubusercontent.com/1312165/44608182-bd2cb180-a7a7-11e8-842d-f64f835ecaa1.png)

After:
![error-msg](https://user-images.githubusercontent.com/1312165/44608626-38429780-a7a9-11e8-823e-b787d12f735e.png)
