### PR TITLE
KIALI-1767: Empty graph on clicking External Namespace Node

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -437,8 +437,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
           graphType: this.props.graphType,
           injectServiceNodes: this.props.injectServiceNodes
         };
-        console.warn('graphParams:');
-        console.dir(graphParams);
+        store.dispatch(NamespaceActions.setActiveNamespace(graphParams.namespace));
         this.context.router.history.push(makeNamespaceGraphUrlFromParams(graphParams));
       }
       return;


### PR DESCRIPTION
** Describe the change **
Double clicking (to zoom) on an external namespace node causes an empty graph screen.

** Issue reference **
https://issues.jboss.org/browse/KIALI-1767

** Backwards compatible? **
Yes

** Screenshot **

Add a screenshot of the UI after your changes.
