### PR TITLE
KIALI-1525 Loading message when graph loads the first time

### DIFF
--- a/src/actions/GraphActions.ts
+++ b/src/actions/GraphActions.ts
@@ -2,11 +2,16 @@ import { createAction } from 'typesafe-actions';
 import { CytoscapeClickEvent } from '../types/Graph';
 
 export enum GraphActionKeys {
+  GRAPH_NAMESPACE_CHANGED = 'GRAPH_NAMESPACE_CHANGED',
   GRAPH_SIDE_PANEL_SHOW_INFO = 'GRAPH_SIDE_PANEL_SHOW_INFO'
 }
 
 // synchronous action creators
 export const GraphActions = {
+  namespaceChanged: createAction(GraphActionKeys.GRAPH_NAMESPACE_CHANGED, (newNamespace: string) => ({
+    type: GraphActionKeys.GRAPH_NAMESPACE_CHANGED,
+    newNamespace
+  })),
   showSidePanelInfo: createAction(GraphActionKeys.GRAPH_SIDE_PANEL_SHOW_INFO, (event: CytoscapeClickEvent) => ({
     type: GraphActionKeys.GRAPH_SIDE_PANEL_SHOW_INFO,
     ...event

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -95,7 +95,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
     this.namespaceChanged = this.namespaceChanged || this.props.namespace.name !== nextProps.namespace.name;
     this.nodeChanged = this.nodeChanged || this.props.node !== nextProps.node;
     this.resetSelection = this.props.namespace.name !== nextProps.namespace.name;
-    const result =
+    let result =
       this.props.namespace.name !== nextProps.namespace.name ||
       this.props.node !== nextProps.node ||
       this.props.graphLayout !== nextProps.graphLayout ||
@@ -107,6 +107,11 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
       this.props.elements !== nextProps.elements ||
       this.props.showTrafficAnimation !== nextProps.showTrafficAnimation ||
       this.props.isError !== nextProps.isError;
+
+    if (!nextProps.elements || !nextProps.elements.nodes || nextProps.elements.nodes.length < 1) {
+      result = true;
+    }
+
     return result;
   }
 

--- a/src/components/GraphFilter/GraphFilterToolbar.tsx
+++ b/src/components/GraphFilter/GraphFilterToolbar.tsx
@@ -5,10 +5,10 @@ import { GraphParamsType, GraphType } from '../../types/Graph';
 import { Duration } from '../../types/GraphFilter';
 import Namespace from '../../types/Namespace';
 import GraphFilterToolbarType from '../../types/GraphFilterToolbar';
-
+import { store } from '../../store/ConfigStore';
 import { makeNamespaceGraphUrlFromParams, makeNodeGraphUrlFromParams } from '../Nav/NavUtils';
-
 import GraphFilter from './GraphFilter';
+import { GraphActions } from '../../actions/GraphActions';
 
 export default class GraphFilterToolbar extends React.PureComponent<GraphFilterToolbarType> {
   static contextTypes = {
@@ -47,6 +47,7 @@ export default class GraphFilterToolbar extends React.PureComponent<GraphFilterT
   };
 
   handleNamespaceChange = (namespace: Namespace) => {
+    store.dispatch(GraphActions.namespaceChanged(namespace.name));
     this.handleFilterChange({
       ...this.getGraphParams(),
       namespace

--- a/src/containers/EmptyGraphLayoutContainer.tsx
+++ b/src/containers/EmptyGraphLayoutContainer.tsx
@@ -82,11 +82,7 @@ export class EmptyGraphLayout extends React.Component<EmptyGraphLayoutProps, Emp
       );
     }
 
-    const isGraphEmpty =
-      !this.props.elements ||
-      this.props.elements.length < 1 ||
-      !this.props.elements.nodes ||
-      this.props.elements.nodes.length < 1;
+    const isGraphEmpty = !this.props.elements || !this.props.elements.nodes || this.props.elements.nodes.length < 1;
 
     if (isGraphEmpty) {
       return (

--- a/src/pages/Graph/GraphPage.tsx
+++ b/src/pages/Graph/GraphPage.tsx
@@ -194,13 +194,24 @@ export default class GraphPage extends React.PureComponent<GraphPageProps> {
   }
 
   private loadGraphDataFromBackend = () => {
-    return this.props.fetchGraphData(
+    const promise = this.props.fetchGraphData(
       this.props.namespace,
       this.props.graphDuration,
       this.props.graphType,
       this.props.injectServiceNodes,
       this.props.node
     );
+    this.pollPromise = makeCancelablePromise(promise);
+
+    this.pollPromise.promise
+      .then(() => {
+        this.scheduleNextPollingIntervalFromProps();
+      })
+      .catch(error => {
+        if (!error.isCanceled) {
+          this.scheduleNextPollingIntervalFromProps();
+        }
+      });
   };
 
   private scheduleNextPollingIntervalFromProps() {
@@ -214,24 +225,16 @@ export default class GraphPage extends React.PureComponent<GraphPageProps> {
   private scheduleNextPollingInterval(pollInterval: number) {
     // Remove any pending timeout to avoid having multiple requests at once
     this.removePollingIntervalTimer();
-    // We are using setTimeout instead of setInterval because we have more control over it
-    // e.g. If a request takes much time, the next interval will fire up anyway and is
-    // possible that it will take much time as well. Instead wait for it to timeout/error to
-    // try again.
-    this.pollTimeoutRef = window.setTimeout(() => {
-      const promise = this.loadGraphDataFromBackend();
-      this.pollPromise = makeCancelablePromise(promise);
 
-      this.pollPromise.promise
-        .then(() => {
-          this.scheduleNextPollingIntervalFromProps();
-        })
-        .catch(error => {
-          if (!error.isCanceled) {
-            this.scheduleNextPollingIntervalFromProps();
-          }
-        });
-    }, pollInterval);
+    if (pollInterval === 0) {
+      this.loadGraphDataFromBackend();
+    } else {
+      // We are using setTimeout instead of setInterval because we have more control over it
+      // e.g. If a request takes much time, the next interval will fire up anyway and is
+      // possible that it will take much time as well. Instead wait for it to timeout/error to
+      // try again.
+      this.pollTimeoutRef = window.setTimeout(this.loadGraphDataFromBackend, pollInterval);
+    }
   }
 
   private removePollingIntervalTimer() {

--- a/src/reducers/GraphDataState.ts
+++ b/src/reducers/GraphDataState.ts
@@ -52,6 +52,11 @@ const graphDataState = (state: GraphState = INITIAL_STATE, action) => {
         graphReference: action.summaryTarget
       };
       break;
+    case GraphActionKeys.GRAPH_NAMESPACE_CHANGED:
+      newState.graphData = INITIAL_STATE.graphData;
+      newState.graphDataTimestamp = INITIAL_STATE.graphDataTimestamp;
+      newState.sidePanelInfo = INITIAL_STATE.sidePanelInfo;
+      break;
     default:
       break;
   }


### PR DESCRIPTION
Loading message was already coded, but it wasn't being shown because CytoscapeGraph.shouldComponentUpdate wasn't allowing it to render when needed. A conditional is aded to let it render.

Also, graph state is now reset to initial values when graph namespace is changed. This allows the loading message to be shown, avoiding the graph of the old namespace to remain.

![loadingempty](https://user-images.githubusercontent.com/23639005/45575936-d4a50a80-b83a-11e8-97cd-02a748b5ffa0.gif)
