### PR TITLE
KIALI-1543 - continuing list filters refactoring

### DIFF
--- a/src/components/Filters/NamespaceFilter.ts
+++ b/src/components/Filters/NamespaceFilter.ts
@@ -1,0 +1,22 @@
+import * as API from '../../services/Api';
+import { authentication } from '../../utils/Authentication';
+import { FILTER_ACTION_APPEND, FilterType } from '../../types/Filters';
+
+export class NamespaceFilter {
+  static create = (): FilterType => {
+    return {
+      id: 'namespace',
+      title: 'Namespace',
+      placeholder: 'Filter by Namespace',
+      filterType: 'select',
+      action: FILTER_ACTION_APPEND,
+      filterValues: [],
+      loader: () =>
+        API.getNamespaces(authentication()).then(response => {
+          return response.data.map(ns => ({ title: ns.name, id: ns.name }));
+        })
+    };
+  };
+}
+
+export default NamespaceFilter;

--- a/src/components/ListPage/ListPage.ts
+++ b/src/components/ListPage/ListPage.ts
@@ -3,13 +3,17 @@ import { RouteComponentProps } from 'react-router';
 import * as MessageCenter from '../../utils/MessageCenter';
 import { URLParameter } from '../../types/Parameters';
 import { Pagination } from '../../types/Pagination';
+import { FilterType, ActiveFilter } from '../../types/Filters';
+import { FilterSelected } from '../Filters/StatefulFilters';
+import { config } from '../../config';
 
 export namespace ListPage {
   const ACTION_APPEND = 'append';
   const ACTION_SET = 'set';
 
   export const perPageOptions: number[] = [5, 10, 15];
-  const defaultRateInterval = 600;
+  const defaultDuration = 600;
+  const defaultPollInterval = config().toolbar.defaultPollInterval;
 
   export interface Hooks {
     handleError: (error: string) => void;
@@ -18,6 +22,12 @@ export namespace ListPage {
     getQueryParam: (queryName: string) => string[] | undefined;
     getSingleQueryParam: (queryName: string) => string | undefined;
     getSingleIntQueryParam: (queryName: string) => number | undefined;
+    setSelectedFiltersFromURL: (filterTypes: FilterType[]) => void;
+    setSelectedFiltersToURL: (filterTypes: FilterType[]) => void;
+    filtersMatchURL: (filterTypes: FilterType[]) => boolean;
+    isCurrentSortAscending: () => boolean;
+    currentDuration: () => number;
+    currentPollInterval: () => number;
   }
 
   export class Component<P, S> extends React.Component<RouteComponentProps<P>, S> implements Hooks {
@@ -84,6 +94,75 @@ export namespace ListPage {
       return p === undefined ? undefined : parseInt(p[0], 10);
     };
 
+    setSelectedFiltersFromURL(filterTypes: FilterType[]) {
+      const urlParams = new URLSearchParams(this.props.location.search);
+      const activeFilters: ActiveFilter[] = [];
+      filterTypes.forEach(filter => {
+        urlParams.getAll(filter.id).forEach(value => {
+          activeFilters.push({
+            label: filter.title + ': ' + value,
+            category: filter.title,
+            value: value
+          });
+        });
+      });
+      FilterSelected.setSelected(activeFilters);
+    }
+
+    setSelectedFiltersToURL(filterTypes: FilterType[]) {
+      const filters = FilterSelected.getSelected();
+      const urlParams = new URLSearchParams(this.props.location.search);
+      filterTypes.forEach(type => {
+        urlParams.delete(type.id);
+      });
+      const cleanFilters: ActiveFilter[] = [];
+      filters.forEach(activeFilter => {
+        const filterType = filterTypes.find(filter => filter.title === activeFilter.category);
+        if (!filterType) {
+          return;
+        }
+        cleanFilters.push(activeFilter);
+        urlParams.append(filterType.id, activeFilter.value);
+      });
+      // Resetting pagination when filters change
+      urlParams.delete('page');
+      this.props.history.push(this.props.location.pathname + '?' + urlParams.toString());
+      // Update the selected filters list, as some may have been removed
+      FilterSelected.setSelected(cleanFilters);
+    }
+
+    filtersMatchURL(filterTypes: FilterType[]): boolean {
+      const filters = FilterSelected.getSelected();
+      // This can probably be improved and/or simplified?
+      const fromFilters: Map<string, string[]> = new Map<string, string[]>();
+      filters.map(activeFilter => {
+        const existingValue = fromFilters.get(activeFilter.category) || [];
+        fromFilters.set(activeFilter.category, existingValue.concat(activeFilter.value));
+      });
+
+      const fromURL: Map<string, string[]> = new Map<string, string[]>();
+      const urlParams = new URLSearchParams(this.props.location.search);
+      filterTypes.forEach(filter => {
+        const values = urlParams.getAll(filter.id);
+        if (values.length > 0) {
+          const existing = fromURL.get(filter.title) || [];
+          fromURL.set(filter.title, existing.concat(values));
+        }
+      });
+
+      if (fromFilters.size !== fromURL.size) {
+        return false;
+      }
+      let equalFilters = true;
+      fromFilters.forEach((filterValues, filterName) => {
+        const aux = fromURL.get(filterName) || [];
+        equalFilters =
+          equalFilters && filterValues.every(value => aux.includes(value)) && filterValues.length === aux.length;
+      });
+
+      return equalFilters;
+    }
+
     currentPagination(): Pagination {
       return {
         page: this.getSingleIntQueryParam('page') || 1,
@@ -92,12 +171,20 @@ export namespace ListPage {
       };
     }
 
-    isCurrentSortAscending() {
+    isCurrentSortAscending(): boolean {
       return (this.getSingleQueryParam('direction') || 'asc') === 'asc';
     }
 
-    currentRateInterval() {
-      return this.getSingleIntQueryParam('rate') || defaultRateInterval;
+    currentDuration() {
+      return this.getSingleIntQueryParam('duration') || defaultDuration;
+    }
+
+    currentPollInterval() {
+      const pi = this.getSingleIntQueryParam('pi');
+      if (pi === undefined) {
+        return defaultPollInterval;
+      }
+      return pi;
     }
   }
 }

--- a/src/components/ListPage/__tests__/ListPage.test.tsx
+++ b/src/components/ListPage/__tests__/ListPage.test.tsx
@@ -1,5 +1,4 @@
 import { ListPage } from '../ListPage';
-import { FilterSelected } from '../../Filters/StatefulFilters';
 import { Location } from 'history';
 import { FilterType } from '../../../types/Filters';
 import { createBrowserHistory } from 'history';
@@ -31,21 +30,18 @@ describe('List page', () => {
       history: history,
       staticContext: mock
     });
-    listPage.setSelectedFiltersFromURL(managedFilterTypes);
-    expect(FilterSelected.getSelected()).toEqual([
+    const filters = listPage.getFiltersFromURL(managedFilterTypes);
+    expect(filters).toEqual([
       {
         category: 'A',
-        label: 'A: 1',
         value: '1'
       },
       {
         category: 'C',
-        label: 'C: 3',
         value: '3'
       },
       {
         category: 'C',
-        label: 'C: 4',
         value: '4'
       }
     ]);
@@ -62,25 +58,22 @@ describe('List page', () => {
       history: history,
       staticContext: mock
     });
-    FilterSelected.setSelected([
+    const cleanFilters = listPage.setFiltersToURL(managedFilterTypes, [
       {
         category: 'A',
-        label: 'A: 1',
         value: '1'
       },
       {
         category: 'C',
-        label: 'C: 3',
         value: '3'
       },
       {
         category: 'C',
-        label: 'C: 4',
         value: '4'
       }
     ]);
-    listPage.setSelectedFiltersToURL(managedFilterTypes);
     expect(listPage.props.history.location.search).toEqual('?b=20&a=1&c=3&c=4');
+    expect(cleanFilters).toHaveLength(3);
   });
 
   it('filters should match URL, ignoring order and non-managed query params', () => {
@@ -94,24 +87,20 @@ describe('List page', () => {
       staticContext: mock
     });
     // Make sure order is ignored
-    FilterSelected.setSelected([
+    const match = listPage.filtersMatchURL(managedFilterTypes, [
       {
         category: 'C',
-        label: 'C: 3',
         value: '3'
       },
       {
         category: 'A',
-        label: 'A: 1',
         value: '1'
       },
       {
         category: 'C',
-        label: 'C: 4',
         value: '4'
       }
     ]);
-    const match = listPage.filtersMatchURL(managedFilterTypes);
     expect(match).toBe(true);
   });
 
@@ -126,103 +115,84 @@ describe('List page', () => {
       staticContext: mock
     });
     // Incorrect value
-    FilterSelected.setSelected([
+    let match = listPage.filtersMatchURL(managedFilterTypes, [
       {
         category: 'A',
-        label: 'A: 1',
         value: '1'
       },
       {
         category: 'C',
-        label: 'C: 3',
         value: '3'
       },
       {
         category: 'C',
-        label: 'C: 5',
         value: '5'
       }
     ]);
-    let match = listPage.filtersMatchURL(managedFilterTypes);
     expect(match).toBe(false);
 
     // Missing value from selection
-    FilterSelected.setSelected([
+    match = listPage.filtersMatchURL(managedFilterTypes, [
       {
         category: 'A',
-        label: 'A: 1',
         value: '1'
       },
       {
         category: 'C',
-        label: 'C: 3',
         value: '3'
       }
     ]);
-    match = listPage.filtersMatchURL(managedFilterTypes);
     expect(match).toBe(false);
 
     // Missing value from URL
-    FilterSelected.setSelected([
+    match = listPage.filtersMatchURL(managedFilterTypes, [
       {
         category: 'A',
-        label: 'A: 1',
         value: '1'
       },
       {
         category: 'C',
-        label: 'C: 3',
         value: '3'
       },
       {
         category: 'C',
-        label: 'C: 4',
         value: '4'
       },
       {
         category: 'C',
-        label: 'C: 5',
         value: '5'
       }
     ]);
-    match = listPage.filtersMatchURL(managedFilterTypes);
     expect(match).toBe(false);
 
     // Missing key from selection
-    FilterSelected.setSelected([
+    match = listPage.filtersMatchURL(managedFilterTypes, [
       {
         category: 'A',
-        label: 'A: 1',
         value: '1'
       }
     ]);
-    match = listPage.filtersMatchURL(managedFilterTypes);
     expect(match).toBe(false);
 
     // Missing key from URL
-    FilterSelected.setSelected([
+    match = listPage.filtersMatchURL(managedFilterTypes, [
       {
         category: 'A',
-        label: 'A: 1',
         value: '1'
       },
       {
         category: 'C',
-        label: 'C: 3',
         value: '3'
       },
       {
         category: 'C',
-        label: 'C: 4',
         value: '4'
       },
       {
         category: 'D',
-        label: 'D: 5',
         value: '5'
       }
     ]);
-    match = listPage.filtersMatchURL(managedFilterTypes);
     expect(match).toBe(false);
   });
 });

--- a/src/components/ListPage/__tests__/ListPage.test.tsx
+++ b/src/components/ListPage/__tests__/ListPage.test.tsx
@@ -1,0 +1,228 @@
+import { ListPage } from '../ListPage';
+import { FilterSelected } from '../../Filters/StatefulFilters';
+import { Location } from 'history';
+import { FilterType } from '../../../types/Filters';
+import { createBrowserHistory } from 'history';
+
+const history = createBrowserHistory({ basename: '' });
+const managedFilterTypes = [
+  {
+    id: 'a',
+    title: 'A'
+  },
+  {
+    id: 'c',
+    title: 'C'
+  },
+  {
+    id: 'd',
+    title: 'D'
+  }
+] as FilterType[];
+
+describe('List page', () => {
+  it('sets selected filters from URL', () => {
+    const mock: any = jest.fn();
+    const listPage = new ListPage.Component({
+      match: mock,
+      location: {
+        search: '?a=1&b=2&c=3&c=4'
+      } as Location,
+      history: history,
+      staticContext: mock
+    });
+    listPage.setSelectedFiltersFromURL(managedFilterTypes);
+    expect(FilterSelected.getSelected()).toEqual([
+      {
+        category: 'A',
+        label: 'A: 1',
+        value: '1'
+      },
+      {
+        category: 'C',
+        label: 'C: 3',
+        value: '3'
+      },
+      {
+        category: 'C',
+        label: 'C: 4',
+        value: '4'
+      }
+    ]);
+  });
+
+  it('sets selected filters to URL', () => {
+    const mock: any = jest.fn();
+    const listPage = new ListPage.Component({
+      match: mock,
+      location: {
+        pathname: 'any',
+        search: '?a=10&b=20&c=30&c=40'
+      } as Location,
+      history: history,
+      staticContext: mock
+    });
+    FilterSelected.setSelected([
+      {
+        category: 'A',
+        label: 'A: 1',
+        value: '1'
+      },
+      {
+        category: 'C',
+        label: 'C: 3',
+        value: '3'
+      },
+      {
+        category: 'C',
+        label: 'C: 4',
+        value: '4'
+      }
+    ]);
+    listPage.setSelectedFiltersToURL(managedFilterTypes);
+    expect(listPage.props.history.location.search).toEqual('?b=20&a=1&c=3&c=4');
+  });
+
+  it('filters should match URL, ignoring order and non-managed query params', () => {
+    const mock: any = jest.fn();
+    const listPage = new ListPage.Component({
+      match: mock,
+      location: {
+        search: '?a=1&b=2&c=3&c=4'
+      } as Location,
+      history: history,
+      staticContext: mock
+    });
+    // Make sure order is ignored
+    FilterSelected.setSelected([
+      {
+        category: 'C',
+        label: 'C: 3',
+        value: '3'
+      },
+      {
+        category: 'A',
+        label: 'A: 1',
+        value: '1'
+      },
+      {
+        category: 'C',
+        label: 'C: 4',
+        value: '4'
+      }
+    ]);
+    const match = listPage.filtersMatchURL(managedFilterTypes);
+    expect(match).toBe(true);
+  });
+
+  it('filters should not match URL', () => {
+    const mock: any = jest.fn();
+    const listPage = new ListPage.Component({
+      match: mock,
+      location: {
+        search: '?a=1&b=2&c=3&c=4'
+      } as Location,
+      history: history,
+      staticContext: mock
+    });
+    // Incorrect value
+    FilterSelected.setSelected([
+      {
+        category: 'A',
+        label: 'A: 1',
+        value: '1'
+      },
+      {
+        category: 'C',
+        label: 'C: 3',
+        value: '3'
+      },
+      {
+        category: 'C',
+        label: 'C: 5',
+        value: '5'
+      }
+    ]);
+    let match = listPage.filtersMatchURL(managedFilterTypes);
+    expect(match).toBe(false);
+
+    // Missing value from selection
+    FilterSelected.setSelected([
+      {
+        category: 'A',
+        label: 'A: 1',
+        value: '1'
+      },
+      {
+        category: 'C',
+        label: 'C: 3',
+        value: '3'
+      }
+    ]);
+    match = listPage.filtersMatchURL(managedFilterTypes);
+    expect(match).toBe(false);
+
+    // Missing value from URL
+    FilterSelected.setSelected([
+      {
+        category: 'A',
+        label: 'A: 1',
+        value: '1'
+      },
+      {
+        category: 'C',
+        label: 'C: 3',
+        value: '3'
+      },
+      {
+        category: 'C',
+        label: 'C: 4',
+        value: '4'
+      },
+      {
+        category: 'C',
+        label: 'C: 5',
+        value: '5'
+      }
+    ]);
+    match = listPage.filtersMatchURL(managedFilterTypes);
+    expect(match).toBe(false);
+
+    // Missing key from selection
+    FilterSelected.setSelected([
+      {
+        category: 'A',
+        label: 'A: 1',
+        value: '1'
+      }
+    ]);
+    match = listPage.filtersMatchURL(managedFilterTypes);
+    expect(match).toBe(false);
+
+    // Missing key from URL
+    FilterSelected.setSelected([
+      {
+        category: 'A',
+        label: 'A: 1',
+        value: '1'
+      },
+      {
+        category: 'C',
+        label: 'C: 3',
+        value: '3'
+      },
+      {
+        category: 'C',
+        label: 'C: 4',
+        value: '4'
+      },
+      {
+        category: 'D',
+        label: 'D: 5',
+        value: '5'
+      }
+    ]);
+    match = listPage.filtersMatchURL(managedFilterTypes);
+    expect(match).toBe(false);
+  });
+});

--- a/src/pages/AppDetails/AppDetailsPage.tsx
+++ b/src/pages/AppDetails/AppDetailsPage.tsx
@@ -8,7 +8,7 @@ import AppInfo from './AppInfo';
 import * as MessageCenter from '../../utils/MessageCenter';
 import AppMetricsContainer from '../../containers/AppMetricsContainer';
 import { AppHealth } from '../../types/Health';
-import { NamespaceFilterSelected } from '../../components/NamespaceFilter/NamespaceFilter';
+import { FilterSelected } from '../../components/Filters/StatefulFilters';
 
 type AppDetailsState = {
   app: App;
@@ -33,7 +33,7 @@ class AppDetails extends React.Component<RouteComponentProps<AppId>, AppDetailsS
   }
 
   clearFilters() {
-    NamespaceFilterSelected.setSelected([]);
+    FilterSelected.setSelected([]);
   }
 
   appPageURL(parsedSearch?: ParsedSearch) {

--- a/src/pages/AppDetails/AppDetailsPage.tsx
+++ b/src/pages/AppDetails/AppDetailsPage.tsx
@@ -32,10 +32,6 @@ class AppDetails extends React.Component<RouteComponentProps<AppId>, AppDetailsS
     this.fetchApp();
   }
 
-  clearFilters() {
-    FilterSelected.setSelected([]);
-  }
-
   appPageURL(parsedSearch?: ParsedSearch) {
     return '/namespaces/' + this.props.match.params.namespace + '/applications/' + this.props.match.params.app;
   }
@@ -62,6 +58,19 @@ class AppDetails extends React.Component<RouteComponentProps<AppId>, AppDetailsS
       });
   };
 
+  namespaceFilters = () => {
+    FilterSelected.setSelected([
+      {
+        category: 'Namespace',
+        value: this.props.match.params.namespace.toString()
+      }
+    ]);
+  };
+
+  clearFilters() {
+    FilterSelected.setSelected([]);
+  }
+
   renderBreadcrumbs = () => {
     const urlParams = new URLSearchParams(this.props.location.search);
     const to = this.appPageURL();
@@ -87,7 +96,10 @@ class AppDetails extends React.Component<RouteComponentProps<AppId>, AppDetailsS
           </Link>
         </Breadcrumb.Item>
         <Breadcrumb.Item componentClass="span">
-          <Link to={`/applications?namespace=${encodeURIComponent(this.props.match.params.namespace)}`}>
+          <Link
+            to={`/applications?namespace=${encodeURIComponent(this.props.match.params.namespace)}`}
+            onClick={this.namespaceFilters}
+          >
             Namespace: {this.props.match.params.namespace}
           </Link>
         </Breadcrumb.Item>

--- a/src/pages/AppList/AppListComponent.tsx
+++ b/src/pages/AppList/AppListComponent.tsx
@@ -6,21 +6,18 @@ import { AxiosError } from 'axios';
 import { AppListItem } from '../../types/AppList';
 import { AppListFilters } from './FiltersAndSorts';
 import { AppListClass } from './AppListClass';
-import {
-  defaultNamespaceFilter,
-  NamespaceFilter,
-  NamespaceFilterSelected
-} from '../../components/NamespaceFilter/NamespaceFilter';
+import { FilterSelected, StatefulFilters } from '../../components/Filters/StatefulFilters';
+import { NamespaceFilter } from '../../components/Filters/NamespaceFilter';
 import { ListView, Sort, Paginator, ToolbarRightContent, Button, Icon } from 'patternfly-react';
 import { Pagination } from '../../types/Pagination';
-import { ActiveFilter, FilterType } from '../../types/NamespaceFilter';
+import { ActiveFilter, FilterType } from '../../types/Filters';
 import { removeDuplicatesArray } from '../../utils/Common';
 import { URLParameter } from '../../types/Parameters';
 import RateIntervalToolbarItem from '../ServiceList/RateIntervalToolbarItem';
 import { ListPage } from '../../components/ListPage/ListPage';
 
 const availableFilters: FilterType[] = [
-  defaultNamespaceFilter,
+  NamespaceFilter.create(),
   AppListFilters.appNameFilter,
   AppListFilters.istioSidecarFilter
 ];
@@ -51,7 +48,7 @@ class AppListComponent extends React.Component<AppListComponentProps, AppListCom
       isSortAscending: this.props.isSortAscending,
       rateInterval: this.props.rateInterval
     };
-    this.setActiveFiltersToURL();
+    this.props.pageHooks.setSelectedFiltersToURL(availableFilters);
   }
 
   componentDidMount() {
@@ -59,7 +56,7 @@ class AppListComponent extends React.Component<AppListComponentProps, AppListCom
   }
 
   updateApps = (resetPagination?: boolean) => {
-    const activeFilters: ActiveFilter[] = NamespaceFilterSelected.getSelected();
+    const activeFilters: ActiveFilter[] = FilterSelected.getSelected();
     let namespacesSelected: string[] = activeFilters
       .filter(activeFilter => activeFilter.category === 'Namespace')
       .map(activeFilter => activeFilter.value);
@@ -83,32 +80,6 @@ class AppListComponent extends React.Component<AppListComponentProps, AppListCom
       this.fetchApps(namespacesSelected, activeFilters, this.props.rateInterval, resetPagination);
     }
   };
-
-  setActiveFiltersToURL() {
-    const params = NamespaceFilterSelected.getSelected()
-      .map(activeFilter => {
-        const availableFilter = availableFilters.find(filter => {
-          return filter.title === activeFilter.category;
-        });
-
-        if (typeof availableFilter === 'undefined') {
-          NamespaceFilterSelected.setSelected(
-            NamespaceFilterSelected.getSelected().filter(nfs => {
-              return nfs.category !== activeFilter.category;
-            })
-          );
-          return null;
-        }
-
-        return {
-          name: availableFilter.id,
-          value: activeFilter.value
-        };
-      })
-      .filter(filter => filter !== null) as URLParameter[];
-
-    this.props.pageHooks.onParamChange(params, 'append', 'replace');
-  }
 
   fetchApps(namespaces: string[], filters: ActiveFilter[], rateInterval: number, resetPagination?: boolean) {
     const appsPromises = namespaces.map(namespace => API.getApps(authentication(), namespace));
@@ -148,7 +119,7 @@ class AppListComponent extends React.Component<AppListComponentProps, AppListCom
         rateInterval: this.props.rateInterval
       });
 
-      NamespaceFilterSelected.setSelected(this.selectedFilters());
+      this.props.pageHooks.setSelectedFiltersFromURL(availableFilters);
       this.updateApps();
     }
   }
@@ -160,35 +131,8 @@ class AppListComponent extends React.Component<AppListComponentProps, AppListCom
       prevProps.rateInterval === this.props.rateInterval &&
       prevProps.isSortAscending === this.props.isSortAscending &&
       prevProps.currentSortField.title === this.props.currentSortField.title &&
-      this.filtersMatch()
+      this.props.pageHooks.filtersMatchURL(availableFilters)
     );
-  }
-
-  filtersMatch() {
-    const selectedFilters: Map<string, string[]> = new Map<string, string[]>();
-
-    NamespaceFilterSelected.getSelected().map(activeFilter => {
-      const existingValue = selectedFilters.get(activeFilter.category) || [];
-      selectedFilters.set(activeFilter.category, existingValue.concat(activeFilter.value));
-    });
-
-    const urlParams: Map<string, string[]> = new Map<string, string[]>();
-    availableFilters.forEach(filter => {
-      const params = this.props.pageHooks.getQueryParam(filter.id);
-      if (params !== undefined) {
-        const existing = urlParams.get(filter.title) || [];
-        urlParams.set(filter.title, existing.concat(params));
-      }
-    });
-
-    let equalFilters = true;
-    selectedFilters.forEach((filterValues, filterName) => {
-      const aux = urlParams.get(filterName) || [];
-      equalFilters =
-        equalFilters && filterValues.every(value => aux.includes(value)) && filterValues.length === aux.length;
-    });
-
-    return selectedFilters.size === urlParams.size && equalFilters;
   }
 
   pageSet = (page: number) => {
@@ -220,21 +164,6 @@ class AppListComponent extends React.Component<AppListComponentProps, AppListCom
 
     this.props.pageHooks.onParamChange([{ name: 'page', value: '1' }, { name: 'perPage', value: String(perPage) }]);
   };
-
-  selectedFilters() {
-    let activeFilters: ActiveFilter[] = [];
-    availableFilters.forEach(filter => {
-      (this.props.pageHooks.getQueryParam(filter.id) || []).forEach(value => {
-        activeFilters.push({
-          label: filter.title + ': ' + value,
-          category: filter.title,
-          value: value
-        });
-      });
-    });
-
-    return activeFilters;
-  }
 
   updateSortField = (sortField: AppListFilters.SortField) => {
     AppListFilters.sortAppsItems(this.state.appListItems, sortField, this.state.isSortAscending).then(sorted => {
@@ -327,9 +256,9 @@ class AppListComponent extends React.Component<AppListComponentProps, AppListCom
 
     return (
       <>
-        <NamespaceFilter
-          initialFilters={[AppListFilters.appNameFilter, AppListFilters.istioSidecarFilter]}
-          initialActiveFilters={this.selectedFilters()}
+        <StatefulFilters
+          initialFilters={availableFilters}
+          initialActiveFilters={FilterSelected.getSelected()}
           onFilterChange={this.onFilterChange}
           onError={this.handleError}
         >
@@ -354,7 +283,7 @@ class AppListComponent extends React.Component<AppListComponentProps, AppListCom
               <Icon name="refresh" />
             </Button>
           </ToolbarRightContent>
-        </NamespaceFilter>
+        </StatefulFilters>
         <ListView>{appItemsList}</ListView>
         <Paginator
           viewType="list"

--- a/src/pages/AppList/AppListPage.tsx
+++ b/src/pages/AppList/AppListPage.tsx
@@ -38,7 +38,7 @@ class AppListPage extends ListPage.Component<AppListProps, AppListState> {
           pageHooks={this}
           currentSortField={this.currentSortField()}
           isSortAscending={this.isCurrentSortAscending()}
-          rateInterval={this.currentRateInterval()}
+          rateInterval={this.currentDuration()}
         />
       </>
     );

--- a/src/pages/AppList/FiltersAndSorts.ts
+++ b/src/pages/AppList/FiltersAndSorts.ts
@@ -1,10 +1,4 @@
-import {
-  ActiveFilter,
-  FILTER_ACTION_APPEND,
-  FILTER_ACTION_UPDATE,
-  FilterType,
-  FilterValue
-} from '../../types/NamespaceFilter';
+import { ActiveFilter, FILTER_ACTION_APPEND, FILTER_ACTION_UPDATE, FilterType, FilterValue } from '../../types/Filters';
 import { AppListItem } from '../../types/AppList';
 import { removeDuplicatesArray } from '../../utils/Common';
 import { getRequestErrorsRatio, AppHealth } from '../../types/Health';

--- a/src/pages/Graph/SummaryPanelGraph.tsx
+++ b/src/pages/Graph/SummaryPanelGraph.tsx
@@ -85,10 +85,10 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
       .size();
     const numEdges = cy.edges().size();
     const trafficRate = getAccumulatedTrafficRate(cy.edges());
-    const servicesLink = (
+    const appsLink = (
       <Link
-        to={this.props.namespace === 'all' ? '../services' : `../services?namespace=${this.props.namespace}`}
-        onClick={this.updateServicesFilter}
+        to={this.props.namespace === 'all' ? '/applications' : `/applications?namespace=${this.props.namespace}`}
+        onClick={this.updateAppsFilter}
       >
         {this.props.namespace}
       </Link>
@@ -97,7 +97,7 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
     return (
       <div className="panel panel-default" style={SummaryPanelGraph.panelStyle}>
         <div className="panel-heading">
-          Namespace: {servicesLink}
+          Namespace: {appsLink}
           {this.renderTopologySummary(numNodes, numEdges)}
         </div>
         <div className="panel-body">
@@ -194,11 +194,10 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
     return graphUtils.toC3Columns(series, title);
   };
 
-  private updateServicesFilter = () => {
+  private updateAppsFilter = () => {
     let filters: ActiveFilter[] = [];
     if (this.props.namespace !== 'all') {
       let activeFilter: ActiveFilter = {
-        label: 'Namespace: ' + this.props.namespace,
         category: 'Namespace',
         value: this.props.namespace.toString()
       };

--- a/src/pages/Graph/SummaryPanelGraph.tsx
+++ b/src/pages/Graph/SummaryPanelGraph.tsx
@@ -6,8 +6,8 @@ import { SummaryPanelPropType } from '../../types/Graph';
 import graphUtils from '../../utils/Graphing';
 import { getAccumulatedTrafficRate } from '../../utils/TrafficRate';
 import * as API from '../../services/Api';
-import { NamespaceFilterSelected } from '../../components/NamespaceFilter/NamespaceFilter';
-import { ActiveFilter } from '../../types/NamespaceFilter';
+import { FilterSelected } from '../../components/Filters/StatefulFilters';
+import { ActiveFilter } from '../../types/Filters';
 import * as M from '../../types/Metrics';
 import { Icon } from 'patternfly-react';
 import { authentication } from '../../utils/Authentication';
@@ -204,6 +204,6 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
       };
       filters = [activeFilter];
     }
-    NamespaceFilterSelected.setSelected(filters);
+    FilterSelected.setSelected(filters);
   };
 }

--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -41,14 +41,12 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
   updateFilters = (addObjectTypeFilter: boolean) => {
     let activeFilters: ActiveFilter[] = [];
     let namespaceFilter: ActiveFilter = {
-      label: 'Namespace: ' + this.props.match.params.namespace,
       category: 'Namespace',
       value: this.props.match.params.namespace.toString()
     };
     activeFilters.push(namespaceFilter);
     if (addObjectTypeFilter) {
       let objectTypeFilter: ActiveFilter = {
-        label: 'Istio Type: ' + dicIstioType[this.props.match.params.objectType],
         category: 'Istio Type',
         value: dicIstioType[this.props.match.params.objectType]
       };

--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { Breadcrumb, Button, Col, Icon, Row } from 'patternfly-react';
 import { Link, RouteComponentProps } from 'react-router-dom';
-import { NamespaceFilterSelected } from '../../components/NamespaceFilter/NamespaceFilter';
-import { ActiveFilter } from '../../types/NamespaceFilter';
+import { FilterSelected } from '../../components/Filters/StatefulFilters';
+import { ActiveFilter } from '../../types/Filters';
 import {
   aceOptions,
   IstioConfigDetails,
@@ -55,15 +55,15 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
       activeFilters.push(objectTypeFilter);
     }
 
-    NamespaceFilterSelected.setSelected(activeFilters);
+    FilterSelected.setSelected(activeFilters);
   };
 
-  updateNamespaceFilter = () => this.updateFilters(false);
+  updateStatefulFilters = () => this.updateFilters(false);
 
   updateTypeFilter = () => this.updateFilters(true);
 
   cleanFilter = () => {
-    NamespaceFilterSelected.setSelected([]);
+    FilterSelected.setSelected([]);
   };
 
   fetchIstioObjectDetails = () => {
@@ -235,7 +235,7 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
           </Link>
         </Breadcrumb.Item>
         <Breadcrumb.Item componentClass={'span'}>
-          <Link to="/istio" onClick={this.updateNamespaceFilter}>
+          <Link to="/istio" onClick={this.updateStatefulFilters}>
             Namespace: {this.props.match.params.namespace}
           </Link>
         </Breadcrumb.Item>

--- a/src/pages/IstioConfigList/IstioConfigListComponent.tsx
+++ b/src/pages/IstioConfigList/IstioConfigListComponent.tsx
@@ -23,7 +23,6 @@ import { authentication } from '../../utils/Authentication';
 import { NamespaceValidations } from '../../types/IstioObjects';
 import { ConfigIndicator } from '../../components/ConfigValidation/ConfigIndicator';
 import { removeDuplicatesArray } from '../../utils/Common';
-import { URLParameter } from '../../types/Parameters';
 import { ListPage } from '../../components/ListPage/ListPage';
 
 export const sortFields: SortField[] = [
@@ -156,7 +155,6 @@ class IstioConfigListComponent extends React.Component<IstioConfigListComponentP
       currentSortField: this.props.currentSortField,
       isSortAscending: this.props.isSortAscending
     };
-    this.props.pageHooks.setSelectedFiltersToURL(availableFilters);
   }
 
   componentDidMount() {
@@ -175,7 +173,6 @@ class IstioConfigListComponent extends React.Component<IstioConfigListComponentP
         isSortAscending: this.props.isSortAscending
       });
 
-      this.props.pageHooks.setSelectedFiltersFromURL(availableFilters);
       this.updateIstioConfig();
     }
   }
@@ -185,35 +182,13 @@ class IstioConfigListComponent extends React.Component<IstioConfigListComponentP
       prevProps.pagination.page === this.props.pagination.page &&
       prevProps.pagination.perPage === this.props.pagination.perPage &&
       prevProps.isSortAscending === this.props.isSortAscending &&
-      prevProps.currentSortField.title === this.props.currentSortField.title &&
-      this.props.pageHooks.filtersMatchURL(availableFilters)
+      prevProps.currentSortField.title === this.props.currentSortField.title
     );
   }
 
-  onFilterChange = (filters: ActiveFilter[]) => {
-    let params: URLParameter[] = [];
-
-    availableFilters.forEach(availableFilter => {
-      params.push({ name: availableFilter.id, value: '' });
-    });
-
-    filters.forEach(activeFilter => {
-      let filterId = (
-        availableFilters.find(filter => {
-          return filter.title === activeFilter.category;
-        }) || availableFilters[2]
-      ).id;
-
-      params.push({
-        name: filterId,
-        value: activeFilter.value
-      });
-    });
-
+  onFilterChange = () => {
     // Resetting pagination when filters change
-    params.push({ name: 'page', value: '' });
-
-    this.props.pageHooks.onParamChange(params, 'append');
+    this.props.pageHooks.onParamChange([{ name: 'page', value: '' }]);
     this.updateIstioConfig(true);
   };
 
@@ -476,9 +451,8 @@ class IstioConfigListComponent extends React.Component<IstioConfigListComponentP
       <>
         <StatefulFilters
           initialFilters={availableFilters}
-          initialActiveFilters={FilterSelected.getSelected()}
+          pageHooks={this.props.pageHooks}
           onFilterChange={this.onFilterChange}
-          onError={this.handleError}
         >
           <Sort>
             <Sort.TypeSelector

--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -10,7 +10,7 @@ import { authentication } from '../../utils/Authentication';
 import IstioObjectDetails from './IstioObjectDetails';
 import ServiceMetricsContainer from '../../containers/ServiceMetricsContainer';
 import ServiceInfo from './ServiceInfo';
-import { NamespaceFilterSelected } from '../../components/NamespaceFilter/NamespaceFilter';
+import { FilterSelected } from '../../components/Filters/StatefulFilters';
 
 type ServiceDetailsState = {
   serviceDetailsInfo: ServiceDetailsInfo;
@@ -162,7 +162,7 @@ class ServiceDetails extends React.Component<RouteComponentProps<ServiceId>, Ser
   };
 
   clearFilters() {
-    NamespaceFilterSelected.setSelected([]);
+    FilterSelected.setSelected([]);
   }
 
   renderBreadcrumbs = (parsedSearch: ParsedSearch, showingDetails: boolean) => {

--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -161,6 +161,15 @@ class ServiceDetails extends React.Component<RouteComponentProps<ServiceId>, Ser
       });
   };
 
+  namespaceFilters = () => {
+    FilterSelected.setSelected([
+      {
+        category: 'Namespace',
+        value: this.props.match.params.namespace.toString()
+      }
+    ]);
+  };
+
   clearFilters() {
     FilterSelected.setSelected([]);
   }
@@ -180,7 +189,10 @@ class ServiceDetails extends React.Component<RouteComponentProps<ServiceId>, Ser
           </Link>
         </Breadcrumb.Item>
         <Breadcrumb.Item componentClass={'span'}>
-          <Link to={`/services?namespace=${encodeURIComponent(this.props.match.params.namespace)}`}>
+          <Link
+            to={`/services?namespace=${encodeURIComponent(this.props.match.params.namespace)}`}
+            onClick={this.namespaceFilters}
+          >
             Namespace: {this.props.match.params.namespace}
           </Link>
         </Breadcrumb.Item>

--- a/src/pages/ServiceList/ServiceListComponent.tsx
+++ b/src/pages/ServiceList/ServiceListComponent.tsx
@@ -12,16 +12,13 @@ import {
 } from 'patternfly-react';
 import { Link } from 'react-router-dom';
 
-import {
-  defaultNamespaceFilter,
-  NamespaceFilter,
-  NamespaceFilterSelected
-} from '../../components/NamespaceFilter/NamespaceFilter';
+import { FilterSelected, StatefulFilters } from '../../components/Filters/StatefulFilters';
+import { NamespaceFilter } from '../../components/Filters/NamespaceFilter';
 import { PfColors } from '../../components/Pf/PfColors';
 import * as API from '../../services/Api';
 import { getRequestErrorsRatio, ServiceHealth } from '../../types/Health';
 import Namespace from '../../types/Namespace';
-import { ActiveFilter, FILTER_ACTION_UPDATE, FilterType } from '../../types/NamespaceFilter';
+import { ActiveFilter, FILTER_ACTION_UPDATE, FilterType } from '../../types/Filters';
 import { Pagination } from '../../types/Pagination';
 import { overviewToItem, ServiceItem, ServiceOverview, SortField } from '../../types/ServiceListComponent';
 import { IstioLogo } from '../../config';
@@ -124,7 +121,7 @@ const istioFilter: FilterType = {
   filterValues: [{ id: 'present', title: 'Present' }, { id: 'not_present', title: 'Not Present' }]
 };
 
-const availableFilters: FilterType[] = [serviceNameFilter, istioFilter, defaultNamespaceFilter];
+const availableFilters: FilterType[] = [NamespaceFilter.create(), serviceNameFilter, istioFilter];
 
 type ServiceListComponentState = {
   services: ServiceItem[];
@@ -145,7 +142,6 @@ type ServiceListComponentProps = {
 class ServiceListComponent extends React.Component<ServiceListComponentProps, ServiceListComponentState> {
   constructor(props: ServiceListComponentProps) {
     super(props);
-
     this.state = {
       services: [],
       pagination: this.props.pagination,
@@ -153,8 +149,7 @@ class ServiceListComponent extends React.Component<ServiceListComponentProps, Se
       isSortAscending: this.props.isSortAscending,
       rateInterval: this.props.rateInterval
     };
-
-    this.setActiveFiltersToURL();
+    this.props.pageHooks.setSelectedFiltersToURL(availableFilters);
   }
 
   componentDidMount() {
@@ -170,7 +165,7 @@ class ServiceListComponent extends React.Component<ServiceListComponentProps, Se
         rateInterval: this.props.rateInterval
       });
 
-      NamespaceFilterSelected.setSelected(this.selectedFilters());
+      this.props.pageHooks.setSelectedFiltersFromURL(availableFilters);
       this.updateServices();
     }
   }
@@ -182,76 +177,8 @@ class ServiceListComponent extends React.Component<ServiceListComponentProps, Se
       prevProps.rateInterval === this.props.rateInterval &&
       prevProps.isSortAscending === this.props.isSortAscending &&
       prevProps.currentSortField.title === this.props.currentSortField.title &&
-      this.filtersMatch()
+      this.props.pageHooks.filtersMatchURL(availableFilters)
     );
-  }
-
-  filtersMatch() {
-    const selectedFilters: Map<string, string[]> = new Map<string, string[]>();
-
-    NamespaceFilterSelected.getSelected().map(activeFilter => {
-      const existingValue = selectedFilters.get(activeFilter.category) || [];
-      selectedFilters.set(activeFilter.category, existingValue.concat(activeFilter.value));
-    });
-
-    let urlParams: Map<string, string[]> = new Map<string, string[]>();
-    availableFilters.forEach(filter => {
-      const param = this.props.pageHooks.getQueryParam(filter.id);
-      if (param !== undefined) {
-        const existing = urlParams.get(filter.title) || [];
-        urlParams.set(filter.title, existing.concat(param));
-      }
-    });
-
-    let equalFilters = true;
-    selectedFilters.forEach((filterValues, filterName) => {
-      const aux = urlParams.get(filterName) || [];
-      equalFilters =
-        equalFilters && filterValues.every(value => aux.includes(value)) && filterValues.length === aux.length;
-    });
-
-    return selectedFilters.size === urlParams.size && equalFilters;
-  }
-
-  setActiveFiltersToURL() {
-    const params = NamespaceFilterSelected.getSelected()
-      .map(activeFilter => {
-        const availableFilter = availableFilters.find(filter => {
-          return filter.title === activeFilter.category;
-        });
-
-        if (typeof availableFilter === 'undefined') {
-          NamespaceFilterSelected.setSelected(
-            NamespaceFilterSelected.getSelected().filter(nfs => {
-              return nfs.category !== activeFilter.category;
-            })
-          );
-          return null;
-        }
-
-        return {
-          name: availableFilter.id,
-          value: activeFilter.value
-        };
-      })
-      .filter(filter => filter !== null) as URLParameter[];
-
-    this.props.pageHooks.onParamChange(params, 'append', 'replace');
-  }
-
-  selectedFilters() {
-    let activeFilters: ActiveFilter[] = [];
-    availableFilters.forEach(filter => {
-      (this.props.pageHooks.getQueryParam(filter.id) || []).forEach(value => {
-        activeFilters = activeFilters.concat({
-          label: filter.title + ': ' + value,
-          category: filter.title,
-          value: value
-        });
-      });
-    });
-
-    return activeFilters;
   }
 
   onFilterChange = (filters: ActiveFilter[]) => {
@@ -366,7 +293,7 @@ class ServiceListComponent extends React.Component<ServiceListComponentProps, Se
   };
 
   updateServices = (resetPagination?: boolean) => {
-    const activeFilters: ActiveFilter[] = NamespaceFilterSelected.getSelected();
+    const activeFilters: ActiveFilter[] = FilterSelected.getSelected();
     let namespacesSelected: string[] = activeFilters
       .filter(activeFilter => activeFilter.category === 'Namespace')
       .map(activeFilter => activeFilter.value);
@@ -511,9 +438,9 @@ class ServiceListComponent extends React.Component<ServiceListComponentProps, Se
     }
     return (
       <div>
-        <NamespaceFilter
-          initialFilters={[serviceNameFilter, istioFilter]}
-          initialActiveFilters={this.selectedFilters()}
+        <StatefulFilters
+          initialFilters={availableFilters}
+          initialActiveFilters={FilterSelected.getSelected()}
           onFilterChange={this.onFilterChange}
           onError={this.handleError}
         >
@@ -538,7 +465,7 @@ class ServiceListComponent extends React.Component<ServiceListComponentProps, Se
               <Icon name="refresh" />
             </Button>
           </ToolbarRightContent>
-        </NamespaceFilter>
+        </StatefulFilters>
         <ListView>{serviceList}</ListView>
         <Paginator
           viewType="list"

--- a/src/pages/ServiceList/ServiceListPage.tsx
+++ b/src/pages/ServiceList/ServiceListPage.tsx
@@ -30,7 +30,7 @@ class ServiceListPage extends ListPage.Component<ServiceListProps, ServiceListSt
           pagination={this.currentPagination()}
           currentSortField={this.currentSortField()}
           isSortAscending={this.isCurrentSortAscending()}
-          rateInterval={this.currentRateInterval()}
+          rateInterval={this.currentDuration()}
         />
       </>
     );

--- a/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -9,7 +9,7 @@ import WorkloadInfo from './WorkloadInfo';
 import * as MessageCenter from '../../utils/MessageCenter';
 import WorkloadMetricsContainer from '../../containers/WorkloadMetricsContainer';
 import { WorkloadHealth } from '../../types/Health';
-import { NamespaceFilterSelected } from '../../components/NamespaceFilter/NamespaceFilter';
+import { FilterSelected } from '../../components/Filters/StatefulFilters';
 
 type WorkloadDetailsState = {
   workload: Deployment;
@@ -101,7 +101,7 @@ class WorkloadDetails extends React.Component<RouteComponentProps<WorkloadId>, W
   };
 
   clearFilters() {
-    NamespaceFilterSelected.setSelected([]);
+    FilterSelected.setSelected([]);
   }
 
   renderBreadcrumbs = () => {

--- a/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -100,6 +100,15 @@ class WorkloadDetails extends React.Component<RouteComponentProps<WorkloadId>, W
     return istioEnabled;
   };
 
+  namespaceFilters = () => {
+    FilterSelected.setSelected([
+      {
+        category: 'Namespace',
+        value: this.props.match.params.namespace.toString()
+      }
+    ]);
+  };
+
   clearFilters() {
     FilterSelected.setSelected([]);
   }
@@ -129,7 +138,10 @@ class WorkloadDetails extends React.Component<RouteComponentProps<WorkloadId>, W
           </Link>
         </Breadcrumb.Item>
         <Breadcrumb.Item componentClass="span">
-          <Link to={`/workloads?namespace=${encodeURIComponent(this.props.match.params.namespace)}`}>
+          <Link
+            to={`/workloads?namespace=${encodeURIComponent(this.props.match.params.namespace)}`}
+            onClick={this.namespaceFilters}
+          >
             Namespace: {this.props.match.params.namespace}
           </Link>
         </Breadcrumb.Item>

--- a/src/pages/WorkloadList/FiltersAndSorts.ts
+++ b/src/pages/WorkloadList/FiltersAndSorts.ts
@@ -1,10 +1,4 @@
-import {
-  ActiveFilter,
-  FILTER_ACTION_APPEND,
-  FILTER_ACTION_UPDATE,
-  FilterType,
-  FilterValue
-} from '../../types/NamespaceFilter';
+import { ActiveFilter, FILTER_ACTION_APPEND, FILTER_ACTION_UPDATE, FilterType, FilterValue } from '../../types/Filters';
 import { WorkloadListItem, WorkloadType } from '../../types/Workload';
 import { removeDuplicatesArray } from '../../utils/Common';
 import { getRequestErrorsRatio, WorkloadHealth } from '../../types/Health';

--- a/src/pages/WorkloadList/WorkloadListComponent.tsx
+++ b/src/pages/WorkloadList/WorkloadListComponent.tsx
@@ -5,14 +5,11 @@ import Namespace from '../../types/Namespace';
 import { AxiosError } from 'axios';
 import { WorkloadListItem, WorkloadNamespaceResponse } from '../../types/Workload';
 import { WorkloadListFilters } from './FiltersAndSorts';
-import {
-  defaultNamespaceFilter,
-  NamespaceFilter,
-  NamespaceFilterSelected
-} from '../../components/NamespaceFilter/NamespaceFilter';
+import { FilterSelected, StatefulFilters } from '../../components/Filters/StatefulFilters';
+import { NamespaceFilter } from '../../components/Filters/NamespaceFilter';
 import { ListView, Sort, Paginator, ToolbarRightContent, Button, Icon } from 'patternfly-react';
 import { Pagination } from '../../types/Pagination';
-import { ActiveFilter, FILTER_ACTION_UPDATE, FilterType } from '../../types/NamespaceFilter';
+import { ActiveFilter, FILTER_ACTION_UPDATE, FilterType } from '../../types/Filters';
 import { removeDuplicatesArray } from '../../utils/Common';
 import { URLParameter } from '../../types/Parameters';
 import ItemDescription from './ItemDescription';
@@ -20,7 +17,7 @@ import RateIntervalToolbarItem from '../ServiceList/RateIntervalToolbarItem';
 import { ListPage } from '../../components/ListPage/ListPage';
 
 const availableFilters: FilterType[] = [
-  defaultNamespaceFilter,
+  NamespaceFilter.create(),
   WorkloadListFilters.workloadNameFilter,
   WorkloadListFilters.workloadTypeFilter,
   WorkloadListFilters.istioSidecarFilter,
@@ -54,7 +51,7 @@ class WorkloadListComponent extends React.Component<WorkloadListComponentProps, 
       isSortAscending: this.props.isSortAscending,
       rateInterval: this.props.rateInterval
     };
-    this.setActiveFiltersToURL();
+    this.props.pageHooks.setSelectedFiltersToURL(availableFilters);
   }
 
   componentDidMount() {
@@ -70,7 +67,7 @@ class WorkloadListComponent extends React.Component<WorkloadListComponentProps, 
         rateInterval: this.props.rateInterval
       });
 
-      NamespaceFilterSelected.setSelected(this.selectedFilters());
+      this.props.pageHooks.setSelectedFiltersFromURL(availableFilters);
       this.updateWorkloads();
     }
   }
@@ -82,39 +79,12 @@ class WorkloadListComponent extends React.Component<WorkloadListComponentProps, 
       prevProps.rateInterval === this.props.rateInterval &&
       prevProps.isSortAscending === this.props.isSortAscending &&
       prevProps.currentSortField.title === this.props.currentSortField.title &&
-      this.filtersMatch()
+      this.props.pageHooks.filtersMatchURL(availableFilters)
     );
   }
 
-  filtersMatch() {
-    const selectedFilters: Map<string, string[]> = new Map<string, string[]>();
-
-    NamespaceFilterSelected.getSelected().map(activeFilter => {
-      const existingValue = selectedFilters.get(activeFilter.category) || [];
-      selectedFilters.set(activeFilter.category, existingValue.concat(activeFilter.value));
-    });
-
-    let urlParams: Map<string, string[]> = new Map<string, string[]>();
-    availableFilters.forEach(filter => {
-      const param = this.props.pageHooks.getQueryParam(filter.id);
-      if (param !== undefined) {
-        const existing = urlParams.get(filter.title) || [];
-        urlParams.set(filter.title, existing.concat(param));
-      }
-    });
-
-    let equalFilters = true;
-    selectedFilters.forEach((filterValues, filterName) => {
-      const aux = urlParams.get(filterName) || [];
-      equalFilters =
-        equalFilters && filterValues.every(value => aux.includes(value)) && filterValues.length === aux.length;
-    });
-
-    return selectedFilters.size === urlParams.size && equalFilters;
-  }
-
   updateWorkloads = (resetPagination?: boolean) => {
-    const activeFilters: ActiveFilter[] = NamespaceFilterSelected.getSelected();
+    const activeFilters: ActiveFilter[] = FilterSelected.getSelected();
     let namespacesSelected: string[] = activeFilters
       .filter(activeFilter => activeFilter.category === 'Namespace')
       .map(activeFilter => activeFilter.value);
@@ -133,32 +103,6 @@ class WorkloadListComponent extends React.Component<WorkloadListComponentProps, 
       this.fetchWorkloads(namespacesSelected, activeFilters, resetPagination);
     }
   };
-
-  setActiveFiltersToURL() {
-    const params = NamespaceFilterSelected.getSelected()
-      .map(activeFilter => {
-        const availableFilter = availableFilters.find(filter => {
-          return filter.title === activeFilter.category;
-        });
-
-        if (typeof availableFilter === 'undefined') {
-          NamespaceFilterSelected.setSelected(
-            NamespaceFilterSelected.getSelected().filter(nfs => {
-              return nfs.category !== activeFilter.category;
-            })
-          );
-          return null;
-        }
-
-        return {
-          name: availableFilter.id,
-          value: activeFilter.value
-        };
-      })
-      .filter(filter => filter !== null) as URLParameter[];
-
-    this.props.pageHooks.onParamChange(params, 'append', 'replace');
-  }
 
   getDeploymentItems = (data: WorkloadNamespaceResponse): WorkloadListItem[] => {
     let workloadsItems: WorkloadListItem[] = [];
@@ -237,21 +181,6 @@ class WorkloadListComponent extends React.Component<WorkloadListComponentProps, 
 
     this.props.pageHooks.onParamChange([{ name: 'page', value: '1' }, { name: 'perPage', value: String(perPage) }]);
   };
-
-  selectedFilters() {
-    let activeFilters: ActiveFilter[] = [];
-    availableFilters.forEach(filter => {
-      (this.props.pageHooks.getQueryParam(filter.id) || []).forEach(value => {
-        activeFilters.push({
-          label: filter.title + ': ' + value,
-          category: filter.title,
-          value: value
-        });
-      });
-    });
-
-    return activeFilters;
-  }
 
   updateSortField = (sortField: WorkloadListFilters.SortField) => {
     WorkloadListFilters.sortWorkloadsItems(this.state.workloadItems, sortField, this.state.isSortAscending).then(
@@ -355,15 +284,9 @@ class WorkloadListComponent extends React.Component<WorkloadListComponentProps, 
 
     return (
       <>
-        <NamespaceFilter
-          initialFilters={[
-            WorkloadListFilters.workloadNameFilter,
-            WorkloadListFilters.workloadTypeFilter,
-            WorkloadListFilters.istioSidecarFilter,
-            WorkloadListFilters.appLabelFilter,
-            WorkloadListFilters.versionLabelFilter
-          ]}
-          initialActiveFilters={this.selectedFilters()}
+        <StatefulFilters
+          initialFilters={availableFilters}
+          initialActiveFilters={FilterSelected.getSelected()}
           onFilterChange={this.onFilterChange}
           onError={this.handleError}
         >
@@ -388,7 +311,7 @@ class WorkloadListComponent extends React.Component<WorkloadListComponentProps, 
               <Icon name="refresh" />
             </Button>
           </ToolbarRightContent>
-        </NamespaceFilter>
+        </StatefulFilters>
         <ListView>{workloadList}</ListView>
         <Paginator
           viewType="list"

--- a/src/pages/WorkloadList/WorkloadListPage.tsx
+++ b/src/pages/WorkloadList/WorkloadListPage.tsx
@@ -38,7 +38,7 @@ class WorkloadListPage extends ListPage.Component<WorkloadListProps, WorkloadLis
           pageHooks={this}
           currentSortField={this.currentSortField()}
           isSortAscending={this.isCurrentSortAscending()}
-          rateInterval={this.currentRateInterval()}
+          rateInterval={this.currentDuration()}
         />
       </>
     );

--- a/src/types/Filters.ts
+++ b/src/types/Filters.ts
@@ -1,10 +1,10 @@
-import PropTypes from 'prop-types';
-
+// FilterValue maps a Patternfly property. Modify with care.
 export interface FilterValue {
   id: string;
   title: string;
 }
 
+// FilterType maps a Patternfly property. Modify with care.
 export interface FilterType {
   id: string;
   title: string;
@@ -12,6 +12,7 @@ export interface FilterType {
   filterType: string;
   action: string;
   filterValues: FilterValue[];
+  loader?: () => Promise<FilterValue[]>;
 }
 
 export const FILTER_ACTION_APPEND = 'append';
@@ -21,18 +22,4 @@ export interface ActiveFilter {
   label: string;
   category: string;
   value: string;
-}
-
-export interface NamespaceFilterProps {
-  onFilterChange: PropTypes.func;
-  onError: PropTypes.func;
-  initialFilters: FilterType[];
-  initialActiveFilters?: ActiveFilter[];
-}
-
-export interface NamespaceFilterState {
-  filterTypeList: FilterType[];
-  currentFilterType: FilterType;
-  activeFilters: ActiveFilter[];
-  currentValue: string;
 }

--- a/src/types/Filters.ts
+++ b/src/types/Filters.ts
@@ -19,7 +19,6 @@ export const FILTER_ACTION_APPEND = 'append';
 export const FILTER_ACTION_UPDATE = 'update';
 
 export interface ActiveFilter {
-  label: string;
   category: string;
   value: string;
 }


### PR DESCRIPTION
This PR has 2 commits:
- ab2f864 takes back the rollbacked PR #667
- 1527eed fixes found issues afterward (KIALI-1562)

The first one was already reviewed, the addition bring by the second are:
- Move more logic into StatefulFilters
- Now shared-memory filters is the "source of truth" (before i was more ambiguous between URL and shared mem)
- As a consequence, when linking with filter, 'onclick' must be set to update shared mem (it was sometimes done before, but not always)
- Some other bits simplified, hopefully not too much

- Also, from Summary Graph panel, replace the "Services list" link to Apps list, as it seems to be a forgotten step from earlier devs.
