### PR TITLE
Kiali 1782 Handle activeNamespace in a more consistent way

### DIFF
--- a/src/actions/GraphDataActions.ts
+++ b/src/actions/GraphDataActions.ts
@@ -155,7 +155,11 @@ export const GraphDataActions = {
           }
         );
       }
-      return API.getGraphElements(authentication(), namespace, restParams).then(
+
+      if (namespace.name !== 'all') {
+        restParams['namespaces'] = namespace.name;
+      }
+      return API.getGraphElements(authentication(), restParams).then(
         response => {
           const responseData: any = response['data'];
           const graphData = responseData && responseData.elements ? responseData.elements : EMPTY_GRAPH_DATA;

--- a/src/actions/NamespaceAction.ts
+++ b/src/actions/NamespaceAction.ts
@@ -2,7 +2,6 @@ import * as Api from '../services/Api';
 import { createAction } from 'typesafe-actions';
 import Namespace from '../types/Namespace';
 import { KialiAppState } from '../store/Store';
-import { JsonString } from '../types/Common';
 
 export enum NamespaceActionKeys {
   NAMESPACE_REQUEST_STARTED = 'NAMESPACE_REQUEST_STARTED',
@@ -24,10 +23,6 @@ export const NamespaceActions = {
   setActiveNamespace: createAction(NamespaceActionKeys.SET_ACTIVE_NAMESPACE, (namespace: Namespace) => ({
     type: NamespaceActionKeys.SET_ACTIVE_NAMESPACE,
     payload: namespace
-  })),
-  setPreviousGraphState: createAction(NamespaceActionKeys.SET_PREVIOUS_GRAPH_STATE, (state: JsonString) => ({
-    type: NamespaceActionKeys.SET_PREVIOUS_GRAPH_STATE,
-    payload: state
   })),
   requestStarted: createAction(NamespaceActionKeys.NAMESPACE_REQUEST_STARTED),
   requestFailed: createAction(NamespaceActionKeys.NAMESPACE_FAILED),

--- a/src/actions/__tests__/NamespaceAction.test.ts
+++ b/src/actions/__tests__/NamespaceAction.test.ts
@@ -35,14 +35,6 @@ describe('NamespaceActions', () => {
     expect(NamespaceActions.setActiveNamespace({ name: 'istio' })).toEqual(expectedAction);
   });
 
-  it('should set previous graph state', () => {
-    const expectedAction = {
-      type: NamespaceActionKeys.SET_PREVIOUS_GRAPH_STATE,
-      payload: "{a: 'b'}"
-    };
-    expect(NamespaceActions.setPreviousGraphState("{a: 'b'}")).toEqual(expectedAction);
-  });
-
   it('request is success', () => {
     const currentDate = new Date();
     const expectedAction = {

--- a/src/components/CytoscapeGraph/__tests__/CytoscapeGraph.test.tsx
+++ b/src/components/CytoscapeGraph/__tests__/CytoscapeGraph.test.tsx
@@ -27,7 +27,6 @@ describe('CytoscapeGraph component test', () => {
 
     const wrapper = shallow(
       <CytoscapeGraph
-        namespace={{ name: testNamespace }}
         elements={GRAPH_DATA[testNamespace].elements}
         graphLayout={myLayout}
         graphDuration={myDuration}

--- a/src/components/GraphFilter/GraphFilter.tsx
+++ b/src/components/GraphFilter/GraphFilter.tsx
@@ -7,14 +7,12 @@ import { Duration, EdgeLabelMode } from '../../types/GraphFilter';
 import { ToolbarDropdown } from '../ToolbarDropdown/ToolbarDropdown';
 import NamespaceDropdownContainer from '../../containers/NamespaceDropdownContainer';
 import { GraphParamsType, GraphType } from '../../types/Graph';
-import Namespace from '../../types/Namespace';
 import GraphRefreshContainer from '../../containers/GraphRefreshContainer';
 import GraphSettingsContainer from '../../containers/GraphSettingsContainer';
 
 export interface GraphFilterProps extends GraphParamsType {
   disabled: boolean;
   onDurationChange: (newDuration: Duration) => void;
-  onNamespaceChange: (newValue: Namespace) => void;
   onNamespaceReturn: () => void;
   onGraphTypeChange: (newType: GraphType) => void;
   onEdgeLabelModeChange: (newEdgeLabelMode: EdgeLabelMode) => void;
@@ -79,10 +77,7 @@ export default class GraphFilter extends React.PureComponent<GraphFilterProps> {
             ) : (
               <label className={namespaceStyle}>Namespace:</label>
             )}
-            <NamespaceDropdownContainer
-              disabled={this.props.node || this.props.disabled}
-              onSelect={this.props.onNamespaceChange}
-            />
+            <NamespaceDropdownContainer disabled={this.props.node || this.props.disabled} />
           </FormGroup>
           <FormGroup className={zeroPaddingLeft}>
             <GraphSettingsContainer {...this.props} />

--- a/src/components/GraphFilter/GraphFilterToolbar.tsx
+++ b/src/components/GraphFilter/GraphFilterToolbar.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 
 import { GraphParamsType, GraphType } from '../../types/Graph';
 import { Duration, EdgeLabelMode } from '../../types/GraphFilter';
-import Namespace from '../../types/Namespace';
 import GraphFilterToolbarType from '../../types/GraphFilterToolbar';
 import { store } from '../../store/ConfigStore';
 import { makeNamespaceGraphUrlFromParams, makeNodeGraphUrlFromParams } from '../Nav/NavUtils';
@@ -17,7 +16,6 @@ export default class GraphFilterToolbar extends React.PureComponent<GraphFilterT
 
   render() {
     const graphParams: GraphParamsType = {
-      namespace: this.props.namespace,
       node: this.props.node,
       graphLayout: this.props.graphLayout,
       graphDuration: this.props.graphDuration,
@@ -30,7 +28,6 @@ export default class GraphFilterToolbar extends React.PureComponent<GraphFilterT
       <GraphFilter
         disabled={this.props.isLoading}
         onDurationChange={this.handleDurationChange}
-        onNamespaceChange={this.handleNamespaceChange}
         onNamespaceReturn={this.handleNamespaceReturn}
         onGraphTypeChange={this.handleGraphTypeChange}
         onEdgeLabelModeChange={this.handleEdgeLabelModeChange}
@@ -47,15 +44,8 @@ export default class GraphFilterToolbar extends React.PureComponent<GraphFilterT
     });
   };
 
-  handleNamespaceChange = (namespace: Namespace) => {
-    store.dispatch(GraphActions.changed());
-    this.handleFilterChange({
-      ...this.getGraphParams(),
-      namespace
-    });
-  };
-
   handleNamespaceReturn = () => {
+    // TODO: This should be handled by a redux action that sets the node to undefined
     this.context.router.history.push(makeNamespaceGraphUrlFromParams({ ...this.getGraphParams(), node: undefined }));
   };
 
@@ -79,7 +69,7 @@ export default class GraphFilterToolbar extends React.PureComponent<GraphFilterT
       store.dispatch(
         // @ts-ignore
         GraphDataActions.fetchGraphData(
-          this.props.namespace,
+          store.getState().namespaces.activeNamespace,
           this.props.graphDuration,
           this.props.graphType,
           this.props.injectServiceNodes,
@@ -102,7 +92,6 @@ export default class GraphFilterToolbar extends React.PureComponent<GraphFilterT
 
   private getGraphParams: () => GraphParamsType = () => {
     return {
-      namespace: this.props.namespace,
       node: this.props.node,
       graphDuration: this.props.graphDuration,
       graphLayout: this.props.graphLayout,

--- a/src/components/GraphFilter/__tests__/GraphFilterToolbar.test.tsx
+++ b/src/components/GraphFilter/__tests__/GraphFilterToolbar.test.tsx
@@ -3,12 +3,10 @@ import { shallow } from 'enzyme';
 
 import { GraphParamsType, GraphType } from '../../../types/Graph';
 import { Duration, EdgeLabelMode } from '../../../types/GraphFilter';
-import Namespace from '../../../types/Namespace';
 
 import GraphFilterToolbar from '../GraphFilterToolbar';
 
 const PARAMS: GraphParamsType = {
-  namespace: { name: 'itsio-system' },
   graphDuration: { value: 60 },
   graphLayout: { name: 'Cose' },
   edgeLabelMode: EdgeLabelMode.HIDE,
@@ -36,10 +34,5 @@ describe('GraphPage test', () => {
     toolbar.handleDurationChange(newDuration); // simulate duration change
     const EXPECT2 = Object.assign({}, PARAMS, { graphDuration: newDuration });
     expect(onParamsChangeMockFn).toHaveBeenLastCalledWith(EXPECT2);
-
-    const newNamespace: Namespace = { name: 'bookinfo' };
-    toolbar.handleNamespaceChange(newNamespace); // simulate name change
-    const EXPECT3 = Object.assign({}, PARAMS, { namespace: newNamespace });
-    expect(onParamsChangeMockFn).toHaveBeenLastCalledWith(EXPECT3);
   });
 });

--- a/src/components/NamespaceDropdown.tsx
+++ b/src/components/NamespaceDropdown.tsx
@@ -20,7 +20,10 @@ export class NamespaceDropdown extends React.PureComponent<NamespaceListType, {}
     this.props.refresh();
   }
 
-  handleSelectNamespace = (namespace: string) => this.props.onSelect({ name: namespace });
+  handleSelectNamespace = (namespace: string) => {
+    this.props.onSelect({ name: namespace });
+  };
+
   handleToggle = (isOpen: boolean) => isOpen && this.props.refresh();
 
   render() {

--- a/src/components/Nav/NavUtils.tsx
+++ b/src/components/Nav/NavUtils.tsx
@@ -1,4 +1,5 @@
 import { GraphParamsType, NodeType } from '../../types/Graph';
+import { store } from '../../store/ConfigStore';
 
 const buildCommonQueryParams = (params: GraphParamsType): string => {
   let q = `layout=${params.graphLayout.name}`;
@@ -10,7 +11,12 @@ const buildCommonQueryParams = (params: GraphParamsType): string => {
 };
 
 export const makeNamespaceGraphUrlFromParams = (params: GraphParamsType): string => {
-  return `/graph/namespaces/${params.namespace.name}?` + buildCommonQueryParams(params);
+  const namespace = store.getState().namespaces.activeNamespace.name;
+  let queryParams = buildCommonQueryParams(params);
+  if (namespace !== 'all') {
+    queryParams += `&namespaces=${namespace}`;
+  }
+  return `/graph/namespaces?` + queryParams;
 };
 
 export const makeNodeGraphUrlFromParams = (params: GraphParamsType): string | undefined => {
@@ -20,23 +26,27 @@ export const makeNodeGraphUrlFromParams = (params: GraphParamsType): string | un
       case NodeType.APP:
         if (node.version && node.version !== 'unknown') {
           return (
-            `/graph/namespaces/${params.namespace.name}/applications/${node.app}/versions/${node.version}?` +
+            `/graph/node/namespaces/${node.namespace.name}/applications/${node.app}/versions/${node.version}?` +
             buildCommonQueryParams(params)
           );
         }
-        return `/graph/namespaces/${params.namespace.name}/applications/${node.app}?` + buildCommonQueryParams(params);
+        return (
+          `/graph/node/namespaces/${node.namespace.name}/applications/${node.app}?` + buildCommonQueryParams(params)
+        );
       case NodeType.WORKLOAD:
         return (
-          `/graph/namespaces/${params.namespace.name}/workloads/${node.workload}?` + buildCommonQueryParams(params)
+          `/graph/node/namespaces/${node.namespace.name}/workloads/${node.workload}?` + buildCommonQueryParams(params)
         );
       case NodeType.SERVICE:
-        return `/graph/namespaces/${params.namespace.name}/services/${node.service}?` + buildCommonQueryParams(params);
+        return (
+          `/graph/node/namespaces/${node.namespace.name}/services/${node.service}?` + buildCommonQueryParams(params)
+        );
       default:
         console.debug('makeNodeUrl defaulting to makeNamespaceUrl');
         return makeNamespaceGraphUrlFromParams(params);
     }
   } else {
-    // this will never happen but typescript needs this
+    // this should never happen but typescript needs this
     return undefined;
   }
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -91,7 +91,7 @@ const conf = {
         `api/namespaces/${namespace}/istio/${objectType}/${object}/istio_validations`,
       jaeger: 'api/jaeger',
       namespaces: 'api/namespaces',
-      namespaceGraphElements: (namespace: string) => `api/namespaces/${namespace}/graph`,
+      namespacesGraphElements: `api/namespaces/graph`,
       namespaceHealth: (namespace: string) => `api/namespaces/${namespace}/health`,
       namespaceMetrics: (namespace: string) => `api/namespaces/${namespace}/metrics`,
       namespaceValidations: (namespace: string) => `api/namespaces/${namespace}/istio_validations`,

--- a/src/containers/GraphPageContainer.ts
+++ b/src/containers/GraphPageContainer.ts
@@ -8,8 +8,10 @@ import { GraphDataActions } from '../actions/GraphDataActions';
 import { GraphFilterActions } from '../actions/GraphFilterActions';
 import { bindActionCreators } from 'redux';
 import { GraphType, NodeParamsType } from '../types/Graph';
+import { activeNamespaceSelector } from '../store/Selectors';
 
 const mapStateToProps = (state: KialiAppState) => ({
+  activeNamespace: activeNamespaceSelector(state),
   graphTimestamp: state.graph.graphDataTimestamp,
   graphData: state.graph.graphData,
   isLoading: state.graph.isLoading,

--- a/src/containers/GraphSettingsContainer.tsx
+++ b/src/containers/GraphSettingsContainer.tsx
@@ -86,7 +86,7 @@ class GraphSettings extends React.PureComponent<GraphSettingsProps> {
       store.dispatch(
         // @ts-ignore
         GraphDataActions.fetchGraphData(
-          this.props.namespace,
+          store.getState().namespaces.activeNamespace,
           this.props.graphDuration,
           this.props.graphType,
           this.props.injectServiceNodes,
@@ -237,7 +237,6 @@ class GraphSettings extends React.PureComponent<GraphSettingsProps> {
 
   private getGraphParams: () => GraphParamsType = () => {
     return {
-      namespace: this.props.namespace,
       node: this.props.node,
       graphDuration: this.props.graphDuration,
       graphLayout: this.props.graphLayout,

--- a/src/pages/Overview/OverviewPage.tsx
+++ b/src/pages/Overview/OverviewPage.tsx
@@ -152,10 +152,6 @@ class OverviewPage extends React.Component<OverviewProps, State> {
     this.setState({ namespaces: sorted });
   };
 
-  handleNamespaceClick = (namespace: string) => {
-    this.props.setActiveNamespace({ name: namespace });
-  };
-
   render() {
     return (
       <>
@@ -168,17 +164,12 @@ class OverviewPage extends React.Component<OverviewProps, State> {
             <Row style={{ marginBottom: '20px', marginTop: '20px' }}>
               {this.state.namespaces.map(ns => {
                 const nbApps = ns.appsInError.length + ns.appsInWarning.length + ns.appsInSuccess.length;
-                const encodedName = encodeURIComponent(ns.name);
+                const encodedNsName = encodeURIComponent(ns.name);
                 return (
                   <Col xs={6} sm={3} md={3} key={ns.name}>
                     <Card matchHeight={true} accented={true} aggregated={true}>
                       <CardTitle>
-                        <Link
-                          to={`/graph/namespaces/${encodedName}`}
-                          onClick={() => this.handleNamespaceClick(ns.name)}
-                        >
-                          {ns.name}
-                        </Link>
+                        <Link to={`/graph/namespaces?namespaces=` + encodedNsName}>{ns.name}</Link>
                       </CardTitle>
                       <CardBody>
                         <ListPageLink target={TargetPage.APPLICATIONS} namespace={ns.name}>
@@ -198,11 +189,7 @@ class OverviewPage extends React.Component<OverviewProps, State> {
                           {nbApps === 0 && <AggregateStatusNotification>N/A</AggregateStatusNotification>}
                         </AggregateStatusNotifications>
                         <div>
-                          <Link
-                            to={`/graph/namespaces/${encodedName}`}
-                            title="Graph"
-                            onClick={() => this.handleNamespaceClick(ns.name)}
-                          >
+                          <Link to={`/graph/namespaces?namespaces=` + ns.name} title="Graph">
                             <Icon type="pf" name="topology" style={{ paddingLeft: 10, paddingRight: 10 }} />
                           </Link>
                           <ListPageLink target={TargetPage.APPLICATIONS} namespace={ns.name} title="Applications list">

--- a/src/reducers/NamespaceState.ts
+++ b/src/reducers/NamespaceState.ts
@@ -4,7 +4,6 @@ import { NamespaceState } from '../store/Store';
 
 export const INITIAL_NAMESPACE_STATE: NamespaceState = {
   activeNamespace: { name: 'all' },
-  previousGraphState: undefined,
   isFetching: false,
   items: ['all'],
   lastUpdated: undefined
@@ -15,11 +14,6 @@ const namespaces = (state: NamespaceState = INITIAL_NAMESPACE_STATE, action) => 
     case NamespaceActionKeys.SET_ACTIVE_NAMESPACE:
       return updateState(state, {
         activeNamespace: { name: action.payload.name }
-      });
-
-    case NamespaceActionKeys.SET_PREVIOUS_GRAPH_STATE:
-      return updateState(state, {
-        previousGraphState: action.payload
       });
 
     case NamespaceActionKeys.NAMESPACE_REQUEST_STARTED:

--- a/src/reducers/__tests__/NamespacesReducer.test.ts
+++ b/src/reducers/__tests__/NamespacesReducer.test.ts
@@ -7,7 +7,6 @@ describe('Namespaces reducer', () => {
     expect(namespaceState(undefined, {})).toEqual({
       isFetching: false,
       activeNamespace: { name: 'all' },
-      previousGraphState: undefined,
       items: ['all'],
       lastUpdated: undefined
     });
@@ -16,7 +15,6 @@ describe('Namespaces reducer', () => {
   it('should handle ACTIVE_NAMESPACE', () => {
     const currentState = {
       activeNamespace: { name: 'all' },
-      previousGraphState: undefined,
       isFetching: false,
       items: [],
       lastUpdated: undefined
@@ -27,29 +25,6 @@ describe('Namespaces reducer', () => {
     };
     const expectedState = {
       activeNamespace: { name: 'istio' },
-      previousGraphState: undefined,
-      isFetching: false,
-      items: [],
-      lastUpdated: undefined
-    };
-    expect(namespaceState(currentState, requestStartedAction)).toEqual(expectedState);
-  });
-
-  it('should handle PREVIOUS_GRAPH_STATE', () => {
-    const currentState = {
-      activeNamespace: { name: 'all' },
-      previousGraphState: undefined,
-      isFetching: false,
-      items: [],
-      lastUpdated: undefined
-    };
-    const requestStartedAction = {
-      type: NamespaceActionKeys.SET_PREVIOUS_GRAPH_STATE,
-      payload: 'abc'
-    };
-    const expectedState = {
-      activeNamespace: { name: 'all' },
-      previousGraphState: 'abc',
       isFetching: false,
       items: [],
       lastUpdated: undefined
@@ -60,7 +35,6 @@ describe('Namespaces reducer', () => {
   it('should handle NAMESPACE_REQUEST_STARTED', () => {
     const currentState = {
       activeNamespace: { name: 'all' },
-      previousGraphState: undefined,
       isFetching: false,
       items: [],
       lastUpdated: undefined
@@ -70,7 +44,6 @@ describe('Namespaces reducer', () => {
     };
     const expectedState = {
       activeNamespace: { name: 'all' },
-      previousGraphState: undefined,
       isFetching: true,
       items: [],
       lastUpdated: undefined
@@ -81,7 +54,6 @@ describe('Namespaces reducer', () => {
   it('should handle NAMESPACE_FAILED', () => {
     const currentState = {
       activeNamespace: { name: 'all' },
-      previousGraphState: undefined,
       isFetching: true,
       items: []
     };
@@ -90,7 +62,6 @@ describe('Namespaces reducer', () => {
     };
     const expectedState = {
       activeNamespace: { name: 'all' },
-      previousGraphState: undefined,
       isFetching: false,
       items: []
     };
@@ -101,7 +72,6 @@ describe('Namespaces reducer', () => {
     const currentDate = new Date();
     const currentState = {
       activeNamespace: { name: 'all' },
-      previousGraphState: undefined,
       isFetching: true,
       items: ['old', 'namespace'],
       lastUpdated: undefined
@@ -113,7 +83,6 @@ describe('Namespaces reducer', () => {
     };
     const expectedState = {
       activeNamespace: { name: 'all' },
-      previousGraphState: undefined,
       isFetching: false,
       items: ['a', 'b', 'c'],
       lastUpdated: currentDate

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -8,7 +8,7 @@ import AppListPage from './pages/AppList/AppListPage';
 import AppDetailsPage from './pages/AppDetails/AppDetailsPage';
 import { MenuItem, Path } from './types/Routes';
 
-import GraphRouteHandlerContainer from './pages/Graph/GraphRouteHandler';
+import GraphRouteHandler from './pages/Graph/GraphRouteHandler';
 import OverviewPageContainer from './containers/OverviewPageContainer';
 import ServiceDetailsPageContainer from './containers/ServiceDetailsPageContainer';
 
@@ -26,7 +26,7 @@ const navItems: MenuItem[] = [
   {
     iconClass: 'fa pficon-topology',
     title: 'Graph',
-    to: '/graph/namespaces/all',
+    to: '/graph/namespaces?keepState=true',
     pathsActive: [/^\/graph\/(.*)/]
   },
   {
@@ -68,24 +68,24 @@ const pathRoutes: Path[] = [
     component: OverviewPageContainer
   },
   {
-    path: '/graph/namespaces/:namespace/applications/:app/versions/:version',
-    component: GraphRouteHandlerContainer
+    path: '/graph/node/namespaces/:namespace/applications/:app/versions/:version',
+    component: GraphRouteHandler
   },
   {
-    path: '/graph/namespaces/:namespace/applications/:app',
-    component: GraphRouteHandlerContainer
+    path: '/graph/node/namespaces/:namespace/applications/:app',
+    component: GraphRouteHandler
   },
   {
-    path: '/graph/namespaces/:namespace/services/:service',
-    component: GraphRouteHandlerContainer
+    path: '/graph/node/namespaces/:namespace/services/:service',
+    component: GraphRouteHandler
   },
   {
-    path: '/graph/namespaces/:namespace/workloads/:workload',
-    component: GraphRouteHandlerContainer
+    path: '/graph/node/namespaces/:namespace/workloads/:workload',
+    component: GraphRouteHandler
   },
   {
-    path: '/graph/namespaces/:namespace',
-    component: GraphRouteHandlerContainer
+    path: '/graph/namespaces',
+    component: GraphRouteHandler
   },
   {
     path: '/namespaces/:namespace/services/:service',

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -272,8 +272,8 @@ export const getJaegerInfo = (auth: AuthToken): Promise<Response<JaegerInfo>> =>
   return newRequest(HTTP_VERBS.GET, urls.jaeger, {}, {}, auth);
 };
 
-export const getGraphElements = (auth: AuthToken, namespace: Namespace, params: any) => {
-  return newRequest(HTTP_VERBS.GET, urls.namespaceGraphElements(namespace.name), params, {}, auth);
+export const getGraphElements = (auth: AuthToken, params: any) => {
+  return newRequest(HTTP_VERBS.GET, urls.namespacesGraphElements, params, {}, auth);
 };
 
 export const getNodeGraphElements = (
@@ -297,7 +297,7 @@ export const getNodeGraphElements = (
       return newRequest(HTTP_VERBS.GET, urls.workloadGraphElements(namespace.name, node.workload), params, {}, auth);
     default:
       // default to namespace graph
-      return getGraphElements(auth, namespace, params);
+      return getGraphElements(auth, { namespaces: namespace.name, ...params });
   }
 };
 

--- a/src/services/__mocks__/Api.ts
+++ b/src/services/__mocks__/Api.ts
@@ -32,9 +32,9 @@ export const getJaegerInfo = () => {
   return mockPromiseFromFile(`./src/services/__mockData__/getJaegerInfo.json`);
 };
 
-export const getGraphElements = (namespace: string, params: any) => {
-  if (GraphData.hasOwnProperty(namespace)) {
-    return Promise.resolve({ data: GraphData[namespace] });
+export const getGraphElements = (params: any) => {
+  if (GraphData.hasOwnProperty(params.namespaces)) {
+    return Promise.resolve({ data: GraphData[params.namespaces] });
   } else {
     return Promise.resolve({ data: {} });
   }

--- a/src/services/__tests__/Api.test.tsx
+++ b/src/services/__tests__/Api.test.tsx
@@ -42,8 +42,8 @@ describe('#getJaegerInfo using Promises', () => {
 });
 
 describe('#GetGraphElements using Promises', () => {
-  it('should load service detail data', () => {
-    return API.getGraphElements('ISTIO_SYSTEM', null).then(({ data }) => {
+  it('should load graph data', () => {
+    return API.getGraphElements({ namespaces: 'ISTIO_SYSTEM' }).then(({ data }) => {
       expect(data).toBeDefined();
       expect(data.elements.nodes).toBeDefined();
       expect(data.elements.nodes).toBeInstanceOf(Array);

--- a/src/services/__tests__/ApiMethods.test.tsx.ts
+++ b/src/services/__tests__/ApiMethods.test.tsx.ts
@@ -108,7 +108,7 @@ describe('#Test Methods return a Promise', () => {
   });
 
   it('#getGraphElements', () => {
-    const result = API.getGraphElements(authentication(), { name: 'istio-system' }, {});
+    const result = API.getGraphElements(authentication(), { namespaces: 'istio-system' });
     evaluatePromise(result);
   });
 

--- a/src/store/Selectors.ts
+++ b/src/store/Selectors.ts
@@ -11,13 +11,6 @@ export const activeNamespaceSelector = createSelector(
   namespace => namespace // identity function in this case, but as a Namespace type
 );
 
-const previousGraphState = (state: KialiAppState) => state.namespaces.previousGraphState;
-
-export const previousGraphStateSelector = createSelector(
-  previousGraphState,
-  x => x // identity function
-);
-
 const namespaceItems = (state: KialiAppState) => state.namespaces.items;
 
 export const namespaceItemsSelector = createSelector(

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -1,6 +1,7 @@
 import { NotificationGroup } from '../types/MessageCenter';
 import Namespace from '../types/Namespace';
-import { JsonString, PollIntervalInMs } from '../types/Common';
+import { PollIntervalInMs } from '../types/Common';
+
 // Store is the Redux Data store
 
 export interface GlobalState {
@@ -10,7 +11,6 @@ export interface GlobalState {
 
 export interface NamespaceState {
   readonly activeNamespace: Namespace;
-  readonly previousGraphState?: JsonString;
   readonly items?: string[];
   readonly isFetching: boolean;
   readonly lastUpdated?: Date;

--- a/src/types/Graph.ts
+++ b/src/types/Graph.ts
@@ -35,15 +35,15 @@ export enum NodeType {
 }
 
 export interface NodeParamsType {
-  nodeType: NodeType;
-  workload: string;
   app: string;
-  version: string;
+  namespace: Namespace;
+  nodeType: NodeType;
   service: string;
+  version: string;
+  workload: string;
 }
 
 export interface GraphParamsType {
-  namespace: Namespace;
   node?: NodeParamsType;
   graphDuration: Duration;
   graphLayout: Layout;


### PR DESCRIPTION
- rely on redux state change to update activeNamespace
- avoid pushing URLs to force change
- avoid handler 'drill-down'
- support bookmarkability
  - trust URLs as the truth on initial navigation
  - trust redux for state change after initial navigation
  - keep URL reflecting current state
- separate redux-managed state from session-managed state

*** Requires Server PR https://github.com/kiali/kiali/pull/622 ***
*** The server PR is because this incorporates the fix for 1542 ***