### PR TITLE
KIALI-1800 Avoid overlapping of compounds nodes

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -371,7 +371,12 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
       // overlap, but we need to have them enabled (nodeDimensionsIncludeLabels: true)
       this.turnNodeLabelsTo(cy, true);
       const layoutOptions = LayoutDictionary.getLayout(this.props.graphLayout);
-      cy.layout({ ...layoutOptions, name: 'group-compound-layout', realLayout: this.props.graphLayout.name }).run();
+      if (cy.nodes('$node > node').length > 0) {
+        // if there is any parent node, run the group-compound-layout
+        cy.layout({ ...layoutOptions, name: 'group-compound-layout', realLayout: this.props.graphLayout.name }).run();
+      } else {
+        cy.layout(layoutOptions).run();
+      }
     }
 
     // Create and destroy labels

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -370,7 +370,8 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
       // Enable labels when doing a relayout, layouts can be told to take into account the labels to avoid
       // overlap, but we need to have them enabled (nodeDimensionsIncludeLabels: true)
       this.turnNodeLabelsTo(cy, true);
-      cy.layout(LayoutDictionary.getLayout(this.props.graphLayout)).run();
+      const layoutOptions = LayoutDictionary.getLayout(this.props.graphLayout);
+      cy.layout({ ...layoutOptions, name: 'group-compound-layout', realLayout: this.props.graphLayout.name }).run();
     }
 
     // Create and destroy labels

--- a/src/components/CytoscapeGraph/CytoscapeReactWrapper.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeReactWrapper.tsx
@@ -7,11 +7,13 @@ import cytoscape from 'cytoscape';
 import cycola from 'cytoscape-cola';
 import dagre from 'cytoscape-dagre';
 import coseBilkent from 'cytoscape-cose-bilkent';
+import GroupCompoundLayout from './Layout/GroupCompoundLayout';
 
 cytoscape.use(canvas);
 cytoscape.use(cycola);
 cytoscape.use(dagre);
 cytoscape.use(coseBilkent);
+cytoscape('layout', 'group-compound-layout', GroupCompoundLayout);
 
 type CytoscapeReactWrapperProps = {};
 

--- a/src/components/CytoscapeGraph/Layout/GroupCompoundLayout.ts
+++ b/src/components/CytoscapeGraph/Layout/GroupCompoundLayout.ts
@@ -1,0 +1,142 @@
+const NAMESPACE_KEY = '_group_compound_layout';
+const CHILDREN_KEY = 'children';
+const PADDING_WIDTH = 5;
+const BETWEEN_NODES_PADDING = 3;
+
+const normalizeToParent = element => {
+  return element.isChild() ? element.parent() : element;
+};
+
+class SyntheticEdgeGenerator {
+  private nextId = 0;
+  private generatedMap = {};
+
+  public getEdge(source: any, target: any) {
+    const sourceId = normalizeToParent(source).id();
+    const targetId = normalizeToParent(target).id();
+    const key = `${sourceId}->${targetId}`;
+
+    if (this.generatedMap[key]) {
+      return false;
+    }
+    return (this.generatedMap[key] = {
+      group: 'edges',
+      data: {
+        id: 'synthetic-edge-' + this.nextId++,
+        source: sourceId,
+        target: targetId
+      }
+    });
+  }
+
+  public getGeneratedEdges() {
+    return Object.keys(this.generatedMap).map(key => this.generatedMap[key]);
+  }
+}
+
+export default class GroupCompoundLayout {
+  private options;
+  private cy;
+  private elements;
+  private syntheticEdgeGenerator;
+
+  constructor(options: any) {
+    this.options = { ...options };
+    this.cy = this.options.cy;
+    this.elements = this.options.eles;
+    this.syntheticEdgeGenerator = new SyntheticEdgeGenerator();
+  }
+
+  run() {
+    const { realLayout } = this.options;
+    const parents = this.parents();
+    if (parents.length > 0) {
+      // Prepare parents by assigning a width and height
+      parents.each(parent => {
+        const boundingBox = parent.children().reduce(
+          (accBoundingBox, child) => {
+            const localBoundingBox = child.boundingBox();
+            accBoundingBox.height += localBoundingBox.h;
+            accBoundingBox.width = Math.max(accBoundingBox.width, localBoundingBox.w + PADDING_WIDTH);
+            return accBoundingBox;
+          },
+          { width: 0, height: 0 }
+        );
+        parent.style('shape', 'rectangle');
+        parent.style('height', `${boundingBox.height}px`);
+        parent.style('width', `${boundingBox.width}px`);
+        this.setScratch(parent, CHILDREN_KEY, parent.children().jsons());
+      });
+      // Remove the children and its edges, add synthetic edges for every edge that touch a child node.
+      let syntheticEdges = this.cy.collection();
+      const elementsToRemove = parents.children().reduce((children, child) => {
+        children.push(child);
+        return children.concat(
+          child.connectedEdges().reduce((edges, edge) => {
+            const syntheticEdge = this.syntheticEdgeGenerator.getEdge(edge.source(), edge.target());
+            if (syntheticEdge) {
+              console.log('Adding synthetic edge:', syntheticEdge);
+              syntheticEdges = syntheticEdges.add(this.cy.add(syntheticEdge));
+              console.log(syntheticEdges);
+            }
+            edges.push(edge);
+            return edges;
+          }, [])
+        );
+      }, []);
+      this.cy.remove(this.cy.collection().add(elementsToRemove));
+      console.log('Will use:', realLayout);
+      const layout = this.cy.layout({
+        // Create a new layout
+        ...this.options, // Sharing the main options
+        name: realLayout, // but using the real layout
+        eles: this.cy.elements(), // and the current elements
+        realLayout: undefined // We don't want this realLayout stuff in there.
+      });
+      layout.pon('layoutstop').then(event => {
+        // Remove synthetic edges and add removed elements
+        console.log('Removing syntheticEdges', syntheticEdges);
+        this.cy.remove(syntheticEdges);
+        // this.cy.add(this.cy.collection().add(elementsToRemove));
+        parents.each(parent => {
+          const position = { ...parent.position() };
+          console.log('parent position:', position);
+          const children = this.cy.add(this.getScratch(parent, CHILDREN_KEY)).map(child => {
+            child.position(position);
+            console.log('child position:', child.position());
+            const boundingBox = child.boundingBox();
+            position.y += boundingBox.h + BETWEEN_NODES_PADDING;
+            this.setScratch(parent, CHILDREN_KEY, undefined);
+            return child;
+          });
+          console.log(children);
+          console.log('scratchPad:', parent.scratch());
+        });
+        this.cy.add(
+          this.cy
+            .collection()
+            .add(elementsToRemove)
+            .edges()
+        );
+      });
+      layout.on('layoutstart layoutready layoutstop', event => {
+        (this as any).emit(event);
+      });
+      layout.run();
+    }
+  }
+
+  parents() {
+    return this.elements.nodes(element => {
+      return element.isParent();
+    });
+  }
+
+  getScratch(element: any, key: string) {
+    return element.scratch(NAMESPACE_KEY + key);
+  }
+
+  setScratch(element: any, key: string, value: any) {
+    element.scratch(NAMESPACE_KEY + key, value);
+  }
+}

--- a/src/components/CytoscapeGraph/Layout/GroupCompoundLayout.ts
+++ b/src/components/CytoscapeGraph/Layout/GroupCompoundLayout.ts
@@ -1,26 +1,62 @@
+/*
+  GroupCompoundLayout
+
+  This is a synthetic layout that helps to layout close to each other the contents of compound nodes,
+  in this way we ensure that the compound node itself is as small as possible, avoiding overlaps with other nodes.
+
+  It requires a real layout to do the actual work, but there are some patches applied to the graph before and after the
+  real layout is run.
+
+  Is composed of:
+   - A compound layout (see included VerticalLayout class) that does the layout of the children of a compound node.
+   - A Synthetic edge generator to help with the creation of synthetic edges (more info below).
+   - The actual GroupCompoundLayout class which is type of cy Layout and can be used along it.
+
+  The algorithm is roughly as follow:
+
+  1. For every compound node:
+    a. Compute how much size is required depending on our compound layout -In the included VerticalLayout we sum up the
+       height of each children plus a padding between each child-.
+    b. With the size of the compound, set the width and height of the node using `cy.style`, so that the real layout
+       honors the size when doing the layout.
+    c. For every edge that goes to a child (or comes from a child), create a synthetic edge that goes to (or comes from) the compound node and remove the original
+       edge. We can cull away repeated edges as they are not needed.
+    d. Remove the children. This is important, else cytoscape won't honor the size specified in previous step.
+       "A compound parent node does not have independent dimensions (position and size), as those values are
+       automatically inferred by the positions and dimensions of the descendant nodes."
+       http://js.cytoscape.org/#notation/compound-nodes
+  2. Run the real layout on this new graph and wait until it finishes.
+  3. Remove the synthetic edges.
+  4. For every original parent node:
+    a. Add back its children and edges.
+    b. Layout the children using the selected compound layout -In the included VerticalLayout, we stack vertically every children
+       setting the relative position of each one to be on top of each other-.
+
+ */
+
 const NAMESPACE_KEY = '_group_compound_layout';
+const BOUNDING_BOX = 'bounding-box';
 const CHILDREN_KEY = 'children';
 const STYLES_KEY = 'styles';
-const PADDING_WIDTH = 5;
 const BETWEEN_NODES_PADDING = 3;
 
-const normalizeToParent = element => {
-  return element.isChild() ? element.parent() : element;
-};
-
+// Styles used to have more control on how the compound nodes are going to be seen by the Layout algorithm.
 interface OverridenStyles {
   shape: string;
   width: string;
   height: string;
 }
 
+/**
+ * Synthetic edge generator takes care of creating edges without repeating the same edge (targetA -> targetB) twice
+ */
 class SyntheticEdgeGenerator {
   private nextId = 0;
   private generatedMap = {};
 
   public getEdge(source: any, target: any) {
-    const sourceId = normalizeToParent(source).id();
-    const targetId = normalizeToParent(target).id();
+    const sourceId = this.normalizeToParent(source).id();
+    const targetId = this.normalizeToParent(target).id();
     const key = `${sourceId}->${targetId}`;
 
     if (this.generatedMap[key]) {
@@ -38,43 +74,98 @@ class SyntheticEdgeGenerator {
       }
     };
   }
+
+  // Returns the parent if any or the element itself.
+  private normalizeToParent(element: any) {
+    return element.isChild() ? element.parent() : element;
+  }
 }
 
+/**
+ * CompoundLayout interface, used to plug in to the GroupCompoundLayout other kinds of layouts for the contents of a
+ * compound node. Examples to implement would be
+ *   VerticalLayout:
+ *    __________
+ *   |          |
+ *   | [ node ] |
+ *   | [ node ] |
+ *   | [ node ] |
+ *   | [ node ] |
+ *   |__________|
+ *
+ *   HorizontalLayout:
+ *    ________________________________________
+ *   |                                        |
+ *   | [ node ]  [ node ]  [ node ]  [ node ] |
+ *   |________________________________________|
+ *
+ *
+ *   or a MatrixLayout:
+ *    ____________________
+ *   |                    |
+ *   | [ node ]  [ node ] |
+ *   | [ node ]  [ node ] |
+ *   |____________________|
+ *
+ */
 interface CompoundLayout {
-  boundingBox(compound: any);
-  layout(compound: any);
+  size(compound: any); // Gets the size required for this compound node to place every children
+  layout(compound: any); // Layouts the children of this compound node.
 }
 
+/**
+ * Implements a vertical layout for the children of a compound node.
+ */
 class VerticalLayout implements CompoundLayout {
-  boundingBox(compound: any) {
-    return compound.children().reduce(
+  /**
+   * This will get the size required for a vertical layout by:
+   * adding all the heights of the contents plus a padding for every space between a node.
+   * finding the max width value to use.
+   */
+  size(compound: any) {
+    const size = compound.children().reduce(
       (accBoundingBox, child) => {
-        // This will produce a vertical layout for the compound contents
         const localBoundingBox = child.boundingBox();
+        // The bounding box reported before adding and after adding differs, I think is related to removing/adding
+        // in a batch, save that value for later
+        child.data(NAMESPACE_KEY + BOUNDING_BOX, localBoundingBox);
         accBoundingBox.height += localBoundingBox.h;
-        accBoundingBox.width = Math.max(accBoundingBox.width, localBoundingBox.w + PADDING_WIDTH);
+        accBoundingBox.width = Math.max(accBoundingBox.width, localBoundingBox.w);
         return accBoundingBox;
       },
       { width: 0, height: 0 }
     );
+    size.height += (compound.children().length - 1) * BETWEEN_NODES_PADDING;
+    return size;
   }
 
+  /**
+   * This will layout the children using a vertical layout, starting on 0,0 we position the nodes relative to the parent
+   * and saving the previous position to use as starting point for the news child.
+   */
   layout(compound: any) {
     const position = { x: 0, y: 0 };
     compound.children().each(child => {
-      child.relativePosition(position);
-      const boundingBox = child.boundingBox();
+      // Retrieve saved bounding box to use, immediately delete as won't be used anymore.
+      const boundingBox = child.data(NAMESPACE_KEY + BOUNDING_BOX);
+      child.removeData(NAMESPACE_KEY + BOUNDING_BOX);
+      // It looks like the relativePosition is given by the center, i haven't been able to confirm this (in the code) but
+      // i'm using its bounding box to place it
+      child.relativePosition({ x: position.x - boundingBox.w * 0.5, y: position.y - boundingBox.h * 0.5 });
       position.y += boundingBox.h + BETWEEN_NODES_PADDING;
     });
   }
 }
 
+/**
+ * Main class for the GroupCompoundLayout, used to bridge with cytoscape to make it easier to integrate with current code
+ */
 export default class GroupCompoundLayout {
   readonly options;
   readonly cy;
   readonly elements;
   readonly syntheticEdgeGenerator;
-  readonly compoundLayout;
+  readonly compoundLayout: CompoundLayout;
 
   constructor(options: any) {
     this.options = { ...options };
@@ -84,84 +175,93 @@ export default class GroupCompoundLayout {
     this.compoundLayout = new VerticalLayout();
   }
 
+  /**
+   * This code gets executed on the cy.layout(...).run() is our entrypoint of this algorithm.
+   */
   run() {
     const { realLayout } = this.options;
     const parents = this.parents();
-    if (parents.length > 0) {
-      // Prepare parents by assigning a width and height
+
+    // (1.a) Prepare parents by assigning a size
+    parents.each(parent => {
+      const boundingBox = this.compoundLayout.size(parent);
+      const backupStyles: OverridenStyles = {
+        shape: parent.style('shape'),
+        height: parent.style('height'),
+        width: parent.style('width')
+      };
+
+      const newStyles: OverridenStyles = {
+        shape: 'rectangle',
+        height: `${boundingBox.height}px`,
+        width: `${boundingBox.width}px`
+      };
+      // Saves a backup of current styles to restore them after we finish
+      this.setScratch(parent, STYLES_KEY, backupStyles);
+      // (1.b) Set the size
+      parent.style(newStyles);
+      // Save the children as jsons in the parent scratchpad for later
+      this.setScratch(parent, CHILDREN_KEY, parent.children().jsons());
+    });
+
+    //  Remove the children and its edges and add synthetic edges for every edge that touches a child node.
+    let syntheticEdges = this.cy.collection();
+    // Removed elements are being stored because later we will add them back.
+    const elementsToRemove = parents.children().reduce((children, child) => {
+      children.push(child);
+      return children.concat(
+        child.connectedEdges().reduce((edges, edge) => {
+          // (1.c) Create synthetic edges.
+          const syntheticEdge = this.syntheticEdgeGenerator.getEdge(edge.source(), edge.target());
+          if (syntheticEdge) {
+            syntheticEdges = syntheticEdges.add(this.cy.add(syntheticEdge));
+          }
+          edges.push(edge);
+          return edges;
+        }, [])
+      );
+    }, []);
+    // (1.d) Remove children and edges that touch a child node.
+    this.cy.remove(this.cy.collection().add(elementsToRemove));
+
+    const layout = this.cy.layout({
+      // Create a new layout
+      ...this.options, // Sharing the main options
+      name: realLayout, // but using the real layout
+      eles: this.cy.elements(), // and the current elements
+      realLayout: undefined // We don't want this realLayout stuff in there.
+    });
+
+    // (2) Add a one-time callback to be fired when the layout stops
+    layout.one('layoutstop', event => {
+      // (3) Remove synthetic edges
+      this.cy.remove(syntheticEdges);
+
+      // Add and position the children nodes according to the layout
       parents.each(parent => {
-        const boundingBox = this.compoundLayout.boundingBox(parent);
-        const backupStyles: OverridenStyles = {
-          shape: parent.style('shape'),
-          height: parent.style('height'),
-          width: parent.style('width')
-        };
+        // (4.a) Add back the children and the edges
+        this.cy.add(this.getScratch(parent, CHILDREN_KEY));
+        // (4.b) Layout the children using our compound layout.
+        this.compoundLayout.layout(parent);
+        parent.style(this.getScratch(parent, STYLES_KEY));
 
-        const newStyles: OverridenStyles = {
-          shape: 'rectangle',
-          height: `${boundingBox.height}px`,
-          width: `${boundingBox.width}px`
-        };
-        this.setScratch(parent, STYLES_KEY, backupStyles);
-        parent.style(newStyles);
-        this.setScratch(parent, CHILDREN_KEY, parent.children().jsons());
+        // Discard the saved values
+        this.setScratch(parent, CHILDREN_KEY, undefined);
+        this.setScratch(parent, STYLES_KEY, undefined);
       });
-
-      // Remove the children and its edges and add synthetic edges for every edge that touches a child node.
-      let syntheticEdges = this.cy.collection();
-      const elementsToRemove = parents.children().reduce((children, child) => {
-        children.push(child);
-        return children.concat(
-          child.connectedEdges().reduce((edges, edge) => {
-            const syntheticEdge = this.syntheticEdgeGenerator.getEdge(edge.source(), edge.target());
-            if (syntheticEdge) {
-              syntheticEdges = syntheticEdges.add(this.cy.add(syntheticEdge));
-            }
-            edges.push(edge);
-            return edges;
-          }, [])
-        );
-      }, []);
-      this.cy.remove(this.cy.collection().add(elementsToRemove));
-
-      const layout = this.cy.layout({
-        // Create a new layout
-        ...this.options, // Sharing the main options
-        name: realLayout, // but using the real layout
-        eles: this.cy.elements(), // and the current elements
-        realLayout: undefined // We don't want this realLayout stuff in there.
-      });
-
-      // Add a callback once the layout stops
-      layout.one('layoutstop', event => {
-        // Remove synthetic edges
-        this.cy.remove(syntheticEdges);
-
-        // Add and position the children nodes according to the layout
-        parents.each(parent => {
-          this.cy.add(this.getScratch(parent, CHILDREN_KEY));
-          this.compoundLayout.layout(parent);
-          parent.style(this.getScratch(parent, STYLES_KEY));
-
-          this.setScratch(parent, CHILDREN_KEY, undefined);
-          this.setScratch(parent, STYLES_KEY, undefined);
-        });
-        // Add the real edges
-        this.cy.add(
-          this.cy
-            .collection()
-            .add(elementsToRemove)
-            .edges()
-        );
-      });
-      layout.run();
-    }
+      // (4.a) Add the real edges, we already added the children nodes.
+      this.cy.add(
+        this.cy
+          .collection()
+          .add(elementsToRemove)
+          .edges()
+      );
+    });
+    layout.run();
   }
 
   parents() {
-    return this.elements.nodes(element => {
-      return element.isParent();
-    });
+    return this.elements.nodes('$node > node');
   }
 
   getScratch(element: any, key: string) {


### PR DESCRIPTION
** Describe the change **

In order to keep compound nodes from being bigger than needed, a pre-process is done on the input to:

1. Remove child nodes and reserve enough size for them.
2. Create synthetic edges to replace edges that go or leave from a compound node.

After the layout is finished, the child nodes are added back and the synthetic edges are removed.

This should work for any discrete layout and any dynamic layout that issues `layoutstop`.

This allows us to keep all the compound nodes as tight as possible, preventing overlap (if the layout prevents that) as the layout positioning only happen on 1st level nodes and we should not have any unwanted surprise when a child node is positioned  (by the layout) on the top left of the screen while the other is positioned on the bottom right of the screen.

Code is mostly done -I have a few things to polish, like setting back values I affected-. I will need to test to ensure is always yielding right results and i'm not missing anything.

Below are some screenshots, but If you have seen a graph with lots of overlaps, please share the json used to generate that.

** Screenshot **

 ### Bookinfo step by step

I'm posting a step by step of what I'm doing to help spot problems. Even though bookinfo doesn't have this problem, I'm going to use it for simplicity along with dagre layout:

 1. Bookinfo with dagre without any change

![bookinfo-before](https://user-images.githubusercontent.com/3845764/47750420-fb859780-dc54-11e8-8f50-310226d27b83.png)

 2. Remove children and nodes

![bookinfo-step-1](https://user-images.githubusercontent.com/3845764/47750484-1d7f1a00-dc55-11e8-80af-612a5ced0164.png)

 3. Reserve enough space for the children (this lets know the layout how big the node needs to be)

![bookinfo-step-2](https://user-images.githubusercontent.com/3845764/47750483-1d7f1a00-dc55-11e8-9582-f900b29b7ca0.png)

 4. Add synthetic edges; for every node that was connected to any children, it creates a synthetic edge from the node to the compound, and from compound to nodes as well.

![bookinfo-step-3](https://user-images.githubusercontent.com/3845764/47750482-1ce68380-dc55-11e8-9b2f-e6808d42a89c.png)

 5. After the layout is finished, the synthetic edges are removed and the children are added back, ordering from top to bottom. We could use other strategies here, row, column, matrix, etc.

![bookinfo-step-4](https://user-images.githubusercontent.com/3845764/47750481-1ce68380-dc55-11e8-866b-b09002fda516.png)

 6. Then we put back the regular edges.

![bookinfo-step-5](https://user-images.githubusercontent.com/3845764/47750480-1ce68380-dc55-11e8-9cae-da141e1234dd.png)

And here is what it looks like in a gif:

![bookinfo-gif](https://user-images.githubusercontent.com/3845764/47751003-4b189300-dc56-11e8-8877-194f0350074f.gif)

Notice how cola and cose both looks similar, i'm not sure if is because of the removal of the children or if I have a bug and i'm using the same layout for both :)

 ### KIALI-1013 faulty graph

I tried with the oudated json found in [KIALI-1013](https://issues.jboss.org/browse/KIALI-1013) and got the following results
Note that the nodes say "error/unknown" because is an old json that doesn't have the new properties.

 #### Dagre 
 It crashed before, it seems to be working now, maybe is because less nodes are being processed with this approach.
![kiali-1013-dagre](https://user-images.githubusercontent.com/3845764/47751261-e90c5d80-dc56-11e8-8d2f-1715844f2427.gif)

 #### Cola
 Freeze my browser before and now it does the same (Eventually it will load, but since it takes ages, is not worth the wait)

edit: It loaded while i was finishing this.

![kiali-1013-cola](https://user-images.githubusercontent.com/3845764/47751916-b06d8380-dc58-11e8-964b-6e3ba40cb774.gif)

 #### Cose 

Notice how the before has some overlaps and the after does not (so much).

- Before:
 ![cose-layout-before](https://issues.jboss.org/secure/attachment/12436827/with-cose-layout.png)
- After:
![kiali-1013-cose](https://user-images.githubusercontent.com/3845764/47751394-38528e00-dc57-11e8-8793-617b978449a9.gif)

~edit: It looks i have something not as good as I want, when adding the children, it appears as if the parent moves.~
edit: It seems that even the cola layout is having problems with only the compound nodes (without children)
![kiali-1013-cose-boxes](https://user-images.githubusercontent.com/3845764/47806845-414b6a00-dd00-11e8-9b1b-31f4f01d61fd.gif)

