### PR TITLE
Trivial: remove old unused methods from GraphRefresh

### DIFF
--- a/src/components/GraphFilter/GraphRefresh.tsx
+++ b/src/components/GraphFilter/GraphRefresh.tsx
@@ -12,17 +12,21 @@ import { style } from 'typestyle';
 type GraphRefreshProps = {
   id: string;
   handleRefresh: () => void;
-  onUpdatePollInterval: (selected: PollIntervalInMs) => void;
-  onUpdateDuration: (duration: DurationInSeconds) => void;
-  pollInterval: PollIntervalInMs;
   refreshIntervals: {
     [interval: number]: string;
   };
-  duration: DurationInSeconds;
   disabled: boolean;
 };
 
-const GraphRefresh: React.SFC<GraphRefreshProps> = props => {
+type ReduxProps = {
+  duration: DurationInSeconds;
+  pollInterval: PollIntervalInMs;
+
+  onUpdatePollInterval: (selected: PollIntervalInMs) => void;
+  onUpdateDuration: (duration: DurationInSeconds) => void;
+};
+
+const GraphRefresh: React.SFC<GraphRefreshProps & ReduxProps> = props => {
   const DURATION_LIST = config().toolbar.intervalDuration;
 
   const formatRefreshText = (key, isTitle: boolean = false): string => {

--- a/src/containers/GraphRefreshContainer.tsx
+++ b/src/containers/GraphRefreshContainer.tsx
@@ -10,13 +10,11 @@ import { DurationInSeconds } from '../types/Common';
 
 const mapStateToProps = (state: KialiAppState) => ({
   duration: durationSelector(state),
-  selected: refreshIntervalSelector(state),
   pollInterval: refreshIntervalSelector(state)
 });
 
 const mapDispatchToProps = (dispatch: Dispatch<any>) => {
   return {
-    onSelect: bindActionCreators(UserSettingsActions.setRefreshInterval, dispatch),
     onUpdatePollInterval: bindActionCreators(UserSettingsActions.setRefreshInterval, dispatch),
     onUpdateDuration: (duration: DurationInSeconds) => {
       dispatch(UserSettingsActions.setDuration(duration));


### PR DESCRIPTION
Removal of the old unused `onSelect` methods and while we are in here... separate the Redux properties from react properties for better comprehension of react/redux props.

** Backwards compatible? **
Yes


** Screenshot **

No visual changes just code cleanup.
