### PR TITLE
KIALI-1651 Add delete action on istio object page

### DIFF
--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Breadcrumb, Button, Col, Icon, Row } from 'patternfly-react';
+import { Breadcrumb, Button, Col, DropdownButton, Icon, MenuItem, MessageDialog, Row } from 'patternfly-react';
 import { Link, RouteComponentProps } from 'react-router-dom';
 import { FilterSelected } from '../../components/Filters/StatefulFilters';
 import { ActiveFilter } from '../../types/Filters';
@@ -28,6 +28,7 @@ const yaml = require('js-yaml');
 interface IstioConfigDetailsState {
   istioObjectDetails?: IstioConfigDetails;
   validations?: Validations;
+  showConfirmModal: boolean;
 }
 
 class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioConfigId>, IstioConfigDetailsState> {
@@ -35,7 +36,7 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
 
   constructor(props: RouteComponentProps<IstioConfigId>) {
     super(props);
-    this.state = {};
+    this.state = { showConfirmModal: false };
     this.aceEditorRef = React.createRef();
   }
 
@@ -160,6 +161,33 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
     }
   }
 
+  onAction = (key: string) => {
+    if (key === 'delete') {
+      this.setState({ showConfirmModal: true });
+    }
+  };
+
+  onDelete = () => {
+    this.hideConfirmModal();
+    API.deleteIstioConfigDetail(
+      authentication(),
+      this.props.match.params.namespace,
+      this.props.match.params.objectType,
+      this.props.match.params.object
+    )
+      .then(r => {
+        // Back to list page
+        ListPageLink.navigateTo(TargetPage.ISTIO, this.props.match.params.namespace);
+      })
+      .catch(error => {
+        MessageCenter.add(API.getErrorMsg('Could not delete IstioConfig details.', error));
+      });
+  };
+
+  hideConfirmModal = () => {
+    this.setState({ showConfirmModal: false });
+  };
+
   renderEditor = (routingObject: any) => {
     const yamlSource = yaml.safeDump(routingObject, safeDumpOptions);
     const aceValidations = parseAceValidations(yamlSource, this.state.validations);
@@ -167,9 +195,7 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
       <div className="container-fluid container-cards-pf">
         <Row className="row-cards-pf">
           <Col>
-            <Button onClick={this.fetchIstioObjectDetails} style={{ float: 'right' }}>
-              <Icon name="refresh" />
-            </Button>
+            {this.renderRightToolbar()}
             <h1>{this.props.match.params.objectType + ': ' + this.props.match.params.object}</h1>
             <AceEditor
               ref={this.aceEditorRef}
@@ -187,6 +213,39 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
           </Col>
         </Row>
       </div>
+    );
+  };
+
+  renderRightToolbar = () => {
+    let canDelete = false;
+    if (this.state.istioObjectDetails) {
+      canDelete = this.state.istioObjectDetails.permissions.delete;
+    }
+    return (
+      <span style={{ float: 'right' }}>
+        <Button onClick={this.fetchIstioObjectDetails}>
+          <Icon name="refresh" />
+        </Button>&nbsp;
+        <DropdownButton title="Actions" onSelect={this.onAction} pullRight={true}>
+          <MenuItem key="delete" eventKey="delete" disabled={!canDelete}>
+            Delete
+          </MenuItem>
+        </DropdownButton>
+        <MessageDialog
+          show={this.state.showConfirmModal}
+          primaryAction={this.onDelete}
+          secondaryAction={this.hideConfirmModal}
+          onHide={this.hideConfirmModal}
+          primaryActionButtonContent="Delete"
+          secondaryActionButtonContent="Cancel"
+          primaryActionButtonBsStyle="danger"
+          title="Confirm Delete"
+          primaryContent={`Are you sure you want to delete the Istio object '${this.props.match.params.object}'? `}
+          secondaryContent="It cannot be undone. Make sure this is something you really want to do!"
+          accessibleName="deleteConfirmationDialog"
+          accessibleDescription="deleteConfirmationDialogContent"
+        />
+      </span>
     );
   };
 
@@ -261,8 +320,8 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
           <IstioRuleInfo
             namespace={this.state.istioObjectDetails.namespace.name}
             rule={this.state.istioObjectDetails.rule}
-            onRefresh={this.fetchIstioObjectDetails}
             parsedSearch={parsedRuleParams}
+            rightToolbar={this.renderRightToolbar}
           />
         ) : (
           undefined

--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -226,7 +226,7 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
         <Button onClick={this.fetchIstioObjectDetails}>
           <Icon name="refresh" />
         </Button>&nbsp;
-        <DropdownButton title="Actions" onSelect={this.onAction} pullRight={true}>
+        <DropdownButton id="actions" title="Actions" onSelect={this.onAction} pullRight={true}>
           <MenuItem key="delete" eventKey="delete" disabled={!canDelete}>
             Delete
           </MenuItem>

--- a/src/pages/IstioConfigDetails/IstioRuleInfo.tsx
+++ b/src/pages/IstioConfigDetails/IstioRuleInfo.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ListView, ListViewItem, Row, Col, Table, Card, CardTitle, CardBody, Icon, Button } from 'patternfly-react';
+import { ListView, ListViewItem, Row, Col, Table, Card, CardTitle, CardBody, Icon } from 'patternfly-react';
 import * as resolve from 'table-resolver';
 import './IstioRuleInfo.css';
 import { aceOptions, safeDumpOptions, IstioRuleDetails, ParsedSearch } from '../../types/IstioConfigDetails';
@@ -14,8 +14,8 @@ const yaml = require('js-yaml');
 interface IstioRuleInfoProps {
   namespace: string;
   rule: IstioRuleDetails;
-  onRefresh: () => void;
   parsedSearch?: ParsedSearch;
+  rightToolbar: () => JSX.Element;
 }
 
 class IstioRuleInfo extends React.Component<IstioRuleInfoProps> {
@@ -181,10 +181,7 @@ class IstioRuleInfo extends React.Component<IstioRuleInfoProps> {
           <Row className="row-cards-pf">
             <Col>
               <div style={{ float: 'right' }}>
-                <Link to={{ pathname: this.getPathname() }}>Back to Rule</Link>{' '}
-                <Button onClick={this.props.onRefresh}>
-                  <Icon name="refresh" />
-                </Button>
+                <Link to={{ pathname: this.getPathname() }}>Back to Rule</Link> {this.props.rightToolbar()}
               </div>
               <h1>{dicIstioType[this.props.parsedSearch.type] + ': ' + this.props.parsedSearch.name}</h1>
               <AceEditor
@@ -208,6 +205,7 @@ class IstioRuleInfo extends React.Component<IstioRuleInfoProps> {
           <CardTitle>
             <strong>Rule: </strong>
             {this.props.rule.name}
+            {this.props.rightToolbar()}
           </CardTitle>
           <CardBody>
             <strong>Match: </strong>

--- a/src/pages/IstioConfigList/__tests__/IstioConfigListComponent.test.ts
+++ b/src/pages/IstioConfigList/__tests__/IstioConfigListComponent.test.ts
@@ -13,7 +13,8 @@ const mockIstioConfigList = (names: string[]): IstioConfigList => {
     serviceEntries: [],
     rules: [],
     quotaSpecs: [],
-    quotaSpecBindings: []
+    quotaSpecBindings: [],
+    permissions: {}
   };
   names.forEach(name => {
     testData.gateways.push({ name: name + '0', createdAt: 't0', resourceVersion: 'r0' });

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -51,7 +51,7 @@ const basicAuth = (username: string, password: string) => {
 };
 
 const newRequest = <T>(method: HTTP_VERBS, url: string, queryParams: any, data: any, auth?: AuthToken) => {
-  return new Promise<Response<Readonly<T>>>((resolve, reject) => {
+  return new Promise<Response<T>>((resolve, reject) => {
     axios({
       method: method,
       url: url,
@@ -118,6 +118,15 @@ export const getIstioConfigDetail = (
   object: string
 ): Promise<Response<IstioConfigDetails>> => {
   return newRequest(HTTP_VERBS.GET, urls.istioConfigDetail(namespace, objectType, object), {}, {}, auth);
+};
+
+export const deleteIstioConfigDetail = (
+  auth: AuthToken,
+  namespace: string,
+  objectType: string,
+  object: string
+): Promise<Response<string>> => {
+  return newRequest(HTTP_VERBS.DELETE, `api/namespaces/${namespace}/istio/${objectType}/${object}`, {}, {}, auth);
 };
 
 export const getServices = (auth: AuthToken, namespace: string): Promise<Response<ServiceList>> => {

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -126,7 +126,7 @@ export const deleteIstioConfigDetail = (
   objectType: string,
   object: string
 ): Promise<Response<string>> => {
-  return newRequest(HTTP_VERBS.DELETE, `api/namespaces/${namespace}/istio/${objectType}/${object}`, {}, {}, auth);
+  return newRequest(HTTP_VERBS.DELETE, urls.istioConfigDetail(namespace, objectType, object), {}, {}, auth);
 };
 
 export const getServices = (auth: AuthToken, namespace: string): Promise<Response<ServiceList>> => {

--- a/src/types/IstioConfigDetails.ts
+++ b/src/types/IstioConfigDetails.ts
@@ -3,6 +3,7 @@ import { DestinationPolicy, DestinationRule, RouteRule, VirtualService } from '.
 import { RuleAction } from './IstioRuleInfo';
 import { AceOptions } from 'react-ace';
 import { Gateway, QuotaSpec, QuotaSpecBinding, ServiceEntry } from './IstioConfigList';
+import { ResourcePermissions } from './Permissions';
 
 export interface IstioConfigId {
   namespace: string;
@@ -28,6 +29,7 @@ export interface IstioConfigDetails {
   rule: IstioRuleDetails;
   quotaSpec: QuotaSpec;
   quotaSpecBinding: QuotaSpecBinding;
+  permissions: ResourcePermissions;
 }
 
 export const aceOptions: AceOptions = {

--- a/src/types/IstioConfigList.ts
+++ b/src/types/IstioConfigList.ts
@@ -1,6 +1,7 @@
 import Namespace from './Namespace';
 import { DestinationRule, VirtualService } from './ServiceInfo';
 import { ObjectValidation } from './IstioObjects';
+import { ResourcePermissions } from './Permissions';
 
 export interface IstioConfigItem {
   namespace: string;
@@ -25,6 +26,7 @@ export interface IstioConfigList {
   rules: IstioRule[];
   quotaSpecs: QuotaSpec[];
   quotaSpecBindings: QuotaSpecBinding[];
+  permissions: { [key: string]: ResourcePermissions };
 }
 
 export interface Gateway {
@@ -166,7 +168,8 @@ export const filterByName = (unfiltered: IstioConfigList, names: string[]) => {
     serviceEntries: unfiltered.serviceEntries.filter(se => includeName(se.name, names)),
     rules: unfiltered.rules.filter(r => includeName(r.name, names)),
     quotaSpecs: unfiltered.quotaSpecs.filter(qs => includeName(qs.name, names)),
-    quotaSpecBindings: unfiltered.quotaSpecBindings.filter(qsb => includeName(qsb.name, names))
+    quotaSpecBindings: unfiltered.quotaSpecBindings.filter(qsb => includeName(qsb.name, names)),
+    permissions: unfiltered.permissions
   };
   return filtered;
 };

--- a/src/types/Permissions.ts
+++ b/src/types/Permissions.ts
@@ -1,0 +1,5 @@
+export interface ResourcePermissions {
+  create: boolean;
+  update: boolean;
+  delete: boolean;
+}


### PR DESCRIPTION
Related backend PR: https://github.com/kiali/kiali/pull/566

Also, we may want to have tasks for istio objects creation & update ready before we merge this one, as "delete" capability alone could sound a little weird?

JIRA: https://issues.jboss.org/browse/KIALI-1651