### PR TITLE
KIALI-1687 (followup): Metrics page, add dynamic labels filtering

### DIFF
--- a/src/components/Metrics/HistogramChart.tsx
+++ b/src/components/Metrics/HistogramChart.tsx
@@ -1,11 +1,13 @@
 import { Histogram } from '../../types/Metrics';
 import graphUtils from '../../utils/Graphing';
+import { MetricsLabels as L } from '../MetricsOptions/MetricsLabels';
 import MetricsChartBase from './MetricsChartBase';
 
 interface HistogramChartProps {
   histogram: Histogram;
   chartName: string;
   unit: string;
+  labelValues: Map<L.PromLabel, L.LabelValues>;
   onExpandRequested?: () => void;
 }
 
@@ -25,13 +27,17 @@ class HistogramChart extends MetricsChartBase<HistogramChartProps> {
   }
 
   protected getSeriesData() {
+    const filtered: Histogram = {};
     Object.keys(this.props.histogram).forEach(stat => {
+      filtered[stat] = {
+        matrix: this.props.histogram[stat].matrix.filter(ts => this.isVisibleMetric(ts.metric, this.props.labelValues))
+      };
       const statName = stat === 'avg' ? 'average' : 'quantile ' + stat;
-      this.nameTimeSeries(this.props.histogram[stat].matrix, statName);
+      this.nameTimeSeries(filtered[stat].matrix, statName);
     });
     return {
       x: 'x',
-      columns: graphUtils.histogramToC3Columns(this.props.histogram)
+      columns: graphUtils.histogramToC3Columns(filtered)
     };
   }
 }

--- a/src/components/Metrics/MetricChart.tsx
+++ b/src/components/Metrics/MetricChart.tsx
@@ -1,5 +1,6 @@
 import graphUtils from '../../utils/Graphing';
 import { TimeSeries } from '../../types/Metrics';
+import { MetricsLabels as L } from '../MetricsOptions/MetricsLabels';
 import MetricsChartBase from './MetricsChartBase';
 
 type MetricChartProps = {

--- a/src/components/Metrics/MetricChart.tsx
+++ b/src/components/Metrics/MetricChart.tsx
@@ -6,6 +6,7 @@ type MetricChartProps = {
   series: TimeSeries[];
   chartName: string;
   unit: string;
+  labelValues: Map<L.PromLabel, L.LabelValues>;
   onExpandRequested?: () => void;
 };
 
@@ -24,9 +25,10 @@ export default class MetricsChart extends MetricsChartBase<MetricChartProps> {
   }
 
   protected getSeriesData() {
+    const filtered = this.props.series.filter(ts => this.isVisibleMetric(ts.metric, this.props.labelValues));
     return {
       x: 'x',
-      columns: graphUtils.toC3Columns(this.nameTimeSeries(this.props.series))
+      columns: graphUtils.toC3Columns(this.nameTimeSeries(filtered))
     };
   }
 }

--- a/src/components/Metrics/MetricsChartBase.tsx
+++ b/src/components/Metrics/MetricsChartBase.tsx
@@ -2,7 +2,8 @@ import * as React from 'react';
 import { LineChart, Icon } from 'patternfly-react';
 import { style } from 'typestyle';
 import { format } from 'd3-format';
-import { TimeSeries } from '../../types/Metrics';
+import { MetricsLabels as L } from '../MetricsOptions/MetricsLabels';
+import { TimeSeries, Metric } from '../../types/Metrics';
 
 type MetricsChartBaseProps = {
   chartName: string;
@@ -32,8 +33,8 @@ abstract class MetricsChartBase<Props extends MetricsChartBaseProps> extends Rea
   protected nameTimeSeries = (matrix: TimeSeries[], groupName?: string): TimeSeries[] => {
     matrix.forEach(ts => {
       const labels = Object.keys(ts.metric)
+        .filter(k => k !== 'reporter')
         .map(k => ts.metric[k])
-        .filter(label => label !== 'source' && label !== 'destination')
         .join(',');
       if (groupName) {
         if (labels === '') {
@@ -112,6 +113,19 @@ abstract class MetricsChartBase<Props extends MetricsChartBaseProps> extends Rea
       </div>
     );
   };
+
+  protected isVisibleMetric(metric: Metric, labelValues: Map<L.PromLabel, L.LabelValues>) {
+    for (let promLabelName in metric) {
+      if (metric.hasOwnProperty(promLabelName)) {
+        const actualValue = metric[promLabelName];
+        const values = labelValues.get(promLabelName);
+        if (values && values.hasOwnProperty(actualValue) && !values[actualValue]) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
 
   checkUnload(data: C3ChartData) {
     const newColumns = data.columns.map(c => c[0] as string);

--- a/src/components/Metrics/__tests__/__snapshots__/Metrics.test.tsx.snap
+++ b/src/components/Metrics/__tests__/__snapshots__/Metrics.test.tsx.snap
@@ -28,7 +28,9 @@ ShallowWrapper {
         undefined,
         <MetricsOptionsBar
           direction={0}
+          labelValues={Map {}}
           metricReporter="destination"
+          onLabelsFiltersChanged={[Function]}
           onOptionsChanged={[Function]}
           onRefresh={[Function]}
           onReporterChanged={[Function]}
@@ -64,7 +66,9 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "direction": 0,
+          "labelValues": Map {},
           "metricReporter": "destination",
+          "onLabelsFiltersChanged": [Function],
           "onOptionsChanged": [Function],
           "onRefresh": [Function],
           "onReporterChanged": [Function],
@@ -195,7 +199,9 @@ ShallowWrapper {
           undefined,
           <MetricsOptionsBar
             direction={0}
+            labelValues={Map {}}
             metricReporter="destination"
+            onLabelsFiltersChanged={[Function]}
             onOptionsChanged={[Function]}
             onRefresh={[Function]}
             onReporterChanged={[Function]}
@@ -231,7 +237,9 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "direction": 0,
+            "labelValues": Map {},
             "metricReporter": "destination",
+            "onLabelsFiltersChanged": [Function],
             "onOptionsChanged": [Function],
             "onRefresh": [Function],
             "onReporterChanged": [Function],
@@ -390,7 +398,9 @@ ShallowWrapper {
         undefined,
         <MetricsOptionsBar
           direction={0}
+          labelValues={Map {}}
           metricReporter="destination"
+          onLabelsFiltersChanged={[Function]}
           onOptionsChanged={[Function]}
           onRefresh={[Function]}
           onReporterChanged={[Function]}
@@ -426,7 +436,9 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "direction": 0,
+          "labelValues": Map {},
           "metricReporter": "destination",
+          "onLabelsFiltersChanged": [Function],
           "onOptionsChanged": [Function],
           "onRefresh": [Function],
           "onReporterChanged": [Function],
@@ -557,7 +569,9 @@ ShallowWrapper {
           undefined,
           <MetricsOptionsBar
             direction={0}
+            labelValues={Map {}}
             metricReporter="destination"
+            onLabelsFiltersChanged={[Function]}
             onOptionsChanged={[Function]}
             onRefresh={[Function]}
             onReporterChanged={[Function]}
@@ -593,7 +607,9 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "direction": 0,
+            "labelValues": Map {},
             "metricReporter": "destination",
+            "onLabelsFiltersChanged": [Function],
             "onOptionsChanged": [Function],
             "onRefresh": [Function],
             "onReporterChanged": [Function],
@@ -752,7 +768,9 @@ ShallowWrapper {
         undefined,
         <MetricsOptionsBar
           direction={0}
+          labelValues={Map {}}
           metricReporter="destination"
+          onLabelsFiltersChanged={[Function]}
           onOptionsChanged={[Function]}
           onRefresh={[Function]}
           onReporterChanged={[Function]}
@@ -788,7 +806,9 @@ ShallowWrapper {
         "nodeType": "class",
         "props": Object {
           "direction": 0,
+          "labelValues": Map {},
           "metricReporter": "destination",
+          "onLabelsFiltersChanged": [Function],
           "onOptionsChanged": [Function],
           "onRefresh": [Function],
           "onReporterChanged": [Function],
@@ -919,7 +939,9 @@ ShallowWrapper {
           undefined,
           <MetricsOptionsBar
             direction={0}
+            labelValues={Map {}}
             metricReporter="destination"
+            onLabelsFiltersChanged={[Function]}
             onOptionsChanged={[Function]}
             onRefresh={[Function]}
             onReporterChanged={[Function]}
@@ -955,7 +977,9 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "direction": 0,
+            "labelValues": Map {},
             "metricReporter": "destination",
+            "onLabelsFiltersChanged": [Function],
             "onOptionsChanged": [Function],
             "onRefresh": [Function],
             "onReporterChanged": [Function],

--- a/src/components/MetricsOptions/MetricsLabels.ts
+++ b/src/components/MetricsOptions/MetricsLabels.ts
@@ -1,0 +1,28 @@
+export namespace MetricsLabels {
+  export type PromLabel = string;
+  export type LabelValues = { [key: string]: boolean };
+  export type LabelName = 'Local version' | 'Remote app' | 'Remote version' | 'Response code';
+
+  const tmpInboundLabels: [LabelName, PromLabel][] = [
+    ['Local version', 'destination_version'],
+    ['Remote app', 'source_app'],
+    ['Remote version', 'source_version'],
+    ['Response code', 'response_code']
+  ];
+  const tmpOutboundLabels: [LabelName, PromLabel][] = [
+    ['Local version', 'source_version'],
+    ['Remote app', 'destination_app'],
+    ['Remote version', 'destination_version'],
+    ['Response code', 'response_code']
+  ];
+
+  export const INBOUND_LABELS: Map<LabelName, PromLabel> = new Map<LabelName, PromLabel>(tmpInboundLabels);
+  export const OUTBOUND_LABELS: Map<LabelName, PromLabel> = new Map<LabelName, PromLabel>(tmpOutboundLabels);
+  export const REVERSE_INBOUND_LABELS: Map<PromLabel, LabelName> = new Map<PromLabel, LabelName>(
+    tmpInboundLabels.map(arr => [arr[1], arr[0]] as [PromLabel, LabelName])
+  );
+  export const REVERSE_OUTBOUND_LABELS: Map<PromLabel, LabelName> = new Map<PromLabel, LabelName>(
+    tmpOutboundLabels.map(arr => [arr[1], arr[0]] as [PromLabel, LabelName])
+  );
+  export const ALL_NAMES = tmpInboundLabels.map(arr => arr[0]);
+}

--- a/src/components/MetricsOptions/__tests__/MetricsOptionsBar.test.tsx
+++ b/src/components/MetricsOptions/__tests__/MetricsOptionsBar.test.tsx
@@ -16,8 +16,10 @@ describe('MetricsOptionsBar', () => {
         onOptionsChanged={jest.fn()}
         onRefresh={jest.fn()}
         onReporterChanged={jest.fn()}
+        onLabelsFiltersChanged={jest.fn()}
         metricReporter={'destination'}
         direction={MetricsDirection.INBOUND}
+        labelValues={new Map()}
       />
     );
     expect(wrapper).toMatchSnapshot();
@@ -29,8 +31,10 @@ describe('MetricsOptionsBar', () => {
         onOptionsChanged={optionsChanged}
         onRefresh={jest.fn()}
         onReporterChanged={jest.fn()}
+        onLabelsFiltersChanged={jest.fn()}
         metricReporter={'destination'}
         direction={MetricsDirection.INBOUND}
+        labelValues={new Map()}
       />
     );
     expect(optionsChanged).toHaveBeenCalledTimes(1);

--- a/src/components/MetricsOptions/__tests__/__snapshots__/MetricsOptionsBar.test.tsx.snap
+++ b/src/components/MetricsOptions/__tests__/__snapshots__/MetricsOptionsBar.test.tsx.snap
@@ -6,7 +6,9 @@ ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <MetricsOptionsBar
     direction={0}
+    labelValues={Map {}}
     metricReporter="destination"
+    onLabelsFiltersChanged={[MockFunction]}
     onOptionsChanged={
       [MockFunction] {
         "calls": Array [
@@ -46,8 +48,10 @@ ShallowWrapper {
           bsClass="form-group"
         >
           <MetricsSettingsDropdown
-            groupingLabels={Array []}
+            activeLabels={Array []}
+            labelValues={Map {}}
             onChanged={[Function]}
+            onLabelsFiltersChanged={[MockFunction]}
             showAverage={true}
             showQuantiles={
               Array [
@@ -120,8 +124,10 @@ ShallowWrapper {
         "props": Object {
           "bsClass": "form-group",
           "children": <MetricsSettingsDropdown
-            groupingLabels={Array []}
+            activeLabels={Array []}
+            labelValues={Map {}}
             onChanged={[Function]}
+            onLabelsFiltersChanged={[MockFunction]}
             showAverage={true}
             showQuantiles={
               Array [
@@ -138,8 +144,10 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "class",
           "props": Object {
-            "groupingLabels": Array [],
+            "activeLabels": Array [],
+            "labelValues": Map {},
             "onChanged": [Function],
+            "onLabelsFiltersChanged": [MockFunction],
             "showAverage": true,
             "showQuantiles": Array [
               "0.5",
@@ -270,8 +278,10 @@ ShallowWrapper {
             bsClass="form-group"
           >
             <MetricsSettingsDropdown
-              groupingLabels={Array []}
+              activeLabels={Array []}
+              labelValues={Map {}}
               onChanged={[Function]}
+              onLabelsFiltersChanged={[MockFunction]}
               showAverage={true}
               showQuantiles={
                 Array [
@@ -344,8 +354,10 @@ ShallowWrapper {
           "props": Object {
             "bsClass": "form-group",
             "children": <MetricsSettingsDropdown
-              groupingLabels={Array []}
+              activeLabels={Array []}
+              labelValues={Map {}}
               onChanged={[Function]}
+              onLabelsFiltersChanged={[MockFunction]}
               showAverage={true}
               showQuantiles={
                 Array [
@@ -362,8 +374,10 @@ ShallowWrapper {
             "key": undefined,
             "nodeType": "class",
             "props": Object {
-              "groupingLabels": Array [],
+              "activeLabels": Array [],
+              "labelValues": Map {},
               "onChanged": [Function],
+              "onLabelsFiltersChanged": [MockFunction],
               "showAverage": true,
               "showQuantiles": Array [
                 "0.5",


### PR DESCRIPTION
Enables filtering based on label values. Example: while showing metrics per remote app, we can now hide metrics by app.

JIRA: https://issues.jboss.org/browse/KIALI-1687

Screenshot:
![Filtering](https://i.imgur.com/mnFlrq4.png)