### PR TITLE
Trivial: In service graph, capitalize 'type' in 'Graph type'

### DIFF
--- a/src/components/GraphFilter/GraphFilter.tsx
+++ b/src/components/GraphFilter/GraphFilter.tsx
@@ -70,7 +70,7 @@ export default class GraphFilter extends React.PureComponent<GraphFilterProps> {
             id={'graph_filter_view_type'}
             disabled={this.props.disabled}
             handleSelect={this.updateViewType}
-            nameDropdown={'Graph type'}
+            nameDropdown={'Graph Type'}
             value={graphTypeKey}
             label={GraphFilter.GRAPH_TYPES[graphTypeKey]}
             options={GraphFilter.GRAPH_TYPES}


### PR DESCRIPTION
** Describe the change **
Change 'Graph type' to 'Graph Type' in service graph toolbar

** Backwards compatible? **
Yes

** Screenshot **

![kiali_console](https://user-images.githubusercontent.com/1312165/45229070-c0c93980-b279-11e8-952b-e4a28f72c6c7.png)
