### PR TITLE
KIALI-1235 Graph: lock icon disappear when json indicates that

### DIFF
--- a/src/actions/ServiceGraphDataActions.ts
+++ b/src/actions/ServiceGraphDataActions.ts
@@ -22,7 +22,8 @@ const decorateGraphData = (graphData: any) => {
       percentErr: undefined,
       percentRate: undefined,
       latency: undefined,
-      isUnused: undefined
+      isUnused: undefined,
+      isMTLS: undefined
     },
     nodes: {
       version: undefined,


### PR DESCRIPTION
** Describe the change **
In graph, lock icon didn't disappear when json stop sending `isMTLS` field. It turns out that there was a missing default value which made the graph to keep the mTLS previous value.

** Issue reference **

https://issues.jboss.org/browse/KIALI-1235
https://issues.jboss.org/browse/KIALI-1238

** Backwards compatible? **
Yes.

Is your pull-request introducing changes in behaviour?
Yes.

Lock icon disappears when istio switch from using security connection to non-security one.

** Screenshot **

![screen recording 2](https://user-images.githubusercontent.com/613814/45087729-2e088d80-b107-11e8-8549-660bbedbfe16.gif)

