### PR TITLE
Remove tslint errors from the 'start' process

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "prettier": "prettier --write \"src/**/*.{js,jsx,ts,tsx,json}\"",
     "lint": "tslint --project ./tsconfig.json",
     "lintfix": "tslint --fix --project ./tsconfig.json",
+    "lint:prod": "tslint --project ./tsconfig.json --config tslint.prod.json",
     "start": "if [ \"${KIALI_ENV}\" = \"production\" ]; then npm run start:prod; else npm run start:dev; fi",
     "start:kiali": "npm run copy-fonts && npm run copy-img && npm run build-css && REACT_APP_VERSION=$npm_package_version REACT_APP_NAME=$npm_package_name REACT_APP_GIT_HASH=$(git rev-parse HEAD) react-scripts-ts start",
     "start:dev": "npm run remove-rcue; REACT_APP_RCUE=false npm run start:kiali",
@@ -61,11 +62,11 @@
     "build": "if [ \"${KIALI_ENV}\" = \"production\" ]; then npm run build:prod; else npm run build:dev; fi",
     "build:dev": "npm run remove-rcue; REACT_APP_RCUE=false npm run build:kiali",
     "build:prod": "npm run restore-rcue; REACT_APP_RCUE=true npm run build:kiali",
-    "build:kiali": "npm run copy-fonts && npm run copy-img && npm run build-css && REACT_APP_VERSION=$npm_package_version REACT_APP_NAME=$npm_package_name REACT_APP_GIT_HASH=$(git rev-parse HEAD) react-scripts-ts build",
+    "build:kiali": "npm run lint:prod && npm run copy-fonts && npm run copy-img && npm run build-css && REACT_APP_VERSION=$npm_package_version REACT_APP_NAME=$npm_package_name REACT_APP_GIT_HASH=$(git rev-parse HEAD) react-scripts-ts build",
     "test": "react-scripts-ts test --env=jsdom __tests__",
     "itest": "export CI=true && react-scripts-ts test  __itests__",
     "set-snapshot-version": "npm-snapshot",
-    "precommit": "npm run prettier -- --list-different || (echo 'Above file(s) were modified by prettier, check them before commiting' && false)"
+    "precommit": "(npm run prettier -- --list-different || (echo 'Above file(s) were modified by prettier, check them before commiting' && false) ) && npm run lint:prod"
   },
   "devDependencies": {
     "@types/enzyme": "3.1.10",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,6 @@
     "noImplicitAny": false,
     "strictNullChecks": true,
     "suppressImplicitAnyIndexErrors": true,
-    "noUnusedLocals": true,
     "allowSyntheticDefaultImports": true
   },
   "exclude": [

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,6 @@
 {
     "extends": ["tslint-react", "tslint-no-circular-imports"],
+    "defaultSeverity": "warning",
     "rules": {
         "align": [
             true,

--- a/tslint.prod.json
+++ b/tslint.prod.json
@@ -1,0 +1,13 @@
+{
+  "extends": ["./tslint.json"],
+  "defaultSeverity": "error",
+  "rules": {
+    "no-debugger": true,
+    /**
+    * There is a strange issue when using no-unused-variable as part of the react build, so we are using it as separate
+    * tslint call, so please don't put that in tslint.json unless below issue gets fixed.
+    * https://github.com/Realytics/fork-ts-checker-webpack-plugin/issues/74
+    */
+    "no-unused-variable": true
+  }
+}


### PR DESCRIPTION
Instead of failing the build when using `yarn start`, it lets you work.
The normal lint will run automatically as part of the build and the precommit hook.

I'm not sure if we want to get this in, but please share your thoughts 