### PR TITLE
KIALI-804 Lowers time between dots for the lower request rates

### DIFF
--- a/src/components/CytoscapeGraph/TrafficAnimation/TrafficRenderer.ts
+++ b/src/components/CytoscapeGraph/TrafficAnimation/TrafficRenderer.ts
@@ -15,7 +15,7 @@ const TIMER_REQUEST_PER_SECOND_MAX = 750;
 // Range of time to use between spawning a new dot.
 // At higher request per second rate, faster dot spawning.
 const TIMER_TIME_BETWEEN_DOTS_MIN = 20;
-const TIMER_TIME_BETWEEN_DOTS_MAX = 2000;
+const TIMER_TIME_BETWEEN_DOTS_MAX = 1000;
 
 // Clamp response time from min to max
 const SPEED_RESPONSE_TIME_MIN = 0;


### PR DESCRIPTION
** Describe the change **

Lowers the time between dots for the low request rate, so slower requests will be more continuos

** Screenshot **

Note that edge unknown -> product page has a higher rate

![peek 2018-09-14 17-17](https://user-images.githubusercontent.com/3845764/45577606-65cbaf80-b842-11e8-8cf0-e6a4f2bfc544.gif)
