### PR TITLE
KIALI-1769 Fix wrong type at variable assignment

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -47,7 +47,6 @@ type CytoscapeGraphType = {
   showUnusedNodes: boolean;
   onReady: (cytoscapeRef: any) => void;
   onClick: (event: CytoscapeClickEvent) => void;
-  onDoubleClick: (event: CytoscapeClickEvent) => void;
   refresh: any;
 };
 

--- a/src/components/CytoscapeGraph/__tests__/CytoscapeGraph.test.tsx
+++ b/src/components/CytoscapeGraph/__tests__/CytoscapeGraph.test.tsx
@@ -19,10 +19,6 @@ const testReadyHandler = () => {
   console.log('ready');
 };
 
-const testDoubleClickHandler = () => {
-  console.log('double click');
-};
-
 describe('CytoscapeGraph component test', () => {
   it('should set correct elements data', () => {
     const myLayout: Layout = { name: 'breadthfirst' };
@@ -37,7 +33,6 @@ describe('CytoscapeGraph component test', () => {
         graphDuration={myDuration}
         edgeLabelMode={myEdgeLabelMode}
         onClick={testClickHandler}
-        onDoubleClick={testDoubleClickHandler}
         onReady={testReadyHandler}
         refresh={testClickHandler}
         showNodeLabels={true}

--- a/src/pages/Graph/GraphRouteHandler.tsx
+++ b/src/pages/Graph/GraphRouteHandler.tsx
@@ -86,7 +86,7 @@ export class GraphRouteHandler extends React.Component<RouteComponentProps<Graph
       GraphRouteHandler.graphParamsDefaults.graphType
     );
     const _injectServiceNodes = urlParams.has('injectServiceNodes')
-      ? (urlParams.get('injectServiceNodes') as boolean)
+      ? urlParams.get('injectServiceNodes') === 'true'
       : GraphRouteHandler.graphParamsDefaults.injectServiceNodes;
 
     return {


### PR DESCRIPTION
Typescript type assertions don't cast the type of the variables. The
_injectServiceNodes variable was being assigned a string instead of a
boolean. This was causing a test failure in
GraphSettingsContainer.constructor, leading to toggling the "Services
nodes" display option.

This ensures that the rigth value and type is assigned to
_injectServiceNodes.

https://issues.jboss.org/browse/KIALI-1769