### PR TITLE
KIALI-1597 Don't try to update state on umounted components

### DIFF
--- a/src/pages/AppList/ItemDescription.tsx
+++ b/src/pages/AppList/ItemDescription.tsx
@@ -3,6 +3,7 @@ import { AppHealth } from '../../types/Health';
 import { DisplayMode, HealthIndicator } from '../../components/Health/HealthIndicator';
 import AppErrorRate from './AppErrorRate';
 import { AppListItem } from '../../types/AppList';
+import { CancelablePromise, makeCancelablePromise } from '../../utils/Common';
 
 interface Props {
   item: AppListItem;
@@ -12,6 +13,8 @@ interface State {
 }
 
 export default class ItemDescription extends React.PureComponent<Props, State> {
+  private healthPromise?: CancelablePromise<AppHealth>;
+
   constructor(props: Props) {
     super(props);
     this.state = { health: undefined };
@@ -27,8 +30,24 @@ export default class ItemDescription extends React.PureComponent<Props, State> {
     }
   }
 
+  componentWillUnmount() {
+    if (this.healthPromise) {
+      this.healthPromise.cancel();
+      this.healthPromise = undefined;
+    }
+  }
+
   onItemChanged(item: AppListItem) {
-    item.healthPromise.then(h => this.setState({ health: h })).catch(err => this.setState({ health: undefined }));
+    if (this.healthPromise) {
+      this.healthPromise.cancel();
+    }
+
+    this.healthPromise = makeCancelablePromise(item.healthPromise);
+    this.healthPromise.promise.then(h => this.setState({ health: h })).catch(err => {
+      if (!err.isCanceled) {
+        this.setState({ health: undefined });
+      }
+    });
   }
 
   render() {

--- a/src/pages/ServiceList/__tests__/ItemDescription.test.tsx
+++ b/src/pages/ServiceList/__tests__/ItemDescription.test.tsx
@@ -24,15 +24,14 @@ describe('ItemDescription', () => {
     };
   });
 
-  it('should render with promise resolving', done => {
+  it('should render with promise resolving', () => {
     const wrapper = shallow(<ItemDescription item={item} />);
     expect(wrapper.text()).toBe('');
 
     resolver(health);
-    item.healthPromise.then(() => {
+    return new Promise(r => setImmediate(r)).then(() => {
       wrapper.update();
       expect(wrapper.text()).toBe('Health: <HealthIndicator /><ServiceErrorRate />');
-      done();
     });
   });
 });

--- a/src/pages/WorkloadList/WorkloadListComponent.tsx
+++ b/src/pages/WorkloadList/WorkloadListComponent.tsx
@@ -7,7 +7,7 @@ import { WorkloadListFilters } from './FiltersAndSorts';
 import { FilterSelected, StatefulFilters } from '../../components/Filters/StatefulFilters';
 import { Button, Icon, ListView, Paginator, Sort, ToolbarRightContent } from 'patternfly-react';
 import { ActiveFilter } from '../../types/Filters';
-import { removeDuplicatesArray } from '../../utils/Common';
+import { CancelablePromise, makeCancelablePromise, removeDuplicatesArray } from '../../utils/Common';
 import ItemDescription from './ItemDescription';
 import RateIntervalToolbarItem from '../ServiceList/RateIntervalToolbarItem';
 import { ListPage } from '../../components/ListPage/ListPage';
@@ -28,6 +28,10 @@ class WorkloadListComponent extends ListComponent.Component<
   WorkloadListComponentState,
   WorkloadListItem
 > {
+  private nsPromise?: CancelablePromise<API.Response<Namespace[]>>;
+  private workloadsPromise?: CancelablePromise<API.Response<WorkloadNamespaceResponse>[]>;
+  private sortPromise?: CancelablePromise<WorkloadListItem[]>;
+
   constructor(props: WorkloadListComponentProps) {
     super(props);
     this.state = {
@@ -56,6 +60,10 @@ class WorkloadListComponent extends ListComponent.Component<
     }
   }
 
+  componentWillUnmount() {
+    this.cancelAsyncs();
+  }
+
   paramsAreSynced(prevProps: WorkloadListComponentProps) {
     return (
       prevProps.pagination.page === this.props.pagination.page &&
@@ -72,10 +80,40 @@ class WorkloadListComponent extends ListComponent.Component<
   };
 
   sortItemList(workloads: WorkloadListItem[], sortField: SortField<WorkloadListItem>, isAscending: boolean) {
-    return WorkloadListFilters.sortWorkloadsItems(workloads, sortField, isAscending);
+    let lastSort: Promise<WorkloadListItem[]>;
+    const sorter = unsorted => {
+      this.sortPromise = makeCancelablePromise(
+        WorkloadListFilters.sortWorkloadsItems(workloads, sortField, isAscending)
+      );
+      this.sortPromise.promise
+        .then(() => {
+          this.sortPromise = undefined;
+        })
+        .catch(() => {
+          this.sortPromise = undefined;
+        });
+      return this.sortPromise.promise;
+    };
+
+    if (!this.sortPromise) {
+      // If there is no "sortPromise" set, take the received (unsorted) list of workloads to sort
+      // them and update the UI with the sorted list.
+      lastSort = sorter(workloads);
+    } else {
+      // If there is a "sortPromise", there may be an ongoing fetch/refresh. So, the received <workloads> list argument
+      // shoudn't be used as it may represent the "old" data before the refresh. Instead, append a callback to the
+      // "sortPromise" to re-sort once the data is fetched. This ensures that the list will display the new data with
+      // the right sorting.
+      // (See other comments in the fetchWorkloads method)
+      lastSort = this.sortPromise.promise.then(sorter);
+    }
+
+    return lastSort;
   }
 
   updateListItems(resetPagination?: boolean) {
+    this.cancelAsyncs();
+
     const activeFilters: ActiveFilter[] = FilterSelected.getSelected();
     let namespacesSelected: string[] = activeFilters
       .filter(activeFilter => activeFilter.category === 'Namespace')
@@ -85,12 +123,18 @@ class WorkloadListComponent extends ListComponent.Component<
     namespacesSelected = removeDuplicatesArray(namespacesSelected);
 
     if (namespacesSelected.length === 0) {
-      API.getNamespaces(authentication())
+      this.nsPromise = makeCancelablePromise(API.getNamespaces(authentication()));
+      this.nsPromise.promise
         .then(namespacesResponse => {
           const namespaces: Namespace[] = namespacesResponse['data'];
           this.fetchWorkloads(namespaces.map(namespace => namespace.name), activeFilters, resetPagination);
+          this.nsPromise = undefined;
         })
-        .catch(namespacesError => this.handleAxiosError('Could not fetch namespace list.', namespacesError));
+        .catch(namespacesError => {
+          if (!namespacesError.isCanceled) {
+            this.handleAxiosError('Could not fetch namespace list.', namespacesError);
+          }
+        });
     } else {
       this.fetchWorkloads(namespacesSelected, activeFilters, resetPagination);
     }
@@ -114,30 +158,56 @@ class WorkloadListComponent extends ListComponent.Component<
 
   fetchWorkloads(namespaces: string[], filters: ActiveFilter[], resetPagination?: boolean) {
     const workloadsConfigPromises = namespaces.map(namespace => API.getWorkloads(authentication(), namespace));
-    Promise.all(workloadsConfigPromises).then(responses => {
-      const currentPage = resetPagination ? 1 : this.state.pagination.page;
-      let workloadsItems: WorkloadListItem[] = [];
-      responses.forEach(response => {
-        WorkloadListFilters.filterBy(response.data, filters);
-        workloadsItems = workloadsItems.concat(this.getDeploymentItems(response.data));
-      });
-      WorkloadListFilters.sortWorkloadsItems(
-        workloadsItems,
-        this.state.currentSortField,
-        this.state.isSortAscending
-      ).then(sorted => {
-        this.setState(prevState => {
-          return {
-            listItems: sorted,
-            pagination: {
-              page: currentPage,
-              perPage: prevState.pagination.perPage,
-              perPageOptions: ListPage.perPageOptions
-            }
-          };
+    this.workloadsPromise = makeCancelablePromise(Promise.all(workloadsConfigPromises));
+    this.workloadsPromise.promise
+      .then(responses => {
+        const currentPage = resetPagination ? 1 : this.state.pagination.page;
+        let workloadsItems: WorkloadListItem[] = [];
+        responses.forEach(response => {
+          WorkloadListFilters.filterBy(response.data, filters);
+          workloadsItems = workloadsItems.concat(this.getDeploymentItems(response.data));
         });
+        if (this.sortPromise) {
+          this.sortPromise.cancel();
+        }
+        // Promises for sorting are needed, because the user may have the list sorted using health/error rates
+        // and these data can be fetched only after the list is retrieved. If the user is sorting using these
+        // criteria, the update of the list is deferred after sorting is possible. This way, it's avoided the
+        // illusion of double-fetch or flickering list.
+        this.sortPromise = makeCancelablePromise(
+          WorkloadListFilters.sortWorkloadsItems(
+            workloadsItems,
+            this.state.currentSortField,
+            this.state.isSortAscending
+          )
+        );
+        this.sortPromise.promise
+          .then(sorted => {
+            this.setState(prevState => {
+              return {
+                listItems: sorted,
+                pagination: {
+                  page: currentPage,
+                  perPage: prevState.pagination.perPage,
+                  perPageOptions: ListPage.perPageOptions
+                }
+              };
+            });
+            this.sortPromise = undefined;
+          })
+          .catch(err => {
+            if (!err.isCanceled) {
+              console.debug(err);
+            }
+            this.sortPromise = undefined;
+          });
+        this.workloadsPromise = undefined;
+      })
+      .catch(err => {
+        if (!err.isCanceled) {
+          console.debug(err);
+        }
       });
-    });
   }
 
   render() {
@@ -196,6 +266,21 @@ class WorkloadListComponent extends ListComponent.Component<
       </>
     );
   }
+
+  private cancelAsyncs = () => {
+    if (this.nsPromise) {
+      this.nsPromise.cancel();
+      this.nsPromise = undefined;
+    }
+    if (this.workloadsPromise) {
+      this.workloadsPromise.cancel();
+      this.workloadsPromise = undefined;
+    }
+    if (this.sortPromise) {
+      this.sortPromise.cancel();
+      this.sortPromise = undefined;
+    }
+  };
 }
 
 export default WorkloadListComponent;


### PR DESCRIPTION
Callback of some async data fetches were trying to update the state of
already umounted components. This was causing some errors to appear in
the browser console.

Currently, errors aren't causing any problems, but by stopping further
processing when component umounts this may prevent future problems.
