### PR TITLE
KIALI-1728 Add Service Health to the Graph and Service Summary

### DIFF
--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -9,7 +9,14 @@ import { NamespaceValidations, Validations } from '../types/IstioObjects';
 import { ServiceDetailsInfo } from '../types/ServiceInfo';
 import JaegerInfo from '../types/JaegerInfo';
 import GrafanaInfo from '../types/GrafanaInfo';
-import { AppHealth, ServiceHealth, WorkloadHealth, NamespaceAppHealth, NamespaceWorkloadHealth } from '../types/Health';
+import {
+  AppHealth,
+  ServiceHealth,
+  WorkloadHealth,
+  NamespaceAppHealth,
+  NamespaceServiceHealth,
+  NamespaceWorkloadHealth
+} from '../types/Health';
 import { ServiceList } from '../types/ServiceList';
 import { AppList } from '../types/AppList';
 import { App } from '../types/App';
@@ -189,6 +196,26 @@ export const getNamespaceAppHealth = (
     const ret: NamespaceAppHealth = {};
     Object.keys(response.data).forEach(k => {
       ret[k] = AppHealth.fromJson(response.data[k], durationSec);
+    });
+    return ret;
+  });
+};
+
+export const getNamespaceServiceHealth = (
+  auth: string,
+  namespace: String,
+  durationSec: number
+): Promise<NamespaceServiceHealth> => {
+  const params: any = {
+    type: 'service'
+  };
+  if (durationSec) {
+    params.rateInterval = String(durationSec) + 's';
+  }
+  return newRequest('get', `api/namespaces/${namespace}/health`, params, {}, auth).then(response => {
+    const ret: NamespaceServiceHealth = {};
+    Object.keys(response.data).forEach(k => {
+      ret[k] = ServiceHealth.fromJson(response.data[k], durationSec);
     });
     return ret;
   });

--- a/src/types/Health.ts
+++ b/src/types/Health.ts
@@ -353,4 +353,5 @@ export const healthNotAvailable = (): AppHealth => {
 };
 
 export type NamespaceAppHealth = { [app: string]: AppHealth };
+export type NamespaceServiceHealth = { [service: string]: ServiceHealth };
 export type NamespaceWorkloadHealth = { [workload: string]: WorkloadHealth };


### PR DESCRIPTION
This requires server-side PR: https://github.com/kiali/kiali/pull/551.

@jmazzitelli The DNM label is there only because of the dependency on the server pr merge.