### PR TITLE
KIALI-1491 Metrics pages don't propagate the parameters into the URL

### DIFF
--- a/src/app/History.tsx
+++ b/src/app/History.tsx
@@ -3,3 +3,16 @@ import { createBrowserHistory } from 'history';
 const baseName = '/console';
 const history = createBrowserHistory({ basename: baseName });
 export default history;
+
+export namespace HistoryManager {
+  export const setParam = (name: string, value: string) => {
+    const urlParams = new URLSearchParams(history.location.search);
+    urlParams.set(name, value);
+    history.replace(history.location.pathname + '?' + urlParams.toString());
+  };
+
+  export const getParam = (name: string): string | null => {
+    const urlParams = new URLSearchParams(history.location.search);
+    return urlParams.get(name);
+  };
+}

--- a/src/components/Metrics/Metrics.tsx
+++ b/src/components/Metrics/Metrics.tsx
@@ -59,7 +59,11 @@ class Metrics extends React.Component<MetricsProps, MetricsState> {
     super(props);
 
     let metricReporter = 'source';
-    if (this.props.metricsType === 'inbound') {
+
+    const metricReporterParam = HistoryManager.getParam('reporter');
+    if (metricReporterParam != null) {
+      metricReporter = metricReporterParam;
+    } else if (this.props.metricsType === 'inbound') {
       metricReporter = 'destination';
     }
 

--- a/src/components/Metrics/Metrics.tsx
+++ b/src/components/Metrics/Metrics.tsx
@@ -10,6 +10,7 @@ import HistogramChart from './HistogramChart';
 import MetricChart from './MetricChart';
 import { Histogram, MetricGroup } from '../../types/Metrics';
 import history from '../../app/History';
+import { HistoryManager } from '../../app/History';
 import { Link } from 'react-router-dom';
 import { style } from 'typestyle';
 
@@ -130,6 +131,7 @@ class Metrics extends React.Component<MetricsProps, MetricsState> {
     options.step = intervalOpts.step;
     options.rateInterval = intervalOpts.rateInterval;
     this.fetchMetrics();
+    HistoryManager.setParam('duration', options.duration!.toString(10));
   };
 
   onPollIntervalChanged = (pollInterval: number) => {
@@ -141,10 +143,12 @@ class Metrics extends React.Component<MetricsProps, MetricsState> {
       newRefInterval = window.setInterval(this.fetchMetrics, pollInterval);
     }
     this.setState({ pollMetrics: newRefInterval });
+    HistoryManager.setParam('pi', pollInterval.toString(10));
   };
 
   onReporterChanged = (reporter: string) => {
     this.setState({ metricReporter: reporter });
+    HistoryManager.setParam('reporter', reporter);
   };
 
   fetchMetrics = () => {

--- a/src/components/MetricsOptions/MetricsOptionsBar.tsx
+++ b/src/components/MetricsOptions/MetricsOptionsBar.tsx
@@ -4,6 +4,7 @@ import { config } from '../../config';
 import ValueSelectHelper from './ValueSelectHelper';
 import MetricsOptions from '../../types/MetricsOptions';
 import { ToolbarDropdown } from '../ToolbarDropdown/ToolbarDropdown';
+import { HistoryManager } from '../../app/History';
 
 interface Props {
   onOptionsChanged: (opts: MetricsOptions) => void;
@@ -69,8 +70,8 @@ export class MetricsOptionsBar extends React.Component<Props, MetricsOptionsStat
     });
 
     this.state = {
-      pollInterval: MetricsOptionsBar.DefaultPollInterval,
-      duration: Number(sessionStorage.getItem('appDuration')) || MetricsOptionsBar.DefaultDuration,
+      pollInterval: this.initialPollInterval(),
+      duration: this.initialDuration(),
       groupByLabels: this.groupByLabelsHelper.selected
     };
   }
@@ -80,6 +81,29 @@ export class MetricsOptionsBar extends React.Component<Props, MetricsOptionsStat
     this.reportOptions();
     this.props.onPollIntervalChanged(this.state.pollInterval);
   }
+
+  initialPollInterval = (): number => {
+    let initialPollInterval = MetricsOptionsBar.DefaultPollInterval;
+
+    const pollIntervalParam = HistoryManager.getParam('pi');
+    if (pollIntervalParam != null) {
+      initialPollInterval = Number(pollIntervalParam);
+    }
+
+    return initialPollInterval;
+  };
+
+  initialDuration = (): number => {
+    let initialDuration = Number(sessionStorage.getItem('appDuration')) || MetricsOptionsBar.DefaultDuration;
+
+    const durationParam = HistoryManager.getParam('duration');
+    if (durationParam != null) {
+      initialDuration = Number(durationParam);
+      sessionStorage.setItem('appDuration', durationParam);
+    }
+
+    return initialDuration;
+  };
 
   onPollIntervalChanged = (key: number) => {
     // We use a specific handler so that changing poll interval doesn't trigger a metrics refresh in parent
@@ -132,12 +156,8 @@ export class MetricsOptionsBar extends React.Component<Props, MetricsOptionsStat
           disabled={false}
           handleSelect={this.onDurationChanged}
           nameDropdown={'Duration'}
-          initialValue={Number(sessionStorage.getItem('appDuration')) || MetricsOptionsBar.DefaultDuration}
-          initialLabel={String(
-            MetricsOptionsBar.Durations[
-              Number(sessionStorage.getItem('appDuration')) || MetricsOptionsBar.DefaultDuration
-            ]
-          )}
+          initialValue={this.state.duration}
+          initialLabel={String(MetricsOptionsBar.Durations[this.state.duration])}
           options={MetricsOptionsBar.Durations}
         />
         <ToolbarDropdown
@@ -145,8 +165,8 @@ export class MetricsOptionsBar extends React.Component<Props, MetricsOptionsStat
           disabled={false}
           handleSelect={this.onPollIntervalChanged}
           nameDropdown={'Poll Interval'}
-          initialValue={MetricsOptionsBar.DefaultPollInterval}
-          initialLabel={String(MetricsOptionsBar.PollIntervals[MetricsOptionsBar.DefaultPollInterval])}
+          initialValue={this.state.pollInterval}
+          initialLabel={String(MetricsOptionsBar.PollIntervals[this.state.pollInterval])}
           options={MetricsOptionsBar.PollIntervals}
         />
         <ToolbarRightContent>

--- a/src/pages/AppDetails/AppDetailsPage.tsx
+++ b/src/pages/AppDetails/AppDetailsPage.tsx
@@ -160,7 +160,7 @@ class AppDetails extends React.Component<RouteComponentProps<AppId>, AppDetailsS
         return;
       }
 
-      const urlParams = new URLSearchParams(this.props.location.search);
+      const urlParams = new URLSearchParams('');
       urlParams.set(tabName, tabKey);
 
       this.props.history.push(this.props.location.pathname + '?' + urlParams.toString());

--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -282,7 +282,7 @@ class ServiceDetails extends React.Component<RouteComponentProps<ServiceId>, Ser
         return;
       }
 
-      const urlParams = new URLSearchParams(this.props.location.search);
+      const urlParams = new URLSearchParams('');
       urlParams.set(tabName, tabKey);
 
       this.props.history.push(this.props.location.pathname + '?' + urlParams.toString());

--- a/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -201,7 +201,7 @@ class WorkloadDetails extends React.Component<RouteComponentProps<WorkloadId>, W
         return;
       }
 
-      const urlParams = new URLSearchParams(this.props.location.search);
+      const urlParams = new URLSearchParams('');
       urlParams.set(tabName, tabKey);
 
       this.props.history.push(this.props.location.pathname + '?' + urlParams.toString());


### PR DESCRIPTION
** Describe the change **
On both service, app, workload metrics page, when changing options they are mapped into param in the URL. They are not creating a new item in the history because navigation it is not implemented yet.

** Issue reference **
https://issues.jboss.org/browse/KIALI-1491

** Backwards compatible? **
yes.

** Screenshot **
![screen recording 8](https://user-images.githubusercontent.com/613814/45223946-022d0980-b2b9-11e8-91dd-fcf13f2cbca6.gif)

