### PR TITLE
Rolling back non-deployment workload list

### DIFF
--- a/src/pages/WorkloadList/FiltersAndSorts.ts
+++ b/src/pages/WorkloadList/FiltersAndSorts.ts
@@ -152,40 +152,12 @@ export namespace WorkloadListFilters {
     action: FILTER_ACTION_APPEND,
     filterValues: [
       {
-        id: WorkloadType.CronJob,
-        title: WorkloadType.CronJob
-      },
-      {
-        id: WorkloadType.DaemonSet,
-        title: WorkloadType.DaemonSet
-      },
-      {
         id: WorkloadType.Deployment,
         title: WorkloadType.Deployment
       },
       {
-        id: WorkloadType.DeploymentConfig,
-        title: WorkloadType.DeploymentConfig
-      },
-      {
-        id: WorkloadType.Job,
-        title: WorkloadType.Job
-      },
-      {
         id: WorkloadType.Pod,
         title: WorkloadType.Pod
-      },
-      {
-        id: WorkloadType.ReplicaSet,
-        title: WorkloadType.ReplicaSet
-      },
-      {
-        id: WorkloadType.ReplicationController,
-        title: WorkloadType.ReplicationController
-      },
-      {
-        id: WorkloadType.StatefulSet,
-        title: WorkloadType.StatefulSet
       }
     ]
   };


### PR DESCRIPTION
** Describe the change **
Disabling non-deployment workload feature. It will allow helm users to properly install kiali.
Base branch is v0.9.0, not v0.9.1. Using 0.9.1 it would be the undo a little bit trickier because there is the deletion feature included.
Had to revert the feature manually, because git-revert would mess the whole codebase.

Backend reference: https://github.com/kiali/kiali/pull/645

** Issue reference **
It should fix the following issues:
#644
#623

** Screenshot **
![screenshot of kiali console 13](https://user-images.githubusercontent.com/613814/48261554-c4b33c80-e41f-11e8-832f-454fb9bcb6d1.png)

