### PR TITLE
[WIP]Kiali-746: Graph duration dropdown is not persisted between

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@kiali/kiali-ui",
   "version": "0.8.0",
+  "proxy": "https://kiali-istio-system.ose.os310-kprod.osoos.centralci.eng.rdu2.redhat.com",
   "bugs": {
     "url": "https://issues.jboss.org/projects/KIALI/issues/"
   },
@@ -32,6 +33,7 @@
     "react-router-dom": "4.2.2",
     "react-scripts-ts": "2.15.1",
     "redux": "3.7.2",
+    "redux-logger": "^3.0.6",
     "redux-mock-store": "1.5.1",
     "redux-persist": "5.9.1",
     "redux-thunk": "2.2.0",

--- a/src/actions/GraphFilterActions.ts
+++ b/src/actions/GraphFilterActions.ts
@@ -1,6 +1,6 @@
 // Action Creators allow us to create typesafe utilities for dispatching actions
 import { createAction } from 'typesafe-actions';
-import { EdgeLabelMode, PollIntervalInMs } from '../types/GraphFilter';
+import { EdgeLabelMode } from '../types/GraphFilter';
 
 export enum GraphFilterActionKeys {
   // Toggle Actions
@@ -12,9 +12,7 @@ export enum GraphFilterActionKeys {
   TOGGLE_TRAFFIC_ANIMATION = 'TOGGLE_TRAFFIC_ANIMATION',
   SET_GRAPH_EDGE_LABEL_MODE = 'SET_GRAPH_EDGE_LABEL_MODE',
   // Disable Actions
-  ENABLE_GRAPH_FILTERS = 'ENABLE_GRAPH_FILTERS',
-  // Refresh Rate
-  SET_GRAPH_REFRESH_RATE = 'SET_GRAPH_REFRESH_RATE'
+  ENABLE_GRAPH_FILTERS = 'ENABLE_GRAPH_FILTERS'
 }
 
 export const graphFilterActions = {
@@ -34,10 +32,6 @@ export const graphFilterActions = {
   toggleTrafficAnimation: createAction(GraphFilterActionKeys.TOGGLE_TRAFFIC_ANIMATION),
   showGraphFilters: createAction(GraphFilterActionKeys.ENABLE_GRAPH_FILTERS, (value: boolean) => ({
     type: GraphFilterActionKeys.ENABLE_GRAPH_FILTERS,
-    payload: value
-  })),
-  setRefreshRate: createAction(GraphFilterActionKeys.SET_GRAPH_REFRESH_RATE, (value: PollIntervalInMs) => ({
-    type: GraphFilterActionKeys.SET_GRAPH_REFRESH_RATE,
     payload: value
   }))
 };

--- a/src/actions/UserSettingsActions.ts
+++ b/src/actions/UserSettingsActions.ts
@@ -1,13 +1,23 @@
 import { createAction } from 'typesafe-actions';
 
 export enum UserSettingsActionKeys {
-  NAV_COLLAPSE = 'NAV_COLLAPSE'
+  NAV_COLLAPSE = 'NAV_COLLAPSE',
+  SET_DURATION_INTERVAL = 'SET_DURATION_INTERVAL',
+  SET_REFRESH_INTERVAL = 'SET_REFRESH_INTERVAL'
 }
 
 export const UserSettingsActions = {
   navCollapse: createAction(UserSettingsActionKeys.NAV_COLLAPSE, (collapsed: boolean) => ({
     type: UserSettingsActionKeys.NAV_COLLAPSE,
     collapse: collapsed
+  })),
+  setDurationInterval: createAction(UserSettingsActionKeys.SET_DURATION_INTERVAL, (duration: number) => ({
+    type: UserSettingsActionKeys.SET_DURATION_INTERVAL,
+    payload: duration
+  })),
+  setRefreshInterval: createAction(UserSettingsActionKeys.SET_REFRESH_INTERVAL, (refreshInterval: number) => ({
+    type: UserSettingsActionKeys.SET_REFRESH_INTERVAL,
+    payload: refreshInterval
   })),
   setNavCollapsed: (collapsed: boolean) => {
     return dispatch => {

--- a/src/actions/__tests__/GraphFilterAction.test.tsx
+++ b/src/actions/__tests__/GraphFilterAction.test.tsx
@@ -70,20 +70,4 @@ describe('GraphFilterActions', () => {
     };
     expect(graphFilterActions.showGraphFilters(false)).toEqual(expectedAction);
   });
-
-  it('should set graph refresh rate to 0', () => {
-    const expectedAction = {
-      type: GraphFilterActionKeys.SET_GRAPH_REFRESH_RATE,
-      payload: 0
-    };
-    expect(graphFilterActions.setRefreshRate(0)).toEqual(expectedAction);
-  });
-
-  it('should set graph refresh rate to 15000', () => {
-    const expectedAction = {
-      type: GraphFilterActionKeys.SET_GRAPH_REFRESH_RATE,
-      payload: 15000
-    };
-    expect(graphFilterActions.setRefreshRate(15000)).toEqual(expectedAction);
-  });
 });

--- a/src/actions/__tests__/UserSettingsAction.test.ts
+++ b/src/actions/__tests__/UserSettingsAction.test.ts
@@ -1,0 +1,23 @@
+import { UserSettingsActionKeys, UserSettingsActions } from '../UserSettingsActions';
+
+describe('UserSettingsActions', () => {
+  it('should set the duration interval', () => {
+    expect(UserSettingsActions.setDurationInterval(60)).toEqual({
+      type: UserSettingsActionKeys.SET_DURATION_INTERVAL,
+      payload: 60
+    });
+  });
+
+  it('should set the refresh interval', () => {
+    expect(UserSettingsActions.setRefreshInterval(60)).toEqual({
+      type: UserSettingsActionKeys.SET_REFRESH_INTERVAL,
+      payload: 60
+    });
+  });
+
+  it('should set Nav Collapsed', () => {
+    expect(UserSettingsActions.navCollapse).toEqual({
+      type: UserSettingsActionKeys.NAV_COLLAPSE
+    });
+  });
+});

--- a/src/components/GraphFilter/GraphFilterToolbar.tsx
+++ b/src/components/GraphFilter/GraphFilterToolbar.tsx
@@ -9,6 +9,8 @@ import GraphFilterToolbarType from '../../types/GraphFilterToolbar';
 import { makeNamespaceGraphUrlFromParams, makeNodeGraphUrlFromParams } from '../Nav/NavUtils';
 
 import GraphFilter from './GraphFilter';
+import { store } from '../../store/ConfigStore';
+import { UserSettingsActions } from '../../actions/UserSettingsActions';
 
 export default class GraphFilterToolbar extends React.PureComponent<GraphFilterToolbarType> {
   static contextTypes = {
@@ -40,14 +42,15 @@ export default class GraphFilterToolbar extends React.PureComponent<GraphFilterT
   }
 
   handleDurationChange = (graphDuration: Duration) => {
-    this.handleFilterChange({
+    this.handleUrlFilterChange({
       ...this.getGraphParams(),
       graphDuration
     });
+    store.dispatch(UserSettingsActions.setDurationInterval(Number(graphDuration)));
   };
 
   handleNamespaceChange = (namespace: Namespace) => {
-    this.handleFilterChange({
+    this.handleUrlFilterChange({
       ...this.getGraphParams(),
       namespace
     });
@@ -60,17 +63,21 @@ export default class GraphFilterToolbar extends React.PureComponent<GraphFilterT
   };
 
   handleGraphTypeChange = (graphType: GraphType) => {
-    this.handleFilterChange({
+    this.handleUrlFilterChange({
       ...this.getGraphParams(),
       graphType
     });
   };
 
-  handleFilterChange = (params: GraphParamsType) => {
+  /**
+   * If we change the graph parameters then change the params in the url
+   * @param graphParams the graph parameters
+   */
+  handleUrlFilterChange = (graphParams: GraphParamsType) => {
     if (this.props.node) {
-      this.context.router.history.push(makeNodeGraphUrlFromParams(this.props.node, params));
+      this.context.router.history.push(makeNodeGraphUrlFromParams(this.props.node, graphParams));
     } else {
-      this.context.router.history.push(makeNamespaceGraphUrlFromParams(params));
+      this.context.router.history.push(makeNamespaceGraphUrlFromParams(graphParams));
     }
   };
 

--- a/src/components/GraphFilter/__tests__/GraphFilterToolbar.test.tsx
+++ b/src/components/GraphFilter/__tests__/GraphFilterToolbar.test.tsx
@@ -23,7 +23,7 @@ describe('GraphPage test', () => {
     const wrapper = shallow(<GraphFilterToolbar {...PARAMS} isLoading={false} handleRefreshClick={jest.fn()} />);
 
     const toolbar = wrapper.instance() as GraphFilterToolbar;
-    toolbar.handleFilterChange = onParamsChangeMockFn;
+    toolbar.handleUrlFilterChange = onParamsChangeMockFn;
 
     const newDuration: Duration = { value: 1800 };
     toolbar.handleDurationChange(newDuration); // simulate duration change

--- a/src/components/Metrics/Metrics.tsx
+++ b/src/components/Metrics/Metrics.tsx
@@ -4,7 +4,6 @@ import GrafanaInfo from '../../types/GrafanaInfo';
 import { authentication } from '../../utils/Authentication';
 import * as API from '../../services/Api';
 import { computePrometheusQueryInterval } from '../../services/Prometheus';
-import MetricsOptionsBar from '../../components/MetricsOptions/MetricsOptionsBar';
 import MetricsOptions from '../../types/MetricsOptions';
 import HistogramChart from './HistogramChart';
 import MetricChart from './MetricChart';
@@ -13,6 +12,7 @@ import history from '../../app/History';
 import { HistoryManager } from '../../app/History';
 import { Link } from 'react-router-dom';
 import { style } from 'typestyle';
+import MetricsOptionsBarContainer from '../MetricsOptions/MetricsOptionsBar';
 
 const expandedChartContainerStyle = style({
   height: 'calc(100vh - 248px)'
@@ -135,6 +135,7 @@ class Metrics extends React.Component<MetricsProps, MetricsState> {
     options.step = intervalOpts.step;
     options.rateInterval = intervalOpts.rateInterval;
     this.fetchMetrics();
+    console.dir(options);
     HistoryManager.setParam('duration', options.duration!.toString(10));
   };
 
@@ -236,7 +237,7 @@ class Metrics extends React.Component<MetricsProps, MetricsState> {
           </h3>
         )}
         {this.state.alertDetails && <Alert onDismiss={this.dismissAlert}>{this.state.alertDetails}</Alert>}
-        <MetricsOptionsBar
+        <MetricsOptionsBarContainer
           onOptionsChanged={this.onOptionsChanged}
           onPollIntervalChanged={this.onPollIntervalChanged}
           onReporterChanged={this.onReporterChanged}

--- a/src/components/Metrics/__tests__/__snapshots__/Metrics.test.tsx.snap
+++ b/src/components/Metrics/__tests__/__snapshots__/Metrics.test.tsx.snap
@@ -26,7 +26,7 @@ ShallowWrapper {
       "children": Array [
         null,
         undefined,
-        <MetricsOptionsBar
+        <Connect(MetricsOptionsBar)
           metricReporter="destination"
           onManualRefresh={[Function]}
           onOptionsChanged={[Function]}
@@ -193,7 +193,7 @@ ShallowWrapper {
         "children": Array [
           null,
           undefined,
-          <MetricsOptionsBar
+          <Connect(MetricsOptionsBar)
             metricReporter="destination"
             onManualRefresh={[Function]}
             onOptionsChanged={[Function]}
@@ -388,7 +388,7 @@ ShallowWrapper {
       "children": Array [
         null,
         undefined,
-        <MetricsOptionsBar
+        <Connect(MetricsOptionsBar)
           metricReporter="destination"
           onManualRefresh={[Function]}
           onOptionsChanged={[Function]}
@@ -555,7 +555,7 @@ ShallowWrapper {
         "children": Array [
           null,
           undefined,
-          <MetricsOptionsBar
+          <Connect(MetricsOptionsBar)
             metricReporter="destination"
             onManualRefresh={[Function]}
             onOptionsChanged={[Function]}
@@ -750,7 +750,7 @@ ShallowWrapper {
       "children": Array [
         null,
         undefined,
-        <MetricsOptionsBar
+        <Connect(MetricsOptionsBar)
           metricReporter="source"
           onManualRefresh={[Function]}
           onOptionsChanged={[Function]}
@@ -917,7 +917,7 @@ ShallowWrapper {
         "children": Array [
           null,
           undefined,
-          <MetricsOptionsBar
+          <Connect(MetricsOptionsBar)
             metricReporter="source"
             onManualRefresh={[Function]}
             onOptionsChanged={[Function]}

--- a/src/components/MetricsOptions/__tests__/__snapshots__/MetricsOptionsBar.test.tsx.snap
+++ b/src/components/MetricsOptions/__tests__/__snapshots__/MetricsOptionsBar.test.tsx.snap
@@ -14,7 +14,7 @@ ShallowWrapper {
             Object {
               "byLabelsIn": Array [],
               "byLabelsOut": Array [],
-              "duration": 60,
+              "duration": undefined,
             },
           ],
         ],
@@ -83,8 +83,8 @@ ShallowWrapper {
           disabled={false}
           handleSelect={[Function]}
           id="metrics_filter_interval_duration"
-          initialLabel="Last minute"
-          initialValue={60}
+          initialLabel="undefined"
+          initialValue={undefined}
           nameDropdown="Duration"
           options={
             Object {
@@ -240,8 +240,8 @@ ShallowWrapper {
           "disabled": false,
           "handleSelect": [Function],
           "id": "metrics_filter_interval_duration",
-          "initialLabel": "Last minute",
-          "initialValue": 60,
+          "initialLabel": "undefined",
+          "initialValue": undefined,
           "nameDropdown": "Duration",
           "options": Object {
             "10800": "Last 3 hours",
@@ -390,8 +390,8 @@ ShallowWrapper {
             disabled={false}
             handleSelect={[Function]}
             id="metrics_filter_interval_duration"
-            initialLabel="Last minute"
-            initialValue={60}
+            initialLabel="undefined"
+            initialValue={undefined}
             nameDropdown="Duration"
             options={
               Object {
@@ -547,8 +547,8 @@ ShallowWrapper {
             "disabled": false,
             "handleSelect": [Function],
             "id": "metrics_filter_interval_duration",
-            "initialLabel": "Last minute",
-            "initialValue": 60,
+            "initialLabel": "undefined",
+            "initialValue": undefined,
             "nameDropdown": "Duration",
             "options": Object {
               "10800": "Last 3 hours",

--- a/src/containers/GraphPageContainer.ts
+++ b/src/containers/GraphPageContainer.ts
@@ -20,7 +20,7 @@ const mapStateToProps = (state: KialiAppState) => ({
       }
     : null,
   showLegend: state.graph.filterState.showLegend,
-  pollInterval: state.graph.filterState.refreshRate,
+  pollInterval: state.userSettings.refreshInterval,
   isPageVisible: state.globalState.isPageVisible,
   isError: state.graph.isError
 });

--- a/src/containers/GraphRefreshContainer.tsx
+++ b/src/containers/GraphRefreshContainer.tsx
@@ -1,20 +1,18 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { graphFilterActions } from '../actions/GraphFilterActions';
 import { KialiAppState } from '../store/Store';
 import GraphRefresh from '../components/GraphFilter/GraphRefresh';
 import { config } from '../config';
+import { UserSettingsActions } from '../actions/UserSettingsActions';
 
 const mapStateToProps = (state: KialiAppState) => ({
-  selected: state.graph.filterState.refreshRate
+  selected: state.userSettings.refreshInterval
 });
 
 const mapDispatchToProps = (dispatch: any) => {
   return {
-    // TODO: We still need to reduxify namespace and duration to be able to use this
-    // handleRefresh: bindActionCreators(GraphDataActions.fetchGraphData, dispatch),
-    onSelect: bindActionCreators(graphFilterActions.setRefreshRate, dispatch)
+    onSelect: bindActionCreators(UserSettingsActions.setRefreshInterval, dispatch)
   };
 };
 

--- a/src/reducers/GraphDataState.ts
+++ b/src/reducers/GraphDataState.ts
@@ -2,7 +2,6 @@ import { GraphState } from '../store/Store';
 import { GraphDataActionKeys } from '../actions/GraphDataActionKeys';
 import { GraphActionKeys } from '../actions/GraphActions';
 import FilterStateReducer from './GraphFilterState';
-import { MILLISECONDS } from '../types/Common';
 
 const INITIAL_STATE: GraphState = {
   isLoading: false,
@@ -17,8 +16,7 @@ const INITIAL_STATE: GraphState = {
     showCircuitBreakers: true,
     showVirtualServices: true,
     showMissingSidecars: true,
-    showTrafficAnimation: false,
-    refreshRate: 15 * MILLISECONDS
+    showTrafficAnimation: false
   }
 };
 

--- a/src/reducers/GraphFilterState.ts
+++ b/src/reducers/GraphFilterState.ts
@@ -1,7 +1,6 @@
 import { GraphFilterState } from '../store/Store';
 import { GraphFilterActionKeys } from '../actions/GraphFilterActions';
 import { updateState } from '../utils/Reducer';
-import { config } from '../config';
 
 const INITIAL_STATE: GraphFilterState = {
   showLegend: false,
@@ -9,11 +8,8 @@ const INITIAL_STATE: GraphFilterState = {
   showCircuitBreakers: true,
   showVirtualServices: true,
   showMissingSidecars: true,
-  showTrafficAnimation: false,
-  // @ todo: add disableLayers back in later
-  // disableLayers: false
-  // edgeLabelMode: EdgeLabelMode.HIDE,
-  refreshRate: config().toolbar.defaultPollInterval
+  showTrafficAnimation: false
+  // refreshRate: config().toolbar.defaultPollInterval
 };
 
 // This Reducer allows changes to the 'graphFilterState' portion of Redux Store
@@ -35,8 +31,6 @@ const graphFilterState = (state: GraphFilterState = INITIAL_STATE, action) => {
       return updateState(state, { showTrafficAnimation: !state.showTrafficAnimation });
     case GraphFilterActionKeys.ENABLE_GRAPH_FILTERS:
       return updateState(state, { disableLayers: action.payload });
-    case GraphFilterActionKeys.SET_GRAPH_REFRESH_RATE:
-      return updateState(state, { refreshRate: action.payload });
     default:
       return state;
   }

--- a/src/reducers/UserSettingsState.ts
+++ b/src/reducers/UserSettingsState.ts
@@ -1,15 +1,27 @@
 import { UserSettings } from '../store/Store';
 import { UserSettingsActionKeys } from '../actions/UserSettingsActions';
+import { config } from '../config';
+import { updateState } from '../utils/Reducer';
 
 const INITIAL_STATE: UserSettings = {
-  interface: { navCollapse: false }
+  interface: { navCollapse: false },
+  durationInterval: config().toolbar.defaultDuration,
+  refreshInterval: config().toolbar.defaultPollInterval
 };
 
 const UserSettingsState = (state: UserSettings = INITIAL_STATE, action) => {
   switch (action.type) {
     case UserSettingsActionKeys.NAV_COLLAPSE:
-      return Object.assign({}, INITIAL_STATE, {
+      return updateState(state, {
         interface: { navCollapse: action.collapse }
+      });
+    case UserSettingsActionKeys.SET_DURATION_INTERVAL:
+      return updateState(state, {
+        durationInterval: action.payload
+      });
+    case UserSettingsActionKeys.SET_REFRESH_INTERVAL:
+      return updateState(state, {
+        refreshInterval: action.payload
       });
     default:
       return state;

--- a/src/reducers/__tests__/GraphFilterStateReducer.test.ts
+++ b/src/reducers/__tests__/GraphFilterStateReducer.test.ts
@@ -9,8 +9,7 @@ describe('GraphFilterState reducer', () => {
       showCircuitBreakers: true,
       showVirtualServices: true,
       showMissingSidecars: true,
-      showTrafficAnimation: false,
-      refreshRate: 15000
+      showTrafficAnimation: false
     });
   });
 
@@ -23,8 +22,7 @@ describe('GraphFilterState reducer', () => {
           showCircuitBreakers: false,
           showVirtualServices: true,
           showMissingSidecars: true,
-          showTrafficAnimation: false,
-          refreshRate: 15000
+          showTrafficAnimation: false
         },
         {
           type: GraphFilterActionKeys.TOGGLE_LEGEND
@@ -36,8 +34,7 @@ describe('GraphFilterState reducer', () => {
       showCircuitBreakers: false,
       showVirtualServices: true,
       showMissingSidecars: true,
-      showTrafficAnimation: false,
-      refreshRate: 15000
+      showTrafficAnimation: false
     });
   });
 
@@ -50,8 +47,7 @@ describe('GraphFilterState reducer', () => {
           showCircuitBreakers: false,
           showVirtualServices: true,
           showMissingSidecars: true,
-          showTrafficAnimation: false,
-          refreshRate: 15000
+          showTrafficAnimation: false
         },
         {
           type: GraphFilterActionKeys.TOGGLE_GRAPH_NODE_LABEL
@@ -63,8 +59,7 @@ describe('GraphFilterState reducer', () => {
       showCircuitBreakers: false,
       showVirtualServices: true,
       showMissingSidecars: true,
-      showTrafficAnimation: false,
-      refreshRate: 15000
+      showTrafficAnimation: false
     });
   });
 
@@ -77,8 +72,7 @@ describe('GraphFilterState reducer', () => {
           showCircuitBreakers: false,
           showVirtualServices: true,
           showMissingSidecars: true,
-          showTrafficAnimation: false,
-          refreshRate: 15000
+          showTrafficAnimation: false
         },
         {
           type: GraphFilterActionKeys.TOGGLE_GRAPH_CIRCUIT_BREAKERS
@@ -90,8 +84,7 @@ describe('GraphFilterState reducer', () => {
       showCircuitBreakers: true,
       showVirtualServices: true,
       showMissingSidecars: true,
-      showTrafficAnimation: false,
-      refreshRate: 15000
+      showTrafficAnimation: false
     });
   });
   it('should handle TOGGLE_GRAPH_VIRTUAL_SERVICES', () => {
@@ -103,8 +96,7 @@ describe('GraphFilterState reducer', () => {
           showCircuitBreakers: false,
           showVirtualServices: true,
           showMissingSidecars: true,
-          showTrafficAnimation: false,
-          refreshRate: 15000
+          showTrafficAnimation: false
         },
         {
           type: GraphFilterActionKeys.TOGGLE_GRAPH_VIRTUAL_SERVICES
@@ -116,8 +108,7 @@ describe('GraphFilterState reducer', () => {
       showCircuitBreakers: false,
       showVirtualServices: false,
       showMissingSidecars: true,
-      showTrafficAnimation: false,
-      refreshRate: 15000
+      showTrafficAnimation: false
     });
   });
   it('should handle TOGGLE_GRAPH_MISSING_SIDECARS', () => {
@@ -129,8 +120,7 @@ describe('GraphFilterState reducer', () => {
           showCircuitBreakers: false,
           showVirtualServices: true,
           showMissingSidecars: true,
-          showTrafficAnimation: false,
-          refreshRate: 15000
+          showTrafficAnimation: false
         },
         {
           type: GraphFilterActionKeys.TOGGLE_GRAPH_MISSING_SIDECARS
@@ -142,8 +132,7 @@ describe('GraphFilterState reducer', () => {
       showCircuitBreakers: false,
       showVirtualServices: true,
       showMissingSidecars: false,
-      showTrafficAnimation: false,
-      refreshRate: 15000
+      showTrafficAnimation: false
     });
   });
   it('should handle TOGGLE_TRAFFIC_ANIMATION', () => {
@@ -155,8 +144,7 @@ describe('GraphFilterState reducer', () => {
           showCircuitBreakers: false,
           showVirtualServices: true,
           showMissingSidecars: true,
-          showTrafficAnimation: false,
-          refreshRate: 15000
+          showTrafficAnimation: false
         },
         {
           type: GraphFilterActionKeys.TOGGLE_TRAFFIC_ANIMATION
@@ -168,35 +156,7 @@ describe('GraphFilterState reducer', () => {
       showCircuitBreakers: false,
       showVirtualServices: true,
       showMissingSidecars: true,
-      showTrafficAnimation: true,
-      refreshRate: 15000
-    });
-  });
-  it('should handle SET_GRAPH_REFRESH_RATE', () => {
-    expect(
-      graphFilterState(
-        {
-          showLegend: false,
-          showNodeLabels: true,
-          showCircuitBreakers: false,
-          showVirtualServices: true,
-          showMissingSidecars: true,
-          showTrafficAnimation: false,
-          refreshRate: 15000
-        },
-        {
-          type: GraphFilterActionKeys.SET_GRAPH_REFRESH_RATE,
-          payload: 10000
-        }
-      )
-    ).toEqual({
-      showLegend: false,
-      showNodeLabels: true,
-      showCircuitBreakers: false,
-      showVirtualServices: true,
-      showMissingSidecars: true,
-      showTrafficAnimation: false,
-      refreshRate: 10000
+      showTrafficAnimation: true
     });
   });
 });

--- a/src/reducers/__tests__/UserSettingsState.test.ts
+++ b/src/reducers/__tests__/UserSettingsState.test.ts
@@ -1,0 +1,71 @@
+import UserSettingsState from '../UserSettingsState';
+import { UserSettingsActionKeys } from '../../actions/UserSettingsActions';
+
+describe('UserSettingsState reducer', () => {
+  it('should return the initial state', () => {
+    expect(UserSettingsState(undefined, {})).toEqual({
+      interface: { navCollapse: false },
+      durationInterval: 60,
+      refreshInterval: 60
+    });
+  });
+
+  it('should collapse the nav', () => {
+    expect(
+      UserSettingsState(
+        {
+          interface: { navCollapse: false },
+          durationInterval: 60,
+          refreshInterval: 60
+        },
+        {
+          type: UserSettingsActionKeys.NAV_COLLAPSE
+        }
+      )
+    ).toEqual({
+      interface: { navCollapse: true },
+      durationInterval: 60,
+      refreshInterval: 60
+    });
+  });
+
+  it('should set duration interval', () => {
+    expect(
+      UserSettingsState(
+        {
+          interface: { navCollapse: false },
+          durationInterval: 60,
+          refreshInterval: 60
+        },
+        {
+          type: UserSettingsActionKeys.SET_DURATION_INTERVAL,
+          payload: 120
+        }
+      )
+    ).toEqual({
+      interface: { navCollapse: false },
+      durationInterval: 120,
+      refreshInterval: 60
+    });
+  });
+
+  it('should set refresh interval', () => {
+    expect(
+      UserSettingsState(
+        {
+          interface: { navCollapse: false },
+          durationInterval: 60,
+          refreshInterval: 60
+        },
+        {
+          type: UserSettingsActionKeys.SET_REFRESH_INTERVAL,
+          payload: 120
+        }
+      )
+    ).toEqual({
+      interface: { navCollapse: false },
+      durationInterval: 60,
+      refreshInterval: 120
+    });
+  });
+});

--- a/src/store/ConfigStore.ts
+++ b/src/store/ConfigStore.ts
@@ -3,11 +3,24 @@ import { KialiAppState } from './Store';
 import { persistStore, persistReducer } from 'redux-persist';
 import rootReducer from '../reducers';
 import thunk from 'redux-thunk';
+// import { createLogger } from 'redux-logger';
 
 // defaults to localStorage for web and AsyncStorage for react-native
 import storage from 'redux-persist/lib/storage';
+// import { GlobalActionKeys } from '../actions/GlobalActions';
 
 declare const window;
+
+// const logger = createLogger({
+//   duration: true,
+//   timestamp: false,
+//   collapsed: true,
+//   level: 'log',
+//   diff: true,
+//   predicate: (getState, action) =>
+//     action.type !== GlobalActionKeys.INCREMENT_LOADING_COUNTER ||
+//     action.type !== GlobalActionKeys.DECREMENT_LOADING_COUNTER
+// });
 
 const persistConfig = {
   key: 'root',

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -1,5 +1,4 @@
 import { NotificationGroup } from '../types/MessageCenter';
-import { PollIntervalInMs } from '../types/GraphFilter';
 // Store is the Redux Data store
 
 export interface GlobalState {
@@ -16,7 +15,7 @@ export interface GraphFilterState {
   readonly showVirtualServices: boolean;
   readonly showMissingSidecars: boolean;
   readonly showTrafficAnimation: boolean;
-  readonly refreshRate: PollIntervalInMs;
+  // readonly refreshRate: PollIntervalInMs;
 }
 
 export interface MessageCenterState {
@@ -71,6 +70,8 @@ export interface InterfaceSettings {
 
 export interface UserSettings {
   interface: InterfaceSettings;
+  refreshInterval: number;
+  durationInterval: number;
 }
 // @todo: Add namespaces interface
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2461,6 +2461,10 @@ decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
 
+deep-diff@^0.3.5:
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-0.3.8.tgz#c01de63efb0eec9798801d40c7e0dae25b582c84"
+
 deep-equal@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
@@ -7308,6 +7312,12 @@ reduce-function-call@^1.0.1:
   resolved "https://registry.yarnpkg.com/reduce-function-call/-/reduce-function-call-1.0.2.tgz#5a200bf92e0e37751752fe45b0ab330fd4b6be99"
   dependencies:
     balanced-match "^0.4.2"
+
+redux-logger@^3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-3.0.6.tgz#f7555966f3098f3c88604c449cf0baf5778274bf"
+  dependencies:
+    deep-diff "^0.3.5"
 
 redux-mock-store@1.5.1:
   version "1.5.1"


### PR DESCRIPTION
Graph duration is not persisted when switching between Metrics and ServiceGraph.
The purpose of this PR is to get graph settings into redux and have all the other screens use these global settings. This is a bit larger than just a bug fix.

** Backwards compatible? **
Yes