### PR TITLE
KIALI-1558 Fix IstioFlag in WorkloadDetails when there are not pods

### DIFF
--- a/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -76,7 +76,10 @@ class WorkloadDetails extends React.Component<RouteComponentProps<WorkloadId>, W
         this.setState({
           workload: resultDetails.data,
           validations: resultValidations.data,
-          istioEnabled: this.checkIstioEnabled(resultValidations.data),
+          istioEnabled:
+            resultDetails.data.pods && resultDetails.data.pods.length > 0
+              ? this.checkIstioEnabled(resultValidations.data)
+              : false,
           health: resultHealth
         });
       })


### PR DESCRIPTION
** Describe the change **

Fix IstioFlag when workload has no pods.
This could be done in backend too, but I guess it is good to have this patch in UI, as probably checkers will be reviewed as part of KIALI-1284.

** Issue reference **

https://issues.jboss.org/browse/KIALI-1558
