### PR TITLE
KIALI-2000 Prepares redux and graph page for multiple namespaces

### DIFF
--- a/src/actions/NamespaceAction.ts
+++ b/src/actions/NamespaceAction.ts
@@ -7,7 +7,8 @@ enum NamespaceActionKeys {
   NAMESPACE_REQUEST_STARTED = 'NAMESPACE_REQUEST_STARTED',
   NAMESPACE_SUCCESS = 'NAMESPACE_SUCCESS',
   NAMESPACE_FAILED = 'NAMESPACE_FAILED',
-  SET_ACTIVE_NAMESPACE = 'SET_ACTIVE_NAMESPACE'
+  TOGGLE_ACTIVE_NAMESPACE = 'TOGGLE_ACTIVE_NAMESPACE',
+  SET_ACTIVE_NAMESPACES = 'SET_ACTIVE_NAMESPACES'
 }
 
 const shouldFetchNamespaces = (state: KialiAppState) => {
@@ -19,7 +20,8 @@ const shouldFetchNamespaces = (state: KialiAppState) => {
 };
 
 export const NamespaceActions = {
-  setActiveNamespace: createStandardAction(NamespaceActionKeys.SET_ACTIVE_NAMESPACE)<Namespace>(),
+  toggleActiveNamespace: createStandardAction(NamespaceActionKeys.TOGGLE_ACTIVE_NAMESPACE)<Namespace>(),
+  setActiveNamespaces: createStandardAction(NamespaceActionKeys.SET_ACTIVE_NAMESPACES)<Namespace[]>(),
   requestStarted: createAction(NamespaceActionKeys.NAMESPACE_REQUEST_STARTED),
   requestFailed: createAction(NamespaceActionKeys.NAMESPACE_FAILED),
   receiveList: createAction(NamespaceActionKeys.NAMESPACE_SUCCESS, resolve => (newList: any, receivedAt: Date) =>

--- a/src/actions/__tests__/NamespaceAction.test.ts
+++ b/src/actions/__tests__/NamespaceAction.test.ts
@@ -20,8 +20,12 @@ describe('NamespaceActions', () => {
     global.Date = RealDate;
   });
 
-  it('should set active namespace', () => {
-    expect(NamespaceActions.setActiveNamespace({ name: 'istio' }).payload).toEqual({ name: 'istio' });
+  it('should set active namespaces', () => {
+    expect(NamespaceActions.setActiveNamespaces([{ name: 'istio' }]).payload).toEqual([{ name: 'istio' }]);
+  });
+
+  it('should toggle active namespace', () => {
+    expect(NamespaceActions.toggleActiveNamespace({ name: 'istio' }).payload).toEqual({ name: 'istio' });
   });
 
   it('request is success', () => {

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -12,7 +12,7 @@ import * as CytoscapeGraphUtils from './CytoscapeGraphUtils';
 import { GraphActions, GraphThunkActions } from '../../actions/GraphActions';
 import * as API from '../../services/Api';
 import { KialiAppState } from '../../store/Store';
-import { activeNamespaceSelector, durationSelector } from '../../store/Selectors';
+import { activeNamespacesSelector, durationSelector } from '../../store/Selectors';
 import {
   CytoscapeBaseEvent,
   CytoscapeClickEvent,
@@ -35,7 +35,7 @@ import { DurationInSeconds } from '../../types/Common';
 import { DagreGraph } from './graphs/DagreGraph';
 
 type CytoscapeGraphType = {
-  activeNamespace: Namespace;
+  activeNamespaces: Namespace[];
   duration: DurationInSeconds;
   elements?: any;
   edgeLabelMode: EdgeLabelMode;
@@ -51,7 +51,7 @@ type CytoscapeGraphType = {
   onClick: (event: CytoscapeClickEvent) => void;
   onReady: (cytoscapeRef: any) => void;
   refresh: () => void;
-  setActiveNamespace: (namespace: Namespace) => void;
+  setActiveNamespaces: (namespace: Namespace[]) => void;
 };
 
 type CytoscapeGraphProps = CytoscapeGraphType &
@@ -183,7 +183,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
         <ReactResizeDetector handleWidth={true} handleHeight={true} skipOnMount={true} onResize={this.onResize} />
         <EmptyGraphLayout
           elements={this.props.elements}
-          namespace={this.props.activeNamespace.name}
+          namespaces={this.props.activeNamespaces}
           action={this.props.refresh}
           isLoading={this.props.isLoading}
           isError={this.props.isError}
@@ -318,6 +318,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
     cy.on('destroy', (evt: any) => {
       this.trafficRenderer.stop();
       this.cy = undefined;
+      this.props.onClick({ summaryType: 'graph', summaryTarget: undefined });
     });
   }
 
@@ -439,7 +440,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
 
     if (target.data('isOutside')) {
       if (!target.data('isInaccessible')) {
-        this.props.setActiveNamespace({ name: target.data('namespace') });
+        this.props.setActiveNamespaces([{ name: target.data('namespace') }]);
       }
       return;
     }
@@ -628,7 +629,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
 }
 
 const mapStateToProps = (state: KialiAppState) => ({
-  activeNamespace: activeNamespaceSelector(state),
+  activeNamespaces: activeNamespacesSelector(state),
   duration: durationSelector(state),
   elements: state.graph.graphData,
   isError: state.graph.isError,
@@ -646,9 +647,9 @@ const mapStateToProps = (state: KialiAppState) => ({
 const mapDispatchToProps = (dispatch: any) => ({
   onClick: (event: CytoscapeClickEvent) => dispatch(GraphActions.showSidePanelInfo(event)),
   onReady: (cy: any) => dispatch(GraphThunkActions.graphRendered(cy)),
-  setActiveNamespace: (namespace: Namespace) => {
+  setActiveNamespaces: (namespaces: Namespace[]) => {
     dispatch(GraphActions.changed());
-    dispatch(NamespaceActions.setActiveNamespace(namespace));
+    dispatch(NamespaceActions.setActiveNamespaces(namespaces));
   }
 });
 

--- a/src/components/CytoscapeGraph/__tests__/CytoscapeGraph.test.tsx
+++ b/src/components/CytoscapeGraph/__tests__/CytoscapeGraph.test.tsx
@@ -30,7 +30,7 @@ describe('CytoscapeGraph component test', () => {
 
     const wrapper = shallow(
       <CytoscapeGraph
-        activeNamespace={{ name: testNamespace }}
+        activeNamespaces={[{ name: testNamespace }]}
         duration={60}
         edgeLabelMode={myEdgeLabelMode}
         elements={GRAPH_DATA[testNamespace].elements}
@@ -38,7 +38,7 @@ describe('CytoscapeGraph component test', () => {
         onClick={testClickHandler}
         onReady={testReadyHandler}
         refresh={testClickHandler}
-        setActiveNamespace={testSetHandler}
+        setActiveNamespaces={testSetHandler}
         showCircuitBreakers={false}
         showMissingSidecars={true}
         showNodeLabels={true}

--- a/src/components/GraphFilter/GraphFilterToolbar.tsx
+++ b/src/components/GraphFilter/GraphFilterToolbar.tsx
@@ -5,11 +5,11 @@ import { GraphParamsType, GraphType, NodeParamsType } from '../../types/Graph';
 import { EdgeLabelMode } from '../../types/GraphFilter';
 import GraphFilterToolbarType from '../../types/GraphFilterToolbar';
 import Namespace from '../../types/Namespace';
-import { makeNamespaceGraphUrlFromParams, makeNodeGraphUrlFromParams } from '../Nav/NavUtils';
+import { makeNamespacesGraphUrlFromParams, makeNodeGraphUrlFromParams } from '../Nav/NavUtils';
 import { GraphDataThunkActions } from '../../actions/GraphDataActions';
 import GraphFilter from '../../components/GraphFilter/GraphFilter';
 import { KialiAppState } from '../../store/Store';
-import { activeNamespaceSelector, durationSelector } from '../../store/Selectors';
+import { activeNamespacesSelector, durationSelector } from '../../store/Selectors';
 
 export class GraphFilterToolbar extends React.PureComponent<GraphFilterToolbarType> {
   static contextTypes = {
@@ -39,7 +39,7 @@ export class GraphFilterToolbar extends React.PureComponent<GraphFilterToolbarTy
 
   handleNamespaceReturn = () => {
     // TODO: This should be handled by a redux action that sets the node to undefined
-    this.context.router.history.push(makeNamespaceGraphUrlFromParams({ ...this.getGraphParams(), node: undefined }));
+    this.context.router.history.push(makeNamespacesGraphUrlFromParams({ ...this.getGraphParams(), node: undefined }));
   };
 
   handleGraphTypeChange = (graphType: GraphType) => {
@@ -59,7 +59,7 @@ export class GraphFilterToolbar extends React.PureComponent<GraphFilterToolbarTy
       // Server-side appender for response time is not run by default unless the edge label is explicitly set. So when switching
       // to this edge label, we need to make a server-side request in order to ensure the appenders is run.
       this.props.fetchGraphData(
-        this.props.activeNamespace,
+        this.props.activeNamespaces,
         this.props.duration,
         this.props.graphType,
         this.props.injectServiceNodes,
@@ -75,7 +75,7 @@ export class GraphFilterToolbar extends React.PureComponent<GraphFilterToolbarTy
     if (this.props.node) {
       this.context.router.history.push(makeNodeGraphUrlFromParams(params));
     } else {
-      this.context.router.history.push(makeNamespaceGraphUrlFromParams(params));
+      this.context.router.history.push(makeNamespacesGraphUrlFromParams(params));
     }
   };
 
@@ -91,13 +91,13 @@ export class GraphFilterToolbar extends React.PureComponent<GraphFilterToolbarTy
 }
 
 const mapStateToProps = (state: KialiAppState) => ({
-  activeNamespace: activeNamespaceSelector(state),
+  activeNamespaces: activeNamespacesSelector(state),
   duration: durationSelector(state)
 });
 
 const mapDispatchToProps = (dispatch: any) => ({
   fetchGraphData: (
-    namespace: Namespace,
+    namespaces: Namespace[],
     duration: DurationInSeconds,
     graphType: GraphType,
     injectServiceNodes: boolean,
@@ -108,7 +108,7 @@ const mapDispatchToProps = (dispatch: any) => ({
   ) =>
     dispatch(
       GraphDataThunkActions.fetchGraphData(
-        namespace,
+        namespaces,
         duration,
         graphType,
         injectServiceNodes,

--- a/src/components/Nav/NavUtils.tsx
+++ b/src/components/Nav/NavUtils.tsx
@@ -1,5 +1,6 @@
 import { GraphParamsType, NodeType } from '../../types/Graph';
 import { store } from '../../store/ConfigStore';
+import { activeNamespacesAsStringSelector } from '../../store/Selectors';
 
 const buildCommonQueryParams = (params: GraphParamsType): string => {
   let q = `layout=${params.graphLayout.name}`;
@@ -10,12 +11,9 @@ const buildCommonQueryParams = (params: GraphParamsType): string => {
   return q;
 };
 
-export const makeNamespaceGraphUrlFromParams = (params: GraphParamsType): string => {
-  const namespace = store.getState().namespaces.activeNamespace.name;
+export const makeNamespacesGraphUrlFromParams = (params: GraphParamsType): string => {
   let queryParams = buildCommonQueryParams(params);
-  if (namespace !== 'all') {
-    queryParams += `&namespaces=${namespace}`;
-  }
+  queryParams += `&namespaces=${activeNamespacesAsStringSelector(store.getState())}`;
   return `/graph/namespaces?` + queryParams;
 };
 
@@ -43,7 +41,7 @@ export const makeNodeGraphUrlFromParams = (params: GraphParamsType): string | un
         );
       default:
         console.debug('makeNodeUrl defaulting to makeNamespaceUrl');
-        return makeNamespaceGraphUrlFromParams(params);
+        return makeNamespacesGraphUrlFromParams(params);
     }
   } else {
     // this should never happen but typescript needs this

--- a/src/containers/EmptyGraphLayoutContainer.tsx
+++ b/src/containers/EmptyGraphLayoutContainer.tsx
@@ -13,6 +13,7 @@ import * as _ from 'lodash';
 import { KialiAppState } from '../store/Store';
 import { GraphFilterActions } from '../actions/GraphFilterActions';
 import { bindActionCreators } from 'redux';
+import Namespace from '../types/Namespace';
 
 const mapStateToProps = (state: KialiAppState) => {
   return {
@@ -29,7 +30,7 @@ const mapDispatchToProps = (dispatch: any) => {
 
 type EmptyGraphLayoutProps = {
   elements?: any;
-  namespace?: string;
+  namespaces: Namespace[];
   action?: any;
   displayUnusedNodes: () => void;
   isDisplayingUnusedNodes: boolean;
@@ -62,7 +63,33 @@ export class EmptyGraphLayout extends React.Component<EmptyGraphLayoutProps, Emp
       return true;
     }
     // Do not update if we have elements and the namespace didn't change, as this means we are refreshing
-    return !(!nextIsEmpty && this.props.namespace === nextProps.namespace);
+    return !(!nextIsEmpty && this.props.namespaces === nextProps.namespaces);
+  }
+
+  namespacesText() {
+    if (this.props.namespaces && this.props.namespaces.length > 0) {
+      if (this.props.namespaces.length === 1) {
+        return (
+          <>
+            namespace <b>{this.props.namespaces[0].name}</b>
+          </>
+        );
+      } else {
+        const namespacesString =
+          this.props.namespaces
+            .slice(0, -1)
+            .map(namespace => namespace.name)
+            .join(',') +
+          ' and ' +
+          this.props.namespaces[this.props.namespaces.length - 1].name;
+        return (
+          <>
+            namespaces <b>{namespacesString}</b>
+          </>
+        );
+      }
+    }
+    return null;
   }
 
   render() {
@@ -83,6 +110,17 @@ export class EmptyGraphLayout extends React.Component<EmptyGraphLayoutProps, Emp
       );
     }
 
+    if (this.props.namespaces.length === 0) {
+      return (
+        <EmptyState className={emptyStateStyle}>
+          <EmptyStateTitle>No namespace is selected</EmptyStateTitle>
+          <EmptyStateInfo>
+            There is currently no namespace selected, please select one using the Namespace selection button.
+          </EmptyStateInfo>
+        </EmptyState>
+      );
+    }
+
     const isGraphEmpty = !this.props.elements || !this.props.elements.nodes || this.props.elements.nodes.length < 1;
 
     if (isGraphEmpty) {
@@ -90,8 +128,9 @@ export class EmptyGraphLayout extends React.Component<EmptyGraphLayoutProps, Emp
         <EmptyState className={emptyStateStyle}>
           <EmptyStateTitle>Empty Graph</EmptyStateTitle>
           <EmptyStateInfo>
-            There is currently no graph available for namespace <b>{this.props.namespace}</b>. This could either mean
-            there is no service mesh available for this namespace or the service mesh has yet to see request traffic.
+            There is currently no graph available for {this.namespacesText()}. This could either mean there is no
+            service mesh available for {this.props.namespaces.length === 1 ? 'this namespace' : 'these namespaces'} or
+            the service mesh has yet to see request traffic.
             {this.props.isDisplayingUnusedNodes && (
               <> You are currently displaying 'Unused nodes', send requests to the service mesh and click 'Refresh'.</>
             )}

--- a/src/containers/GraphPageContainer.ts
+++ b/src/containers/GraphPageContainer.ts
@@ -8,12 +8,11 @@ import { GraphDataThunkActions } from '../actions/GraphDataActions';
 import { GraphFilterActions } from '../actions/GraphFilterActions';
 import { bindActionCreators } from 'redux';
 import { GraphType, NodeParamsType } from '../types/Graph';
-import { refreshIntervalSelector } from '../store/Selectors';
-import { activeNamespaceSelector, durationSelector } from '../store/Selectors';
+import { activeNamespacesSelector, durationSelector, refreshIntervalSelector } from '../store/Selectors';
 import { DurationInSeconds } from '../types/Common';
 
 const mapStateToProps = (state: KialiAppState) => ({
-  activeNamespace: activeNamespaceSelector(state),
+  activeNamespaces: activeNamespacesSelector(state),
   duration: durationSelector(state),
   graphTimestamp: state.graph.graphDataTimestamp,
   graphData: state.graph.graphData,
@@ -34,7 +33,7 @@ const mapStateToProps = (state: KialiAppState) => ({
 
 const mapDispatchToProps = (dispatch: any) => ({
   fetchGraphData: (
-    namespace: Namespace,
+    namespaces: Namespace[],
     duration: DurationInSeconds,
     graphType: GraphType,
     injectServiceNodes: boolean,
@@ -45,7 +44,7 @@ const mapDispatchToProps = (dispatch: any) => ({
   ) =>
     dispatch(
       GraphDataThunkActions.fetchGraphData(
-        namespace,
+        namespaces,
         duration,
         graphType,
         injectServiceNodes,

--- a/src/containers/GraphSettingsContainer.tsx
+++ b/src/containers/GraphSettingsContainer.tsx
@@ -8,15 +8,15 @@ import { EdgeLabelMode } from '../types/GraphFilter';
 import Namespace from '../types/Namespace';
 import { GraphFilterActions } from '../actions/GraphFilterActions';
 import { style } from 'typestyle';
-import { makeNamespaceGraphUrlFromParams, makeNodeGraphUrlFromParams } from '../components/Nav/NavUtils';
+import { makeNamespacesGraphUrlFromParams, makeNodeGraphUrlFromParams } from '../components/Nav/NavUtils';
 import { GraphDataThunkActions } from '../actions/GraphDataActions';
 import { KialiAppState, GraphFilterState } from '../store/Store';
-import { activeNamespaceSelector, durationSelector } from '../store/Selectors';
+import { activeNamespacesSelector, durationSelector } from '../store/Selectors';
 
 interface GraphDispatch {
   // Dispatch methods
   fetchGraphData: (
-    namespace: Namespace,
+    namespaces: Namespace[],
     duration: DurationInSeconds,
     graphType: GraphType,
     injectServiceNodes: boolean,
@@ -39,7 +39,7 @@ interface GraphDispatch {
 type GraphSettingsProps = GraphDispatch &
   GraphFilterState &
   GraphParamsType & {
-    activeNamespace: Namespace;
+    activeNamespaces: Namespace[];
     duration: DurationInSeconds;
   };
 
@@ -77,7 +77,7 @@ class GraphSettings extends React.PureComponent<GraphSettingsProps> {
       // when turning on security, or toggling unused node, we need to perform a fetch, because we don't pull
       // security or unused node data by default.
       this.props.fetchGraphData(
-        this.props.activeNamespace,
+        this.props.activeNamespaces,
         this.props.duration,
         this.props.graphType,
         this.props.injectServiceNodes,
@@ -94,7 +94,7 @@ class GraphSettings extends React.PureComponent<GraphSettingsProps> {
     if (params.node) {
       this.context.router.history.push(makeNodeGraphUrlFromParams(params));
     } else {
-      this.context.router.history.push(makeNamespaceGraphUrlFromParams(params));
+      this.context.router.history.push(makeNamespacesGraphUrlFromParams(params));
     }
   };
 
@@ -238,7 +238,7 @@ class GraphSettings extends React.PureComponent<GraphSettingsProps> {
 
 // Allow Redux to map sections of our global app state to our props
 const mapStateToProps = (state: KialiAppState) => ({
-  activeNamespace: activeNamespaceSelector(state),
+  activeNamespaces: activeNamespacesSelector(state),
   duration: durationSelector(state),
   showCircuitBreakers: state.graph.filterState.showCircuitBreakers,
   showMissingSidecars: state.graph.filterState.showMissingSidecars,
@@ -254,7 +254,7 @@ const mapStateToProps = (state: KialiAppState) => ({
 const mapDispatchToProps = (dispatch: any) => {
   return {
     fetchGraphData: (
-      namespace: Namespace,
+      namespaces: Namespace[],
       duration: DurationInSeconds,
       graphType: GraphType,
       injectServiceNodes: boolean,
@@ -265,7 +265,7 @@ const mapDispatchToProps = (dispatch: any) => {
     ) =>
       dispatch(
         GraphDataThunkActions.fetchGraphData(
-          namespace,
+          namespaces,
           duration,
           graphType,
           injectServiceNodes,

--- a/src/containers/NamespaceDropdownContainer.tsx
+++ b/src/containers/NamespaceDropdownContainer.tsx
@@ -6,12 +6,12 @@ import { NamespaceDropdown } from '../components/NamespaceDropdown';
 import Namespace from '../types/Namespace';
 import { KialiAppState } from '../store/Store';
 import { Dispatch } from 'redux';
-import { activeNamespaceSelector, namespaceItemsSelector } from '../store/Selectors';
+import { activeNamespacesSelector, namespaceItemsSelector } from '../store/Selectors';
 
 const mapStateToProps = (state: KialiAppState) => {
   return {
     items: namespaceItemsSelector(state),
-    activeNamespace: activeNamespaceSelector(state)
+    activeNamespace: activeNamespacesSelector(state)[0]
   };
 };
 
@@ -22,7 +22,7 @@ const mapDispatchToProps = (dispatch: Dispatch<any>) => {
     },
     onSelect: (namespace: Namespace) => {
       dispatch(GraphActions.changed());
-      dispatch(NamespaceActions.setActiveNamespace(namespace));
+      dispatch(NamespaceActions.setActiveNamespaces([namespace]));
     }
   };
 };

--- a/src/containers/OverviewPageContainer.ts
+++ b/src/containers/OverviewPageContainer.ts
@@ -1,0 +1,20 @@
+import { connect } from 'react-redux';
+
+import { NamespaceActions } from '../actions/NamespaceAction';
+import Namespace from '../types/Namespace';
+import { Dispatch } from 'redux';
+import OverviewPage from '../pages/Overview/OverviewPage';
+
+const mapDispatchToProps = (dispatch: Dispatch<any>) => {
+  return {
+    setActiveNamespace: (namespace: Namespace) => {
+      dispatch(NamespaceActions.setActiveNamespaces([namespace]));
+    }
+  };
+};
+
+const OverviewPageContainer = connect(
+  null,
+  mapDispatchToProps
+)(OverviewPage);
+export default OverviewPageContainer;

--- a/src/pages/Graph/GraphPage.tsx
+++ b/src/pages/Graph/GraphPage.tsx
@@ -20,7 +20,7 @@ import * as MessageCenterUtils from '../../utils/MessageCenter';
 import GraphLegend from '../../components/GraphFilter/GraphLegend';
 import EmptyGraphLayoutContainer from '../../containers/EmptyGraphLayoutContainer';
 import { CytoscapeToolbar } from '../../components/CytoscapeGraph/CytoscapeToolbar';
-import { makeNamespaceGraphUrlFromParams, makeNodeGraphUrlFromParams } from '../../components/Nav/NavUtils';
+import { makeNamespacesGraphUrlFromParams, makeNodeGraphUrlFromParams } from '../../components/Nav/NavUtils';
 
 import StatefulTour from '../../components/Tour/StatefulTour';
 
@@ -40,7 +40,7 @@ type GraphPageProps = GraphParamsType & {
   summaryData: SummaryData | null;
   // functions
   fetchGraphData: (
-    namespace: Namespace,
+    namespaces: Namespace[],
     duration: DurationInSeconds,
     graphType: GraphType,
     injectServiceNodes: boolean,
@@ -51,7 +51,7 @@ type GraphPageProps = GraphParamsType & {
   ) => any;
   toggleLegend: () => void;
   // redux store props (to avoid ts-ignore)
-  activeNamespace: Namespace;
+  activeNamespaces: Namespace[];
   duration: DurationInSeconds;
 };
 
@@ -131,16 +131,16 @@ export default class GraphPage extends React.Component<GraphPageProps, GraphPage
     if (this.props.node) {
       this.context.router.history.replace(makeNodeGraphUrlFromParams({ ...graphParams }));
     } else {
-      this.context.router.history.replace(makeNamespaceGraphUrlFromParams({ ...graphParams }));
+      this.context.router.history.replace(makeNamespacesGraphUrlFromParams({ ...graphParams }));
     }
 
-    const prevActiveNamespace = prevProps.activeNamespace;
+    const prevActiveNamespaces = prevProps.activeNamespaces;
     const prevDuration = prevProps.duration;
     const prevGraphType = prevProps.graphType;
     const prevInjectServiceNodes = prevProps.injectServiceNodes;
     const prevPollInterval = prevProps.pollInterval;
 
-    const activeNamespaceHasChanged = prevActiveNamespace.name !== this.props.activeNamespace.name;
+    const activeNamespaceHasChanged = prevActiveNamespaces !== this.props.activeNamespaces;
     const durationHasChanged = prevDuration !== this.props.duration;
     const graphTypeHasChanged = prevGraphType !== this.props.graphType;
     const injectServiceNodesHasChanged = prevInjectServiceNodes !== this.props.injectServiceNodes;
@@ -181,7 +181,7 @@ export default class GraphPage extends React.Component<GraphPageProps, GraphPage
     if (params.node) {
       this.context.router.history.replace(makeNodeGraphUrlFromParams({ ...params, graphLayout: layout }));
     } else {
-      this.context.router.history.replace(makeNamespaceGraphUrlFromParams({ ...params, graphLayout: layout }));
+      this.context.router.history.replace(makeNamespacesGraphUrlFromParams({ ...params, graphLayout: layout }));
     }
   };
 
@@ -256,7 +256,7 @@ export default class GraphPage extends React.Component<GraphPageProps, GraphPage
             {this.props.summaryData ? (
               <SummaryPanel
                 data={this.props.summaryData}
-                namespace={this.props.activeNamespace.name}
+                namespaces={this.props.activeNamespaces}
                 graphType={this.props.graphType}
                 injectServiceNodes={this.props.injectServiceNodes}
                 queryTime={this.props.graphTimestamp}
@@ -280,7 +280,7 @@ export default class GraphPage extends React.Component<GraphPageProps, GraphPage
 
   private loadGraphDataFromBackend = () => {
     const promise = this.props.fetchGraphData(
-      this.props.node ? this.props.node.namespace : this.props.activeNamespace,
+      this.props.node ? [this.props.node.namespace] : this.props.activeNamespaces,
       this.props.duration,
       this.props.graphType,
       this.props.injectServiceNodes,

--- a/src/pages/Graph/GraphRouteHandler.tsx
+++ b/src/pages/Graph/GraphRouteHandler.tsx
@@ -7,12 +7,13 @@ import * as LayoutDictionary from '../../components/CytoscapeGraph/graphs/Layout
 import { config } from '../../config';
 import * as Enum from '../../utils/Enum';
 import { NamespaceActions } from '../../actions/NamespaceAction';
-import Namespace from '../../types/Namespace';
+import Namespace, { namespacesFromString } from '../../types/Namespace';
 import { store } from '../../store/ConfigStore';
 import GraphPageContainer from '../../containers/GraphPageContainer';
 import { DurationInSeconds } from '../../types/Common';
 import { UserSettingsActions } from '../../actions/UserSettingsActions';
 import { GraphActions } from '../../actions/GraphActions';
+import { arrayEquals } from '../../utils/Common';
 
 const URLSearchParams = require('url-search-params');
 
@@ -46,7 +47,7 @@ type GraphURLPathProps = {
 type GraphURLQueryProps = GraphParamsType & {
   graphDuration: DurationInSeconds;
   keepState: boolean;
-  namespaces: Namespace;
+  namespaces: Namespace[];
 };
 
 /**
@@ -87,7 +88,7 @@ export default class GraphRouteHandler extends React.Component<
       ? urlParams.get('injectServiceNodes') === 'true'
       : GraphRouteHandler.graphParamsDefaults.injectServiceNodes;
     const _keepState = urlParams.has('keepState') ? urlParams.get('keepState') === 'true' : false;
-    const _namespaces = urlParams.has('namespaces') ? { name: urlParams.get('namespaces') } : { name: 'all' };
+    const _namespaces = urlParams.has('namespaces') ? namespacesFromString(urlParams.get('namespaces')) : [];
 
     const result = {
       edgeLabelMode: _edgeLabelMode,
@@ -152,7 +153,7 @@ export default class GraphRouteHandler extends React.Component<
       return null;
     }
 
-    const reduxNamespaces = store.getState().namespaces.activeNamespace;
+    const currentNamespaces = store.getState().namespaces.activeNamespaces;
     const reduxDuration = store.getState().userSettings.duration;
 
     const durationHasChanged = nextGraphDuration !== reduxDuration;
@@ -160,7 +161,8 @@ export default class GraphRouteHandler extends React.Component<
     const graphTypeChanged = nextGraphType !== currentState.graphType;
     const injectServiceNodesChanged = nextInjectServiceNodes !== currentState.injectServiceNodes;
     const layoutHasChanged = nextLayout.name !== currentState.graphLayout.name;
-    const namespaceHasChanged = !nextNode && nextNamespaces.name !== reduxNamespaces.name;
+    const namespacesHaveChanged =
+      !nextNode && arrayEquals(nextNamespaces, currentNamespaces, (n1, n2) => n1.name === n2.name);
     const nodeAppHasChanged = nextNode && currentState.node && nextNode.app !== currentState.node.app;
     const nodeServiceHasChanged = nextNode && currentState.node && nextNode.service !== currentState.node.service;
     const nodeVersionHasChanged = nextNode && currentState.node && nextNode.version !== currentState.node.version;
@@ -179,11 +181,11 @@ export default class GraphRouteHandler extends React.Component<
     if (durationHasChanged) {
       store.dispatch(UserSettingsActions.setDuration(nextGraphDuration));
     }
-    if (namespaceHasChanged) {
-      store.dispatch(NamespaceActions.setActiveNamespace(nextNamespaces));
+    if (namespacesHaveChanged) {
+      store.dispatch(NamespaceActions.setActiveNamespaces(nextNamespaces));
     }
     // if the graph has fundamentally changed then init relevant redux graph state
-    if (graphTypeChanged || injectServiceNodesChanged || namespaceHasChanged || nodeHasChanged) {
+    if (graphTypeChanged || injectServiceNodesChanged || namespacesHaveChanged || nodeHasChanged) {
       store.dispatch(GraphActions.changed());
     }
 

--- a/src/pages/Graph/GraphRouteHandler.tsx
+++ b/src/pages/Graph/GraphRouteHandler.tsx
@@ -162,7 +162,7 @@ export default class GraphRouteHandler extends React.Component<
     const injectServiceNodesChanged = nextInjectServiceNodes !== currentState.injectServiceNodes;
     const layoutHasChanged = nextLayout.name !== currentState.graphLayout.name;
     const namespacesHaveChanged =
-      !nextNode && arrayEquals(nextNamespaces, currentNamespaces, (n1, n2) => n1.name === n2.name);
+      !nextNode && !arrayEquals(nextNamespaces, currentNamespaces, (n1, n2) => n1.name === n2.name);
     const nodeAppHasChanged = nextNode && currentState.node && nextNode.app !== currentState.node.app;
     const nodeServiceHasChanged = nextNode && currentState.node && nextNode.service !== currentState.node.service;
     const nodeVersionHasChanged = nextNode && currentState.node && nextNode.version !== currentState.node.version;

--- a/src/pages/Graph/SummaryLink.tsx
+++ b/src/pages/Graph/SummaryLink.tsx
@@ -57,16 +57,23 @@ const getLink = (data: NodeData, nodeType?: NodeType) => {
     );
   }
 
-  return displayName;
+  return <span key={key}>{displayName}</span>;
 };
 
-export const renderLink = (data: NodeData, nodeType?: NodeType) => {
-  const link = getLink(data, nodeType);
+type RenderLinkProps = {
+  data: NodeData;
+  nodeType?: NodeType;
+};
+
+export const RenderLink = (props: RenderLinkProps) => {
+  const link = getLink(props.data, props.nodeType);
 
   return (
     <>
       {link}
-      {isInaccessible(data) && <Icon name="private" type="pf" style={{ 'padding-left': '2px', width: '10px' }} />}
+      {isInaccessible(props.data) && (
+        <Icon key="link-icon" name="private" type="pf" style={{ 'padding-left': '2px', width: '10px' }} />
+      )}
     </>
   );
 };
@@ -107,8 +114,8 @@ export const renderDestServicesLinks = (node: any) => {
 
   Object.keys(destServices).forEach(k => {
     serviceNodeData.service = k;
-    links.push(renderLink(serviceNodeData));
-    links.push(', ');
+    links.push(<RenderLink key={k} data={serviceNodeData} />);
+    links.push(<span key={`comma-after-${k}`}>, </span>);
   });
 
   if (links.length > 0) {

--- a/src/pages/Graph/SummaryPanel.tsx
+++ b/src/pages/Graph/SummaryPanel.tsx
@@ -24,7 +24,7 @@ export default class SummaryPanel extends React.Component<MainSummaryPanelPropTy
         {this.props.data.summaryType === 'graph' ? (
           <SummaryPanelGraph
             data={this.props.data}
-            namespace={this.props.namespace}
+            namespaces={this.props.namespaces}
             graphType={this.props.graphType}
             injectServiceNodes={this.props.injectServiceNodes}
             queryTime={this.props.queryTime}
@@ -36,7 +36,7 @@ export default class SummaryPanel extends React.Component<MainSummaryPanelPropTy
         {this.props.data.summaryType === 'group' ? (
           <SummaryPanelGroup
             data={this.props.data}
-            namespace={this.props.namespace}
+            namespaces={this.props.data.summaryTarget.namespaces}
             graphType={this.props.graphType}
             injectServiceNodes={this.props.injectServiceNodes}
             queryTime={this.props.queryTime}
@@ -49,7 +49,7 @@ export default class SummaryPanel extends React.Component<MainSummaryPanelPropTy
           <SummaryPanelNode
             data={this.props.data}
             queryTime={this.props.queryTime}
-            namespace={this.props.namespace}
+            namespaces={this.props.data.summaryTarget.namespaces}
             graphType={this.props.graphType}
             injectServiceNodes={this.props.injectServiceNodes}
             duration={this.props.duration}

--- a/src/pages/Graph/SummaryPanelEdge.tsx
+++ b/src/pages/Graph/SummaryPanelEdge.tsx
@@ -220,7 +220,7 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
         // HTTP
         let useDest = sourceData.nodeType === NodeType.UNKNOWN;
         useDest =
-          useDest || this.props.namespace === serverConfig().istioNamespace || sourceData.nodeType === NodeType.SERVICE;
+          useDest || sourceData.namespace === serverConfig().istioNamespace || sourceData.nodeType === NodeType.SERVICE;
         let reporter = useDest ? response.data.dest : response.data.source;
         let metrics = reporter.metrics;
         const histograms = reporter.histograms;
@@ -268,7 +268,7 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
         );
         // TCP (uses slightly different reporting)
         useDest = sourceData.nodeType === NodeType.UNKNOWN;
-        useDest = useDest || this.props.namespace === serverConfig().istioNamespace;
+        useDest = useDest || sourceData.namespace === serverConfig().istioNamespace;
         reporter = useDest ? response.data.dest : response.data.source;
         metrics = reporter.metrics;
         const tcpSentRates = this.getNodeDataPoints(

--- a/src/pages/Graph/SummaryPanelGraph.tsx
+++ b/src/pages/Graph/SummaryPanelGraph.tsx
@@ -44,7 +44,7 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
   }
 
   componentDidMount() {
-    if (this.props.namespace !== 'all') {
+    if (this.props.namespaces.length === 1) {
       this.updateRpsChart(this.props);
     }
   }
@@ -60,7 +60,7 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
     if (shouldRefreshData(prevProps, this.props)) {
       // TODO (maybe) we omit the rps chart when dealing with multiple namespaces. There is no backend
       // API support to gather the data. The whole-graph chart is of nominal value, it will likely be OK.
-      if (this.props.namespace !== 'all') {
+      if (this.props.namespaces.length === 1) {
         this.updateRpsChart(this.props);
       }
     }
@@ -87,15 +87,16 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
     const numApps = baseQuery.filter('[nodeType="app"]').size();
     const numEdges = cy.edges().size();
     const trafficRate = getAccumulatedTrafficRate(cy.edges());
-    const namespace = this.props.namespace === 'all' ? undefined : this.props.namespace;
 
     return (
       <div className="panel panel-default" style={SummaryPanelGraph.panelStyle}>
         <div className="panel-heading">
-          Namespace:
-          <ListPageLink target={TargetPage.APPLICATIONS} namespace={namespace}>
-            {' ' + this.props.namespace}
-          </ListPageLink>
+          Namespace{this.props.namespaces.length > 1 ? 's' : ''}:
+          {this.props.namespaces.map(namespace => (
+            <ListPageLink key={namespace.name} target={TargetPage.APPLICATIONS} namespace={namespace.name}>
+              {' ' + namespace.name}
+            </ListPageLink>
+          ))}
           {this.renderTopologySummary(numSvc, numWorkloads, numApps, numEdges)}
         </div>
         <div className="panel-body">
@@ -107,7 +108,7 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
               rate4xx={trafficRate.rate4xx}
               rate5xx={trafficRate.rate5xx}
             />
-            {this.props.namespace !== 'all' && (
+            {this.props.namespaces.length === 1 && (
               <div>
                 <hr />
                 {this.renderRpsChart()}
@@ -126,7 +127,7 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
       step: props.step,
       rateInterval: props.rateInterval
     };
-    const promise = API.getNamespaceMetrics(authentication(), props.namespace, options);
+    const promise = API.getNamespaceMetrics(authentication(), props.namespaces[0].name, options);
     this.metricsPromise = makeCancelablePromise(promise);
 
     this.metricsPromise.promise

--- a/src/pages/Graph/SummaryPanelGroup.tsx
+++ b/src/pages/Graph/SummaryPanelGroup.tsx
@@ -6,7 +6,7 @@ import { RpsChart, TcpChart } from '../../components/SummaryPanel/RpsChart';
 import { NodeType, SummaryPanelPropType } from '../../types/Graph';
 import graphUtils from '../../utils/Graphing';
 import { getAccumulatedTrafficRate } from '../../utils/TrafficRate';
-import { renderLink, renderTitle } from './SummaryLink';
+import { RenderLink, renderTitle } from './SummaryLink';
 import {
   shouldRefreshData,
   updateHealth,
@@ -111,7 +111,7 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
               />
             )
           )}
-          <span>{[' ', renderTitle(data)]}</span>
+          <span> {renderTitle(data)}</span>
           <div className="label-collection" style={{ paddingTop: '3px' }}>
             <Label name="namespace" value={namespace} key={namespace} />
             {this.renderVersionBadges()}
@@ -163,7 +163,7 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
       .then(response => {
         // use source metrics for outgoing, except for:
         // - is is the istio namespace
-        let useDest = this.props.namespace === serverConfig().istioNamespace;
+        let useDest = this.props.data.summaryTarget.namespace === serverConfig().istioNamespace;
         let metrics = useDest ? response.data.dest.metrics : response.data.source.metrics;
         const rcOut = metrics['request_count_out'];
         const ecOut = metrics['request_error_count_out'];
@@ -268,11 +268,13 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
       httpCharts = (
         <>
           <RpsChart
+            key="http-inbound-request"
             label="HTTP - Inbound Request Traffic"
             dataRps={this.state.requestCountIn!}
             dataErrors={this.state.errorCountIn}
           />
           <RpsChart
+            key="http-outbound-request"
             label="HTTP - Outbound Request Traffic"
             dataRps={this.state.requestCountOut}
             dataErrors={this.state.errorCountOut}
@@ -286,11 +288,13 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
       tcpCharts = (
         <>
           <TcpChart
+            key="tcp-inbound-request"
             label="TCP - Inbound Traffic"
             receivedRates={this.state.tcpReceivedIn}
             sentRates={this.state.tcpSentIn}
           />
           <TcpChart
+            key="tcp-outbound-request"
             label="TCP - Outbound Traffic"
             receivedRates={this.state.tcpReceivedOut}
             sentRates={this.state.tcpSentOut}
@@ -311,12 +315,12 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
   private renderWorkloadList = (group): any[] => {
     let workloadList: any[] = [];
 
-    group.children().forEach(node => {
+    group.children().forEach((node, index) => {
       const data = nodeData(node);
 
       if (data.workload) {
-        workloadList.push(renderLink(data, NodeType.WORKLOAD));
-        workloadList.push(', ');
+        workloadList.push(<RenderLink key={`node-${index}`} data={data} nodeType={NodeType.WORKLOAD} />);
+        workloadList.push(<span key={`node-comma-${index}`}>, </span>);
       }
     });
 

--- a/src/pages/Graph/SummaryPanelNode.tsx
+++ b/src/pages/Graph/SummaryPanelNode.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { renderDestServicesLinks, renderLink, renderTitle } from './SummaryLink';
+import { renderDestServicesLinks, RenderLink, renderTitle } from './SummaryLink';
 import { Icon } from 'patternfly-react';
 
 import { getTrafficRate, getAccumulatedTrafficRate } from '../../utils/TrafficRate';
@@ -143,7 +143,7 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
       };
     } else if (data.isRoot) {
       comparator = (metric: Metric) => {
-        return metric['destination_service_namespace'] === this.props.namespace;
+        return metric['destination_service_namespace'] === data.namespace;
       };
     }
     let metrics;
@@ -162,7 +162,7 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
       // - unknown nodes (no source telemetry)
       // - istio namespace nodes (no source telemetry)
       let useDest = data.nodeType === NodeType.UNKNOWN;
-      useDest = useDest || this.props.namespace === serverConfig().istioNamespace;
+      useDest = useDest || data.namespace === serverConfig().istioNamespace;
       metrics = useDest ? all.dest.metrics : all.source.metrics;
       rcOut = metrics['request_count_out'];
       ecOut = metrics['request_error_count_out'];
@@ -243,7 +243,7 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
           {shouldRenderWorkload && (
             <div>
               <strong>Workload: </strong>
-              {renderLink(data, NodeType.WORKLOAD)}
+              <RenderLink data={data} nodeType={NodeType.WORKLOAD} />
             </div>
           )}
           {(shouldRenderSvcList || shouldRenderWorkload) && <hr />}

--- a/src/reducers/NamespaceState.ts
+++ b/src/reducers/NamespaceState.ts
@@ -5,18 +5,28 @@ import { KialiAppAction } from '../actions/KialiAppAction';
 import { NamespaceActions } from '../actions/NamespaceAction';
 
 export const INITIAL_NAMESPACE_STATE: NamespaceState = {
-  activeNamespace: { name: 'all' },
+  activeNamespaces: [{ name: 'all' }],
   isFetching: false,
-  items: ['all'],
+  items: [],
   lastUpdated: undefined
 };
 
 const namespaces = (state: NamespaceState = INITIAL_NAMESPACE_STATE, action: KialiAppAction): NamespaceState => {
   switch (action.type) {
-    case getType(NamespaceActions.setActiveNamespace):
-      return updateState(state, {
-        activeNamespace: { name: action.payload.name }
-      });
+    case getType(NamespaceActions.toggleActiveNamespace):
+      const namespaceIndex = state.activeNamespaces.findIndex(namespace => namespace.name === action.payload.name);
+      if (namespaceIndex === -1) {
+        return updateState(state, {
+          activeNamespaces: [...state.activeNamespaces, { name: action.payload.name }]
+        });
+      } else {
+        const activeNamespaces = [...state.activeNamespaces];
+        activeNamespaces.splice(namespaceIndex, 1);
+        return updateState(state, { activeNamespaces });
+      }
+
+    case getType(NamespaceActions.setActiveNamespaces):
+      return updateState(state, { activeNamespaces: action.payload });
 
     case getType(NamespaceActions.requestStarted):
       return updateState(state, {

--- a/src/reducers/__tests__/NamespacesReducer.test.ts
+++ b/src/reducers/__tests__/NamespacesReducer.test.ts
@@ -6,22 +6,56 @@ describe('Namespaces reducer', () => {
   it('should return the initial state', () => {
     expect(namespaceState(undefined, GlobalActions.nil())).toEqual({
       isFetching: false,
-      activeNamespace: { name: 'all' },
-      items: ['all'],
+      activeNamespaces: [{ name: 'all' }],
+      items: [],
       lastUpdated: undefined
     });
   });
 
-  it('should handle ACTIVE_NAMESPACE', () => {
+  it('should handle ACTIVE_NAMESPACES', () => {
     const currentState = {
-      activeNamespace: { name: 'all' },
+      activeNamespaces: [{ name: 'my-namespace' }],
       isFetching: false,
       items: [],
       lastUpdated: undefined
     };
-    const requestStartedAction = NamespaceActions.setActiveNamespace({ name: 'istio' });
+    const requestStartedAction = NamespaceActions.setActiveNamespaces([{ name: 'istio' }]);
     const expectedState = {
-      activeNamespace: { name: 'istio' },
+      activeNamespaces: [{ name: 'istio' }],
+      isFetching: false,
+      items: [],
+      lastUpdated: undefined
+    };
+    expect(namespaceState(currentState, requestStartedAction)).toEqual(expectedState);
+  });
+
+  it('should handle TOGGLE_NAMESPACE to remove a namespace', () => {
+    const currentState = {
+      activeNamespaces: [{ name: 'my-namespace' }, { name: 'my-namespace-2' }],
+      isFetching: false,
+      items: [],
+      lastUpdated: undefined
+    };
+    const requestStartedAction = NamespaceActions.toggleActiveNamespace({ name: 'my-namespace' });
+    const expectedState = {
+      activeNamespaces: [{ name: 'my-namespace-2' }],
+      isFetching: false,
+      items: [],
+      lastUpdated: undefined
+    };
+    expect(namespaceState(currentState, requestStartedAction)).toEqual(expectedState);
+  });
+
+  it('should handle TOGGLE_NAMESPACE to add a namespace', () => {
+    const currentState = {
+      activeNamespaces: [{ name: 'my-namespace' }, { name: 'my-namespace-2' }],
+      isFetching: false,
+      items: [],
+      lastUpdated: undefined
+    };
+    const requestStartedAction = NamespaceActions.toggleActiveNamespace({ name: 'my-namespace-3' });
+    const expectedState = {
+      activeNamespaces: [{ name: 'my-namespace' }, { name: 'my-namespace-2' }, { name: 'my-namespace-3' }],
       isFetching: false,
       items: [],
       lastUpdated: undefined
@@ -31,14 +65,14 @@ describe('Namespaces reducer', () => {
 
   it('should handle NAMESPACE_REQUEST_STARTED', () => {
     const currentState = {
-      activeNamespace: { name: 'all' },
+      activeNamespaces: [{ name: 'my-namespace' }],
       isFetching: false,
       items: [],
       lastUpdated: undefined
     };
     const requestStartedAction = NamespaceActions.requestStarted();
     const expectedState = {
-      activeNamespace: { name: 'all' },
+      activeNamespaces: [{ name: 'my-namespace' }],
       isFetching: true,
       items: [],
       lastUpdated: undefined
@@ -48,13 +82,13 @@ describe('Namespaces reducer', () => {
 
   it('should handle NAMESPACE_FAILED', () => {
     const currentState = {
-      activeNamespace: { name: 'all' },
+      activeNamespaces: [{ name: 'my-namespace' }],
       isFetching: true,
       items: []
     };
     const requestStartedAction = NamespaceActions.requestFailed();
     const expectedState = {
-      activeNamespace: { name: 'all' },
+      activeNamespaces: [{ name: 'my-namespace' }],
       isFetching: false,
       items: []
     };
@@ -64,14 +98,14 @@ describe('Namespaces reducer', () => {
   it('should handle NAMESPACE_SUCCESS', () => {
     const currentDate = new Date();
     const currentState = {
-      activeNamespace: { name: 'all' },
+      activeNamespaces: [{ name: 'my-namespace' }],
       isFetching: true,
       items: ['old', 'namespace'],
       lastUpdated: undefined
     };
     const requestStartedAction = NamespaceActions.receiveList(['a', 'b', 'c'], currentDate);
     const expectedState = {
-      activeNamespace: { name: 'all' },
+      activeNamespaces: [{ name: 'my-namespace' }],
       isFetching: false,
       items: ['a', 'b', 'c'],
       lastUpdated: currentDate

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -308,28 +308,29 @@ export const getGraphElements = (auth: AuthToken, params: any) => {
   return newRequest(HTTP_VERBS.GET, urls.namespacesGraphElements, params, {}, auth);
 };
 
-export const getNodeGraphElements = (
-  auth: AuthToken,
-  namespace: Namespace,
-  node: NodeParamsType,
-  params: Partial<GraphParamsType>
-) => {
+export const getNodeGraphElements = (auth: AuthToken, node: NodeParamsType, params: Partial<GraphParamsType>) => {
   switch (node.nodeType) {
     case NodeType.APP:
       return newRequest(
         HTTP_VERBS.GET,
-        urls.appGraphElements(namespace.name, node.app, node.version),
+        urls.appGraphElements(node.namespace.name, node.app, node.version),
         params,
         {},
         auth
       );
     case NodeType.SERVICE:
-      return newRequest(HTTP_VERBS.GET, urls.serviceGraphElements(namespace.name, node.service), params, {}, auth);
+      return newRequest(HTTP_VERBS.GET, urls.serviceGraphElements(node.namespace.name, node.service), params, {}, auth);
     case NodeType.WORKLOAD:
-      return newRequest(HTTP_VERBS.GET, urls.workloadGraphElements(namespace.name, node.workload), params, {}, auth);
+      return newRequest(
+        HTTP_VERBS.GET,
+        urls.workloadGraphElements(node.namespace.name, node.workload),
+        params,
+        {},
+        auth
+      );
     default:
       // default to namespace graph
-      return getGraphElements(auth, { namespaces: namespace.name, ...params });
+      return getGraphElements(auth, { namespaces: node.namespace.name, ...params });
   }
 };
 

--- a/src/store/Selectors.ts
+++ b/src/store/Selectors.ts
@@ -3,12 +3,20 @@ import { KialiAppState } from './Store';
 // These memoized selectors are from Redux Reselect package
 
 // select the proper field from Redux State
-const activeNamespace = (state: KialiAppState) => state.namespaces.activeNamespace;
+const activeNamespaces = (state: KialiAppState) => state.namespaces.activeNamespaces;
 
 // Select from the above field(s) and the last function is the formatter
-export const activeNamespaceSelector = createSelector(
-  activeNamespace,
-  namespace => namespace // identity function in this case, but as a Namespace type
+export const activeNamespacesSelector = createSelector(
+  activeNamespaces,
+  namespaces => namespaces // identity function in this case, but as a Namespace[] type
+);
+
+/**
+ * Gets a comma separated list of the namespaces for displaying
+ * @type {OutputSelector<KialiAppState, any, (res: Namespace[]) => any>}
+ */
+export const activeNamespacesAsStringSelector = createSelector(activeNamespaces, namespaces =>
+  namespaces.map(namespace => namespace.name).join(', ')
 );
 
 const namespaceItems = (state: KialiAppState) => state.namespaces.items;

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -10,7 +10,7 @@ export interface GlobalState {
 }
 
 export interface NamespaceState {
-  readonly activeNamespace: Namespace;
+  readonly activeNamespaces: Namespace[];
   readonly items?: string[];
   readonly isFetching: boolean;
   readonly lastUpdated?: Date;

--- a/src/types/Graph.ts
+++ b/src/types/Graph.ts
@@ -11,7 +11,7 @@ export interface SummaryData {
 
 export interface SummaryPanelPropType {
   data: SummaryData;
-  namespace: string;
+  namespaces: Namespace[];
   graphType: GraphType;
   injectServiceNodes: boolean;
   queryTime: string;

--- a/src/types/GraphFilterToolbar.ts
+++ b/src/types/GraphFilterToolbar.ts
@@ -4,14 +4,14 @@ import { GraphType, GraphParamsType, NodeParamsType } from './Graph';
 import { EdgeLabelMode } from './GraphFilter';
 
 export default interface GraphFilterToolbarType extends GraphParamsType {
-  activeNamespace: Namespace;
+  activeNamespaces: Namespace[];
   duration: DurationInSeconds;
   isLoading: boolean;
   showSecurity: boolean;
   showUnusedNodes: boolean;
   // functions
   fetchGraphData: (
-    namespace: Namespace,
+    namespaces: Namespace[],
     duration: DurationInSeconds,
     graphType: GraphType,
     injectServiceNodes: boolean,

--- a/src/types/Namespace.ts
+++ b/src/types/Namespace.ts
@@ -3,3 +3,11 @@ interface Namespace {
 }
 
 export default Namespace;
+
+export const namespaceFromString = (namespace: string) => ({ name });
+
+export const namespacesFromString = (namespaces: string) => {
+  return namespaces.split(',').map(name => namespaceFromString(name));
+};
+
+export const namespacesToString = (namespaces: Namespace[]) => namespaces.map(namespace => namespace.name).join(',');

--- a/src/types/Namespace.ts
+++ b/src/types/Namespace.ts
@@ -4,7 +4,7 @@ interface Namespace {
 
 export default Namespace;
 
-export const namespaceFromString = (namespace: string) => ({ name });
+export const namespaceFromString = (namespace: string) => ({ name: namespace });
 
 export const namespacesFromString = (namespaces: string) => {
   return namespaces.split(',').map(name => namespaceFromString(name));

--- a/src/utils/Common.ts
+++ b/src/utils/Common.ts
@@ -1,1 +1,13 @@
 export const removeDuplicatesArray = a => [...Array.from(new Set(a))] as string[];
+
+export const arrayEquals = <T>(a1: T[], a2: T[], comparator: (v1: T, v2: T) => boolean) => {
+  if (a1.length !== a2.length) {
+    return false;
+  }
+  for (let i = 0; i < a1.length; ++i) {
+    if (!comparator(a1[i], a2[i])) {
+      return false;
+    }
+  }
+  return true;
+};


### PR DESCRIPTION
 - Handle multiple namespaces in the sidebar
 - Add key attribute to some elements
 - Uses PromiseRegistry to ignore requests
 - Avoids loading an "empty" namespace
 - Unselects cy object when the graph is destroyed

** Describe the change **

This PR adds support for multiple namespaces to the redux store and the graph page, but it doesn't do any change to the Namespace Component (is a subset of #802).

I think this will be easier to review/merge and later we can focus only on the dropdown component and its interaction.

** Backwards compatible? **

Yes


** Screenshot **

No UI changes.
