### PR TITLE
KIALI-1958 allow for anonymous access without requiring login screen

### DIFF
--- a/src/app/__tests__/App.test.tsx
+++ b/src/app/__tests__/App.test.tsx
@@ -17,7 +17,7 @@ window.getComputedStyle = jest.fn().mockImplementation(element => {
   return computedStyle;
 });
 
-jest.mock('../../services/Api');
+// jest.mock('../../services/Api');
 
 process.env.REACT_APP_NAME = 'kiali-ui-test';
 process.env.REACT_APP_VERSION = '1.0.1';


### PR DESCRIPTION
** Describe the change **
This allows the UI to anonymously log in when the server allows for anonymous login (that is, it does not require credentials when submitting requests).

** Issue reference **
https://issues.jboss.org/browse/KIALI-1958

** Backwards compatible? **
Yes.

- [x] Is your pull-request introducing changes in behaviour?

Before, if the server did not have credentials defined thus allowing for anonymous access, the UI console would still show you the login screen (at which time the user would be able to type any username and any password and the login would succeed - that is because the credentials were ignored on the server).

Now, if you go to any URL in the UI console, and the server allows for anonymous access, the UI console will not ask for the user to type in username and password; instead, the UI console will consider itself logged "anonymously".

To test this, [delete these lines from the deployment yaml](https://github.com/kiali/kiali/blob/282a03514d52628f2673166ba9f360b48cf9d08f/deploy/openshift/deployment.yaml#L42-L51) (the username and passphrase env vars pointing to the kiali secret) and re-deploy kiali. Now Kiali is in anonymous mode - go to a new UI (restart your browser to clear out any state) and see you are not asked to login and you can see data in the UI as normal.