### PR TITLE
KIALI-1561 Add status-filtered links to overview page

### DIFF
--- a/src/components/Filters/NamespaceFilter.ts
+++ b/src/components/Filters/NamespaceFilter.ts
@@ -3,11 +3,12 @@ import { authentication } from '../../utils/Authentication';
 import { FILTER_ACTION_APPEND, FilterType } from '../../types/Filters';
 
 export class NamespaceFilter {
+  static id = 'namespace';
   static category = 'Namespace';
 
   static create = (): FilterType => {
     return {
-      id: 'namespace',
+      id: NamespaceFilter.id,
       title: NamespaceFilter.category,
       placeholder: 'Filter by Namespace',
       filterType: 'select',

--- a/src/components/ListPage/ListPageLink.tsx
+++ b/src/components/ListPage/ListPageLink.tsx
@@ -3,6 +3,8 @@ import { Link } from 'react-router-dom';
 import { FilterSelected } from '../Filters/StatefulFilters';
 import history from '../../app/History';
 import NamespaceFilter from '../Filters/NamespaceFilter';
+import { ActiveFilter } from 'src/types/Filters';
+import { healthFilter } from '../Filters/CommonFilters';
 
 export enum TargetPage {
   APPLICATIONS = 'applications',
@@ -12,38 +14,39 @@ export enum TargetPage {
 }
 
 type Props = {
-  namespace?: string;
-  title?: string;
   target: TargetPage;
+  title?: string;
+  namespace?: string;
+  health?: string;
   onClick?: () => void;
 };
 
 export class ListPageLink extends React.PureComponent<Props, {}> {
-  static navigateTo(target: TargetPage, namespace?: string) {
-    const info = ListPageLink.buildLinkInfo(target, namespace);
+  static navigateTo(target: TargetPage, namespace?: string, health?: string) {
+    const info = ListPageLink.buildLinkInfo(target, namespace, health);
     info.updateFilters();
     history.push(info.to);
   }
 
-  private static buildLinkInfo(target: TargetPage, namespace?: string) {
+  private static buildLinkInfo(target: TargetPage, namespace?: string, health?: string) {
+    const filters: (ActiveFilter & { id: string })[] = [];
     if (namespace) {
-      return {
-        to: `/${target}?namespace=${encodeURIComponent(namespace)}`,
-        updateFilters: () => {
-          FilterSelected.setSelected([
-            {
-              category: NamespaceFilter.category,
-              value: namespace
-            }
-          ]);
-        }
-      };
+      filters.push({
+        id: NamespaceFilter.id,
+        category: NamespaceFilter.category,
+        value: encodeURIComponent(namespace)
+      });
+    }
+    if (health) {
+      filters.push({
+        id: healthFilter.id,
+        category: healthFilter.title,
+        value: health
+      });
     }
     return {
-      to: `/${target}`,
-      updateFilters: () => {
-        FilterSelected.setSelected([]);
-      }
+      to: `/${target}?${filters.map(f => f.id + '=' + f.value).join('&')}`,
+      updateFilters: () => FilterSelected.setSelected(filters)
     };
   }
 
@@ -52,7 +55,7 @@ export class ListPageLink extends React.PureComponent<Props, {}> {
   }
 
   render() {
-    const info = ListPageLink.buildLinkInfo(this.props.target, this.props.namespace);
+    const info = ListPageLink.buildLinkInfo(this.props.target, this.props.namespace, this.props.health);
     const onClick = () => {
       info.updateFilters();
       if (this.props.onClick) {

--- a/src/pages/Overview/OverviewPage.tsx
+++ b/src/pages/Overview/OverviewPage.tsx
@@ -178,13 +178,28 @@ class OverviewPage extends React.Component<OverviewProps, State> {
                         </ListPageLink>
                         <AggregateStatusNotifications>
                           {ns.appsInError.length > 0 && (
-                            <OverviewStatus id={ns.name + '-failure'} status={FAILURE} items={ns.appsInError} />
+                            <OverviewStatus
+                              id={ns.name + '-failure'}
+                              namespace={ns.name}
+                              status={FAILURE}
+                              items={ns.appsInError}
+                            />
                           )}
                           {ns.appsInWarning.length > 0 && (
-                            <OverviewStatus id={ns.name + '-degraded'} status={DEGRADED} items={ns.appsInWarning} />
+                            <OverviewStatus
+                              id={ns.name + '-degraded'}
+                              namespace={ns.name}
+                              status={DEGRADED}
+                              items={ns.appsInWarning}
+                            />
                           )}
                           {ns.appsInSuccess.length > 0 && (
-                            <OverviewStatus id={ns.name + '-healthy'} status={HEALTHY} items={ns.appsInSuccess} />
+                            <OverviewStatus
+                              id={ns.name + '-healthy'}
+                              namespace={ns.name}
+                              status={HEALTHY}
+                              items={ns.appsInSuccess}
+                            />
                           )}
                           {nbApps === 0 && <AggregateStatusNotification>N/A</AggregateStatusNotification>}
                         </AggregateStatusNotifications>

--- a/src/pages/Overview/OverviewStatus.tsx
+++ b/src/pages/Overview/OverviewStatus.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
 import { AggregateStatusNotification, Icon, OverlayTrigger, Popover } from 'patternfly-react';
 
+import { ListPageLink, TargetPage } from '../../components/ListPage/ListPageLink';
 import { Status } from '../../types/Health';
 
 type Props = {
   id: string;
+  namespace: string;
   status: Status;
   items: string[];
 };
@@ -35,8 +37,14 @@ class OverviewStatus extends React.Component<Props, {}> {
         rootClose={true}
       >
         <AggregateStatusNotification>
-          <Icon type="pf" name={this.props.status.icon} />
-          {length}
+          <ListPageLink
+            target={TargetPage.APPLICATIONS}
+            namespace={this.props.namespace}
+            health={this.props.status.name}
+          >
+            <Icon type="pf" name={this.props.status.icon} />
+            {length}
+          </ListPageLink>
         </AggregateStatusNotification>
       </OverlayTrigger>
     );


### PR DESCRIPTION
When clicking on a status icon in overview (ex: degraded in namespace X), it will bring you to the Apps list page with namespace=X and health=degraded filters.

JIRA: https://issues.jboss.org/browse/KIALI-1561