### PR TITLE
KIALI-1156 Fix behavior of message center; add system errors panel

### DIFF
--- a/src/actions/HelpDropdownActions.ts
+++ b/src/actions/HelpDropdownActions.ts
@@ -30,7 +30,7 @@ export const HelpDropdownActions = {
             )
           );
           status['data']['warningMessages'].forEach(wMsg => {
-            dispatch(MessageCenterActions.addMessage(wMsg, 'default', MessageType.WARNING));
+            dispatch(MessageCenterActions.addMessage(wMsg, 'systemErrors', MessageType.WARNING));
           });
         },
         error => {

--- a/src/actions/LoginActions.ts
+++ b/src/actions/LoginActions.ts
@@ -76,6 +76,7 @@ export const LoginActions = {
                   actualState['authentication']['username']
                 )
               );
+              dispatch(HelpDropdownActions.refresh());
             },
             error => {
               /** Logout user */

--- a/src/actions/MessageCenterActions.ts
+++ b/src/actions/MessageCenterActions.ts
@@ -12,7 +12,8 @@ export const enum MessageCenterActionKeys {
   HIDE = 'HIDE',
   TOGGLE_EXPAND = 'TOGGLE_EXPAND',
   TOGGLE_GROUP = 'TOGGLE_GROUP',
-  HIDE_NOTIFICATION = 'HIDE_NOTIFICATION'
+  HIDE_NOTIFICATION = 'HIDE_NOTIFICATION',
+  EXPAND_GROUP = 'EXPAND_GROUP'
 }
 
 type numberOrNumberArray = number | number[];
@@ -52,6 +53,13 @@ export const MessageCenterActions = {
       groupId
     };
   }),
+  expandGroup: createAction(MessageCenterActionKeys.EXPAND_GROUP, (groupId: string) => {
+    const type = MessageCenterActionKeys.EXPAND_GROUP;
+    return {
+      type,
+      groupId
+    };
+  }),
   hideNotification: createAction(MessageCenterActionKeys.HIDE_NOTIFICATION, (messageId: numberOrNumberArray) => {
     const type = MessageCenterActionKeys.HIDE_NOTIFICATION;
     messageId = toNumberArray(messageId);
@@ -70,6 +78,19 @@ export const MessageCenterActions = {
       const state = getState();
       if (state.messageCenter.hidden) {
         dispatch(MessageCenterActions.showMessageCenter());
+        dispatch(MessageCenterActions.expandGroup('default'));
+      } else {
+        dispatch(MessageCenterActions.hideMessageCenter());
+      }
+      return Promise.resolve();
+    };
+  },
+  toggleSystemErrorsCenter: () => {
+    return (dispatch, getState) => {
+      const state = getState();
+      if (state.messageCenter.hidden) {
+        dispatch(MessageCenterActions.showMessageCenter());
+        dispatch(MessageCenterActions.expandGroup('systemErrors'));
       } else {
         dispatch(MessageCenterActions.hideMessageCenter());
       }

--- a/src/actions/__tests__/MessageCenterAction.test.ts
+++ b/src/actions/__tests__/MessageCenterAction.test.ts
@@ -90,6 +90,10 @@ describe('MessageCenterActions', () => {
     const expectedActions = [
       {
         type: MessageCenterActionKeys.SHOW
+      },
+      {
+        groupId: 'default',
+        type: 'EXPAND_GROUP'
       }
     ];
     const store = mockStore({ messageCenter: { hidden: true } });

--- a/src/components/MessageCenter/MessageCenterTrigger.tsx
+++ b/src/components/MessageCenter/MessageCenterTrigger.tsx
@@ -1,31 +1,55 @@
 import * as React from 'react';
 import * as PfReact from 'patternfly-react';
 
-type StateType = {};
 type PropsType = {
   newMessagesCount: number;
+  systemErrorsCount: number;
   badgeDanger: boolean;
   toggleMessageCenter: () => void;
+  toggleSystemErrorsCenter: () => void;
 };
 
-export default class MessageCenterTrigger extends React.PureComponent<PropsType, StateType> {
+export default class MessageCenterTrigger extends React.PureComponent<PropsType, {}> {
   render() {
-    let icon;
-    if (this.props.newMessagesCount > 0) {
-      icon = (
-        <div>
-          <PfReact.Icon name="warning-triangle-o" type="pf" /> {this.props.newMessagesCount} open issues
-        </div>
-      );
-    } else {
-      icon = <PfReact.Icon name="bell" />;
+    return (
+      <>
+        {this.renderSystemErrorBadge()}
+        {this.renderMessageCenterBadge()}
+      </>
+    );
+  }
+
+  private renderSystemErrorBadge = () => {
+    if (this.props.systemErrorsCount === 0) {
+      return;
     }
+
     return (
       <li className="drawer-pf-trigger">
-        <a className="nav-item-iconic" onClick={this.props.toggleMessageCenter}>
-          {icon}
+        <a className="nav-item-iconic" onClick={this.props.toggleSystemErrorsCenter}>
+          <PfReact.Icon name="warning-triangle-o" type="pf" /> {this.props.systemErrorsCount}
+          {this.props.systemErrorsCount === 1 ? ' Open Issue' : ' Open Issues'}
         </a>
       </li>
     );
-  }
+  };
+
+  private renderMessageCenterBadge = () => {
+    return (
+      <li className="drawer-pf-trigger">
+        <a className="nav-item-iconic" onClick={this.props.toggleMessageCenter}>
+          <PfReact.Icon name="bell" />
+          {(this.props.systemErrorsCount > 0 || this.props.newMessagesCount > 0) && (
+            <PfReact.Badge
+              className={
+                'pf-badge-bodered' + (this.props.badgeDanger || this.props.systemErrorsCount > 0 ? ' badge-danger' : '')
+              }
+            >
+              {this.props.newMessagesCount > 0 ? this.props.newMessagesCount : ' '}
+            </PfReact.Badge>
+          )}
+        </a>
+      </li>
+    );
+  };
 }

--- a/src/components/MessageCenter/NotificationDrawer.tsx
+++ b/src/components/MessageCenter/NotificationDrawer.tsx
@@ -88,6 +88,11 @@ class NotificationGroupWrapper extends React.PureComponent<NotificationGroupWrap
   render() {
     const group = this.props.group;
     const isExpanded = this.props.isExpanded;
+
+    if (group.hideIfEmpty && group.messages.length === 0) {
+      return null;
+    }
+
     return (
       <PfNotificationDrawer.Panel expanded={isExpanded}>
         <PfNotificationDrawer.PanelHeading onClick={() => this.props.onToggle(group)}>
@@ -106,21 +111,22 @@ class NotificationGroupWrapper extends React.PureComponent<NotificationGroupWrap
                 <NotificationWrapper key={message.id} message={message} onClick={this.props.onNotificationClick} />
               ))}
             </PfNotificationDrawer.PanelBody>
-            {group.messages.length > 0 && (
-              <PfNotificationDrawer.PanelAction>
-                <PfNotificationDrawer.PanelActionLink className="drawer-pf-action-link">
-                  <Button bsStyle="link" onClick={() => this.props.onMarkGroupAsRead(group)}>
-                    Mark All Read
-                  </Button>
-                </PfNotificationDrawer.PanelActionLink>
-                <PfNotificationDrawer.PanelActionLink data-toggle="clear-all">
-                  <Button bsStyle="link" onClick={() => this.props.onClearGroup(group)}>
-                    <Icon type="pf" name="close" />
-                    Clear All
-                  </Button>
-                </PfNotificationDrawer.PanelActionLink>
-              </PfNotificationDrawer.PanelAction>
-            )}
+            {group.showActions &&
+              group.messages.length > 0 && (
+                <PfNotificationDrawer.PanelAction>
+                  <PfNotificationDrawer.PanelActionLink className="drawer-pf-action-link">
+                    <Button bsStyle="link" onClick={() => this.props.onMarkGroupAsRead(group)}>
+                      Mark All Read
+                    </Button>
+                  </PfNotificationDrawer.PanelActionLink>
+                  <PfNotificationDrawer.PanelActionLink data-toggle="clear-all">
+                    <Button bsStyle="link" onClick={() => this.props.onClearGroup(group)}>
+                      <Icon type="pf" name="close" />
+                      Clear All
+                    </Button>
+                  </PfNotificationDrawer.PanelActionLink>
+                </PfNotificationDrawer.PanelAction>
+              )}
           </PfNotificationDrawer.PanelCollapse>
         </Collapse>
       </PfNotificationDrawer.Panel>

--- a/src/components/MessageCenter/__tests__/MessageCenter.test.tsx
+++ b/src/components/MessageCenter/__tests__/MessageCenter.test.tsx
@@ -10,6 +10,8 @@ describe('MessageCenter', () => {
     {
       id: 'first',
       title: 'im first',
+      showActions: true,
+      hideIfEmpty: false,
       messages: [
         {
           id: 1,
@@ -31,6 +33,8 @@ describe('MessageCenter', () => {
     {
       id: 'second',
       title: 'im second',
+      showActions: true,
+      hideIfEmpty: false,
       messages: [
         {
           id: 2,

--- a/src/containers/HelpDropdownContainer.ts
+++ b/src/containers/HelpDropdownContainer.ts
@@ -2,20 +2,11 @@ import { KialiAppState } from '../store/Store';
 import { connect } from 'react-redux';
 import HelpDropdown from '../components/Nav/HelpDropdown';
 
-import { HelpDropdownActions } from '../actions/HelpDropdownActions';
-
 const mapStateToProps = (state: KialiAppState) => ({
   status: state.statusState.status,
   components: state.statusState.components,
   warningMessages: state.statusState.warningMessages
 });
 
-const mapDispatchToProps = (dispatch: any) => ({
-  refresh: () => dispatch(HelpDropdownActions.refresh())
-});
-
-const HelpDropdownConnected = connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(HelpDropdown);
+const HelpDropdownConnected = connect(mapStateToProps)(HelpDropdown);
 export default HelpDropdownConnected;

--- a/src/containers/MessageCenterContainer.tsx
+++ b/src/containers/MessageCenterContainer.tsx
@@ -35,8 +35,16 @@ const mapStateToPropsMessageCenterTrigger = state => {
   type MessageCenterTriggerPropsToMap = {
     newMessagesCount: number;
     badgeDanger: boolean;
+    systemErrorsCount: number;
   };
   const dangerousMessageTypes = [MessageType.ERROR, MessageType.WARNING];
+  let systemErrorsCount = 0;
+
+  const systemErrorsGroup = state.messageCenter.groups.find(item => item.id === 'systemErrors');
+  if (systemErrorsGroup) {
+    systemErrorsCount = systemErrorsGroup.messages.length;
+  }
+
   return state.messageCenter.groups
     .reduce((unreadMessages: any[], group) => {
       return unreadMessages.concat(
@@ -54,13 +62,14 @@ const mapStateToPropsMessageCenterTrigger = state => {
         propsToMap.badgeDanger = propsToMap.badgeDanger || dangerousMessageTypes.includes(message.type);
         return propsToMap;
       },
-      { newMessagesCount: 0, badgeDanger: false }
+      { newMessagesCount: 0, systemErrorsCount: systemErrorsCount, badgeDanger: false }
     );
 };
 
 const mapDispatchToPropsMessageCenterTrigger = dispatch => {
   return {
-    toggleMessageCenter: () => dispatch(MessageCenterActions.toggleMessageCenter())
+    toggleMessageCenter: () => dispatch(MessageCenterActions.toggleMessageCenter()),
+    toggleSystemErrorsCenter: () => dispatch(MessageCenterActions.toggleSystemErrorsCenter())
   };
 };
 

--- a/src/reducers/MessageCenter.ts
+++ b/src/reducers/MessageCenter.ts
@@ -6,9 +6,18 @@ const INITIAL_STATE: MessageCenterState = {
   nextId: 0,
   groups: [
     {
+      id: 'systemErrors',
+      title: 'Open issues',
+      messages: [],
+      showActions: false,
+      hideIfEmpty: true
+    },
+    {
       id: 'default',
-      title: 'Default',
-      messages: []
+      title: 'Notifications',
+      messages: [],
+      showActions: true,
+      hideIfEmpty: false
     }
   ],
   hidden: true,
@@ -91,12 +100,15 @@ const Messages = (state: MessageCenterState = INITIAL_STATE, action) => {
       return state;
     case MessageCenterActionKeys.TOGGLE_EXPAND:
       return mergeToState(state, { expanded: !state.expanded });
-
     case MessageCenterActionKeys.TOGGLE_GROUP: {
       const { groupId } = action;
       if (state.expandedGroupId === groupId) {
         return mergeToState(state, { expandedGroupId: undefined });
       }
+      return mergeToState(state, { expandedGroupId: groupId });
+    }
+    case MessageCenterActionKeys.EXPAND_GROUP: {
+      const { groupId } = action;
       return mergeToState(state, { expandedGroupId: groupId });
     }
 

--- a/src/reducers/__tests__/MessageCenterReducer.test.ts
+++ b/src/reducers/__tests__/MessageCenterReducer.test.ts
@@ -20,9 +20,18 @@ describe('MessageCenter reducer', () => {
       expandedGroupId: 'default',
       groups: [
         {
+          id: 'systemErrors',
+          title: 'Open issues',
+          messages: [],
+          showActions: false,
+          hideIfEmpty: true
+        },
+        {
           id: 'default',
           messages: [],
-          title: 'Default'
+          title: 'Notifications',
+          showActions: true,
+          hideIfEmpty: false
         }
       ],
       hidden: true,
@@ -40,7 +49,9 @@ describe('MessageCenter reducer', () => {
             {
               id: 'default',
               messages: [],
-              title: 'Default'
+              title: 'Default',
+              showActions: true,
+              hideIfEmpty: false
             }
           ],
           hidden: true,
@@ -69,7 +80,9 @@ describe('MessageCenter reducer', () => {
               created: date
             }
           ],
-          title: 'Default'
+          title: 'Default',
+          showActions: true,
+          hideIfEmpty: false
         }
       ],
       hidden: true,
@@ -86,6 +99,8 @@ describe('MessageCenter reducer', () => {
           groups: [
             {
               id: 'default',
+              showActions: true,
+              hideIfEmpty: false,
               messages: [
                 {
                   id: 0,
@@ -139,7 +154,9 @@ describe('MessageCenter reducer', () => {
               created: date
             }
           ],
-          title: 'Default'
+          title: 'Default',
+          showActions: true,
+          hideIfEmpty: false
         }
       ],
       hidden: true,
@@ -156,6 +173,8 @@ describe('MessageCenter reducer', () => {
           groups: [
             {
               id: 'default',
+              showActions: true,
+              hideIfEmpty: false,
               messages: [
                 {
                   id: 0,
@@ -225,7 +244,9 @@ describe('MessageCenter reducer', () => {
               created: date
             }
           ],
-          title: 'Default'
+          title: 'Default',
+          showActions: true,
+          hideIfEmpty: false
         }
       ],
       hidden: true,
@@ -242,6 +263,8 @@ describe('MessageCenter reducer', () => {
           groups: [
             {
               id: 'default',
+              showActions: true,
+              hideIfEmpty: false,
               messages: [
                 {
                   id: 0,
@@ -295,7 +318,9 @@ describe('MessageCenter reducer', () => {
               created: date
             }
           ],
-          title: 'Default'
+          title: 'Default',
+          showActions: true,
+          hideIfEmpty: false
         }
       ],
       hidden: true,
@@ -312,7 +337,9 @@ describe('MessageCenter reducer', () => {
             {
               id: 'default',
               messages: [],
-              title: 'Default'
+              title: 'Default',
+              showActions: true,
+              hideIfEmpty: false
             }
           ],
           hidden: true,
@@ -329,7 +356,9 @@ describe('MessageCenter reducer', () => {
         {
           id: 'default',
           messages: [],
-          title: 'Default'
+          title: 'Default',
+          showActions: true,
+          hideIfEmpty: false
         }
       ],
       hidden: false,
@@ -346,7 +375,9 @@ describe('MessageCenter reducer', () => {
             {
               id: 'default',
               messages: [],
-              title: 'Default'
+              title: 'Default',
+              showActions: true,
+              hideIfEmpty: false
             }
           ],
           hidden: false,
@@ -363,7 +394,9 @@ describe('MessageCenter reducer', () => {
         {
           id: 'default',
           messages: [],
-          title: 'Default'
+          title: 'Default',
+          showActions: true,
+          hideIfEmpty: false
         }
       ],
       hidden: true,
@@ -380,7 +413,9 @@ describe('MessageCenter reducer', () => {
             {
               id: 'default',
               messages: [],
-              title: 'Default'
+              title: 'Default',
+              showActions: true,
+              hideIfEmpty: false
             }
           ],
           hidden: false,
@@ -397,7 +432,9 @@ describe('MessageCenter reducer', () => {
         {
           id: 'default',
           messages: [],
-          title: 'Default'
+          title: 'Default',
+          showActions: true,
+          hideIfEmpty: false
         }
       ],
       hidden: false,
@@ -414,7 +451,9 @@ describe('MessageCenter reducer', () => {
             {
               id: 'default',
               messages: [],
-              title: 'Default'
+              title: 'Default',
+              showActions: true,
+              hideIfEmpty: false
             }
           ],
           hidden: false,
@@ -432,7 +471,9 @@ describe('MessageCenter reducer', () => {
         {
           id: 'default',
           messages: [],
-          title: 'Default'
+          title: 'Default',
+          showActions: true,
+          hideIfEmpty: false
         }
       ],
       hidden: false,
@@ -449,7 +490,9 @@ describe('MessageCenter reducer', () => {
             {
               id: 'default',
               messages: [],
-              title: 'Default'
+              title: 'Default',
+              showActions: true,
+              hideIfEmpty: false
             }
           ],
           hidden: false,
@@ -467,7 +510,9 @@ describe('MessageCenter reducer', () => {
         {
           id: 'default',
           messages: [],
-          title: 'Default'
+          title: 'Default',
+          showActions: true,
+          hideIfEmpty: false
         }
       ],
       hidden: false,

--- a/src/types/MessageCenter.ts
+++ b/src/types/MessageCenter.ts
@@ -20,6 +20,8 @@ export interface NotificationGroup {
   id: string;
   title: string;
   messages: NotificationMessage[];
+  showActions: boolean;
+  hideIfEmpty: boolean;
 }
 
 export interface MessageCenterPropsType {


### PR DESCRIPTION
** Backwards in compatible? **
Is your pull-request introducing changes in behaviour? **Yes**

Per some discussion, the notification bell and the "open issues" message
aren't following the pattern suggested by UX. This fixes the behavior of
the messsage center, and the notifications in the main header of Kiali
page.

* Regular kiali errors and warnings (mainly, network errors) will now
show the standard bell with a badge when there are messages in the
message center. If there are errors or warnings, the badge will be red;
other types of messages will show the blue badge (we don't have any of
those kinds as of now). This is the standard PF behavior of the
notification bell and notification drawer.

![image](https://user-images.githubusercontent.com/23639005/44832327-1786a180-abf0-11e8-832a-400264aee0a6.png)

* The warning "open issues" won't replace the notifications bell. For
now, the only issue that raise this kind of warning to show up is the
unsupported Istio version warning (reported by the backend).

![image](https://user-images.githubusercontent.com/23639005/44924769-fcac4e00-ad11-11e8-80f2-1d4abfb471c4.png)

* An "Open issues" panel is added to the message center. This panel is
visible only when there are system errors (for now, only the Istio version warning).
Messages in this new panel can be marked as read, but cannot be cleared.

![image](https://user-images.githubusercontent.com/23639005/45061345-bfc1bd80-b069-11e8-84cc-6ad7fa47e5e4.png)

_Open issues panel is open by default when clicking in the "open issues" message. "Notifications" panel is open by default when clicking the bell_

* Marking system errors as read will clear the notifications count, but won't clear the "open issues" message:

![image](https://user-images.githubusercontent.com/23639005/45061429-0c0cfd80-b06a-11e8-9f71-5dcdcac8f5d6.png)

This is to remind the user that there is something wrong.

* Backend status is now fetched on browser refresh, if user is already
logged in. This is to fetch and raise the Istio version warning, if
needed. This ensures that the user is aware of the problematic
condition.

