### PR TITLE
KIALI-1706 Initialize Cy on graph type change

### DIFF
--- a/src/actions/GraphActions.ts
+++ b/src/actions/GraphActions.ts
@@ -2,15 +2,14 @@ import { createAction } from 'typesafe-actions';
 import { CytoscapeClickEvent } from '../types/Graph';
 
 export enum GraphActionKeys {
-  GRAPH_NAMESPACE_CHANGED = 'GRAPH_NAMESPACE_CHANGED',
+  GRAPH_CHANGED = 'GRAPH_CHANGED',
   GRAPH_SIDE_PANEL_SHOW_INFO = 'GRAPH_SIDE_PANEL_SHOW_INFO'
 }
 
 // synchronous action creators
 export const GraphActions = {
-  namespaceChanged: createAction(GraphActionKeys.GRAPH_NAMESPACE_CHANGED, (newNamespace: string) => ({
-    type: GraphActionKeys.GRAPH_NAMESPACE_CHANGED,
-    newNamespace
+  changed: createAction(GraphActionKeys.GRAPH_CHANGED, () => ({
+    type: GraphActionKeys.GRAPH_CHANGED
   })),
   showSidePanelInfo: createAction(GraphActionKeys.GRAPH_SIDE_PANEL_SHOW_INFO, (event: CytoscapeClickEvent) => ({
     type: GraphActionKeys.GRAPH_SIDE_PANEL_SHOW_INFO,

--- a/src/components/GraphFilter/GraphFilterToolbar.tsx
+++ b/src/components/GraphFilter/GraphFilterToolbar.tsx
@@ -49,7 +49,7 @@ export default class GraphFilterToolbar extends React.PureComponent<GraphFilterT
   };
 
   handleNamespaceChange = (namespace: Namespace) => {
-    store.dispatch(GraphActions.namespaceChanged(namespace.name));
+    store.dispatch(GraphActions.changed());
     this.handleFilterChange({
       ...this.getGraphParams(),
       namespace
@@ -61,6 +61,7 @@ export default class GraphFilterToolbar extends React.PureComponent<GraphFilterT
   };
 
   handleGraphTypeChange = (graphType: GraphType) => {
+    store.dispatch(GraphActions.changed());
     this.handleFilterChange({
       ...this.getGraphParams(),
       graphType

--- a/src/reducers/GraphDataState.ts
+++ b/src/reducers/GraphDataState.ts
@@ -54,7 +54,7 @@ const graphDataState = (state: GraphState = INITIAL_GRAPH_STATE, action) => {
         graphReference: action.summaryTarget
       };
       break;
-    case GraphActionKeys.GRAPH_NAMESPACE_CHANGED:
+    case GraphActionKeys.GRAPH_CHANGED:
       newState.graphData = INITIAL_GRAPH_STATE.graphData;
       newState.graphDataTimestamp = INITIAL_GRAPH_STATE.graphDataTimestamp;
       newState.sidePanelInfo = INITIAL_GRAPH_STATE.sidePanelInfo;


### PR DESCRIPTION
- Because graph type and node type interact, make sure we reinit cy
  when fundamentally changing the graph (as we already do on namespace change)
