### PR TITLE
KIALI-1493 add appender query param

### DIFF
--- a/src/components/GraphFilter/GraphFilterToolbar.tsx
+++ b/src/components/GraphFilter/GraphFilterToolbar.tsx
@@ -9,6 +9,7 @@ import { store } from '../../store/ConfigStore';
 import { makeNamespaceGraphUrlFromParams, makeNodeGraphUrlFromParams } from '../Nav/NavUtils';
 import GraphFilter from './GraphFilter';
 import { GraphActions } from '../../actions/GraphActions';
+import { GraphDataActions } from '../../actions/GraphDataActions';
 
 export default class GraphFilterToolbar extends React.PureComponent<GraphFilterToolbarType> {
   static contextTypes = {
@@ -71,6 +72,21 @@ export default class GraphFilterToolbar extends React.PureComponent<GraphFilterT
       ...this.getGraphParams(),
       edgeLabelMode
     });
+
+    if (edgeLabelMode === EdgeLabelMode.RESPONSE_TIME_95TH_PERCENTILE || edgeLabelMode === EdgeLabelMode.MTLS_ENABLED) {
+      // Server-side appenders for security and response time are not run by default unless those edge labels are specifically requested.
+      // So when switching to these edge labels, we have to ensure we make a server-side request in order to ensure those appenders are run.
+      store.dispatch(
+        GraphDataActions.fetchGraphData(
+          this.props.namespace,
+          this.props.graphDuration,
+          this.props.graphType,
+          this.props.injectServiceNodes,
+          edgeLabelMode,
+          this.props.node
+        )
+      );
+    }
   };
 
   handleFilterChange = (params: GraphParamsType) => {

--- a/src/components/GraphFilter/__tests__/GraphFilterToolbar.test.tsx
+++ b/src/components/GraphFilter/__tests__/GraphFilterToolbar.test.tsx
@@ -12,7 +12,6 @@ const PARAMS: GraphParamsType = {
   graphDuration: { value: 60 },
   graphLayout: { name: 'Cose' },
   edgeLabelMode: EdgeLabelMode.HIDE,
-  // TODO: GraphType not yet added into the UI
   graphType: GraphType.VERSIONED_APP,
   injectServiceNodes: false
 };

--- a/src/components/Nav/NavUtils.tsx
+++ b/src/components/Nav/NavUtils.tsx
@@ -1,34 +1,32 @@
 import { GraphParamsType, NodeParamsType, NodeType } from '../../types/Graph';
 
+const buildCommonQueryParams = (params: GraphParamsType): string => {
+  let q = `layout=${params.graphLayout.name}`;
+  q += `&duration=${params.graphDuration.value}`;
+  q += `&edges=${params.edgeLabelMode}`;
+  q += `&graphType=${params.graphType}`;
+  q += `&injectServiceNodes=${params.injectServiceNodes}`;
+  return q;
+};
+
 export const makeNamespaceGraphUrlFromParams = (params: GraphParamsType) => {
-  return `/graph/namespaces/${params.namespace.name}?layout=${params.graphLayout.name}&duration=${
-    params.graphDuration.value
-  }&edges=${params.edgeLabelMode}&graphType=${params.graphType}&injectServiceNodes=${params.injectServiceNodes}`;
+  return `/graph/namespaces/${params.namespace.name}?` + buildCommonQueryParams(params);
 };
 
 export const makeNodeGraphUrlFromParams = (node: NodeParamsType, params: GraphParamsType) => {
   switch (node.nodeType) {
     case NodeType.APP:
       if (node.version && node.version !== 'unknown') {
-        return `/graph/namespaces/${params.namespace.name}/applications/${node.app}/versions/${node.version}?layout=${
-          params.graphLayout.name
-        }&duration=${params.graphDuration.value}&edges=${params.edgeLabelMode}&graphType=${
-          params.graphType
-        }&injectServiceNodes=${params.injectServiceNodes}`;
+        return (
+          `/graph/namespaces/${params.namespace.name}/applications/${node.app}/versions/${node.version}?` +
+          buildCommonQueryParams(params)
+        );
       }
-      return `/graph/namespaces/${params.namespace.name}/applications/${node.app}?layout=${
-        params.graphLayout.name
-      }&duration=${params.graphDuration.value}&edges=${params.edgeLabelMode}&graphType=${
-        params.graphType
-      }&injectServiceNodes=${params.injectServiceNodes}`;
+      return `/graph/namespaces/${params.namespace.name}/applications/${node.app}?` + buildCommonQueryParams(params);
     case NodeType.WORKLOAD:
-      return `/graph/namespaces/${params.namespace.name}/workloads/${node.workload}?layout=${
-        params.graphLayout.name
-      }&duration=${params.graphDuration.value}&edges=${params.edgeLabelMode}&graphType=${
-        params.graphType
-      }&injectServiceNodes=${params.injectServiceNodes}`;
+      return `/graph/namespaces/${params.namespace.name}/workloads/${node.workload}?` + buildCommonQueryParams(params);
     default:
-      console.log('makeNodeUrl defaulting to makeNamespaceUrl');
+      console.debug('makeNodeUrl defaulting to makeNamespaceUrl');
       return makeNamespaceGraphUrlFromParams(params);
   }
 };

--- a/src/containers/GraphPageContainer.ts
+++ b/src/containers/GraphPageContainer.ts
@@ -1,7 +1,7 @@
 import { KialiAppState } from '../store/Store';
 import { connect } from 'react-redux';
 import Namespace from '../types/Namespace';
-import { Duration } from '../types/GraphFilter';
+import { Duration, EdgeLabelMode } from '../types/GraphFilter';
 import GraphPage from '../pages/Graph/GraphPage';
 
 import { GraphDataActions } from '../actions/GraphDataActions';
@@ -31,8 +31,12 @@ const mapDispatchToProps = (dispatch: any) => ({
     graphDuration: Duration,
     graphType: GraphType,
     injectServiceNodes: boolean,
+    edgeLabelMode: EdgeLabelMode,
     node?: NodeParamsType
-  ) => dispatch(GraphDataActions.fetchGraphData(namespace, graphDuration, graphType, injectServiceNodes, node)),
+  ) =>
+    dispatch(
+      GraphDataActions.fetchGraphData(namespace, graphDuration, graphType, injectServiceNodes, edgeLabelMode, node)
+    ),
   toggleLegend: bindActionCreators(GraphFilterActions.toggleLegend, dispatch)
 });
 

--- a/src/pages/Graph/GraphPage.tsx
+++ b/src/pages/Graph/GraphPage.tsx
@@ -6,7 +6,7 @@ import { Breadcrumb } from 'patternfly-react';
 import { PollIntervalInMs } from '../../types/Common';
 import Namespace from '../../types/Namespace';
 import { GraphParamsType, SummaryData, NodeParamsType, GraphType } from '../../types/Graph';
-import { Duration, Layout } from '../../types/GraphFilter';
+import { Duration, Layout, EdgeLabelMode } from '../../types/GraphFilter';
 
 import SummaryPanel from './SummaryPanel';
 import CytoscapeGraph from '../../components/CytoscapeGraph/CytoscapeGraph';
@@ -34,6 +34,7 @@ type GraphPageProps = GraphParamsType & {
     graphDuration: Duration,
     graphType: GraphType,
     injectServiceNodes: boolean,
+    edgeLabelMode: EdgeLabelMode,
     node?: NodeParamsType
   ) => any;
   toggleLegend: () => void;
@@ -228,6 +229,7 @@ export default class GraphPage extends React.PureComponent<GraphPageProps> {
       this.props.graphDuration,
       this.props.graphType,
       this.props.injectServiceNodes,
+      this.props.edgeLabelMode,
       this.props.node
     );
     this.pollPromise = makeCancelablePromise(promise);


### PR DESCRIPTION
** Describe the change **

There are a set of "appenders" that the server-side runs in order to append the graph JSON with additional data. Before, all of those appenders were always run. However, some appenders use alot of resources so we should only run appenders when needed. Specifically, the response time appender is compute-intensive.

This PR ensures we only run the appenders when necessary. It seems most of the appenders are needed all the time - however, the security and response_time appenders are only needed if/when the user selects the edge labels that need that data (i.e. the security and response time edge labels).

** Backwards compatible? **

Yes.
