### PR TITLE
Customize persist key

### DIFF
--- a/src/store/ConfigStore.ts
+++ b/src/store/ConfigStore.ts
@@ -16,8 +16,11 @@ import { INITIAL_STATUS_STATE } from '../reducers/HelpDropdownState';
 
 declare const window;
 
+const webRoot = (window as any).WEB_ROOT ? (window as any).WEB_ROOT : undefined;
+const persistKey = webRoot && webRoot !== '/' ? webRoot.substring(1) : 'root';
+
 const persistConfig = {
-  key: 'root',
+  key: persistKey,
   storage: storage,
   whitelist: ['authentication', 'statusState', 'userSettings']
 };

--- a/src/store/ConfigStore.ts
+++ b/src/store/ConfigStore.ts
@@ -17,7 +17,7 @@ import { INITIAL_STATUS_STATE } from '../reducers/HelpDropdownState';
 declare const window;
 
 const webRoot = (window as any).WEB_ROOT ? (window as any).WEB_ROOT : undefined;
-const persistKey = webRoot && webRoot !== '/' ? webRoot.substring(1) : 'root';
+const persistKey = 'kiali-' + (webRoot && webRoot !== '/' ? webRoot.substring(1) : 'root');
 
 const persistConfig = {
   key: persistKey,


### PR DESCRIPTION
Signed-off-by: Chun Lin Yang <clyang@cn.ibm.com>

** Describe the change **

right now, the persist key is hard-coded as `root` in config. it may conflict with other application which is also using `persist:root` as key in localStorage. Since Kaili supports customize base path (fixed in https://github.com/kiali/kiali-ui/pull/569) so that we should get the WEB_ROOT instead of hardcode.

** Backwards compatible? **

Yes
