### PR TITLE
KIALI-1873 Show inbound/outbound error rate for requests health

### DIFF
--- a/src/components/Health/__tests__/HealthDetails.test.tsx
+++ b/src/components/Health/__tests__/HealthDetails.test.tsx
@@ -8,7 +8,7 @@ describe('HealthDetails', () => {
   it('renders healthy', () => {
     const health = new ServiceHealth(
       { inbound: { healthy: 1, total: 1 }, outbound: { healthy: 1, total: 1 } },
-      { errorRatio: -1 },
+      { errorRatio: -1, inboundErrorRatio: -1, outboundErrorRatio: -1 },
       60
     );
 
@@ -19,7 +19,7 @@ describe('HealthDetails', () => {
   it('renders envoy degraded', () => {
     const health = new ServiceHealth(
       { inbound: { healthy: 1, total: 10 }, outbound: { healthy: 1, total: 1 } },
-      { errorRatio: -1 },
+      { errorRatio: -1, inboundErrorRatio: -1, outboundErrorRatio: -1 },
       60
     );
 
@@ -30,7 +30,7 @@ describe('HealthDetails', () => {
   it('renders deployments failure', () => {
     const health = new ServiceHealth(
       { inbound: { healthy: 1, total: 10 }, outbound: { healthy: 1, total: 1 } },
-      { errorRatio: -1 },
+      { errorRatio: -1, inboundErrorRatio: -1, outboundErrorRatio: -1 },
       60
     );
 

--- a/src/components/Health/__tests__/HealthIndicator.test.tsx
+++ b/src/components/Health/__tests__/HealthIndicator.test.tsx
@@ -19,7 +19,7 @@ describe('HealthIndicator', () => {
     const health = new AppHealth(
       [{ inbound: { healthy: 1, total: 1 }, outbound: { healthy: 1, total: 1 } }],
       [{ name: 'A', available: 1, replicas: 1 }, { name: 'B', available: 2, replicas: 2 }],
-      { errorRatio: -1 },
+      { errorRatio: -1, inboundErrorRatio: -1, outboundErrorRatio: -1 },
       600
     );
 
@@ -40,7 +40,7 @@ describe('HealthIndicator', () => {
     const health = new AppHealth(
       [{ inbound: { healthy: 1, total: 1 }, outbound: { healthy: 1, total: 1 } }],
       [{ name: 'A', available: 1, replicas: 10 }, { name: 'B', available: 2, replicas: 2 }],
-      { errorRatio: -1 },
+      { errorRatio: -1, inboundErrorRatio: -1, outboundErrorRatio: -1 },
       600
     );
 
@@ -62,7 +62,7 @@ describe('HealthIndicator', () => {
     const health = new AppHealth(
       [{ inbound: { healthy: 0, total: 10 }, outbound: { healthy: 1, total: 1 } }],
       [{ name: 'A', available: 1, replicas: 10 }, { name: 'B', available: 2, replicas: 2 }],
-      { errorRatio: -1 },
+      { errorRatio: -1, inboundErrorRatio: -1, outboundErrorRatio: -1 },
       600
     );
 
@@ -85,7 +85,7 @@ describe('HealthIndicator', () => {
     const health = new AppHealth(
       [{ inbound: { healthy: 1, total: 1 }, outbound: { healthy: 1, total: 1 } }],
       [{ name: 'A', available: 0, replicas: 0 }, { name: 'B', available: 2, replicas: 2 }],
-      { errorRatio: -1 },
+      { errorRatio: -1, inboundErrorRatio: -1, outboundErrorRatio: -1 },
       600
     );
 
@@ -107,7 +107,7 @@ describe('HealthIndicator', () => {
     const health = new AppHealth(
       [{ inbound: { healthy: 1, total: 1 }, outbound: { healthy: 1, total: 1 } }],
       [{ name: 'A', available: 0, replicas: 0 }, { name: 'B', available: 0, replicas: 0 }],
-      { errorRatio: -1 },
+      { errorRatio: -1, inboundErrorRatio: -1, outboundErrorRatio: -1 },
       600
     );
 
@@ -129,7 +129,7 @@ describe('HealthIndicator', () => {
     const health = new AppHealth(
       [{ inbound: { healthy: 1, total: 10 }, outbound: { healthy: 1, total: 10 } }],
       [{ name: 'A', available: 1, replicas: 1 }],
-      { errorRatio: 0.3 },
+      { errorRatio: 0.3, inboundErrorRatio: 0.1, outboundErrorRatio: 0.2 },
       600
     );
 

--- a/src/components/Health/__tests__/HealthIndicator.test.tsx
+++ b/src/components/Health/__tests__/HealthIndicator.test.tsx
@@ -144,6 +144,7 @@ describe('HealthIndicator', () => {
     expect(wrapper).toMatchSnapshot();
     html = wrapper.html();
     expect(html).toContain('pficon-error');
-    expect(html).toContain('Error rate failure');
+    expect(html).toContain('Outbound errors failure');
+    expect(html).toContain('Inbound errors degraded');
   });
 });

--- a/src/components/Health/__tests__/__snapshots__/HealthDetails.test.tsx.snap
+++ b/src/components/Health/__tests__/__snapshots__/HealthDetails.test.tsx.snap
@@ -63,6 +63,8 @@ ShallowWrapper {
         "rateInterval": 60,
         "requests": Object {
           "errorRatio": -1,
+          "inboundErrorRatio": -1,
+          "outboundErrorRatio": -1,
         },
       }
     }
@@ -309,6 +311,8 @@ ShallowWrapper {
         "rateInterval": 60,
         "requests": Object {
           "errorRatio": -1,
+          "inboundErrorRatio": -1,
+          "outboundErrorRatio": -1,
         },
       }
     }
@@ -554,6 +558,8 @@ ShallowWrapper {
         "rateInterval": 60,
         "requests": Object {
           "errorRatio": -1,
+          "inboundErrorRatio": -1,
+          "outboundErrorRatio": -1,
         },
       }
     }

--- a/src/components/Health/__tests__/__snapshots__/HealthIndicator.test.tsx.snap
+++ b/src/components/Health/__tests__/__snapshots__/HealthIndicator.test.tsx.snap
@@ -80,14 +80,33 @@ ShallowWrapper {
             "title": "Envoy Health",
           },
           Object {
+            "children": Array [
+              Object {
+                "status": Object {
+                  "color": "#72767b",
+                  "name": "No health information",
+                  "priority": 0,
+                  "text": "N/A",
+                },
+                "text": "Inbound: No requests",
+              },
+              Object {
+                "status": Object {
+                  "color": "#72767b",
+                  "name": "No health information",
+                  "priority": 0,
+                  "text": "N/A",
+                },
+                "text": "Outbound: No requests",
+              },
+            ],
             "status": Object {
               "color": "#72767b",
               "name": "No health information",
               "priority": 0,
               "text": "N/A",
             },
-            "text": "No requests over last 10 min",
-            "title": "Error Rate",
+            "title": "Error Rate over last 10 min",
           },
         ],
         "rateInterval": 600,
@@ -203,14 +222,33 @@ ShallowWrapper {
                 "title": "Envoy Health",
               },
               Object {
+                "children": Array [
+                  Object {
+                    "status": Object {
+                      "color": "#72767b",
+                      "name": "No health information",
+                      "priority": 0,
+                      "text": "N/A",
+                    },
+                    "text": "Inbound: No requests",
+                  },
+                  Object {
+                    "status": Object {
+                      "color": "#72767b",
+                      "name": "No health information",
+                      "priority": 0,
+                      "text": "N/A",
+                    },
+                    "text": "Outbound: No requests",
+                  },
+                ],
                 "status": Object {
                   "color": "#72767b",
                   "name": "No health information",
                   "priority": 0,
                   "text": "N/A",
                 },
-                "text": "No requests over last 10 min",
-                "title": "Error Rate",
+                "title": "Error Rate over last 10 min",
               },
             ],
             "rateInterval": 600,
@@ -341,14 +379,33 @@ ShallowWrapper {
               "title": "Envoy Health",
             },
             Object {
+              "children": Array [
+                Object {
+                  "status": Object {
+                    "color": "#72767b",
+                    "name": "No health information",
+                    "priority": 0,
+                    "text": "N/A",
+                  },
+                  "text": "Inbound: No requests",
+                },
+                Object {
+                  "status": Object {
+                    "color": "#72767b",
+                    "name": "No health information",
+                    "priority": 0,
+                    "text": "N/A",
+                  },
+                  "text": "Outbound: No requests",
+                },
+              ],
               "status": Object {
                 "color": "#72767b",
                 "name": "No health information",
                 "priority": 0,
                 "text": "N/A",
               },
-              "text": "No requests over last 10 min",
-              "title": "Error Rate",
+              "title": "Error Rate over last 10 min",
             },
           ],
           "rateInterval": 600,
@@ -478,14 +535,33 @@ ShallowWrapper {
                   "title": "Envoy Health",
                 },
                 Object {
+                  "children": Array [
+                    Object {
+                      "status": Object {
+                        "color": "#72767b",
+                        "name": "No health information",
+                        "priority": 0,
+                        "text": "N/A",
+                      },
+                      "text": "Inbound: No requests",
+                    },
+                    Object {
+                      "status": Object {
+                        "color": "#72767b",
+                        "name": "No health information",
+                        "priority": 0,
+                        "text": "N/A",
+                      },
+                      "text": "Outbound: No requests",
+                    },
+                  ],
                   "status": Object {
                     "color": "#72767b",
                     "name": "No health information",
                     "priority": 0,
                     "text": "N/A",
                   },
-                  "text": "No requests over last 10 min",
-                  "title": "Error Rate",
+                  "title": "Error Rate over last 10 min",
                 },
               ],
               "rateInterval": 600,
@@ -616,14 +692,33 @@ ShallowWrapper {
                 "title": "Envoy Health",
               },
               Object {
+                "children": Array [
+                  Object {
+                    "status": Object {
+                      "color": "#72767b",
+                      "name": "No health information",
+                      "priority": 0,
+                      "text": "N/A",
+                    },
+                    "text": "Inbound: No requests",
+                  },
+                  Object {
+                    "status": Object {
+                      "color": "#72767b",
+                      "name": "No health information",
+                      "priority": 0,
+                      "text": "N/A",
+                    },
+                    "text": "Outbound: No requests",
+                  },
+                ],
                 "status": Object {
                   "color": "#72767b",
                   "name": "No health information",
                   "priority": 0,
                   "text": "N/A",
                 },
-                "text": "No requests over last 10 min",
-                "title": "Error Rate",
+                "title": "Error Rate over last 10 min",
               },
             ],
             "rateInterval": 600,
@@ -771,14 +866,33 @@ ShallowWrapper {
             "title": "Envoy Health",
           },
           Object {
+            "children": Array [
+              Object {
+                "status": Object {
+                  "color": "#72767b",
+                  "name": "No health information",
+                  "priority": 0,
+                  "text": "N/A",
+                },
+                "text": "Inbound: No requests",
+              },
+              Object {
+                "status": Object {
+                  "color": "#72767b",
+                  "name": "No health information",
+                  "priority": 0,
+                  "text": "N/A",
+                },
+                "text": "Outbound: No requests",
+              },
+            ],
             "status": Object {
               "color": "#72767b",
               "name": "No health information",
               "priority": 0,
               "text": "N/A",
             },
-            "text": "No requests over last 10 min",
-            "title": "Error Rate",
+            "title": "Error Rate over last 10 min",
           },
         ],
         "rateInterval": 600,
@@ -895,14 +1009,33 @@ ShallowWrapper {
                   "title": "Envoy Health",
                 },
                 Object {
+                  "children": Array [
+                    Object {
+                      "status": Object {
+                        "color": "#72767b",
+                        "name": "No health information",
+                        "priority": 0,
+                        "text": "N/A",
+                      },
+                      "text": "Inbound: No requests",
+                    },
+                    Object {
+                      "status": Object {
+                        "color": "#72767b",
+                        "name": "No health information",
+                        "priority": 0,
+                        "text": "N/A",
+                      },
+                      "text": "Outbound: No requests",
+                    },
+                  ],
                   "status": Object {
                     "color": "#72767b",
                     "name": "No health information",
                     "priority": 0,
                     "text": "N/A",
                   },
-                  "text": "No requests over last 10 min",
-                  "title": "Error Rate",
+                  "title": "Error Rate over last 10 min",
                 },
               ],
               "rateInterval": 600,
@@ -1041,14 +1174,33 @@ ShallowWrapper {
                 "title": "Envoy Health",
               },
               Object {
+                "children": Array [
+                  Object {
+                    "status": Object {
+                      "color": "#72767b",
+                      "name": "No health information",
+                      "priority": 0,
+                      "text": "N/A",
+                    },
+                    "text": "Inbound: No requests",
+                  },
+                  Object {
+                    "status": Object {
+                      "color": "#72767b",
+                      "name": "No health information",
+                      "priority": 0,
+                      "text": "N/A",
+                    },
+                    "text": "Outbound: No requests",
+                  },
+                ],
                 "status": Object {
                   "color": "#72767b",
                   "name": "No health information",
                   "priority": 0,
                   "text": "N/A",
                 },
-                "text": "No requests over last 10 min",
-                "title": "Error Rate",
+                "title": "Error Rate over last 10 min",
               },
             ],
             "rateInterval": 600,
@@ -1191,14 +1343,33 @@ ShallowWrapper {
                     "title": "Envoy Health",
                   },
                   Object {
+                    "children": Array [
+                      Object {
+                        "status": Object {
+                          "color": "#72767b",
+                          "name": "No health information",
+                          "priority": 0,
+                          "text": "N/A",
+                        },
+                        "text": "Inbound: No requests",
+                      },
+                      Object {
+                        "status": Object {
+                          "color": "#72767b",
+                          "name": "No health information",
+                          "priority": 0,
+                          "text": "N/A",
+                        },
+                        "text": "Outbound: No requests",
+                      },
+                    ],
                     "status": Object {
                       "color": "#72767b",
                       "name": "No health information",
                       "priority": 0,
                       "text": "N/A",
                     },
-                    "text": "No requests over last 10 min",
-                    "title": "Error Rate",
+                    "title": "Error Rate over last 10 min",
                   },
                 ],
                 "rateInterval": 600,
@@ -1337,14 +1508,33 @@ ShallowWrapper {
                   "title": "Envoy Health",
                 },
                 Object {
+                  "children": Array [
+                    Object {
+                      "status": Object {
+                        "color": "#72767b",
+                        "name": "No health information",
+                        "priority": 0,
+                        "text": "N/A",
+                      },
+                      "text": "Inbound: No requests",
+                    },
+                    Object {
+                      "status": Object {
+                        "color": "#72767b",
+                        "name": "No health information",
+                        "priority": 0,
+                        "text": "N/A",
+                      },
+                      "text": "Outbound: No requests",
+                    },
+                  ],
                   "status": Object {
                     "color": "#72767b",
                     "name": "No health information",
                     "priority": 0,
                     "text": "N/A",
                   },
-                  "text": "No requests over last 10 min",
-                  "title": "Error Rate",
+                  "title": "Error Rate over last 10 min",
                 },
               ],
               "rateInterval": 600,
@@ -1505,14 +1695,33 @@ ShallowWrapper {
             "title": "Envoy Health",
           },
           Object {
+            "children": Array [
+              Object {
+                "status": Object {
+                  "color": "#72767b",
+                  "name": "No health information",
+                  "priority": 0,
+                  "text": "N/A",
+                },
+                "text": "Inbound: No requests",
+              },
+              Object {
+                "status": Object {
+                  "color": "#72767b",
+                  "name": "No health information",
+                  "priority": 0,
+                  "text": "N/A",
+                },
+                "text": "Outbound: No requests",
+              },
+            ],
             "status": Object {
               "color": "#72767b",
               "name": "No health information",
               "priority": 0,
               "text": "N/A",
             },
-            "text": "No requests over last 10 min",
-            "title": "Error Rate",
+            "title": "Error Rate over last 10 min",
           },
         ],
         "rateInterval": 600,
@@ -1629,14 +1838,33 @@ ShallowWrapper {
                 "title": "Envoy Health",
               },
               Object {
+                "children": Array [
+                  Object {
+                    "status": Object {
+                      "color": "#72767b",
+                      "name": "No health information",
+                      "priority": 0,
+                      "text": "N/A",
+                    },
+                    "text": "Inbound: No requests",
+                  },
+                  Object {
+                    "status": Object {
+                      "color": "#72767b",
+                      "name": "No health information",
+                      "priority": 0,
+                      "text": "N/A",
+                    },
+                    "text": "Outbound: No requests",
+                  },
+                ],
                 "status": Object {
                   "color": "#72767b",
                   "name": "No health information",
                   "priority": 0,
                   "text": "N/A",
                 },
-                "text": "No requests over last 10 min",
-                "title": "Error Rate",
+                "title": "Error Rate over last 10 min",
               },
             ],
             "rateInterval": 600,
@@ -1768,14 +1996,33 @@ ShallowWrapper {
               "title": "Envoy Health",
             },
             Object {
+              "children": Array [
+                Object {
+                  "status": Object {
+                    "color": "#72767b",
+                    "name": "No health information",
+                    "priority": 0,
+                    "text": "N/A",
+                  },
+                  "text": "Inbound: No requests",
+                },
+                Object {
+                  "status": Object {
+                    "color": "#72767b",
+                    "name": "No health information",
+                    "priority": 0,
+                    "text": "N/A",
+                  },
+                  "text": "Outbound: No requests",
+                },
+              ],
               "status": Object {
                 "color": "#72767b",
                 "name": "No health information",
                 "priority": 0,
                 "text": "N/A",
               },
-              "text": "No requests over last 10 min",
-              "title": "Error Rate",
+              "title": "Error Rate over last 10 min",
             },
           ],
           "rateInterval": 600,
@@ -1906,14 +2153,33 @@ ShallowWrapper {
                   "title": "Envoy Health",
                 },
                 Object {
+                  "children": Array [
+                    Object {
+                      "status": Object {
+                        "color": "#72767b",
+                        "name": "No health information",
+                        "priority": 0,
+                        "text": "N/A",
+                      },
+                      "text": "Inbound: No requests",
+                    },
+                    Object {
+                      "status": Object {
+                        "color": "#72767b",
+                        "name": "No health information",
+                        "priority": 0,
+                        "text": "N/A",
+                      },
+                      "text": "Outbound: No requests",
+                    },
+                  ],
                   "status": Object {
                     "color": "#72767b",
                     "name": "No health information",
                     "priority": 0,
                     "text": "N/A",
                   },
-                  "text": "No requests over last 10 min",
-                  "title": "Error Rate",
+                  "title": "Error Rate over last 10 min",
                 },
               ],
               "rateInterval": 600,
@@ -2045,14 +2311,33 @@ ShallowWrapper {
                 "title": "Envoy Health",
               },
               Object {
+                "children": Array [
+                  Object {
+                    "status": Object {
+                      "color": "#72767b",
+                      "name": "No health information",
+                      "priority": 0,
+                      "text": "N/A",
+                    },
+                    "text": "Inbound: No requests",
+                  },
+                  Object {
+                    "status": Object {
+                      "color": "#72767b",
+                      "name": "No health information",
+                      "priority": 0,
+                      "text": "N/A",
+                    },
+                    "text": "Outbound: No requests",
+                  },
+                ],
                 "status": Object {
                   "color": "#72767b",
                   "name": "No health information",
                   "priority": 0,
                   "text": "N/A",
                 },
-                "text": "No requests over last 10 min",
-                "title": "Error Rate",
+                "title": "Error Rate over last 10 min",
               },
             ],
             "rateInterval": 600,
@@ -2201,14 +2486,33 @@ ShallowWrapper {
             "title": "Envoy Health",
           },
           Object {
+            "children": Array [
+              Object {
+                "status": Object {
+                  "color": "#72767b",
+                  "name": "No health information",
+                  "priority": 0,
+                  "text": "N/A",
+                },
+                "text": "Inbound: No requests",
+              },
+              Object {
+                "status": Object {
+                  "color": "#72767b",
+                  "name": "No health information",
+                  "priority": 0,
+                  "text": "N/A",
+                },
+                "text": "Outbound: No requests",
+              },
+            ],
             "status": Object {
               "color": "#72767b",
               "name": "No health information",
               "priority": 0,
               "text": "N/A",
             },
-            "text": "No requests over last 10 min",
-            "title": "Error Rate",
+            "title": "Error Rate over last 10 min",
           },
         ],
         "rateInterval": 600,
@@ -2326,14 +2630,33 @@ ShallowWrapper {
                   "title": "Envoy Health",
                 },
                 Object {
+                  "children": Array [
+                    Object {
+                      "status": Object {
+                        "color": "#72767b",
+                        "name": "No health information",
+                        "priority": 0,
+                        "text": "N/A",
+                      },
+                      "text": "Inbound: No requests",
+                    },
+                    Object {
+                      "status": Object {
+                        "color": "#72767b",
+                        "name": "No health information",
+                        "priority": 0,
+                        "text": "N/A",
+                      },
+                      "text": "Outbound: No requests",
+                    },
+                  ],
                   "status": Object {
                     "color": "#72767b",
                     "name": "No health information",
                     "priority": 0,
                     "text": "N/A",
                   },
-                  "text": "No requests over last 10 min",
-                  "title": "Error Rate",
+                  "title": "Error Rate over last 10 min",
                 },
               ],
               "rateInterval": 600,
@@ -2486,14 +2809,33 @@ ShallowWrapper {
                 "title": "Envoy Health",
               },
               Object {
+                "children": Array [
+                  Object {
+                    "status": Object {
+                      "color": "#72767b",
+                      "name": "No health information",
+                      "priority": 0,
+                      "text": "N/A",
+                    },
+                    "text": "Inbound: No requests",
+                  },
+                  Object {
+                    "status": Object {
+                      "color": "#72767b",
+                      "name": "No health information",
+                      "priority": 0,
+                      "text": "N/A",
+                    },
+                    "text": "Outbound: No requests",
+                  },
+                ],
                 "status": Object {
                   "color": "#72767b",
                   "name": "No health information",
                   "priority": 0,
                   "text": "N/A",
                 },
-                "text": "No requests over last 10 min",
-                "title": "Error Rate",
+                "title": "Error Rate over last 10 min",
               },
             ],
             "rateInterval": 600,
@@ -2680,14 +3022,33 @@ ShallowWrapper {
                     "title": "Envoy Health",
                   },
                   Object {
+                    "children": Array [
+                      Object {
+                        "status": Object {
+                          "color": "#72767b",
+                          "name": "No health information",
+                          "priority": 0,
+                          "text": "N/A",
+                        },
+                        "text": "Inbound: No requests",
+                      },
+                      Object {
+                        "status": Object {
+                          "color": "#72767b",
+                          "name": "No health information",
+                          "priority": 0,
+                          "text": "N/A",
+                        },
+                        "text": "Outbound: No requests",
+                      },
+                    ],
                     "status": Object {
                       "color": "#72767b",
                       "name": "No health information",
                       "priority": 0,
                       "text": "N/A",
                     },
-                    "text": "No requests over last 10 min",
-                    "title": "Error Rate",
+                    "title": "Error Rate over last 10 min",
                   },
                 ],
                 "rateInterval": 600,
@@ -2840,14 +3201,33 @@ ShallowWrapper {
                   "title": "Envoy Health",
                 },
                 Object {
+                  "children": Array [
+                    Object {
+                      "status": Object {
+                        "color": "#72767b",
+                        "name": "No health information",
+                        "priority": 0,
+                        "text": "N/A",
+                      },
+                      "text": "Inbound: No requests",
+                    },
+                    Object {
+                      "status": Object {
+                        "color": "#72767b",
+                        "name": "No health information",
+                        "priority": 0,
+                        "text": "N/A",
+                      },
+                      "text": "Outbound: No requests",
+                    },
+                  ],
                   "status": Object {
                     "color": "#72767b",
                     "name": "No health information",
                     "priority": 0,
                     "text": "N/A",
                   },
-                  "text": "No requests over last 10 min",
-                  "title": "Error Rate",
+                  "title": "Error Rate over last 10 min",
                 },
               ],
               "rateInterval": 600,
@@ -3049,7 +3429,7 @@ ShallowWrapper {
                   "name": "Degraded",
                   "priority": 2,
                 },
-                "text": "10.00% inbound error",
+                "text": "Inbound: 10.00%",
               },
               Object {
                 "status": Object {
@@ -3058,18 +3438,17 @@ ShallowWrapper {
                   "name": "Failure",
                   "priority": 3,
                 },
-                "text": "20.00% outbound error",
+                "text": "Outbound: 20.00%",
               },
             ],
-            "report": "Error rate failure: 30.00%>=20%",
+            "report": "Inbound errors degraded: 10.00%>=0.1%, Outbound errors failure: 20.00%>=20%",
             "status": Object {
               "color": "#cc0000",
               "icon": "error-circle-o",
               "name": "Failure",
               "priority": 3,
             },
-            "text": "30.00% over last 10 min",
-            "title": "Error Rate",
+            "title": "Error Rate over last 10 min",
           },
         ],
         "rateInterval": 600,
@@ -3179,7 +3558,7 @@ ShallowWrapper {
                       "name": "Degraded",
                       "priority": 2,
                     },
-                    "text": "10.00% inbound error",
+                    "text": "Inbound: 10.00%",
                   },
                   Object {
                     "status": Object {
@@ -3188,18 +3567,17 @@ ShallowWrapper {
                       "name": "Failure",
                       "priority": 3,
                     },
-                    "text": "20.00% outbound error",
+                    "text": "Outbound: 20.00%",
                   },
                 ],
-                "report": "Error rate failure: 30.00%>=20%",
+                "report": "Inbound errors degraded: 10.00%>=0.1%, Outbound errors failure: 20.00%>=20%",
                 "status": Object {
                   "color": "#cc0000",
                   "icon": "error-circle-o",
                   "name": "Failure",
                   "priority": 3,
                 },
-                "text": "30.00% over last 10 min",
-                "title": "Error Rate",
+                "title": "Error Rate over last 10 min",
               },
             ],
             "rateInterval": 600,
@@ -3324,7 +3702,7 @@ ShallowWrapper {
                     "name": "Degraded",
                     "priority": 2,
                   },
-                  "text": "10.00% inbound error",
+                  "text": "Inbound: 10.00%",
                 },
                 Object {
                   "status": Object {
@@ -3333,18 +3711,17 @@ ShallowWrapper {
                     "name": "Failure",
                     "priority": 3,
                   },
-                  "text": "20.00% outbound error",
+                  "text": "Outbound: 20.00%",
                 },
               ],
-              "report": "Error rate failure: 30.00%>=20%",
+              "report": "Inbound errors degraded: 10.00%>=0.1%, Outbound errors failure: 20.00%>=20%",
               "status": Object {
                 "color": "#cc0000",
                 "icon": "error-circle-o",
                 "name": "Failure",
                 "priority": 3,
               },
-              "text": "30.00% over last 10 min",
-              "title": "Error Rate",
+              "title": "Error Rate over last 10 min",
             },
           ],
           "rateInterval": 600,
@@ -3468,7 +3845,7 @@ ShallowWrapper {
                         "name": "Degraded",
                         "priority": 2,
                       },
-                      "text": "10.00% inbound error",
+                      "text": "Inbound: 10.00%",
                     },
                     Object {
                       "status": Object {
@@ -3477,18 +3854,17 @@ ShallowWrapper {
                         "name": "Failure",
                         "priority": 3,
                       },
-                      "text": "20.00% outbound error",
+                      "text": "Outbound: 20.00%",
                     },
                   ],
-                  "report": "Error rate failure: 30.00%>=20%",
+                  "report": "Inbound errors degraded: 10.00%>=0.1%, Outbound errors failure: 20.00%>=20%",
                   "status": Object {
                     "color": "#cc0000",
                     "icon": "error-circle-o",
                     "name": "Failure",
                     "priority": 3,
                   },
-                  "text": "30.00% over last 10 min",
-                  "title": "Error Rate",
+                  "title": "Error Rate over last 10 min",
                 },
               ],
               "rateInterval": 600,
@@ -3613,7 +3989,7 @@ ShallowWrapper {
                       "name": "Degraded",
                       "priority": 2,
                     },
-                    "text": "10.00% inbound error",
+                    "text": "Inbound: 10.00%",
                   },
                   Object {
                     "status": Object {
@@ -3622,18 +3998,17 @@ ShallowWrapper {
                       "name": "Failure",
                       "priority": 3,
                     },
-                    "text": "20.00% outbound error",
+                    "text": "Outbound: 20.00%",
                   },
                 ],
-                "report": "Error rate failure: 30.00%>=20%",
+                "report": "Inbound errors degraded: 10.00%>=0.1%, Outbound errors failure: 20.00%>=20%",
                 "status": Object {
                   "color": "#cc0000",
                   "icon": "error-circle-o",
                   "name": "Failure",
                   "priority": 3,
                 },
-                "text": "30.00% over last 10 min",
-                "title": "Error Rate",
+                "title": "Error Rate over last 10 min",
               },
             ],
             "rateInterval": 600,
@@ -3775,7 +4150,7 @@ ShallowWrapper {
                   "name": "Degraded",
                   "priority": 2,
                 },
-                "text": "10.00% inbound error",
+                "text": "Inbound: 10.00%",
               },
               Object {
                 "status": Object {
@@ -3784,18 +4159,17 @@ ShallowWrapper {
                   "name": "Failure",
                   "priority": 3,
                 },
-                "text": "20.00% outbound error",
+                "text": "Outbound: 20.00%",
               },
             ],
-            "report": "Error rate failure: 30.00%>=20%",
+            "report": "Inbound errors degraded: 10.00%>=0.1%, Outbound errors failure: 20.00%>=20%",
             "status": Object {
               "color": "#cc0000",
               "icon": "error-circle-o",
               "name": "Failure",
               "priority": 3,
             },
-            "text": "30.00% over last 10 min",
-            "title": "Error Rate",
+            "title": "Error Rate over last 10 min",
           },
         ],
         "rateInterval": 600,
@@ -3906,7 +4280,7 @@ ShallowWrapper {
                         "name": "Degraded",
                         "priority": 2,
                       },
-                      "text": "10.00% inbound error",
+                      "text": "Inbound: 10.00%",
                     },
                     Object {
                       "status": Object {
@@ -3915,18 +4289,17 @@ ShallowWrapper {
                         "name": "Failure",
                         "priority": 3,
                       },
-                      "text": "20.00% outbound error",
+                      "text": "Outbound: 20.00%",
                     },
                   ],
-                  "report": "Error rate failure: 30.00%>=20%",
+                  "report": "Inbound errors degraded: 10.00%>=0.1%, Outbound errors failure: 20.00%>=20%",
                   "status": Object {
                     "color": "#cc0000",
                     "icon": "error-circle-o",
                     "name": "Failure",
                     "priority": 3,
                   },
-                  "text": "30.00% over last 10 min",
-                  "title": "Error Rate",
+                  "title": "Error Rate over last 10 min",
                 },
               ],
               "rateInterval": 600,
@@ -3972,7 +4345,7 @@ ShallowWrapper {
             Envoy health degraded
           </li>
           <li>
-            Error rate failure: 30.00%&gt;=20%
+            Inbound errors degraded: 10.00%&gt;=0.1%, Outbound errors failure: 20.00%&gt;=20%
           </li>
         </ul>,
       ],
@@ -4072,7 +4445,7 @@ ShallowWrapper {
                       "name": "Degraded",
                       "priority": 2,
                     },
-                    "text": "10.00% inbound error",
+                    "text": "Inbound: 10.00%",
                   },
                   Object {
                     "status": Object {
@@ -4081,18 +4454,17 @@ ShallowWrapper {
                       "name": "Failure",
                       "priority": 3,
                     },
-                    "text": "20.00% outbound error",
+                    "text": "Outbound: 20.00%",
                   },
                 ],
-                "report": "Error rate failure: 30.00%>=20%",
+                "report": "Inbound errors degraded: 10.00%>=0.1%, Outbound errors failure: 20.00%>=20%",
                 "status": Object {
                   "color": "#cc0000",
                   "icon": "error-circle-o",
                   "name": "Failure",
                   "priority": 3,
                 },
-                "text": "30.00% over last 10 min",
-                "title": "Error Rate",
+                "title": "Error Rate over last 10 min",
               },
             ],
             "rateInterval": 600,
@@ -4152,7 +4524,7 @@ ShallowWrapper {
               Envoy health degraded
             </li>,
             <li>
-              Error rate failure: 30.00%&gt;=20%
+              Inbound errors degraded: 10.00%&gt;=0.1%, Outbound errors failure: 20.00%&gt;=20%
             </li>,
           ],
           "style": Object {
@@ -4177,10 +4549,10 @@ ShallowWrapper {
             "key": "1",
             "nodeType": "host",
             "props": Object {
-              "children": "Error rate failure: 30.00%>=20%",
+              "children": "Inbound errors degraded: 10.00%>=0.1%, Outbound errors failure: 20.00%>=20%",
             },
             "ref": null,
-            "rendered": "Error rate failure: 30.00%>=20%",
+            "rendered": "Inbound errors degraded: 10.00%>=0.1%, Outbound errors failure: 20.00%>=20%",
             "type": "li",
           },
         ],
@@ -4272,7 +4644,7 @@ ShallowWrapper {
                           "name": "Degraded",
                           "priority": 2,
                         },
-                        "text": "10.00% inbound error",
+                        "text": "Inbound: 10.00%",
                       },
                       Object {
                         "status": Object {
@@ -4281,18 +4653,17 @@ ShallowWrapper {
                           "name": "Failure",
                           "priority": 3,
                         },
-                        "text": "20.00% outbound error",
+                        "text": "Outbound: 20.00%",
                       },
                     ],
-                    "report": "Error rate failure: 30.00%>=20%",
+                    "report": "Inbound errors degraded: 10.00%>=0.1%, Outbound errors failure: 20.00%>=20%",
                     "status": Object {
                       "color": "#cc0000",
                       "icon": "error-circle-o",
                       "name": "Failure",
                       "priority": 3,
                     },
-                    "text": "30.00% over last 10 min",
-                    "title": "Error Rate",
+                    "title": "Error Rate over last 10 min",
                   },
                 ],
                 "rateInterval": 600,
@@ -4338,7 +4709,7 @@ ShallowWrapper {
               Envoy health degraded
             </li>
             <li>
-              Error rate failure: 30.00%&gt;=20%
+              Inbound errors degraded: 10.00%&gt;=0.1%, Outbound errors failure: 20.00%&gt;=20%
             </li>
           </ul>,
         ],
@@ -4438,7 +4809,7 @@ ShallowWrapper {
                         "name": "Degraded",
                         "priority": 2,
                       },
-                      "text": "10.00% inbound error",
+                      "text": "Inbound: 10.00%",
                     },
                     Object {
                       "status": Object {
@@ -4447,18 +4818,17 @@ ShallowWrapper {
                         "name": "Failure",
                         "priority": 3,
                       },
-                      "text": "20.00% outbound error",
+                      "text": "Outbound: 20.00%",
                     },
                   ],
-                  "report": "Error rate failure: 30.00%>=20%",
+                  "report": "Inbound errors degraded: 10.00%>=0.1%, Outbound errors failure: 20.00%>=20%",
                   "status": Object {
                     "color": "#cc0000",
                     "icon": "error-circle-o",
                     "name": "Failure",
                     "priority": 3,
                   },
-                  "text": "30.00% over last 10 min",
-                  "title": "Error Rate",
+                  "title": "Error Rate over last 10 min",
                 },
               ],
               "rateInterval": 600,
@@ -4518,7 +4888,7 @@ ShallowWrapper {
                 Envoy health degraded
               </li>,
               <li>
-                Error rate failure: 30.00%&gt;=20%
+                Inbound errors degraded: 10.00%&gt;=0.1%, Outbound errors failure: 20.00%&gt;=20%
               </li>,
             ],
             "style": Object {
@@ -4543,10 +4913,10 @@ ShallowWrapper {
               "key": "1",
               "nodeType": "host",
               "props": Object {
-                "children": "Error rate failure: 30.00%>=20%",
+                "children": "Inbound errors degraded: 10.00%>=0.1%, Outbound errors failure: 20.00%>=20%",
               },
               "ref": null,
-              "rendered": "Error rate failure: 30.00%>=20%",
+              "rendered": "Inbound errors degraded: 10.00%>=0.1%, Outbound errors failure: 20.00%>=20%",
               "type": "li",
             },
           ],
@@ -4655,14 +5025,33 @@ ShallowWrapper {
             "title": "Envoy Health",
           },
           Object {
+            "children": Array [
+              Object {
+                "status": Object {
+                  "color": "#72767b",
+                  "name": "No health information",
+                  "priority": 0,
+                  "text": "N/A",
+                },
+                "text": "Inbound: No requests",
+              },
+              Object {
+                "status": Object {
+                  "color": "#72767b",
+                  "name": "No health information",
+                  "priority": 0,
+                  "text": "N/A",
+                },
+                "text": "Outbound: No requests",
+              },
+            ],
             "status": Object {
               "color": "#72767b",
               "name": "No health information",
               "priority": 0,
               "text": "N/A",
             },
-            "text": "No requests over last 10 min",
-            "title": "Error Rate",
+            "title": "Error Rate over last 10 min",
           },
         ],
         "rateInterval": 600,
@@ -4777,14 +5166,33 @@ ShallowWrapper {
                 "title": "Envoy Health",
               },
               Object {
+                "children": Array [
+                  Object {
+                    "status": Object {
+                      "color": "#72767b",
+                      "name": "No health information",
+                      "priority": 0,
+                      "text": "N/A",
+                    },
+                    "text": "Inbound: No requests",
+                  },
+                  Object {
+                    "status": Object {
+                      "color": "#72767b",
+                      "name": "No health information",
+                      "priority": 0,
+                      "text": "N/A",
+                    },
+                    "text": "Outbound: No requests",
+                  },
+                ],
                 "status": Object {
                   "color": "#72767b",
                   "name": "No health information",
                   "priority": 0,
                   "text": "N/A",
                 },
-                "text": "No requests over last 10 min",
-                "title": "Error Rate",
+                "title": "Error Rate over last 10 min",
               },
             ],
             "rateInterval": 600,
@@ -4914,14 +5322,33 @@ ShallowWrapper {
               "title": "Envoy Health",
             },
             Object {
+              "children": Array [
+                Object {
+                  "status": Object {
+                    "color": "#72767b",
+                    "name": "No health information",
+                    "priority": 0,
+                    "text": "N/A",
+                  },
+                  "text": "Inbound: No requests",
+                },
+                Object {
+                  "status": Object {
+                    "color": "#72767b",
+                    "name": "No health information",
+                    "priority": 0,
+                    "text": "N/A",
+                  },
+                  "text": "Outbound: No requests",
+                },
+              ],
               "status": Object {
                 "color": "#72767b",
                 "name": "No health information",
                 "priority": 0,
                 "text": "N/A",
               },
-              "text": "No requests over last 10 min",
-              "title": "Error Rate",
+              "title": "Error Rate over last 10 min",
             },
           ],
           "rateInterval": 600,
@@ -5050,14 +5477,33 @@ ShallowWrapper {
                   "title": "Envoy Health",
                 },
                 Object {
+                  "children": Array [
+                    Object {
+                      "status": Object {
+                        "color": "#72767b",
+                        "name": "No health information",
+                        "priority": 0,
+                        "text": "N/A",
+                      },
+                      "text": "Inbound: No requests",
+                    },
+                    Object {
+                      "status": Object {
+                        "color": "#72767b",
+                        "name": "No health information",
+                        "priority": 0,
+                        "text": "N/A",
+                      },
+                      "text": "Outbound: No requests",
+                    },
+                  ],
                   "status": Object {
                     "color": "#72767b",
                     "name": "No health information",
                     "priority": 0,
                     "text": "N/A",
                   },
-                  "text": "No requests over last 10 min",
-                  "title": "Error Rate",
+                  "title": "Error Rate over last 10 min",
                 },
               ],
               "rateInterval": 600,
@@ -5187,14 +5633,33 @@ ShallowWrapper {
                 "title": "Envoy Health",
               },
               Object {
+                "children": Array [
+                  Object {
+                    "status": Object {
+                      "color": "#72767b",
+                      "name": "No health information",
+                      "priority": 0,
+                      "text": "N/A",
+                    },
+                    "text": "Inbound: No requests",
+                  },
+                  Object {
+                    "status": Object {
+                      "color": "#72767b",
+                      "name": "No health information",
+                      "priority": 0,
+                      "text": "N/A",
+                    },
+                    "text": "Outbound: No requests",
+                  },
+                ],
                 "status": Object {
                   "color": "#72767b",
                   "name": "No health information",
                   "priority": 0,
                   "text": "N/A",
                 },
-                "text": "No requests over last 10 min",
-                "title": "Error Rate",
+                "title": "Error Rate over last 10 min",
               },
             ],
             "rateInterval": 600,
@@ -5341,14 +5806,33 @@ ShallowWrapper {
             "title": "Envoy Health",
           },
           Object {
+            "children": Array [
+              Object {
+                "status": Object {
+                  "color": "#72767b",
+                  "name": "No health information",
+                  "priority": 0,
+                  "text": "N/A",
+                },
+                "text": "Inbound: No requests",
+              },
+              Object {
+                "status": Object {
+                  "color": "#72767b",
+                  "name": "No health information",
+                  "priority": 0,
+                  "text": "N/A",
+                },
+                "text": "Outbound: No requests",
+              },
+            ],
             "status": Object {
               "color": "#72767b",
               "name": "No health information",
               "priority": 0,
               "text": "N/A",
             },
-            "text": "No requests over last 10 min",
-            "title": "Error Rate",
+            "title": "Error Rate over last 10 min",
           },
         ],
         "rateInterval": 600,
@@ -5464,14 +5948,33 @@ ShallowWrapper {
                   "title": "Envoy Health",
                 },
                 Object {
+                  "children": Array [
+                    Object {
+                      "status": Object {
+                        "color": "#72767b",
+                        "name": "No health information",
+                        "priority": 0,
+                        "text": "N/A",
+                      },
+                      "text": "Inbound: No requests",
+                    },
+                    Object {
+                      "status": Object {
+                        "color": "#72767b",
+                        "name": "No health information",
+                        "priority": 0,
+                        "text": "N/A",
+                      },
+                      "text": "Outbound: No requests",
+                    },
+                  ],
                   "status": Object {
                     "color": "#72767b",
                     "name": "No health information",
                     "priority": 0,
                     "text": "N/A",
                   },
-                  "text": "No requests over last 10 min",
-                  "title": "Error Rate",
+                  "title": "Error Rate over last 10 min",
                 },
               ],
               "rateInterval": 600,
@@ -5609,14 +6112,33 @@ ShallowWrapper {
                 "title": "Envoy Health",
               },
               Object {
+                "children": Array [
+                  Object {
+                    "status": Object {
+                      "color": "#72767b",
+                      "name": "No health information",
+                      "priority": 0,
+                      "text": "N/A",
+                    },
+                    "text": "Inbound: No requests",
+                  },
+                  Object {
+                    "status": Object {
+                      "color": "#72767b",
+                      "name": "No health information",
+                      "priority": 0,
+                      "text": "N/A",
+                    },
+                    "text": "Outbound: No requests",
+                  },
+                ],
                 "status": Object {
                   "color": "#72767b",
                   "name": "No health information",
                   "priority": 0,
                   "text": "N/A",
                 },
-                "text": "No requests over last 10 min",
-                "title": "Error Rate",
+                "title": "Error Rate over last 10 min",
               },
             ],
             "rateInterval": 600,
@@ -5758,14 +6280,33 @@ ShallowWrapper {
                     "title": "Envoy Health",
                   },
                   Object {
+                    "children": Array [
+                      Object {
+                        "status": Object {
+                          "color": "#72767b",
+                          "name": "No health information",
+                          "priority": 0,
+                          "text": "N/A",
+                        },
+                        "text": "Inbound: No requests",
+                      },
+                      Object {
+                        "status": Object {
+                          "color": "#72767b",
+                          "name": "No health information",
+                          "priority": 0,
+                          "text": "N/A",
+                        },
+                        "text": "Outbound: No requests",
+                      },
+                    ],
                     "status": Object {
                       "color": "#72767b",
                       "name": "No health information",
                       "priority": 0,
                       "text": "N/A",
                     },
-                    "text": "No requests over last 10 min",
-                    "title": "Error Rate",
+                    "title": "Error Rate over last 10 min",
                   },
                 ],
                 "rateInterval": 600,
@@ -5903,14 +6444,33 @@ ShallowWrapper {
                   "title": "Envoy Health",
                 },
                 Object {
+                  "children": Array [
+                    Object {
+                      "status": Object {
+                        "color": "#72767b",
+                        "name": "No health information",
+                        "priority": 0,
+                        "text": "N/A",
+                      },
+                      "text": "Inbound: No requests",
+                    },
+                    Object {
+                      "status": Object {
+                        "color": "#72767b",
+                        "name": "No health information",
+                        "priority": 0,
+                        "text": "N/A",
+                      },
+                      "text": "Outbound: No requests",
+                    },
+                  ],
                   "status": Object {
                     "color": "#72767b",
                     "name": "No health information",
                     "priority": 0,
                     "text": "N/A",
                   },
-                  "text": "No requests over last 10 min",
-                  "title": "Error Rate",
+                  "title": "Error Rate over last 10 min",
                 },
               ],
               "rateInterval": 600,
@@ -6070,14 +6630,33 @@ ShallowWrapper {
             "title": "Envoy Health",
           },
           Object {
+            "children": Array [
+              Object {
+                "status": Object {
+                  "color": "#72767b",
+                  "name": "No health information",
+                  "priority": 0,
+                  "text": "N/A",
+                },
+                "text": "Inbound: No requests",
+              },
+              Object {
+                "status": Object {
+                  "color": "#72767b",
+                  "name": "No health information",
+                  "priority": 0,
+                  "text": "N/A",
+                },
+                "text": "Outbound: No requests",
+              },
+            ],
             "status": Object {
               "color": "#72767b",
               "name": "No health information",
               "priority": 0,
               "text": "N/A",
             },
-            "text": "No requests over last 10 min",
-            "title": "Error Rate",
+            "title": "Error Rate over last 10 min",
           },
         ],
         "rateInterval": 600,
@@ -6193,14 +6772,33 @@ ShallowWrapper {
                 "title": "Envoy Health",
               },
               Object {
+                "children": Array [
+                  Object {
+                    "status": Object {
+                      "color": "#72767b",
+                      "name": "No health information",
+                      "priority": 0,
+                      "text": "N/A",
+                    },
+                    "text": "Inbound: No requests",
+                  },
+                  Object {
+                    "status": Object {
+                      "color": "#72767b",
+                      "name": "No health information",
+                      "priority": 0,
+                      "text": "N/A",
+                    },
+                    "text": "Outbound: No requests",
+                  },
+                ],
                 "status": Object {
                   "color": "#72767b",
                   "name": "No health information",
                   "priority": 0,
                   "text": "N/A",
                 },
-                "text": "No requests over last 10 min",
-                "title": "Error Rate",
+                "title": "Error Rate over last 10 min",
               },
             ],
             "rateInterval": 600,
@@ -6331,14 +6929,33 @@ ShallowWrapper {
               "title": "Envoy Health",
             },
             Object {
+              "children": Array [
+                Object {
+                  "status": Object {
+                    "color": "#72767b",
+                    "name": "No health information",
+                    "priority": 0,
+                    "text": "N/A",
+                  },
+                  "text": "Inbound: No requests",
+                },
+                Object {
+                  "status": Object {
+                    "color": "#72767b",
+                    "name": "No health information",
+                    "priority": 0,
+                    "text": "N/A",
+                  },
+                  "text": "Outbound: No requests",
+                },
+              ],
               "status": Object {
                 "color": "#72767b",
                 "name": "No health information",
                 "priority": 0,
                 "text": "N/A",
               },
-              "text": "No requests over last 10 min",
-              "title": "Error Rate",
+              "title": "Error Rate over last 10 min",
             },
           ],
           "rateInterval": 600,
@@ -6468,14 +7085,33 @@ ShallowWrapper {
                   "title": "Envoy Health",
                 },
                 Object {
+                  "children": Array [
+                    Object {
+                      "status": Object {
+                        "color": "#72767b",
+                        "name": "No health information",
+                        "priority": 0,
+                        "text": "N/A",
+                      },
+                      "text": "Inbound: No requests",
+                    },
+                    Object {
+                      "status": Object {
+                        "color": "#72767b",
+                        "name": "No health information",
+                        "priority": 0,
+                        "text": "N/A",
+                      },
+                      "text": "Outbound: No requests",
+                    },
+                  ],
                   "status": Object {
                     "color": "#72767b",
                     "name": "No health information",
                     "priority": 0,
                     "text": "N/A",
                   },
-                  "text": "No requests over last 10 min",
-                  "title": "Error Rate",
+                  "title": "Error Rate over last 10 min",
                 },
               ],
               "rateInterval": 600,
@@ -6606,14 +7242,33 @@ ShallowWrapper {
                 "title": "Envoy Health",
               },
               Object {
+                "children": Array [
+                  Object {
+                    "status": Object {
+                      "color": "#72767b",
+                      "name": "No health information",
+                      "priority": 0,
+                      "text": "N/A",
+                    },
+                    "text": "Inbound: No requests",
+                  },
+                  Object {
+                    "status": Object {
+                      "color": "#72767b",
+                      "name": "No health information",
+                      "priority": 0,
+                      "text": "N/A",
+                    },
+                    "text": "Outbound: No requests",
+                  },
+                ],
                 "status": Object {
                   "color": "#72767b",
                   "name": "No health information",
                   "priority": 0,
                   "text": "N/A",
                 },
-                "text": "No requests over last 10 min",
-                "title": "Error Rate",
+                "title": "Error Rate over last 10 min",
               },
             ],
             "rateInterval": 600,
@@ -6761,14 +7416,33 @@ ShallowWrapper {
             "title": "Envoy Health",
           },
           Object {
+            "children": Array [
+              Object {
+                "status": Object {
+                  "color": "#72767b",
+                  "name": "No health information",
+                  "priority": 0,
+                  "text": "N/A",
+                },
+                "text": "Inbound: No requests",
+              },
+              Object {
+                "status": Object {
+                  "color": "#72767b",
+                  "name": "No health information",
+                  "priority": 0,
+                  "text": "N/A",
+                },
+                "text": "Outbound: No requests",
+              },
+            ],
             "status": Object {
               "color": "#72767b",
               "name": "No health information",
               "priority": 0,
               "text": "N/A",
             },
-            "text": "No requests over last 10 min",
-            "title": "Error Rate",
+            "title": "Error Rate over last 10 min",
           },
         ],
         "rateInterval": 600,
@@ -6885,14 +7559,33 @@ ShallowWrapper {
                   "title": "Envoy Health",
                 },
                 Object {
+                  "children": Array [
+                    Object {
+                      "status": Object {
+                        "color": "#72767b",
+                        "name": "No health information",
+                        "priority": 0,
+                        "text": "N/A",
+                      },
+                      "text": "Inbound: No requests",
+                    },
+                    Object {
+                      "status": Object {
+                        "color": "#72767b",
+                        "name": "No health information",
+                        "priority": 0,
+                        "text": "N/A",
+                      },
+                      "text": "Outbound: No requests",
+                    },
+                  ],
                   "status": Object {
                     "color": "#72767b",
                     "name": "No health information",
                     "priority": 0,
                     "text": "N/A",
                   },
-                  "text": "No requests over last 10 min",
-                  "title": "Error Rate",
+                  "title": "Error Rate over last 10 min",
                 },
               ],
               "rateInterval": 600,
@@ -7031,14 +7724,33 @@ ShallowWrapper {
                 "title": "Envoy Health",
               },
               Object {
+                "children": Array [
+                  Object {
+                    "status": Object {
+                      "color": "#72767b",
+                      "name": "No health information",
+                      "priority": 0,
+                      "text": "N/A",
+                    },
+                    "text": "Inbound: No requests",
+                  },
+                  Object {
+                    "status": Object {
+                      "color": "#72767b",
+                      "name": "No health information",
+                      "priority": 0,
+                      "text": "N/A",
+                    },
+                    "text": "Outbound: No requests",
+                  },
+                ],
                 "status": Object {
                   "color": "#72767b",
                   "name": "No health information",
                   "priority": 0,
                   "text": "N/A",
                 },
-                "text": "No requests over last 10 min",
-                "title": "Error Rate",
+                "title": "Error Rate over last 10 min",
               },
             ],
             "rateInterval": 600,
@@ -7181,14 +7893,33 @@ ShallowWrapper {
                     "title": "Envoy Health",
                   },
                   Object {
+                    "children": Array [
+                      Object {
+                        "status": Object {
+                          "color": "#72767b",
+                          "name": "No health information",
+                          "priority": 0,
+                          "text": "N/A",
+                        },
+                        "text": "Inbound: No requests",
+                      },
+                      Object {
+                        "status": Object {
+                          "color": "#72767b",
+                          "name": "No health information",
+                          "priority": 0,
+                          "text": "N/A",
+                        },
+                        "text": "Outbound: No requests",
+                      },
+                    ],
                     "status": Object {
                       "color": "#72767b",
                       "name": "No health information",
                       "priority": 0,
                       "text": "N/A",
                     },
-                    "text": "No requests over last 10 min",
-                    "title": "Error Rate",
+                    "title": "Error Rate over last 10 min",
                   },
                 ],
                 "rateInterval": 600,
@@ -7327,14 +8058,33 @@ ShallowWrapper {
                   "title": "Envoy Health",
                 },
                 Object {
+                  "children": Array [
+                    Object {
+                      "status": Object {
+                        "color": "#72767b",
+                        "name": "No health information",
+                        "priority": 0,
+                        "text": "N/A",
+                      },
+                      "text": "Inbound: No requests",
+                    },
+                    Object {
+                      "status": Object {
+                        "color": "#72767b",
+                        "name": "No health information",
+                        "priority": 0,
+                        "text": "N/A",
+                      },
+                      "text": "Outbound: No requests",
+                    },
+                  ],
                   "status": Object {
                     "color": "#72767b",
                     "name": "No health information",
                     "priority": 0,
                     "text": "N/A",
                   },
-                  "text": "No requests over last 10 min",
-                  "title": "Error Rate",
+                  "title": "Error Rate over last 10 min",
                 },
               ],
               "rateInterval": 600,
@@ -7494,14 +8244,33 @@ ShallowWrapper {
             "title": "Envoy Health",
           },
           Object {
+            "children": Array [
+              Object {
+                "status": Object {
+                  "color": "#72767b",
+                  "name": "No health information",
+                  "priority": 0,
+                  "text": "N/A",
+                },
+                "text": "Inbound: No requests",
+              },
+              Object {
+                "status": Object {
+                  "color": "#72767b",
+                  "name": "No health information",
+                  "priority": 0,
+                  "text": "N/A",
+                },
+                "text": "Outbound: No requests",
+              },
+            ],
             "status": Object {
               "color": "#72767b",
               "name": "No health information",
               "priority": 0,
               "text": "N/A",
             },
-            "text": "No requests over last 10 min",
-            "title": "Error Rate",
+            "title": "Error Rate over last 10 min",
           },
         ],
         "rateInterval": 600,
@@ -7617,14 +8386,33 @@ ShallowWrapper {
                 "title": "Envoy Health",
               },
               Object {
+                "children": Array [
+                  Object {
+                    "status": Object {
+                      "color": "#72767b",
+                      "name": "No health information",
+                      "priority": 0,
+                      "text": "N/A",
+                    },
+                    "text": "Inbound: No requests",
+                  },
+                  Object {
+                    "status": Object {
+                      "color": "#72767b",
+                      "name": "No health information",
+                      "priority": 0,
+                      "text": "N/A",
+                    },
+                    "text": "Outbound: No requests",
+                  },
+                ],
                 "status": Object {
                   "color": "#72767b",
                   "name": "No health information",
                   "priority": 0,
                   "text": "N/A",
                 },
-                "text": "No requests over last 10 min",
-                "title": "Error Rate",
+                "title": "Error Rate over last 10 min",
               },
             ],
             "rateInterval": 600,
@@ -7755,14 +8543,33 @@ ShallowWrapper {
               "title": "Envoy Health",
             },
             Object {
+              "children": Array [
+                Object {
+                  "status": Object {
+                    "color": "#72767b",
+                    "name": "No health information",
+                    "priority": 0,
+                    "text": "N/A",
+                  },
+                  "text": "Inbound: No requests",
+                },
+                Object {
+                  "status": Object {
+                    "color": "#72767b",
+                    "name": "No health information",
+                    "priority": 0,
+                    "text": "N/A",
+                  },
+                  "text": "Outbound: No requests",
+                },
+              ],
               "status": Object {
                 "color": "#72767b",
                 "name": "No health information",
                 "priority": 0,
                 "text": "N/A",
               },
-              "text": "No requests over last 10 min",
-              "title": "Error Rate",
+              "title": "Error Rate over last 10 min",
             },
           ],
           "rateInterval": 600,
@@ -7892,14 +8699,33 @@ ShallowWrapper {
                   "title": "Envoy Health",
                 },
                 Object {
+                  "children": Array [
+                    Object {
+                      "status": Object {
+                        "color": "#72767b",
+                        "name": "No health information",
+                        "priority": 0,
+                        "text": "N/A",
+                      },
+                      "text": "Inbound: No requests",
+                    },
+                    Object {
+                      "status": Object {
+                        "color": "#72767b",
+                        "name": "No health information",
+                        "priority": 0,
+                        "text": "N/A",
+                      },
+                      "text": "Outbound: No requests",
+                    },
+                  ],
                   "status": Object {
                     "color": "#72767b",
                     "name": "No health information",
                     "priority": 0,
                     "text": "N/A",
                   },
-                  "text": "No requests over last 10 min",
-                  "title": "Error Rate",
+                  "title": "Error Rate over last 10 min",
                 },
               ],
               "rateInterval": 600,
@@ -8030,14 +8856,33 @@ ShallowWrapper {
                 "title": "Envoy Health",
               },
               Object {
+                "children": Array [
+                  Object {
+                    "status": Object {
+                      "color": "#72767b",
+                      "name": "No health information",
+                      "priority": 0,
+                      "text": "N/A",
+                    },
+                    "text": "Inbound: No requests",
+                  },
+                  Object {
+                    "status": Object {
+                      "color": "#72767b",
+                      "name": "No health information",
+                      "priority": 0,
+                      "text": "N/A",
+                    },
+                    "text": "Outbound: No requests",
+                  },
+                ],
                 "status": Object {
                   "color": "#72767b",
                   "name": "No health information",
                   "priority": 0,
                   "text": "N/A",
                 },
-                "text": "No requests over last 10 min",
-                "title": "Error Rate",
+                "title": "Error Rate over last 10 min",
               },
             ],
             "rateInterval": 600,
@@ -8185,14 +9030,33 @@ ShallowWrapper {
             "title": "Envoy Health",
           },
           Object {
+            "children": Array [
+              Object {
+                "status": Object {
+                  "color": "#72767b",
+                  "name": "No health information",
+                  "priority": 0,
+                  "text": "N/A",
+                },
+                "text": "Inbound: No requests",
+              },
+              Object {
+                "status": Object {
+                  "color": "#72767b",
+                  "name": "No health information",
+                  "priority": 0,
+                  "text": "N/A",
+                },
+                "text": "Outbound: No requests",
+              },
+            ],
             "status": Object {
               "color": "#72767b",
               "name": "No health information",
               "priority": 0,
               "text": "N/A",
             },
-            "text": "No requests over last 10 min",
-            "title": "Error Rate",
+            "title": "Error Rate over last 10 min",
           },
         ],
         "rateInterval": 600,
@@ -8309,14 +9173,33 @@ ShallowWrapper {
                   "title": "Envoy Health",
                 },
                 Object {
+                  "children": Array [
+                    Object {
+                      "status": Object {
+                        "color": "#72767b",
+                        "name": "No health information",
+                        "priority": 0,
+                        "text": "N/A",
+                      },
+                      "text": "Inbound: No requests",
+                    },
+                    Object {
+                      "status": Object {
+                        "color": "#72767b",
+                        "name": "No health information",
+                        "priority": 0,
+                        "text": "N/A",
+                      },
+                      "text": "Outbound: No requests",
+                    },
+                  ],
                   "status": Object {
                     "color": "#72767b",
                     "name": "No health information",
                     "priority": 0,
                     "text": "N/A",
                   },
-                  "text": "No requests over last 10 min",
-                  "title": "Error Rate",
+                  "title": "Error Rate over last 10 min",
                 },
               ],
               "rateInterval": 600,
@@ -8455,14 +9338,33 @@ ShallowWrapper {
                 "title": "Envoy Health",
               },
               Object {
+                "children": Array [
+                  Object {
+                    "status": Object {
+                      "color": "#72767b",
+                      "name": "No health information",
+                      "priority": 0,
+                      "text": "N/A",
+                    },
+                    "text": "Inbound: No requests",
+                  },
+                  Object {
+                    "status": Object {
+                      "color": "#72767b",
+                      "name": "No health information",
+                      "priority": 0,
+                      "text": "N/A",
+                    },
+                    "text": "Outbound: No requests",
+                  },
+                ],
                 "status": Object {
                   "color": "#72767b",
                   "name": "No health information",
                   "priority": 0,
                   "text": "N/A",
                 },
-                "text": "No requests over last 10 min",
-                "title": "Error Rate",
+                "title": "Error Rate over last 10 min",
               },
             ],
             "rateInterval": 600,
@@ -8605,14 +9507,33 @@ ShallowWrapper {
                     "title": "Envoy Health",
                   },
                   Object {
+                    "children": Array [
+                      Object {
+                        "status": Object {
+                          "color": "#72767b",
+                          "name": "No health information",
+                          "priority": 0,
+                          "text": "N/A",
+                        },
+                        "text": "Inbound: No requests",
+                      },
+                      Object {
+                        "status": Object {
+                          "color": "#72767b",
+                          "name": "No health information",
+                          "priority": 0,
+                          "text": "N/A",
+                        },
+                        "text": "Outbound: No requests",
+                      },
+                    ],
                     "status": Object {
                       "color": "#72767b",
                       "name": "No health information",
                       "priority": 0,
                       "text": "N/A",
                     },
-                    "text": "No requests over last 10 min",
-                    "title": "Error Rate",
+                    "title": "Error Rate over last 10 min",
                   },
                 ],
                 "rateInterval": 600,
@@ -8751,14 +9672,33 @@ ShallowWrapper {
                   "title": "Envoy Health",
                 },
                 Object {
+                  "children": Array [
+                    Object {
+                      "status": Object {
+                        "color": "#72767b",
+                        "name": "No health information",
+                        "priority": 0,
+                        "text": "N/A",
+                      },
+                      "text": "Inbound: No requests",
+                    },
+                    Object {
+                      "status": Object {
+                        "color": "#72767b",
+                        "name": "No health information",
+                        "priority": 0,
+                        "text": "N/A",
+                      },
+                      "text": "Outbound: No requests",
+                    },
+                  ],
                   "status": Object {
                     "color": "#72767b",
                     "name": "No health information",
                     "priority": 0,
                     "text": "N/A",
                   },
-                  "text": "No requests over last 10 min",
-                  "title": "Error Rate",
+                  "title": "Error Rate over last 10 min",
                 },
               ],
               "rateInterval": 600,

--- a/src/components/Health/__tests__/__snapshots__/HealthIndicator.test.tsx.snap
+++ b/src/components/Health/__tests__/__snapshots__/HealthIndicator.test.tsx.snap
@@ -93,6 +93,8 @@ ShallowWrapper {
         "rateInterval": 600,
         "requests": Object {
           "errorRatio": -1,
+          "inboundErrorRatio": -1,
+          "outboundErrorRatio": -1,
         },
         "workloadStatuses": Array [
           Object {
@@ -214,6 +216,8 @@ ShallowWrapper {
             "rateInterval": 600,
             "requests": Object {
               "errorRatio": -1,
+              "inboundErrorRatio": -1,
+              "outboundErrorRatio": -1,
             },
             "workloadStatuses": Array [
               Object {
@@ -350,6 +354,8 @@ ShallowWrapper {
           "rateInterval": 600,
           "requests": Object {
             "errorRatio": -1,
+            "inboundErrorRatio": -1,
+            "outboundErrorRatio": -1,
           },
           "workloadStatuses": Array [
             Object {
@@ -485,6 +491,8 @@ ShallowWrapper {
               "rateInterval": 600,
               "requests": Object {
                 "errorRatio": -1,
+                "inboundErrorRatio": -1,
+                "outboundErrorRatio": -1,
               },
               "workloadStatuses": Array [
                 Object {
@@ -621,6 +629,8 @@ ShallowWrapper {
             "rateInterval": 600,
             "requests": Object {
               "errorRatio": -1,
+              "inboundErrorRatio": -1,
+              "outboundErrorRatio": -1,
             },
             "workloadStatuses": Array [
               Object {
@@ -774,6 +784,8 @@ ShallowWrapper {
         "rateInterval": 600,
         "requests": Object {
           "errorRatio": -1,
+          "inboundErrorRatio": -1,
+          "outboundErrorRatio": -1,
         },
         "workloadStatuses": Array [
           Object {
@@ -896,6 +908,8 @@ ShallowWrapper {
               "rateInterval": 600,
               "requests": Object {
                 "errorRatio": -1,
+                "inboundErrorRatio": -1,
+                "outboundErrorRatio": -1,
               },
               "workloadStatuses": Array [
                 Object {
@@ -1040,6 +1054,8 @@ ShallowWrapper {
             "rateInterval": 600,
             "requests": Object {
               "errorRatio": -1,
+              "inboundErrorRatio": -1,
+              "outboundErrorRatio": -1,
             },
             "workloadStatuses": Array [
               Object {
@@ -1188,6 +1204,8 @@ ShallowWrapper {
                 "rateInterval": 600,
                 "requests": Object {
                   "errorRatio": -1,
+                  "inboundErrorRatio": -1,
+                  "outboundErrorRatio": -1,
                 },
                 "workloadStatuses": Array [
                   Object {
@@ -1332,6 +1350,8 @@ ShallowWrapper {
               "rateInterval": 600,
               "requests": Object {
                 "errorRatio": -1,
+                "inboundErrorRatio": -1,
+                "outboundErrorRatio": -1,
               },
               "workloadStatuses": Array [
                 Object {
@@ -1498,6 +1518,8 @@ ShallowWrapper {
         "rateInterval": 600,
         "requests": Object {
           "errorRatio": -1,
+          "inboundErrorRatio": -1,
+          "outboundErrorRatio": -1,
         },
         "workloadStatuses": Array [
           Object {
@@ -1620,6 +1642,8 @@ ShallowWrapper {
             "rateInterval": 600,
             "requests": Object {
               "errorRatio": -1,
+              "inboundErrorRatio": -1,
+              "outboundErrorRatio": -1,
             },
             "workloadStatuses": Array [
               Object {
@@ -1757,6 +1781,8 @@ ShallowWrapper {
           "rateInterval": 600,
           "requests": Object {
             "errorRatio": -1,
+            "inboundErrorRatio": -1,
+            "outboundErrorRatio": -1,
           },
           "workloadStatuses": Array [
             Object {
@@ -1893,6 +1919,8 @@ ShallowWrapper {
               "rateInterval": 600,
               "requests": Object {
                 "errorRatio": -1,
+                "inboundErrorRatio": -1,
+                "outboundErrorRatio": -1,
               },
               "workloadStatuses": Array [
                 Object {
@@ -2030,6 +2058,8 @@ ShallowWrapper {
             "rateInterval": 600,
             "requests": Object {
               "errorRatio": -1,
+              "inboundErrorRatio": -1,
+              "outboundErrorRatio": -1,
             },
             "workloadStatuses": Array [
               Object {
@@ -2184,6 +2214,8 @@ ShallowWrapper {
         "rateInterval": 600,
         "requests": Object {
           "errorRatio": -1,
+          "inboundErrorRatio": -1,
+          "outboundErrorRatio": -1,
         },
         "workloadStatuses": Array [
           Object {
@@ -2307,6 +2339,8 @@ ShallowWrapper {
               "rateInterval": 600,
               "requests": Object {
                 "errorRatio": -1,
+                "inboundErrorRatio": -1,
+                "outboundErrorRatio": -1,
               },
               "workloadStatuses": Array [
                 Object {
@@ -2465,6 +2499,8 @@ ShallowWrapper {
             "rateInterval": 600,
             "requests": Object {
               "errorRatio": -1,
+              "inboundErrorRatio": -1,
+              "outboundErrorRatio": -1,
             },
             "workloadStatuses": Array [
               Object {
@@ -2657,6 +2693,8 @@ ShallowWrapper {
                 "rateInterval": 600,
                 "requests": Object {
                   "errorRatio": -1,
+                  "inboundErrorRatio": -1,
+                  "outboundErrorRatio": -1,
                 },
                 "workloadStatuses": Array [
                   Object {
@@ -2815,6 +2853,8 @@ ShallowWrapper {
               "rateInterval": 600,
               "requests": Object {
                 "errorRatio": -1,
+                "inboundErrorRatio": -1,
+                "outboundErrorRatio": -1,
               },
               "workloadStatuses": Array [
                 Object {
@@ -3001,6 +3041,26 @@ ShallowWrapper {
             "title": "Envoy Health",
           },
           Object {
+            "children": Array [
+              Object {
+                "status": Object {
+                  "color": "#ec7a08",
+                  "icon": "warning-triangle-o",
+                  "name": "Degraded",
+                  "priority": 2,
+                },
+                "text": "10.00% inbound error",
+              },
+              Object {
+                "status": Object {
+                  "color": "#cc0000",
+                  "icon": "error-circle-o",
+                  "name": "Failure",
+                  "priority": 3,
+                },
+                "text": "20.00% outbound error",
+              },
+            ],
             "report": "Error rate failure: 30.00%>=20%",
             "status": Object {
               "color": "#cc0000",
@@ -3015,6 +3075,8 @@ ShallowWrapper {
         "rateInterval": 600,
         "requests": Object {
           "errorRatio": 0.3,
+          "inboundErrorRatio": 0.1,
+          "outboundErrorRatio": 0.2,
         },
         "workloadStatuses": Array [
           Object {
@@ -3109,6 +3171,26 @@ ShallowWrapper {
                 "title": "Envoy Health",
               },
               Object {
+                "children": Array [
+                  Object {
+                    "status": Object {
+                      "color": "#ec7a08",
+                      "icon": "warning-triangle-o",
+                      "name": "Degraded",
+                      "priority": 2,
+                    },
+                    "text": "10.00% inbound error",
+                  },
+                  Object {
+                    "status": Object {
+                      "color": "#cc0000",
+                      "icon": "error-circle-o",
+                      "name": "Failure",
+                      "priority": 3,
+                    },
+                    "text": "20.00% outbound error",
+                  },
+                ],
                 "report": "Error rate failure: 30.00%>=20%",
                 "status": Object {
                   "color": "#cc0000",
@@ -3123,6 +3205,8 @@ ShallowWrapper {
             "rateInterval": 600,
             "requests": Object {
               "errorRatio": 0.3,
+              "inboundErrorRatio": 0.1,
+              "outboundErrorRatio": 0.2,
             },
             "workloadStatuses": Array [
               Object {
@@ -3232,6 +3316,26 @@ ShallowWrapper {
               "title": "Envoy Health",
             },
             Object {
+              "children": Array [
+                Object {
+                  "status": Object {
+                    "color": "#ec7a08",
+                    "icon": "warning-triangle-o",
+                    "name": "Degraded",
+                    "priority": 2,
+                  },
+                  "text": "10.00% inbound error",
+                },
+                Object {
+                  "status": Object {
+                    "color": "#cc0000",
+                    "icon": "error-circle-o",
+                    "name": "Failure",
+                    "priority": 3,
+                  },
+                  "text": "20.00% outbound error",
+                },
+              ],
               "report": "Error rate failure: 30.00%>=20%",
               "status": Object {
                 "color": "#cc0000",
@@ -3246,6 +3350,8 @@ ShallowWrapper {
           "rateInterval": 600,
           "requests": Object {
             "errorRatio": 0.3,
+            "inboundErrorRatio": 0.1,
+            "outboundErrorRatio": 0.2,
           },
           "workloadStatuses": Array [
             Object {
@@ -3354,6 +3460,26 @@ ShallowWrapper {
                   "title": "Envoy Health",
                 },
                 Object {
+                  "children": Array [
+                    Object {
+                      "status": Object {
+                        "color": "#ec7a08",
+                        "icon": "warning-triangle-o",
+                        "name": "Degraded",
+                        "priority": 2,
+                      },
+                      "text": "10.00% inbound error",
+                    },
+                    Object {
+                      "status": Object {
+                        "color": "#cc0000",
+                        "icon": "error-circle-o",
+                        "name": "Failure",
+                        "priority": 3,
+                      },
+                      "text": "20.00% outbound error",
+                    },
+                  ],
                   "report": "Error rate failure: 30.00%>=20%",
                   "status": Object {
                     "color": "#cc0000",
@@ -3368,6 +3494,8 @@ ShallowWrapper {
               "rateInterval": 600,
               "requests": Object {
                 "errorRatio": 0.3,
+                "inboundErrorRatio": 0.1,
+                "outboundErrorRatio": 0.2,
               },
               "workloadStatuses": Array [
                 Object {
@@ -3477,6 +3605,26 @@ ShallowWrapper {
                 "title": "Envoy Health",
               },
               Object {
+                "children": Array [
+                  Object {
+                    "status": Object {
+                      "color": "#ec7a08",
+                      "icon": "warning-triangle-o",
+                      "name": "Degraded",
+                      "priority": 2,
+                    },
+                    "text": "10.00% inbound error",
+                  },
+                  Object {
+                    "status": Object {
+                      "color": "#cc0000",
+                      "icon": "error-circle-o",
+                      "name": "Failure",
+                      "priority": 3,
+                    },
+                    "text": "20.00% outbound error",
+                  },
+                ],
                 "report": "Error rate failure: 30.00%>=20%",
                 "status": Object {
                   "color": "#cc0000",
@@ -3491,6 +3639,8 @@ ShallowWrapper {
             "rateInterval": 600,
             "requests": Object {
               "errorRatio": 0.3,
+              "inboundErrorRatio": 0.1,
+              "outboundErrorRatio": 0.2,
             },
             "workloadStatuses": Array [
               Object {
@@ -3617,6 +3767,26 @@ ShallowWrapper {
             "title": "Envoy Health",
           },
           Object {
+            "children": Array [
+              Object {
+                "status": Object {
+                  "color": "#ec7a08",
+                  "icon": "warning-triangle-o",
+                  "name": "Degraded",
+                  "priority": 2,
+                },
+                "text": "10.00% inbound error",
+              },
+              Object {
+                "status": Object {
+                  "color": "#cc0000",
+                  "icon": "error-circle-o",
+                  "name": "Failure",
+                  "priority": 3,
+                },
+                "text": "20.00% outbound error",
+              },
+            ],
             "report": "Error rate failure: 30.00%>=20%",
             "status": Object {
               "color": "#cc0000",
@@ -3631,6 +3801,8 @@ ShallowWrapper {
         "rateInterval": 600,
         "requests": Object {
           "errorRatio": 0.3,
+          "inboundErrorRatio": 0.1,
+          "outboundErrorRatio": 0.2,
         },
         "workloadStatuses": Array [
           Object {
@@ -3726,6 +3898,26 @@ ShallowWrapper {
                   "title": "Envoy Health",
                 },
                 Object {
+                  "children": Array [
+                    Object {
+                      "status": Object {
+                        "color": "#ec7a08",
+                        "icon": "warning-triangle-o",
+                        "name": "Degraded",
+                        "priority": 2,
+                      },
+                      "text": "10.00% inbound error",
+                    },
+                    Object {
+                      "status": Object {
+                        "color": "#cc0000",
+                        "icon": "error-circle-o",
+                        "name": "Failure",
+                        "priority": 3,
+                      },
+                      "text": "20.00% outbound error",
+                    },
+                  ],
                   "report": "Error rate failure: 30.00%>=20%",
                   "status": Object {
                     "color": "#cc0000",
@@ -3740,6 +3932,8 @@ ShallowWrapper {
               "rateInterval": 600,
               "requests": Object {
                 "errorRatio": 0.3,
+                "inboundErrorRatio": 0.1,
+                "outboundErrorRatio": 0.2,
               },
               "workloadStatuses": Array [
                 Object {
@@ -3870,6 +4064,26 @@ ShallowWrapper {
                 "title": "Envoy Health",
               },
               Object {
+                "children": Array [
+                  Object {
+                    "status": Object {
+                      "color": "#ec7a08",
+                      "icon": "warning-triangle-o",
+                      "name": "Degraded",
+                      "priority": 2,
+                    },
+                    "text": "10.00% inbound error",
+                  },
+                  Object {
+                    "status": Object {
+                      "color": "#cc0000",
+                      "icon": "error-circle-o",
+                      "name": "Failure",
+                      "priority": 3,
+                    },
+                    "text": "20.00% outbound error",
+                  },
+                ],
                 "report": "Error rate failure: 30.00%>=20%",
                 "status": Object {
                   "color": "#cc0000",
@@ -3884,6 +4098,8 @@ ShallowWrapper {
             "rateInterval": 600,
             "requests": Object {
               "errorRatio": 0.3,
+              "inboundErrorRatio": 0.1,
+              "outboundErrorRatio": 0.2,
             },
             "workloadStatuses": Array [
               Object {
@@ -4048,6 +4264,26 @@ ShallowWrapper {
                     "title": "Envoy Health",
                   },
                   Object {
+                    "children": Array [
+                      Object {
+                        "status": Object {
+                          "color": "#ec7a08",
+                          "icon": "warning-triangle-o",
+                          "name": "Degraded",
+                          "priority": 2,
+                        },
+                        "text": "10.00% inbound error",
+                      },
+                      Object {
+                        "status": Object {
+                          "color": "#cc0000",
+                          "icon": "error-circle-o",
+                          "name": "Failure",
+                          "priority": 3,
+                        },
+                        "text": "20.00% outbound error",
+                      },
+                    ],
                     "report": "Error rate failure: 30.00%>=20%",
                     "status": Object {
                       "color": "#cc0000",
@@ -4062,6 +4298,8 @@ ShallowWrapper {
                 "rateInterval": 600,
                 "requests": Object {
                   "errorRatio": 0.3,
+                  "inboundErrorRatio": 0.1,
+                  "outboundErrorRatio": 0.2,
                 },
                 "workloadStatuses": Array [
                   Object {
@@ -4192,6 +4430,26 @@ ShallowWrapper {
                   "title": "Envoy Health",
                 },
                 Object {
+                  "children": Array [
+                    Object {
+                      "status": Object {
+                        "color": "#ec7a08",
+                        "icon": "warning-triangle-o",
+                        "name": "Degraded",
+                        "priority": 2,
+                      },
+                      "text": "10.00% inbound error",
+                    },
+                    Object {
+                      "status": Object {
+                        "color": "#cc0000",
+                        "icon": "error-circle-o",
+                        "name": "Failure",
+                        "priority": 3,
+                      },
+                      "text": "20.00% outbound error",
+                    },
+                  ],
                   "report": "Error rate failure: 30.00%>=20%",
                   "status": Object {
                     "color": "#cc0000",
@@ -4206,6 +4464,8 @@ ShallowWrapper {
               "rateInterval": 600,
               "requests": Object {
                 "errorRatio": 0.3,
+                "inboundErrorRatio": 0.1,
+                "outboundErrorRatio": 0.2,
               },
               "workloadStatuses": Array [
                 Object {
@@ -4408,6 +4668,8 @@ ShallowWrapper {
         "rateInterval": 600,
         "requests": Object {
           "errorRatio": -1,
+          "inboundErrorRatio": -1,
+          "outboundErrorRatio": -1,
         },
         "workloadStatuses": Array [
           Object {
@@ -4528,6 +4790,8 @@ ShallowWrapper {
             "rateInterval": 600,
             "requests": Object {
               "errorRatio": -1,
+              "inboundErrorRatio": -1,
+              "outboundErrorRatio": -1,
             },
             "workloadStatuses": Array [
               Object {
@@ -4663,6 +4927,8 @@ ShallowWrapper {
           "rateInterval": 600,
           "requests": Object {
             "errorRatio": -1,
+            "inboundErrorRatio": -1,
+            "outboundErrorRatio": -1,
           },
           "workloadStatuses": Array [
             Object {
@@ -4797,6 +5063,8 @@ ShallowWrapper {
               "rateInterval": 600,
               "requests": Object {
                 "errorRatio": -1,
+                "inboundErrorRatio": -1,
+                "outboundErrorRatio": -1,
               },
               "workloadStatuses": Array [
                 Object {
@@ -4932,6 +5200,8 @@ ShallowWrapper {
             "rateInterval": 600,
             "requests": Object {
               "errorRatio": -1,
+              "inboundErrorRatio": -1,
+              "outboundErrorRatio": -1,
             },
             "workloadStatuses": Array [
               Object {
@@ -5084,6 +5354,8 @@ ShallowWrapper {
         "rateInterval": 600,
         "requests": Object {
           "errorRatio": -1,
+          "inboundErrorRatio": -1,
+          "outboundErrorRatio": -1,
         },
         "workloadStatuses": Array [
           Object {
@@ -5205,6 +5477,8 @@ ShallowWrapper {
               "rateInterval": 600,
               "requests": Object {
                 "errorRatio": -1,
+                "inboundErrorRatio": -1,
+                "outboundErrorRatio": -1,
               },
               "workloadStatuses": Array [
                 Object {
@@ -5348,6 +5622,8 @@ ShallowWrapper {
             "rateInterval": 600,
             "requests": Object {
               "errorRatio": -1,
+              "inboundErrorRatio": -1,
+              "outboundErrorRatio": -1,
             },
             "workloadStatuses": Array [
               Object {
@@ -5495,6 +5771,8 @@ ShallowWrapper {
                 "rateInterval": 600,
                 "requests": Object {
                   "errorRatio": -1,
+                  "inboundErrorRatio": -1,
+                  "outboundErrorRatio": -1,
                 },
                 "workloadStatuses": Array [
                   Object {
@@ -5638,6 +5916,8 @@ ShallowWrapper {
               "rateInterval": 600,
               "requests": Object {
                 "errorRatio": -1,
+                "inboundErrorRatio": -1,
+                "outboundErrorRatio": -1,
               },
               "workloadStatuses": Array [
                 Object {
@@ -5803,6 +6083,8 @@ ShallowWrapper {
         "rateInterval": 600,
         "requests": Object {
           "errorRatio": -1,
+          "inboundErrorRatio": -1,
+          "outboundErrorRatio": -1,
         },
         "workloadStatuses": Array [
           Object {
@@ -5924,6 +6206,8 @@ ShallowWrapper {
             "rateInterval": 600,
             "requests": Object {
               "errorRatio": -1,
+              "inboundErrorRatio": -1,
+              "outboundErrorRatio": -1,
             },
             "workloadStatuses": Array [
               Object {
@@ -6060,6 +6344,8 @@ ShallowWrapper {
           "rateInterval": 600,
           "requests": Object {
             "errorRatio": -1,
+            "inboundErrorRatio": -1,
+            "outboundErrorRatio": -1,
           },
           "workloadStatuses": Array [
             Object {
@@ -6195,6 +6481,8 @@ ShallowWrapper {
               "rateInterval": 600,
               "requests": Object {
                 "errorRatio": -1,
+                "inboundErrorRatio": -1,
+                "outboundErrorRatio": -1,
               },
               "workloadStatuses": Array [
                 Object {
@@ -6331,6 +6619,8 @@ ShallowWrapper {
             "rateInterval": 600,
             "requests": Object {
               "errorRatio": -1,
+              "inboundErrorRatio": -1,
+              "outboundErrorRatio": -1,
             },
             "workloadStatuses": Array [
               Object {
@@ -6484,6 +6774,8 @@ ShallowWrapper {
         "rateInterval": 600,
         "requests": Object {
           "errorRatio": -1,
+          "inboundErrorRatio": -1,
+          "outboundErrorRatio": -1,
         },
         "workloadStatuses": Array [
           Object {
@@ -6606,6 +6898,8 @@ ShallowWrapper {
               "rateInterval": 600,
               "requests": Object {
                 "errorRatio": -1,
+                "inboundErrorRatio": -1,
+                "outboundErrorRatio": -1,
               },
               "workloadStatuses": Array [
                 Object {
@@ -6750,6 +7044,8 @@ ShallowWrapper {
             "rateInterval": 600,
             "requests": Object {
               "errorRatio": -1,
+              "inboundErrorRatio": -1,
+              "outboundErrorRatio": -1,
             },
             "workloadStatuses": Array [
               Object {
@@ -6898,6 +7194,8 @@ ShallowWrapper {
                 "rateInterval": 600,
                 "requests": Object {
                   "errorRatio": -1,
+                  "inboundErrorRatio": -1,
+                  "outboundErrorRatio": -1,
                 },
                 "workloadStatuses": Array [
                   Object {
@@ -7042,6 +7340,8 @@ ShallowWrapper {
               "rateInterval": 600,
               "requests": Object {
                 "errorRatio": -1,
+                "inboundErrorRatio": -1,
+                "outboundErrorRatio": -1,
               },
               "workloadStatuses": Array [
                 Object {
@@ -7207,6 +7507,8 @@ ShallowWrapper {
         "rateInterval": 600,
         "requests": Object {
           "errorRatio": -1,
+          "inboundErrorRatio": -1,
+          "outboundErrorRatio": -1,
         },
         "workloadStatuses": Array [
           Object {
@@ -7328,6 +7630,8 @@ ShallowWrapper {
             "rateInterval": 600,
             "requests": Object {
               "errorRatio": -1,
+              "inboundErrorRatio": -1,
+              "outboundErrorRatio": -1,
             },
             "workloadStatuses": Array [
               Object {
@@ -7464,6 +7768,8 @@ ShallowWrapper {
           "rateInterval": 600,
           "requests": Object {
             "errorRatio": -1,
+            "inboundErrorRatio": -1,
+            "outboundErrorRatio": -1,
           },
           "workloadStatuses": Array [
             Object {
@@ -7599,6 +7905,8 @@ ShallowWrapper {
               "rateInterval": 600,
               "requests": Object {
                 "errorRatio": -1,
+                "inboundErrorRatio": -1,
+                "outboundErrorRatio": -1,
               },
               "workloadStatuses": Array [
                 Object {
@@ -7735,6 +8043,8 @@ ShallowWrapper {
             "rateInterval": 600,
             "requests": Object {
               "errorRatio": -1,
+              "inboundErrorRatio": -1,
+              "outboundErrorRatio": -1,
             },
             "workloadStatuses": Array [
               Object {
@@ -7888,6 +8198,8 @@ ShallowWrapper {
         "rateInterval": 600,
         "requests": Object {
           "errorRatio": -1,
+          "inboundErrorRatio": -1,
+          "outboundErrorRatio": -1,
         },
         "workloadStatuses": Array [
           Object {
@@ -8010,6 +8322,8 @@ ShallowWrapper {
               "rateInterval": 600,
               "requests": Object {
                 "errorRatio": -1,
+                "inboundErrorRatio": -1,
+                "outboundErrorRatio": -1,
               },
               "workloadStatuses": Array [
                 Object {
@@ -8154,6 +8468,8 @@ ShallowWrapper {
             "rateInterval": 600,
             "requests": Object {
               "errorRatio": -1,
+              "inboundErrorRatio": -1,
+              "outboundErrorRatio": -1,
             },
             "workloadStatuses": Array [
               Object {
@@ -8302,6 +8618,8 @@ ShallowWrapper {
                 "rateInterval": 600,
                 "requests": Object {
                   "errorRatio": -1,
+                  "inboundErrorRatio": -1,
+                  "outboundErrorRatio": -1,
                 },
                 "workloadStatuses": Array [
                   Object {
@@ -8446,6 +8764,8 @@ ShallowWrapper {
               "rateInterval": 600,
               "requests": Object {
                 "errorRatio": -1,
+                "inboundErrorRatio": -1,
+                "outboundErrorRatio": -1,
               },
               "workloadStatuses": Array [
                 Object {

--- a/src/pages/AppList/AppErrorRate.tsx
+++ b/src/pages/AppList/AppErrorRate.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { NA, getRequestErrorsRatio, RequestHealth } from '../../types/Health';
+import { NA, getRequestErrorsStatus, RequestHealth } from '../../types/Health';
 
 type AppErrorRateProps = {
   requestHealth: RequestHealth;
@@ -16,7 +16,7 @@ export default class AppErrorRate extends React.Component<AppErrorRateProps> {
   }
 
   private errorRateIndicator = () => {
-    const ratio = getRequestErrorsRatio(this.props.requestHealth);
+    const ratio = getRequestErrorsStatus(this.props.requestHealth.errorRatio);
     return ratio.status === NA ? 'No requests' : ratio.value.toFixed(2) + '%';
   };
 }

--- a/src/pages/AppList/FiltersAndSorts.ts
+++ b/src/pages/AppList/FiltersAndSorts.ts
@@ -1,7 +1,7 @@
 import { ActiveFilter, FILTER_ACTION_APPEND, FilterType } from '../../types/Filters';
 import { AppListItem } from '../../types/AppList';
 import { SortField } from '../../types/SortFilters';
-import { AppHealth, getRequestErrorsRatio } from '../../types/Health';
+import { AppHealth, getRequestErrorsStatus } from '../../types/Health';
 import NamespaceFilter from '../../components/Filters/NamespaceFilter';
 import {
   istioSidecarFilter,
@@ -57,8 +57,8 @@ export namespace AppListFilters {
       param: 'er',
       compare: (a: AppListItemHealth, b: AppListItemHealth) => {
         if (a.health && b.health) {
-          const ratioA = getRequestErrorsRatio(a.health.requests).value;
-          const ratioB = getRequestErrorsRatio(b.health.requests).value;
+          const ratioA = getRequestErrorsStatus(a.health.requests.errorRatio).value;
+          const ratioB = getRequestErrorsStatus(b.health.requests.errorRatio).value;
           return ratioA === ratioB ? a.name.localeCompare(b.name) : ratioA - ratioB;
         }
         return 0;

--- a/src/pages/ServiceList/FiltersAndSorts.ts
+++ b/src/pages/ServiceList/FiltersAndSorts.ts
@@ -1,5 +1,5 @@
 import { ActiveFilter, FilterType, FILTER_ACTION_APPEND } from '../../types/Filters';
-import { getRequestErrorsRatio, ServiceHealth } from '../../types/Health';
+import { getRequestErrorsStatus, ServiceHealth } from '../../types/Health';
 import { ServiceListItem } from '../../types/ServiceList';
 import { SortField } from '../../types/SortFilters';
 import NamespaceFilter from '../../components/Filters/NamespaceFilter';
@@ -56,8 +56,8 @@ export namespace ServiceListFilters {
       isNumeric: true,
       param: 'er',
       compare: (a: ServiceItemHealth, b: ServiceItemHealth) => {
-        const ratioA = getRequestErrorsRatio(a.health.requests).value;
-        const ratioB = getRequestErrorsRatio(b.health.requests).value;
+        const ratioA = getRequestErrorsStatus(a.health.requests.errorRatio).value;
+        const ratioB = getRequestErrorsStatus(b.health.requests.errorRatio).value;
         return ratioA === ratioB ? a.name.localeCompare(b.name) : ratioA - ratioB;
       }
     }

--- a/src/pages/ServiceList/ServiceErrorRate.tsx
+++ b/src/pages/ServiceList/ServiceErrorRate.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { NA, getRequestErrorsRatio, RequestHealth } from '../../types/Health';
+import { NA, getRequestErrorsStatus, RequestHealth } from '../../types/Health';
 
 type ServiceErrorRateProps = {
   requestHealth: RequestHealth;
@@ -16,7 +16,7 @@ export default class ServiceErrorRate extends React.Component<ServiceErrorRatePr
   }
 
   private errorRateIndicator = () => {
-    const ratio = getRequestErrorsRatio(this.props.requestHealth);
+    const ratio = getRequestErrorsStatus(this.props.requestHealth.errorRatio);
     return ratio.status === NA ? 'No requests' : ratio.value.toFixed(2) + '%';
   };
 }

--- a/src/pages/ServiceList/__tests__/ItemDescription.test.tsx
+++ b/src/pages/ServiceList/__tests__/ItemDescription.test.tsx
@@ -6,7 +6,7 @@ import { ServiceListItem } from '../../../types/ServiceList';
 
 const health = new ServiceHealth(
   { inbound: { healthy: 1, total: 1 }, outbound: { healthy: 1, total: 1 } },
-  { errorRatio: 0.1 },
+  { errorRatio: 0.1, inboundErrorRatio: 0.17, outboundErrorRatio: -1 },
   60
 );
 

--- a/src/pages/ServiceList/__tests__/ServiceErrorRate.test.tsx
+++ b/src/pages/ServiceList/__tests__/ServiceErrorRate.test.tsx
@@ -6,21 +6,27 @@ import { RequestHealth } from '../../../types/Health';
 describe('ServiceErrorRate', () => {
   it('should render correctly with basic data', () => {
     const reqErr: RequestHealth = {
-      errorRatio: 0
+      errorRatio: 0,
+      inboundErrorRatio: 0,
+      outboundErrorRatio: 0
     };
     const wrapper = shallow(<ServiceErrorRate requestHealth={reqErr} />);
     expect(wrapper.text()).toBe('Error Rate: 0.00%');
   });
   it('should render correctly with some errors', () => {
     const reqErr: RequestHealth = {
-      errorRatio: 0.4
+      errorRatio: 0.4,
+      inboundErrorRatio: 0.25,
+      outboundErrorRatio: 0.55
     };
     const wrapper = shallow(<ServiceErrorRate requestHealth={reqErr} />);
     expect(wrapper.text()).toBe('Error Rate: 40.00%');
   });
   it('should render correctly with no data', () => {
     const reqErr: RequestHealth = {
-      errorRatio: -1
+      errorRatio: -1,
+      inboundErrorRatio: -1,
+      outboundErrorRatio: -1
     };
     const wrapper = shallow(<ServiceErrorRate requestHealth={reqErr} />);
     expect(wrapper.text()).toMatch(/No requests/);

--- a/src/pages/ServiceList/__tests__/ServiceListComponent.test.ts
+++ b/src/pages/ServiceList/__tests__/ServiceListComponent.test.ts
@@ -3,7 +3,7 @@ import { ServiceHealth, RequestHealth, EnvoyHealth } from '../../../types/Health
 import { ServiceListFilters } from '../FiltersAndSorts';
 
 const makeService = (name: string, errRatio: number): ServiceListItem & { health: ServiceHealth } => {
-  const reqErrs: RequestHealth = { errorRatio: errRatio };
+  const reqErrs: RequestHealth = { errorRatio: errRatio, inboundErrorRatio: errRatio, outboundErrorRatio: -1 };
   const envoy: EnvoyHealth = {
     inbound: { healthy: 0, total: 0 },
     outbound: { healthy: 0, total: 0 }

--- a/src/pages/WorkloadList/ErrorRate.tsx
+++ b/src/pages/WorkloadList/ErrorRate.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { NA, getRequestErrorsRatio, RequestHealth } from '../../types/Health';
+import { NA, getRequestErrorsStatus, RequestHealth } from '../../types/Health';
 
 type ErrorRateProps = {
   requestHealth: RequestHealth;
@@ -16,7 +16,7 @@ export default class ErrorRate extends React.Component<ErrorRateProps> {
   }
 
   private errorRateIndicator = () => {
-    const ratio = getRequestErrorsRatio(this.props.requestHealth);
+    const ratio = getRequestErrorsStatus(this.props.requestHealth.errorRatio);
     return ratio.status === NA ? 'No requests' : ratio.value.toFixed(2) + '%';
   };
 }

--- a/src/pages/WorkloadList/FiltersAndSorts.ts
+++ b/src/pages/WorkloadList/FiltersAndSorts.ts
@@ -1,7 +1,7 @@
 import { ActiveFilter, FILTER_ACTION_APPEND, FILTER_ACTION_UPDATE, FilterType } from '../../types/Filters';
 import { WorkloadListItem, WorkloadType } from '../../types/Workload';
 import { SortField } from '../../types/SortFilters';
-import { getRequestErrorsRatio, WorkloadHealth } from '../../types/Health';
+import { getRequestErrorsStatus, WorkloadHealth } from '../../types/Health';
 import NamespaceFilter from '../../components/Filters/NamespaceFilter';
 import {
   presenceValues,
@@ -95,8 +95,8 @@ export namespace WorkloadListFilters {
       param: 'er',
       compare: (a: WorkloadItemHealth, b: WorkloadItemHealth) => {
         if (a.health && b.health) {
-          const ratioA = getRequestErrorsRatio(a.health.requests).value;
-          const ratioB = getRequestErrorsRatio(b.health.requests).value;
+          const ratioA = getRequestErrorsStatus(a.health.requests.errorRatio).value;
+          const ratioB = getRequestErrorsStatus(b.health.requests.errorRatio).value;
           return ratioA === ratioB ? a.workload.name.localeCompare(b.workload.name) : ratioA - ratioB;
         }
         return 0;

--- a/src/types/Health.ts
+++ b/src/types/Health.ts
@@ -123,45 +123,36 @@ const ascendingThresholdCheck = (value: number, thresholds: Thresholds): Thresho
   return { value: value, status: HEALTHY };
 };
 
-export const getRequestErrorsRatio = (rh: RequestHealth, propName?: keyof RequestHealth): ThresholdStatus => {
-  if (propName === undefined) {
-    propName = 'errorRatio';
-  }
-
-  if (rh[propName] < 0) {
+export const getRequestErrorsStatus = (ratio: number): ThresholdStatus => {
+  if (ratio < 0) {
     return {
       value: RATIO_NA,
       status: NA
     };
   }
-  return ascendingThresholdCheck(100 * rh[propName], REQUESTS_THRESHOLDS);
+  return ascendingThresholdCheck(100 * ratio, REQUESTS_THRESHOLDS);
+};
+
+export const getRequestErrorsSubItem = (thresholdStatus: ThresholdStatus, prefix: string): HealthSubItem => {
+  return {
+    status: thresholdStatus.status,
+    text: prefix + ': ' + (thresholdStatus.status === NA ? 'No requests' : thresholdStatus.value.toFixed(2) + '%')
+  };
+};
+
+export const getRequestErrorsViolations = (reqIn: ThresholdStatus, reqOut: ThresholdStatus): string => {
+  const violations: string[] = [];
+  if (reqIn.violation) {
+    violations.push(`Inbound errors ${reqIn.status.name.toLowerCase()}: ${reqIn.violation}`);
+  }
+  if (reqOut.violation) {
+    violations.push(`Outbound errors ${reqOut.status.name.toLowerCase()}: ${reqOut.violation}`);
+  }
+  return violations.join(', ');
 };
 
 export abstract class Health {
   items: HealthItem[];
-
-  protected static getErrorsRatioDetail(rh: RequestHealth, direction: 'inbound' | 'outbound'): HealthSubItem {
-    const errorRatio = getRequestErrorsRatio(rh, `${direction}ErrorRatio` as keyof RequestHealth);
-    const health: HealthSubItem = {
-      status: errorRatio.status,
-      text: errorRatio.status === NA ? `No ${direction} requests` : `${errorRatio.value.toFixed(2)}% ${direction} error`
-    };
-
-    return health;
-  }
-
-  protected static adjustOverallHealth(health: HealthItem) {
-    // Show in the overall requests health status, the one of the highest priority
-    if (health.children === undefined) {
-      return;
-    }
-
-    health.children.forEach(child => {
-      if (child.status.priority > health.status.priority) {
-        health.status = child.status;
-      }
-    });
-  }
 
   constructor(items: HealthItem[]) {
     this.items = items;
@@ -208,7 +199,7 @@ export class ServiceHealth extends Health {
     }
     {
       // Request errors
-      const reqErrorsRatio = getRequestErrorsRatio(requests);
+      const reqErrorsRatio = getRequestErrorsStatus(requests.errorRatio);
       const reqErrorsText = reqErrorsRatio.status === NA ? 'No requests' : reqErrorsRatio.value.toFixed(2) + '%';
       const item: HealthItem = {
         title: 'Error Rate',
@@ -295,26 +286,19 @@ export class AppHealth extends Health {
     }
     {
       // Request errors
-      const reqErrorsRatio = getRequestErrorsRatio(requests);
-      const reqErrorsText = reqErrorsRatio.status === NA ? 'No requests' : reqErrorsRatio.value.toFixed(2) + '%';
+      const reqIn = getRequestErrorsStatus(requests.inboundErrorRatio);
+      const reqOut = getRequestErrorsStatus(requests.outboundErrorRatio);
+      const both = mergeStatus(reqIn.status, reqOut.status);
       const item: HealthItem = {
-        title: 'Error Rate',
-        status: reqErrorsRatio.status,
-        text: reqErrorsText + ' over ' + getName(rateInterval).toLowerCase()
+        title: 'Error Rate over ' + getName(rateInterval).toLowerCase(),
+        status: both,
+        children: [getRequestErrorsSubItem(reqIn, 'Inbound'), getRequestErrorsSubItem(reqOut, 'Outbound')]
       };
-      if (reqErrorsRatio.violation) {
-        item.report = `Error rate ${reqErrorsRatio.status.name.toLowerCase()}: ${reqErrorsRatio.violation}`;
+      const violations = getRequestErrorsViolations(reqIn, reqOut);
+      if (violations.length > 0) {
+        item.report = violations;
       }
 
-      if (reqErrorsRatio.status !== NA) {
-        // Inbound and outbound detail
-        item.children = [
-          this.getErrorsRatioDetail(requests, 'inbound'),
-          this.getErrorsRatioDetail(requests, 'outbound')
-        ];
-      }
-
-      this.adjustOverallHealth(item);
       items.push(item);
     }
     return items;
@@ -355,26 +339,19 @@ export class WorkloadHealth extends Health {
     }
     {
       // Request errors
-      const reqErrorsRatio = getRequestErrorsRatio(requests);
-      const reqErrorsText = reqErrorsRatio.status === NA ? 'No requests' : reqErrorsRatio.value.toFixed(2) + '%';
+      const reqIn = getRequestErrorsStatus(requests.inboundErrorRatio);
+      const reqOut = getRequestErrorsStatus(requests.outboundErrorRatio);
+      const both = mergeStatus(reqIn.status, reqOut.status);
       const item: HealthItem = {
-        title: 'Error Rate',
-        status: reqErrorsRatio.status,
-        text: reqErrorsText + ' over ' + getName(rateInterval).toLowerCase()
+        title: 'Error Rate over ' + getName(rateInterval).toLowerCase(),
+        status: both,
+        children: [getRequestErrorsSubItem(reqIn, 'Inbound'), getRequestErrorsSubItem(reqOut, 'Outbound')]
       };
-      if (reqErrorsRatio.violation) {
-        item.report = `Error rate ${reqErrorsRatio.status.name.toLowerCase()}: ${reqErrorsRatio.violation}`;
+      const violations = getRequestErrorsViolations(reqIn, reqOut);
+      if (violations.length > 0) {
+        item.report = violations;
       }
 
-      if (reqErrorsRatio.status !== NA) {
-        // Inbound and outbound detail
-        item.children = [
-          this.getErrorsRatioDetail(requests, 'inbound'),
-          this.getErrorsRatioDetail(requests, 'outbound')
-        ];
-      }
-
-      this.adjustOverallHealth(item);
       items.push(item);
     }
     return items;

--- a/src/types/__tests__/Health.test.ts
+++ b/src/types/__tests__/Health.test.ts
@@ -28,31 +28,40 @@ describe('Health', () => {
     expect(status).toEqual(H.FAILURE);
   });
   it('should not get requests error ratio', () => {
-    const result = H.getRequestErrorsRatio({ errorRatio: -1 });
+    const result = H.getRequestErrorsRatio({ errorRatio: -1, inboundErrorRatio: -1, outboundErrorRatio: -1 });
     expect(result.status).toEqual(H.NA);
     expect(result.violation).toBeUndefined();
   });
   it('should get healthy requests error ratio', () => {
-    const result = H.getRequestErrorsRatio({ errorRatio: 0 });
+    const result = H.getRequestErrorsRatio({ errorRatio: 0, inboundErrorRatio: -1, outboundErrorRatio: -1 });
     expect(result.status).toEqual(H.HEALTHY);
     expect(result.value).toEqual(0);
     expect(result.violation).toBeUndefined();
   });
   it('should get degraded requests error ratio', () => {
-    const result = H.getRequestErrorsRatio({ errorRatio: 0.1 });
+    const result = H.getRequestErrorsRatio({ errorRatio: 0.1, inboundErrorRatio: -1, outboundErrorRatio: -1 });
     expect(result.status).toEqual(H.DEGRADED);
     expect(result.value).toEqual(10);
     expect(result.violation).toEqual('10.00%>=0.1%');
   });
   it('should get failing requests error ratio', () => {
-    const result = H.getRequestErrorsRatio({ errorRatio: 0.5 });
+    const result = H.getRequestErrorsRatio({ errorRatio: 0.5, inboundErrorRatio: -1, outboundErrorRatio: -1 });
+    expect(result.status).toEqual(H.FAILURE);
+    expect(result.value).toEqual(50);
+    expect(result.violation).toEqual('50.00%>=20%');
+  });
+  it('should calculate error ratio with specified property', () => {
+    const result = H.getRequestErrorsRatio(
+      { errorRatio: -1, inboundErrorRatio: 0.5, outboundErrorRatio: -1 },
+      'inboundErrorRatio'
+    );
     expect(result.status).toEqual(H.FAILURE);
     expect(result.value).toEqual(50);
     expect(result.violation).toEqual('50.00%>=20%');
   });
   it('should get comparable error ratio with NA', () => {
-    const r1 = H.getRequestErrorsRatio({ errorRatio: -1 });
-    const r2 = H.getRequestErrorsRatio({ errorRatio: 0 });
+    const r1 = H.getRequestErrorsRatio({ errorRatio: -1, inboundErrorRatio: -1, outboundErrorRatio: -1 });
+    const r2 = H.getRequestErrorsRatio({ errorRatio: 0, inboundErrorRatio: 0, outboundErrorRatio: 0 });
     expect(r2.value).toBeGreaterThan(r1.value);
     expect(r1.value).toBeLessThan(r2.value);
   });
@@ -60,7 +69,7 @@ describe('Health', () => {
     const health = new H.AppHealth(
       [{ inbound: { healthy: 0, total: 1 }, outbound: { healthy: 1, total: 1 } }],
       [{ available: 0, replicas: 1, name: 'a' }],
-      { errorRatio: 1 },
+      { errorRatio: 1, inboundErrorRatio: 1, outboundErrorRatio: 1 },
       60
     );
     expect(health.getGlobalStatus()).toEqual(H.FAILURE);
@@ -69,7 +78,7 @@ describe('Health', () => {
     const health = new H.AppHealth(
       [{ inbound: { healthy: 1, total: 1 }, outbound: { healthy: 1, total: 1 } }],
       [{ available: 1, replicas: 1, name: 'a' }, { available: 2, replicas: 2, name: 'b' }],
-      { errorRatio: 0 },
+      { errorRatio: 0, inboundErrorRatio: 0, outboundErrorRatio: 0 },
       60
     );
     expect(health.getGlobalStatus()).toEqual(H.HEALTHY);
@@ -79,7 +88,7 @@ describe('Health', () => {
     const health = new H.AppHealth(
       [{ inbound: { healthy: 1, total: 1 }, outbound: { healthy: 1, total: 1 } }],
       [{ available: 1, replicas: 1, name: 'a' }, { available: 1, replicas: 2, name: 'b' }],
-      { errorRatio: 0 },
+      { errorRatio: 0, inboundErrorRatio: 0, outboundErrorRatio: 0 },
       60
     );
     expect(health.getGlobalStatus()).toEqual(H.DEGRADED);
@@ -89,7 +98,7 @@ describe('Health', () => {
     const health = new H.AppHealth(
       [{ inbound: { healthy: 0, total: 1 }, outbound: { healthy: 1, total: 1 } }],
       [{ available: 1, replicas: 1, name: 'a' }, { available: 2, replicas: 2, name: 'b' }],
-      { errorRatio: 0 },
+      { errorRatio: 0, inboundErrorRatio: 0, outboundErrorRatio: 0 },
       60
     );
     expect(health.getGlobalStatus()).toEqual(H.FAILURE);
@@ -99,7 +108,7 @@ describe('Health', () => {
     const health = new H.AppHealth(
       [{ inbound: { healthy: 1, total: 1 }, outbound: { healthy: 1, total: 1 } }],
       [{ available: 1, replicas: 1, name: 'a' }, { available: 2, replicas: 2, name: 'b' }],
-      { errorRatio: 0.2 },
+      { errorRatio: 0.2, inboundErrorRatio: 0.3, outboundErrorRatio: 0.1 },
       60
     );
     expect(health.getGlobalStatus()).toEqual(H.FAILURE);
@@ -109,7 +118,7 @@ describe('Health', () => {
     const health = new H.AppHealth(
       [{ inbound: { healthy: 1, total: 1 }, outbound: { healthy: 1, total: 3 } }],
       [{ available: 0, replicas: 0, name: 'a' }, { available: 0, replicas: 0, name: 'b' }],
-      { errorRatio: 0.2 },
+      { errorRatio: 0.2, inboundErrorRatio: 0.3, outboundErrorRatio: 0.1 },
       60
     );
     expect(health.getGlobalStatus()).toEqual(H.FAILURE);

--- a/src/types/__tests__/Health.test.ts
+++ b/src/types/__tests__/Health.test.ts
@@ -28,40 +28,31 @@ describe('Health', () => {
     expect(status).toEqual(H.FAILURE);
   });
   it('should not get requests error ratio', () => {
-    const result = H.getRequestErrorsRatio({ errorRatio: -1, inboundErrorRatio: -1, outboundErrorRatio: -1 });
+    const result = H.getRequestErrorsStatus(-1);
     expect(result.status).toEqual(H.NA);
     expect(result.violation).toBeUndefined();
   });
   it('should get healthy requests error ratio', () => {
-    const result = H.getRequestErrorsRatio({ errorRatio: 0, inboundErrorRatio: -1, outboundErrorRatio: -1 });
+    const result = H.getRequestErrorsStatus(0);
     expect(result.status).toEqual(H.HEALTHY);
     expect(result.value).toEqual(0);
     expect(result.violation).toBeUndefined();
   });
   it('should get degraded requests error ratio', () => {
-    const result = H.getRequestErrorsRatio({ errorRatio: 0.1, inboundErrorRatio: -1, outboundErrorRatio: -1 });
+    const result = H.getRequestErrorsStatus(0.1);
     expect(result.status).toEqual(H.DEGRADED);
     expect(result.value).toEqual(10);
     expect(result.violation).toEqual('10.00%>=0.1%');
   });
   it('should get failing requests error ratio', () => {
-    const result = H.getRequestErrorsRatio({ errorRatio: 0.5, inboundErrorRatio: -1, outboundErrorRatio: -1 });
-    expect(result.status).toEqual(H.FAILURE);
-    expect(result.value).toEqual(50);
-    expect(result.violation).toEqual('50.00%>=20%');
-  });
-  it('should calculate error ratio with specified property', () => {
-    const result = H.getRequestErrorsRatio(
-      { errorRatio: -1, inboundErrorRatio: 0.5, outboundErrorRatio: -1 },
-      'inboundErrorRatio'
-    );
+    const result = H.getRequestErrorsStatus(0.5);
     expect(result.status).toEqual(H.FAILURE);
     expect(result.value).toEqual(50);
     expect(result.violation).toEqual('50.00%>=20%');
   });
   it('should get comparable error ratio with NA', () => {
-    const r1 = H.getRequestErrorsRatio({ errorRatio: -1, inboundErrorRatio: -1, outboundErrorRatio: -1 });
-    const r2 = H.getRequestErrorsRatio({ errorRatio: 0, inboundErrorRatio: 0, outboundErrorRatio: 0 });
+    const r1 = H.getRequestErrorsStatus(-1);
+    const r2 = H.getRequestErrorsStatus(0);
     expect(r2.value).toBeGreaterThan(r1.value);
     expect(r1.value).toBeLessThan(r2.value);
   });
@@ -112,7 +103,7 @@ describe('Health', () => {
       60
     );
     expect(health.getGlobalStatus()).toEqual(H.FAILURE);
-    expect(health.getReport()).toEqual(['Error rate failure: 20.00%>=20%']);
+    expect(health.getReport()).toEqual(['Inbound errors failure: 30.00%>=20%, Outbound errors degraded: 10.00%>=0.1%']);
   });
   it('should aggregate multiple issues', () => {
     const health = new H.AppHealth(
@@ -125,7 +116,7 @@ describe('Health', () => {
     expect(health.getReport()).toEqual([
       'No active workload!',
       'Envoy health degraded',
-      'Error rate failure: 20.00%>=20%'
+      'Inbound errors failure: 30.00%>=20%, Outbound errors degraded: 10.00%>=0.1%'
     ]);
   });
 });


### PR DESCRIPTION
In order to bring a better idea about where to look for issues, provide the detail about if errors are for incoming connections or for outgoing connections (or both). This is shown in health pop-overs.

Since pop-over is shared across all Kiali, all pop-overs got the details except for service health where only inbound health is available.

https://issues.jboss.org/browse/KIALI-1873

**Dependant PR:** https://github.com/kiali/kiali/pull/647

Example screenshot:

![image](https://user-images.githubusercontent.com/23639005/48800804-6d8b5280-ecd0-11e8-8784-d1fe4fc9c06b.png)
