### PR TITLE
KIALI-1542 Use new namespaces graph REST endpoint

### DIFF
--- a/src/actions/GraphDataActions.ts
+++ b/src/actions/GraphDataActions.ts
@@ -155,7 +155,11 @@ export const GraphDataActions = {
           }
         );
       }
-      return API.getGraphElements(authentication(), namespace, restParams).then(
+
+      if (namespace.name !== 'all') {
+        restParams['namespaces'] = namespace.name;
+      }
+      return API.getGraphElements(authentication(), restParams).then(
         response => {
           const responseData: any = response['data'];
           const graphData = responseData && responseData.elements ? responseData.elements : EMPTY_GRAPH_DATA;

--- a/src/config.ts
+++ b/src/config.ts
@@ -91,7 +91,7 @@ const conf = {
         `api/namespaces/${namespace}/istio/${objectType}/${object}/istio_validations`,
       jaeger: 'api/jaeger',
       namespaces: 'api/namespaces',
-      namespaceGraphElements: (namespace: string) => `api/namespaces/${namespace}/graph`,
+      namespacesGraphElements: `api/namespaces/graph`,
       namespaceHealth: (namespace: string) => `api/namespaces/${namespace}/health`,
       namespaceMetrics: (namespace: string) => `api/namespaces/${namespace}/metrics`,
       namespaceValidations: (namespace: string) => `api/namespaces/${namespace}/istio_validations`,

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -272,8 +272,8 @@ export const getJaegerInfo = (auth: AuthToken): Promise<Response<JaegerInfo>> =>
   return newRequest(HTTP_VERBS.GET, urls.jaeger, {}, {}, auth);
 };
 
-export const getGraphElements = (auth: AuthToken, namespace: Namespace, params: any) => {
-  return newRequest(HTTP_VERBS.GET, urls.namespaceGraphElements(namespace.name), params, {}, auth);
+export const getGraphElements = (auth: AuthToken, params: any) => {
+  return newRequest(HTTP_VERBS.GET, urls.namespacesGraphElements, params, {}, auth);
 };
 
 export const getNodeGraphElements = (
@@ -297,7 +297,7 @@ export const getNodeGraphElements = (
       return newRequest(HTTP_VERBS.GET, urls.workloadGraphElements(namespace.name, node.workload), params, {}, auth);
     default:
       // default to namespace graph
-      return getGraphElements(auth, namespace, params);
+      return getGraphElements(auth, { namespaces: namespace.name, ...params });
   }
 };
 

--- a/src/services/__mocks__/Api.ts
+++ b/src/services/__mocks__/Api.ts
@@ -32,9 +32,9 @@ export const getJaegerInfo = () => {
   return mockPromiseFromFile(`./src/services/__mockData__/getJaegerInfo.json`);
 };
 
-export const getGraphElements = (namespace: string, params: any) => {
-  if (GraphData.hasOwnProperty(namespace)) {
-    return Promise.resolve({ data: GraphData[namespace] });
+export const getGraphElements = (params: any) => {
+  if (GraphData.hasOwnProperty(params.namespaces)) {
+    return Promise.resolve({ data: GraphData[params.namespaces] });
   } else {
     return Promise.resolve({ data: {} });
   }

--- a/src/services/__tests__/Api.test.tsx
+++ b/src/services/__tests__/Api.test.tsx
@@ -42,8 +42,8 @@ describe('#getJaegerInfo using Promises', () => {
 });
 
 describe('#GetGraphElements using Promises', () => {
-  it('should load service detail data', () => {
-    return API.getGraphElements('ISTIO_SYSTEM', null).then(({ data }) => {
+  it('should load graph data', () => {
+    return API.getGraphElements({ namespaces: 'ISTIO_SYSTEM' }).then(({ data }) => {
       expect(data).toBeDefined();
       expect(data.elements.nodes).toBeDefined();
       expect(data.elements.nodes).toBeInstanceOf(Array);

--- a/src/services/__tests__/ApiMethods.test.tsx.ts
+++ b/src/services/__tests__/ApiMethods.test.tsx.ts
@@ -108,7 +108,7 @@ describe('#Test Methods return a Promise', () => {
   });
 
   it('#getGraphElements', () => {
-    const result = API.getGraphElements(authentication(), { name: 'istio-system' }, {});
+    const result = API.getGraphElements(authentication(), { namespaces: 'istio-system' });
     evaluatePromise(result);
   });
 


### PR DESCRIPTION
Use the new namespace graph endpoint.

** Backwards compatible? **
NO

This requires server PR: https://github.com/kiali/kiali/pull/622
