### PR TITLE
KIALI-1185 - Implement oAuth support for OCP/OKD/Maistra clients

### DIFF
--- a/src/actions/LoginActions.ts
+++ b/src/actions/LoginActions.ts
@@ -33,15 +33,13 @@ export const LoginActions = {
         sessionTimeOut: currentTimeOut + config().session.extendedSessionTimeOut
       } as LoginPayload)
   ),
-  loginSuccess: createAction(
-    LoginActionKeys.LOGIN_SUCCESS,
-    resolve => (token: Token, username: string, currentTimeOut?: number) =>
-      resolve({
-        token: token,
-        username: username,
-        logged: true,
-        sessionTimeOut: currentTimeOut || new Date().getTime() + config().session.sessionTimeOut
-      } as LoginPayload)
+  loginSuccess: createAction(LoginActionKeys.LOGIN_SUCCESS, resolve => (token: Token, currentTimeOut?: number) =>
+    resolve({
+      token: token,
+      username: token.username,
+      logged: true,
+      sessionTimeOut: currentTimeOut || new Date().getTime() + config().session.sessionTimeOut
+    } as LoginPayload)
   ),
   loginFailure: createAction(LoginActionKeys.LOGIN_FAILURE, resolve => (error: any) =>
     resolve({ error: error } as LoginFailurePayload)

--- a/src/actions/LoginThunkActions.ts
+++ b/src/actions/LoginThunkActions.ts
@@ -11,11 +11,7 @@ import * as API from '../services/Api';
 type Dispatch = ThunkDispatch<KialiAppState, void, KialiAppAction>;
 type GetState = () => KialiAppState;
 
-const performLogin = (
-  dispatch: Dispatch,
-  username?: string,
-  password?: string
-) => {
+const performLogin = (dispatch: Dispatch, username?: string, password?: string) => {
   dispatch(LoginActions.loginRequest());
 
   let anonymous = username === undefined;
@@ -66,7 +62,7 @@ const LoginThunkActions = {
         API.checkOauth().then(
           response => {
             performLogin(dispatch, '', '');
-            LoginThunkActions.loginSuccess(dispatch, getState, 'not-necessary');
+            dispatch(LoginThunkActions.loginSuccess(dispatch, getState, 'not-necessary'));
           },
           error => {
             if (error.response && error.response.status === HTTP_CODES.UNAUTHORIZED) {

--- a/src/actions/__tests__/LoginAction.test.ts
+++ b/src/actions/__tests__/LoginAction.test.ts
@@ -13,7 +13,7 @@ describe('LoginActions', () => {
       username: username,
       logged: true
     };
-    const result = LoginActions.loginSuccess({ token: token, expired_at: expiredAt }, username);
+    const result = LoginActions.loginSuccess({ token, username, expired_at: expiredAt });
     expect(result.type).toEqual(getType(LoginActions.loginSuccess));
     expect(result.payload.token).toEqual(expectedAction.token);
     expect(result.payload.username).toEqual(expectedAction.username);

--- a/src/components/Nav/UserDropdown.tsx
+++ b/src/components/Nav/UserDropdown.tsx
@@ -72,7 +72,7 @@ class UserDropdown extends React.Component<UserProps, UserState> {
     this.props.logout();
 
     if (serverConfig().authStrategy === 'openshift') {
-      window.location.href = '/oauth/sign_in';
+      window.location.href = '/oauth/sign_out';
     } else {
       const el = document.documentElement;
 

--- a/src/components/Nav/UserDropdown.tsx
+++ b/src/components/Nav/UserDropdown.tsx
@@ -69,13 +69,11 @@ class UserDropdown extends React.Component<UserProps, UserState> {
   };
 
   handleLogout() {
-    console.log(serverConfig());
-    if (serverConfig().authStrategy === 'oauth') {
-      console.log('I got here...');
+    this.props.logout();
+
+    if (serverConfig().authStrategy === 'openshift') {
       window.location.href = '/oauth/sign_in';
     } else {
-      this.props.logout();
-
       const el = document.documentElement;
 
       if (el) {

--- a/src/components/Nav/UserDropdown.tsx
+++ b/src/components/Nav/UserDropdown.tsx
@@ -5,6 +5,8 @@ import { config } from '../../config';
 import { MILLISECONDS } from '../../types/Common';
 import Timer = NodeJS.Timer;
 
+import { serverConfig } from '../../config';
+
 type UserProps = {
   username: string;
   logout: () => void;
@@ -26,6 +28,8 @@ class UserDropdown extends React.Component<UserProps, UserState> {
       showSessionTimeOut: false,
       timeCountDownSeconds: this.timeLeft() / MILLISECONDS
     };
+
+    this.handleLogout = this.handleLogout.bind(this);
   }
   componentDidMount() {
     let checkSessionTimerId = setInterval(() => {
@@ -65,10 +69,18 @@ class UserDropdown extends React.Component<UserProps, UserState> {
   };
 
   handleLogout() {
-    this.props.logout();
-    const el = document.documentElement;
-    if (el) {
-      el.className = 'login-pf';
+    console.log(serverConfig());
+    if (serverConfig().authStrategy === 'oauth') {
+      console.log('I got here...');
+      window.location.href = '/oauth/sign_in';
+    } else {
+      this.props.logout();
+
+      const el = document.documentElement;
+
+      if (el) {
+        el.className = 'login-pf';
+      }
     }
   }
 
@@ -91,7 +103,7 @@ class UserDropdown extends React.Component<UserProps, UserState> {
             <Icon type="pf" name="user" /> {this.props.username}
           </Dropdown.Toggle>
           <Dropdown.Menu>
-            <MenuItem id="usermenu_logout" onClick={() => this.handleLogout()}>
+            <MenuItem id="usermenu_logout" onClick={this.handleLogout}>
               Logout
             </MenuItem>
           </Dropdown.Menu>

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -84,6 +84,7 @@ const conf = {
       },
       appHealth: (namespace: string, app: string) => `api/namespaces/${namespace}/apps/${app}/health`,
       appMetrics: (namespace: string, app: string) => `api/namespaces/${namespace}/apps/${app}/metrics`,
+      checkOauth: 'oauth/auth',
       grafana: 'api/grafana',
       istioConfig: (namespace: string) => `api/namespaces/${namespace}/istio`,
       istioConfigDetail: (namespace: string, objectType: string, object: string) =>
@@ -126,11 +127,13 @@ export const config = () => {
 };
 
 export interface ServerConfig {
+  authStrategy: string;
   istioNamespace: string;
   istioLabels: { [key: string]: string };
 }
 
 let serverConf: ServerConfig = {
+  authStrategy: 'login',
   istioNamespace: 'istio-system',
   istioLabels: {
     AppLabelName: 'app',
@@ -143,5 +146,5 @@ export const setServerConfig = (newServerConf: ServerConfig) => {
 };
 
 export const serverConfig = () => {
-  return deepFreeze(serverConf) as typeof serverConf;
+  return deepFreeze(serverConf) as ServerConfig;
 };

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -77,6 +77,15 @@ export const login = (username: string, password: string) => {
   });
 };
 
+/** This endpoint is provided by the oauth proxy, and returns 202 when the user
+ * is signed in, and 403 if not. We use that to check if the user is signed in
+ * without touching the actual API. If the proxy is not available, it will
+ * return an error as well, and we can ignore those.
+ */
+export const checkOauth = () => {
+  return newRequest(HTTP_VERBS.GET, urls.checkOauth, {}, {});
+};
+
 export const getStatus = () => {
   return newRequest(HTTP_VERBS.GET, urls.status, {}, {});
 };

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -59,8 +59,9 @@ export interface GraphState {
 }
 
 export interface Token {
-  token: string;
   expired_at: string;
+  token: string;
+  username: string;
 }
 export interface LoginState {
   token?: Token;

--- a/src/utils/__tests__/Authentication.test.ts
+++ b/src/utils/__tests__/Authentication.test.ts
@@ -13,7 +13,7 @@ describe('Authentication', () => {
   });
 
   it('should return username and password object ', () => {
-    store.dispatch(LoginActions.loginSuccess({ token: token, expired_at: expiredAt }, username));
+    store.dispatch(LoginActions.loginSuccess({ token, username, expired_at: expiredAt }));
     expect(authentication()).toEqual('Bearer ' + token);
   });
 });


### PR DESCRIPTION
** Describe the change **

UI counterpart for kiali/kiali#640.

This PR implements the server-side support for oauth-proxy, enabled only on Openshift. It uses the oauth token (the same that we can use to connect to k8s) and handles most of the use cases.

** What still needs to be done **

* [x] Handle signout gracefully.

** Backwards incompatible? **

No.
