### PR TITLE
KIALI-1894 Simplify GraphFilter component

### DIFF
--- a/src/components/GraphFilter/GraphFilter.tsx
+++ b/src/components/GraphFilter/GraphFilter.tsx
@@ -1,21 +1,16 @@
 import * as React from 'react';
-import { connect } from 'react-redux';
 import { style } from 'typestyle';
 import { Toolbar, FormGroup, Button } from 'patternfly-react';
 import * as _ from 'lodash';
-import { DurationInSeconds } from '../../types/Common';
 import { GraphParamsType, GraphType } from '../../types/Graph';
 import { EdgeLabelMode } from '../../types/GraphFilter';
 import { ToolbarDropdown } from '../ToolbarDropdown/ToolbarDropdown';
 import NamespaceDropdownContainer from '../../containers/NamespaceDropdownContainer';
 import GraphSettingsContainer from '../../containers/GraphSettingsContainer';
 import { GraphRefreshContainerDefaultRefreshIntervals } from '../../containers/GraphRefreshContainer';
-import { KialiAppState } from '../../store/Store';
-import { durationSelector } from '../../store/Selectors';
 
 export interface GraphFilterProps extends GraphParamsType {
   disabled: boolean;
-  duration: DurationInSeconds;
   onNamespaceReturn: () => void;
   onGraphTypeChange: (newType: GraphType) => void;
   onEdgeLabelModeChange: (newEdgeLabelMode: EdgeLabelMode) => void;
@@ -34,7 +29,7 @@ const namespaceStyle = style({
   marginRight: '5px'
 });
 
-export class GraphFilter extends React.PureComponent<GraphFilterPropsReadOnly> {
+export default class GraphFilter extends React.PureComponent<GraphFilterPropsReadOnly> {
   // GraphFilter should be minimal and used for assembling those filtering components.
 
   /**
@@ -105,7 +100,6 @@ export class GraphFilter extends React.PureComponent<GraphFilterPropsReadOnly> {
               id="graph_refresh_container"
               disabled={this.props.disabled}
               handleRefresh={this.handleRefresh}
-              duration={this.props.duration}
             />
           </Toolbar.RightContent>
         </Toolbar>
@@ -127,13 +121,3 @@ export class GraphFilter extends React.PureComponent<GraphFilterPropsReadOnly> {
     }
   };
 }
-
-const mapStateToProps = (state: KialiAppState) => ({
-  duration: durationSelector(state)
-});
-
-const GraphFilterContainer = connect(
-  mapStateToProps,
-  null
-)(GraphFilter);
-export default GraphFilterContainer;

--- a/src/components/GraphFilter/GraphFilterToolbar.tsx
+++ b/src/components/GraphFilter/GraphFilterToolbar.tsx
@@ -7,7 +7,7 @@ import GraphFilterToolbarType from '../../types/GraphFilterToolbar';
 import Namespace from '../../types/Namespace';
 import { makeNamespaceGraphUrlFromParams, makeNodeGraphUrlFromParams } from '../Nav/NavUtils';
 import { GraphDataActions } from '../../actions/GraphDataActions';
-import GraphFilterContainer from '../../components/GraphFilter/GraphFilter';
+import GraphFilter from '../../components/GraphFilter/GraphFilter';
 import { KialiAppState } from '../../store/Store';
 import { activeNamespaceSelector, durationSelector } from '../../store/Selectors';
 
@@ -26,7 +26,7 @@ export class GraphFilterToolbar extends React.PureComponent<GraphFilterToolbarTy
     };
 
     return (
-      <GraphFilterContainer
+      <GraphFilter
         disabled={this.props.isLoading}
         onNamespaceReturn={this.handleNamespaceReturn}
         onGraphTypeChange={this.handleGraphTypeChange}


### PR DESCRIPTION
- remove access to duration in the redux store
- remove the container, it's no longer currently needed

@israel-hdez This is the follow up PR to your review comment in 1880 about simplifying GraphFilter because it did not need to access "duration" in the store.