### PR TITLE
KIALI-1649 maintain health and selections after layout change

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -347,10 +347,14 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
 
     cy.startBatch();
 
-    if (updateLayout) {
-      // To get a more consistent layout, remove every node and start again (only when a relayout is a must)
-      cy.remove(cy.elements());
-    }
+    // Note, to resolve some layout issues for KIALI-1291 we introduced a complete wipe of cy elements prior to a layout change. This
+    // caused the issue in KIALI-1649. I'm not sure we still need the wipe, my testing shows good behavior without wiping the existing
+    // elements. So, I'm commenting it out.  If we need to re-instate it then we need to also add a fix for 1649. For that we'd probably
+    // need to gather the elements that have added classes (like Health info) and also capture any selected element. Then re-apply the
+    // settings on the replacement elements, for those elements that still exist.
+    // if (updateLayout) {
+    //   cy.remove(cy.elements());
+    // }
 
     // update the entire set of nodes and edges to keep the graph up-to-date
     cy.json({ elements: this.props.elements });

--- a/src/components/CytoscapeGraph/graphs/ColaGraph.ts
+++ b/src/components/CytoscapeGraph/graphs/ColaGraph.ts
@@ -3,8 +3,10 @@ export class ColaGraph {
     return {
       name: 'cola',
       animate: false,
+      fit: false,
       flow: { axis: 'x' },
-      nodeDimensionsIncludeLabels: true
+      nodeDimensionsIncludeLabels: true,
+      randomize: false
     };
   }
 }

--- a/src/components/CytoscapeGraph/graphs/CoseGraph.ts
+++ b/src/components/CytoscapeGraph/graphs/CoseGraph.ts
@@ -3,6 +3,7 @@ export class CoseGraph {
     return {
       name: 'cose-bilkent',
       animate: false,
+      fit: false,
       nodeDimensionsIncludeLabels: true
     };
   }

--- a/src/components/CytoscapeGraph/graphs/DagreGraph.ts
+++ b/src/components/CytoscapeGraph/graphs/DagreGraph.ts
@@ -2,8 +2,9 @@ export class DagreGraph {
   static getLayout() {
     return {
       name: 'dagre',
-      rankDir: 'LR',
-      nodeDimensionsIncludeLabels: true
+      fit: false,
+      nodeDimensionsIncludeLabels: true,
+      rankDir: 'LR'
     };
   }
 }


### PR DESCRIPTION
- The fix for this is to revert part of KIALI-1291, which introduced a wipe
  of the graph elements prior to a layout change.  From what I can tell we
  don't need that anymore. But if we do we'll need to revisit this issue.
- also, turn off the 'fit' option on the layouts, we don't need to fit during
  the batch operation, we do a fit at the end.
