### PR TITLE
KIALI-1485 WorkloadDetails page: allow user to see services when there aren't pods

### DIFF
--- a/src/pages/WorkloadDetails/WorkloadInfo.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo.tsx
@@ -114,7 +114,7 @@ class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInfoState>
                       {pods.length > 0 && <WorkloadPods pods={pods} validations={this.props.validations!['pod']} />}
                     </TabPane>
                     <TabPane eventKey={'services'}>
-                      {pods.length > 0 && <WorkloadServices services={services} namespace={this.props.namespace} />}
+                      {services.length > 0 && <WorkloadServices services={services} namespace={this.props.namespace} />}
                     </TabPane>
                   </TabContent>
                 </div>


### PR DESCRIPTION
** Describe the change **
Allow user to see services when there aren't pods in workload details page.
There was a copy&paste error.

** Issue reference **
https://issues.jboss.org/browse/KIALI-1485

** Backwards compatible? **
yes.

** Screenshot **

![screenshot of kiali console 1](https://user-images.githubusercontent.com/613814/45102259-9d917380-b12d-11e8-94d4-3e0046437b41.png)
