### PR TITLE
KIALI-1425 Add control to change reporter in the metrics detail pages

### DIFF
--- a/src/components/Metrics/__tests__/__snapshots__/Metrics.test.tsx.snap
+++ b/src/components/Metrics/__tests__/__snapshots__/Metrics.test.tsx.snap
@@ -27,9 +27,11 @@ ShallowWrapper {
         null,
         undefined,
         <MetricsOptionsBar
+          metricReporter="destination"
           onManualRefresh={[Function]}
           onOptionsChanged={[Function]}
           onPollIntervalChanged={[Function]}
+          onReporterChanged={[Function]}
         />,
         <div
           className="card-pf"
@@ -61,9 +63,11 @@ ShallowWrapper {
         "key": undefined,
         "nodeType": "class",
         "props": Object {
+          "metricReporter": "destination",
           "onManualRefresh": [Function],
           "onOptionsChanged": [Function],
           "onPollIntervalChanged": [Function],
+          "onReporterChanged": [Function],
         },
         "ref": null,
         "rendered": null,
@@ -190,9 +194,11 @@ ShallowWrapper {
           null,
           undefined,
           <MetricsOptionsBar
+            metricReporter="destination"
             onManualRefresh={[Function]}
             onOptionsChanged={[Function]}
             onPollIntervalChanged={[Function]}
+            onReporterChanged={[Function]}
           />,
           <div
             className="card-pf"
@@ -224,9 +230,11 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "class",
           "props": Object {
+            "metricReporter": "destination",
             "onManualRefresh": [Function],
             "onOptionsChanged": [Function],
             "onPollIntervalChanged": [Function],
+            "onReporterChanged": [Function],
           },
           "ref": null,
           "rendered": null,
@@ -381,9 +389,11 @@ ShallowWrapper {
         null,
         undefined,
         <MetricsOptionsBar
+          metricReporter="destination"
           onManualRefresh={[Function]}
           onOptionsChanged={[Function]}
           onPollIntervalChanged={[Function]}
+          onReporterChanged={[Function]}
         />,
         <div
           className="card-pf"
@@ -415,9 +425,11 @@ ShallowWrapper {
         "key": undefined,
         "nodeType": "class",
         "props": Object {
+          "metricReporter": "destination",
           "onManualRefresh": [Function],
           "onOptionsChanged": [Function],
           "onPollIntervalChanged": [Function],
+          "onReporterChanged": [Function],
         },
         "ref": null,
         "rendered": null,
@@ -544,9 +556,11 @@ ShallowWrapper {
           null,
           undefined,
           <MetricsOptionsBar
+            metricReporter="destination"
             onManualRefresh={[Function]}
             onOptionsChanged={[Function]}
             onPollIntervalChanged={[Function]}
+            onReporterChanged={[Function]}
           />,
           <div
             className="card-pf"
@@ -578,9 +592,11 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "class",
           "props": Object {
+            "metricReporter": "destination",
             "onManualRefresh": [Function],
             "onOptionsChanged": [Function],
             "onPollIntervalChanged": [Function],
+            "onReporterChanged": [Function],
           },
           "ref": null,
           "rendered": null,
@@ -735,9 +751,11 @@ ShallowWrapper {
         null,
         undefined,
         <MetricsOptionsBar
+          metricReporter="source"
           onManualRefresh={[Function]}
           onOptionsChanged={[Function]}
           onPollIntervalChanged={[Function]}
+          onReporterChanged={[Function]}
         />,
         <div
           className="card-pf"
@@ -769,9 +787,11 @@ ShallowWrapper {
         "key": undefined,
         "nodeType": "class",
         "props": Object {
+          "metricReporter": "source",
           "onManualRefresh": [Function],
           "onOptionsChanged": [Function],
           "onPollIntervalChanged": [Function],
+          "onReporterChanged": [Function],
         },
         "ref": null,
         "rendered": null,
@@ -898,9 +918,11 @@ ShallowWrapper {
           null,
           undefined,
           <MetricsOptionsBar
+            metricReporter="source"
             onManualRefresh={[Function]}
             onOptionsChanged={[Function]}
             onPollIntervalChanged={[Function]}
+            onReporterChanged={[Function]}
           />,
           <div
             className="card-pf"
@@ -932,9 +954,11 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "class",
           "props": Object {
+            "metricReporter": "source",
             "onManualRefresh": [Function],
             "onOptionsChanged": [Function],
             "onPollIntervalChanged": [Function],
+            "onReporterChanged": [Function],
           },
           "ref": null,
           "rendered": null,

--- a/src/components/MetricsOptions/MetricsOptionsBar.tsx
+++ b/src/components/MetricsOptions/MetricsOptionsBar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, Icon, Toolbar, ToolbarRightContent } from 'patternfly-react';
+import { Button, Icon, Toolbar, ToolbarRightContent, FormGroup } from 'patternfly-react';
 import { config } from '../../config';
 import ValueSelectHelper from './ValueSelectHelper';
 import MetricsOptions from '../../types/MetricsOptions';
@@ -8,7 +8,9 @@ import { ToolbarDropdown } from '../ToolbarDropdown/ToolbarDropdown';
 interface Props {
   onOptionsChanged: (opts: MetricsOptions) => void;
   onPollIntervalChanged: (interval: number) => void;
+  onReporterChanged: (reporter: string) => void;
   onManualRefresh: () => void;
+  metricReporter: string;
 }
 
 interface MetricsOptionsState {
@@ -46,6 +48,11 @@ export class MetricsOptionsBar extends React.Component<Props, MetricsOptionsStat
       labelIn: 'response_code',
       labelOut: 'response_code'
     }
+  };
+
+  static ReporterOptions: { [key: string]: string } = {
+    destination: 'Destination',
+    source: 'Source'
   };
 
   groupByLabelsHelper: ValueSelectHelper;
@@ -109,6 +116,17 @@ export class MetricsOptionsBar extends React.Component<Props, MetricsOptionsStat
     return (
       <Toolbar>
         {this.groupByLabelsHelper.renderDropdown()}
+        <FormGroup>
+          <ToolbarDropdown
+            id={'metrics_filter_reporter'}
+            disabled={false}
+            handleSelect={this.props.onReporterChanged}
+            nameDropdown={'Reported from'}
+            value={this.props.metricReporter}
+            initialLabel={MetricsOptionsBar.ReporterOptions[this.props.metricReporter]}
+            options={MetricsOptionsBar.ReporterOptions}
+          />
+        </FormGroup>
         <ToolbarDropdown
           id={'metrics_filter_interval_duration'}
           disabled={false}
@@ -131,7 +149,6 @@ export class MetricsOptionsBar extends React.Component<Props, MetricsOptionsStat
           initialLabel={String(MetricsOptionsBar.PollIntervals[MetricsOptionsBar.DefaultPollInterval])}
           options={MetricsOptionsBar.PollIntervals}
         />
-
         <ToolbarRightContent>
           <Button onClick={this.props.onManualRefresh}>
             <Icon name="refresh" />

--- a/src/components/MetricsOptions/__tests__/MetricsOptionsBar.test.tsx
+++ b/src/components/MetricsOptions/__tests__/MetricsOptionsBar.test.tsx
@@ -11,7 +11,13 @@ const lastOptionsChanged = () => {
 describe('MetricsOptionsBar', () => {
   it('renders initial layout', () => {
     const wrapper = shallow(
-      <MetricsOptionsBar onOptionsChanged={jest.fn()} onPollIntervalChanged={jest.fn()} onManualRefresh={jest.fn()} />
+      <MetricsOptionsBar
+        onOptionsChanged={jest.fn()}
+        onPollIntervalChanged={jest.fn()}
+        onManualRefresh={jest.fn()}
+        onReporterChanged={jest.fn()}
+        metricReporter={'destination'}
+      />
     );
     expect(wrapper).toMatchSnapshot();
   });
@@ -22,6 +28,8 @@ describe('MetricsOptionsBar', () => {
         onOptionsChanged={optionsChanged}
         onPollIntervalChanged={jest.fn()}
         onManualRefresh={jest.fn()}
+        onReporterChanged={jest.fn()}
+        metricReporter={'destination'}
       />
     );
     expect(optionsChanged).toHaveBeenCalledTimes(1);

--- a/src/components/MetricsOptions/__tests__/__snapshots__/MetricsOptionsBar.test.tsx.snap
+++ b/src/components/MetricsOptions/__tests__/__snapshots__/MetricsOptionsBar.test.tsx.snap
@@ -5,6 +5,7 @@ ShallowWrapper {
   "length": 1,
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <MetricsOptionsBar
+    metricReporter="destination"
     onManualRefresh={[MockFunction]}
     onOptionsChanged={
       [MockFunction] {
@@ -28,6 +29,7 @@ ShallowWrapper {
         ],
       }
     }
+    onReporterChanged={[MockFunction]}
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -59,6 +61,24 @@ ShallowWrapper {
             placeholder="Group by"
           />
         </getContext(Filter)>,
+        <FormGroup
+          bsClass="form-group"
+        >
+          <ToolbarDropdown
+            disabled={false}
+            handleSelect={[MockFunction]}
+            id="metrics_filter_reporter"
+            initialLabel="Destination"
+            nameDropdown="Reported from"
+            options={
+              Object {
+                "destination": "Destination",
+                "source": "Source",
+              }
+            }
+            value="destination"
+          />
+        </FormGroup>,
         <ToolbarDropdown
           disabled={false}
           handleSelect={[Function]}
@@ -161,6 +181,50 @@ ShallowWrapper {
             "id": "",
             "onFilterValueSelected": [Function],
             "placeholder": "Group by",
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        "type": [Function],
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "bsClass": "form-group",
+          "children": <ToolbarDropdown
+            disabled={false}
+            handleSelect={[MockFunction]}
+            id="metrics_filter_reporter"
+            initialLabel="Destination"
+            nameDropdown="Reported from"
+            options={
+              Object {
+                "destination": "Destination",
+                "source": "Source",
+              }
+            }
+            value="destination"
+          />,
+        },
+        "ref": null,
+        "rendered": Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "disabled": false,
+            "handleSelect": [MockFunction],
+            "id": "metrics_filter_reporter",
+            "initialLabel": "Destination",
+            "nameDropdown": "Reported from",
+            "options": Object {
+              "destination": "Destination",
+              "source": "Source",
+            },
+            "value": "destination",
           },
           "ref": null,
           "rendered": null,
@@ -304,6 +368,24 @@ ShallowWrapper {
               placeholder="Group by"
             />
           </getContext(Filter)>,
+          <FormGroup
+            bsClass="form-group"
+          >
+            <ToolbarDropdown
+              disabled={false}
+              handleSelect={[MockFunction]}
+              id="metrics_filter_reporter"
+              initialLabel="Destination"
+              nameDropdown="Reported from"
+              options={
+                Object {
+                  "destination": "Destination",
+                  "source": "Source",
+                }
+              }
+              value="destination"
+            />
+          </FormGroup>,
           <ToolbarDropdown
             disabled={false}
             handleSelect={[Function]}
@@ -406,6 +488,50 @@ ShallowWrapper {
               "id": "",
               "onFilterValueSelected": [Function],
               "placeholder": "Group by",
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
+          "type": [Function],
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "bsClass": "form-group",
+            "children": <ToolbarDropdown
+              disabled={false}
+              handleSelect={[MockFunction]}
+              id="metrics_filter_reporter"
+              initialLabel="Destination"
+              nameDropdown="Reported from"
+              options={
+                Object {
+                  "destination": "Destination",
+                  "source": "Source",
+                }
+              }
+              value="destination"
+            />,
+          },
+          "ref": null,
+          "rendered": Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "disabled": false,
+              "handleSelect": [MockFunction],
+              "id": "metrics_filter_reporter",
+              "initialLabel": "Destination",
+              "nameDropdown": "Reported from",
+              "options": Object {
+                "destination": "Destination",
+                "source": "Source",
+              },
+              "value": "destination",
             },
             "ref": null,
             "rendered": null,


### PR DESCRIPTION
Showing metrics only for one reporter leads to some gaps in the available data. In order to fill the gaps, a dropdown is added to the metrics page to let the user choose the reporting entity to view the available metrics.

Related to KIALI-1421 KIALI-1422 which are about an issue with an inconsistency in the metrics being shown. This is not really an inconsistency, but a difference in the metrics, depending on the point of view of the reporter. The reporter could be the workload generating the traffic (source) or the workload receiving the traffic (destination).

_By default, inbound metrics are reporter="destination" and outbound are reporter="source"_

![image](https://user-images.githubusercontent.com/23639005/44692899-b2ce1a00-aa2a-11e8-9363-c211e58d649d.png)
