### PR TITLE
KIALI-1433 Fix edge font-size

### DIFF
--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -10,9 +10,11 @@ const EdgeColor = PfColors.Green400;
 const EdgeColorDead = PfColors.Black500;
 const EdgeColorDegraded = PfColors.Orange;
 const EdgeColorFailure = PfColors.Red;
+const EdgeFont = 'Verdana,Arial,Helvetica,sans-serif';
+const EdgeFontSize = '6px';
+const EdgeTextMargin = '6px';
 const EdgeWidth = 1;
 const EdgeWidthSelected = 3;
-const EdgeText = '6px';
 const NodeColorBorder = PfColors.Black400;
 const NodeColorBorderDegraded = PfColors.Orange;
 const NodeColorBorderFailure = PfColors.Red;
@@ -23,9 +25,10 @@ const NodeColorFillBox = PfColors.Black100;
 const NodeColorFillHover = PfColors.Blue50;
 const NodeColorFillHoverDegraded = '#fdf2e5';
 const NodeColorFillHoverFailure = '#ffe6e6';
+const NodeFont = EdgeFont;
+const NodeFontSize = '8px';
 const NodeWidth = '1px';
 const NodeWidthSelected = '3px';
-const NodeText = '8px';
 
 export class GraphStyles {
   static options() {
@@ -138,7 +141,8 @@ export class GraphStyles {
             return ele.data('isUnused') ? 'dotted' : 'solid';
           },
           'border-width': NodeWidth,
-          'font-size': NodeText,
+          'font-family': NodeFont,
+          'font-size': NodeFontSize,
           'overlay-padding': '6px',
           'text-halign': 'center',
           'text-valign': 'center',
@@ -229,12 +233,9 @@ export class GraphStyles {
           },
           'curve-style': 'bezier',
           'font-family': (ele: any) => {
-            return getTLSValue(ele, 'PatternFlyIcons-webfont', 'inherit');
+            return getTLSValue(ele, 'PatternFlyIcons-webfont', EdgeFont);
           },
-          'text-rotation': (ele: any) => {
-            return getTLSValue(ele, '0deg', 'autorotate');
-          },
-          'font-size': EdgeText,
+          'font-size': EdgeFontSize,
           'line-color': (ele: any) => {
             return getEdgeColor(ele);
           },
@@ -245,7 +246,10 @@ export class GraphStyles {
           'target-arrow-color': (ele: any) => {
             return getEdgeColor(ele);
           },
-          'text-margin-x': '4px',
+          'text-margin-x': EdgeTextMargin,
+          'text-rotation': (ele: any) => {
+            return getTLSValue(ele, '0deg', 'autorotate');
+          },
           width: EdgeWidth
         }
       },


### PR DESCRIPTION
- also, formalize font for node and edge text

@cshinn , @xeviknal ,  This change fixes a regression such that the font-size of edge labels was getting ignored.  The fix involved setting a specific font-family.  The thing is, I can't find any document from UX that specifies a recommended font-family or font-size for node or label text.  So the chosen values are up for review.  See the screenshot below for the values I'm currently using, which are:

font (both node and edge):  Verdana, Arial, Helvetica, sans-serif  // see note
node font-size: 8px
edge font-size: 6px

Note that the font is a list, in order of preference, depending on what is available.  I just chose a common grouping of sans-serif fonts.

![screenshot](https://user-images.githubusercontent.com/2104052/44740227-e57a2000-aac7-11e8-898c-937db76acf2a.jpg)
