### PR TITLE
KIALI-1916 Use dagre for the layout of compound nodes

### DIFF
--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -2,6 +2,7 @@ import { PfColors } from '../../../components/Pf/PfColors';
 import { EdgeLabelMode } from '../../../types/GraphFilter';
 import { FAILURE, DEGRADED, REQUESTS_THRESHOLDS } from '../../../types/Health';
 import { GraphType, NodeType, CytoscapeGlobalScratchNamespace, CytoscapeGlobalScratchData } from '../../../types/Graph';
+import { COMPOUND_PARENT_NODE_CLASS } from '../Layout/GroupCompoundLayout';
 
 export const DimClass = 'mousedim';
 
@@ -282,7 +283,7 @@ export class GraphStyles {
       },
       {
         // version group
-        selector: '$node > node',
+        selector: `$node > node, node.${COMPOUND_PARENT_NODE_CLASS}`,
         css: {
           'text-valign': 'top',
           'text-halign': 'right',


### PR DESCRIPTION
** Describe the change **

Adds a real layout for the contents of the compounds nodes, we were using a "vertical" layout and now we are using dagre that works better with https://github.com/kiali/kiali-ui/pull/820

** Screenshot **

## With master

Before:

![before](https://user-images.githubusercontent.com/3845764/48492075-9900cf80-e7ee-11e8-8211-15431a4bc05b.gif)


After:

![after](https://user-images.githubusercontent.com/3845764/48492101-a7e78200-e7ee-11e8-877c-884b90fb6d94.gif)


## In the context of #820 

Before:

![without-dagre-for-compounds](https://user-images.githubusercontent.com/3845764/48451938-6addaa00-e772-11e8-91da-8db7b43bdff2.gif)


After:

![dagre-for-compounds](https://user-images.githubusercontent.com/3845764/48451930-5ef1e800-e772-11e8-86a7-8a69caa4fd9c.gif)
