### PR TITLE
KIALI-1827 Resize columns to allow for longer labels.

### DIFF
--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
@@ -37,7 +37,7 @@ class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps
         istio={this.props.istioEnabled}
         items={
           <Row>
-            <Col xs={12} sm={6} md={2} lg={2}>
+            <Col xs={12} sm={6} md={5} lg={5}>
               <div className="progress-description">
                 <strong>Labels</strong>
               </div>
@@ -61,7 +61,7 @@ class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps
                 <strong>Resource Version</strong> {this.props.resourceVersion}
               </div>
             </Col>
-            <Col xs={12} sm={6} md={3} lg={3}>
+            <Col xs={12} sm={4} md={2} lg={2}>
               <div className="progress-description">
                 <strong>Ports</strong>
               </div>
@@ -73,7 +73,7 @@ class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps
                 ))}
               </ul>
             </Col>
-            <Col xs={12} sm={6} md={5} lg={5}>
+            <Col xs={12} sm={6} md={3} lg={3}>
               <div className="progress-description">
                 <strong>Endpoints</strong>
               </div>

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
@@ -69,8 +69,8 @@ ShallowWrapper {
         <Col
           bsClass="col"
           componentClass="div"
-          lg={2}
-          md={2}
+          lg={5}
+          md={5}
           sm={6}
           xs={12}
         >
@@ -125,9 +125,9 @@ ShallowWrapper {
         <Col
           bsClass="col"
           componentClass="div"
-          lg={3}
-          md={3}
-          sm={6}
+          lg={2}
+          md={2}
+          sm={4}
           xs={12}
         >
           <div
@@ -148,8 +148,8 @@ ShallowWrapper {
         <Col
           bsClass="col"
           componentClass="div"
-          lg={5}
-          md={5}
+          lg={3}
+          md={3}
           sm={6}
           xs={12}
         >
@@ -252,8 +252,8 @@ ShallowWrapper {
           <Col
             bsClass="col"
             componentClass="div"
-            lg={2}
-            md={2}
+            lg={5}
+            md={5}
             sm={6}
             xs={12}
           >
@@ -308,9 +308,9 @@ ShallowWrapper {
           <Col
             bsClass="col"
             componentClass="div"
-            lg={3}
-            md={3}
-            sm={6}
+            lg={2}
+            md={2}
+            sm={4}
             xs={12}
           >
             <div
@@ -331,8 +331,8 @@ ShallowWrapper {
           <Col
             bsClass="col"
             componentClass="div"
-            lg={5}
-            md={5}
+            lg={3}
+            md={3}
             sm={6}
             xs={12}
           >

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadDescription.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadDescription.tsx
@@ -31,7 +31,7 @@ class WorkloadDescription extends React.Component<WorkloadDescriptionProps, Work
         istio={this.props.istioEnabled}
         items={
           <Row>
-            <Col xs={12} sm={6} md={2} lg={2}>
+            <Col xs={12} sm={8} md={6} lg={6}>
               <div className="progress-description">
                 <strong>Labels</strong>
               </div>
@@ -52,8 +52,8 @@ class WorkloadDescription extends React.Component<WorkloadDescriptionProps, Work
                 <strong>Resource Version</strong> {workload.resourceVersion}
               </div>
             </Col>
-            <Col xs={12} sm={6} md={8} lg={8} />
-            <Col xs={12} sm={6} md={2} lg={2}>
+            <Col xs={12} sm={4} md={4} lg={4} />
+            <Col xs={12} sm={4} md={2} lg={2}>
               <div className="progress-description">
                 <strong>Health</strong>
               </div>


### PR DESCRIPTION
** Describe the change **

Long labels are cut off


** Backwards compatible? **

[X] Is your pull-request introducing changes in behaviour?

_Describe the changes if appropriate. E.g. a new link, a change on what a click does, etc_

** Screenshot **

For before see 

![](https://issues.jboss.org/secure/attachment/12442348/Bildschirmfoto%202018-10-26%20um%2015.14.36.png)

Now:

![bildschirmfoto 2018-10-31 um 11 10 02](https://user-images.githubusercontent.com/208246/47781249-8fab3980-dcfd-11e8-84e1-282a1c6a257a.png)

Note: perhaps we should in the longer run not have the labels as part of the table, but rather
as a row that is as wide as the whole table.

