### PR TITLE
KIALI-1563 smaller dots in animation

### DIFF
--- a/src/components/CytoscapeGraph/TrafficAnimation/TrafficRenderer.ts
+++ b/src/components/CytoscapeGraph/TrafficAnimation/TrafficRenderer.ts
@@ -62,8 +62,8 @@ enum TrafficEdgeType {
  */
 const getTrafficPointRendererForHttpError: (edge: any) => TrafficPointRenderer = (edge: any) => {
   return new TrafficPointConcentricDiamondRenderer(
-    new Diamond(4, PfColors.White, PfColors.Red100, 1.0),
-    new Diamond(2, PfColors.Red100, PfColors.Red100, 1.0)
+    new Diamond(2.5, PfColors.White, PfColors.Red100, 1.0),
+    new Diamond(1, PfColors.Red100, PfColors.Red100, 1.0)
   );
 };
 
@@ -73,7 +73,7 @@ const getTrafficPointRendererForHttpError: (edge: any) => TrafficPointRenderer =
  * @returns {TrafficPointRenderer}
  */
 const getTrafficPointRendererForHttpSuccess: (edge: any) => TrafficPointRenderer = (edge: any) => {
-  return new TrafficPointCircleRenderer(3, PfColors.White, edge.style('line-color'), 2);
+  return new TrafficPointCircleRenderer(1, PfColors.White, edge.style('line-color'), 2);
 };
 
 /**


### PR DESCRIPTION
I reduced the size of the green dots and red triangles for HTTP traffic.

Here's what they look like - with slow rate and a little faster rate:

![size-1-slow ogv](https://user-images.githubusercontent.com/2029470/45684047-212a6780-bb13-11e8-9de4-61f966ff2eb4.gif)
![size-1-red-slow ogv](https://user-images.githubusercontent.com/2029470/45684048-212a6780-bb13-11e8-97ce-36e47a2d5862.gif)
![size-1 ogv](https://user-images.githubusercontent.com/2029470/45684050-212a6780-bb13-11e8-958a-7af9df174def.gif)
![size-1-red ogv](https://user-images.githubusercontent.com/2029470/45684049-212a6780-bb13-11e8-91f8-09b0781a7c74.gif)
