### PR TITLE
KIALI-1696 Make showing unused nodes optional

### DIFF
--- a/src/actions/GraphDataActions.ts
+++ b/src/actions/GraphDataActions.ts
@@ -85,6 +85,7 @@ export const GraphDataActions = {
     injectServiceNodes: boolean,
     edgeLabelMode: EdgeLabelMode,
     showSecurity: boolean,
+    showUnusedNodes: boolean,
     node?: NodeParamsType
   ) => {
     return dispatch => {
@@ -99,8 +100,9 @@ export const GraphDataActions = {
       // Some appenders are expensive so only specify an appender if needed.
       let appenders: string = 'dead_node,sidecars_check,istio';
 
-      if (!node) {
-        // note we only use the unused_node appender if this is NOT a drilled-in node graph
+      if (!node && showUnusedNodes) {
+        // note we only use the unused_node appender if this is NOT a drilled-in node graph and
+        // the user specifically requests to see unused nodes.
         appenders += ',unused_node';
       }
 

--- a/src/actions/GraphFilterActions.ts
+++ b/src/actions/GraphFilterActions.ts
@@ -13,6 +13,7 @@ export enum GraphFilterActionKeys {
   TOGGLE_GRAPH_SECURITY = 'TOGGLE_GRAPH_SECURITY',
   TOGGLE_SERVICE_NODES = 'TOGGLE_SERVICE_NODES',
   TOGGLE_TRAFFIC_ANIMATION = 'TOGGLE_TRAFFIC_ANIMATION',
+  TOGGLE_UNUSED_NODES = 'TOGGLE_UNUSED_NODES',
   SET_GRAPH_EDGE_LABEL_MODE = 'SET_GRAPH_EDGE_LABEL_MODE',
   // Disable Actions
   ENABLE_GRAPH_FILTERS = 'ENABLE_GRAPH_FILTERS',
@@ -35,8 +36,9 @@ export const GraphFilterActions = {
   toggleGraphCircuitBreakers: createAction(GraphFilterActionKeys.TOGGLE_GRAPH_CIRCUIT_BREAKERS),
   toggleGraphMissingSidecars: createAction(GraphFilterActionKeys.TOGGLE_GRAPH_MISSING_SIDECARS),
   toggleGraphSecurity: createAction(GraphFilterActionKeys.TOGGLE_GRAPH_SECURITY),
-  toggleTrafficAnimation: createAction(GraphFilterActionKeys.TOGGLE_TRAFFIC_ANIMATION),
   toggleServiceNodes: createAction(GraphFilterActionKeys.TOGGLE_SERVICE_NODES),
+  toggleTrafficAnimation: createAction(GraphFilterActionKeys.TOGGLE_TRAFFIC_ANIMATION),
+  toggleUnusedNodes: createAction(GraphFilterActionKeys.TOGGLE_UNUSED_NODES),
   showGraphFilters: createAction(GraphFilterActionKeys.ENABLE_GRAPH_FILTERS, (value: boolean) => ({
     type: GraphFilterActionKeys.ENABLE_GRAPH_FILTERS,
     payload: value

--- a/src/actions/__tests__/GraphFilterAction.test.tsx
+++ b/src/actions/__tests__/GraphFilterAction.test.tsx
@@ -55,11 +55,25 @@ describe('GraphFilterActions', () => {
     expect(GraphFilterActions.toggleGraphSecurity()).toEqual(expectedAction);
   });
 
+  it('should toggle service nodes', () => {
+    const expectedAction = {
+      type: GraphFilterActionKeys.TOGGLE_SERVICE_NODES
+    };
+    expect(GraphFilterActions.toggleServiceNodes()).toEqual(expectedAction);
+  });
+
   it('should toggle traffic animations', () => {
     const expectedAction = {
       type: GraphFilterActionKeys.TOGGLE_TRAFFIC_ANIMATION
     };
     expect(GraphFilterActions.toggleTrafficAnimation()).toEqual(expectedAction);
+  });
+
+  it('should toggle unused nodes', () => {
+    const expectedAction = {
+      type: GraphFilterActionKeys.TOGGLE_UNUSED_NODES
+    };
+    expect(GraphFilterActions.toggleUnusedNodes()).toEqual(expectedAction);
   });
 
   it('should enable graph filters toggles', () => {

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -40,8 +40,9 @@ type CytoscapeGraphType = {
   showVirtualServices: boolean;
   showMissingSidecars: boolean;
   showSecurity: boolean;
-  showTrafficAnimation: boolean;
   showServiceNodes: boolean;
+  showTrafficAnimation: boolean;
+  showUnusedNodes: boolean;
   onReady: (cytoscapeRef: any) => void;
   onClick: (event: CytoscapeClickEvent) => void;
   onDoubleClick: (event: CytoscapeClickEvent) => void;
@@ -112,8 +113,9 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
       this.props.showVirtualServices !== nextProps.showVirtualServices ||
       this.props.showMissingSidecars !== nextProps.showMissingSidecars ||
       this.props.showSecurity !== nextProps.showSecurity ||
-      this.props.showTrafficAnimation !== nextProps.showTrafficAnimation ||
       this.props.showServiceNodes !== nextProps.showServiceNodes ||
+      this.props.showTrafficAnimation !== nextProps.showTrafficAnimation ||
+      this.props.showUnusedNodes !== nextProps.showUnusedNodes ||
       this.props.elements !== nextProps.elements ||
       this.props.isError !== nextProps.isError;
 
@@ -589,7 +591,9 @@ const mapStateToProps = (state: KialiAppState) => ({
   showVirtualServices: state.graph.filterState.showVirtualServices,
   showMissingSidecars: state.graph.filterState.showMissingSidecars,
   showSecurity: state.graph.filterState.showSecurity,
+  showServiceNodes: state.graph.filterState.showServiceNodes,
   showTrafficAnimation: state.graph.filterState.showTrafficAnimation,
+  showUnusedNodes: state.graph.filterState.showUnusedNodes,
   elements: state.graph.graphData,
   isLoading: state.graph.isLoading,
   isError: state.graph.isError

--- a/src/components/CytoscapeGraph/__tests__/CytoscapeGraph.test.tsx
+++ b/src/components/CytoscapeGraph/__tests__/CytoscapeGraph.test.tsx
@@ -47,6 +47,7 @@ describe('CytoscapeGraph component test', () => {
         showSecurity={true}
         showServiceNodes={false}
         showTrafficAnimation={false}
+        showUnusedNodes={false}
         isLoading={false}
         isError={false}
         graphType={GraphType.VERSIONED_APP}

--- a/src/components/GraphFilter/GraphFilterToolbar.tsx
+++ b/src/components/GraphFilter/GraphFilterToolbar.tsx
@@ -74,8 +74,8 @@ export default class GraphFilterToolbar extends React.PureComponent<GraphFilterT
     });
 
     if (edgeLabelMode === EdgeLabelMode.RESPONSE_TIME_95TH_PERCENTILE) {
-      // Server-side appenders for security and response time are not run by default unless those edge labels are specifically requested.
-      // So when switching to these edge labels, we have to ensure we make a server-side request in order to ensure those appenders are run.
+      // Server-side appender for response time is not run by default unless the edge label is explicitly set. So when switching
+      // to this edge label, we need to make a server-side request in order to ensure the appenders is run.
       store.dispatch(
         // @ts-ignore
         GraphDataActions.fetchGraphData(
@@ -85,6 +85,7 @@ export default class GraphFilterToolbar extends React.PureComponent<GraphFilterT
           this.props.injectServiceNodes,
           edgeLabelMode,
           this.props.showSecurity,
+          this.props.showUnusedNodes,
           this.props.node
         )
       );

--- a/src/components/GraphFilter/__tests__/GraphFilterToolbar.test.tsx
+++ b/src/components/GraphFilter/__tests__/GraphFilterToolbar.test.tsx
@@ -20,7 +20,13 @@ describe('GraphPage test', () => {
   it('should propagate filter params change with correct value', () => {
     const onParamsChangeMockFn = jest.fn();
     const wrapper = shallow(
-      <GraphFilterToolbar {...PARAMS} showSecurity={true} isLoading={false} handleRefreshClick={jest.fn()} />
+      <GraphFilterToolbar
+        {...PARAMS}
+        showSecurity={true}
+        showUnusedNodes={false}
+        isLoading={false}
+        handleRefreshClick={jest.fn()}
+      />
     );
 
     const toolbar = wrapper.instance() as GraphFilterToolbar;

--- a/src/containers/GraphPageContainer.ts
+++ b/src/containers/GraphPageContainer.ts
@@ -23,6 +23,7 @@ const mapStateToProps = (state: KialiAppState) => ({
   pollInterval: state.graph.filterState.refreshRate,
   isPageVisible: state.globalState.isPageVisible,
   showSecurity: state.graph.filterState.showSecurity,
+  showUnusedNodes: state.graph.filterState.showUnusedNodes,
   isError: state.graph.isError
 });
 
@@ -34,6 +35,7 @@ const mapDispatchToProps = (dispatch: any) => ({
     injectServiceNodes: boolean,
     edgeLabelMode: EdgeLabelMode,
     showSecurity: boolean,
+    showUnusedNodes: boolean,
     node?: NodeParamsType
   ) =>
     dispatch(
@@ -44,6 +46,7 @@ const mapDispatchToProps = (dispatch: any) => ({
         injectServiceNodes,
         edgeLabelMode,
         showSecurity,
+        showUnusedNodes,
         node
       )
     ),

--- a/src/containers/GraphSettingsContainer.tsx
+++ b/src/containers/GraphSettingsContainer.tsx
@@ -18,8 +18,9 @@ interface GraphDispatch {
   toggleGraphVirtualServices(): void;
   toggleGraphMissingSidecars(): void;
   toggleGraphSecurity(): void;
-  toggleTrafficAnimation(): void;
   toggleServiceNodes(): void;
+  toggleTrafficAnimation(): void;
+  toggleUnusedNodes(): void;
 }
 
 // inherit all of our Reducer state section  and Dispatch methods for redux
@@ -32,8 +33,9 @@ const mapStateToProps = (state: KialiAppState) => ({
   showVirtualServices: state.graph.filterState.showVirtualServices,
   showMissingSidecars: state.graph.filterState.showMissingSidecars,
   showSecurity: state.graph.filterState.showSecurity,
+  showServiceNodes: state.graph.filterState.showServiceNodes,
   showTrafficAnimation: state.graph.filterState.showTrafficAnimation,
-  showServiceNodes: state.graph.filterState.showServiceNodes
+  showUnusedNodes: state.graph.filterState.showUnusedNodes
 });
 
 // Map our actions to Redux
@@ -44,8 +46,9 @@ const mapDispatchToProps = (dispatch: any) => {
     toggleGraphVirtualServices: bindActionCreators(GraphFilterActions.toggleGraphVirtualServices, dispatch),
     toggleGraphMissingSidecars: bindActionCreators(GraphFilterActions.toggleGraphMissingSidecars, dispatch),
     toggleGraphSecurity: bindActionCreators(GraphFilterActions.toggleGraphSecurity, dispatch),
+    toggleServiceNodes: bindActionCreators(GraphFilterActions.toggleServiceNodes, dispatch),
     toggleTrafficAnimation: bindActionCreators(GraphFilterActions.toggleTrafficAnimation, dispatch),
-    toggleServiceNodes: bindActionCreators(GraphFilterActions.toggleServiceNodes, dispatch)
+    toggleUnusedNodes: bindActionCreators(GraphFilterActions.toggleUnusedNodes, dispatch)
   };
 };
 
@@ -75,8 +78,12 @@ class GraphSettings extends React.PureComponent<GraphSettingsProps> {
         ...this.getGraphParams(),
         injectServiceNodes: this.props.showServiceNodes
       });
-    } else if (this.props.showSecurity && this.props.showSecurity !== prevProps.showSecurity) {
-      // when turning on security we need to perform a fetch, because we don't pull security data by default
+    } else if (
+      (this.props.showSecurity && this.props.showSecurity !== prevProps.showSecurity) ||
+      this.props.showUnusedNodes !== prevProps.showUnusedNodes
+    ) {
+      // when turning on security, or toggling unused node, we need to perform a fetch, because we don't pull
+      // security or unused node data by default.
       store.dispatch(
         // @ts-ignore
         GraphDataActions.fetchGraphData(
@@ -86,6 +93,7 @@ class GraphSettings extends React.PureComponent<GraphSettingsProps> {
           this.props.injectServiceNodes,
           this.props.edgeLabelMode,
           this.props.showSecurity,
+          this.props.showUnusedNodes,
           this.props.node
         )
       );
@@ -109,8 +117,9 @@ class GraphSettings extends React.PureComponent<GraphSettingsProps> {
       showNodeLabels,
       showMissingSidecars,
       showSecurity,
+      showServiceNodes,
       showTrafficAnimation,
-      showServiceNodes
+      showUnusedNodes
     } = this.props;
 
     // map or dispatchers for redux
@@ -120,8 +129,9 @@ class GraphSettings extends React.PureComponent<GraphSettingsProps> {
       toggleGraphNodeLabels,
       toggleGraphMissingSidecars,
       toggleGraphSecurity,
+      toggleServiceNodes,
       toggleTrafficAnimation,
-      toggleServiceNodes
+      toggleUnusedNodes
     } = this.props;
 
     const visibilityLayers: VisibilityLayersType[] = [
@@ -142,6 +152,12 @@ class GraphSettings extends React.PureComponent<GraphSettingsProps> {
         labelText: 'Traffic Animation',
         value: showTrafficAnimation,
         onChange: toggleTrafficAnimation
+      },
+      {
+        id: 'filterUnusedNodes',
+        labelText: 'Unused Nodes',
+        value: showUnusedNodes,
+        onChange: toggleUnusedNodes
       }
     ];
 

--- a/src/pages/Graph/GraphPage.tsx
+++ b/src/pages/Graph/GraphPage.tsx
@@ -37,6 +37,7 @@ type GraphPageProps = GraphParamsType & {
     injectServiceNodes: boolean,
     edgeLabelMode: EdgeLabelMode,
     showSecurity: boolean,
+    showUnusedNodes: boolean,
     node?: NodeParamsType
   ) => any;
   toggleLegend: () => void;
@@ -44,6 +45,7 @@ type GraphPageProps = GraphParamsType & {
   pollInterval: PollIntervalInMs;
   isPageVisible: boolean;
   showSecurity: boolean;
+  showUnusedNodes: boolean;
   isError: boolean;
 };
 
@@ -203,6 +205,7 @@ export default class GraphPage extends React.Component<GraphPageProps, GraphPage
             <GraphFilterToolbar
               isLoading={this.props.isLoading}
               showSecurity={this.props.showSecurity}
+              showUnusedNodes={this.props.showUnusedNodes}
               handleRefreshClick={this.handleRefreshClick}
               {...graphParams}
             />
@@ -269,6 +272,7 @@ export default class GraphPage extends React.Component<GraphPageProps, GraphPage
       this.props.injectServiceNodes,
       this.props.edgeLabelMode,
       this.props.showSecurity,
+      this.props.showUnusedNodes,
       this.props.node
     );
     this.pollPromise = makeCancelablePromise(promise);

--- a/src/reducers/GraphDataState.ts
+++ b/src/reducers/GraphDataState.ts
@@ -18,8 +18,9 @@ export const INITIAL_GRAPH_STATE: GraphState = {
     showVirtualServices: true,
     showMissingSidecars: true,
     showSecurity: false,
-    showTrafficAnimation: false,
     showServiceNodes: false,
+    showTrafficAnimation: false,
+    showUnusedNodes: false,
     refreshRate: 15 * MILLISECONDS
   }
 };

--- a/src/reducers/GraphFilterState.ts
+++ b/src/reducers/GraphFilterState.ts
@@ -10,8 +10,9 @@ const INITIAL_STATE: GraphFilterState = {
   showVirtualServices: true,
   showMissingSidecars: true,
   showSecurity: false,
-  showTrafficAnimation: false,
   showServiceNodes: false,
+  showTrafficAnimation: false,
+  showUnusedNodes: false,
   // @ todo: add disableLayers back in later
   // disableLayers: false
   // edgeLabelMode: EdgeLabelMode.HIDE,
@@ -35,10 +36,12 @@ const graphFilterState = (state: GraphFilterState = INITIAL_STATE, action) => {
       return updateState(state, { showMissingSidecars: !state.showMissingSidecars });
     case GraphFilterActionKeys.TOGGLE_GRAPH_SECURITY:
       return updateState(state, { showSecurity: !state.showSecurity });
-    case GraphFilterActionKeys.TOGGLE_TRAFFIC_ANIMATION:
-      return updateState(state, { showTrafficAnimation: !state.showTrafficAnimation });
     case GraphFilterActionKeys.TOGGLE_SERVICE_NODES:
       return updateState(state, { showServiceNodes: !state.showServiceNodes });
+    case GraphFilterActionKeys.TOGGLE_TRAFFIC_ANIMATION:
+      return updateState(state, { showTrafficAnimation: !state.showTrafficAnimation });
+    case GraphFilterActionKeys.TOGGLE_UNUSED_NODES:
+      return updateState(state, { showUnusedNodes: !state.showUnusedNodes });
     case GraphFilterActionKeys.ENABLE_GRAPH_FILTERS:
       return updateState(state, { disableLayers: action.payload });
     case GraphFilterActionKeys.SET_GRAPH_REFRESH_RATE:

--- a/src/reducers/__tests__/GraphFilterStateReducer.test.ts
+++ b/src/reducers/__tests__/GraphFilterStateReducer.test.ts
@@ -12,6 +12,7 @@ describe('GraphFilterState reducer', () => {
       showSecurity: false,
       showTrafficAnimation: false,
       showServiceNodes: false,
+      showUnusedNodes: false,
       refreshRate: 15000
     });
   });
@@ -28,6 +29,7 @@ describe('GraphFilterState reducer', () => {
           showSecurity: false,
           showTrafficAnimation: false,
           showServiceNodes: false,
+          showUnusedNodes: false,
           refreshRate: 15000
         },
         {
@@ -43,6 +45,7 @@ describe('GraphFilterState reducer', () => {
       showSecurity: false,
       showTrafficAnimation: false,
       showServiceNodes: false,
+      showUnusedNodes: false,
       refreshRate: 15000
     });
   });
@@ -59,6 +62,7 @@ describe('GraphFilterState reducer', () => {
           showSecurity: false,
           showTrafficAnimation: false,
           showServiceNodes: false,
+          showUnusedNodes: false,
           refreshRate: 15000
         },
         {
@@ -74,6 +78,7 @@ describe('GraphFilterState reducer', () => {
       showSecurity: false,
       showTrafficAnimation: false,
       showServiceNodes: false,
+      showUnusedNodes: false,
       refreshRate: 15000
     });
   });
@@ -90,6 +95,7 @@ describe('GraphFilterState reducer', () => {
           showSecurity: false,
           showTrafficAnimation: false,
           showServiceNodes: false,
+          showUnusedNodes: false,
           refreshRate: 15000
         },
         {
@@ -105,6 +111,7 @@ describe('GraphFilterState reducer', () => {
       showSecurity: false,
       showTrafficAnimation: false,
       showServiceNodes: false,
+      showUnusedNodes: false,
       refreshRate: 15000
     });
   });
@@ -120,6 +127,7 @@ describe('GraphFilterState reducer', () => {
           showSecurity: false,
           showTrafficAnimation: false,
           showServiceNodes: false,
+          showUnusedNodes: false,
           refreshRate: 15000
         },
         {
@@ -135,6 +143,7 @@ describe('GraphFilterState reducer', () => {
       showSecurity: false,
       showTrafficAnimation: false,
       showServiceNodes: false,
+      showUnusedNodes: false,
       refreshRate: 15000
     });
   });
@@ -150,6 +159,7 @@ describe('GraphFilterState reducer', () => {
           showSecurity: false,
           showTrafficAnimation: false,
           showServiceNodes: false,
+          showUnusedNodes: false,
           refreshRate: 15000
         },
         {
@@ -165,6 +175,7 @@ describe('GraphFilterState reducer', () => {
       showSecurity: false,
       showTrafficAnimation: false,
       showServiceNodes: false,
+      showUnusedNodes: false,
       refreshRate: 15000
     });
   });
@@ -180,6 +191,7 @@ describe('GraphFilterState reducer', () => {
           showSecurity: false,
           showTrafficAnimation: false,
           showServiceNodes: false,
+          showUnusedNodes: false,
           refreshRate: 15000
         },
         {
@@ -195,6 +207,7 @@ describe('GraphFilterState reducer', () => {
       showSecurity: true,
       showTrafficAnimation: false,
       showServiceNodes: false,
+      showUnusedNodes: false,
       refreshRate: 15000
     });
   });
@@ -210,6 +223,7 @@ describe('GraphFilterState reducer', () => {
           showSecurity: false,
           showTrafficAnimation: false,
           showServiceNodes: false,
+          showUnusedNodes: false,
           refreshRate: 15000
         },
         {
@@ -225,6 +239,7 @@ describe('GraphFilterState reducer', () => {
       showSecurity: false,
       showTrafficAnimation: true,
       showServiceNodes: false,
+      showUnusedNodes: false,
       refreshRate: 15000
     });
   });
@@ -240,6 +255,7 @@ describe('GraphFilterState reducer', () => {
           showSecurity: false,
           showTrafficAnimation: false,
           showServiceNodes: false,
+          showUnusedNodes: false,
           refreshRate: 15000
         },
         {
@@ -255,6 +271,39 @@ describe('GraphFilterState reducer', () => {
       showSecurity: false,
       showTrafficAnimation: false,
       showServiceNodes: true,
+      showUnusedNodes: false,
+      refreshRate: 15000
+    });
+  });
+  it('should handle TOGGLE_UNUSED_NODES', () => {
+    expect(
+      graphFilterState(
+        {
+          showLegend: false,
+          showNodeLabels: true,
+          showCircuitBreakers: false,
+          showVirtualServices: true,
+          showMissingSidecars: true,
+          showSecurity: false,
+          showTrafficAnimation: false,
+          showServiceNodes: false,
+          showUnusedNodes: false,
+          refreshRate: 15000
+        },
+        {
+          type: GraphFilterActionKeys.TOGGLE_UNUSED_NODES
+        }
+      )
+    ).toEqual({
+      showLegend: false,
+      showNodeLabels: true,
+      showCircuitBreakers: false,
+      showVirtualServices: true,
+      showMissingSidecars: true,
+      showSecurity: false,
+      showTrafficAnimation: false,
+      showServiceNodes: false,
+      showUnusedNodes: true,
       refreshRate: 15000
     });
   });
@@ -270,6 +319,7 @@ describe('GraphFilterState reducer', () => {
           showSecurity: false,
           showTrafficAnimation: false,
           showServiceNodes: false,
+          showUnusedNodes: false,
           refreshRate: 15000
         },
         {
@@ -286,6 +336,7 @@ describe('GraphFilterState reducer', () => {
       showSecurity: false,
       showTrafficAnimation: false,
       showServiceNodes: false,
+      showUnusedNodes: false,
       refreshRate: 10000
     });
   });

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -16,8 +16,9 @@ export interface GraphFilterState {
   readonly showVirtualServices: boolean;
   readonly showMissingSidecars: boolean;
   readonly showSecurity: boolean;
-  readonly showTrafficAnimation: boolean;
   readonly showServiceNodes: boolean;
+  readonly showTrafficAnimation: boolean;
+  readonly showUnusedNodes: boolean;
   readonly refreshRate: PollIntervalInMs;
 }
 

--- a/src/types/GraphFilterToolbar.ts
+++ b/src/types/GraphFilterToolbar.ts
@@ -3,5 +3,6 @@ import { GraphParamsType } from './Graph';
 export default interface GraphFilterToolbarType extends GraphParamsType {
   isLoading: boolean;
   showSecurity: boolean;
+  showUnusedNodes: boolean;
   handleRefreshClick: () => void;
 }


### PR DESCRIPTION
This allows for cleaner layouts and faster refresh when the option is off.  It is off by default in this PR.  We could easily change the default based on user feedback.

Option on:
![pr-1](https://user-images.githubusercontent.com/2104052/46490554-4f2bcf00-c7d6-11e8-9cce-8fb9897a78d3.jpg)

Option off:
![pr-2](https://user-images.githubusercontent.com/2104052/46490555-4f2bcf00-c7d6-11e8-8bdc-abc7ad04487e.jpg)
