### PR TITLE
KIALI-1867 Istio Config - Filtering by Type Fails

### DIFF
--- a/src/types/IstioConfigList.ts
+++ b/src/types/IstioConfigList.ts
@@ -215,22 +215,26 @@ export const toIstioItems = (istioConfigList: IstioConfigList): IstioConfigItem[
   istioConfigList.gateways.forEach(gw =>
     istioItems.push({ namespace: istioConfigList.namespace.name, type: 'gateway', name: gw.name, gateway: gw })
   );
-  istioConfigList.virtualServices.items.forEach(vs =>
-    istioItems.push({
-      namespace: istioConfigList.namespace.name,
-      type: 'virtualservice',
-      name: vs.name,
-      virtualService: vs
-    })
-  );
-  istioConfigList.destinationRules.items.forEach(dr =>
-    istioItems.push({
-      namespace: istioConfigList.namespace.name,
-      type: 'destinationrule',
-      name: dr.name,
-      destinationRule: dr
-    })
-  );
+  if (istioConfigList.virtualServices.items) {
+    istioConfigList.virtualServices.items.forEach(vs =>
+      istioItems.push({
+        namespace: istioConfigList.namespace.name,
+        type: 'virtualservice',
+        name: vs.name,
+        virtualService: vs
+      })
+    );
+  }
+  if (istioConfigList.destinationRules.items) {
+    istioConfigList.destinationRules.items.forEach(dr =>
+      istioItems.push({
+        namespace: istioConfigList.namespace.name,
+        type: 'destinationrule',
+        name: dr.name,
+        destinationRule: dr
+      })
+    );
+  }
   istioConfigList.serviceEntries.forEach(se =>
     istioItems.push({
       namespace: istioConfigList.namespace.name,
@@ -239,6 +243,7 @@ export const toIstioItems = (istioConfigList: IstioConfigList): IstioConfigItem[
       serviceEntry: se
     })
   );
+
   istioConfigList.rules.forEach(r =>
     istioItems.push({ namespace: istioConfigList.namespace.name, type: 'rule', name: r.name, rule: r })
   );


### PR DESCRIPTION
[KIALI-1867](https://issues.jboss.org/browse/KIALI-1867)
cc @lucasponce the backend returns a null value when there isn't items
Request /api/namespaces/bookinfo/istio?objects=destinationrules
```json
{"virtualServices":{"permissions":{"update":false,"delete":false},"items":null}}
```

I think that we should return empty array instead of null or set a omitEmpty to avoid this instead of make the change in the front. What do you think?