### PR TITLE
KIALI-1482 Clicking menu items erase applied filters

### DIFF
--- a/src/pages/AppList/AppListComponent.tsx
+++ b/src/pages/AppList/AppListComponent.tsx
@@ -260,7 +260,7 @@ class AppListComponent extends React.Component<AppListComponentProps, AppListCom
         isSortAscending: !this.state.isSortAscending,
         appListItems: sorted
       });
-      this.props.onParamChange([{ name: 'direction', value: this.state.isSortAscending ? 'desc' : 'asc' }]);
+      this.props.onParamChange([{ name: 'direction', value: this.state.isSortAscending ? 'asc' : 'desc' }]);
     });
   };
 

--- a/src/pages/AppList/AppListComponent.tsx
+++ b/src/pages/AppList/AppListComponent.tsx
@@ -143,6 +143,58 @@ class AppListComponent extends React.Component<AppListComponentProps, AppListCom
     });
   }
 
+  componentDidUpdate(prevProps: AppListComponentProps, prevState: AppListComponentState, snapshot: any) {
+    if (!this.paramsAreSynced(prevProps)) {
+      this.setState({
+        pagination: this.props.pagination,
+        currentSortField: this.props.currentSortField,
+        isSortAscending: this.props.isSortAscending,
+        rateInterval: this.props.rateInterval
+      });
+
+      NamespaceFilterSelected.setSelected(this.selectedFilters());
+      this.updateApps();
+    }
+  }
+
+  paramsAreSynced(prevProps: AppListComponentProps) {
+    return (
+      prevProps.pagination.page === this.props.pagination.page &&
+      prevProps.pagination.perPage === this.props.pagination.perPage &&
+      prevProps.rateInterval === this.props.rateInterval &&
+      prevProps.isSortAscending === this.props.isSortAscending &&
+      prevProps.currentSortField.title === this.props.currentSortField.title &&
+      this.filtersMatch()
+    );
+  }
+
+  filtersMatch() {
+    const selectedFilters: Map<string, string[]> = new Map<string, string[]>();
+
+    NamespaceFilterSelected.getSelected().map(activeFilter => {
+      const existingValue = selectedFilters.get(activeFilter.category) || [];
+      selectedFilters.set(activeFilter.category, existingValue.concat(activeFilter.value));
+    });
+
+    let urlParams: Map<string, string[]> = new Map<string, string[]>();
+    availableFilters.forEach(filter => {
+      const param = this.props.queryParam(filter.id, ['']);
+      if (param[0] !== '') {
+        const existing = urlParams.get(filter.title) || [];
+        urlParams.set(filter.title, existing.concat(param));
+      }
+    });
+
+    let equalFilters = true;
+    selectedFilters.forEach((filterValues, filterName) => {
+      const aux = urlParams.get(filterName) || [];
+      equalFilters =
+        equalFilters && filterValues.every(value => aux.includes(value)) && filterValues.length === aux.length;
+    });
+
+    return selectedFilters.size === urlParams.size && equalFilters;
+  }
+
   pageSet = (page: number) => {
     this.setState(prevState => {
       return {

--- a/src/pages/WorkloadList/WorkloadListComponent.tsx
+++ b/src/pages/WorkloadList/WorkloadListComponent.tsx
@@ -65,6 +65,58 @@ class WorkloadListComponent extends React.Component<WorkloadListComponentProps, 
     this.updateWorkloads();
   }
 
+  componentDidUpdate(prevProps: WorkloadListComponentProps, prevState: WorkloadListComponentState, snapshot: any) {
+    if (!this.paramsAreSynced(prevProps)) {
+      this.setState({
+        pagination: this.props.pagination,
+        currentSortField: this.props.currentSortField,
+        isSortAscending: this.props.isSortAscending,
+        rateInterval: this.props.rateInterval
+      });
+
+      NamespaceFilterSelected.setSelected(this.selectedFilters());
+      this.updateWorkloads();
+    }
+  }
+
+  paramsAreSynced(prevProps: WorkloadListComponentProps) {
+    return (
+      prevProps.pagination.page === this.props.pagination.page &&
+      prevProps.pagination.perPage === this.props.pagination.perPage &&
+      prevProps.rateInterval === this.props.rateInterval &&
+      prevProps.isSortAscending === this.props.isSortAscending &&
+      prevProps.currentSortField.title === this.props.currentSortField.title &&
+      this.filtersMatch()
+    );
+  }
+
+  filtersMatch() {
+    const selectedFilters: Map<string, string[]> = new Map<string, string[]>();
+
+    NamespaceFilterSelected.getSelected().map(activeFilter => {
+      const existingValue = selectedFilters.get(activeFilter.category) || [];
+      selectedFilters.set(activeFilter.category, existingValue.concat(activeFilter.value));
+    });
+
+    let urlParams: Map<string, string[]> = new Map<string, string[]>();
+    availableFilters.forEach(filter => {
+      const param = this.props.queryParam(filter.id, ['']);
+      if (param[0] !== '') {
+        const existing = urlParams.get(filter.title) || [];
+        urlParams.set(filter.title, existing.concat(param));
+      }
+    });
+
+    let equalFilters = true;
+    selectedFilters.forEach((filterValues, filterName) => {
+      const aux = urlParams.get(filterName) || [];
+      equalFilters =
+        equalFilters && filterValues.every(value => aux.includes(value)) && filterValues.length === aux.length;
+    });
+
+    return selectedFilters.size === urlParams.size && equalFilters;
+  }
+
   updateWorkloads = (resetPagination?: boolean) => {
     const activeFilters: ActiveFilter[] = NamespaceFilterSelected.getSelected();
     let namespacesSelected: string[] = activeFilters

--- a/src/pages/WorkloadList/WorkloadListComponent.tsx
+++ b/src/pages/WorkloadList/WorkloadListComponent.tsx
@@ -279,7 +279,7 @@ class WorkloadListComponent extends React.Component<WorkloadListComponentProps, 
         isSortAscending: !this.state.isSortAscending,
         workloadItems: sorted
       });
-      this.props.onParamChange([{ name: 'direction', value: this.state.isSortAscending ? 'desc' : 'asc' }]);
+      this.props.onParamChange([{ name: 'direction', value: this.state.isSortAscending ? 'asc' : 'desc' }]);
     });
   };
 


### PR DESCRIPTION
** Describe the change **

bug fix: application and workload lists didnt removed the applied filters on clicking to its respective menu item.

** Issue reference **

https://issues.jboss.org/browse/KIALI-1482

** Backwards compatible? **
yes.

** Screenshot **

![screen recording 4](https://user-images.githubusercontent.com/613814/45091179-f521e600-b111-11e8-8f12-31290aff89b1.gif)

![screen recording 3](https://user-images.githubusercontent.com/613814/45091183-f8b56d00-b111-11e8-9644-afb7ccdaa912.gif)

