### PR TITLE
KIALI-1725: Standardize package.json via sort-package-json 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,61 @@
 {
   "name": "@kiali/kiali-ui",
   "version": "0.9.0",
+  "description": "React UI for [Kiali](https://github.com/kiali/kiali).",
+  "keywords": [
+    "istio service mesh",
+    "kiali",
+    "monitoring",
+    "observability",
+    "okd",
+    "openshift"
+  ],
+  "homepage-comment": [
+    "*Do not* change this setting if you wish run Kiali under different server root.",
+    "Instead update 'web_root' in Kaili config map in OpenShift console."
+  ],
+  "homepage": "./",
   "bugs": {
     "url": "https://issues.jboss.org/projects/KIALI/issues/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kiali/kiali-ui.git"
+  },
+  "license": "Apache-2.0",
+  "author": "Red Hat",
+  "main": "index.js",
+  "publishConfig": {
+    "access": "public"
+  },
+  "script-comments": [
+    "When adding new scripts, please be careful to using `npm run` instead of `yarn` for the tasks.",
+    "Some build environments we use do not include npm access, and installing yarn is not possible."
+  ],
+  "scripts": {
+    "backup-rcue": "if [ ! -f node_modules/patternfly/dist/css/rcue.css.copy ]; then mv node_modules/patternfly/dist/css/rcue.css node_modules/patternfly/dist/css/rcue.css.copy; touch node_modules/patternfly/dist/css/rcue.css; fi",
+    "backup-rcue-additions": "if [ ! -f node_modules/patternfly/dist/css/rcue-additions.css.copy ]; then mv node_modules/patternfly/dist/css/rcue-additions.css node_modules/patternfly/dist/css/rcue-additions.css.copy; touch node_modules/patternfly/dist/css/rcue-additions.css; fi",
+    "build": "if [ \"${KIALI_ENV}\" = \"production\" ]; then npm run build:prod; else npm run build:dev; fi",
+    "build-css": "node-sass-chokidar src/ --output-style compressed --include-path $npm_package_sassIncludes_src --include-path $npm_package_sassIncludes_patternfly --include-path $npm_package_sassIncludes_patternflyReact --include-path $npm_package_sassIncludes_bootstrap --include-path $npm_package_sassIncludes_fontAwesome -o src/",
+    "build:dev": "npm run remove-rcue; REACT_APP_RCUE=false npm run build:kiali",
+    "build:kiali": "npm run lint:prod && npm run copy-fonts && npm run copy-img && npm run build-css && REACT_APP_VERSION=$npm_package_version REACT_APP_NAME=$npm_package_name REACT_APP_GIT_HASH=$(git rev-parse HEAD) react-scripts-ts build",
+    "build:prod": "npm run restore-rcue; REACT_APP_RCUE=true npm run build:kiali",
+    "precommit": "(npm run prettier -- --list-different || (echo 'Above file(s) were modified by prettier, check them before commiting' && false) ) && npm run lint:prod",
+    "copy-fonts": "cp -r node_modules/patternfly/dist/fonts src/",
+    "copy-img": "cp -r node_modules/patternfly/dist/img src/",
+    "itest": "export CI=true && react-scripts-ts test  __itests__",
+    "lint": "tslint --project ./tsconfig.json",
+    "lint:prod": "tslint --project ./tsconfig.json --config tslint.prod.json",
+    "lintfix": "tslint --fix --project ./tsconfig.json",
+    "remove-rcue": "npm run backup-rcue ; npm run backup-rcue-additions",
+    "restore-rcue": "mv node_modules/patternfly/dist/css/rcue.css.copy node_modules/patternfly/dist/css/rcue.css && mv node_modules/patternfly/dist/css/rcue-additions.css.copy node_modules/patternfly/dist/css/rcue-additions.css",
+    "set-snapshot-version": "npm-snapshot",
+    "start": "if [ \"${KIALI_ENV}\" = \"production\" ]; then npm run start:prod; else npm run start:dev; fi",
+    "start:dev": "npm run remove-rcue; REACT_APP_RCUE=false npm run start:kiali",
+    "start:kiali": "npm run copy-fonts && npm run copy-img && npm run build-css && REACT_APP_VERSION=$npm_package_version REACT_APP_NAME=$npm_package_name REACT_APP_GIT_HASH=$(git rev-parse HEAD) react-scripts-ts start",
+    "start:prod": "npm run restore-rcue; REACT_APP_RCUE=true npm run start:kiali",
+    "test": "react-scripts-ts test --env=jsdom __tests__",
+    "prettier": "prettier --write \"src/**/*.{js,jsx,ts,tsx,json}\""
   },
   "dependencies": {
     "axios": "0.18.0",
@@ -13,8 +66,8 @@
     "cytoscape-cola": "2.2.3",
     "cytoscape-cose-bilkent": "4.0.0",
     "cytoscape-dagre": "2.2.1",
-    "deep-freeze": "0.0.1",
     "d3-format": "1.3.2",
+    "deep-freeze": "0.0.1",
     "js-yaml": "3.12.0",
     "lodash": "4.17.11",
     "patternfly": "3.48.3",
@@ -39,35 +92,6 @@
     "typestyle": "2.0.1",
     "url-search-params": "1.1.0",
     "visibilityjs": "2.0.2"
-  },
-  "script-comments": [
-    "When adding new scripts, please be careful to using `npm run` instead of `yarn` for the tasks.",
-    "Some build environments we use do not include npm access, and installing yarn is not possible."
-  ],
-  "scripts": {
-    "copy-fonts": "cp -r node_modules/patternfly/dist/fonts src/",
-    "copy-img": "cp -r node_modules/patternfly/dist/img src/",
-    "backup-rcue": "if [ ! -f node_modules/patternfly/dist/css/rcue.css.copy ]; then mv node_modules/patternfly/dist/css/rcue.css node_modules/patternfly/dist/css/rcue.css.copy; touch node_modules/patternfly/dist/css/rcue.css; fi",
-    "backup-rcue-additions": "if [ ! -f node_modules/patternfly/dist/css/rcue-additions.css.copy ]; then mv node_modules/patternfly/dist/css/rcue-additions.css node_modules/patternfly/dist/css/rcue-additions.css.copy; touch node_modules/patternfly/dist/css/rcue-additions.css; fi",
-    "remove-rcue": "npm run backup-rcue ; npm run backup-rcue-additions",
-    "restore-rcue": "mv node_modules/patternfly/dist/css/rcue.css.copy node_modules/patternfly/dist/css/rcue.css && mv node_modules/patternfly/dist/css/rcue-additions.css.copy node_modules/patternfly/dist/css/rcue-additions.css",
-    "build-css": "node-sass-chokidar src/ --output-style compressed --include-path $npm_package_sassIncludes_src --include-path $npm_package_sassIncludes_patternfly --include-path $npm_package_sassIncludes_patternflyReact --include-path $npm_package_sassIncludes_bootstrap --include-path $npm_package_sassIncludes_fontAwesome -o src/",
-    "prettier": "prettier --write \"src/**/*.{js,jsx,ts,tsx,json}\"",
-    "lint": "tslint --project ./tsconfig.json",
-    "lintfix": "tslint --fix --project ./tsconfig.json",
-    "lint:prod": "tslint --project ./tsconfig.json --config tslint.prod.json",
-    "start": "if [ \"${KIALI_ENV}\" = \"production\" ]; then npm run start:prod; else npm run start:dev; fi",
-    "start:kiali": "npm run copy-fonts && npm run copy-img && npm run build-css && REACT_APP_VERSION=$npm_package_version REACT_APP_NAME=$npm_package_name REACT_APP_GIT_HASH=$(git rev-parse HEAD) react-scripts-ts start",
-    "start:dev": "npm run remove-rcue; REACT_APP_RCUE=false npm run start:kiali",
-    "start:prod": "npm run restore-rcue; REACT_APP_RCUE=true npm run start:kiali",
-    "build": "if [ \"${KIALI_ENV}\" = \"production\" ]; then npm run build:prod; else npm run build:dev; fi",
-    "build:dev": "npm run remove-rcue; REACT_APP_RCUE=false npm run build:kiali",
-    "build:prod": "npm run restore-rcue; REACT_APP_RCUE=true npm run build:kiali",
-    "build:kiali": "npm run lint:prod && npm run copy-fonts && npm run copy-img && npm run build-css && REACT_APP_VERSION=$npm_package_version REACT_APP_NAME=$npm_package_name REACT_APP_GIT_HASH=$(git rev-parse HEAD) react-scripts-ts build",
-    "test": "react-scripts-ts test --env=jsdom __tests__",
-    "itest": "export CI=true && react-scripts-ts test  __itests__",
-    "set-snapshot-version": "npm-snapshot",
-    "precommit": "(npm run prettier -- --list-different || (echo 'Above file(s) were modified by prettier, check them before commiting' && false) ) && npm run lint:prod"
   },
   "devDependencies": {
     "@types/d3-format": "1.3.0",
@@ -99,37 +123,16 @@
     "tslint-no-circular-imports": "0.5.0",
     "typescript": "2.8.4"
   },
+  "engines": {
+    "node": ">=8.0.0 ",
+    "npm": ">=5.0.0 ",
+    "yarn": ">=1.0.0 "
+  },
   "sassIncludes": {
     "src": "src",
     "patternfly": "node_modules/patternfly/dist/sass",
     "patternflyReact": "node_modules/patternfly-react/dist/sass",
     "bootstrap": "node_modules/bootstrap-sass/assets/stylesheets",
     "fontAwesome": "node_modules/font-awesome-sass/assets/stylesheets"
-  },
-  "description": "React UI for [Kiali](https://github.com/kiali/kiali).",
-  "main": "index.js",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/kiali/kiali-ui.git"
-  },
-  "keywords": [
-    "istio service mesh",
-    "kiali",
-    "openshift",
-    "observability",
-    "monitoring"
-  ],
-  "author": "Red Hat",
-  "license": "Apache-2.0",
-  "homepage-comment": ["*Do not* change this setting if you wish run Kiali under different server root.",
-                       "Instead update 'web_root' in Kaili config map in OpenShift console."],
-  "homepage": "./",
-  "publishConfig": {
-    "access": "public"
-  },
-  "engines": {
-    "node": ">=8.0.0 ",
-    "npm": ">=5.0.0 ",
-    "yarn": ">=1.0.0 "
   }
 }


### PR DESCRIPTION

** Describe the change **
Standardize the package.json structure via: - https://www.npmjs.com/package/sort-package-json

This arose out of the need to see both _dependencies_ and _dev-dependencies_ near one another -- as their versions are linked -- most especially with the '@types/*' stuff for typescript definitions.
Obviously, others have already solved this issue.

** Issue reference **

https://issues.jboss.org/browse/KIALI-1725

** Backwards compatible? **
yes


