### PR TITLE
Add auto login using url query params

### DIFF
--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -4,6 +4,8 @@ import { KEY_CODES } from '../../types/Common';
 
 const kialiTitle = require('../../assets/img/logo-login.svg');
 
+const URLSearchParams = require('url-search-params');
+
 type LoginProps = {
   user: { username: string; password: string } | undefined;
   logging: boolean;
@@ -37,6 +39,11 @@ export default class LoginPage extends React.Component<LoginProps, LoginState> {
     const el = document.documentElement;
     if (el) {
       el.className = 'login-pf';
+    }
+    // auto login
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.get('username') != null && urlParams.get('password') != null) {
+      this.props.authenticate(urlParams.get('username'), urlParams.get('password'));
     }
   }
 


### PR DESCRIPTION
** Describe the change **

Use
`http://kiali.k8s.local/console/graph/namespaces?layout=dagre&duration=60&edges=hide&graphType=versionedApp&injectServiceNodes=false&username=admin&password=admin` link to view graph page directly(skip login page).

** Issue reference **

* [#652](https://github.com/kiali/kiali/issues/652)

** Backwards compatible? **

[ * ] Is your pull-request introducing changes in behaviour?

View target page directly if URL params has valid `username` and `password`(skip login page)

