### PR TITLE
KIALI-1892 avoid direct access to the redux store

### DIFF
--- a/src/components/CytoscapeGraph/__tests__/CytoscapeGraph.test.tsx
+++ b/src/components/CytoscapeGraph/__tests__/CytoscapeGraph.test.tsx
@@ -19,6 +19,10 @@ const testReadyHandler = () => {
   console.log('ready');
 };
 
+const testSetHandler = () => {
+  console.log('set');
+};
+
 describe('CytoscapeGraph component test', () => {
   it('should set correct elements data', () => {
     const myLayout: Layout = { name: 'breadthfirst' };
@@ -26,12 +30,15 @@ describe('CytoscapeGraph component test', () => {
 
     const wrapper = shallow(
       <CytoscapeGraph
+        activeNamespace={{ name: testNamespace }}
+        duration={60}
         elements={GRAPH_DATA[testNamespace].elements}
         graphLayout={myLayout}
         edgeLabelMode={myEdgeLabelMode}
         onClick={testClickHandler}
         onReady={testReadyHandler}
         refresh={testClickHandler}
+        setActiveNamespace={testSetHandler}
         showNodeLabels={true}
         showCircuitBreakers={false}
         showVirtualServices={true}

--- a/src/components/GraphFilter/GraphFilter.tsx
+++ b/src/components/GraphFilter/GraphFilter.tsx
@@ -1,18 +1,21 @@
 import * as React from 'react';
+import { connect } from 'react-redux';
 import { style } from 'typestyle';
 import { Toolbar, FormGroup, Button } from 'patternfly-react';
 import * as _ from 'lodash';
-
+import { DurationInSeconds } from '../../types/Common';
+import { GraphParamsType, GraphType } from '../../types/Graph';
 import { EdgeLabelMode } from '../../types/GraphFilter';
 import { ToolbarDropdown } from '../ToolbarDropdown/ToolbarDropdown';
 import NamespaceDropdownContainer from '../../containers/NamespaceDropdownContainer';
-import { GraphParamsType, GraphType } from '../../types/Graph';
 import GraphSettingsContainer from '../../containers/GraphSettingsContainer';
 import { GraphRefreshContainerDefaultRefreshIntervals } from '../../containers/GraphRefreshContainer';
-import { store } from '../../store/ConfigStore';
+import { KialiAppState } from '../../store/Store';
+import { durationSelector } from '../../store/Selectors';
 
 export interface GraphFilterProps extends GraphParamsType {
   disabled: boolean;
+  duration: DurationInSeconds;
   onNamespaceReturn: () => void;
   onGraphTypeChange: (newType: GraphType) => void;
   onEdgeLabelModeChange: (newEdgeLabelMode: EdgeLabelMode) => void;
@@ -31,7 +34,7 @@ const namespaceStyle = style({
   marginRight: '5px'
 });
 
-export default class GraphFilter extends React.PureComponent<GraphFilterPropsReadOnly> {
+export class GraphFilter extends React.PureComponent<GraphFilterPropsReadOnly> {
   // GraphFilter should be minimal and used for assembling those filtering components.
 
   /**
@@ -68,12 +71,14 @@ export default class GraphFilter extends React.PureComponent<GraphFilterPropsRea
           <FormGroup className={zeroPaddingLeft}>
             {this.props.node ? (
               <Button className={namespaceStyle} onClick={this.props.onNamespaceReturn}>
-                Back To Namespace
+                Back to Full Graph...
               </Button>
             ) : (
-              <label className={namespaceStyle}>Namespace</label>
+              <>
+                <label className={namespaceStyle}>Namespace</label>
+                <NamespaceDropdownContainer disabled={this.props.disabled} />
+              </>
             )}
-            <NamespaceDropdownContainer disabled={this.props.node || this.props.disabled} />
           </FormGroup>
           <FormGroup className={zeroPaddingLeft}>
             <GraphSettingsContainer {...this.props} />
@@ -100,7 +105,7 @@ export default class GraphFilter extends React.PureComponent<GraphFilterPropsRea
               id="graph_refresh_container"
               disabled={this.props.disabled}
               handleRefresh={this.handleRefresh}
-              duration={store.getState().userSettings.duration}
+              duration={this.props.duration}
             />
           </Toolbar.RightContent>
         </Toolbar>
@@ -122,3 +127,13 @@ export default class GraphFilter extends React.PureComponent<GraphFilterPropsRea
     }
   };
 }
+
+const mapStateToProps = (state: KialiAppState) => ({
+  duration: durationSelector(state)
+});
+
+const GraphFilterContainer = connect(
+  mapStateToProps,
+  null
+)(GraphFilter);
+export default GraphFilterContainer;

--- a/src/pages/Graph/GraphPage.tsx
+++ b/src/pages/Graph/GraphPage.tsx
@@ -8,9 +8,9 @@ import { GraphParamsType, SummaryData, NodeParamsType, GraphType } from '../../t
 import { Layout, EdgeLabelMode } from '../../types/GraphFilter';
 
 import SummaryPanel from './SummaryPanel';
-import CytoscapeGraph from '../../components/CytoscapeGraph/CytoscapeGraph';
+import CytoscapeGraphContainer from '../../components/CytoscapeGraph/CytoscapeGraph';
 import ErrorBoundary from '../../components/ErrorBoundary/ErrorBoundary';
-import GraphFilterToolbar from '../../components/GraphFilter/GraphFilterToolbar';
+import GraphFilterToolbarContainer from '../../components/GraphFilter/GraphFilterToolbar';
 import { computePrometheusQueryInterval } from '../../services/Prometheus';
 import { style } from 'typestyle';
 
@@ -217,7 +217,7 @@ export default class GraphPage extends React.Component<GraphPageProps, GraphPage
           </Breadcrumb>
           <div>
             {/* Use empty div to reset the flex, this component doesn't seem to like that. It renders all its contents in the center */}
-            <GraphFilterToolbar
+            <GraphFilterToolbarContainer
               isLoading={this.props.isLoading}
               showSecurity={this.props.showSecurity}
               showUnusedNodes={this.props.showUnusedNodes}
@@ -231,7 +231,7 @@ export default class GraphPage extends React.Component<GraphPageProps, GraphPage
               onError={this.notifyError}
               fallBackComponent={<GraphErrorBoundaryFallback />}
             >
-              <CytoscapeGraph
+              <CytoscapeGraphContainer
                 {...graphParams}
                 isLoading={this.props.isLoading}
                 elements={this.props.graphData}

--- a/src/pages/Graph/GraphRouteHandler.tsx
+++ b/src/pages/Graph/GraphRouteHandler.tsx
@@ -12,6 +12,7 @@ import { store } from '../../store/ConfigStore';
 import GraphPageContainer from '../../containers/GraphPageContainer';
 import { DurationInSeconds } from '../../types/Common';
 import { UserSettingsActions } from '../../actions/UserSettingsActions';
+import { GraphActions } from '../../actions/GraphActions';
 
 const URLSearchParams = require('url-search-params');
 
@@ -180,6 +181,9 @@ export default class GraphRouteHandler extends React.Component<
     }
     if (namespaceHasChanged) {
       store.dispatch(NamespaceActions.setActiveNamespace(nextNamespaces));
+    }
+    if (graphTypeChanged || namespaceHasChanged || nodeHasChanged) {
+      store.dispatch(GraphActions.changed());
     }
 
     if (edgeLabelModeChanged || injectServiceNodesChanged || graphTypeChanged || layoutHasChanged || nodeHasChanged) {

--- a/src/types/GraphFilterToolbar.ts
+++ b/src/types/GraphFilterToolbar.ts
@@ -1,8 +1,24 @@
-import { GraphParamsType } from './Graph';
+import { DurationInSeconds } from './Common';
+import Namespace from './Namespace';
+import { GraphType, GraphParamsType, NodeParamsType } from './Graph';
+import { EdgeLabelMode } from './GraphFilter';
 
 export default interface GraphFilterToolbarType extends GraphParamsType {
+  activeNamespace: Namespace;
+  duration: DurationInSeconds;
   isLoading: boolean;
   showSecurity: boolean;
   showUnusedNodes: boolean;
+  // functions
+  fetchGraphData: (
+    namespace: Namespace,
+    duration: DurationInSeconds,
+    graphType: GraphType,
+    injectServiceNodes: boolean,
+    edgeLabelMode: EdgeLabelMode,
+    showSecurity: boolean,
+    showUnusedNodes: boolean,
+    node?: NodeParamsType
+  ) => any;
   handleRefreshClick: () => void;
 }


### PR DESCRIPTION
- add connected components as needed
- replace direct store access with property-based access
- Use XxxContainer naming for connected components and access them directly
- Avoid inner code from having to both push a URL and perform redux init,
  centralize the logic in GraphRouteHandler; when processing a URL now
  ensure that for a new graph we do redux initializiation as needed.
also:
- make a tweak to the focus graph filter toolbar, don't show namespace dropdown
  because going forward it will be unable to show multiple namespaces.

![image](https://user-images.githubusercontent.com/2104052/48226969-0d5eed00-e36f-11e8-9862-e3b1d9ead2f5.png)
