### PR TITLE
KIALI-1726: Move Logo images into their own config file 'logos.ts'

### DIFF
--- a/src/components/About/AboutUIModal.tsx
+++ b/src/components/About/AboutUIModal.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { AboutModal, Icon } from 'patternfly-react';
 import { Component } from '../../store/Store';
-import { config, KialiLogo } from '../../config';
+import { config } from '../../config';
+import { KialiLogo } from '../../logos';
 
 const KIALI_CORE_COMMIT_HASH = 'Kiali core commit hash';
 const KIALI_CORE_VERSION = 'Kiali core version';

--- a/src/components/Nav/Navigation.tsx
+++ b/src/components/Nav/Navigation.tsx
@@ -15,7 +15,7 @@ import { store } from '../../store/ConfigStore';
 import PfSpinnerContainer from '../../containers/PfSpinnerContainer';
 import * as API from '../../services/Api';
 import { authentication } from '../../utils/Authentication';
-import { KialiLogo } from '../../config';
+import { KialiLogo } from '../../logos';
 
 export const istioConfigTitle = 'Istio Config';
 export const servicesTitle = 'Services';

--- a/src/components/Pf/PfInfoCard.tsx
+++ b/src/components/Pf/PfInfoCard.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Icon } from 'patternfly-react';
-import { IstioLogo } from '../../config';
+import { IstioLogo } from '../../logos';
 
 interface CardProps {
   iconType?: string;

--- a/src/config.ts
+++ b/src/config.ts
@@ -75,9 +75,3 @@ const conf = {
 export const config = () => {
   return deepFreeze(conf) as typeof conf;
 };
-
-/** Istio logo */
-export const IstioLogo = require('./assets/img/istio-logo.svg');
-
-/** Kiali logo */
-export const KialiLogo = require('./assets/img/logo-alt.svg');

--- a/src/logos.ts
+++ b/src/logos.ts
@@ -1,0 +1,7 @@
+// All logo images go in here
+
+/** Istio logo */
+export const IstioLogo = require('./assets/img/istio-logo.svg');
+
+/** Kiali logo */
+export const KialiLogo = require('./assets/img/logo-alt.svg');

--- a/src/pages/AppDetails/AppInfo/AppDescription.tsx
+++ b/src/pages/AppDetails/AppInfo/AppDescription.tsx
@@ -5,8 +5,8 @@ import { DisplayMode, HealthIndicator } from '../../../components/Health/HealthI
 import { AppHealth } from '../../../types/Health';
 import { App, AppWorkload } from '../../../types/App';
 import { WorkloadIcon } from '../../../types/Workload';
-import { IstioLogo } from '../../../config';
 import { Link } from 'react-router-dom';
+import { IstioLogo } from '../../../logos';
 
 type AppDescriptionProps = {
   app: App;

--- a/src/pages/AppList/AppListClass.tsx
+++ b/src/pages/AppList/AppListClass.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { ListViewIcon, ListViewItem } from 'patternfly-react';
-import { IstioLogo } from '../../config';
 import { PfColors } from '../../components/Pf/PfColors';
 import { AppList, AppListItem } from '../../types/AppList';
 import * as API from '../../services/Api';
 import { authentication } from '../../utils/Authentication';
 import ItemDescription from './ItemDescription';
+import { IstioLogo } from '../../logos';
 
 export namespace AppListClass {
   export const getAppItems = (data: AppList, rateInterval: number): AppListItem[] => {

--- a/src/pages/ServiceList/ServiceListComponent.tsx
+++ b/src/pages/ServiceList/ServiceListComponent.tsx
@@ -16,7 +16,6 @@ import * as API from '../../services/Api';
 import Namespace from '../../types/Namespace';
 import { ActiveFilter } from '../../types/Filters';
 import { ServiceList, ServiceListItem } from '../../types/ServiceList';
-import { IstioLogo } from '../../config';
 import { authentication } from '../../utils/Authentication';
 import { CancelablePromise, makeCancelablePromise, removeDuplicatesArray } from '../../utils/Common';
 import RateIntervalToolbarItem from './RateIntervalToolbarItem';
@@ -28,6 +27,7 @@ import './ServiceListComponent.css';
 import { SortField } from '../../types/SortFilters';
 import { ListComponent } from '../../components/ListPage/ListComponent';
 import { HistoryManager, URLParams } from '../../app/History';
+import { IstioLogo } from '../../logos';
 
 interface ServiceListComponentState extends ListComponent.State<ServiceListItem> {
   rateInterval: number;

--- a/src/pages/WorkloadList/ItemDescription.tsx
+++ b/src/pages/WorkloadList/ItemDescription.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Badge, ListViewItem, ListViewIcon } from 'patternfly-react';
-import { IstioLogo } from '../../config';
+import { IstioLogo } from '../../logos';
 import { WorkloadIcon, WorkloadListItem, worloadLink } from '../../types/Workload';
 import { PfColors } from '../../components/Pf/PfColors';
 import { Link } from 'react-router-dom';


### PR DESCRIPTION
** Describe the change **

Application configuration and style/logo configuration are different separations of concerns and deserve different configurations. Also, this makes it easier for UxD to change.

** Issue reference **

https://issues.jboss.org/browse/KIALI-1726

** Backwards compatible? **
Yes
