### PR TITLE
KIALI-1503 Fix expand link not taking effect until data refresh

### DIFF
--- a/src/components/Metrics/Metrics.tsx
+++ b/src/components/Metrics/Metrics.tsx
@@ -317,4 +317,5 @@ class Metrics extends React.Component<MetricsProps, MetricsState> {
   };
 }
 
+export { MetricsProps };
 export default Metrics;

--- a/src/containers/AppMetricsContainer.tsx
+++ b/src/containers/AppMetricsContainer.tsx
@@ -1,11 +1,12 @@
 import { KialiAppState } from '../store/Store';
 import { connect } from 'react-redux';
-import GraphPage from '../components/Metrics/Metrics';
+import GraphPage, { MetricsProps } from '../components/Metrics/Metrics';
+import { RouteComponentProps, withRouter } from 'react-router';
 
 const mapStateToProps = (state: KialiAppState) => ({
   isPageVisible: state.globalState.isPageVisible
 });
 
-const AppMetricsConnected = connect(mapStateToProps)(GraphPage);
+const AppMetricsConnected = withRouter<RouteComponentProps<{}> & MetricsProps>(connect(mapStateToProps)(GraphPage));
 
 export default AppMetricsConnected;

--- a/src/containers/ServiceMetricsContainer.tsx
+++ b/src/containers/ServiceMetricsContainer.tsx
@@ -1,11 +1,12 @@
 import { KialiAppState } from '../store/Store';
 import { connect } from 'react-redux';
-import GraphPage from '../components/Metrics/Metrics';
+import GraphPage, { MetricsProps } from '../components/Metrics/Metrics';
+import { RouteComponentProps, withRouter } from 'react-router';
 
 const mapStateToProps = (state: KialiAppState) => ({
   isPageVisible: state.globalState.isPageVisible
 });
 
-const ServiceMetricsConnected = connect(mapStateToProps)(GraphPage);
+const ServiceMetricsConnected = withRouter<RouteComponentProps<{}> & MetricsProps>(connect(mapStateToProps)(GraphPage));
 
 export default ServiceMetricsConnected;

--- a/src/containers/WorkloadMetricsContainer.tsx
+++ b/src/containers/WorkloadMetricsContainer.tsx
@@ -1,11 +1,14 @@
 import { KialiAppState } from '../store/Store';
 import { connect } from 'react-redux';
-import GraphPage from '../components/Metrics/Metrics';
+import GraphPage, { MetricsProps } from '../components/Metrics/Metrics';
+import { RouteComponentProps, withRouter } from 'react-router';
 
 const mapStateToProps = (state: KialiAppState) => ({
   isPageVisible: state.globalState.isPageVisible
 });
 
-const WorkloadMetricsConnected = connect(mapStateToProps)(GraphPage);
+const WorkloadMetricsConnected = withRouter<RouteComponentProps<{}> & MetricsProps>(
+  connect(mapStateToProps)(GraphPage)
+);
 
 export default WorkloadMetricsConnected;


### PR DESCRIPTION
Expand link uses react-router to inject an URL parameter to show the expanded graph. Because the metrics component is redux-wrapped, redux was preventing the component to re-render because redux was unaware of the parameter change.

Re-wrapping the redux-wrapped components into react-router solves the issue.
