### PR TITLE
KIALI-936 Enhance metrics page

### DIFF
--- a/src/app/History.tsx
+++ b/src/app/History.tsx
@@ -6,14 +6,23 @@ const history = createBrowserHistory({ basename: baseName });
 
 export default history;
 
+export enum URLParams {
+  POLL_INTERVAL = 'pi',
+  DURATION = 'duration',
+  REPORTER = 'reporter',
+  SHOW_AVERAGE = 'avg',
+  QUANTILES = 'quantiles',
+  BY_LABELS = 'bylbl'
+}
+
 export namespace HistoryManager {
-  export const setParam = (name: string, value: string) => {
+  export const setParam = (name: URLParams, value: string) => {
     const urlParams = new URLSearchParams(history.location.search);
     urlParams.set(name, value);
     history.replace(history.location.pathname + '?' + urlParams.toString());
   };
 
-  export const getParam = (name: string): string | null => {
+  export const getParam = (name: URLParams): string | null => {
     const urlParams = new URLSearchParams(history.location.search);
     return urlParams.get(name);
   };

--- a/src/components/Metrics/HistogramChart.tsx
+++ b/src/components/Metrics/HistogramChart.tsx
@@ -4,32 +4,33 @@ import MetricsChartBase from './MetricsChartBase';
 
 interface HistogramChartProps {
   histogram: Histogram;
-  familyName: string;
+  chartName: string;
   onExpandRequested?: () => void;
 }
 
 class HistogramChart extends MetricsChartBase<HistogramChartProps> {
   protected get controlKey() {
-    if (this.props.histogram.average.matrix.length === 0) {
+    const keys = Object.keys(this.props.histogram);
+    if (keys.length === 0 || this.props.histogram[keys[0]].matrix.length === 0) {
       return 'blank';
     }
 
-    const labelNames = Object.keys(this.props.histogram.average.matrix[0].metric);
+    const labelNames = Object.keys(this.props.histogram[keys[0]].matrix[0].metric);
     if (labelNames.length === 0) {
-      return this.props.familyName;
+      return this.props.chartName;
     }
 
-    return this.props.familyName + '-' + labelNames.join('-');
+    return this.props.chartName + '-' + labelNames.join('-');
   }
 
   protected get seriesData() {
+    Object.keys(this.props.histogram).forEach(stat => {
+      const statName = stat === 'avg' ? 'average' : 'quantile ' + stat;
+      this.nameTimeSeries(this.props.histogram[stat].matrix, statName);
+    });
     return {
       x: 'x',
-      columns: graphUtils
-        .toC3Columns(this.nameTimeSeries('[avg]', this.props.histogram.average.matrix))
-        .concat(graphUtils.toC3ValueColumns(this.nameTimeSeries('[med]', this.props.histogram.median.matrix)))
-        .concat(graphUtils.toC3ValueColumns(this.nameTimeSeries('[p95]', this.props.histogram.percentile95.matrix)))
-        .concat(graphUtils.toC3ValueColumns(this.nameTimeSeries('[p99]', this.props.histogram.percentile99.matrix)))
+      columns: graphUtils.histogramToC3Columns(this.props.histogram)
     };
   }
 }

--- a/src/components/Metrics/HistogramChart.tsx
+++ b/src/components/Metrics/HistogramChart.tsx
@@ -9,7 +9,7 @@ interface HistogramChartProps {
 }
 
 class HistogramChart extends MetricsChartBase<HistogramChartProps> {
-  protected get controlKey() {
+  protected getControlKey() {
     const keys = Object.keys(this.props.histogram);
     if (keys.length === 0 || this.props.histogram[keys[0]].matrix.length === 0) {
       return 'blank';
@@ -23,7 +23,7 @@ class HistogramChart extends MetricsChartBase<HistogramChartProps> {
     return this.props.chartName + '-' + labelNames.join('-');
   }
 
-  protected get seriesData() {
+  protected getSeriesData() {
     Object.keys(this.props.histogram).forEach(stat => {
       const statName = stat === 'avg' ? 'average' : 'quantile ' + stat;
       this.nameTimeSeries(this.props.histogram[stat].matrix, statName);

--- a/src/components/Metrics/MetricChart.tsx
+++ b/src/components/Metrics/MetricChart.tsx
@@ -9,7 +9,7 @@ type MetricChartProps = {
 };
 
 export default class MetricsChart extends MetricsChartBase<MetricChartProps> {
-  protected get controlKey(): string {
+  protected getControlKey(): string {
     if (this.props.series.length === 0) {
       return 'blank';
     }
@@ -22,7 +22,7 @@ export default class MetricsChart extends MetricsChartBase<MetricChartProps> {
     return this.props.chartName + '-' + labelNames.join('-');
   }
 
-  protected get seriesData() {
+  protected getSeriesData() {
     return {
       x: 'x',
       columns: graphUtils.toC3Columns(this.nameTimeSeries(this.props.series))

--- a/src/components/Metrics/MetricChart.tsx
+++ b/src/components/Metrics/MetricChart.tsx
@@ -4,7 +4,7 @@ import MetricsChartBase from './MetricsChartBase';
 
 type MetricChartProps = {
   series: TimeSeries[];
-  familyName: string;
+  chartName: string;
   onExpandRequested?: () => void;
 };
 
@@ -16,16 +16,16 @@ export default class MetricsChart extends MetricsChartBase<MetricChartProps> {
 
     const labelNames = Object.keys(this.props.series[0].metric);
     if (labelNames.length === 0) {
-      return this.props.familyName;
+      return this.props.chartName;
     }
 
-    return this.props.familyName + '-' + labelNames.join('-');
+    return this.props.chartName + '-' + labelNames.join('-');
   }
 
   protected get seriesData() {
     return {
       x: 'x',
-      columns: graphUtils.toC3Columns(this.nameTimeSeries('', this.props.series))
+      columns: graphUtils.toC3Columns(this.nameTimeSeries(this.props.series))
     };
   }
 }

--- a/src/components/Metrics/Metrics.tsx
+++ b/src/components/Metrics/Metrics.tsx
@@ -24,7 +24,7 @@ const expandedChartBackLinkStyle = style({
 });
 
 type ChartDefinition = {
-  familyName: string;
+  name: string;
   component: any;
   metrics?: MetricGroup | Histogram;
 };
@@ -74,23 +74,23 @@ class Metrics extends React.Component<MetricsProps, MetricsState> {
 
   getChartsDef(): { [key: string]: ChartDefinition } {
     let inboundCharts = {
-      request_count_in: { familyName: 'Request volume (ops)', component: MetricChart },
-      request_duration_in: { familyName: 'Request duration (seconds)', component: HistogramChart },
-      request_size_in: { familyName: 'Request size (bytes)', component: HistogramChart },
-      response_size_in: { familyName: 'Response size (bytes)', component: HistogramChart },
-      tcp_received_in: { familyName: 'TCP received (bps)', component: MetricChart },
-      tcp_sent_in: { familyName: 'TCP sent (bps)', component: MetricChart }
+      request_count_in: { name: 'Request volume (ops)', component: MetricChart },
+      request_duration_in: { name: 'Request duration (seconds)', component: HistogramChart },
+      request_size_in: { name: 'Request size (bytes)', component: HistogramChart },
+      response_size_in: { name: 'Response size (bytes)', component: HistogramChart },
+      tcp_received_in: { name: 'TCP received (bps)', component: MetricChart },
+      tcp_sent_in: { name: 'TCP sent (bps)', component: MetricChart }
     };
     let charts: { [key: string]: ChartDefinition } = inboundCharts;
 
     if (this.props.metricsType === 'outbound') {
       charts = {
-        request_count_out: { familyName: 'Request volume (ops)', component: MetricChart },
-        request_duration_out: { familyName: 'Request duration (seconds)', component: HistogramChart },
-        request_size_out: { familyName: 'Request size (bytes)', component: HistogramChart },
-        response_size_out: { familyName: 'Response size (bytes)', component: HistogramChart },
-        tcp_received_out: { familyName: 'TCP received (bps)', component: MetricChart },
-        tcp_sent_out: { familyName: 'TCP sent (bps)', component: MetricChart }
+        request_count_out: { name: 'Request volume (ops)', component: MetricChart },
+        request_duration_out: { name: 'Request duration (seconds)', component: HistogramChart },
+        request_size_out: { name: 'Request size (bytes)', component: HistogramChart },
+        response_size_out: { name: 'Response size (bytes)', component: HistogramChart },
+        tcp_received_out: { name: 'TCP received (bps)', component: MetricChart },
+        tcp_sent_out: { name: 'TCP sent (bps)', component: MetricChart }
       };
     }
 
@@ -295,7 +295,7 @@ class Metrics extends React.Component<MetricsProps, MetricsState> {
     }
     const props: any = {
       key: chartKey + this.state.metricReporter,
-      familyName: chart.familyName
+      chartName: chart.name
     };
     if ((chart.metrics as MetricGroup).matrix) {
       props.series = (chart.metrics as MetricGroup).matrix;

--- a/src/components/Metrics/MetricsChartBase.tsx
+++ b/src/components/Metrics/MetricsChartBase.tsx
@@ -15,9 +15,17 @@ const expandBlockStyle = style({
   textAlign: 'right'
 });
 
+interface C3ChartData {
+  x: string;
+  columns: any[][];
+  unload?: string[];
+}
+
 abstract class MetricsChartBase<Props extends MetricsChartBaseProps> extends React.Component<Props> {
-  protected abstract get controlKey(): string;
-  protected abstract get seriesData(): any;
+  private previousColumns: string[] = [];
+
+  protected abstract getControlKey(): string;
+  protected abstract getSeriesData(): C3ChartData;
 
   protected nameTimeSeries = (matrix: TimeSeries[], groupName?: string): TimeSeries[] => {
     matrix.forEach(ts => {
@@ -88,11 +96,25 @@ abstract class MetricsChartBase<Props extends MetricsChartBaseProps> extends Rea
     );
   };
 
+  checkUnload(data: C3ChartData) {
+    const newColumns = data.columns.map(c => c[0] as string);
+    const diff = this.previousColumns.filter(col => !newColumns.includes(col));
+    if (diff.length > 0) {
+      data.unload = diff;
+    }
+    this.previousColumns = newColumns;
+  }
+
   render() {
-    const data = this.seriesData;
+    const data = this.getSeriesData();
+    this.checkUnload(data);
     const height = this.adjustHeight(data.columns);
+    // Note: if any direct interaction is needed with the C3 chart,
+    //  use "oninit" hook and reference "this" as the C3 chart object.
+    //  see commented code
+    // const self = this;
     return (
-      <div key={this.controlKey} style={{ height: '100%' }}>
+      <div key={this.getControlKey()} style={{ height: '100%' }}>
         {this.props.onExpandRequested && this.renderExpand()}
         <LineChart
           style={{ height: this.props.onExpandRequested ? height : '99%' }}
@@ -101,6 +123,9 @@ abstract class MetricsChartBase<Props extends MetricsChartBaseProps> extends Rea
           data={data}
           axis={this.axisDefinition}
           point={{ show: false }}
+          // oninit={function(this: any) {
+          //   self.chartRef = this;
+          // }}
         />
       </div>
     );

--- a/src/components/Metrics/__tests__/Metrics.test.tsx
+++ b/src/components/Metrics/__tests__/Metrics.test.tsx
@@ -3,6 +3,7 @@ import { mount, shallow, ReactWrapper } from 'enzyme';
 
 import Metrics from '../Metrics';
 import * as API from '../../../services/Api';
+import { MetricsDirection, MetricsObjectTypes } from '../../../types/Metrics';
 
 window['SVGPathElement'] = a => a;
 let mounted: ReactWrapper<any, any> | null;
@@ -96,7 +97,14 @@ describe('Metrics for a service', () => {
 
   it('renders initial layout', () => {
     mockGrafanaInfo({});
-    const wrapper = shallow(<Metrics namespace="ns" object="svc" objectType={'service'} metricsType={'inbound'} />);
+    const wrapper = shallow(
+      <Metrics
+        namespace="ns"
+        object="svc"
+        objectType={MetricsObjectTypes.SERVICE}
+        direction={MetricsDirection.INBOUND}
+      />
+    );
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -127,7 +135,14 @@ describe('Metrics for a service', () => {
         .catch(err => done.fail(err))
     ];
     Promise.all(allMocksDone).then(() => done());
-    mounted = mount(<Metrics namespace="ns" object="svc" objectType={'service'} metricsType={'inbound'} />);
+    mounted = mount(
+      <Metrics
+        namespace="ns"
+        object="svc"
+        objectType={MetricsObjectTypes.SERVICE}
+        direction={MetricsDirection.INBOUND}
+      />
+    );
   });
 
   it(
@@ -152,7 +167,14 @@ describe('Metrics for a service', () => {
         mockGrafanaInfo({})
       ];
       Promise.all(allMocksDone).then(() => done());
-      mounted = mount(<Metrics namespace="ns" object="svc" objectType={'service'} metricsType={'inbound'} />);
+      mounted = mount(
+        <Metrics
+          namespace="ns"
+          object="svc"
+          objectType={MetricsObjectTypes.SERVICE}
+          direction={MetricsDirection.INBOUND}
+        />
+      );
     },
     10000
   ); // Increase timeout for this test
@@ -170,7 +192,14 @@ describe('Inbound Metrics for a workload', () => {
 
   it('renders initial layout', () => {
     mockGrafanaInfo({});
-    const wrapper = shallow(<Metrics namespace="ns" object="svc" objectType={'workload'} metricsType={'inbound'} />);
+    const wrapper = shallow(
+      <Metrics
+        namespace="ns"
+        object="svc"
+        objectType={MetricsObjectTypes.WORKLOAD}
+        direction={MetricsDirection.INBOUND}
+      />
+    );
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -204,7 +233,14 @@ describe('Inbound Metrics for a workload', () => {
         .catch(err => done.fail(err))
     ];
     Promise.all(allMocksDone).then(() => done());
-    mounted = mount(<Metrics namespace="ns" object="svc" objectType={'workload'} metricsType={'inbound'} />);
+    mounted = mount(
+      <Metrics
+        namespace="ns"
+        object="svc"
+        objectType={MetricsObjectTypes.WORKLOAD}
+        direction={MetricsDirection.INBOUND}
+      />
+    );
   });
 
   it(
@@ -229,7 +265,14 @@ describe('Inbound Metrics for a workload', () => {
         mockGrafanaInfo({})
       ];
       Promise.all(allMocksDone).then(() => done());
-      mounted = mount(<Metrics namespace="ns" object="svc" objectType={'workload'} metricsType={'inbound'} />);
+      mounted = mount(
+        <Metrics
+          namespace="ns"
+          object="svc"
+          objectType={MetricsObjectTypes.WORKLOAD}
+          direction={MetricsDirection.INBOUND}
+        />
+      );
     },
     10000
   ); // Increase timeout for this test
@@ -247,7 +290,14 @@ describe('Outbound Metrics for a workload', () => {
 
   it('renders initial layout', () => {
     mockGrafanaInfo({});
-    const wrapper = shallow(<Metrics namespace="ns" object="svc" objectType={'workload'} metricsType={'outbound'} />);
+    const wrapper = shallow(
+      <Metrics
+        namespace="ns"
+        object="svc"
+        objectType={MetricsObjectTypes.WORKLOAD}
+        direction={MetricsDirection.INBOUND}
+      />
+    );
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -281,7 +331,14 @@ describe('Outbound Metrics for a workload', () => {
         .catch(err => done.fail(err))
     ];
     Promise.all(allMocksDone).then(() => done());
-    mounted = mount(<Metrics namespace="ns" object="svc" objectType={'workload'} metricsType={'outbound'} />);
+    mounted = mount(
+      <Metrics
+        namespace="ns"
+        object="svc"
+        objectType={MetricsObjectTypes.WORKLOAD}
+        direction={MetricsDirection.INBOUND}
+      />
+    );
   });
 
   it(
@@ -306,7 +363,14 @@ describe('Outbound Metrics for a workload', () => {
         mockGrafanaInfo({})
       ];
       Promise.all(allMocksDone).then(() => done());
-      mounted = mount(<Metrics namespace="ns" object="svc" objectType={'workload'} metricsType={'outbound'} />);
+      mounted = mount(
+        <Metrics
+          namespace="ns"
+          object="svc"
+          objectType={MetricsObjectTypes.WORKLOAD}
+          direction={MetricsDirection.OUTBOUND}
+        />
+      );
     },
     10000
   ); // Increase timeout for this test

--- a/src/components/Metrics/__tests__/__snapshots__/Metrics.test.tsx.snap
+++ b/src/components/Metrics/__tests__/__snapshots__/Metrics.test.tsx.snap
@@ -5,11 +5,11 @@ ShallowWrapper {
   "length": 1,
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Metrics
+    direction={0}
     isPageVisible={true}
-    metricsType="inbound"
     namespace="ns"
     object="svc"
-    objectType="workload"
+    objectType={1}
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -27,10 +27,10 @@ ShallowWrapper {
         null,
         undefined,
         <MetricsOptionsBar
+          direction={0}
           metricReporter="destination"
-          onManualRefresh={[Function]}
           onOptionsChanged={[Function]}
-          onPollIntervalChanged={[Function]}
+          onRefresh={[Function]}
           onReporterChanged={[Function]}
         />,
         <div
@@ -63,10 +63,10 @@ ShallowWrapper {
         "key": undefined,
         "nodeType": "class",
         "props": Object {
+          "direction": 0,
           "metricReporter": "destination",
-          "onManualRefresh": [Function],
           "onOptionsChanged": [Function],
-          "onPollIntervalChanged": [Function],
+          "onRefresh": [Function],
           "onReporterChanged": [Function],
         },
         "ref": null,
@@ -194,10 +194,10 @@ ShallowWrapper {
           null,
           undefined,
           <MetricsOptionsBar
+            direction={0}
             metricReporter="destination"
-            onManualRefresh={[Function]}
             onOptionsChanged={[Function]}
-            onPollIntervalChanged={[Function]}
+            onRefresh={[Function]}
             onReporterChanged={[Function]}
           />,
           <div
@@ -230,10 +230,10 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "class",
           "props": Object {
+            "direction": 0,
             "metricReporter": "destination",
-            "onManualRefresh": [Function],
             "onOptionsChanged": [Function],
-            "onPollIntervalChanged": [Function],
+            "onRefresh": [Function],
             "onReporterChanged": [Function],
           },
           "ref": null,
@@ -367,11 +367,11 @@ ShallowWrapper {
   "length": 1,
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Metrics
+    direction={0}
     isPageVisible={true}
-    metricsType="inbound"
     namespace="ns"
     object="svc"
-    objectType="service"
+    objectType={0}
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -389,10 +389,10 @@ ShallowWrapper {
         null,
         undefined,
         <MetricsOptionsBar
+          direction={0}
           metricReporter="destination"
-          onManualRefresh={[Function]}
           onOptionsChanged={[Function]}
-          onPollIntervalChanged={[Function]}
+          onRefresh={[Function]}
           onReporterChanged={[Function]}
         />,
         <div
@@ -425,10 +425,10 @@ ShallowWrapper {
         "key": undefined,
         "nodeType": "class",
         "props": Object {
+          "direction": 0,
           "metricReporter": "destination",
-          "onManualRefresh": [Function],
           "onOptionsChanged": [Function],
-          "onPollIntervalChanged": [Function],
+          "onRefresh": [Function],
           "onReporterChanged": [Function],
         },
         "ref": null,
@@ -556,10 +556,10 @@ ShallowWrapper {
           null,
           undefined,
           <MetricsOptionsBar
+            direction={0}
             metricReporter="destination"
-            onManualRefresh={[Function]}
             onOptionsChanged={[Function]}
-            onPollIntervalChanged={[Function]}
+            onRefresh={[Function]}
             onReporterChanged={[Function]}
           />,
           <div
@@ -592,10 +592,10 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "class",
           "props": Object {
+            "direction": 0,
             "metricReporter": "destination",
-            "onManualRefresh": [Function],
             "onOptionsChanged": [Function],
-            "onPollIntervalChanged": [Function],
+            "onRefresh": [Function],
             "onReporterChanged": [Function],
           },
           "ref": null,
@@ -729,11 +729,11 @@ ShallowWrapper {
   "length": 1,
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Metrics
+    direction={0}
     isPageVisible={true}
-    metricsType="outbound"
     namespace="ns"
     object="svc"
-    objectType="workload"
+    objectType={1}
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -751,10 +751,10 @@ ShallowWrapper {
         null,
         undefined,
         <MetricsOptionsBar
-          metricReporter="source"
-          onManualRefresh={[Function]}
+          direction={0}
+          metricReporter="destination"
           onOptionsChanged={[Function]}
-          onPollIntervalChanged={[Function]}
+          onRefresh={[Function]}
           onReporterChanged={[Function]}
         />,
         <div
@@ -787,10 +787,10 @@ ShallowWrapper {
         "key": undefined,
         "nodeType": "class",
         "props": Object {
-          "metricReporter": "source",
-          "onManualRefresh": [Function],
+          "direction": 0,
+          "metricReporter": "destination",
           "onOptionsChanged": [Function],
-          "onPollIntervalChanged": [Function],
+          "onRefresh": [Function],
           "onReporterChanged": [Function],
         },
         "ref": null,
@@ -918,10 +918,10 @@ ShallowWrapper {
           null,
           undefined,
           <MetricsOptionsBar
-            metricReporter="source"
-            onManualRefresh={[Function]}
+            direction={0}
+            metricReporter="destination"
             onOptionsChanged={[Function]}
-            onPollIntervalChanged={[Function]}
+            onRefresh={[Function]}
             onReporterChanged={[Function]}
           />,
           <div
@@ -954,10 +954,10 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "class",
           "props": Object {
-            "metricReporter": "source",
-            "onManualRefresh": [Function],
+            "direction": 0,
+            "metricReporter": "destination",
             "onOptionsChanged": [Function],
-            "onPollIntervalChanged": [Function],
+            "onRefresh": [Function],
             "onReporterChanged": [Function],
           },
           "ref": null,

--- a/src/components/MetricsOptions/MetricsOptionsBar.tsx
+++ b/src/components/MetricsOptions/MetricsOptionsBar.tsx
@@ -5,6 +5,7 @@ import ValueSelectHelper from './ValueSelectHelper';
 import MetricsOptions from '../../types/MetricsOptions';
 import { ToolbarDropdown } from '../ToolbarDropdown/ToolbarDropdown';
 import { HistoryManager } from '../../app/History';
+import { MetricsSettings, Quantiles, MetricsSettingsDropdown } from './MetricsSettings';
 
 interface Props {
   onOptionsChanged: (opts: MetricsOptions) => void;
@@ -18,6 +19,7 @@ interface MetricsOptionsState {
   pollInterval: number;
   duration: number;
   groupByLabels: string[];
+  metricsSettings: MetricsSettings;
 }
 
 interface GroupByLabel {
@@ -72,7 +74,12 @@ export class MetricsOptionsBar extends React.Component<Props, MetricsOptionsStat
     this.state = {
       pollInterval: this.initialPollInterval(),
       duration: this.initialDuration(),
-      groupByLabels: this.groupByLabelsHelper.selected
+      groupByLabels: this.groupByLabelsHelper.selected,
+      metricsSettings: {
+        showAverage: true,
+        showQuantiles: [Quantiles.MEDIAN, Quantiles.Q0_95, Quantiles.Q0_99],
+        groupingLabels: []
+      }
     };
   }
 
@@ -126,7 +133,9 @@ export class MetricsOptionsBar extends React.Component<Props, MetricsOptionsStat
     this.props.onOptionsChanged({
       duration: this.state.duration,
       byLabelsIn: labelsIn,
-      byLabelsOut: labelsOut
+      byLabelsOut: labelsOut,
+      avg: this.state.metricsSettings.showAverage,
+      quantiles: this.state.metricsSettings.showQuantiles
     });
   }
 
@@ -136,11 +145,18 @@ export class MetricsOptionsBar extends React.Component<Props, MetricsOptionsStat
     });
   };
 
+  onMetricsSettingsChanged = (settings: MetricsSettings) => {
+    this.setState({ metricsSettings: settings }, () => {
+      this.reportOptions();
+    });
+  };
+
   render() {
     return (
       <Toolbar>
         {this.groupByLabelsHelper.renderDropdown()}
         <FormGroup>
+          <MetricsSettingsDropdown onChanged={this.onMetricsSettingsChanged} {...this.state.metricsSettings} />
           <ToolbarDropdown
             id={'metrics_filter_reporter'}
             disabled={false}

--- a/src/components/MetricsOptions/MetricsOptionsBar.tsx
+++ b/src/components/MetricsOptions/MetricsOptionsBar.tsx
@@ -1,31 +1,44 @@
 import * as React from 'react';
-import { Button, Icon, Toolbar, ToolbarRightContent, FormGroup } from 'patternfly-react';
-import { config } from '../../config';
-import ValueSelectHelper from './ValueSelectHelper';
-import MetricsOptions from '../../types/MetricsOptions';
+import { Toolbar, ToolbarRightContent, FormGroup } from 'patternfly-react';
+
+import Refresh from '../Refresh/Refresh';
 import { ToolbarDropdown } from '../ToolbarDropdown/ToolbarDropdown';
-import { HistoryManager } from '../../app/History';
-import { MetricsSettings, Quantiles, MetricsSettingsDropdown } from './MetricsSettings';
+import history, { URLParams, HistoryManager } from '../../app/History';
+import { config } from '../../config';
+import MetricsOptions from '../../types/MetricsOptions';
+import { MetricsDirection } from '../../types/Metrics';
+
+import { MetricsSettings, Quantiles, MetricsSettingsDropdown, Grouping } from './MetricsSettings';
 
 interface Props {
   onOptionsChanged: (opts: MetricsOptions) => void;
-  onPollIntervalChanged: (interval: number) => void;
   onReporterChanged: (reporter: string) => void;
-  onManualRefresh: () => void;
+  onRefresh: () => void;
   metricReporter: string;
+  direction: MetricsDirection;
 }
 
 interface MetricsOptionsState {
   pollInterval: number;
   duration: number;
-  groupByLabels: string[];
   metricsSettings: MetricsSettings;
 }
 
-interface GroupByLabel {
-  labelIn: string;
-  labelOut: string;
-}
+type Label = string;
+
+const INBOUND_GROUPING_LABELS: Map<Grouping, Label> = new Map<Grouping, Label>([
+  ['Local version', 'destination_version'],
+  ['Remote app', 'source_app'],
+  ['Remote version', 'source_version'],
+  ['Response code', 'response_code']
+]);
+
+const OUTBOUND_GROUPING_LABELS: Map<Grouping, Label> = new Map<Grouping, Label>([
+  ['Local version', 'source_version'],
+  ['Remote app', 'destination_app'],
+  ['Remote version', 'destination_version'],
+  ['Response code', 'response_code']
+]);
 
 export class MetricsOptionsBar extends React.Component<Props, MetricsOptionsState> {
   static PollIntervals = config().toolbar.pollInterval;
@@ -34,93 +47,75 @@ export class MetricsOptionsBar extends React.Component<Props, MetricsOptionsStat
   static Durations = config().toolbar.intervalDuration;
   static DefaultDuration = config().toolbar.defaultDuration;
 
-  static GroupByLabelOptions: { [key: string]: GroupByLabel } = {
-    'Local version': {
-      labelIn: 'destination_version',
-      labelOut: 'source_version'
-    },
-    'Remote app': {
-      labelIn: 'source_app',
-      labelOut: 'destination_app'
-    },
-    'Remote version': {
-      labelIn: 'source_version',
-      labelOut: 'destination_version'
-    },
-    'Response code': {
-      labelIn: 'response_code',
-      labelOut: 'response_code'
-    }
-  };
-
   static ReporterOptions: { [key: string]: string } = {
     destination: 'Destination',
     source: 'Source'
   };
 
-  groupByLabelsHelper: ValueSelectHelper;
-
   constructor(props: Props) {
     super(props);
 
-    this.groupByLabelsHelper = new ValueSelectHelper({
-      items: Object.keys(MetricsOptionsBar.GroupByLabelOptions),
-      onChange: this.changedGroupByLabel,
-      dropdownTitle: 'Group by',
-      resultsTitle: 'Grouping by:',
-      urlAttrName: 'groupings'
-    });
+    const urlParams = new URLSearchParams(history.location.search);
 
     this.state = {
-      pollInterval: this.initialPollInterval(),
-      duration: this.initialDuration(),
-      groupByLabels: this.groupByLabelsHelper.selected,
-      metricsSettings: {
-        showAverage: true,
-        showQuantiles: [Quantiles.MEDIAN, Quantiles.Q0_95, Quantiles.Q0_99],
-        groupingLabels: []
-      }
+      pollInterval: this.initialPollInterval(urlParams),
+      duration: this.initialDuration(urlParams),
+      metricsSettings: this.initialMetricsSettings(urlParams)
     };
   }
 
   componentDidMount() {
     // Init state upstream
     this.reportOptions();
-    this.props.onPollIntervalChanged(this.state.pollInterval);
   }
 
-  initialPollInterval = (): number => {
-    let initialPollInterval = MetricsOptionsBar.DefaultPollInterval;
-
-    const pollIntervalParam = HistoryManager.getParam('pi');
-    if (pollIntervalParam != null) {
-      initialPollInterval = Number(pollIntervalParam);
+  initialPollInterval = (urlParams: URLSearchParams): number => {
+    const pi = urlParams.get(URLParams.POLL_INTERVAL);
+    if (pi !== null) {
+      return Number(pi);
     }
-
-    return initialPollInterval;
+    return MetricsOptionsBar.DefaultPollInterval;
   };
 
-  initialDuration = (): number => {
-    let initialDuration = Number(sessionStorage.getItem('appDuration')) || MetricsOptionsBar.DefaultDuration;
-
-    const durationParam = HistoryManager.getParam('duration');
-    if (durationParam != null) {
-      initialDuration = Number(durationParam);
-      sessionStorage.setItem('appDuration', durationParam);
+  initialDuration = (urlParams: URLSearchParams): number => {
+    let d = urlParams.get(URLParams.DURATION);
+    if (d !== null) {
+      sessionStorage.setItem(URLParams.DURATION, d);
+      return Number(d);
     }
+    d = sessionStorage.getItem(URLParams.DURATION);
+    return d !== null ? Number(d) : MetricsOptionsBar.DefaultDuration;
+  };
 
-    return initialDuration;
+  initialMetricsSettings = (urlParams: URLSearchParams): MetricsSettings => {
+    const settings: MetricsSettings = {
+      showAverage: true,
+      showQuantiles: ['0.5', '0.95', '0.99'],
+      groupingLabels: []
+    };
+    const avg = urlParams.get(URLParams.SHOW_AVERAGE);
+    if (avg !== null) {
+      settings.showAverage = avg === 'true';
+    }
+    const quantiles = urlParams.getAll(URLParams.QUANTILES);
+    if (quantiles.length !== 0) {
+      settings.showQuantiles = quantiles as Quantiles[];
+    }
+    const byLabels = urlParams.getAll(URLParams.BY_LABELS);
+    if (byLabels.length !== 0) {
+      settings.groupingLabels = byLabels as Grouping[];
+    }
+    return settings;
   };
 
   onPollIntervalChanged = (key: number) => {
-    // We use a specific handler so that changing poll interval doesn't trigger a metrics refresh in parent
-    // Especially useful when pausing
-    this.props.onPollIntervalChanged(key);
+    HistoryManager.setParam(URLParams.POLL_INTERVAL, String(key));
     this.setState({ pollInterval: key });
   };
 
   onDurationChanged = (key: number) => {
-    sessionStorage.setItem('appDuration', String(key));
+    sessionStorage.setItem(URLParams.DURATION, String(key));
+    HistoryManager.setParam(URLParams.DURATION, String(key));
     this.setState({ duration: key }, () => {
       this.reportOptions();
     });
@@ -128,8 +123,13 @@ export class MetricsOptionsBar extends React.Component<Props, MetricsOptionsStat
 
   reportOptions() {
     // State-to-options converter (removes unnecessary properties)
-    const labelsIn = this.state.groupByLabels.map(lbl => MetricsOptionsBar.GroupByLabelOptions[lbl].labelIn);
-    const labelsOut = this.state.groupByLabels.map(lbl => MetricsOptionsBar.GroupByLabelOptions[lbl].labelOut);
+    let labelsIn: Label[] = [];
+    let labelsOut: Label[] = [];
+    if (this.props.direction === MetricsDirection.INBOUND) {
+      labelsIn = this.state.metricsSettings.groupingLabels.map(lbl => INBOUND_GROUPING_LABELS.get(lbl)!);
+    } else {
+      labelsOut = this.state.metricsSettings.groupingLabels.map(lbl => OUTBOUND_GROUPING_LABELS.get(lbl)!);
+    }
     this.props.onOptionsChanged({
       duration: this.state.duration,
       byLabelsIn: labelsIn,
@@ -139,13 +139,19 @@ export class MetricsOptionsBar extends React.Component<Props, MetricsOptionsStat
     });
   }
 
-  changedGroupByLabel = (labels: string[]) => {
-    this.setState({ groupByLabels: labels }, () => {
-      this.reportOptions();
-    });
+  onReporterChanged = (reporter: string) => {
+    HistoryManager.setParam(URLParams.REPORTER, reporter);
+    this.props.onReporterChanged(reporter);
   };
 
   onMetricsSettingsChanged = (settings: MetricsSettings) => {
+    const urlParams = new URLSearchParams(history.location.search);
+    urlParams.set(URLParams.SHOW_AVERAGE, String(settings.showAverage));
+    urlParams.delete(URLParams.QUANTILES);
+    urlParams.delete(URLParams.BY_LABELS);
+    settings.showQuantiles.forEach(q => urlParams.append(URLParams.QUANTILES, q));
+    settings.groupingLabels.forEach(lbl => urlParams.append(URLParams.BY_LABELS, lbl));
+    history.replace(history.location.pathname + '?' + urlParams.toString());
     this.setState({ metricsSettings: settings }, () => {
       this.reportOptions();
     });
@@ -154,13 +160,14 @@ export class MetricsOptionsBar extends React.Component<Props, MetricsOptionsStat
   render() {
     return (
       <Toolbar>
-        {this.groupByLabelsHelper.renderDropdown()}
         <FormGroup>
           <MetricsSettingsDropdown onChanged={this.onMetricsSettingsChanged} {...this.state.metricsSettings} />
+        </FormGroup>
+        <FormGroup>
           <ToolbarDropdown
             id={'metrics_filter_reporter'}
             disabled={false}
-            handleSelect={this.props.onReporterChanged}
+            handleSelect={this.onReporterChanged}
             nameDropdown={'Reported from'}
             value={this.props.metricReporter}
             initialLabel={MetricsOptionsBar.ReporterOptions[this.props.metricReporter]}
@@ -171,28 +178,19 @@ export class MetricsOptionsBar extends React.Component<Props, MetricsOptionsStat
           id={'metrics_filter_interval_duration'}
           disabled={false}
           handleSelect={this.onDurationChanged}
-          nameDropdown={'Duration'}
+          nameDropdown={'Displaying'}
           initialValue={this.state.duration}
           initialLabel={String(MetricsOptionsBar.Durations[this.state.duration])}
           options={MetricsOptionsBar.Durations}
         />
-        <ToolbarDropdown
-          id={'metrics_filter_poll_interval'}
-          disabled={false}
-          handleSelect={this.onPollIntervalChanged}
-          nameDropdown={'Poll Interval'}
-          initialValue={this.state.pollInterval}
-          initialLabel={String(MetricsOptionsBar.PollIntervals[this.state.pollInterval])}
-          options={MetricsOptionsBar.PollIntervals}
-        />
         <ToolbarRightContent>
-          <Button onClick={this.props.onManualRefresh}>
-            <Icon name="refresh" />
-          </Button>
+          <Refresh
+            id="metrics-refresh"
+            handleRefresh={this.props.onRefresh}
+            onSelect={this.onPollIntervalChanged}
+            pollInterval={this.state.pollInterval}
+          />
         </ToolbarRightContent>
-        {this.groupByLabelsHelper.hasResults() && (
-          <Toolbar.Results>{this.groupByLabelsHelper.renderResults()}</Toolbar.Results>
-        )}
       </Toolbar>
     );
   }

--- a/src/components/MetricsOptions/MetricsSettings.tsx
+++ b/src/components/MetricsOptions/MetricsSettings.tsx
@@ -2,35 +2,11 @@ import * as React from 'react';
 import { Button, Icon, OverlayTrigger, Popover } from 'patternfly-react';
 import { style } from 'typestyle';
 
-export enum Grouping {
-  LOCAL_VERSION = 'Local version',
-  REMOTE_APP = 'Remote app',
-  REMOTE_VERSION = 'Remote version',
-  RESPONSE_CODE = 'Response code'
-}
+export type Grouping = 'Local version' | 'Remote app' | 'Remote version' | 'Response code';
+const allGroupings: Grouping[] = ['Local version', 'Remote app', 'Remote version', 'Response code'];
 
-export enum Quantiles {
-  MEDIAN = '0.5',
-  Q0_95 = '0.95',
-  Q0_99 = '0.99',
-  Q0_999 = '0.999'
-}
-
-// type Label = string;
-
-// export const INBOUND_GROUPING_LABELS: Map<Grouping, Label> = new Map([
-//   [Grouping.LOCAL_VERSION, 'destination_version'],
-//   [Grouping.REMOTE_APP, 'source_app'],
-//   [Grouping.REMOTE_VERSION, 'source_version'],
-//   [Grouping.RESPONSE_CODE, 'response_code']
-// ]);
-
-// export const OUTBOUND_GROUPING_LABELS: Map<Grouping, Label> = new Map([
-//   [Grouping.LOCAL_VERSION, 'source_version'],
-//   [Grouping.REMOTE_APP, 'destination_app'],
-//   [Grouping.REMOTE_VERSION, 'destination_version'],
-//   [Grouping.RESPONSE_CODE, 'response_code']
-// ]);
+export type Quantiles = '0.5' | '0.95' | '0.99' | '0.999';
+const allQuantiles: Quantiles[] = ['0.5', '0.95', '0.99', '0.999'];
 
 export interface MetricsSettings {
   groupingLabels: Grouping[];
@@ -77,12 +53,7 @@ export class MetricsSettingsDropdown extends React.PureComponent<Props, State> {
   render() {
     const checkboxStyle = style({ marginLeft: 5 });
 
-    const displayGroupingLabels = [
-      Grouping.LOCAL_VERSION,
-      Grouping.REMOTE_APP,
-      Grouping.REMOTE_VERSION,
-      Grouping.RESPONSE_CODE
-    ].map((g, idx) => {
+    const displayGroupingLabels = allGroupings.map((g, idx) => {
       const checked = this.state.groupingLabels.includes(g);
       return (
         <div key={'groupings_' + idx}>
@@ -112,7 +83,7 @@ export class MetricsSettingsDropdown extends React.PureComponent<Props, State> {
         </label>
       </div>
     )].concat(
-      [Quantiles.MEDIAN, Quantiles.Q0_95, Quantiles.Q0_99, Quantiles.Q0_999].map((o, idx) => {
+      allQuantiles.map((o, idx) => {
         const checked = this.state.showQuantiles.includes(o);
         return (
           <div key={'histo_' + idx}>

--- a/src/components/MetricsOptions/MetricsSettings.tsx
+++ b/src/components/MetricsOptions/MetricsSettings.tsx
@@ -1,0 +1,155 @@
+import * as React from 'react';
+import { Button, Icon, OverlayTrigger, Popover } from 'patternfly-react';
+import { style } from 'typestyle';
+
+export enum Grouping {
+  LOCAL_VERSION = 'Local version',
+  REMOTE_APP = 'Remote app',
+  REMOTE_VERSION = 'Remote version',
+  RESPONSE_CODE = 'Response code'
+}
+
+export enum Quantiles {
+  MEDIAN = '0.5',
+  Q0_95 = '0.95',
+  Q0_99 = '0.99',
+  Q0_999 = '0.999'
+}
+
+// type Label = string;
+
+// export const INBOUND_GROUPING_LABELS: Map<Grouping, Label> = new Map([
+//   [Grouping.LOCAL_VERSION, 'destination_version'],
+//   [Grouping.REMOTE_APP, 'source_app'],
+//   [Grouping.REMOTE_VERSION, 'source_version'],
+//   [Grouping.RESPONSE_CODE, 'response_code']
+// ]);
+
+// export const OUTBOUND_GROUPING_LABELS: Map<Grouping, Label> = new Map([
+//   [Grouping.LOCAL_VERSION, 'source_version'],
+//   [Grouping.REMOTE_APP, 'destination_app'],
+//   [Grouping.REMOTE_VERSION, 'destination_version'],
+//   [Grouping.RESPONSE_CODE, 'response_code']
+// ]);
+
+export interface MetricsSettings {
+  groupingLabels: Grouping[];
+  showAverage: boolean;
+  showQuantiles: Quantiles[];
+}
+
+interface Props extends MetricsSettings {
+  onChanged: (state: MetricsSettings) => void;
+}
+
+interface State extends MetricsSettings {}
+
+export class MetricsSettingsDropdown extends React.PureComponent<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      groupingLabels: props.groupingLabels,
+      showAverage: props.showAverage,
+      showQuantiles: props.showQuantiles
+    };
+  }
+
+  onGroupingChanged = (label: Grouping, checked: boolean) => {
+    const newLabels = checked
+      ? [label].concat(this.state.groupingLabels)
+      : this.state.groupingLabels.filter(g => label !== g);
+
+    this.setState({ groupingLabels: newLabels }, () => this.props.onChanged(this.state));
+  };
+
+  onHistogramAverageChanged = (checked: boolean) => {
+    this.setState({ showAverage: checked }, () => this.props.onChanged(this.state));
+  };
+
+  onHistogramOptionsChanged = (quantile: Quantiles, checked: boolean) => {
+    const newQuantiles = checked
+      ? [quantile].concat(this.state.showQuantiles)
+      : this.state.showQuantiles.filter(q => quantile !== q);
+
+    this.setState({ showQuantiles: newQuantiles }, () => this.props.onChanged(this.state));
+  };
+
+  render() {
+    const checkboxStyle = style({ marginLeft: 5 });
+
+    const displayGroupingLabels = [
+      Grouping.LOCAL_VERSION,
+      Grouping.REMOTE_APP,
+      Grouping.REMOTE_VERSION,
+      Grouping.RESPONSE_CODE
+    ].map((g, idx) => {
+      const checked = this.state.groupingLabels.includes(g);
+      return (
+        <div key={'groupings_' + idx}>
+          <label>
+            <input
+              type="checkbox"
+              checked={checked}
+              onChange={event => this.onGroupingChanged(g, event.target.checked)}
+            />
+            <span className={checkboxStyle}>{g}</span>
+          </label>
+        </div>
+      );
+    });
+
+    // Prettier removes the parenthesis introducing JSX
+    // prettier-ignore
+    const displayHistogramOptions = [(
+      <div key={'histo_avg'}>
+        <label>
+          <input
+            type="checkbox"
+            checked={this.state.showAverage}
+            onChange={event => this.onHistogramAverageChanged(event.target.checked)}
+          />
+          <span className={checkboxStyle}>Average</span>
+        </label>
+      </div>
+    )].concat(
+      [Quantiles.MEDIAN, Quantiles.Q0_95, Quantiles.Q0_99, Quantiles.Q0_999].map((o, idx) => {
+        const checked = this.state.showQuantiles.includes(o);
+        return (
+          <div key={'histo_' + idx}>
+            <label>
+              <input
+                type="checkbox"
+                checked={checked}
+                onChange={event => this.onHistogramOptionsChanged(o, event.target.checked)}
+              />
+              <span className={checkboxStyle}>Quantile {o}</span>
+            </label>
+          </div>
+        );
+      })
+    );
+
+    const spacerStyle = style({
+      height: '1em'
+    });
+
+    const metricsSettingsPopover = (
+      <Popover id="layers-popover">
+        <label>Show metrics by:</label>
+        {displayGroupingLabels}
+        <div className={spacerStyle} />
+        <label>Histograms:</label>
+        {displayHistogramOptions}
+        <div className={spacerStyle} />
+      </Popover>
+    );
+
+    return (
+      <OverlayTrigger overlay={metricsSettingsPopover} placement="bottom" trigger={['click']} rootClose={true}>
+        <Button>
+          Metrics Settings <Icon name="angle-down" />
+        </Button>
+      </OverlayTrigger>
+    );
+  }
+}

--- a/src/components/MetricsOptions/__tests__/MetricsOptionsBar.test.tsx
+++ b/src/components/MetricsOptions/__tests__/MetricsOptionsBar.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { mount, shallow } from 'enzyme';
 
 import MetricsOptionsBar from '../MetricsOptionsBar';
+import { MetricsDirection } from '../../../types/Metrics';
 
 const optionsChanged = jest.fn();
 const lastOptionsChanged = () => {
@@ -13,10 +14,10 @@ describe('MetricsOptionsBar', () => {
     const wrapper = shallow(
       <MetricsOptionsBar
         onOptionsChanged={jest.fn()}
-        onPollIntervalChanged={jest.fn()}
-        onManualRefresh={jest.fn()}
+        onRefresh={jest.fn()}
         onReporterChanged={jest.fn()}
         metricReporter={'destination'}
+        direction={MetricsDirection.INBOUND}
       />
     );
     expect(wrapper).toMatchSnapshot();
@@ -26,10 +27,10 @@ describe('MetricsOptionsBar', () => {
     const wrapper = mount(
       <MetricsOptionsBar
         onOptionsChanged={optionsChanged}
-        onPollIntervalChanged={jest.fn()}
-        onManualRefresh={jest.fn()}
+        onRefresh={jest.fn()}
         onReporterChanged={jest.fn()}
         metricReporter={'destination'}
+        direction={MetricsDirection.INBOUND}
       />
     );
     expect(optionsChanged).toHaveBeenCalledTimes(1);

--- a/src/components/MetricsOptions/__tests__/__snapshots__/MetricsOptionsBar.test.tsx.snap
+++ b/src/components/MetricsOptions/__tests__/__snapshots__/MetricsOptionsBar.test.tsx.snap
@@ -5,30 +5,28 @@ ShallowWrapper {
   "length": 1,
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <MetricsOptionsBar
+    direction={0}
     metricReporter="destination"
-    onManualRefresh={[MockFunction]}
     onOptionsChanged={
       [MockFunction] {
         "calls": Array [
           Array [
             Object {
+              "avg": true,
               "byLabelsIn": Array [],
               "byLabelsOut": Array [],
               "duration": 60,
+              "quantiles": Array [
+                "0.5",
+                "0.95",
+                "0.99",
+              ],
             },
           ],
         ],
       }
     }
-    onPollIntervalChanged={
-      [MockFunction] {
-        "calls": Array [
-          Array [
-            15000,
-          ],
-        ],
-      }
-    }
+    onRefresh={[MockFunction]}
     onReporterChanged={[MockFunction]}
   />,
   Symbol(enzyme.__renderer__): Object {
@@ -44,29 +42,28 @@ ShallowWrapper {
     "nodeType": "class",
     "props": Object {
       "children": Array [
-        <getContext(Filter)>
-          <FilterValueSelector
-            className=""
-            currentValue=""
-            filterValues={
+        <FormGroup
+          bsClass="form-group"
+        >
+          <MetricsSettingsDropdown
+            groupingLabels={Array []}
+            onChanged={[Function]}
+            showAverage={true}
+            showQuantiles={
               Array [
-                "Local version",
-                "Remote app",
-                "Remote version",
-                "Response code",
+                "0.5",
+                "0.95",
+                "0.99",
               ]
             }
-            id=""
-            onFilterValueSelected={[Function]}
-            placeholder="Group by"
           />
-        </getContext(Filter)>,
+        </FormGroup>,
         <FormGroup
           bsClass="form-group"
         >
           <ToolbarDropdown
             disabled={false}
-            handleSelect={[MockFunction]}
+            handleSelect={[Function]}
             id="metrics_filter_reporter"
             initialLabel="Destination"
             nameDropdown="Reported from"
@@ -85,7 +82,7 @@ ShallowWrapper {
           id="metrics_filter_interval_duration"
           initialLabel="Last min"
           initialValue={60}
-          nameDropdown="Duration"
+          nameDropdown="Displaying"
           options={
             Object {
               "10800": "Last 3 hours",
@@ -102,43 +99,16 @@ ShallowWrapper {
             }
           }
         />,
-        <ToolbarDropdown
-          disabled={false}
-          handleSelect={[Function]}
-          id="metrics_filter_poll_interval"
-          initialLabel="15 sec"
-          initialValue={15000}
-          nameDropdown="Poll Interval"
-          options={
-            Object {
-              "0": "Pause",
-              "10000": "10 sec",
-              "15000": "15 sec",
-              "30000": "30 sec",
-              "300000": "5 min",
-              "5000": "5 sec",
-              "60000": "1 min",
-            }
-          }
-        />,
         <ToolbarRightContent
           className=""
         >
-          <Button
-            active={false}
-            block={false}
-            bsClass="btn"
-            bsStyle="default"
-            disabled={false}
-            onClick={[MockFunction]}
-          >
-            <Icon
-              name="refresh"
-              type="fa"
-            />
-          </Button>
+          <Refresh
+            handleRefresh={[MockFunction]}
+            id="metrics-refresh"
+            onSelect={[Function]}
+            pollInterval={15000}
+          />
         </ToolbarRightContent>,
-        false,
       ],
     },
     "ref": null,
@@ -146,41 +116,36 @@ ShallowWrapper {
       Object {
         "instance": null,
         "key": undefined,
-        "nodeType": "function",
+        "nodeType": "class",
         "props": Object {
-          "children": <FilterValueSelector
-            className=""
-            currentValue=""
-            filterValues={
+          "bsClass": "form-group",
+          "children": <MetricsSettingsDropdown
+            groupingLabels={Array []}
+            onChanged={[Function]}
+            showAverage={true}
+            showQuantiles={
               Array [
-                "Local version",
-                "Remote app",
-                "Remote version",
-                "Response code",
+                "0.5",
+                "0.95",
+                "0.99",
               ]
             }
-            id=""
-            onFilterValueSelected={[Function]}
-            placeholder="Group by"
           />,
         },
         "ref": null,
         "rendered": Object {
           "instance": null,
           "key": undefined,
-          "nodeType": "function",
+          "nodeType": "class",
           "props": Object {
-            "className": "",
-            "currentValue": "",
-            "filterValues": Array [
-              "Local version",
-              "Remote app",
-              "Remote version",
-              "Response code",
+            "groupingLabels": Array [],
+            "onChanged": [Function],
+            "showAverage": true,
+            "showQuantiles": Array [
+              "0.5",
+              "0.95",
+              "0.99",
             ],
-            "id": "",
-            "onFilterValueSelected": [Function],
-            "placeholder": "Group by",
           },
           "ref": null,
           "rendered": null,
@@ -196,7 +161,7 @@ ShallowWrapper {
           "bsClass": "form-group",
           "children": <ToolbarDropdown
             disabled={false}
-            handleSelect={[MockFunction]}
+            handleSelect={[Function]}
             id="metrics_filter_reporter"
             initialLabel="Destination"
             nameDropdown="Reported from"
@@ -216,7 +181,7 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "disabled": false,
-            "handleSelect": [MockFunction],
+            "handleSelect": [Function],
             "id": "metrics_filter_reporter",
             "initialLabel": "Destination",
             "nameDropdown": "Reported from",
@@ -242,7 +207,7 @@ ShallowWrapper {
           "id": "metrics_filter_interval_duration",
           "initialLabel": "Last min",
           "initialValue": 60,
-          "nameDropdown": "Duration",
+          "nameDropdown": "Displaying",
           "options": Object {
             "10800": "Last 3 hours",
             "1800": "Last 30 min",
@@ -264,46 +229,14 @@ ShallowWrapper {
       Object {
         "instance": null,
         "key": undefined,
-        "nodeType": "class",
-        "props": Object {
-          "disabled": false,
-          "handleSelect": [Function],
-          "id": "metrics_filter_poll_interval",
-          "initialLabel": "15 sec",
-          "initialValue": 15000,
-          "nameDropdown": "Poll Interval",
-          "options": Object {
-            "0": "Pause",
-            "10000": "10 sec",
-            "15000": "15 sec",
-            "30000": "30 sec",
-            "300000": "5 min",
-            "5000": "5 sec",
-            "60000": "1 min",
-          },
-        },
-        "ref": null,
-        "rendered": null,
-        "type": [Function],
-      },
-      Object {
-        "instance": null,
-        "key": undefined,
         "nodeType": "function",
         "props": Object {
-          "children": <Button
-            active={false}
-            block={false}
-            bsClass="btn"
-            bsStyle="default"
-            disabled={false}
-            onClick={[MockFunction]}
-          >
-            <Icon
-              name="refresh"
-              type="fa"
-            />
-          </Button>,
+          "children": <Refresh
+            handleRefresh={[MockFunction]}
+            id="metrics-refresh"
+            onSelect={[Function]}
+            pollInterval={15000}
+          />,
           "className": "",
         },
         "ref": null,
@@ -312,35 +245,17 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "class",
           "props": Object {
-            "active": false,
-            "block": false,
-            "bsClass": "btn",
-            "bsStyle": "default",
-            "children": <Icon
-              name="refresh"
-              type="fa"
-            />,
-            "disabled": false,
-            "onClick": [MockFunction],
+            "handleRefresh": [MockFunction],
+            "id": "metrics-refresh",
+            "onSelect": [Function],
+            "pollInterval": 15000,
           },
           "ref": null,
-          "rendered": Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "function",
-            "props": Object {
-              "name": "refresh",
-              "type": "fa",
-            },
-            "ref": null,
-            "rendered": null,
-            "type": [Function],
-          },
+          "rendered": null,
           "type": [Function],
         },
         "type": [Function],
       },
-      false,
     ],
     "type": [Function],
   },
@@ -351,29 +266,28 @@ ShallowWrapper {
       "nodeType": "class",
       "props": Object {
         "children": Array [
-          <getContext(Filter)>
-            <FilterValueSelector
-              className=""
-              currentValue=""
-              filterValues={
+          <FormGroup
+            bsClass="form-group"
+          >
+            <MetricsSettingsDropdown
+              groupingLabels={Array []}
+              onChanged={[Function]}
+              showAverage={true}
+              showQuantiles={
                 Array [
-                  "Local version",
-                  "Remote app",
-                  "Remote version",
-                  "Response code",
+                  "0.5",
+                  "0.95",
+                  "0.99",
                 ]
               }
-              id=""
-              onFilterValueSelected={[Function]}
-              placeholder="Group by"
             />
-          </getContext(Filter)>,
+          </FormGroup>,
           <FormGroup
             bsClass="form-group"
           >
             <ToolbarDropdown
               disabled={false}
-              handleSelect={[MockFunction]}
+              handleSelect={[Function]}
               id="metrics_filter_reporter"
               initialLabel="Destination"
               nameDropdown="Reported from"
@@ -392,7 +306,7 @@ ShallowWrapper {
             id="metrics_filter_interval_duration"
             initialLabel="Last min"
             initialValue={60}
-            nameDropdown="Duration"
+            nameDropdown="Displaying"
             options={
               Object {
                 "10800": "Last 3 hours",
@@ -409,43 +323,16 @@ ShallowWrapper {
               }
             }
           />,
-          <ToolbarDropdown
-            disabled={false}
-            handleSelect={[Function]}
-            id="metrics_filter_poll_interval"
-            initialLabel="15 sec"
-            initialValue={15000}
-            nameDropdown="Poll Interval"
-            options={
-              Object {
-                "0": "Pause",
-                "10000": "10 sec",
-                "15000": "15 sec",
-                "30000": "30 sec",
-                "300000": "5 min",
-                "5000": "5 sec",
-                "60000": "1 min",
-              }
-            }
-          />,
           <ToolbarRightContent
             className=""
           >
-            <Button
-              active={false}
-              block={false}
-              bsClass="btn"
-              bsStyle="default"
-              disabled={false}
-              onClick={[MockFunction]}
-            >
-              <Icon
-                name="refresh"
-                type="fa"
-              />
-            </Button>
+            <Refresh
+              handleRefresh={[MockFunction]}
+              id="metrics-refresh"
+              onSelect={[Function]}
+              pollInterval={15000}
+            />
           </ToolbarRightContent>,
-          false,
         ],
       },
       "ref": null,
@@ -453,41 +340,36 @@ ShallowWrapper {
         Object {
           "instance": null,
           "key": undefined,
-          "nodeType": "function",
+          "nodeType": "class",
           "props": Object {
-            "children": <FilterValueSelector
-              className=""
-              currentValue=""
-              filterValues={
+            "bsClass": "form-group",
+            "children": <MetricsSettingsDropdown
+              groupingLabels={Array []}
+              onChanged={[Function]}
+              showAverage={true}
+              showQuantiles={
                 Array [
-                  "Local version",
-                  "Remote app",
-                  "Remote version",
-                  "Response code",
+                  "0.5",
+                  "0.95",
+                  "0.99",
                 ]
               }
-              id=""
-              onFilterValueSelected={[Function]}
-              placeholder="Group by"
             />,
           },
           "ref": null,
           "rendered": Object {
             "instance": null,
             "key": undefined,
-            "nodeType": "function",
+            "nodeType": "class",
             "props": Object {
-              "className": "",
-              "currentValue": "",
-              "filterValues": Array [
-                "Local version",
-                "Remote app",
-                "Remote version",
-                "Response code",
+              "groupingLabels": Array [],
+              "onChanged": [Function],
+              "showAverage": true,
+              "showQuantiles": Array [
+                "0.5",
+                "0.95",
+                "0.99",
               ],
-              "id": "",
-              "onFilterValueSelected": [Function],
-              "placeholder": "Group by",
             },
             "ref": null,
             "rendered": null,
@@ -503,7 +385,7 @@ ShallowWrapper {
             "bsClass": "form-group",
             "children": <ToolbarDropdown
               disabled={false}
-              handleSelect={[MockFunction]}
+              handleSelect={[Function]}
               id="metrics_filter_reporter"
               initialLabel="Destination"
               nameDropdown="Reported from"
@@ -523,7 +405,7 @@ ShallowWrapper {
             "nodeType": "class",
             "props": Object {
               "disabled": false,
-              "handleSelect": [MockFunction],
+              "handleSelect": [Function],
               "id": "metrics_filter_reporter",
               "initialLabel": "Destination",
               "nameDropdown": "Reported from",
@@ -549,7 +431,7 @@ ShallowWrapper {
             "id": "metrics_filter_interval_duration",
             "initialLabel": "Last min",
             "initialValue": 60,
-            "nameDropdown": "Duration",
+            "nameDropdown": "Displaying",
             "options": Object {
               "10800": "Last 3 hours",
               "1800": "Last 30 min",
@@ -571,46 +453,14 @@ ShallowWrapper {
         Object {
           "instance": null,
           "key": undefined,
-          "nodeType": "class",
-          "props": Object {
-            "disabled": false,
-            "handleSelect": [Function],
-            "id": "metrics_filter_poll_interval",
-            "initialLabel": "15 sec",
-            "initialValue": 15000,
-            "nameDropdown": "Poll Interval",
-            "options": Object {
-              "0": "Pause",
-              "10000": "10 sec",
-              "15000": "15 sec",
-              "30000": "30 sec",
-              "300000": "5 min",
-              "5000": "5 sec",
-              "60000": "1 min",
-            },
-          },
-          "ref": null,
-          "rendered": null,
-          "type": [Function],
-        },
-        Object {
-          "instance": null,
-          "key": undefined,
           "nodeType": "function",
           "props": Object {
-            "children": <Button
-              active={false}
-              block={false}
-              bsClass="btn"
-              bsStyle="default"
-              disabled={false}
-              onClick={[MockFunction]}
-            >
-              <Icon
-                name="refresh"
-                type="fa"
-              />
-            </Button>,
+            "children": <Refresh
+              handleRefresh={[MockFunction]}
+              id="metrics-refresh"
+              onSelect={[Function]}
+              pollInterval={15000}
+            />,
             "className": "",
           },
           "ref": null,
@@ -619,35 +469,17 @@ ShallowWrapper {
             "key": undefined,
             "nodeType": "class",
             "props": Object {
-              "active": false,
-              "block": false,
-              "bsClass": "btn",
-              "bsStyle": "default",
-              "children": <Icon
-                name="refresh"
-                type="fa"
-              />,
-              "disabled": false,
-              "onClick": [MockFunction],
+              "handleRefresh": [MockFunction],
+              "id": "metrics-refresh",
+              "onSelect": [Function],
+              "pollInterval": 15000,
             },
             "ref": null,
-            "rendered": Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "function",
-              "props": Object {
-                "name": "refresh",
-                "type": "fa",
-              },
-              "ref": null,
-              "rendered": null,
-              "type": [Function],
-            },
+            "rendered": null,
             "type": [Function],
           },
           "type": [Function],
         },
-        false,
       ],
       "type": [Function],
     },

--- a/src/pages/AppDetails/AppDetailsPage.tsx
+++ b/src/pages/AppDetails/AppDetailsPage.tsx
@@ -9,6 +9,7 @@ import * as MessageCenter from '../../utils/MessageCenter';
 import AppMetricsContainer from '../../containers/AppMetricsContainer';
 import { AppHealth } from '../../types/Health';
 import { ListPageLink, TargetPage } from '../../components/ListPage/ListPageLink';
+import { MetricsObjectTypes, MetricsDirection } from '../../types/Metrics';
 
 type AppDetailsState = {
   app: App;
@@ -125,16 +126,16 @@ class AppDetails extends React.Component<RouteComponentProps<AppId>, AppDetailsS
                 <AppMetricsContainer
                   namespace={this.props.match.params.namespace}
                   object={this.props.match.params.app}
-                  objectType={'app'}
-                  metricsType={'inbound'}
+                  objectType={MetricsObjectTypes.APP}
+                  direction={MetricsDirection.INBOUND}
                 />
               </TabPane>
               <TabPane eventKey="out_metrics" mountOnEnter={true} unmountOnExit={true}>
                 <AppMetricsContainer
                   namespace={this.props.match.params.namespace}
                   object={this.props.match.params.app}
-                  objectType={'app'}
-                  metricsType={'outbound'}
+                  objectType={MetricsObjectTypes.APP}
+                  direction={MetricsDirection.OUTBOUND}
                 />
               </TabPane>
             </TabContent>

--- a/src/pages/Graph/SummaryPanelCommon.tsx
+++ b/src/pages/Graph/SummaryPanelCommon.tsx
@@ -134,6 +134,7 @@ export const getNodeMetrics = (
   node: any,
   props: SummaryPanelPropType,
   filters: Array<string>,
+  quantiles?: Array<string>,
   byLabelsIn?: Array<string>,
   byLabelsOut?: Array<string>
 ): Promise<Response<M.Metrics>> => {
@@ -144,6 +145,7 @@ export const getNodeMetrics = (
     step: props.step,
     rateInterval: props.rateInterval,
     filters: filters,
+    quantiles: quantiles,
     byLabelsIn: byLabelsIn,
     byLabelsOut: byLabelsOut
   };

--- a/src/pages/Graph/SummaryPanelEdge.tsx
+++ b/src/pages/Graph/SummaryPanelEdge.tsx
@@ -194,9 +194,10 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
     }
 
     const filters = ['request_count', 'request_duration', 'request_error_count', 'tcp_sent', 'tcp_received'];
+    const quantiles = ['0.5', '0.95', '0.99'];
     const byLabelsIn = this.getByLabelsIn(sourceMetricType, destMetricType);
 
-    const promise = getNodeMetrics(destMetricType, edge.target(), props, filters, byLabelsIn);
+    const promise = getNodeMetrics(destMetricType, edge.target(), props, filters, quantiles, byLabelsIn);
     this.metricsPromise = makeCancelablePromise(promise);
 
     this.metricsPromise.promise
@@ -221,28 +222,28 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
           sourceData
         );
         const rtAvg = this.getNodeDataPoints(
-          histograms['request_duration_in']['average'],
+          histograms['request_duration_in']['avg'],
           'Average',
           sourceMetricType,
           destMetricType,
           sourceData
         );
         const rtMed = this.getNodeDataPoints(
-          histograms['request_duration_in']['median'],
+          histograms['request_duration_in']['0.5'],
           'Median',
           sourceMetricType,
           destMetricType,
           sourceData
         );
         const rt95 = this.getNodeDataPoints(
-          histograms['request_duration_in']['percentile95'],
+          histograms['request_duration_in']['0.95'],
           '95th',
           sourceMetricType,
           destMetricType,
           sourceData
         );
         const rt99 = this.getNodeDataPoints(
-          histograms['request_duration_in']['percentile99'],
+          histograms['request_duration_in']['0.99'],
           '99th',
           sourceMetricType,
           destMetricType,

--- a/src/pages/Graph/SummaryPanelNode.tsx
+++ b/src/pages/Graph/SummaryPanelNode.tsx
@@ -115,7 +115,7 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
         : undefined;
     let byLabelsOut = data.isRoot ? ['destination_service_namespace'] : undefined;
 
-    const promise = getNodeMetrics(nodeMetricType, target, props, filters, byLabelsIn, byLabelsOut);
+    const promise = getNodeMetrics(nodeMetricType, target, props, filters, undefined, byLabelsIn, byLabelsOut);
     this.metricsPromise = makeCancelablePromise(promise);
     this.metricsPromise.promise
       .then(response => {

--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -11,6 +11,7 @@ import IstioObjectDetails from './IstioObjectDetails';
 import ServiceMetricsContainer from '../../containers/ServiceMetricsContainer';
 import ServiceInfo from './ServiceInfo';
 import { TargetPage, ListPageLink } from '../../components/ListPage/ListPageLink';
+import { MetricsObjectTypes, MetricsDirection } from '../../types/Metrics';
 
 type ServiceDetailsState = {
   serviceDetailsInfo: ServiceDetailsInfo;
@@ -254,8 +255,8 @@ class ServiceDetails extends React.Component<RouteComponentProps<ServiceId>, Ser
                   <ServiceMetricsContainer
                     namespace={this.props.match.params.namespace}
                     object={this.props.match.params.service}
-                    objectType={'service'}
-                    metricsType={'inbound'}
+                    objectType={MetricsObjectTypes.SERVICE}
+                    direction={MetricsDirection.INBOUND}
                   />
                 </TabPane>
               </TabContent>

--- a/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -10,6 +10,7 @@ import * as MessageCenter from '../../utils/MessageCenter';
 import WorkloadMetricsContainer from '../../containers/WorkloadMetricsContainer';
 import { WorkloadHealth } from '../../types/Health';
 import { ListPageLink, TargetPage } from '../../components/ListPage/ListPageLink';
+import { MetricsObjectTypes, MetricsDirection } from '../../types/Metrics';
 
 type WorkloadDetailsState = {
   workload: Deployment;
@@ -169,16 +170,16 @@ class WorkloadDetails extends React.Component<RouteComponentProps<WorkloadId>, W
                 <WorkloadMetricsContainer
                   namespace={this.props.match.params.namespace}
                   object={this.props.match.params.workload}
-                  objectType={'workload'}
-                  metricsType={'inbound'}
+                  objectType={MetricsObjectTypes.WORKLOAD}
+                  direction={MetricsDirection.INBOUND}
                 />
               </TabPane>
               <TabPane eventKey="out_metrics" mountOnEnter={true} unmountOnExit={true}>
                 <WorkloadMetricsContainer
                   namespace={this.props.match.params.namespace}
                   object={this.props.match.params.workload}
-                  objectType={'workload'}
-                  metricsType={'outbound'}
+                  objectType={MetricsObjectTypes.WORKLOAD}
+                  direction={MetricsDirection.OUTBOUND}
                 />
               </TabPane>
             </TabContent>

--- a/src/types/Metrics.ts
+++ b/src/types/Metrics.ts
@@ -8,12 +8,7 @@ export interface ReporterMetrics {
   histograms: { [key: string]: Histogram };
 }
 
-export interface Histogram {
-  average: MetricGroup;
-  median: MetricGroup;
-  percentile95: MetricGroup;
-  percentile99: MetricGroup;
-}
+export type Histogram = { [key: string]: MetricGroup };
 
 export interface MetricGroup {
   matrix: TimeSeries[];

--- a/src/types/Metrics.ts
+++ b/src/types/Metrics.ts
@@ -26,3 +26,14 @@ export interface TimeSeries {
 
 // First is timestamp, second is value
 export type Datapoint = [number, number];
+
+export enum MetricsDirection {
+  INBOUND,
+  OUTBOUND
+}
+
+export enum MetricsObjectTypes {
+  SERVICE,
+  WORKLOAD,
+  APP
+}

--- a/src/types/MetricsOptions.ts
+++ b/src/types/MetricsOptions.ts
@@ -6,6 +6,8 @@ interface MetricsOptions {
   step?: number;
   version?: string;
   filters?: string[];
+  quantiles?: string[];
+  avg?: boolean;
   byLabelsIn?: string[];
   byLabelsOut?: string[];
 }

--- a/src/utils/Graphing.ts
+++ b/src/utils/Graphing.ts
@@ -1,6 +1,22 @@
-import { TimeSeries } from '../types/Metrics';
+import { TimeSeries, Histogram } from '../types/Metrics';
 
 export default {
+  histogramToC3Columns(histogram: Histogram) {
+    const stats = Object.keys(histogram);
+    if (stats.length === 0 || histogram[stats[0]].matrix.length === 0) {
+      return [['x'], ['']];
+    }
+
+    let series = [(['x'] as any[]).concat(histogram[stats[0]].matrix[0].values.map(dp => dp[0] * 1000))];
+    stats.forEach(stat => {
+      const statSeries = histogram[stat].matrix.map(mat => {
+        return [mat.name as any].concat(mat.values.map(dp => dp[1]));
+      });
+      series = series.concat(statSeries);
+    });
+    return series;
+  },
+
   toC3Columns(matrix?: TimeSeries[], title?: string) {
     if (!matrix || matrix.length === 0) {
       return [['x'], [title || '']];
@@ -19,12 +35,5 @@ export default {
 
     // timestamps + data is the format required by C3 (all concatenated: an array with arrays)
     return [xseries, ...yseries];
-  },
-
-  toC3ValueColumns(matrix: TimeSeries[], title?: string) {
-    return matrix.map(mat => {
-      let yseries: any = [title || mat.name];
-      return yseries.concat(mat.values.map(dp => dp[1]));
-    });
   }
 };


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/KIALI-936
Needs backend PR https://github.com/kiali/kiali/pull/514 in order to work.

- Consume new REST api for quantiles
- Add new url params for metrics options (and centralize declaration of URL parameters)
- Use enums for metrics object types and in/out direction
- Use the new Refresh component in Metrics, delegating management of polling job
- C3 Charts: need to tell explicitely which series to unload
- Add quantile 0.999 (hence rename percentile => quantile)

Screenshot:
![screenshot](https://screenshotscdn.firefoxusercontent.com/images/a08cf43d-c515-441d-8000-77b594822289.png)