### PR TITLE
KIALI-1806 Fixing broken layout for destination rules in Service Details

### DIFF
--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDestinationRules.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDestinationRules.tsx
@@ -139,17 +139,23 @@ class ServiceInfoDestinationRules extends React.Component<ServiceInfoDestination
   generateSubsets(subsets: Subset[]) {
     let childrenList: any = [];
     subsets.map(subset => {
-      Object.keys(subset.labels).forEach((key, v) =>
-        childrenList.push(
-          <li key={this.generateKey() + '_k' + v}>
-            <span style={{ float: 'left', paddingRight: '10px', paddingTop: '3px' }}>{subset.name}</span>{' '}
-            <Label name={key} value={subset.labels[key]} />
-            <DetailObject name="trafficPolicy" detail={subset.trafficPolicy} />
-          </li>
-        )
+      childrenList.push(
+        <li key={this.generateKey() + '_k' + subset.name} style={{ marginBottom: '13px' }}>
+          <Row>
+            <Col xs={3}>
+              <span style={{ paddingRight: '10px', paddingTop: '3px' }}>{subset.name}</span>{' '}
+            </Col>
+            <Col xs={4}>
+              {Object.keys(subset.labels).map((key, _) => <Label key={key} name={key} value={subset.labels[key]} />)}
+            </Col>
+            <Col xs={4}>
+              <DetailObject name={subset.trafficPolicy ? 'trafficPolicy' : ''} detail={subset.trafficPolicy} />
+            </Col>
+          </Row>
+        </li>
       );
     });
-    return <ul style={{ listStyleType: 'none', float: 'left' }}>{childrenList}</ul>;
+    return <ul style={{ listStyleType: 'none', paddingLeft: '0px' }}>{childrenList}</ul>;
   }
 
   renderTable() {


### PR DESCRIPTION
** Describe the change **
In destination Rules, within Service Details has a trafficPolicy layout broken in subset column.

** Issue reference **
https://issues.jboss.org/browse/KIALI-1806

** Screenshot **

Before:
![screenshot of kiali console 21](https://user-images.githubusercontent.com/613814/48485327-d11d0800-e818-11e8-9a91-97671e4eee70.png)
After:
![screenshot of kiali console 20](https://user-images.githubusercontent.com/613814/48485335-d4b08f00-e818-11e8-8d72-0f65cd073421.png)
