### PR TITLE
KIALI-1351 Breadcrumb leads to virtual service list from virtual service

### DIFF
--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -169,6 +169,7 @@ class ServiceDetails extends React.Component<RouteComponentProps<ServiceId>, Ser
     const urlParams = new URLSearchParams(this.props.location.search);
     const parsedSearchTypeHuman = parsedSearch.type === 'virtualservice' ? 'Virtual Service' : 'Destination Rule';
     const to = this.servicePageURL();
+    const toDetailsTab = to + '?list=' + parsedSearch.type + 's';
     const toDetails = to + '?' + parsedSearch.type + '=' + parsedSearch.name;
     return (
       <Breadcrumb title={true}>
@@ -192,7 +193,7 @@ class ServiceDetails extends React.Component<RouteComponentProps<ServiceId>, Ser
         ) : (
           <>
             <Breadcrumb.Item componentClass={'span'}>
-              <Link to={to}>Service Info</Link>
+              <Link to={toDetailsTab}>Service Info</Link>
             </Breadcrumb.Item>
             <Breadcrumb.Item componentClass={'span'}>
               <Link to={toDetails}>


### PR DESCRIPTION
** Describe the change **

When visiting virtual service detail page:
1. `Service Info` leads to Service Details page, but listing Virtual Services.
2. `Service: service name` leads to Service Details page, listing default list

Please, reviewers, have in mind that we have an ongoing discussion about breadcrumbs: https://github.com/kiali/kiali-design/issues/9

** Issue reference **
https://issues.jboss.org/browse/KIALI-1351

** Backwards in compatible? **
yes.

** Screenshot **
![screen recording 2](https://user-images.githubusercontent.com/613814/44712598-77c2f980-aab1-11e8-83e8-7e3cd9c1696d.gif)
