### PR TITLE
KIALI-1999 Ensure Tour doesn't take any space when hidden.

### DIFF
--- a/src/components/Tour/Tour.tsx
+++ b/src/components/Tour/Tour.tsx
@@ -120,6 +120,9 @@ export default class Tour extends React.PureComponent<TourProps> {
   };
 
   render() {
+    if (!this.props.show) {
+      return null;
+    }
     const step = this.props.steps[this.props.currentStep];
 
     return (
@@ -133,7 +136,7 @@ export default class Tour extends React.PureComponent<TourProps> {
           disableAnimation={true}
           target={step.target}
           component={TourModal(this.props, step)}
-          open={this.props.show}
+          open={true}
           placement={step.placement ? step.placement : defaults.placement}
           offset={step.offset !== undefined ? step.offset : defaults.offset}
         />


### PR DESCRIPTION
** Describe the change **

Before, when focusing on a node, the tour would take space (hidden) at the bottom of the page, making a space to appear.

This fixes it

** Issue reference **


** Screenshot **

Before

![tour-space-1](https://user-images.githubusercontent.com/3845764/49029531-74034980-f16a-11e8-88b9-5cc4e8e6ba90.png)

![tour-space-2](https://user-images.githubusercontent.com/3845764/49029541-7796d080-f16a-11e8-93d4-12f43d62ea46.png)

The after is the same image without the empty bottom space :)