### PR TITLE
KIALI-1573: Properly initialize the redux store with defaults

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -34,9 +34,9 @@ Visibility.change((e, state) => {
   }
 });
 if (Visibility.hidden()) {
-  store.dispatch(GlobalActions.setPageVisibilityHidden);
+  store.dispatch(GlobalActions.setPageVisibilityHidden());
 } else {
-  store.dispatch(GlobalActions.setPageVisibilityVisible);
+  store.dispatch(GlobalActions.setPageVisibilityVisible());
 }
 
 const getIsLoadingState = () => {

--- a/src/reducers/GlobalState.ts
+++ b/src/reducers/GlobalState.ts
@@ -2,7 +2,7 @@ import { GlobalState } from '../store/Store';
 import { updateState } from '../utils/Reducer';
 import { GlobalActionKeys } from '../actions/GlobalActions';
 
-const INITIAL_GLOBAL_STATE: GlobalState = {
+export const INITIAL_GLOBAL_STATE: GlobalState = {
   loadingCounter: 0,
   isPageVisible: true
 };

--- a/src/reducers/GraphDataState.ts
+++ b/src/reducers/GraphDataState.ts
@@ -4,7 +4,7 @@ import { GraphActionKeys } from '../actions/GraphActions';
 import FilterStateReducer from './GraphFilterState';
 import { MILLISECONDS } from '../types/Common';
 
-const INITIAL_STATE: GraphState = {
+export const INITIAL_GRAPH_STATE: GraphState = {
   isLoading: false,
   isError: false,
   error: undefined,
@@ -24,7 +24,7 @@ const INITIAL_STATE: GraphState = {
 };
 
 // This Reducer allows changes to the 'graphDataState' portion of Redux Store
-const graphDataState = (state: GraphState = INITIAL_STATE, action) => {
+const graphDataState = (state: GraphState = INITIAL_GRAPH_STATE, action) => {
   const filterState = FilterStateReducer(state.filterState, action);
   let newState: GraphState = {
     ...state,
@@ -54,9 +54,9 @@ const graphDataState = (state: GraphState = INITIAL_STATE, action) => {
       };
       break;
     case GraphActionKeys.GRAPH_NAMESPACE_CHANGED:
-      newState.graphData = INITIAL_STATE.graphData;
-      newState.graphDataTimestamp = INITIAL_STATE.graphDataTimestamp;
-      newState.sidePanelInfo = INITIAL_STATE.sidePanelInfo;
+      newState.graphData = INITIAL_GRAPH_STATE.graphData;
+      newState.graphDataTimestamp = INITIAL_GRAPH_STATE.graphDataTimestamp;
+      newState.sidePanelInfo = INITIAL_GRAPH_STATE.sidePanelInfo;
       break;
     default:
       break;

--- a/src/reducers/HelpDropdownState.ts
+++ b/src/reducers/HelpDropdownState.ts
@@ -1,17 +1,17 @@
 import { StatusState } from '../store/Store';
 import { HelpDropdownActionKeys } from '../actions/HelpDropdownActions';
 
-const INITIAL_STATE: StatusState = {
+export const INITIAL_STATUS_STATE: StatusState = {
   status: {},
   components: [],
   warningMessages: []
 };
 
 // This Reducer allows changes to the 'graphDataState' portion of Redux Store
-const HelpDropdownState = (state: StatusState = INITIAL_STATE, action) => {
+const HelpDropdownState = (state: StatusState = INITIAL_STATUS_STATE, action) => {
   switch (action.type) {
     case HelpDropdownActionKeys.STATUS_REFRESH:
-      return Object.assign({}, INITIAL_STATE, {
+      return Object.assign({}, INITIAL_STATUS_STATE, {
         status: action.status,
         components: action.components,
         warningMessages: action.warningMessages

--- a/src/reducers/LoginState.ts
+++ b/src/reducers/LoginState.ts
@@ -1,7 +1,7 @@
 import { LoginState } from '../store/Store';
 import { LoginActionKeys } from '../actions/LoginActions';
 
-const INITIAL_STATE: LoginState = {
+export const INITIAL_LOGIN_STATE: LoginState = {
   token: undefined,
   username: undefined,
   error: false,
@@ -12,21 +12,21 @@ const INITIAL_STATE: LoginState = {
 };
 
 // This Reducer allows changes to the 'LoginState' portion of Redux Store
-const LoginState = (state: LoginState = INITIAL_STATE, action) => {
+const LoginState = (state: LoginState = INITIAL_LOGIN_STATE, action) => {
   switch (action.type) {
     case LoginActionKeys.LOGIN_REQUEST:
-      return Object.assign({}, INITIAL_STATE, {
+      return Object.assign({}, INITIAL_LOGIN_STATE, {
         logging: true
       });
     case LoginActionKeys.LOGIN_SUCCESS:
-      return Object.assign({}, INITIAL_STATE, {
+      return Object.assign({}, INITIAL_LOGIN_STATE, {
         logged: true,
         token: action.token,
         username: action.username,
         sessionTimeOut: action.sessionTimeOut
       });
     case LoginActionKeys.LOGIN_EXTEND:
-      return Object.assign({}, INITIAL_STATE, {
+      return Object.assign({}, INITIAL_LOGIN_STATE, {
         logged: true,
         token: action.token,
         username: action.username,
@@ -37,12 +37,12 @@ const LoginState = (state: LoginState = INITIAL_STATE, action) => {
       if (action.error.request.status === 401) {
         message = 'Unauthorized. Error in username or password';
       }
-      return Object.assign({}, INITIAL_STATE, {
+      return Object.assign({}, INITIAL_LOGIN_STATE, {
         error: true,
         message: message
       });
     case LoginActionKeys.LOGOUT_SUCCESS:
-      return INITIAL_STATE;
+      return INITIAL_LOGIN_STATE;
     default:
       return state;
   }

--- a/src/reducers/MessageCenter.ts
+++ b/src/reducers/MessageCenter.ts
@@ -2,7 +2,7 @@ import { MessageType } from '../types/MessageCenter';
 import { MessageCenterState } from '../store/Store';
 import { MessageCenterActionKeys } from '../actions/MessageCenterActions';
 
-const INITIAL_STATE: MessageCenterState = {
+export const INITIAL_MESSAGE_CENTER_STATE: MessageCenterState = {
   nextId: 0,
   groups: [
     {
@@ -55,7 +55,7 @@ const updateMessage = (state: MessageCenterState, messageIds: number[], updater)
   return mergeToState(state, { groups });
 };
 
-const Messages = (state: MessageCenterState = INITIAL_STATE, action) => {
+const Messages = (state: MessageCenterState = INITIAL_MESSAGE_CENTER_STATE, action) => {
   switch (action.type) {
     case MessageCenterActionKeys.ADD_MESSAGE: {
       const { groupId, content, messageType } = action;

--- a/src/reducers/Namespaces.ts
+++ b/src/reducers/Namespaces.ts
@@ -1,11 +1,11 @@
 import { NamespaceActionKeys } from '../actions/NamespaceAction';
 
-const INITIAL_STATE = {
+export const INITIAL_NAMESPACE_STATE = {
   isFetching: false,
   items: [] as Array<string>
 };
 
-const namespaces = (state = INITIAL_STATE, action) => {
+const namespaces = (state = INITIAL_NAMESPACE_STATE, action) => {
   switch (action.type) {
     case NamespaceActionKeys.NAMESPACE_REQUEST_STARTED:
       return Object.assign({}, state, {

--- a/src/reducers/UserSettingsState.ts
+++ b/src/reducers/UserSettingsState.ts
@@ -1,14 +1,14 @@
 import { UserSettings } from '../store/Store';
 import { UserSettingsActionKeys } from '../actions/UserSettingsActions';
 
-const INITIAL_STATE: UserSettings = {
+export const INITIAL_USER_SETTINGS_STATE: UserSettings = {
   interface: { navCollapse: false }
 };
 
-const UserSettingsState = (state: UserSettings = INITIAL_STATE, action) => {
+const UserSettingsState = (state: UserSettings = INITIAL_USER_SETTINGS_STATE, action) => {
   switch (action.type) {
     case UserSettingsActionKeys.NAV_COLLAPSE:
-      return Object.assign({}, INITIAL_STATE, {
+      return Object.assign({}, INITIAL_USER_SETTINGS_STATE, {
         interface: { navCollapse: action.collapse }
       });
     default:

--- a/src/store/ConfigStore.ts
+++ b/src/store/ConfigStore.ts
@@ -6,6 +6,13 @@ import thunk from 'redux-thunk';
 
 // defaults to localStorage for web and AsyncStorage for react-native
 import storage from 'redux-persist/lib/storage';
+import { INITIAL_GLOBAL_STATE } from '../reducers/GlobalState';
+import { INITIAL_NAMESPACE_STATE } from '../reducers/Namespaces';
+import { INITIAL_LOGIN_STATE } from '../reducers/LoginState';
+import { INITIAL_GRAPH_STATE } from '../reducers/GraphDataState';
+import { INITIAL_USER_SETTINGS_STATE } from '../reducers/UserSettingsState';
+import { INITIAL_MESSAGE_CENTER_STATE } from '../reducers/MessageCenter';
+import { INITIAL_STATUS_STATE } from '../reducers/HelpDropdownState';
 
 declare const window;
 
@@ -18,19 +25,30 @@ const persistConfig = {
 const composeEnhancers =
   (process.env.NODE_ENV === 'development' && window && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) || compose;
 
-const configureStore = (initialState?: KialiAppState) => {
+const configureStore = (initialState: KialiAppState) => {
   // configure middlewares
   const middlewares = [thunk];
   // compose enhancers
   const enhancer = composeEnhancers(applyMiddleware(...middlewares));
   // persist reducers
   const persistentReducer = persistReducer(persistConfig, rootReducer);
-  // the ts-ignore is needed with the new version of Redux 4.0
-  // create store
-  // @ts-ignore
+
   return createStore(persistentReducer, initialState, enhancer);
 };
 
+// Setup the initial state of the Redux store with defaults
+// (instead of having things be undefined until they are populated by query)
+// Redux 4.0 actually required this
+let initialStore: KialiAppState = {
+  globalState: INITIAL_GLOBAL_STATE,
+  statusState: INITIAL_STATUS_STATE,
+  namespaces: INITIAL_NAMESPACE_STATE,
+  authentication: INITIAL_LOGIN_STATE,
+  messageCenter: INITIAL_MESSAGE_CENTER_STATE,
+  graph: INITIAL_GRAPH_STATE,
+  userSettings: INITIAL_USER_SETTINGS_STATE
+};
+
 // pass an optional param to rehydrate state on app start
-export const store = configureStore();
+export const store = configureStore(initialStore);
 export const persistor = persistStore(store);

--- a/src/utils/Authentication.ts
+++ b/src/utils/Authentication.ts
@@ -3,6 +3,7 @@ import { store } from '../store/ConfigStore';
 export const authentication = () => {
   const actualState = store.getState() || {};
   if (actualState['authentication']['token'] !== undefined) {
+    // @ts-ignore
     return 'Bearer ' + actualState['authentication']['token']['token'];
   }
   return '';

--- a/src/utils/MessageCenter.ts
+++ b/src/utils/MessageCenter.ts
@@ -7,5 +7,7 @@ export const add = (content: string, group?: string, type?: MessageType) => {
 };
 
 export const toggleMessageCenter = () => {
+  // @Todo: nothing has really changed WRT this; not sure why the warning
+  // @ts-ignore
   store.dispatch(MessageCenterActions.toggleMessageCenter());
 };


### PR DESCRIPTION
 Properly initialize the **redux** store with defaults instead of starting with an undefined state.

** Describe the change **

Initialize the Redux store with defined defaults instead of starting with a _undefined_ store that gradually fills in based on requests eventually populating the redux store.  Even then, there might be gaps in the store being populated because certain queries or parts of the application have not been accessed.

This also has implications into Redux _known_ state. If anything is undefined, we really don't know what state it should be -- an initial known state is a much better starting point.

Some of this seems to be pushed via the new version of Redux 4.0

** Issue reference **
https://issues.jboss.org/browse/KIALI-1573

This became a blocker to: https://issues.jboss.org/browse/KIALI-1337

** Backwards compatible? **
Yes
