### PR TITLE
KIALI-1830 Fix sparkline issue for edge leading from service

### DIFF
--- a/src/pages/Graph/SummaryPanelEdge.tsx
+++ b/src/pages/Graph/SummaryPanelEdge.tsx
@@ -215,10 +215,11 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
 
     this.metricsPromise.promise
       .then(response => {
+        // HTTP
         let useDest = sourceData.nodeType === NodeType.UNKNOWN;
-        useDest = useDest || this.props.namespace === 'istio-system';
-        const reporter = useDest ? response.data.dest : response.data.source;
-        const metrics = reporter.metrics;
+        useDest = useDest || this.props.namespace === 'istio-system' || sourceData.nodeType === NodeType.SERVICE;
+        let reporter = useDest ? response.data.dest : response.data.source;
+        let metrics = reporter.metrics;
         const histograms = reporter.histograms;
         const reqRates = this.getNodeDataPoints(
           metrics['request_count_in'],
@@ -262,6 +263,11 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
           destMetricType,
           sourceData
         );
+        // TCP (uses slightly different reporting)
+        useDest = sourceData.nodeType === NodeType.UNKNOWN;
+        useDest = useDest || this.props.namespace === 'istio-system';
+        reporter = useDest ? response.data.dest : response.data.source;
+        metrics = reporter.metrics;
         const tcpSentRates = this.getNodeDataPoints(
           metrics['tcp_sent_in'],
           'Sent',


### PR DESCRIPTION
Fix sparkline issue for edge leading from service and including traffic from unknown
- make sure this fix does not break the fix in kiali-1732 for TCP sparkine
  for edges leading from a service.

After the fix we have both sparklines correct, The http sparkline combines  traffic from unknown and ingress:

![image](https://user-images.githubusercontent.com/2104052/47591650-62960a00-d93e-11e8-8ebc-8f7adac9ede3.png)

The TCP traffic is shown corrrectly as well:

![image](https://user-images.githubusercontent.com/2104052/47591679-780b3400-d93e-11e8-9f09-a71395646c83.png)
