### PR TITLE
KIALI-1434 Fix Grafana link on App/Workload metric pages

### DIFF
--- a/src/components/Metrics/Metrics.tsx
+++ b/src/components/Metrics/Metrics.tsx
@@ -174,9 +174,22 @@ class Metrics extends React.Component<MetricsProps, MetricsState> {
   };
 
   getGrafanaLink(info: GrafanaInfo): string {
-    return `${info.url}${info.serviceDashboardPath}?${info.varService}=${this.props.object}.${
-      this.props.namespace
-    }.svc.cluster.local`;
+    let grafanaLink;
+    switch (this.props.objectType) {
+      case 'service':
+        grafanaLink = `${info.url}${info.serviceDashboardPath}?${info.varService}=${this.props.object}.${
+          this.props.namespace
+        }.svc.cluster.local`;
+        break;
+      case 'workload':
+        grafanaLink = `${info.url}${info.workloadDashboardPath}?${info.varNamespace}=${this.props.namespace}&${
+          info.varWorkload
+        }=${this.props.object}`;
+        break;
+      default:
+        grafanaLink = `${info.url}${info.workloadDashboardPath}?${info.varNamespace}=${this.props.namespace}`;
+    }
+    return grafanaLink;
   }
 
   getGrafanaInfo = () => {

--- a/src/components/Metrics/__tests__/Metrics.test.tsx
+++ b/src/components/Metrics/__tests__/Metrics.test.tsx
@@ -186,14 +186,17 @@ describe('Inbound Metrics for a workload', () => {
       mockGrafanaInfo({
         url: 'http://172.30.139.113:3000',
         serviceDashboardPath: '/dashboard/db/istio-dashboard',
-        varService: 'var-service'
+        workloadDashboardPath: '/dashboard/db/istio-dashboard',
+        varService: 'var-service',
+        varNamespace: 'var-namespace',
+        varWorkload: 'var-workload'
       })
         .then(() => {
           mounted!.update();
           expect(mounted!.find('#grafana-link > a').map(div => div.getElement().props)).toEqual([
             {
               children: 'View in Grafana',
-              href: 'http://172.30.139.113:3000/dashboard/db/istio-dashboard?var-service=svc.ns.svc.cluster.local',
+              href: 'http://172.30.139.113:3000/dashboard/db/istio-dashboard?var-namespace=ns&var-workload=svc',
               target: '_blank'
             }
           ]);
@@ -260,14 +263,17 @@ describe('Outbound Metrics for a workload', () => {
       mockGrafanaInfo({
         url: 'http://172.30.139.113:3000',
         serviceDashboardPath: '/dashboard/db/istio-dashboard',
-        varService: 'var-service'
+        workloadDashboardPath: '/dashboard/db/istio-dashboard',
+        varService: 'var-service',
+        varNamespace: 'var-namespace',
+        varWorkload: 'var-workload'
       })
         .then(() => {
           mounted!.update();
           expect(mounted!.find('#grafana-link > a').map(div => div.getElement().props)).toEqual([
             {
               children: 'View in Grafana',
-              href: 'http://172.30.139.113:3000/dashboard/db/istio-dashboard?var-service=svc.ns.svc.cluster.local',
+              href: 'http://172.30.139.113:3000/dashboard/db/istio-dashboard?var-namespace=ns&var-workload=svc',
               target: '_blank'
             }
           ]);


### PR DESCRIPTION
Grafana link was pointing always to Services dashboard, so, in App/Workload details it was showed a wrong empty dashboard.


