### PR TITLE
KIALI-1416 AppDetails and WorkloadDetails pages count just one item in history

### DIFF
--- a/src/pages/AppDetails/AppDetailsPage.tsx
+++ b/src/pages/AppDetails/AppDetailsPage.tsx
@@ -127,7 +127,7 @@ class AppDetails extends React.Component<RouteComponentProps<AppId>, AppDetailsS
                   health={this.state.health}
                 />
               </TabPane>
-              <TabPane eventKey="in_metrics">
+              <TabPane eventKey="in_metrics" mountOnEnter={true} unmountOnExit={true}>
                 <AppMetricsContainer
                   namespace={this.props.match.params.namespace}
                   object={this.props.match.params.app}
@@ -135,7 +135,7 @@ class AppDetails extends React.Component<RouteComponentProps<AppId>, AppDetailsS
                   metricsType={'inbound'}
                 />
               </TabPane>
-              <TabPane eventKey="out_metrics">
+              <TabPane eventKey="out_metrics" mountOnEnter={true} unmountOnExit={true}>
                 <AppMetricsContainer
                   namespace={this.props.match.params.namespace}
                   object={this.props.match.params.app}

--- a/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -168,7 +168,7 @@ class WorkloadDetails extends React.Component<RouteComponentProps<WorkloadId>, W
                   health={this.state.health}
                 />
               </TabPane>
-              <TabPane eventKey="in_metrics">
+              <TabPane eventKey="in_metrics" mountOnEnter={true} unmountOnExit={true}>
                 <WorkloadMetricsContainer
                   namespace={this.props.match.params.namespace}
                   object={this.props.match.params.workload}
@@ -176,7 +176,7 @@ class WorkloadDetails extends React.Component<RouteComponentProps<WorkloadId>, W
                   metricsType={'inbound'}
                 />
               </TabPane>
-              <TabPane eventKey="out_metrics">
+              <TabPane eventKey="out_metrics" mountOnEnter={true} unmountOnExit={true}>
                 <WorkloadMetricsContainer
                   namespace={this.props.match.params.namespace}
                   object={this.props.match.params.workload}


### PR DESCRIPTION
** Describe the change **

When user got into workload/app details page, the console appended 3 times the visit into browser's history.
The problem was that the metrics tab reloaded 2 extra times the metrics container.

** Issue reference **
https://issues.jboss.org/browse/KIALI-1416

** Backwards in compatible? **
yes.

[NO] Is your pull-request introducing changes in behaviour?

** Screenshot **
In the following screenshot, you will see that is possible to navigate backwards from app details page to app list with just one click. Same for workload list/details page.

![screen recording 3](https://user-images.githubusercontent.com/613814/44795556-43336880-abab-11e8-81ff-ea1116e1292c.gif)

