### PR TITLE
KIALI-1739 Counting last line for drawing validations into ACEditor

### DIFF
--- a/src/types/AceValidations.ts
+++ b/src/types/AceValidations.ts
@@ -137,7 +137,7 @@ const parseMarker = (
   }
 
   // Once start is calculated, we should calculate the end of the element iterating by rows
-  for (let row = aceMarker.startRow + 1; row < maxRows; row++) {
+  for (let row = aceMarker.startRow + 1; row < maxRows + 1; row++) {
     // It searches by row and column, starting from the beginning of the line
     for (let col = 0; col <= aceMarker.startCol; col++) {
       let endTokenPos = rowColToPos(yaml, row, col);


### PR DESCRIPTION
** Describe the change **

TLS validations weren fully shown as HTTP and TCP ones.

![screenshot of kiali console 5](https://user-images.githubusercontent.com/613814/47015127-72e30380-d14c-11e8-974c-05712b14cb2e.png)

** Issue reference **

https://issues.jboss.org/browse/KIALI-1739

This PR is adding TLS and TCP subset validations: https://github.com/kiali/kiali/pull/565

** Screenshot **

![screenshot of kiali console 6](https://user-images.githubusercontent.com/613814/47027147-307af000-d167-11e8-9ec5-aea7f9ba1eec.png)

