### PR TITLE
KIALI-1587 Jaeger link tries to open popup

### DIFF
--- a/src/actions/GrafanaActions.ts
+++ b/src/actions/GrafanaActions.ts
@@ -1,0 +1,38 @@
+import { createAction } from 'typesafe-actions';
+import { GrafanaInfo } from '../store/Store';
+import * as API from '../services/Api';
+import { MessageCenterActions } from './MessageCenterActions';
+import { MessageType } from '../types/MessageCenter';
+
+export enum GrafanaActionKeys {
+  SET_INFO = 'SET_INFO'
+}
+
+export const GrafanaActions = {
+  setinfo: createAction(GrafanaActionKeys.SET_INFO, (grafanaInfo: GrafanaInfo) => ({
+    type: GrafanaActionKeys.SET_INFO,
+    url: grafanaInfo.url,
+    serviceDashboardPath: grafanaInfo.serviceDashboardPath,
+    workloadDashboardPath: grafanaInfo.workloadDashboardPath,
+    varNamespace: grafanaInfo.varNamespace,
+    varService: grafanaInfo.varService,
+    varWorkload: grafanaInfo.varWorkload
+  })),
+  getInfo: (auth: string) => {
+    return dispatch => {
+      API.getGrafanaInfo(auth)
+        .then(response => {
+          dispatch(GrafanaActions.setinfo(response.data));
+        })
+        .catch(error => {
+          dispatch(
+            MessageCenterActions.addMessage(
+              API.getErrorMsg('Error fetching Grafana Info.', error),
+              'default',
+              MessageType.WARNING
+            )
+          );
+        });
+    };
+  }
+};

--- a/src/actions/LoginActions.ts
+++ b/src/actions/LoginActions.ts
@@ -3,6 +3,7 @@ import * as API from '../services/Api';
 import { Token } from '../store/Store';
 import { HTTP_CODES } from '../types/Common';
 import { HelpDropdownActions } from './HelpDropdownActions';
+import { GrafanaActions } from './GrafanaActions';
 import { config } from '../config';
 
 export enum LoginActionKeys {
@@ -81,6 +82,7 @@ export const LoginActions = {
                 )
               );
               dispatch(HelpDropdownActions.refresh());
+              dispatch(GrafanaActions.getInfo(auth));
             },
             error => {
               /** Logout user */

--- a/src/components/About/AboutUIModal.tsx
+++ b/src/components/About/AboutUIModal.tsx
@@ -48,7 +48,13 @@ class AboutUIModal extends React.Component<AboutUIModalProps, AboutUIModalState>
           <h3>Components </h3>
           {this.props.components &&
             this.props.components.map(component => (
-              <AboutModal.VersionItem key={component.name} label={component.name} versionText={component.version} />
+              <AboutModal.VersionItem
+                key={component.name}
+                label={component.name}
+                versionText={`${component.version ? component.version : ''} ${
+                  component.url ? `(${component.url})` : ''
+                }`}
+              />
             ))}
         </AboutModal.Versions>
         {this.renderWebsiteLink()}

--- a/src/components/Metrics/__tests__/Metrics.test.tsx
+++ b/src/components/Metrics/__tests__/Metrics.test.tsx
@@ -103,6 +103,14 @@ describe('Metrics for a service', () => {
         object="svc"
         objectType={MetricsObjectTypes.SERVICE}
         direction={MetricsDirection.INBOUND}
+        grafanaInfo={{
+          url: 'http://172.30.139.113:3000',
+          serviceDashboardPath: '/dashboard/db/istio-dashboard',
+          workloadDashboardPath: '/dashboard/db/istio-dashboard',
+          varService: 'var-service',
+          varNamespace: 'var-namespace',
+          varWorkload: 'var-workload'
+        }}
       />
     );
     expect(wrapper).toMatchSnapshot();
@@ -116,22 +124,6 @@ describe('Metrics for a service', () => {
           expect(mounted!.find('.card-pf-body')).toHaveLength(1);
           mounted!.find('.card-pf-body').forEach(pfCard => expect(pfCard.children().length === 0));
         })
-        .catch(err => done.fail(err)),
-      mockGrafanaInfo({
-        url: 'http://172.30.139.113:3000',
-        serviceDashboardPath: '/dashboard/db/istio-dashboard',
-        varService: 'var-service'
-      })
-        .then(() => {
-          mounted!.update();
-          expect(mounted!.find('#grafana-link > a').map(div => div.getElement().props)).toEqual([
-            {
-              children: 'View in Grafana',
-              href: 'http://172.30.139.113:3000/dashboard/db/istio-dashboard?var-service=svc.ns.svc.cluster.local',
-              target: '_blank'
-            }
-          ]);
-        })
         .catch(err => done.fail(err))
     ];
     Promise.all(allMocksDone).then(() => done());
@@ -141,6 +133,14 @@ describe('Metrics for a service', () => {
         object="svc"
         objectType={MetricsObjectTypes.SERVICE}
         direction={MetricsDirection.INBOUND}
+        grafanaInfo={{
+          url: 'http://172.30.139.113:3000',
+          serviceDashboardPath: '/dashboard/db/istio-dashboard',
+          workloadDashboardPath: '/dashboard/db/istio-dashboard',
+          varService: 'var-service',
+          varNamespace: 'var-namespace',
+          varWorkload: 'var-workload'
+        }}
       />
     );
   });
@@ -163,8 +163,7 @@ describe('Metrics for a service', () => {
             mounted!.update();
             expect(mounted!.find('LineChart')).toHaveLength(4);
           })
-          .catch(err => done.fail(err)),
-        mockGrafanaInfo({})
+          .catch(err => done.fail(err))
       ];
       Promise.all(allMocksDone).then(() => done());
       mounted = mount(
@@ -173,6 +172,14 @@ describe('Metrics for a service', () => {
           object="svc"
           objectType={MetricsObjectTypes.SERVICE}
           direction={MetricsDirection.INBOUND}
+          grafanaInfo={{
+            url: 'http://172.30.139.113:3000',
+            serviceDashboardPath: '/dashboard/db/istio-dashboard',
+            workloadDashboardPath: '/dashboard/db/istio-dashboard',
+            varService: 'var-service',
+            varNamespace: 'var-namespace',
+            varWorkload: 'var-workload'
+          }}
         />
       );
     },
@@ -191,13 +198,20 @@ describe('Inbound Metrics for a workload', () => {
   });
 
   it('renders initial layout', () => {
-    mockGrafanaInfo({});
     const wrapper = shallow(
       <Metrics
         namespace="ns"
         object="svc"
         objectType={MetricsObjectTypes.WORKLOAD}
         direction={MetricsDirection.INBOUND}
+        grafanaInfo={{
+          url: 'http://172.30.139.113:3000',
+          serviceDashboardPath: '/dashboard/db/istio-dashboard',
+          workloadDashboardPath: '/dashboard/db/istio-dashboard',
+          varService: 'var-service',
+          varNamespace: 'var-namespace',
+          varWorkload: 'var-workload'
+        }}
       />
     );
     expect(wrapper).toMatchSnapshot();
@@ -211,25 +225,6 @@ describe('Inbound Metrics for a workload', () => {
           expect(mounted!.find('.card-pf-body')).toHaveLength(1);
           mounted!.find('.card-pf-body').forEach(pfCard => expect(pfCard.children().length === 0));
         })
-        .catch(err => done.fail(err)),
-      mockGrafanaInfo({
-        url: 'http://172.30.139.113:3000',
-        serviceDashboardPath: '/dashboard/db/istio-dashboard',
-        workloadDashboardPath: '/dashboard/db/istio-dashboard',
-        varService: 'var-service',
-        varNamespace: 'var-namespace',
-        varWorkload: 'var-workload'
-      })
-        .then(() => {
-          mounted!.update();
-          expect(mounted!.find('#grafana-link > a').map(div => div.getElement().props)).toEqual([
-            {
-              children: 'View in Grafana',
-              href: 'http://172.30.139.113:3000/dashboard/db/istio-dashboard?var-namespace=ns&var-workload=svc',
-              target: '_blank'
-            }
-          ]);
-        })
         .catch(err => done.fail(err))
     ];
     Promise.all(allMocksDone).then(() => done());
@@ -239,6 +234,14 @@ describe('Inbound Metrics for a workload', () => {
         object="svc"
         objectType={MetricsObjectTypes.WORKLOAD}
         direction={MetricsDirection.INBOUND}
+        grafanaInfo={{
+          url: 'http://172.30.139.113:3000',
+          serviceDashboardPath: '/dashboard/db/istio-dashboard',
+          workloadDashboardPath: '/dashboard/db/istio-dashboard',
+          varService: 'var-service',
+          varNamespace: 'var-namespace',
+          varWorkload: 'var-workload'
+        }}
       />
     );
   });
@@ -261,8 +264,7 @@ describe('Inbound Metrics for a workload', () => {
             mounted!.update();
             expect(mounted!.find('LineChart')).toHaveLength(4);
           })
-          .catch(err => done.fail(err)),
-        mockGrafanaInfo({})
+          .catch(err => done.fail(err))
       ];
       Promise.all(allMocksDone).then(() => done());
       mounted = mount(
@@ -271,6 +273,14 @@ describe('Inbound Metrics for a workload', () => {
           object="svc"
           objectType={MetricsObjectTypes.WORKLOAD}
           direction={MetricsDirection.INBOUND}
+          grafanaInfo={{
+            url: 'http://172.30.139.113:3000',
+            serviceDashboardPath: '/dashboard/db/istio-dashboard',
+            workloadDashboardPath: '/dashboard/db/istio-dashboard',
+            varService: 'var-service',
+            varNamespace: 'var-namespace',
+            varWorkload: 'var-workload'
+          }}
         />
       );
     },
@@ -289,13 +299,20 @@ describe('Outbound Metrics for a workload', () => {
   });
 
   it('renders initial layout', () => {
-    mockGrafanaInfo({});
     const wrapper = shallow(
       <Metrics
         namespace="ns"
         object="svc"
         objectType={MetricsObjectTypes.WORKLOAD}
         direction={MetricsDirection.INBOUND}
+        grafanaInfo={{
+          url: 'http://172.30.139.113:3000',
+          serviceDashboardPath: '/dashboard/db/istio-dashboard',
+          workloadDashboardPath: '/dashboard/db/istio-dashboard',
+          varService: 'var-service',
+          varNamespace: 'var-namespace',
+          varWorkload: 'var-workload'
+        }}
       />
     );
     expect(wrapper).toMatchSnapshot();
@@ -309,25 +326,6 @@ describe('Outbound Metrics for a workload', () => {
           expect(mounted!.find('.card-pf-body')).toHaveLength(1);
           mounted!.find('.card-pf-body').forEach(pfCard => expect(pfCard.children().length === 0));
         })
-        .catch(err => done.fail(err)),
-      mockGrafanaInfo({
-        url: 'http://172.30.139.113:3000',
-        serviceDashboardPath: '/dashboard/db/istio-dashboard',
-        workloadDashboardPath: '/dashboard/db/istio-dashboard',
-        varService: 'var-service',
-        varNamespace: 'var-namespace',
-        varWorkload: 'var-workload'
-      })
-        .then(() => {
-          mounted!.update();
-          expect(mounted!.find('#grafana-link > a').map(div => div.getElement().props)).toEqual([
-            {
-              children: 'View in Grafana',
-              href: 'http://172.30.139.113:3000/dashboard/db/istio-dashboard?var-namespace=ns&var-workload=svc',
-              target: '_blank'
-            }
-          ]);
-        })
         .catch(err => done.fail(err))
     ];
     Promise.all(allMocksDone).then(() => done());
@@ -337,6 +335,14 @@ describe('Outbound Metrics for a workload', () => {
         object="svc"
         objectType={MetricsObjectTypes.WORKLOAD}
         direction={MetricsDirection.INBOUND}
+        grafanaInfo={{
+          url: 'http://172.30.139.113:3000',
+          serviceDashboardPath: '/dashboard/db/istio-dashboard',
+          workloadDashboardPath: '/dashboard/db/istio-dashboard',
+          varService: 'var-service',
+          varNamespace: 'var-namespace',
+          varWorkload: 'var-workload'
+        }}
       />
     );
   });
@@ -359,8 +365,7 @@ describe('Outbound Metrics for a workload', () => {
             mounted!.update();
             expect(mounted!.find('LineChart')).toHaveLength(4);
           })
-          .catch(err => done.fail(err)),
-        mockGrafanaInfo({})
+          .catch(err => done.fail(err))
       ];
       Promise.all(allMocksDone).then(() => done());
       mounted = mount(
@@ -369,6 +374,14 @@ describe('Outbound Metrics for a workload', () => {
           object="svc"
           objectType={MetricsObjectTypes.WORKLOAD}
           direction={MetricsDirection.OUTBOUND}
+          grafanaInfo={{
+            url: 'http://172.30.139.113:3000',
+            serviceDashboardPath: '/dashboard/db/istio-dashboard',
+            workloadDashboardPath: '/dashboard/db/istio-dashboard',
+            varService: 'var-service',
+            varNamespace: 'var-namespace',
+            varWorkload: 'var-workload'
+          }}
         />
       );
     },

--- a/src/components/Metrics/__tests__/__snapshots__/Metrics.test.tsx.snap
+++ b/src/components/Metrics/__tests__/__snapshots__/Metrics.test.tsx.snap
@@ -6,6 +6,16 @@ ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Metrics
     direction={0}
+    grafanaInfo={
+      Object {
+        "serviceDashboardPath": "/dashboard/db/istio-dashboard",
+        "url": "http://172.30.139.113:3000",
+        "varNamespace": "var-namespace",
+        "varService": "var-service",
+        "varWorkload": "var-workload",
+        "workloadDashboardPath": "/dashboard/db/istio-dashboard",
+      }
+    }
     isPageVisible={true}
     namespace="ns"
     object="svc"
@@ -52,6 +62,16 @@ ShallowWrapper {
                 />
               </div>
             </div>
+            <span
+              id="grafana-link"
+            >
+              <a
+                href="http://172.30.139.113:3000/dashboard/db/istio-dashboard?var-namespace=ns&var-workload=svc"
+                target="_blank"
+              >
+                View in Grafana
+              </a>
+            </span>
           </div>
         </div>,
       ],
@@ -96,6 +116,16 @@ ShallowWrapper {
                 />
               </div>
             </div>
+            <span
+              id="grafana-link"
+            >
+              <a
+                href="http://172.30.139.113:3000/dashboard/db/istio-dashboard?var-namespace=ns&var-workload=svc"
+                target="_blank"
+              >
+                View in Grafana
+              </a>
+            </span>
           </div>,
           "className": "card-pf",
         },
@@ -117,7 +147,16 @@ ShallowWrapper {
                   />
                 </div>
               </div>,
-              undefined,
+              <span
+                id="grafana-link"
+              >
+                <a
+                  href="http://172.30.139.113:3000/dashboard/db/istio-dashboard?var-namespace=ns&var-workload=svc"
+                  target="_blank"
+                >
+                  View in Grafana
+                </a>
+              </span>,
             ],
             "className": "row row-cards-pf",
           },
@@ -179,7 +218,35 @@ ShallowWrapper {
               },
               "type": "div",
             },
-            undefined,
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": <a
+                  href="http://172.30.139.113:3000/dashboard/db/istio-dashboard?var-namespace=ns&var-workload=svc"
+                  target="_blank"
+                >
+                  View in Grafana
+                </a>,
+                "id": "grafana-link",
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": "View in Grafana",
+                  "href": "http://172.30.139.113:3000/dashboard/db/istio-dashboard?var-namespace=ns&var-workload=svc",
+                  "target": "_blank",
+                },
+                "ref": null,
+                "rendered": "View in Grafana",
+                "type": "a",
+              },
+              "type": "span",
+            },
           ],
           "type": "div",
         },
@@ -223,6 +290,16 @@ ShallowWrapper {
                   />
                 </div>
               </div>
+              <span
+                id="grafana-link"
+              >
+                <a
+                  href="http://172.30.139.113:3000/dashboard/db/istio-dashboard?var-namespace=ns&var-workload=svc"
+                  target="_blank"
+                >
+                  View in Grafana
+                </a>
+              </span>
             </div>
           </div>,
         ],
@@ -267,6 +344,16 @@ ShallowWrapper {
                   />
                 </div>
               </div>
+              <span
+                id="grafana-link"
+              >
+                <a
+                  href="http://172.30.139.113:3000/dashboard/db/istio-dashboard?var-namespace=ns&var-workload=svc"
+                  target="_blank"
+                >
+                  View in Grafana
+                </a>
+              </span>
             </div>,
             "className": "card-pf",
           },
@@ -288,7 +375,16 @@ ShallowWrapper {
                     />
                   </div>
                 </div>,
-                undefined,
+                <span
+                  id="grafana-link"
+                >
+                  <a
+                    href="http://172.30.139.113:3000/dashboard/db/istio-dashboard?var-namespace=ns&var-workload=svc"
+                    target="_blank"
+                  >
+                    View in Grafana
+                  </a>
+                </span>,
               ],
               "className": "row row-cards-pf",
             },
@@ -350,7 +446,35 @@ ShallowWrapper {
                 },
                 "type": "div",
               },
-              undefined,
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": <a
+                    href="http://172.30.139.113:3000/dashboard/db/istio-dashboard?var-namespace=ns&var-workload=svc"
+                    target="_blank"
+                  >
+                    View in Grafana
+                  </a>,
+                  "id": "grafana-link",
+                },
+                "ref": null,
+                "rendered": Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": "View in Grafana",
+                    "href": "http://172.30.139.113:3000/dashboard/db/istio-dashboard?var-namespace=ns&var-workload=svc",
+                    "target": "_blank",
+                  },
+                  "ref": null,
+                  "rendered": "View in Grafana",
+                  "type": "a",
+                },
+                "type": "span",
+              },
             ],
             "type": "div",
           },
@@ -376,6 +500,16 @@ ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Metrics
     direction={0}
+    grafanaInfo={
+      Object {
+        "serviceDashboardPath": "/dashboard/db/istio-dashboard",
+        "url": "http://172.30.139.113:3000",
+        "varNamespace": "var-namespace",
+        "varService": "var-service",
+        "varWorkload": "var-workload",
+        "workloadDashboardPath": "/dashboard/db/istio-dashboard",
+      }
+    }
     isPageVisible={true}
     namespace="ns"
     object="svc"
@@ -422,6 +556,16 @@ ShallowWrapper {
                 />
               </div>
             </div>
+            <span
+              id="grafana-link"
+            >
+              <a
+                href="http://172.30.139.113:3000/dashboard/db/istio-dashboard?var-service=svc.ns.svc.cluster.local"
+                target="_blank"
+              >
+                View in Grafana
+              </a>
+            </span>
           </div>
         </div>,
       ],
@@ -466,6 +610,16 @@ ShallowWrapper {
                 />
               </div>
             </div>
+            <span
+              id="grafana-link"
+            >
+              <a
+                href="http://172.30.139.113:3000/dashboard/db/istio-dashboard?var-service=svc.ns.svc.cluster.local"
+                target="_blank"
+              >
+                View in Grafana
+              </a>
+            </span>
           </div>,
           "className": "card-pf",
         },
@@ -487,7 +641,16 @@ ShallowWrapper {
                   />
                 </div>
               </div>,
-              undefined,
+              <span
+                id="grafana-link"
+              >
+                <a
+                  href="http://172.30.139.113:3000/dashboard/db/istio-dashboard?var-service=svc.ns.svc.cluster.local"
+                  target="_blank"
+                >
+                  View in Grafana
+                </a>
+              </span>,
             ],
             "className": "row row-cards-pf",
           },
@@ -549,7 +712,35 @@ ShallowWrapper {
               },
               "type": "div",
             },
-            undefined,
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": <a
+                  href="http://172.30.139.113:3000/dashboard/db/istio-dashboard?var-service=svc.ns.svc.cluster.local"
+                  target="_blank"
+                >
+                  View in Grafana
+                </a>,
+                "id": "grafana-link",
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": "View in Grafana",
+                  "href": "http://172.30.139.113:3000/dashboard/db/istio-dashboard?var-service=svc.ns.svc.cluster.local",
+                  "target": "_blank",
+                },
+                "ref": null,
+                "rendered": "View in Grafana",
+                "type": "a",
+              },
+              "type": "span",
+            },
           ],
           "type": "div",
         },
@@ -593,6 +784,16 @@ ShallowWrapper {
                   />
                 </div>
               </div>
+              <span
+                id="grafana-link"
+              >
+                <a
+                  href="http://172.30.139.113:3000/dashboard/db/istio-dashboard?var-service=svc.ns.svc.cluster.local"
+                  target="_blank"
+                >
+                  View in Grafana
+                </a>
+              </span>
             </div>
           </div>,
         ],
@@ -637,6 +838,16 @@ ShallowWrapper {
                   />
                 </div>
               </div>
+              <span
+                id="grafana-link"
+              >
+                <a
+                  href="http://172.30.139.113:3000/dashboard/db/istio-dashboard?var-service=svc.ns.svc.cluster.local"
+                  target="_blank"
+                >
+                  View in Grafana
+                </a>
+              </span>
             </div>,
             "className": "card-pf",
           },
@@ -658,7 +869,16 @@ ShallowWrapper {
                     />
                   </div>
                 </div>,
-                undefined,
+                <span
+                  id="grafana-link"
+                >
+                  <a
+                    href="http://172.30.139.113:3000/dashboard/db/istio-dashboard?var-service=svc.ns.svc.cluster.local"
+                    target="_blank"
+                  >
+                    View in Grafana
+                  </a>
+                </span>,
               ],
               "className": "row row-cards-pf",
             },
@@ -720,7 +940,35 @@ ShallowWrapper {
                 },
                 "type": "div",
               },
-              undefined,
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": <a
+                    href="http://172.30.139.113:3000/dashboard/db/istio-dashboard?var-service=svc.ns.svc.cluster.local"
+                    target="_blank"
+                  >
+                    View in Grafana
+                  </a>,
+                  "id": "grafana-link",
+                },
+                "ref": null,
+                "rendered": Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": "View in Grafana",
+                    "href": "http://172.30.139.113:3000/dashboard/db/istio-dashboard?var-service=svc.ns.svc.cluster.local",
+                    "target": "_blank",
+                  },
+                  "ref": null,
+                  "rendered": "View in Grafana",
+                  "type": "a",
+                },
+                "type": "span",
+              },
             ],
             "type": "div",
           },
@@ -746,6 +994,16 @@ ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Metrics
     direction={0}
+    grafanaInfo={
+      Object {
+        "serviceDashboardPath": "/dashboard/db/istio-dashboard",
+        "url": "http://172.30.139.113:3000",
+        "varNamespace": "var-namespace",
+        "varService": "var-service",
+        "varWorkload": "var-workload",
+        "workloadDashboardPath": "/dashboard/db/istio-dashboard",
+      }
+    }
     isPageVisible={true}
     namespace="ns"
     object="svc"
@@ -792,6 +1050,16 @@ ShallowWrapper {
                 />
               </div>
             </div>
+            <span
+              id="grafana-link"
+            >
+              <a
+                href="http://172.30.139.113:3000/dashboard/db/istio-dashboard?var-namespace=ns&var-workload=svc"
+                target="_blank"
+              >
+                View in Grafana
+              </a>
+            </span>
           </div>
         </div>,
       ],
@@ -836,6 +1104,16 @@ ShallowWrapper {
                 />
               </div>
             </div>
+            <span
+              id="grafana-link"
+            >
+              <a
+                href="http://172.30.139.113:3000/dashboard/db/istio-dashboard?var-namespace=ns&var-workload=svc"
+                target="_blank"
+              >
+                View in Grafana
+              </a>
+            </span>
           </div>,
           "className": "card-pf",
         },
@@ -857,7 +1135,16 @@ ShallowWrapper {
                   />
                 </div>
               </div>,
-              undefined,
+              <span
+                id="grafana-link"
+              >
+                <a
+                  href="http://172.30.139.113:3000/dashboard/db/istio-dashboard?var-namespace=ns&var-workload=svc"
+                  target="_blank"
+                >
+                  View in Grafana
+                </a>
+              </span>,
             ],
             "className": "row row-cards-pf",
           },
@@ -919,7 +1206,35 @@ ShallowWrapper {
               },
               "type": "div",
             },
-            undefined,
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": <a
+                  href="http://172.30.139.113:3000/dashboard/db/istio-dashboard?var-namespace=ns&var-workload=svc"
+                  target="_blank"
+                >
+                  View in Grafana
+                </a>,
+                "id": "grafana-link",
+              },
+              "ref": null,
+              "rendered": Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": "View in Grafana",
+                  "href": "http://172.30.139.113:3000/dashboard/db/istio-dashboard?var-namespace=ns&var-workload=svc",
+                  "target": "_blank",
+                },
+                "ref": null,
+                "rendered": "View in Grafana",
+                "type": "a",
+              },
+              "type": "span",
+            },
           ],
           "type": "div",
         },
@@ -963,6 +1278,16 @@ ShallowWrapper {
                   />
                 </div>
               </div>
+              <span
+                id="grafana-link"
+              >
+                <a
+                  href="http://172.30.139.113:3000/dashboard/db/istio-dashboard?var-namespace=ns&var-workload=svc"
+                  target="_blank"
+                >
+                  View in Grafana
+                </a>
+              </span>
             </div>
           </div>,
         ],
@@ -1007,6 +1332,16 @@ ShallowWrapper {
                   />
                 </div>
               </div>
+              <span
+                id="grafana-link"
+              >
+                <a
+                  href="http://172.30.139.113:3000/dashboard/db/istio-dashboard?var-namespace=ns&var-workload=svc"
+                  target="_blank"
+                >
+                  View in Grafana
+                </a>
+              </span>
             </div>,
             "className": "card-pf",
           },
@@ -1028,7 +1363,16 @@ ShallowWrapper {
                     />
                   </div>
                 </div>,
-                undefined,
+                <span
+                  id="grafana-link"
+                >
+                  <a
+                    href="http://172.30.139.113:3000/dashboard/db/istio-dashboard?var-namespace=ns&var-workload=svc"
+                    target="_blank"
+                  >
+                    View in Grafana
+                  </a>
+                </span>,
               ],
               "className": "row row-cards-pf",
             },
@@ -1090,7 +1434,35 @@ ShallowWrapper {
                 },
                 "type": "div",
               },
-              undefined,
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": <a
+                    href="http://172.30.139.113:3000/dashboard/db/istio-dashboard?var-namespace=ns&var-workload=svc"
+                    target="_blank"
+                  >
+                    View in Grafana
+                  </a>,
+                  "id": "grafana-link",
+                },
+                "ref": null,
+                "rendered": Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": "View in Grafana",
+                    "href": "http://172.30.139.113:3000/dashboard/db/istio-dashboard?var-namespace=ns&var-workload=svc",
+                    "target": "_blank",
+                  },
+                  "ref": null,
+                  "rendered": "View in Grafana",
+                  "type": "a",
+                },
+                "type": "span",
+              },
             ],
             "type": "div",
           },

--- a/src/components/Nav/Navigation.tsx
+++ b/src/components/Nav/Navigation.tsx
@@ -7,14 +7,11 @@ import { matchPath } from 'react-router';
 import _ from 'lodash';
 
 import MessageCenter from '../../containers/MessageCenterContainer';
-import * as MsgCenter from '../../utils/MessageCenter';
 import HelpDropdown from '../../containers/HelpDropdownContainer';
 import UserDropdown from '../../containers/UserDropdownContainer';
 import LoginPage from '../../containers/LoginPageContainer';
 import { store } from '../../store/ConfigStore';
 import PfSpinnerContainer from '../../containers/PfSpinnerContainer';
-import * as API from '../../services/Api';
-import { authentication } from '../../utils/Authentication';
 import { KialiLogo } from '../../logos';
 
 export const istioConfigTitle = 'Istio Config';
@@ -26,6 +23,7 @@ type PropsType = {
   navCollapsed: boolean;
   checkCredentials: () => void;
   setNavCollapsed: (collapse: boolean) => void;
+  jaegerUrl: string;
 };
 
 class Navigation extends React.Component<PropsType> {
@@ -57,15 +55,7 @@ class Navigation extends React.Component<PropsType> {
   };
 
   goTojaeger() {
-    API.getJaegerInfo(authentication())
-      .then(response => {
-        let data = response['data'];
-        window.open(data.url, '_blank');
-      })
-      .catch(error => {
-        MsgCenter.add(API.getErrorMsg('Could not fetch Jaeger info', error));
-        console.log(error);
-      });
+    window.open(this.props.jaegerUrl, '_blank');
   }
 
   renderMenuItems() {
@@ -79,6 +69,9 @@ class Navigation extends React.Component<PropsType> {
     });
     return navItems.map(item => {
       if (item.title === 'Distributed Tracing') {
+        if (this.props.jaegerUrl === '') {
+          return '';
+        }
         return (
           <VerticalNav.Item
             key={item.to}

--- a/src/components/Nav/__tests__/Navigation.test.tsx
+++ b/src/components/Nav/__tests__/Navigation.test.tsx
@@ -12,6 +12,7 @@ const _tester = (path: string, expectedMenuPath: string) => {
       checkCredentials={jest.fn()}
       navCollapsed={false}
       setNavCollapsed={jest.fn()}
+      jaegerUrl={''}
     />
   );
 

--- a/src/containers/NavigationContainer.ts
+++ b/src/containers/NavigationContainer.ts
@@ -1,12 +1,18 @@
-import { KialiAppState } from '../store/Store';
+import { KialiAppState, Component } from '../store/Store';
 import { connect } from 'react-redux';
 import Navigation from '../components/Nav/Navigation';
 import { LoginActions } from '../actions/LoginActions';
 import { UserSettingsActions } from '../actions/UserSettingsActions';
 
+const getJaegerUrl = (components: Component[]) => {
+  const jaegerinfo = components.find(comp => comp.name === 'Jaeger');
+  return jaegerinfo ? jaegerinfo.url : '';
+};
+
 const mapStateToProps = (state: KialiAppState) => ({
   authenticated: state.authentication.logged,
-  navCollapsed: state.userSettings.interface.navCollapse
+  navCollapsed: state.userSettings.interface.navCollapse,
+  jaegerUrl: getJaegerUrl(state.statusState.components)
 });
 
 const mapDispatchToProps = (dispatch: any) => ({

--- a/src/containers/ServiceMetricsContainer.tsx
+++ b/src/containers/ServiceMetricsContainer.tsx
@@ -4,7 +4,8 @@ import { RouteComponentProps, withRouter } from 'react-router';
 import Metrics, { MetricsProps } from '../components/Metrics/Metrics';
 
 const mapStateToProps = (state: KialiAppState) => ({
-  isPageVisible: state.globalState.isPageVisible
+  isPageVisible: state.globalState.isPageVisible,
+  grafanaInfo: state.grafanaInfo
 });
 
 const ServiceMetricsConnected = withRouter<RouteComponentProps<{}> & MetricsProps>(connect(mapStateToProps)(Metrics));

--- a/src/reducers/GrafanaState.ts
+++ b/src/reducers/GrafanaState.ts
@@ -1,0 +1,30 @@
+import { GrafanaInfo } from '../store/Store';
+import { GrafanaActionKeys } from '../actions/GrafanaActions';
+
+export const INITIAL_GRAFANA_STATE: GrafanaInfo = {
+  url: '',
+  serviceDashboardPath: '',
+  workloadDashboardPath: '',
+  varNamespace: '',
+  varService: '',
+  varWorkload: ''
+};
+
+// This Reducer allows changes to the 'graphDataState' portion of Redux Store
+const GrafanaState = (state: GrafanaInfo = INITIAL_GRAFANA_STATE, action) => {
+  switch (action.type) {
+    case GrafanaActionKeys.SET_INFO:
+      return Object.assign({}, INITIAL_GRAFANA_STATE, {
+        url: action.url,
+        serviceDashboardPath: action.serviceDashboardPath,
+        workloadDashboardPath: action.workloadDashboardPath,
+        varNamespace: action.varNamespace,
+        varService: action.varService,
+        varWorkload: action.varWorkload
+      });
+    default:
+      return state;
+  }
+};
+
+export default GrafanaState;

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -8,6 +8,7 @@ import graphDataState from './GraphDataState';
 import globalState from './GlobalState';
 import namespaceState from './NamespaceState';
 import UserSettingsState from './UserSettingsState';
+import GrafanaState from './GrafanaState';
 
 const rootReducer = combineReducers<KialiAppState>({
   authentication: LoginState,
@@ -16,7 +17,8 @@ const rootReducer = combineReducers<KialiAppState>({
   namespaces: namespaceState,
   globalState: globalState,
   graph: graphDataState,
-  userSettings: UserSettingsState
+  userSettings: UserSettingsState,
+  grafanaInfo: GrafanaState
 });
 
 export default rootReducer;

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -8,7 +8,7 @@ import { Workload, WorkloadNamespaceResponse } from '../types/Workload';
 import { NamespaceValidations, Validations } from '../types/IstioObjects';
 import { ServiceDetailsInfo } from '../types/ServiceInfo';
 import JaegerInfo from '../types/JaegerInfo';
-import GrafanaInfo from '../types/GrafanaInfo';
+import { GrafanaInfo } from '../store/Store';
 import {
   AppHealth,
   ServiceHealth,

--- a/src/store/ConfigStore.ts
+++ b/src/store/ConfigStore.ts
@@ -13,6 +13,7 @@ import { INITIAL_USER_SETTINGS_STATE } from '../reducers/UserSettingsState';
 import { INITIAL_MESSAGE_CENTER_STATE } from '../reducers/MessageCenter';
 import { INITIAL_STATUS_STATE } from '../reducers/HelpDropdownState';
 import { INITIAL_NAMESPACE_STATE } from '../reducers/NamespaceState';
+import { INITIAL_GRAFANA_STATE } from '../reducers/GrafanaState';
 
 declare const window;
 
@@ -49,7 +50,8 @@ let initialStore: KialiAppState = {
   authentication: INITIAL_LOGIN_STATE,
   messageCenter: INITIAL_MESSAGE_CENTER_STATE,
   graph: INITIAL_GRAPH_STATE,
-  userSettings: INITIAL_USER_SETTINGS_STATE
+  userSettings: INITIAL_USER_SETTINGS_STATE,
+  grafanaInfo: INITIAL_GRAFANA_STATE
 };
 
 // pass an optional param to rehydrate state on app start

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -86,11 +86,21 @@ export interface UserSettings {
   interface: InterfaceSettings;
 }
 
+export interface GrafanaInfo {
+  url: string;
+  serviceDashboardPath: string;
+  workloadDashboardPath: string;
+  varNamespace: string;
+  varService: string;
+  varWorkload: string;
+}
+
 // This defines the Kiali Global Application State
 export interface KialiAppState {
   // Global state === across multiple pages
   // could also be session state
   globalState: GlobalState;
+  grafanaInfo?: GrafanaInfo;
   statusState: StatusState;
   /** Page Settings */
   authentication: LoginState;

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -68,7 +68,8 @@ export interface LoginState {
 
 export interface Component {
   name: string;
-  version: string;
+  version?: string;
+  url?: string;
 }
 
 export interface StatusState {

--- a/src/types/GrafanaInfo.ts
+++ b/src/types/GrafanaInfo.ts
@@ -1,8 +1,0 @@
-export default interface GrafanaInfo {
-  url: string;
-  serviceDashboardPath: string;
-  workloadDashboardPath: string;
-  varNamespace: string;
-  varService: string;
-  varWorkload: string;
-}


### PR DESCRIPTION
** Describe the change **

Now we can see the url services in the status after the merge of https://github.com/kiali/kiali/pull/573 . /api/status provide us of the urls and versions now. So we only need to check one time to get all the urls
![status](https://user-images.githubusercontent.com/3019213/47148635-7fdd2f80-d2d1-11e8-959c-fbaa5d73cff2.png)

When the jaeger url is empty we have not menu item in the navigation
![without jaeger url](https://user-images.githubusercontent.com/3019213/47148512-2d037800-d2d1-11e8-85f4-082cea958f34.png)

behaviour in Firefox with https popup, now we have not warning message.
![firefox_behaviour_jaeger_popup](https://user-images.githubusercontent.com/3019213/47148511-2d037800-d2d1-11e8-8966-333d18a63468.gif)

** Issue reference **
[KIALI-1587](
https://issues.jboss.org/browse/KIALI-1587)

