### PR TITLE
KIALI-1534 Introduce Service Graph

### DIFF
--- a/src/components/SummaryPanel/ResponseTimeChart.tsx
+++ b/src/components/SummaryPanel/ResponseTimeChart.tsx
@@ -8,6 +8,7 @@ type ResponseTimeChartTypeProp = {
   rtMed: [string, number][];
   rt95: [string, number][];
   rt99: [string, number][];
+  hide?: boolean;
 };
 
 export default class ResponseTimeChart extends React.Component<ResponseTimeChartTypeProp, {}> {
@@ -42,17 +43,21 @@ export default class ResponseTimeChart extends React.Component<ResponseTimeChart
 
     return (
       <>
-        <div>
-          <strong>{this.props.label}:</strong>
-        </div>
-        <AreaChart
-          size={{ height: 80 }}
-          color={{ pattern: [PfColors.Black, PfColors.Green400, PfColors.Blue, PfColors.Orange400] }}
-          legend={{ show: true }}
-          grid={{ y: { show: false } }}
-          axis={axis}
-          data={chartData}
-        />
+        {!this.props.hide && (
+          <div>
+            <div>
+              <strong>{this.props.label}:</strong>
+            </div>
+            <AreaChart
+              size={{ height: 80 }}
+              color={{ pattern: [PfColors.Black, PfColors.Green400, PfColors.Blue, PfColors.Orange400] }}
+              legend={{ show: true }}
+              grid={{ y: { show: false } }}
+              axis={axis}
+              data={chartData}
+            />
+          </div>
+        )}
       </>
     );
   }

--- a/src/components/SummaryPanel/RpsChart.tsx
+++ b/src/components/SummaryPanel/RpsChart.tsx
@@ -7,12 +7,14 @@ type RpsChartTypeProp = {
   label: string;
   dataRps: [string, number][];
   dataErrors: [string, number][];
+  hide?: boolean;
 };
 
 type TcpChartTypeProp = {
   label: string;
   sentRates: [string, number][];
   receivedRates: [string, number][];
+  hide?: boolean;
 };
 
 type BytesAbbreviation = {
@@ -94,13 +96,17 @@ export class RpsChart extends React.Component<RpsChartTypeProp, {}> {
 
   render() {
     return (
-      <div className={blockStyle}>
-        <div>
-          <strong>{this.props.label} min / max:</strong>
-        </div>
-        {thereIsTrafficData(this.props.dataRps) ? this.renderMinMaxStats() : renderNoTrafficLegend()}
-        {this.renderSparkline()}
-      </div>
+      <>
+        {!this.props.hide && (
+          <div className={blockStyle}>
+            <div>
+              <strong>{this.props.label} min / max:</strong>
+            </div>
+            {thereIsTrafficData(this.props.dataRps) ? this.renderMinMaxStats() : renderNoTrafficLegend()}
+            {this.renderSparkline()}
+          </div>
+        )}
+      </>
     );
   }
 
@@ -155,13 +161,17 @@ export class RpsChart extends React.Component<RpsChartTypeProp, {}> {
 export class TcpChart extends React.Component<TcpChartTypeProp, {}> {
   render() {
     return (
-      <div className={blockStyle}>
-        <div>
-          <strong>{this.props.label} - min / max:</strong>
-        </div>
-        {this.thereIsTrafficData() ? this.renderMinMaxStats() : renderNoTrafficLegend()}
-        {this.renderSparkline()}
-      </div>
+      <>
+        {!this.props.hide && (
+          <div className={blockStyle}>
+            <div>
+              <strong>{this.props.label} - min / max:</strong>
+            </div>
+            {this.thereIsTrafficData() ? this.renderMinMaxStats() : renderNoTrafficLegend()}
+            {this.renderSparkline()}
+          </div>
+        )}
+      </>
     );
   }
 

--- a/src/pages/Graph/SummaryPanelCommon.tsx
+++ b/src/pages/Graph/SummaryPanelCommon.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import * as React from 'react';
+import { Icon } from 'patternfly-react';
 import { NodeType, SummaryPanelPropType } from '../../types/Graph';
 import { Health, healthNotAvailable } from '../../types/Health';
 import MetricsOptions from '../../types/MetricsOptions';
@@ -217,6 +218,16 @@ export const renderPanelTitle = node => {
   return (
     <>
       {nodeTypeToString(nodeType)}: {displaySpan}
+    </>
+  );
+};
+
+export const renderNoTraffic = (protocol?: string) => {
+  return (
+    <>
+      <div>
+        <Icon type="pf" name="info" /> No {protocol ? protocol : ''} traffic logged.
+      </div>
     </>
   );
 };

--- a/src/pages/Graph/SummaryPanelEdge.tsx
+++ b/src/pages/Graph/SummaryPanelEdge.tsx
@@ -1,16 +1,16 @@
 import * as React from 'react';
 import { Icon } from 'patternfly-react';
-
 import RateTable from '../../components/SummaryPanel/RateTable';
 import { RpsChart, TcpChart } from '../../components/SummaryPanel/RpsChart';
 import ResponseTimeChart from '../../components/SummaryPanel/ResponseTimeChart';
-import { NodeType, SummaryPanelPropType } from '../../types/Graph';
+import { GraphType, NodeType, SummaryPanelPropType } from '../../types/Graph';
 import {
   shouldRefreshData,
   nodeData,
   getDatapoints,
   getNodeMetrics,
   getNodeMetricType,
+  renderNoTraffic,
   renderPanelTitle,
   NodeData,
   NodeMetricType
@@ -106,7 +106,7 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
         <HeadingBlock prefix="Source" node={source} />
         <HeadingBlock prefix="Destination" node={dest} />
         <div className="panel-body">
-          {this.hasHttpMetrics(edge) && (
+          {this.hasHttpMetrics(edge) ? (
             <>
               <RateTable
                 title="HTTP Traffic (requests per second):"
@@ -117,6 +117,8 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
               />
               <hr />
             </>
+          ) : (
+            !this.hasTcpMetrics(edge) && renderNoTraffic()
           )}
           {this.renderCharts(edge)}
         </div>
@@ -127,23 +129,21 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
   private getByLabelsIn = (sourceMetricType: NodeMetricType, destMetricType: NodeMetricType) => {
     let sourceLabel: string;
     switch (sourceMetricType) {
-      case NodeMetricType.WORKLOAD:
-        sourceLabel = 'source_workload';
-        break;
       case NodeMetricType.APP:
         sourceLabel = 'source_app';
         break;
       case NodeMetricType.SERVICE:
-      default:
         sourceLabel = 'destination_service_name';
         break;
+      case NodeMetricType.WORKLOAD:
+      // fall through, workload is default
+      default:
+        sourceLabel = 'source_workload';
+        break;
     }
-    // when not injecting service nodes the only service nodes are those representing client failures. For
-    // those we want to narrow the data to only TS with 'unknown' workloads (see the related comparator in getNodeDatapoints).
-    if (destMetricType === NodeMetricType.SERVICE && !this.props.injectServiceNodes) {
-      return [sourceLabel, 'destination_workload'];
-    }
-    return [sourceLabel];
+    // For special service dest nodes we want to narrow the data to only TS with 'unknown' workloads (see the related
+    // comparator in getNodeDatapoints).
+    return this.isSpecialServiceDest(destMetricType) ? [sourceLabel, 'destination_workload'] : [sourceLabel];
   };
 
   private getNodeDataPoints = (
@@ -156,21 +156,22 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
     let sourceLabel: string;
     let sourceValue: string;
     switch (sourceMetricType) {
-      case NodeMetricType.WORKLOAD:
-        sourceLabel = 'source_workload';
-        sourceValue = data.workload;
-        break;
       case NodeMetricType.APP:
         sourceLabel = 'source_app';
         sourceValue = data.app;
         break;
       case NodeMetricType.SERVICE:
-      default:
         sourceLabel = 'destination_service_name';
         sourceValue = data.service;
+        break;
+      case NodeMetricType.WORKLOAD:
+      // fall through, use workload as the default
+      default:
+        sourceLabel = 'source_workload';
+        sourceValue = data.workload;
     }
     let comparator = (metric: Metric) => {
-      if (destMetricType === NodeMetricType.SERVICE && !this.props.injectServiceNodes) {
+      if (this.isSpecialServiceDest(destMetricType)) {
         return metric[sourceLabel] === sourceValue && metric['destination_workload'] === 'unknown';
       }
       return metric[sourceLabel] === sourceValue;
@@ -190,7 +191,16 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
       this.metricsPromise = undefined;
     }
 
-    if (!destMetricType || !sourceMetricType || (!this.hasHttpMetrics(edge) && !this.hasTcpMetrics(edge))) {
+    // Just return if the metric types are unset, there is no data, or charts are unsupported
+    if (
+      !destMetricType ||
+      !sourceMetricType ||
+      !this.hasSupportedCharts(edge) ||
+      (!this.hasHttpMetrics(edge) && !this.hasTcpMetrics(edge))
+    ) {
+      this.setState({
+        loading: false
+      });
       return;
     }
 
@@ -202,7 +212,7 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
 
     this.metricsPromise.promise
       .then(response => {
-        let useDest = sourceData.nodeType === NodeType.UNKNOWN;
+        let useDest = sourceData.nodeType === NodeType.UNKNOWN || sourceData.nodeType === NodeType.SERVICE;
         useDest = useDest || this.props.namespace === 'istio-system';
         const reporter = useDest ? response.data.dest : response.data.source;
         const metrics = reporter.metrics;
@@ -278,7 +288,7 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
       })
       .catch(error => {
         if (error.isCanceled) {
-          console.log('SummaryPanelEdge: Ignore fetch error (canceled).');
+          console.debug('SummaryPanelEdge: Ignore fetch error (canceled).');
           return;
         }
         const errorMsg = error.response && error.response.data.error ? error.response.data.error : error.message;
@@ -304,9 +314,19 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
   );
 
   private renderCharts = edge => {
+    if (!this.hasSupportedCharts(edge)) {
+      return (
+        <>
+          <Icon type="pf" name="info" /> Service graphs do not support service-to-service aggregate sparklines. See the
+          chart above for aggregate traffic or use the workload graph type to observe individual workload-to-service
+          edge sparklines.
+        </>
+      );
+    }
     if (this.state.loading && !this.state.reqRates) {
       return <strong>Loading charts...</strong>;
-    } else if (this.state.metricsLoadError) {
+    }
+    if (this.state.metricsLoadError) {
       return (
         <div>
           <Icon type="pf" name="warning-triangle-o" /> <strong>Error loading metrics: </strong>
@@ -347,17 +367,32 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
     );
   };
 
+  private hasSupportedCharts = edge => {
+    const sourceData = nodeData(edge.source());
+    const destData = nodeData(edge.target());
+    const sourceMetricType = getNodeMetricType(sourceData);
+    const destMetricType = getNodeMetricType(destData);
+
+    // service-to-service edges are unsupported because they represent aggregations (of multiple workload to service edges)
+    const chartsSupported = sourceMetricType !== NodeMetricType.SERVICE || destMetricType !== NodeMetricType.SERVICE;
+    return chartsSupported;
+  };
+
+  // We need to handle the special case of a dest service node showing client failures. These service nodes show up in
+  // non-service graphs, even when not injecting service nodes.
+  private isSpecialServiceDest(destMetricType: NodeMetricType) {
+    return (
+      destMetricType === NodeMetricType.SERVICE &&
+      !this.props.injectServiceNodes &&
+      this.props.graphType !== GraphType.SERVICE
+    );
+  }
+
   private hasHttpMetrics = (edge): boolean => {
-    if (edge.data('rate')) {
-      return true;
-    }
-    return false;
+    return edge.data('rate') ? true : false;
   };
 
   private hasTcpMetrics = (edge): boolean => {
-    if (edge.data('tcpSentRate')) {
-      return true;
-    }
-    return false;
+    return edge.data('tcpSentRate') ? true : false;
   };
 }

--- a/src/pages/Graph/SummaryPanelGroup.tsx
+++ b/src/pages/Graph/SummaryPanelGroup.tsx
@@ -12,6 +12,7 @@ import {
   nodeData,
   getNodeMetrics,
   getNodeMetricType,
+  renderNoTraffic,
   renderPanelTitle
 } from './SummaryPanelCommon';
 import { DisplayMode, HealthIndicator } from '../../components/Health/HealthIndicator';
@@ -130,7 +131,7 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
               View detailed charts <Icon name="angle-double-right" />
             </Link>
           </p> */}
-          {this.hasHttpTraffic(group) && this.renderHttpRates(group)}
+          {this.hasHttpTraffic(group) ? this.renderHttpRates(group) : renderNoTraffic('HTTP')}
           <div>{this.renderSparklines(group)}</div>
         </div>
       </div>

--- a/src/pages/Graph/SummaryPanelNode.tsx
+++ b/src/pages/Graph/SummaryPanelNode.tsx
@@ -5,7 +5,7 @@ import { Icon } from 'patternfly-react';
 import { getTrafficRate, getAccumulatedTrafficRate } from '../../utils/TrafficRate';
 import InOutRateTable from '../../components/SummaryPanel/InOutRateTable';
 import { RpsChart, TcpChart } from '../../components/SummaryPanel/RpsChart';
-import { NodeType, SummaryPanelPropType } from '../../types/Graph';
+import { GraphType, NodeType, SummaryPanelPropType } from '../../types/Graph';
 import { Metrics, Metric } from '../../types/Metrics';
 import {
   shouldRefreshData,
@@ -17,6 +17,7 @@ import {
   getNodeMetrics,
   getNodeMetricType,
   getServicesLinkList,
+  renderNoTraffic,
   renderPanelTitle
 } from './SummaryPanelCommon';
 import { HealthIndicator, DisplayMode } from '../../components/Health/HealthIndicator';
@@ -108,12 +109,9 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
     }
 
     const filters = ['request_count', 'request_error_count', 'tcp_sent', 'tcp_received'];
-    // when not injecting service nodes the only service nodes are those representing client failures. For
-    // those we want to narrow the data to only TS with 'unknown' workloads (see the related comparator in getNodeDatapoints).
-    let byLabelsIn =
-      nodeMetricType === NodeMetricType.SERVICE && !this.props.injectServiceNodes
-        ? ['destination_workload']
-        : undefined;
+    // For special service dest nodes we want to narrow the data to only TS with 'unknown' workloads (see the related
+    // comparator in getNodeDatapoints).
+    let byLabelsIn = this.isSpecialServiceDest(nodeMetricType) ? ['destination_workload'] : undefined;
     let byLabelsOut = data.isRoot ? ['destination_service_namespace'] : undefined;
 
     const promise = getNodeMetrics(nodeMetricType, target, props, filters, byLabelsIn, byLabelsOut);
@@ -124,7 +122,7 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
       })
       .catch(error => {
         if (error.isCanceled) {
-          console.log('SummaryPanelNode: Ignore fetch error (canceled).');
+          console.debug('SummaryPanelNode: Ignore fetch error (canceled).');
           return;
         }
         const errorMsg = error.response && error.response.data.error ? error.response.data.error : error.message;
@@ -140,7 +138,7 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
 
   showRequestCountMetrics(all: Metrics, data: NodeData, nodeMetricType: NodeMetricType) {
     let comparator;
-    if (nodeMetricType === NodeMetricType.SERVICE && !this.props.injectServiceNodes) {
+    if (this.isSpecialServiceDest(nodeMetricType)) {
       comparator = (metric: Metric) => {
         return metric['destination_workload'] === 'unknown';
       };
@@ -158,43 +156,29 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
     let ecIn;
     let tcpSentIn;
     let tcpReceivedIn;
-    // set outgoing unless it is a non-root outsider (because they have no outgoing edges)
-    if (data.isRoot || !data.isOutsider) {
+    // set outgoing unless it is a non-root outsider (because they have no outgoing edges) or a
+    // service node (because they don't have "real" outgoing edges).
+    if (data.nodeType !== NodeType.SERVICE && (data.isRoot || !data.isOutsider)) {
       // use source metrics for outgoing, except for:
       // - unknown nodes (no source telemetry)
       // - istio namespace nodes (no source telemetry)
-      // - service nodes (to filter out source errors, see below)
       let useDest = data.nodeType === NodeType.UNKNOWN;
-      useDest = useDest || data.nodeType === NodeType.SERVICE;
       useDest = useDest || this.props.namespace === 'istio-system';
       metrics = useDest ? all.dest.metrics : all.source.metrics;
-      if (data.nodeType !== NodeType.SERVICE) {
-        rcOut = metrics['request_count_out'];
-        ecOut = metrics['request_error_count_out'];
+      rcOut = metrics['request_count_out'];
+      ecOut = metrics['request_error_count_out'];
 
-        // These will be empty if destination metrics are being used. That's fine
-        // it's not possible to report TCP metrics, because there is no TCP telemetry (either
-        // in source nor destination) in the cases where dest. metrics are used.
-        tcpSentOut = metrics['tcp_sent_out'];
-        tcpReceivedOut = metrics['tcp_received_out'];
-      } else {
-        // for service nodes incoming requests = outgoing requests less source side erros. Use
-        // destination-reported incoming metrics here, because destination telemetry can not
-        // include source-side errors (because the request never reaches the dest).
-        rcOut = metrics['request_count_in'];
-        ecOut = metrics['request_error_count_in'];
-
-        // Unfortunately, destination side doesn't have good TCP telemetry.
-        // Fallback to "mirror" the "in" metrics in the "out" metrics. This is
-        // the current best effort.
-        tcpSentOut = all.source.metrics['tcp_sent_in'];
-        tcpReceivedOut = all.source.metrics['tcp_received_in'];
-      }
+      // These will be empty if destination metrics are being used. That's fine
+      // it's not possible to report TCP metrics, because there is no TCP telemetry (either
+      // in source nor destination) in the cases where dest. metrics are used.
+      tcpSentOut = metrics['tcp_sent_out'];
+      tcpReceivedOut = metrics['tcp_received_out'];
     }
     // set incoming unless it is a root (because they have no incoming edges)
     if (!data.isRoot) {
-      // use dest metrics for incoming, except for service nodes in order to capturing source errors
-      metrics = data.nodeType === NodeType.SERVICE ? all.source.metrics : all.dest.metrics;
+      // use dest metrics for incoming, except for service nodes which need source metrics to capture source errors
+      const useSource = data.nodeType === NodeType.SERVICE && data.namespace !== 'istio-system';
+      metrics = useSource ? all.source.metrics : all.dest.metrics;
       rcIn = metrics['request_count_in'];
       ecIn = metrics['request_error_count_in'];
 
@@ -269,7 +253,7 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
               </Link>
             </p>
           )} */}
-          {this.hasHttpTraffic(node) && this.renderHttpRates(node)}
+          {this.hasHttpTraffic(node) ? this.renderHttpRates(node) : renderNoTraffic('HTTP')}
           <div>{this.renderSparklines(node)}</div>
         </div>
       </div>
@@ -310,20 +294,38 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
       );
     }
 
+    const isServiceNode = node.data('nodeType') === NodeType.SERVICE;
+    let serviceWithUnknownSource: boolean = false;
+    if (isServiceNode) {
+      for (const n of node.incomers()) {
+        if (NodeType.UNKNOWN === n.data('nodeType')) {
+          serviceWithUnknownSource = true;
+          break;
+        }
+      }
+    }
     let httpCharts, tcpCharts;
 
     if (this.hasHttpTraffic(node)) {
       httpCharts = (
         <>
           <RpsChart
-            label="HTTP - Inbound Request Traffic"
+            label={isServiceNode ? 'HTTP - Request Traffic' : 'HTTP - Inbound Request Traffic'}
             dataRps={this.state.requestCountIn!}
             dataErrors={this.state.errorCountIn}
           />
+          {serviceWithUnknownSource && (
+            <>
+              <div>
+                <Icon type="pf" name="info" /> Traffic from unknown not included. Use edge for details.
+              </div>
+            </>
+          )}
           <RpsChart
             label="HTTP - Outbound Request Traffic"
             dataRps={this.state.requestCountOut}
             dataErrors={this.state.errorCountOut}
+            hide={isServiceNode}
           />
           <hr />
         </>
@@ -334,7 +336,7 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
       tcpCharts = (
         <>
           <TcpChart
-            label="TCP - Inbound Traffic"
+            label={isServiceNode ? 'TCP - Traffic' : 'TCP - Inbound Traffic'}
             receivedRates={this.state.tcpReceivedIn}
             sentRates={this.state.tcpSentIn}
           />
@@ -342,6 +344,7 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
             label="TCP - Outbound Traffic"
             receivedRates={this.state.tcpReceivedOut}
             sentRates={this.state.tcpSentOut}
+            hide={isServiceNode}
           />
           <hr />
         </>
@@ -380,6 +383,16 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
       </>
     );
   };
+
+  // We need to handle the special case of a dest service node showing client failures. These service nodes show up in
+  // non-service graphs, even when not injecting service nodes.
+  private isSpecialServiceDest(nodeMetricType: NodeMetricType) {
+    return (
+      nodeMetricType === NodeMetricType.SERVICE &&
+      !this.props.injectServiceNodes &&
+      this.props.graphType !== GraphType.SERVICE
+    );
+  }
 
   private hasHttpTraffic = (node): boolean => {
     if (node.data('rate') || node.data('rateOut')) {

--- a/src/types/Graph.ts
+++ b/src/types/Graph.ts
@@ -22,6 +22,7 @@ export interface SummaryPanelPropType {
 
 export enum GraphType {
   APP = 'app',
+  SERVICE = 'service',
   VERSIONED_APP = 'versionedApp',
   WORKLOAD = 'workload'
 }


### PR DESCRIPTION
- Add Service to graph type selector
- For service node side panels:
  - stop showing inbound/outbound graphs, only one graph with new title
  - add 'hide' option to RpsChart and TcpChart and ResponseTimeChart
- For edge side panels:
  - don't support any charts for service-to-service edges in the new graph type
    - the graph already performs aggregation, so show the bar chart.  But to
      do that aggregation in the sparklines would be difficult, so just omit it
    - fix a bug that could leave "Loading graph..." message displayed
