### PR TITLE
KIALI-1618 Overview: sort namespaces after refresh

### DIFF
--- a/src/components/ListPage/ListPage.ts
+++ b/src/components/ListPage/ListPage.ts
@@ -25,6 +25,7 @@ export namespace ListPage {
     setFiltersToURL: (filterTypes: FilterType[], filters: ActiveFilter[]) => ActiveFilter[];
     filtersMatchURL: (filterTypes: FilterType[], filters: ActiveFilter[]) => boolean;
     isCurrentSortAscending: () => boolean;
+    currentSortFieldId: () => string | undefined;
     currentDuration: () => number;
     currentPollInterval: () => number;
   }
@@ -168,6 +169,10 @@ export namespace ListPage {
 
     isCurrentSortAscending(): boolean {
       return (this.getSingleQueryParam('direction') || 'asc') === 'asc';
+    }
+
+    currentSortFieldId(): string | undefined {
+      return this.getSingleQueryParam('sort');
     }
 
     currentDuration() {

--- a/src/pages/Overview/FiltersAndSorts.ts
+++ b/src/pages/Overview/FiltersAndSorts.ts
@@ -60,11 +60,11 @@ export namespace FiltersAndSorts {
       isNumeric: false,
       param: 'h',
       compare: (a: NamespaceInfo, b: NamespaceInfo) => {
-        let diff = a.appsInError.length - b.appsInError.length;
+        let diff = b.appsInError.length - a.appsInError.length;
         if (diff !== 0) {
           return diff;
         }
-        diff = a.appsInWarning.length - b.appsInWarning.length;
+        diff = b.appsInWarning.length - a.appsInWarning.length;
         if (diff !== 0) {
           return diff;
         }
@@ -73,4 +73,12 @@ export namespace FiltersAndSorts {
       }
     }
   ];
+
+  export const sortFunc = (
+    allNamespaces: NamespaceInfo[],
+    sortField: FiltersAndSorts.SortField,
+    isAscending: boolean
+  ) => {
+    return allNamespaces.sort(isAscending ? sortField.compare : (a, b) => sortField.compare(b, a));
+  };
 }

--- a/src/pages/Overview/OverviewToolbar.tsx
+++ b/src/pages/Overview/OverviewToolbar.tsx
@@ -26,10 +26,18 @@ type State = {
 const DURATIONS = config().toolbar.intervalDuration;
 
 class OverviewToolbar extends React.Component<Props, State> {
+  static findSortField(id?: string): FiltersAndSorts.SortField {
+    if (id) {
+      const field = FiltersAndSorts.sortFields.find(sortField => sortField.param === id);
+      return field || FiltersAndSorts.sortFields[0];
+    }
+    return FiltersAndSorts.sortFields[0];
+  }
+
   constructor(props: Props) {
     super(props);
     this.state = {
-      sortField: this.currentSortField(),
+      sortField: OverviewToolbar.findSortField(this.props.pageHooks.currentSortFieldId()),
       isSortAscending: this.props.pageHooks.isCurrentSortAscending(),
       duration: this.props.pageHooks.currentDuration(),
       pollInterval: this.props.pageHooks.currentPollInterval()
@@ -37,7 +45,7 @@ class OverviewToolbar extends React.Component<Props, State> {
   }
 
   componentDidUpdate() {
-    const urlSortField = this.currentSortField();
+    const urlSortField = OverviewToolbar.findSortField(this.props.pageHooks.currentSortFieldId());
     const urlIsSortAscending = this.props.pageHooks.isCurrentSortAscending();
     const urlDuration = this.props.pageHooks.currentDuration();
     const urlPollInterval = this.props.pageHooks.currentPollInterval();
@@ -66,20 +74,10 @@ class OverviewToolbar extends React.Component<Props, State> {
     );
   }
 
-  currentSortField(): FiltersAndSorts.SortField {
-    const fromURL = this.props.pageHooks.getSingleQueryParam('sort');
-    if (fromURL) {
-      const field = FiltersAndSorts.sortFields.find(sortField => sortField.param === fromURL);
-      return field || FiltersAndSorts.sortFields[0];
-    }
-    return FiltersAndSorts.sortFields[0];
-  }
-
   updateSortField = (sortField: FiltersAndSorts.SortField) => {
     this.props.sort(sortField, this.state.isSortAscending);
-    this.setState({ sortField: sortField }, () => {
-      this.props.pageHooks.onParamChange([{ name: 'sort', value: sortField.param }]);
-    });
+    this.props.pageHooks.onParamChange([{ name: 'sort', value: sortField.param }]);
+    this.setState({ sortField: sortField });
   };
 
   updateSortDirection = () => {


### PR DESCRIPTION
Also:
- avoid refresh after changing sort field, it's not needed
- reverse sort order for status: by default, failures first

JIRA: https://issues.jboss.org/browse/KIALI-1618