### PR TITLE
Remove 'parseFloat' and replace with Typescript 'Number()' for type safety

### DIFF
--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -58,11 +58,11 @@ export class GraphStyles {
     };
 
     const getEdgeColor = (ele: any): string => {
-      const rate = ele.data('rate') ? parseFloat(ele.data('rate')) : 0;
+      const rate = ele.data('rate') ? Number(ele.data('rate')) : 0;
       if (rate === 0 || ele.data('isUnused')) {
         return EdgeColorDead;
       }
-      const pErr = ele.data('percentErr') ? parseFloat(ele.data('percentErr')) : 0;
+      const pErr = ele.data('percentErr') ? Number(ele.data('percentErr')) : 0;
       if (pErr > REQUESTS_THRESHOLDS.failure) {
         return EdgeColorFailure;
       }
@@ -94,14 +94,14 @@ export class GraphStyles {
           break;
         }
         case EdgeLabelMode.RESPONSE_TIME_95TH_PERCENTILE: {
-          const responseTime = ele.data('responseTime') ? parseFloat(ele.data('responseTime')) : 0;
+          const responseTime = ele.data('responseTime') ? Number(ele.data('responseTime')) : 0;
           if (responseTime > 0) {
             content = responseTime < 1.0 ? (responseTime * 1000).toFixed(0) + 'ms' : responseTime.toFixed(2) + 's';
           }
           break;
         }
         case EdgeLabelMode.REQUESTS_PERCENT_OF_TOTAL: {
-          const percentRate = ele.data('percentRate') ? parseFloat(ele.data('percentRate')) : 0;
+          const percentRate = ele.data('percentRate') ? Number(ele.data('percentRate')) : 0;
           content = percentRate > 0 ? percentRate.toFixed(0) + '%' : '';
           break;
         }

--- a/src/pages/Graph/SummaryPanelEdge.tsx
+++ b/src/pages/Graph/SummaryPanelEdge.tsx
@@ -306,7 +306,7 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
   };
 
   private safeRate = (s: string) => {
-    return s === undefined ? 0.0 : parseFloat(s);
+    return s === undefined ? 0.0 : Number(s);
   };
 
   private renderLabels = (ns: string, ver: string) => (

--- a/src/utils/TrafficRate.ts
+++ b/src/utils/TrafficRate.ts
@@ -1,4 +1,4 @@
-const safeRate = (rate: string) => (rate ? parseFloat(rate) : 0.0);
+const safeRate = (rate: string) => (rate ? Number(rate) : 0.0);
 const RATE = 'rate';
 const RATE3XX = 'rate3XX';
 const RATE4XX = 'rate4XX';

--- a/tslint.json
+++ b/tslint.json
@@ -9,7 +9,8 @@
         ],
         "ban": [
             true,
-            "parseInt"
+            "parseInt",
+            "parseFloat"
         ],
         "class-name": true,
         "comment-format": [


### PR DESCRIPTION
** Describe the change **
It is typescript best practices to use `Number()` instead of `parseFloat()` as it is typesafe and won't parse garbage as `parseFloat` does.

For further information on this: https://stackoverflow.com/questions/23437476/in-typescript-how-to-check-if-a-string-is-numeric/23440948#23440948

** Backwards compatible? **
Yes

** Screenshot **

Non-UI change