### PR TITLE
KIALI-1878 Overview: allow to switch to workloads health

### DIFF
--- a/src/app/History.ts
+++ b/src/app/History.ts
@@ -9,6 +9,7 @@ export enum URLParams {
   BY_LABELS = 'bylbl',
   DIRECTION = 'direction',
   DURATION = 'duration',
+  OVERVIEW_TYPE = 'otype',
   PAGE = 'page',
   PER_PAGE = 'perPage',
   POLL_INTERVAL = 'pi',

--- a/src/pages/Overview/FiltersAndSorts.ts
+++ b/src/pages/Overview/FiltersAndSorts.ts
@@ -53,11 +53,11 @@ export namespace FiltersAndSorts {
       isNumeric: false,
       param: 'h',
       compare: (a: NamespaceInfo, b: NamespaceInfo) => {
-        let diff = b.appsInError.length - a.appsInError.length;
+        let diff = b.inError.length - a.inError.length;
         if (diff !== 0) {
           return diff;
         }
-        diff = b.appsInWarning.length - a.appsInWarning.length;
+        diff = b.inWarning.length - a.inWarning.length;
         if (diff !== 0) {
           return diff;
         }

--- a/src/pages/Overview/NamespaceInfo.ts
+++ b/src/pages/Overview/NamespaceInfo.ts
@@ -1,8 +1,8 @@
 export type NamespaceInfo = {
   name: string;
-  appsInError: string[];
-  appsInWarning: string[];
-  appsInSuccess: string[];
+  inError: string[];
+  inWarning: string[];
+  inSuccess: string[];
 };
 
 export default NamespaceInfo;

--- a/src/pages/Overview/OverviewStatus.tsx
+++ b/src/pages/Overview/OverviewStatus.tsx
@@ -9,6 +9,7 @@ type Props = {
   namespace: string;
   status: Status;
   items: string[];
+  isApp: boolean;
 };
 
 class OverviewStatus extends React.Component<Props, {}> {
@@ -38,7 +39,7 @@ class OverviewStatus extends React.Component<Props, {}> {
       >
         <AggregateStatusNotification>
           <ListPageLink
-            target={TargetPage.APPLICATIONS}
+            target={this.props.isApp ? TargetPage.APPLICATIONS : TargetPage.WORKLOADS}
             namespace={this.props.namespace}
             health={this.props.status.name}
           >

--- a/src/pages/Overview/__tests__/OverviewPage.test.tsx
+++ b/src/pages/Overview/__tests__/OverviewPage.test.tsx
@@ -44,7 +44,7 @@ const mountPage = () => {
   mounted = mount(
     <Provider store={store}>
       <Router>
-        <OverviewPage setActiveNamespace={jest.fn()} />
+        <OverviewPage />
       </Router>
     </Provider>
   );
@@ -61,7 +61,7 @@ describe('Overview page', () => {
   });
 
   it('renders initial layout', () => {
-    const wrapper = shallow(<OverviewPage setActiveNamespace={jest.fn()} />);
+    const wrapper = shallow(<OverviewPage />);
     expect(wrapper).toMatchSnapshot();
   });
 

--- a/src/pages/Overview/__tests__/__snapshots__/OverviewPage.test.tsx.snap
+++ b/src/pages/Overview/__tests__/__snapshots__/OverviewPage.test.tsx.snap
@@ -4,9 +4,7 @@ exports[`Overview page renders initial layout 1`] = `
 ShallowWrapper {
   "length": 1,
   Symbol(enzyme.__root__): [Circular],
-  Symbol(enzyme.__unrendered__): <OverviewPage
-    setActiveNamespace={[MockFunction]}
-  />,
+  Symbol(enzyme.__unrendered__): <OverviewPage />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
     "getNode": [Function],


### PR DESCRIPTION
- Add switch between app-based health and workload-based health
- In toolbar, some perf enhancements as refresh is not needed in every component change, and prevents unnecessary change checks & state updates (less renders)
- Remove unused function setActiveNamespace

JIRA: https://issues.jboss.org/browse/KIALI-1878

Screenshoft:
![overview](https://screenshotscdn.firefoxusercontent.com/images/133dfa98-aaff-470b-836c-1ec0f8858007.png)