### PR TITLE
KIALI-1145 Add VirtualService TLS routes to details page

### DIFF
--- a/src/pages/ServiceDetails/ServiceInfo/IstioObjectDetails/VirtualServiceDetail.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/IstioObjectDetails/VirtualServiceDetail.tsx
@@ -123,6 +123,18 @@ class VirtualServiceDetail extends React.Component<VirtualServiceProps> {
           ) : (
             undefined
           )}
+          {virtualService.tls && virtualService.tls.length > 0 ? (
+            <>
+              <VirtualServiceRoute
+                name={virtualService.name}
+                kind="TLS"
+                routes={virtualService.tls}
+                validations={this.props.validations}
+              />
+            </>
+          ) : (
+            undefined
+          )}
         </Col>
       </Row>
     );

--- a/src/types/ServiceInfo.ts
+++ b/src/types/ServiceInfo.ts
@@ -63,6 +63,14 @@ export interface L4MatchAttributes {
   destinationSubnet: string[];
 }
 
+export interface TLSMatchAttributes {
+  sniHosts: string[];
+  destinationSubnet: string[];
+  port: number;
+  sourceLabels: { [key: string]: string };
+  gateways: string[];
+}
+
 export interface MatchRequest {
   headers: { [key: string]: StringMatch };
 }
@@ -237,6 +245,11 @@ export interface TCPRoute {
   route?: DestinationWeight[];
 }
 
+export interface TLSRoute {
+  match?: TLSMatchAttributes[];
+  route?: DestinationWeight[];
+}
+
 export interface VirtualService {
   name: string;
   createdAt: string;
@@ -245,6 +258,7 @@ export interface VirtualService {
   gateways?: string[];
   http?: HTTPRoute[];
   tcp?: TCPRoute[];
+  tls?: TLSRoute[];
 }
 
 // Destination Rule


### PR DESCRIPTION
** Describe the change **

n Istio 1.0 VirtualServices have a new type of routes called tls. This PR adds those routes to the Virtual Service details page. Including the existent validations.

This PR needs https://github.com/kiali/kiali/pull/467 to be fully working.

** Issue reference **
https://issues.jboss.org/browse/KIALI-1145

** Backwards in compatible? **
yes.

** Screenshot **
![screenshot of kiali console 3](https://user-images.githubusercontent.com/613814/44737398-31da5580-aaf2-11e8-8944-720ca4170469.png)
