### PR TITLE
KIALI-1798 Make Namespace dropdown reflect current choice

### DIFF
--- a/src/components/GraphFilter/GraphFilter.tsx
+++ b/src/components/GraphFilter/GraphFilter.tsx
@@ -81,7 +81,6 @@ export default class GraphFilter extends React.PureComponent<GraphFilterProps> {
             )}
             <NamespaceDropdownContainer
               disabled={this.props.node || this.props.disabled}
-              activeNamespace={this.props.namespace}
               onSelect={this.props.onNamespaceChange}
             />
           </FormGroup>

--- a/src/components/NamespaceDropdown.tsx
+++ b/src/components/NamespaceDropdown.tsx
@@ -26,8 +26,7 @@ export class NamespaceDropdown extends React.PureComponent<NamespaceListType, {}
   render() {
     const disabled = this.props.disabled ? true : false;
 
-    // convert namespace array to an object {"ns1": "ns1"} to make it
-    // compatible with <ToolbarDropdown />
+    // convert namespace array to an object {"ns1": "ns1"} to make it compatible with <ToolbarDropdown />
     const items: { [key: string]: string } = this.props.items.reduce((list, item) => {
       list[item.name] = item.name;
       return list;
@@ -35,13 +34,13 @@ export class NamespaceDropdown extends React.PureComponent<NamespaceListType, {}
 
     return (
       <ToolbarDropdown
-        disabled={disabled}
-        useName={true}
         id="namespace-selector"
-        initialLabel={this.props.activeNamespace.name}
-        handleSelect={this.handleSelectNamespace}
-        value={this.props.activeNamespace.name}
+        disabled={disabled}
         options={items}
+        value={this.props.activeNamespace.name}
+        label={this.props.activeNamespace.name}
+        useName={true}
+        handleSelect={this.handleSelectNamespace}
         onToggle={this.handleToggle}
       />
     );

--- a/src/components/ToolbarDropdown/ToolbarDropdown.tsx
+++ b/src/components/ToolbarDropdown/ToolbarDropdown.tsx
@@ -7,8 +7,8 @@ type ToolbarDropdownProps = {
   id?: string;
   nameDropdown?: string;
   value?: number | string;
-  initialValue?: number | string;
   label?: string;
+  initialValue?: number | string;
   initialLabel?: string;
   handleSelect: Function;
   options: { [key: string]: string };
@@ -24,8 +24,8 @@ export class ToolbarDropdown extends React.Component<ToolbarDropdownProps, Toolb
   constructor(props: ToolbarDropdownProps) {
     super(props);
     this.state = {
-      currentValue: props.initialValue,
-      currentName: props.initialLabel
+      currentValue: props.value || props.initialValue,
+      currentName: props.label || props.initialLabel
     };
   }
 


### PR DESCRIPTION
- remove redundant setting of activeNamespace (defer to container setting)
- make sure value and label are both set and take precendance over initial values when set
