### PR TITLE
[KIALI-1700] Move const loginHeaders to config.ts

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -63,6 +63,12 @@ const conf = {
       iconType: 'fa',
       linkText: 'Visit our web page'
     }
+  },
+  /**  Login configuration */
+  login: {
+    headers: {
+      'X-Auth-Type-Kiali-UI': '1'
+    }
   }
 };
 

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -14,6 +14,7 @@ import { ServiceList } from '../types/ServiceList';
 import { AppList } from '../types/AppList';
 import { App } from '../types/App';
 import { NodeParamsType, NodeType } from '../types/Graph';
+import { config } from '../config';
 
 export interface Response<T> {
   data: T;
@@ -21,7 +22,7 @@ export interface Response<T> {
 
 /**  Headers Definitions */
 
-const loginHeaders = { 'X-Auth-Type-Kiali-UI': '1' };
+const loginHeaders = config().login.headers;
 const authHeader = (auth: string) => ({ Authorization: auth });
 
 /**  Helpers to Requests */


### PR DESCRIPTION
**Description**

Moved const loginHeaders from `src/services/Api.ts` to `src/config.ts`.

**Issue reference**

https://issues.jboss.org/browse/KIALI-1700

**Backwards compatible?**

Yes