### PR TITLE
KIALI-1668 Remove VirtualService route/weight validations

### DIFF
--- a/src/pages/ServiceDetails/ServiceInfo/IstioObjectDetails/VirtualServiceRoute.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/IstioObjectDetails/VirtualServiceRoute.tsx
@@ -163,22 +163,8 @@ class VirtualServiceRoute extends React.Component<VirtualServiceRouteProps> {
   statusFrom(validation: ObjectValidation, routeItem: DestinationWeight, routeIndex: number, destinationIndex: number) {
     let checks = checkForPath(
       validation,
-      'spec/' +
-        this.props.kind.toLowerCase() +
-        '[' +
-        routeIndex +
-        ']/route[' +
-        destinationIndex +
-        ']/weight/' +
-        routeItem.weight
+      'spec/' + this.props.kind.toLowerCase() + '[' + routeIndex + ']/route[' + destinationIndex + ']/destination'
     );
-    checks.push(
-      ...checkForPath(
-        validation,
-        'spec/' + this.props.kind.toLowerCase() + '[' + routeIndex + ']/route[' + destinationIndex + ']/destination'
-      )
-    );
-
     let severity = highestSeverity(checks);
     let iconName = severity ? severityToIconName(severity) : 'ok';
     if (iconName !== 'ok') {


### PR DESCRIPTION
** Describe the change **

Due to Galley overlap validations, we can remove them from UI too since they are not going to happen anymore.

PR in backend: https://github.com/kiali/kiali/pull/555

** Issue reference **
https://issues.jboss.org/browse/KIALI-1668

