### PR TITLE
KIALI-1473 Highlight top of first selected item in nav bar

### DIFF
--- a/src/app/App.scss
+++ b/src/app/App.scss
@@ -107,6 +107,10 @@ a:focus {
 .nav-pf-vertical .list-group-item {
   border-color: #18546b;
 }
-.nav-pf-vertical {
+.nav-pf-vertical .list-group .list-group-item:first-child {
   border-top: 2px solid #18546b;
 }
+.nav-pf-vertical .list-group .list-group-item.active:first-child {
+  border-top: 2px solid #438fdd;
+}
+


### PR DESCRIPTION
** Describe the change **

We were not highlighting the top of the first element in the vertical nav bar:

![screenshot from 2018-09-24 16-34-14](https://user-images.githubusercontent.com/691166/45977874-cd3ee780-c018-11e8-9a0a-dd54f5118b80.png)

While any other selected element did have it top highlighted:

![screenshot from 2018-09-24 16-34-20](https://user-images.githubusercontent.com/691166/45977919-ea73b600-c018-11e8-80ca-0b7a2d224ce1.png)

This change will now highlight the top of the first element in the vertical nav bar if its selected:

![screenshot from 2018-09-24 16-34-25](https://user-images.githubusercontent.com/691166/45977967-037c6700-c019-11e8-8f09-c6aa09ce7cbc.png)

Note: the top of the first selected item is a bit thicker, this is due to have the current top border is when things are not selected (see the second screenshot).

See https://issues.jboss.org/browse/KIALI-1473