### PR TITLE
KIALI-1380 Add links to the website and github organization

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,12 @@
   ],
   "author": "Red Hat",
   "license": "Apache-2.0",
+  "homepage-comment": [
+    "By default, Create React App produces a build assuming your app is hosted at the server root.",
+    "To override this, specify the homepage in your package.json:",
+    "We don't want this, so don't touch homepage.",
+    "https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#building-for-relative-paths"
+  ],
   "homepage": "/",
   "publishConfig": {
     "access": "public"

--- a/src/components/About/AboutUIModal.tsx
+++ b/src/components/About/AboutUIModal.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { AboutModal } from 'patternfly-react';
+import { AboutModal, Icon } from 'patternfly-react';
 import { Component } from '../../store/Store';
-import { KialiLogo } from '../../config';
+import { config, KialiLogo } from '../../config';
 
 const KIALI_CORE_COMMIT_HASH = 'Kiali core commit hash';
 const KIALI_CORE_VERSION = 'Kiali core version';
@@ -46,9 +46,51 @@ class AboutUIModal extends React.Component<AboutUIModalProps, AboutUIModalState>
             <AboutModal.VersionItem key={component.name} label={component.name} versionText={component.version} />
           ))}
         </AboutModal.Versions>
+        {this.renderWebsiteLink()}
+        {this.renderProjectLink()}
       </AboutModal>
     );
   }
+
+  private renderWebsiteLink = () => {
+    if (config().about && config().about.website) {
+      return (
+        <div>
+          <a href={config().about.website.url} target="_blank">
+            <Icon
+              name={config().about.website.iconName}
+              type={config().about.website.iconType}
+              size="lg"
+              style={{ color: 'white' }}
+            />{' '}
+            {config().about.website.linkText}
+          </a>
+        </div>
+      );
+    }
+
+    return null;
+  };
+
+  private renderProjectLink = () => {
+    if (config().about && config().about.project) {
+      return (
+        <div>
+          <a href={config().about.project.url} target="_blank">
+            <Icon
+              name={config().about.project.iconName}
+              type={config().about.project.iconType}
+              size="lg"
+              style={{ color: 'white' }}
+            />{' '}
+            {config().about.project.linkText}
+          </a>
+        </div>
+      );
+    }
+
+    return null;
+  };
 }
 
 export default AboutUIModal;

--- a/src/config.ts
+++ b/src/config.ts
@@ -49,6 +49,21 @@ export const config = () => {
         'cose-bilkent': 'Cose',
         dagre: 'Dagre'
       }
+    },
+    /** About dialog configuration */
+    about: {
+      project: {
+        url: 'https://github.com/kiali',
+        iconName: 'github',
+        iconType: 'fa',
+        linkText: 'Find us on GitHub'
+      },
+      website: {
+        url: 'http://kiali.io',
+        iconName: 'home',
+        iconType: 'fa',
+        linkText: 'Visit our web page'
+      }
     }
   });
 };


### PR DESCRIPTION
** Backwards in compatible? **
[ ] Is your pull-request introducing changes in behaviour? **No**

--

Links are added to the 'about' dialog.

Links, icons and text are configurable in the config.ts file. The 'about' section config.ts file can be absent completely, or have only the webpage or project sections. The about box will hide and show what is available in the config file.

![image](https://user-images.githubusercontent.com/23639005/44930326-929ca480-ad23-11e8-992a-ac4cbaa8e968.png)
