### PR TITLE
KIALI-1564 Always run build:dev in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ cache:
 install: yarn --frozen-lockfile --non-interactive || (echo 'package.json is not in sync with yarn.lock, check that you include yarn.lock' && false)
 script:
   - yarn prettier --list-different &&
-    yarn build &&
+    yarn build:dev &&
     yarn test --forceExit --maxWorkers=4
   - ./run_itest.sh
 before_deploy:


### PR DESCRIPTION
** Describe the change **

Forces the dev build in travis to avoid using rcue in upstream builds