### PR TITLE
KIALI-1459 VS Breadcrumb fix when switching from yaml to overview

### DIFF
--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -171,7 +171,7 @@ class ServiceDetails extends React.Component<RouteComponentProps<ServiceId>, Ser
     const to = this.servicePageURL();
     const toDetailsTab = to + '?list=' + parsedSearch.type + 's';
     const toDetails = to + '?' + parsedSearch.type + '=' + parsedSearch.name;
-    const detailTab = parsedSearch.type === 'virtualservice' ? 'Virtual Service' : 'Destination Rule';
+    const defaultDetailTab = parsedSearch.type === 'virtualservice' ? 'overview' : 'yaml';
     return (
       <Breadcrumb title={true}>
         <Breadcrumb.Item componentClass={'span'}>
@@ -202,7 +202,8 @@ class ServiceDetails extends React.Component<RouteComponentProps<ServiceId>, Ser
               </Link>
             </Breadcrumb.Item>
             <Breadcrumb.Item active={true}>
-              {parsedSearchTypeHuman} {(urlParams.get('detail') || detailTab) === 'overview' ? 'Overview' : 'YAML'}
+              {parsedSearchTypeHuman}{' '}
+              {(urlParams.get('detail') || defaultDetailTab) === 'overview' ? 'Overview' : 'YAML'}
             </Breadcrumb.Item>
           </>
         )}


### PR DESCRIPTION
** Describe the change **

Fixes the breadcrumb title when switching from yaml tab to overview using the breadcrumb link in virtual service detail page.

** Issue reference **

https://issues.jboss.org/browse/KIALI-1459

** Backwards in compatible? **
Yes.

** Screenshot **

![screen recording 1](https://user-images.githubusercontent.com/613814/44921542-203bbc80-ad43-11e8-934a-a410ac76e4a9.gif)

