### PR TITLE
KIALI-1466 Session timeout dialog box shows negative seconds remaining for timeout

### DIFF
--- a/src/components/Nav/UserDropdown.tsx
+++ b/src/components/Nav/UserDropdown.tsx
@@ -36,6 +36,9 @@ class UserDropdown extends React.Component<UserProps, UserState> {
 
   timeLeft = (): number => {
     const nowDate = new Date().getTime();
+    if (this.props.sessionTimeOut - nowDate < 1) {
+      this.handleLogout();
+    }
     return this.props.sessionTimeOut - nowDate;
   };
 


### PR DESCRIPTION
### Before
![before](https://user-images.githubusercontent.com/3019213/44987422-6d0fd500-af87-11e8-8026-a5aad6267c6f.gif)

### After
![after](https://user-images.githubusercontent.com/3019213/44987425-70a35c00-af87-11e8-8323-e3fd7d871bc5.gif)

** Issue reference **

[KIALI-1466](https://issues.jboss.org/browse/KIALI-1466)

