### PR TITLE
KIALI-1852 User proper lock icon for inaccessible link in side panel

### DIFF
--- a/src/pages/Graph/SummaryLink.tsx
+++ b/src/pages/Graph/SummaryLink.tsx
@@ -66,7 +66,7 @@ export const renderLink = (data: NodeData, nodeType?: NodeType) => {
   return (
     <>
       {link}
-      {isInaccessible(data) && <Icon name="lock" type="fa" style={{ width: '10px' }} />}
+      {isInaccessible(data) && <Icon name="private" type="pf" style={{ 'padding-left': '2px', width: '10px' }} />}
     </>
   );
 };
@@ -77,7 +77,7 @@ export const renderTitle = (data: NodeData) => {
   return (
     <>
       <strong>{nodeTypeToString(data.nodeType)}:</strong> {link}{' '}
-      {isInaccessible(data) && <Icon name="lock" type="fa" style={{ width: '10px' }} />}
+      {isInaccessible(data) && <Icon name="private" type="pf" style={{ 'padding-left': '2px', width: '10px' }} />}
     </>
   );
 };


### PR DESCRIPTION
@mwringe pointed me to the correct lock icon  (pficon-private), so there is no longer a re-use of the fa-lock icon and no an inaccessible node and it's links are handled with the same image.

![image](https://user-images.githubusercontent.com/2104052/48154458-abcb4f80-e296-11e8-9605-2cb8929b5d81.png)
