### PR TITLE
KIALI-1673 Removes systemError count dependency from the blue/red dot

### DIFF
--- a/src/components/MessageCenter/MessageCenterTrigger.tsx
+++ b/src/components/MessageCenter/MessageCenterTrigger.tsx
@@ -39,12 +39,8 @@ export default class MessageCenterTrigger extends React.PureComponent<PropsType,
       <li className="drawer-pf-trigger">
         <a className="nav-item-iconic" onClick={this.props.toggleMessageCenter}>
           <PfReact.Icon name="bell" />
-          {(this.props.systemErrorsCount > 0 || this.props.newMessagesCount > 0) && (
-            <PfReact.Badge
-              className={
-                'pf-badge-bodered' + (this.props.badgeDanger || this.props.systemErrorsCount > 0 ? ' badge-danger' : '')
-              }
-            >
+          {this.props.newMessagesCount > 0 && (
+            <PfReact.Badge className={'pf-badge-bodered' + (this.props.badgeDanger ? ' badge-danger' : '')}>
               {this.props.newMessagesCount > 0 ? this.props.newMessagesCount : ' '}
             </PfReact.Badge>
           )}


### PR DESCRIPTION
 The system errors make the yellow triangle appear, the blue dot appear
 on unread notifications and red dot appears when any unread error appears

 systemErrors are errors, they will make the red dot appear, but when read the
 dot will dissapear.

** Screenshot **

Before:
![before](https://issues.jboss.org/secure/attachment/12441207/mc.ogv.gif)

After:
![after](https://user-images.githubusercontent.com/3845764/47037585-e1bc5e80-d144-11e8-9f08-05a4aefd39cd.gif)
