### PR TITLE
KIALI-1919 Add status for destination rules list into service details page

### DIFF
--- a/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -188,6 +188,7 @@ class ServiceInfo extends React.Component<ServiceDetails, ServiceInfoState> {
                         <ServiceInfoDestinationRules
                           destinationRules={destinationRules.items}
                           editorLink={editorLink}
+                          validations={this.props.validations!['destinationrule']}
                         />
                       )}
                     </TabPane>

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDestinationRules.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDestinationRules.tsx
@@ -6,9 +6,12 @@ import LocalTime from '../../../components/Time/LocalTime';
 import Label from '../../../components/Label/Label';
 import DetailObject from '../../../components/Details/DetailObject';
 import { Link } from 'react-router-dom';
+import { ConfigIndicator } from '../../../components/ConfigValidation/ConfigIndicator';
+import { ObjectValidation } from '../../../types/IstioObjects';
 
 interface ServiceInfoDestinationRulesProps extends EditorLink {
   destinationRules?: DestinationRule[];
+  validations: { [key: string]: ObjectValidation };
 }
 
 class ServiceInfoDestinationRules extends React.Component<ServiceInfoDestinationRulesProps> {
@@ -27,6 +30,19 @@ class ServiceInfoDestinationRules extends React.Component<ServiceInfoDestination
   columns() {
     return {
       columns: [
+        {
+          property: 'status',
+          header: {
+            label: 'Status',
+            formatters: [this.headerFormat]
+          },
+          cell: {
+            formatters: [this.cellFormat],
+            props: {
+              align: 'text-center'
+            }
+          }
+        },
         {
           property: 'name',
           header: {
@@ -107,10 +123,15 @@ class ServiceInfoDestinationRules extends React.Component<ServiceInfoDestination
     );
   }
 
+  validation(destinationRule: DestinationRule): ObjectValidation {
+    return this.props.validations[destinationRule.name];
+  }
+
   rows() {
     return (this.props.destinationRules || []).map((destinationRule, vsIdx) => ({
       id: vsIdx,
       name: destinationRule.name,
+      status: <ConfigIndicator id={vsIdx + '-config-validation'} validations={[this.validation(destinationRule)]} />,
       trafficPolicy: destinationRule.trafficPolicy ? (
         <DetailObject name="" detail={destinationRule.trafficPolicy} />
       ) : (

--- a/src/pages/ServiceDetails/__tests__/ServiceInfo.test.tsx
+++ b/src/pages/ServiceDetails/__tests__/ServiceInfo.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import ServiceInfo from '../ServiceInfo';
 import { hasIstioSidecar, ServiceDetailsInfo } from '../../../types/ServiceInfo';
+import { Validations } from '../../../types/IstioObjects';
 
 jest.mock('../../../services/Api');
 
@@ -29,12 +30,26 @@ describe('#ServiceInfo render correctly with data', () => {
         health: data.health
       };
 
+      const validations: Validations = {
+        destinationrule: {
+          reviews: {
+            name: 'details',
+            objectType: 'destinationrule',
+            valid: false,
+            checks: [
+              { message: 'This subset is not found from the host', severity: 'error', path: 'spec/subsets[0]/version' },
+              { message: 'This subset is not found from the host', severity: 'error', path: 'spec/subsets[1]/version' }
+            ]
+          }
+        }
+      };
+
       const wrapper = shallow(
         <ServiceInfo
           namespace="istio-system"
           service="reviews"
           serviceDetails={serviceDetailsInfo}
-          validations={{}}
+          validations={validations}
           onRefresh={jest.fn()}
           onSelectTab={jest.fn()}
           activeTab={jest.fn()}

--- a/src/pages/ServiceDetails/__tests__/__snapshots__/ServiceInfo.test.tsx.snap
+++ b/src/pages/ServiceDetails/__tests__/__snapshots__/ServiceInfo.test.tsx.snap
@@ -175,7 +175,29 @@ ShallowWrapper {
         },
       }
     }
-    validations={Object {}}
+    validations={
+      Object {
+        "destinationrule": Object {
+          "reviews": Object {
+            "checks": Array [
+              Object {
+                "message": "This subset is not found from the host",
+                "path": "spec/subsets[0]/version",
+                "severity": "error",
+              },
+              Object {
+                "message": "This subset is not found from the host",
+                "path": "spec/subsets[1]/version",
+                "severity": "error",
+              },
+            ],
+            "name": "details",
+            "objectType": "destinationrule",
+            "valid": false,
+          },
+        },
+      }
+    }
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -367,6 +389,13 @@ ShallowWrapper {
                       eventKey="destinationrules"
                     >
                       Destination Rules (1)
+                      <span>
+                         
+                        <Icon
+                          name="error-circle-o"
+                          type="pf"
+                        />
+                      </span>
                     </NavItem>
                   </Nav>
                   <TabContent
@@ -456,6 +485,27 @@ ShallowWrapper {
                           ]
                         }
                         editorLink="/namespaces/istio-system/services/reviews"
+                        validations={
+                          Object {
+                            "reviews": Object {
+                              "checks": Array [
+                                Object {
+                                  "message": "This subset is not found from the host",
+                                  "path": "spec/subsets[0]/version",
+                                  "severity": "error",
+                                },
+                                Object {
+                                  "message": "This subset is not found from the host",
+                                  "path": "spec/subsets[1]/version",
+                                  "severity": "error",
+                                },
+                              ],
+                              "name": "details",
+                              "objectType": "destinationrule",
+                              "valid": false,
+                            },
+                          }
+                        }
                       />
                     </TabPane>
                   </TabContent>
@@ -647,6 +697,13 @@ ShallowWrapper {
                         eventKey="destinationrules"
                       >
                         Destination Rules (1)
+                        <span>
+                           
+                          <Icon
+                            name="error-circle-o"
+                            type="pf"
+                          />
+                        </span>
                       </NavItem>
                     </Nav>
                     <TabContent
@@ -736,6 +793,27 @@ ShallowWrapper {
                             ]
                           }
                           editorLink="/namespaces/istio-system/services/reviews"
+                          validations={
+                            Object {
+                              "reviews": Object {
+                                "checks": Array [
+                                  Object {
+                                    "message": "This subset is not found from the host",
+                                    "path": "spec/subsets[0]/version",
+                                    "severity": "error",
+                                  },
+                                  Object {
+                                    "message": "This subset is not found from the host",
+                                    "path": "spec/subsets[1]/version",
+                                    "severity": "error",
+                                  },
+                                ],
+                                "name": "details",
+                                "objectType": "destinationrule",
+                                "valid": false,
+                              },
+                            }
+                          }
                         />
                       </TabPane>
                     </TabContent>
@@ -1170,6 +1248,13 @@ ShallowWrapper {
                         eventKey="destinationrules"
                       >
                         Destination Rules (1)
+                        <span>
+                           
+                          <Icon
+                            name="error-circle-o"
+                            type="pf"
+                          />
+                        </span>
                       </NavItem>
                     </Nav>
                     <TabContent
@@ -1259,6 +1344,27 @@ ShallowWrapper {
                             ]
                           }
                           editorLink="/namespaces/istio-system/services/reviews"
+                          validations={
+                            Object {
+                              "reviews": Object {
+                                "checks": Array [
+                                  Object {
+                                    "message": "This subset is not found from the host",
+                                    "path": "spec/subsets[0]/version",
+                                    "severity": "error",
+                                  },
+                                  Object {
+                                    "message": "This subset is not found from the host",
+                                    "path": "spec/subsets[1]/version",
+                                    "severity": "error",
+                                  },
+                                ],
+                                "name": "details",
+                                "objectType": "destinationrule",
+                                "valid": false,
+                              },
+                            }
+                          }
                         />
                       </TabPane>
                     </TabContent>
@@ -1315,6 +1421,13 @@ ShallowWrapper {
                         eventKey="destinationrules"
                       >
                         Destination Rules (1)
+                        <span>
+                           
+                          <Icon
+                            name="error-circle-o"
+                            type="pf"
+                          />
+                        </span>
                       </NavItem>
                     </Nav>
                     <TabContent
@@ -1404,6 +1517,27 @@ ShallowWrapper {
                             ]
                           }
                           editorLink="/namespaces/istio-system/services/reviews"
+                          validations={
+                            Object {
+                              "reviews": Object {
+                                "checks": Array [
+                                  Object {
+                                    "message": "This subset is not found from the host",
+                                    "path": "spec/subsets[0]/version",
+                                    "severity": "error",
+                                  },
+                                  Object {
+                                    "message": "This subset is not found from the host",
+                                    "path": "spec/subsets[1]/version",
+                                    "severity": "error",
+                                  },
+                                ],
+                                "name": "details",
+                                "objectType": "destinationrule",
+                                "valid": false,
+                              },
+                            }
+                          }
                         />
                       </TabPane>
                     </TabContent>
@@ -1457,6 +1591,13 @@ ShallowWrapper {
                         eventKey="destinationrules"
                       >
                         Destination Rules (1)
+                        <span>
+                           
+                          <Icon
+                            name="error-circle-o"
+                            type="pf"
+                          />
+                        </span>
                       </NavItem>
                     </Nav>
                     <TabContent
@@ -1546,6 +1687,27 @@ ShallowWrapper {
                             ]
                           }
                           editorLink="/namespaces/istio-system/services/reviews"
+                          validations={
+                            Object {
+                              "reviews": Object {
+                                "checks": Array [
+                                  Object {
+                                    "message": "This subset is not found from the host",
+                                    "path": "spec/subsets[0]/version",
+                                    "severity": "error",
+                                  },
+                                  Object {
+                                    "message": "This subset is not found from the host",
+                                    "path": "spec/subsets[1]/version",
+                                    "severity": "error",
+                                  },
+                                ],
+                                "name": "details",
+                                "objectType": "destinationrule",
+                                "valid": false,
+                              },
+                            }
+                          }
                         />
                       </TabPane>
                     </TabContent>
@@ -1594,6 +1756,13 @@ ShallowWrapper {
                           eventKey="destinationrules"
                         >
                           Destination Rules (1)
+                          <span>
+                             
+                            <Icon
+                              name="error-circle-o"
+                              type="pf"
+                            />
+                          </span>
                         </NavItem>
                       </Nav>,
                       <TabContent
@@ -1683,6 +1852,27 @@ ShallowWrapper {
                               ]
                             }
                             editorLink="/namespaces/istio-system/services/reviews"
+                            validations={
+                              Object {
+                                "reviews": Object {
+                                  "checks": Array [
+                                    Object {
+                                      "message": "This subset is not found from the host",
+                                      "path": "spec/subsets[0]/version",
+                                      "severity": "error",
+                                    },
+                                    Object {
+                                      "message": "This subset is not found from the host",
+                                      "path": "spec/subsets[1]/version",
+                                      "severity": "error",
+                                    },
+                                  ],
+                                  "name": "details",
+                                  "objectType": "destinationrule",
+                                  "valid": false,
+                                },
+                              }
+                            }
                           />
                         </TabPane>
                       </TabContent>,
@@ -1724,6 +1914,13 @@ ShallowWrapper {
                             eventKey="destinationrules"
                           >
                             Destination Rules (1)
+                            <span>
+                               
+                              <Icon
+                                name="error-circle-o"
+                                type="pf"
+                              />
+                            </span>
                           </NavItem>,
                         ],
                         "justified": false,
@@ -1789,7 +1986,13 @@ ShallowWrapper {
                             "active": false,
                             "children": Array [
                               "Destination Rules (1)",
-                              undefined,
+                              <span>
+                                 
+                                <Icon
+                                  name="error-circle-o"
+                                  type="pf"
+                                />
+                              </span>,
                             ],
                             "disabled": false,
                             "eventKey": "destinationrules",
@@ -1797,7 +2000,37 @@ ShallowWrapper {
                           "ref": null,
                           "rendered": Array [
                             "Destination Rules (1)",
-                            undefined,
+                            Object {
+                              "instance": null,
+                              "key": undefined,
+                              "nodeType": "host",
+                              "props": Object {
+                                "children": Array [
+                                  " ",
+                                  <Icon
+                                    name="error-circle-o"
+                                    type="pf"
+                                  />,
+                                ],
+                              },
+                              "ref": null,
+                              "rendered": Array [
+                                " ",
+                                Object {
+                                  "instance": null,
+                                  "key": undefined,
+                                  "nodeType": "function",
+                                  "props": Object {
+                                    "name": "error-circle-o",
+                                    "type": "pf",
+                                  },
+                                  "ref": null,
+                                  "rendered": null,
+                                  "type": [Function],
+                                },
+                              ],
+                              "type": "span",
+                            },
                           ],
                           "type": [Function],
                         },
@@ -1892,6 +2125,27 @@ ShallowWrapper {
                                 ]
                               }
                               editorLink="/namespaces/istio-system/services/reviews"
+                              validations={
+                                Object {
+                                  "reviews": Object {
+                                    "checks": Array [
+                                      Object {
+                                        "message": "This subset is not found from the host",
+                                        "path": "spec/subsets[0]/version",
+                                        "severity": "error",
+                                      },
+                                      Object {
+                                        "message": "This subset is not found from the host",
+                                        "path": "spec/subsets[1]/version",
+                                        "severity": "error",
+                                      },
+                                    ],
+                                    "name": "details",
+                                    "objectType": "destinationrule",
+                                    "valid": false,
+                                  },
+                                }
+                              }
                             />
                           </TabPane>,
                         ],
@@ -2043,6 +2297,27 @@ ShallowWrapper {
                                 ]
                               }
                               editorLink="/namespaces/istio-system/services/reviews"
+                              validations={
+                                Object {
+                                  "reviews": Object {
+                                    "checks": Array [
+                                      Object {
+                                        "message": "This subset is not found from the host",
+                                        "path": "spec/subsets[0]/version",
+                                        "severity": "error",
+                                      },
+                                      Object {
+                                        "message": "This subset is not found from the host",
+                                        "path": "spec/subsets[1]/version",
+                                        "severity": "error",
+                                      },
+                                    ],
+                                    "name": "details",
+                                    "objectType": "destinationrule",
+                                    "valid": false,
+                                  },
+                                }
+                              }
                             />,
                             "eventKey": "destinationrules",
                           },
@@ -2082,6 +2357,25 @@ ShallowWrapper {
                                 },
                               ],
                               "editorLink": "/namespaces/istio-system/services/reviews",
+                              "validations": Object {
+                                "reviews": Object {
+                                  "checks": Array [
+                                    Object {
+                                      "message": "This subset is not found from the host",
+                                      "path": "spec/subsets[0]/version",
+                                      "severity": "error",
+                                    },
+                                    Object {
+                                      "message": "This subset is not found from the host",
+                                      "path": "spec/subsets[1]/version",
+                                      "severity": "error",
+                                    },
+                                  ],
+                                  "name": "details",
+                                  "objectType": "destinationrule",
+                                  "valid": false,
+                                },
+                              },
                             },
                             "ref": null,
                             "rendered": null,
@@ -2290,6 +2584,13 @@ ShallowWrapper {
                         eventKey="destinationrules"
                       >
                         Destination Rules (1)
+                        <span>
+                           
+                          <Icon
+                            name="error-circle-o"
+                            type="pf"
+                          />
+                        </span>
                       </NavItem>
                     </Nav>
                     <TabContent
@@ -2379,6 +2680,27 @@ ShallowWrapper {
                             ]
                           }
                           editorLink="/namespaces/istio-system/services/reviews"
+                          validations={
+                            Object {
+                              "reviews": Object {
+                                "checks": Array [
+                                  Object {
+                                    "message": "This subset is not found from the host",
+                                    "path": "spec/subsets[0]/version",
+                                    "severity": "error",
+                                  },
+                                  Object {
+                                    "message": "This subset is not found from the host",
+                                    "path": "spec/subsets[1]/version",
+                                    "severity": "error",
+                                  },
+                                ],
+                                "name": "details",
+                                "objectType": "destinationrule",
+                                "valid": false,
+                              },
+                            }
+                          }
                         />
                       </TabPane>
                     </TabContent>
@@ -2570,6 +2892,13 @@ ShallowWrapper {
                           eventKey="destinationrules"
                         >
                           Destination Rules (1)
+                          <span>
+                             
+                            <Icon
+                              name="error-circle-o"
+                              type="pf"
+                            />
+                          </span>
                         </NavItem>
                       </Nav>
                       <TabContent
@@ -2659,6 +2988,27 @@ ShallowWrapper {
                               ]
                             }
                             editorLink="/namespaces/istio-system/services/reviews"
+                            validations={
+                              Object {
+                                "reviews": Object {
+                                  "checks": Array [
+                                    Object {
+                                      "message": "This subset is not found from the host",
+                                      "path": "spec/subsets[0]/version",
+                                      "severity": "error",
+                                    },
+                                    Object {
+                                      "message": "This subset is not found from the host",
+                                      "path": "spec/subsets[1]/version",
+                                      "severity": "error",
+                                    },
+                                  ],
+                                  "name": "details",
+                                  "objectType": "destinationrule",
+                                  "valid": false,
+                                },
+                              }
+                            }
                           />
                         </TabPane>
                       </TabContent>
@@ -3093,6 +3443,13 @@ ShallowWrapper {
                           eventKey="destinationrules"
                         >
                           Destination Rules (1)
+                          <span>
+                             
+                            <Icon
+                              name="error-circle-o"
+                              type="pf"
+                            />
+                          </span>
                         </NavItem>
                       </Nav>
                       <TabContent
@@ -3182,6 +3539,27 @@ ShallowWrapper {
                               ]
                             }
                             editorLink="/namespaces/istio-system/services/reviews"
+                            validations={
+                              Object {
+                                "reviews": Object {
+                                  "checks": Array [
+                                    Object {
+                                      "message": "This subset is not found from the host",
+                                      "path": "spec/subsets[0]/version",
+                                      "severity": "error",
+                                    },
+                                    Object {
+                                      "message": "This subset is not found from the host",
+                                      "path": "spec/subsets[1]/version",
+                                      "severity": "error",
+                                    },
+                                  ],
+                                  "name": "details",
+                                  "objectType": "destinationrule",
+                                  "valid": false,
+                                },
+                              }
+                            }
                           />
                         </TabPane>
                       </TabContent>
@@ -3238,6 +3616,13 @@ ShallowWrapper {
                           eventKey="destinationrules"
                         >
                           Destination Rules (1)
+                          <span>
+                             
+                            <Icon
+                              name="error-circle-o"
+                              type="pf"
+                            />
+                          </span>
                         </NavItem>
                       </Nav>
                       <TabContent
@@ -3327,6 +3712,27 @@ ShallowWrapper {
                               ]
                             }
                             editorLink="/namespaces/istio-system/services/reviews"
+                            validations={
+                              Object {
+                                "reviews": Object {
+                                  "checks": Array [
+                                    Object {
+                                      "message": "This subset is not found from the host",
+                                      "path": "spec/subsets[0]/version",
+                                      "severity": "error",
+                                    },
+                                    Object {
+                                      "message": "This subset is not found from the host",
+                                      "path": "spec/subsets[1]/version",
+                                      "severity": "error",
+                                    },
+                                  ],
+                                  "name": "details",
+                                  "objectType": "destinationrule",
+                                  "valid": false,
+                                },
+                              }
+                            }
                           />
                         </TabPane>
                       </TabContent>
@@ -3380,6 +3786,13 @@ ShallowWrapper {
                           eventKey="destinationrules"
                         >
                           Destination Rules (1)
+                          <span>
+                             
+                            <Icon
+                              name="error-circle-o"
+                              type="pf"
+                            />
+                          </span>
                         </NavItem>
                       </Nav>
                       <TabContent
@@ -3469,6 +3882,27 @@ ShallowWrapper {
                               ]
                             }
                             editorLink="/namespaces/istio-system/services/reviews"
+                            validations={
+                              Object {
+                                "reviews": Object {
+                                  "checks": Array [
+                                    Object {
+                                      "message": "This subset is not found from the host",
+                                      "path": "spec/subsets[0]/version",
+                                      "severity": "error",
+                                    },
+                                    Object {
+                                      "message": "This subset is not found from the host",
+                                      "path": "spec/subsets[1]/version",
+                                      "severity": "error",
+                                    },
+                                  ],
+                                  "name": "details",
+                                  "objectType": "destinationrule",
+                                  "valid": false,
+                                },
+                              }
+                            }
                           />
                         </TabPane>
                       </TabContent>
@@ -3517,6 +3951,13 @@ ShallowWrapper {
                             eventKey="destinationrules"
                           >
                             Destination Rules (1)
+                            <span>
+                               
+                              <Icon
+                                name="error-circle-o"
+                                type="pf"
+                              />
+                            </span>
                           </NavItem>
                         </Nav>,
                         <TabContent
@@ -3606,6 +4047,27 @@ ShallowWrapper {
                                 ]
                               }
                               editorLink="/namespaces/istio-system/services/reviews"
+                              validations={
+                                Object {
+                                  "reviews": Object {
+                                    "checks": Array [
+                                      Object {
+                                        "message": "This subset is not found from the host",
+                                        "path": "spec/subsets[0]/version",
+                                        "severity": "error",
+                                      },
+                                      Object {
+                                        "message": "This subset is not found from the host",
+                                        "path": "spec/subsets[1]/version",
+                                        "severity": "error",
+                                      },
+                                    ],
+                                    "name": "details",
+                                    "objectType": "destinationrule",
+                                    "valid": false,
+                                  },
+                                }
+                              }
                             />
                           </TabPane>
                         </TabContent>,
@@ -3647,6 +4109,13 @@ ShallowWrapper {
                               eventKey="destinationrules"
                             >
                               Destination Rules (1)
+                              <span>
+                                 
+                                <Icon
+                                  name="error-circle-o"
+                                  type="pf"
+                                />
+                              </span>
                             </NavItem>,
                           ],
                           "justified": false,
@@ -3712,7 +4181,13 @@ ShallowWrapper {
                               "active": false,
                               "children": Array [
                                 "Destination Rules (1)",
-                                undefined,
+                                <span>
+                                   
+                                  <Icon
+                                    name="error-circle-o"
+                                    type="pf"
+                                  />
+                                </span>,
                               ],
                               "disabled": false,
                               "eventKey": "destinationrules",
@@ -3720,7 +4195,37 @@ ShallowWrapper {
                             "ref": null,
                             "rendered": Array [
                               "Destination Rules (1)",
-                              undefined,
+                              Object {
+                                "instance": null,
+                                "key": undefined,
+                                "nodeType": "host",
+                                "props": Object {
+                                  "children": Array [
+                                    " ",
+                                    <Icon
+                                      name="error-circle-o"
+                                      type="pf"
+                                    />,
+                                  ],
+                                },
+                                "ref": null,
+                                "rendered": Array [
+                                  " ",
+                                  Object {
+                                    "instance": null,
+                                    "key": undefined,
+                                    "nodeType": "function",
+                                    "props": Object {
+                                      "name": "error-circle-o",
+                                      "type": "pf",
+                                    },
+                                    "ref": null,
+                                    "rendered": null,
+                                    "type": [Function],
+                                  },
+                                ],
+                                "type": "span",
+                              },
                             ],
                             "type": [Function],
                           },
@@ -3815,6 +4320,27 @@ ShallowWrapper {
                                   ]
                                 }
                                 editorLink="/namespaces/istio-system/services/reviews"
+                                validations={
+                                  Object {
+                                    "reviews": Object {
+                                      "checks": Array [
+                                        Object {
+                                          "message": "This subset is not found from the host",
+                                          "path": "spec/subsets[0]/version",
+                                          "severity": "error",
+                                        },
+                                        Object {
+                                          "message": "This subset is not found from the host",
+                                          "path": "spec/subsets[1]/version",
+                                          "severity": "error",
+                                        },
+                                      ],
+                                      "name": "details",
+                                      "objectType": "destinationrule",
+                                      "valid": false,
+                                    },
+                                  }
+                                }
                               />
                             </TabPane>,
                           ],
@@ -3966,6 +4492,27 @@ ShallowWrapper {
                                   ]
                                 }
                                 editorLink="/namespaces/istio-system/services/reviews"
+                                validations={
+                                  Object {
+                                    "reviews": Object {
+                                      "checks": Array [
+                                        Object {
+                                          "message": "This subset is not found from the host",
+                                          "path": "spec/subsets[0]/version",
+                                          "severity": "error",
+                                        },
+                                        Object {
+                                          "message": "This subset is not found from the host",
+                                          "path": "spec/subsets[1]/version",
+                                          "severity": "error",
+                                        },
+                                      ],
+                                      "name": "details",
+                                      "objectType": "destinationrule",
+                                      "valid": false,
+                                    },
+                                  }
+                                }
                               />,
                               "eventKey": "destinationrules",
                             },
@@ -4005,6 +4552,25 @@ ShallowWrapper {
                                   },
                                 ],
                                 "editorLink": "/namespaces/istio-system/services/reviews",
+                                "validations": Object {
+                                  "reviews": Object {
+                                    "checks": Array [
+                                      Object {
+                                        "message": "This subset is not found from the host",
+                                        "path": "spec/subsets[0]/version",
+                                        "severity": "error",
+                                      },
+                                      Object {
+                                        "message": "This subset is not found from the host",
+                                        "path": "spec/subsets[1]/version",
+                                        "severity": "error",
+                                      },
+                                    ],
+                                    "name": "details",
+                                    "objectType": "destinationrule",
+                                    "valid": false,
+                                  },
+                                },
                               },
                               "ref": null,
                               "rendered": null,


### PR DESCRIPTION
** Describe the change **
Adding missing icon to DR list within Service Details page.

** Issue reference **
https://issues.jboss.org/browse/KIALI-1919

** Screenshot **
Following the pattern from VS, which is:
![screenshot of kiali console 17](https://user-images.githubusercontent.com/613814/48429792-1a644d80-e76e-11e8-8b1a-c12040ab57f2.png)

Here you have the DR one:
![screenshot of kiali console 18](https://user-images.githubusercontent.com/613814/48429835-34059500-e76e-11e8-93d7-7c48038ad9b5.png)

