### PR TITLE
KIALI-1432 DestinationRule breadcrumb white page fixed

### DIFF
--- a/src/pages/ServiceDetails/IstioObjectDetails.tsx
+++ b/src/pages/ServiceDetails/IstioObjectDetails.tsx
@@ -108,6 +108,10 @@ export default class IstioObjectDetails extends React.Component<IstioObjectDetai
     );
   }
 
+  isVirtualService() {
+    return this.typeIstioObject() === 'VirtualService';
+  }
+
   typeIstioObject() {
     if ('tcp' in this.props.object && 'http' in this.props.object) {
       return 'VirtualService';
@@ -117,7 +121,7 @@ export default class IstioObjectDetails extends React.Component<IstioObjectDetai
 
   overviewTab() {
     const istioObj: VirtualService | DestinationRule = this.props.object as VirtualService | DestinationRule;
-    if (this.typeIstioObject() === 'VirtualService') {
+    if (this.isVirtualService()) {
       return (
         <TabPane eventKey="overview">
           <VirtualServiceDetail virtualService={istioObj} validations={this.props.validations['virtualservice']} />
@@ -131,7 +135,7 @@ export default class IstioObjectDetails extends React.Component<IstioObjectDetai
     return (
       <>
         <Nav bsClass="nav nav-tabs nav-tabs-pf">
-          {this.typeIstioObject() === 'VirtualService' && (
+          {this.isVirtualService() && (
             <NavItem eventKey="overview">
               <div>Overview</div>
             </NavItem>
@@ -145,13 +149,14 @@ export default class IstioObjectDetails extends React.Component<IstioObjectDetai
   }
 
   render() {
+    const defaultDetailTab = this.isVirtualService() ? 'overview' : 'yaml';
     return (
       <div className="container-fluid container-cards-pf">
         <Row className="row-cards-pf">
           <Col>
             <TabContainer
               id="basic-tabs"
-              activeKey={this.props.activeTab('detail', 'overview')}
+              activeKey={this.props.activeTab('detail', defaultDetailTab)}
               onSelect={this.props.onSelectTab('detail')}
             >
               <>

--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -171,6 +171,7 @@ class ServiceDetails extends React.Component<RouteComponentProps<ServiceId>, Ser
     const to = this.servicePageURL();
     const toDetailsTab = to + '?list=' + parsedSearch.type + 's';
     const toDetails = to + '?' + parsedSearch.type + '=' + parsedSearch.name;
+    const detailTab = parsedSearch.type === 'virtualservice' ? 'Virtual Service' : 'Destination Rule';
     return (
       <Breadcrumb title={true}>
         <Breadcrumb.Item componentClass={'span'}>
@@ -201,7 +202,7 @@ class ServiceDetails extends React.Component<RouteComponentProps<ServiceId>, Ser
               </Link>
             </Breadcrumb.Item>
             <Breadcrumb.Item active={true}>
-              {parsedSearchTypeHuman} {(urlParams.get('detail') || 'overview') === 'overview' ? 'Overview' : 'YAML'}
+              {parsedSearchTypeHuman} {(urlParams.get('detail') || detailTab) === 'overview' ? 'Overview' : 'YAML'}
             </Breadcrumb.Item>
           </>
         )}


### PR DESCRIPTION
** Describe the change **

1. Go to Destination Rule details page.
2. Click to `Destination Rule: name` breadcrumb item
3. Console shows a blank page.

** Issue reference **
https://issues.jboss.org/browse/KIALI-1432

** Backwards in compatible? **
Yes.

** Screenshot **
![screen recording 4](https://user-images.githubusercontent.com/613814/44858799-18ace280-ac73-11e8-8ce4-d63d09e9c7ca.gif)
