### PR TITLE
KIALI-1403 Add error handling to the side panels when loading sparklines

### DIFF
--- a/src/pages/ServiceGraph/ServiceGraphPage.tsx
+++ b/src/pages/ServiceGraph/ServiceGraphPage.tsx
@@ -14,6 +14,7 @@ import GraphFilterToolbar from '../../components/GraphFilter/GraphFilterToolbar'
 import { computePrometheusQueryInterval } from '../../services/Prometheus';
 import { style } from 'typestyle';
 
+import { CancelablePromise, makeCancelablePromise } from '../../utils/Common';
 import * as MessageCenterUtils from '../../utils/MessageCenter';
 
 import GraphLegend from '../../components/GraphFilter/GraphLegend';
@@ -40,24 +41,6 @@ const containerStyle = style({
 
 const cytoscapeGraphContainerStyle = style({ flex: '1', minWidth: '350px', zIndex: 0, paddingRight: '5px' });
 
-const makeCancelablePromise = (promise: Promise<any>) => {
-  let hasCanceled = false;
-
-  const wrappedPromise = new Promise((resolve, reject) => {
-    promise.then(
-      val => (hasCanceled ? reject({ isCanceled: true }) : resolve(val)),
-      error => (hasCanceled ? reject({ isCanceled: true }) : reject(error))
-    );
-  });
-
-  return {
-    promise: wrappedPromise,
-    cancel() {
-      hasCanceled = true;
-    }
-  };
-};
-
 const ServiceGraphErrorBoundaryFallback = () => {
   return (
     <div className={cytoscapeGraphContainerStyle}>
@@ -68,7 +51,7 @@ const ServiceGraphErrorBoundaryFallback = () => {
 
 export default class ServiceGraphPage extends React.PureComponent<ServiceGraphPageProps> {
   private pollTimeoutRef?: number;
-  private pollPromise?;
+  private pollPromise?: CancelablePromise<any>;
   private readonly errorBoundaryRef: any;
   constructor(props: ServiceGraphPageProps) {
     super(props);

--- a/src/pages/ServiceGraph/SummaryPanelCommon.tsx
+++ b/src/pages/ServiceGraph/SummaryPanelCommon.tsx
@@ -8,6 +8,7 @@ import { authentication } from '../../utils/Authentication';
 import * as M from '../../types/Metrics';
 import graphUtils from '../../utils/Graphing';
 import { Metric } from '../../types/Metrics';
+import { Response } from '../../services/Api';
 
 export interface NodeData {
   namespace: string;
@@ -130,7 +131,7 @@ export const getNodeMetrics = (
   filters: Array<string>,
   byLabelsIn?: Array<string>,
   byLabelsOut?: Array<string>
-) => {
+): Promise<Response<M.Metrics>> => {
   const data = nodeData(node);
   const options: MetricsOptions = {
     queryTime: props.queryTime,

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -14,7 +14,7 @@ import { ServiceList } from '../types/ServiceListComponent';
 import { AppList } from '../types/AppList';
 import { App } from '../types/App';
 
-interface Response<T> {
+export interface Response<T> {
   data: T;
 }
 

--- a/src/utils/Common.ts
+++ b/src/utils/Common.ts
@@ -1,1 +1,24 @@
+export interface CancelablePromise<T> {
+  promise: Promise<T>;
+  cancel(): void;
+}
+
 export const removeDuplicatesArray = a => [...Array.from(new Set(a))] as string[];
+
+export const makeCancelablePromise = <T>(promise: Promise<T>): CancelablePromise<T> => {
+  let hasCanceled = false;
+
+  const wrappedPromise = new Promise<T>((resolve, reject) => {
+    promise.then(
+      val => (hasCanceled ? reject({ isCanceled: true }) : resolve(val)),
+      error => (hasCanceled ? reject({ isCanceled: true }) : reject(error))
+    );
+  });
+
+  return {
+    promise: wrappedPromise,
+    cancel() {
+      hasCanceled = true;
+    }
+  };
+};


### PR DESCRIPTION
Now, a warning is shown in the side panel if data cannot be loaded.

![peek 2018-08-28 17-05](https://user-images.githubusercontent.com/23639005/44753775-e53c4d80-aae4-11e8-8b50-70fbe1ab7620.gif)
