### PR TITLE
KIALI-1611 Show full requests-per-second precision if it is less than 1rps

### DIFF
--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -2,6 +2,7 @@ import { PfColors } from '../../../components/Pf/PfColors';
 import { EdgeLabelMode } from '../../../types/GraphFilter';
 import { FAILURE, DEGRADED, REQUESTS_THRESHOLDS } from '../../../types/Health';
 import { GraphType, NodeType, CytoscapeGlobalScratchNamespace, CytoscapeGlobalScratchData } from '../../../types/Graph';
+import { formatTrafficRate } from '../../../utils/TrafficRate';
 
 export const DimClass = 'mousedim';
 
@@ -83,12 +84,13 @@ export class GraphStyles {
             const rate = Number(ele.data('rate'));
             if (rate > 0) {
               const pErr = ele.data('percentErr') ? Number(ele.data('percentErr')) : 0;
-              content = pErr > 0 ? rate.toFixed(2) + ', ' + pErr.toFixed(1) + '%' : rate.toFixed(2);
+              const rateStr = formatTrafficRate(rate);
+              content = pErr > 0 ? rateStr + ', ' + pErr.toFixed(1) + '%' : rateStr;
             }
           } else if (ele.data('tcpSentRate')) {
             const rate = Number(ele.data('tcpSentRate'));
             if (rate > 0) {
-              content = `${rate.toFixed(2)}`;
+              content = `${formatTrafficRate(rate)}`;
             }
           }
           break;

--- a/src/components/SummaryPanel/InOutRateTable.tsx
+++ b/src/components/SummaryPanel/InOutRateTable.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import InOutRateChart from './InOutRateChart';
+import { formatTrafficRate } from '../../utils/TrafficRate';
 
 type InOutRateTablePropType = {
   title: string;
@@ -56,13 +57,13 @@ export default class InOutRateTable extends React.Component<InOutRateTablePropTy
           <tbody>
             <tr>
               <td>In</td>
-              <td>{this.props.inRate.toFixed(2)}</td>
+              <td>{formatTrafficRate(this.props.inRate)}</td>
               <td>{percentInSuccess.toFixed(2)}</td>
               <td>{percentInErr.toFixed(2)}</td>
             </tr>
             <tr>
               <td>Out</td>
-              <td>{this.props.outRate.toFixed(2)}</td>
+              <td>{formatTrafficRate(this.props.outRate)}</td>
               <td>{percentOutSuccess.toFixed(2)}</td>
               <td>{percentOutErr.toFixed(2)}</td>
             </tr>

--- a/src/utils/TrafficRate.ts
+++ b/src/utils/TrafficRate.ts
@@ -33,3 +33,5 @@ export const getAccumulatedTrafficRate = (elements): TrafficRate => {
     { rate: 0, rate3xx: 0, rate4xx: 0, rate5xx: 0 }
   );
 };
+
+export const formatTrafficRate = (rate: number): string => (rate < 1 ? rate.toFixed(3) : rate.toFixed(2));


### PR DESCRIPTION
This prevents showing "0.00" in the edges and confusing the user.

Before:

![image](https://user-images.githubusercontent.com/23639005/47531563-9fe19580-d873-11e8-8d83-d36da07ef75b.png)

After (with everything < 1rps)

![image](https://user-images.githubusercontent.com/23639005/47531587-ac65ee00-d873-11e8-9ca8-9598165f0cab.png)

(with some < 1rps)

![image](https://user-images.githubusercontent.com/23639005/47531640-d4555180-d873-11e8-944a-c811e4d7f472.png)
