### PR TITLE
KIALI-1099 Add TCP charts to side panel

### DIFF
--- a/src/pages/Graph/SummaryPanelCommon.tsx
+++ b/src/pages/Graph/SummaryPanelCommon.tsx
@@ -161,7 +161,7 @@ export const getNodeMetrics = (
 export const getDatapoints = (
   mg: M.MetricGroup,
   title: string,
-  comparator: (metric: Metric) => boolean
+  comparator?: (metric: Metric) => boolean
 ): [string, number][] => {
   let series: M.TimeSeries[] = [];
   if (mg && mg.matrix) {

--- a/src/utils/Graphing.ts
+++ b/src/utils/Graphing.ts
@@ -6,13 +6,19 @@ export default {
       return [['x'], [title || '']];
     }
 
+    // xseries are timestamps. Timestamps are taken from the first series and assumed
+    // that all series have the same timestamps.
     let xseries: any = ['x'];
-    return [xseries.concat(matrix[0].values.map(dp => dp[0] * 1000))].concat(
-      matrix.map(mat => {
-        let yseries: any = [title || mat.name];
-        return yseries.concat(mat.values.map(dp => dp[1]));
-      })
-    );
+    xseries = xseries.concat(matrix[0].values.map(dp => dp[0] * 1000));
+
+    // yseries are the values of each serie.
+    let yseries: any[] = matrix.map(mat => {
+      let serie: any = [title || mat.name];
+      return serie.concat(mat.values.map(dp => dp[1]));
+    });
+
+    // timestamps + data is the format required by C3 (all concatenated: an array with arrays)
+    return [xseries, ...yseries];
   },
 
   toC3ValueColumns(matrix: TimeSeries[], title?: string) {


### PR DESCRIPTION
TCP sparklines will be shown only if the selected node, group or edge
has any TCP traffic.

The HTTP charts will also show this behavior: they will be hidden if
there is no HTTP traffic.

So, if a node is "unused" no charts will appear.

** Backwards compatible? ** It should be compatible

Node only with TCP traffic:

![image](https://user-images.githubusercontent.com/23639005/45443045-43426680-b689-11e8-8385-90988732f602.png)

Node with both TCP and HTTP traffic - very similar for versioned group box (this is zoomed in the browser, panel will usually show scrollbars):

![image](https://user-images.githubusercontent.com/23639005/45443092-5e14db00-b689-11e8-92a8-8a286bad6818.png)

Edge:
Note: Per https://issues.jboss.org/browse/KIALI-1401, the edges shouldn't have both TCP and HTTP. So, I only tested individual cases.

![image](https://user-images.githubusercontent.com/23639005/45443127-74bb3200-b689-11e8-9737-4247189bc588.png)

Graph (namespace; no selected item in graph):
_This panel won't hide any graph_

![image](https://user-images.githubusercontent.com/23639005/45443229-b77d0a00-b689-11e8-8d5c-28a44bb05fd3.png)
