### PR TITLE
KIALI-1695 Performance issues on apps/svc/workload list pages

### DIFF
--- a/src/pages/AppList/AppListClass.tsx
+++ b/src/pages/AppList/AppListClass.tsx
@@ -10,19 +10,15 @@ import ItemDescription from './ItemDescription';
 
 export namespace AppListClass {
   export const getAppItems = (data: AppList, rateInterval: number): AppListItem[] => {
-    let appItems: AppListItem[] = [];
     if (data.applications) {
-      data.applications.forEach(app => {
-        const healthProm = API.getAppHealth(authentication(), data.namespace.name, app.name, rateInterval);
-        appItems.push({
-          namespace: data.namespace.name,
-          name: app.name,
-          istioSidecar: app.istioSidecar,
-          healthPromise: healthProm
-        });
-      });
+      return data.applications.map(app => ({
+        namespace: data.namespace.name,
+        name: app.name,
+        istioSidecar: app.istioSidecar,
+        healthPromise: API.getAppHealth(authentication(), data.namespace.name, app.name, rateInterval)
+      }));
     }
-    return appItems;
+    return [];
   };
 
   export const appLink = (namespace: string, app: string): string => {

--- a/src/pages/AppList/AppListComponent.tsx
+++ b/src/pages/AppList/AppListComponent.tsx
@@ -62,9 +62,8 @@ class AppListComponent extends ListComponent.Component<AppListComponentProps, Ap
   }
 
   rateIntervalChangedHandler = (key: number) => {
-    this.setState({ rateInterval: key });
     HistoryManager.setParam(URLParams.DURATION, String(key));
-    this.updateListItems();
+    this.setState({ rateInterval: key });
   };
 
   sortItemList(apps: AppListItem[], sortField: SortField<AppListItem>, isAscending: boolean) {
@@ -104,9 +103,8 @@ class AppListComponent extends ListComponent.Component<AppListComponentProps, Ap
 
       let appListItems: AppListItem[] = [];
       responses.forEach(response => {
-        appListItems = appListItems.concat(
-          AppListFilters.filterBy(AppListClass.getAppItems(response.data, rateInterval), filters)
-        );
+        AppListFilters.filterBy(response.data, filters);
+        appListItems = appListItems.concat(AppListClass.getAppItems(response.data, rateInterval));
       });
 
       AppListFilters.sortAppsItems(appListItems, this.state.currentSortField, this.state.isSortAscending).then(

--- a/src/pages/AppList/FiltersAndSorts.ts
+++ b/src/pages/AppList/FiltersAndSorts.ts
@@ -5,7 +5,7 @@ import {
   FilterType,
   presenceValues
 } from '../../types/Filters';
-import { AppListItem } from '../../types/AppList';
+import { AppListItem, AppList, AppOverview } from '../../types/AppList';
 import { SortField } from '../../types/SortFilters';
 import { removeDuplicatesArray } from '../../utils/Common';
 import { AppHealth, getRequestErrorsRatio } from '../../types/Health';
@@ -88,9 +88,8 @@ export namespace AppListFilters {
 
   /** Filter Method */
 
-  const filterByName = (items: AppListItem[], names: string[]): AppListItem[] => {
-    let result = items;
-    result = result.filter(item => {
+  const filterByName = (items: AppOverview[], names: string[]): AppOverview[] => {
+    return items.filter(item => {
       let appNameFiltered = true;
       if (names.length > 0) {
         appNameFiltered = false;
@@ -103,15 +102,13 @@ export namespace AppListFilters {
       }
       return appNameFiltered;
     });
-    return result;
   };
 
-  const filterByIstioSidecar = (items: AppListItem[], istioSidecar: boolean): AppListItem[] => {
+  const filterByIstioSidecar = (items: AppOverview[], istioSidecar: boolean): AppOverview[] => {
     return items.filter(item => item.istioSidecar === istioSidecar);
   };
 
-  export const filterBy = (items: AppListItem[], filters: ActiveFilter[]) => {
-    let results = items;
+  export const filterBy = (appsList: AppList, filters: ActiveFilter[]): void => {
     /** Get AppName filter */
     let appNamesSelected: string[] = filters
       .filter(activeFilter => activeFilter.category === 'App Name')
@@ -128,13 +125,12 @@ export namespace AppListFilters {
 
     if (istioSidecarValidationFilters.length > 0) {
       istioSidecar = istioSidecarValidationFilters[0].value === 'Present';
-      results = filterByIstioSidecar(results, istioSidecar);
+      appsList.applications = filterByIstioSidecar(appsList.applications, istioSidecar);
     }
 
     if (appNamesSelected.length > 0) {
-      results = filterByName(results, appNamesSelected);
+      appsList.applications = filterByName(appsList.applications, appNamesSelected);
     }
-    return results;
   };
 
   /** Sort Method */

--- a/src/pages/ServiceList/FiltersAndSorts.ts
+++ b/src/pages/ServiceList/FiltersAndSorts.ts
@@ -1,6 +1,6 @@
 import { ActiveFilter, FilterType, presenceValues } from '../../types/Filters';
 import { getRequestErrorsRatio, ServiceHealth } from '../../types/Health';
-import { ServiceListItem } from '../../types/ServiceList';
+import { ServiceListItem, ServiceList, ServiceOverview } from '../../types/ServiceList';
 import { SortField } from '../../types/SortFilters';
 import { removeDuplicatesArray } from '../../utils/Common';
 import NamespaceFilter from '../../components/Filters/NamespaceFilter';
@@ -77,13 +77,12 @@ export namespace ServiceListFilters {
 
   export const availableFilters: FilterType[] = [NamespaceFilter.create(), serviceNameFilter, istioFilter];
 
-  const filterByIstioSidecar = (items: ServiceListItem[], istioSidecar: boolean): ServiceListItem[] => {
+  const filterByIstioSidecar = (items: ServiceOverview[], istioSidecar: boolean): ServiceOverview[] => {
     return items.filter(item => item.istioSidecar === istioSidecar);
   };
 
-  const filterByName = (items: ServiceListItem[], names: string[]): ServiceListItem[] => {
-    let result = items;
-    result = result.filter(item => {
+  const filterByName = (items: ServiceOverview[], names: string[]): ServiceOverview[] => {
+    return items.filter(item => {
       let serviceNameFiltered = true;
       if (names.length > 0) {
         serviceNameFiltered = false;
@@ -96,11 +95,9 @@ export namespace ServiceListFilters {
       }
       return serviceNameFiltered;
     });
-    return result;
   };
 
-  export const filterBy = (items: ServiceListItem[], filters: ActiveFilter[]) => {
-    let results = items;
+  export const filterBy = (list: ServiceList, filters: ActiveFilter[]): void => {
     /** Get ServiceName filter */
     let serviceNamesSelected: string[] = filters
       .filter(activeFilter => activeFilter.category === 'Service Name')
@@ -113,17 +110,15 @@ export namespace ServiceListFilters {
     let istioSidecarValidationFilters: ActiveFilter[] = filters.filter(
       activeFilter => activeFilter.category === 'Istio Sidecar'
     );
-    let istioSidecar: boolean | undefined = undefined;
 
     if (istioSidecarValidationFilters.length > 0) {
-      istioSidecar = istioSidecarValidationFilters[0].value === 'Present';
-      results = filterByIstioSidecar(results, istioSidecar);
+      const istioSidecar = istioSidecarValidationFilters[0].value === 'Present';
+      list.services = filterByIstioSidecar(list.services, istioSidecar);
     }
 
     if (serviceNamesSelected.length > 0) {
-      results = filterByName(results, serviceNamesSelected);
+      list.services = filterByName(list.services, serviceNamesSelected);
     }
-    return results;
   };
 
   // Exported for test

--- a/src/pages/ServiceList/ServiceListComponent.tsx
+++ b/src/pages/ServiceList/ServiceListComponent.tsx
@@ -82,9 +82,8 @@ class ServiceListComponent extends ListComponent.Component<
   }
 
   rateIntervalChangedHandler = (key: number) => {
-    this.setState({ rateInterval: key });
     HistoryManager.setParam(URLParams.DURATION, String(key));
-    this.updateListItems();
+    this.setState({ rateInterval: key });
   };
 
   sortItemList(services: ServiceListItem[], sortField: SortField<ServiceListItem>, isAscending: boolean) {
@@ -118,19 +117,15 @@ class ServiceListComponent extends ListComponent.Component<
   }
 
   getServiceItem(data: ServiceList, rateInterval: number): ServiceListItem[] {
-    let serviceItems: ServiceListItem[] = [];
     if (data.services) {
-      data.services.forEach(service => {
-        const healthProm = API.getServiceHealth(authentication(), data.namespace.name, service.name, rateInterval);
-        serviceItems.push({
-          name: service.name,
-          istioSidecar: service.istioSidecar,
-          namespace: data.namespace.name,
-          healthPromise: healthProm
-        });
-      });
+      return data.services.map(service => ({
+        name: service.name,
+        istioSidecar: service.istioSidecar,
+        namespace: data.namespace.name,
+        healthPromise: API.getServiceHealth(authentication(), data.namespace.name, service.name, rateInterval)
+      }));
     }
-    return serviceItems;
+    return [];
   }
 
   fetchServices(namespaces: string[], filters: ActiveFilter[], rateInterval: number, resetPagination?: boolean) {
@@ -141,9 +136,8 @@ class ServiceListComponent extends ListComponent.Component<
 
       let serviceListItems: ServiceListItem[] = [];
       responses.forEach(response => {
-        serviceListItems = serviceListItems.concat(
-          ServiceListFilters.filterBy(this.getServiceItem(response.data, rateInterval), filters)
-        );
+        ServiceListFilters.filterBy(response.data, filters);
+        serviceListItems = serviceListItems.concat(this.getServiceItem(response.data, rateInterval));
       });
 
       ServiceListFilters.sortServices(serviceListItems, this.state.currentSortField, this.state.isSortAscending).then(

--- a/src/pages/WorkloadList/ItemDescription.tsx
+++ b/src/pages/WorkloadList/ItemDescription.tsx
@@ -4,8 +4,6 @@ import { IstioLogo } from '../../config';
 import { WorkloadIcons, WorkloadListItem, worloadLink } from '../../types/Workload';
 import { PfColors } from '../../components/Pf/PfColors';
 import { Link } from 'react-router-dom';
-import * as API from '../../services/Api';
-import { authentication } from '../../utils/Authentication';
 import { WorkloadHealth } from '../../types/Health';
 import { DisplayMode, HealthIndicator } from '../../components/Health/HealthIndicator';
 import ErrorRate from './ErrorRate';
@@ -25,34 +23,21 @@ class ItemDescription extends React.Component<ItemDescriptionProps, ItemDescript
     this.state = {
       health: undefined
     };
-    this.fetchHealth();
   }
 
   componentDidMount() {
-    this.fetchHealth();
+    this.onItemChanged(this.props.workloadItem);
   }
 
   componentDidUpdate(prevProps: ItemDescriptionProps) {
     if (this.props.workloadItem !== prevProps.workloadItem) {
-      this.fetchHealth();
+      this.onItemChanged(this.props.workloadItem);
     }
   }
 
-  fetchHealth = () => {
-    API.getWorkloadHealth(
-      authentication(),
-      this.props.workloadItem.namespace,
-      this.props.workloadItem.workload.name,
-      600
-    )
-      .then(response => {
-        this.setState({ health: response });
-      })
-      .catch(error => {
-        console.log(error);
-        this.setState({ health: undefined });
-      });
-  };
+  onItemChanged(item: WorkloadListItem) {
+    item.healthPromise.then(h => this.setState({ health: h })).catch(err => this.setState({ health: undefined }));
+  }
 
   render() {
     let namespace = this.props.workloadItem.namespace;

--- a/src/pages/WorkloadList/WorkloadListComponent.tsx
+++ b/src/pages/WorkloadList/WorkloadListComponent.tsx
@@ -67,9 +67,8 @@ class WorkloadListComponent extends ListComponent.Component<
   }
 
   rateIntervalChangedHandler = (key: number) => {
-    this.setState({ rateInterval: key });
     HistoryManager.setParam(URLParams.DURATION, String(key));
-    this.updateListItems();
+    this.setState({ rateInterval: key });
   };
 
   sortItemList(workloads: WorkloadListItem[], sortField: SortField<WorkloadListItem>, isAscending: boolean) {
@@ -98,22 +97,19 @@ class WorkloadListComponent extends ListComponent.Component<
   }
 
   getDeploymentItems = (data: WorkloadNamespaceResponse): WorkloadListItem[] => {
-    let workloadsItems: WorkloadListItem[] = [];
     if (data.workloads) {
-      data.workloads.forEach(deployment => {
-        workloadsItems.push({
-          namespace: data.namespace.name,
-          workload: deployment,
-          healthPromise: API.getWorkloadHealth(
-            authentication(),
-            data.namespace.name,
-            deployment.name,
-            this.state.rateInterval
-          )
-        });
-      });
+      return data.workloads.map(deployment => ({
+        namespace: data.namespace.name,
+        workload: deployment,
+        healthPromise: API.getWorkloadHealth(
+          authentication(),
+          data.namespace.name,
+          deployment.name,
+          this.state.rateInterval
+        )
+      }));
     }
-    return workloadsItems;
+    return [];
   };
 
   fetchWorkloads(namespaces: string[], filters: ActiveFilter[], resetPagination?: boolean) {
@@ -122,9 +118,8 @@ class WorkloadListComponent extends ListComponent.Component<
       const currentPage = resetPagination ? 1 : this.state.pagination.page;
       let workloadsItems: WorkloadListItem[] = [];
       responses.forEach(response => {
-        workloadsItems = workloadsItems.concat(
-          WorkloadListFilters.filterBy(this.getDeploymentItems(response.data), filters)
-        );
+        WorkloadListFilters.filterBy(response.data, filters);
+        workloadsItems = workloadsItems.concat(this.getDeploymentItems(response.data));
       });
       WorkloadListFilters.sortWorkloadsItems(
         workloadsItems,


### PR DESCRIPTION
- When rate interval changes, do not trigger an explicit reload as state change will trigger one (avoiding 2 reloads for the same action)
- When fetching backend data, filter it before calling for health (avoiding unnecessary health fetch)
- Remove incorrect health fetching from workloads 'ItemDescription' that triggered additional and incorrect queries

JIRA: https://issues.jboss.org/browse/KIALI-1695