### PR TITLE
Overview page: add back titles in links

### DIFF
--- a/src/pages/Overview/OverviewPage.tsx
+++ b/src/pages/Overview/OverviewPage.tsx
@@ -183,13 +183,13 @@ class OverviewPage extends ListPage.Component<{}, State> {
                           <Link to={`/graph/namespaces/${encodedName}`} title="Graph">
                             <Icon type="pf" name="topology" style={{ paddingLeft: 10, paddingRight: 10 }} />
                           </Link>
-                          <ListPageLink target={TargetPage.APPLICATIONS} namespace={ns.name}>
+                          <ListPageLink target={TargetPage.APPLICATIONS} namespace={ns.name} title="Applications list">
                             <Icon type="pf" name="applications" style={{ paddingLeft: 10, paddingRight: 10 }} />
                           </ListPageLink>
-                          <ListPageLink target={TargetPage.WORKLOADS} namespace={ns.name}>
+                          <ListPageLink target={TargetPage.WORKLOADS} namespace={ns.name} title="Workloads list">
                             <Icon type="pf" name="bundle" style={{ paddingLeft: 10, paddingRight: 10 }} />
                           </ListPageLink>
-                          <ListPageLink target={TargetPage.SERVICES} namespace={ns.name}>
+                          <ListPageLink target={TargetPage.SERVICES} namespace={ns.name} title="Services list">
                             <Icon type="pf" name="service" style={{ paddingLeft: 10, paddingRight: 10 }} />
                           </ListPageLink>
                         </div>


### PR DESCRIPTION
They were accidentally removed

(cf KIALI-1528 for overall task)
