### PR TITLE
KIALI-1887: Make sure overview page refresh rate is in sync with other pages

### DIFF
--- a/src/components/Refresh/Refresh.tsx
+++ b/src/components/Refresh/Refresh.tsx
@@ -4,12 +4,17 @@ import { Button, MenuItem, Icon, DropdownButton } from 'patternfly-react';
 import { config } from '../../config';
 import { PollIntervalInMs } from '../../types/Common';
 
-type Props = {
+type ComponentProps = {
   id: string;
-  pollInterval?: PollIntervalInMs;
   handleRefresh: () => void;
-  onSelect: (selected: PollIntervalInMs) => void;
 };
+
+type ReduxProps = {
+  pollInterval: PollIntervalInMs;
+  setRefreshInterval: (pollInterval: PollIntervalInMs) => void;
+};
+
+type Props = ComponentProps & ReduxProps;
 
 type State = {
   pollInterval?: PollIntervalInMs;
@@ -46,7 +51,7 @@ class Refresh extends React.Component<Props, State> {
       newRefInterval = window.setInterval(this.props.handleRefresh, pollInterval);
     }
     this.setState({ pollerRef: newRefInterval, pollInterval: pollInterval });
-    this.props.onSelect(pollInterval);
+    this.props.setRefreshInterval(pollInterval); // notify redux of the change
   };
 
   render() {

--- a/src/containers/OverviewPageContainer.ts
+++ b/src/containers/OverviewPageContainer.ts
@@ -4,17 +4,29 @@ import { NamespaceActions } from '../actions/NamespaceAction';
 import Namespace from '../types/Namespace';
 import { Dispatch } from 'redux';
 import OverviewPage from '../pages/Overview/OverviewPage';
+import { UserSettingsActions } from '../actions/UserSettingsActions';
+import { PollIntervalInMs } from '../types/Common';
+import { KialiAppState } from '../store/Store';
+import { durationSelector, refreshIntervalSelector } from '../store/Selectors';
+
+const mapStateToProps = (state: KialiAppState) => ({
+  duration: durationSelector(state),
+  pollInterval: refreshIntervalSelector(state)
+});
 
 const mapDispatchToProps = (dispatch: Dispatch<any>) => {
   return {
     setActiveNamespace: (namespace: Namespace) => {
       dispatch(NamespaceActions.setActiveNamespace(namespace));
+    },
+    setRefreshlInterval: (refresh: PollIntervalInMs) => {
+      dispatch(UserSettingsActions.setRefreshInterval(refresh));
     }
   };
 };
 
 const OverviewPageContainer = connect(
-  null,
+  mapStateToProps,
   mapDispatchToProps
 )(OverviewPage);
 export default OverviewPageContainer;

--- a/src/containers/RefreshContainer.tsx
+++ b/src/containers/RefreshContainer.tsx
@@ -1,19 +1,20 @@
 import { connect } from 'react-redux';
-import { bindActionCreators, Dispatch } from 'redux';
+import { Dispatch } from 'redux';
 import { KialiAppState } from '../store/Store';
 import { UserSettingsActions } from '../actions/UserSettingsActions';
 import { refreshIntervalSelector } from '../store/Selectors';
 import Refresh from '../components/Refresh/Refresh';
+import { PollIntervalInMs } from '../types/Common';
 
 const mapStateToProps = (state: KialiAppState) => ({
-  selected: refreshIntervalSelector(state),
   pollInterval: refreshIntervalSelector(state)
 });
 
 const mapDispatchToProps = (dispatch: Dispatch<any>) => {
   return {
-    onSelect: bindActionCreators(UserSettingsActions.setRefreshInterval, dispatch),
-    onUpdatePollInterval: bindActionCreators(UserSettingsActions.setRefreshInterval, dispatch)
+    setRefreshInterval: (refresh: PollIntervalInMs) => {
+      dispatch(UserSettingsActions.setRefreshInterval(refresh));
+    }
   };
 };
 

--- a/src/pages/Overview/OverviewToolbar.tsx
+++ b/src/pages/Overview/OverviewToolbar.tsx
@@ -3,7 +3,6 @@ import { Sort, ToolbarRightContent } from 'patternfly-react';
 
 import { StatefulFilters } from '../../components/Filters/StatefulFilters';
 import { ListPagesHelper } from '../../components/ListPage/ListPagesHelper';
-import Refresh from '../../components/Refresh/Refresh';
 import { ToolbarDropdown } from '../../components/ToolbarDropdown/ToolbarDropdown';
 import { config } from '../../config';
 
@@ -11,6 +10,8 @@ import { FiltersAndSorts } from './FiltersAndSorts';
 import { SortField } from '../../types/SortFilters';
 import NamespaceInfo from './NamespaceInfo';
 import { HistoryManager, URLParams } from '../../app/History';
+import { PollIntervalInMs } from '../../types/Common';
+import RefreshContainer from '../../containers/RefreshContainer';
 
 type Props = {
   onRefresh: () => void;
@@ -86,7 +87,7 @@ class OverviewToolbar extends React.Component<Props, State> {
     this.setState({ duration: duration });
   };
 
-  updatePollInterval = (pollInterval: number) => {
+  updatePollInterval = (pollInterval: PollIntervalInMs) => {
     HistoryManager.setParam(URLParams.POLL_INTERVAL, String(pollInterval));
     this.setState({ pollInterval: pollInterval });
   };
@@ -116,7 +117,7 @@ class OverviewToolbar extends React.Component<Props, State> {
           options={DURATIONS}
         />
         <ToolbarRightContent>
-          <Refresh
+          <RefreshContainer
             id="overview-refresh"
             handleRefresh={this.props.onRefresh}
             onSelect={this.updatePollInterval}

--- a/src/pages/Overview/__tests__/OverviewPage.test.tsx
+++ b/src/pages/Overview/__tests__/OverviewPage.test.tsx
@@ -1,10 +1,13 @@
 import * as React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
+import { Provider } from 'react-redux';
+
 import { mount, shallow, ReactWrapper } from 'enzyme';
 import OverviewPage from '../OverviewPage';
 import { FilterSelected } from '../../../components/Filters/StatefulFilters';
 import * as API from '../../../services/Api';
 import { AppHealth, NamespaceAppHealth, HEALTHY, FAILURE, DEGRADED } from '../../../types/Health';
+import { store } from '../../../store/ConfigStore';
 
 const mockAPIToPromise = (func: keyof typeof API, obj: any, encapsData: boolean): Promise<void> => {
   return new Promise((resolve, reject) => {
@@ -39,9 +42,11 @@ let mounted: ReactWrapper<any, any> | null;
 
 const mountPage = () => {
   mounted = mount(
-    <Router>
-      <OverviewPage setActiveNamespace={jest.fn()} />
-    </Router>
+    <Provider store={store}>
+      <Router>
+        <OverviewPage setActiveNamespace={jest.fn()} />
+      </Router>
+    </Provider>
   );
 };
 


### PR DESCRIPTION
This PR uses redux global state to enable synchronization of the refresh rate with other pages in the application. So refresh rates appear consistent in their state between screen navigation. Adds reduxification of Refresh component.

** Describe the change **
This is the quick low-risk fix for this issue as this just provides common global state between multiple components. The ultimate solution would be to create a new common `Refresh` component that is shared all over the application. However, we still have design and unanswered questions on this so here is the immediate fix.

** Issue reference **
https://issues.jboss.org/browse/KIALI-1887

Next steps:
https://issues.jboss.org/browse/KIALI-1929

** Backwards compatible? **
Yes

** Screenshot **
![overview](https://user-images.githubusercontent.com/1312165/48455324-9c08ab00-e76f-11e8-9f6c-87877a998ca5.gif)

