### PR TITLE
KIALI-1884 Unify yaml editor component between Istio Config and Services pages

### DIFF
--- a/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -188,6 +188,7 @@ class ServiceInfo extends React.Component<ServiceDetails, ServiceInfoState> {
                     <TabPane eventKey={'virtualservices'}>
                       {(virtualServices.items.length > 0 || this.props.serviceDetails.istioSidecar) && (
                         <ServiceInfoVirtualServices
+                          namespace={this.props.namespace}
                           virtualServices={virtualServices.items}
                           editorLink={editorLink}
                           validations={this.props.validations!['virtualservice']}
@@ -197,6 +198,7 @@ class ServiceInfo extends React.Component<ServiceDetails, ServiceInfoState> {
                     <TabPane eventKey={'destinationrules'}>
                       {(destinationRules.items.length > 0 || this.props.serviceDetails.istioSidecar) && (
                         <ServiceInfoDestinationRules
+                          namespace={this.props.namespace}
                           destinationRules={destinationRules.items}
                           editorLink={editorLink}
                           validations={this.props.validations!['destinationrule']}

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDestinationRules.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDestinationRules.tsx
@@ -10,6 +10,7 @@ import { ConfigIndicator } from '../../../components/ConfigValidation/ConfigIndi
 import { ObjectValidation } from '../../../types/IstioObjects';
 
 interface ServiceInfoDestinationRulesProps extends EditorLink {
+  namespace: string;
   destinationRules?: DestinationRule[];
   validations: { [key: string]: ObjectValidation };
 }
@@ -119,7 +120,7 @@ class ServiceInfoDestinationRules extends React.Component<ServiceInfoDestination
 
   yamlLink(destinationRule: DestinationRule) {
     return (
-      <Link to={this.props.editorLink + '?destinationrule=' + destinationRule.name + '&detail=yaml'}>View YAML</Link>
+      <Link to={`/namespaces/${this.props.namespace}/istio/destinationrules/${destinationRule.name}`}>View YAML</Link>
     );
   }
 

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoVirtualServices.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoVirtualServices.tsx
@@ -9,6 +9,7 @@ import LocalTime from '../../../components/Time/LocalTime';
 import { ConfigIndicator } from '../../../components/ConfigValidation/ConfigIndicator';
 
 interface ServiceInfoVirtualServicesProps extends EditorLink {
+  namespace: string;
   virtualServices?: VirtualService[];
   validations: { [key: string]: ObjectValidation };
 }
@@ -100,7 +101,7 @@ class ServiceInfoVirtualServices extends React.Component<ServiceInfoVirtualServi
 
   yamlLink(virtualService: VirtualService) {
     return (
-      <Link to={this.props.editorLink + '?virtualservice=' + virtualService.name + '&detail=yaml'}>View YAML</Link>
+      <Link to={`/namespaces/${this.props.namespace}/istio/virtualservices/${virtualService.name}`}>View YAML</Link>
     );
   }
 

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/ServiceInfoRouteVirtualServices.test.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/ServiceInfoRouteVirtualServices.test.tsx
@@ -58,6 +58,7 @@ describe('#ServiceInfoVirtualServices render correctly with data', () => {
   it('should render service virtual services', () => {
     const wrapper = shallow(
       <ServiceInfoVirtualServices
+        namespace={'test_namespace'}
         virtualServices={virtualServices}
         editorLink={'/namespaces/test_namespace/services/test_services'}
         validations={{}}

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoRouteVirtualServices.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoRouteVirtualServices.test.tsx.snap
@@ -6,6 +6,7 @@ ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <ServiceInfoVirtualServices
     editorLink="/namespaces/test_namespace/services/test_services"
+    namespace="test_namespace"
     validations={Object {}}
     virtualServices={
       Array [
@@ -274,7 +275,7 @@ ShallowWrapper {
                 Object {
                   "actions": <Link
                     replace={false}
-                    to="/namespaces/test_namespace/services/test_services?virtualservice=reviews-default&detail=yaml"
+                    to="/namespaces/test_namespace/istio/virtualservices/reviews-default"
                   >
                     View YAML
                   </Link>,
@@ -504,7 +505,7 @@ ShallowWrapper {
                 Object {
                   "actions": <Link
                     replace={false}
-                    to="/namespaces/test_namespace/services/test_services?virtualservice=reviews-default&detail=yaml"
+                    to="/namespaces/test_namespace/istio/virtualservices/reviews-default"
                   >
                     View YAML
                   </Link>,
@@ -647,7 +648,7 @@ ShallowWrapper {
                   Object {
                     "actions": <Link
                       replace={false}
-                      to="/namespaces/test_namespace/services/test_services?virtualservice=reviews-default&detail=yaml"
+                      to="/namespaces/test_namespace/istio/virtualservices/reviews-default"
                     >
                       View YAML
                     </Link>,
@@ -873,7 +874,7 @@ ShallowWrapper {
                 Object {
                   "actions": <Link
                     replace={false}
-                    to="/namespaces/test_namespace/services/test_services?virtualservice=reviews-default&detail=yaml"
+                    to="/namespaces/test_namespace/istio/virtualservices/reviews-default"
                   >
                     View YAML
                   </Link>,
@@ -1113,7 +1114,7 @@ ShallowWrapper {
                   Object {
                     "actions": <Link
                       replace={false}
-                      to="/namespaces/test_namespace/services/test_services?virtualservice=reviews-default&detail=yaml"
+                      to="/namespaces/test_namespace/istio/virtualservices/reviews-default"
                     >
                       View YAML
                     </Link>,
@@ -1343,7 +1344,7 @@ ShallowWrapper {
                   Object {
                     "actions": <Link
                       replace={false}
-                      to="/namespaces/test_namespace/services/test_services?virtualservice=reviews-default&detail=yaml"
+                      to="/namespaces/test_namespace/istio/virtualservices/reviews-default"
                     >
                       View YAML
                     </Link>,
@@ -1486,7 +1487,7 @@ ShallowWrapper {
                     Object {
                       "actions": <Link
                         replace={false}
-                        to="/namespaces/test_namespace/services/test_services?virtualservice=reviews-default&detail=yaml"
+                        to="/namespaces/test_namespace/istio/virtualservices/reviews-default"
                       >
                         View YAML
                       </Link>,
@@ -1712,7 +1713,7 @@ ShallowWrapper {
                   Object {
                     "actions": <Link
                       replace={false}
-                      to="/namespaces/test_namespace/services/test_services?virtualservice=reviews-default&detail=yaml"
+                      to="/namespaces/test_namespace/istio/virtualservices/reviews-default"
                     >
                       View YAML
                     </Link>,

--- a/src/pages/ServiceDetails/__tests__/__snapshots__/ServiceInfo.test.tsx.snap
+++ b/src/pages/ServiceDetails/__tests__/__snapshots__/ServiceInfo.test.tsx.snap
@@ -419,6 +419,7 @@ ShallowWrapper {
                     >
                       <ServiceInfoVirtualServices
                         editorLink="/namespaces/istio-system/services/reviews"
+                        namespace="istio-system"
                         validations={undefined}
                         virtualServices={
                           Array [
@@ -485,6 +486,7 @@ ShallowWrapper {
                           ]
                         }
                         editorLink="/namespaces/istio-system/services/reviews"
+                        namespace="istio-system"
                         validations={
                           Object {
                             "reviews": Object {
@@ -727,6 +729,7 @@ ShallowWrapper {
                       >
                         <ServiceInfoVirtualServices
                           editorLink="/namespaces/istio-system/services/reviews"
+                          namespace="istio-system"
                           validations={undefined}
                           virtualServices={
                             Array [
@@ -793,6 +796,7 @@ ShallowWrapper {
                             ]
                           }
                           editorLink="/namespaces/istio-system/services/reviews"
+                          namespace="istio-system"
                           validations={
                             Object {
                               "reviews": Object {
@@ -1278,6 +1282,7 @@ ShallowWrapper {
                       >
                         <ServiceInfoVirtualServices
                           editorLink="/namespaces/istio-system/services/reviews"
+                          namespace="istio-system"
                           validations={undefined}
                           virtualServices={
                             Array [
@@ -1344,6 +1349,7 @@ ShallowWrapper {
                             ]
                           }
                           editorLink="/namespaces/istio-system/services/reviews"
+                          namespace="istio-system"
                           validations={
                             Object {
                               "reviews": Object {
@@ -1451,6 +1457,7 @@ ShallowWrapper {
                       >
                         <ServiceInfoVirtualServices
                           editorLink="/namespaces/istio-system/services/reviews"
+                          namespace="istio-system"
                           validations={undefined}
                           virtualServices={
                             Array [
@@ -1517,6 +1524,7 @@ ShallowWrapper {
                             ]
                           }
                           editorLink="/namespaces/istio-system/services/reviews"
+                          namespace="istio-system"
                           validations={
                             Object {
                               "reviews": Object {
@@ -1621,6 +1629,7 @@ ShallowWrapper {
                       >
                         <ServiceInfoVirtualServices
                           editorLink="/namespaces/istio-system/services/reviews"
+                          namespace="istio-system"
                           validations={undefined}
                           virtualServices={
                             Array [
@@ -1687,6 +1696,7 @@ ShallowWrapper {
                             ]
                           }
                           editorLink="/namespaces/istio-system/services/reviews"
+                          namespace="istio-system"
                           validations={
                             Object {
                               "reviews": Object {
@@ -1786,6 +1796,7 @@ ShallowWrapper {
                         >
                           <ServiceInfoVirtualServices
                             editorLink="/namespaces/istio-system/services/reviews"
+                            namespace="istio-system"
                             validations={undefined}
                             virtualServices={
                               Array [
@@ -1852,6 +1863,7 @@ ShallowWrapper {
                               ]
                             }
                             editorLink="/namespaces/istio-system/services/reviews"
+                            namespace="istio-system"
                             validations={
                               Object {
                                 "reviews": Object {
@@ -2059,6 +2071,7 @@ ShallowWrapper {
                           >
                             <ServiceInfoVirtualServices
                               editorLink="/namespaces/istio-system/services/reviews"
+                              namespace="istio-system"
                               validations={undefined}
                               virtualServices={
                                 Array [
@@ -2125,6 +2138,7 @@ ShallowWrapper {
                                 ]
                               }
                               editorLink="/namespaces/istio-system/services/reviews"
+                              namespace="istio-system"
                               validations={
                                 Object {
                                   "reviews": Object {
@@ -2189,6 +2203,7 @@ ShallowWrapper {
                             "bsClass": "tab-pane",
                             "children": <ServiceInfoVirtualServices
                               editorLink="/namespaces/istio-system/services/reviews"
+                              namespace="istio-system"
                               validations={undefined}
                               virtualServices={
                                 Array [
@@ -2226,6 +2241,7 @@ ShallowWrapper {
                             "nodeType": "class",
                             "props": Object {
                               "editorLink": "/namespaces/istio-system/services/reviews",
+                              "namespace": "istio-system",
                               "validations": undefined,
                               "virtualServices": Array [
                                 Object {
@@ -2297,6 +2313,7 @@ ShallowWrapper {
                                 ]
                               }
                               editorLink="/namespaces/istio-system/services/reviews"
+                              namespace="istio-system"
                               validations={
                                 Object {
                                   "reviews": Object {
@@ -2357,6 +2374,7 @@ ShallowWrapper {
                                 },
                               ],
                               "editorLink": "/namespaces/istio-system/services/reviews",
+                              "namespace": "istio-system",
                               "validations": Object {
                                 "reviews": Object {
                                   "checks": Array [
@@ -2614,6 +2632,7 @@ ShallowWrapper {
                       >
                         <ServiceInfoVirtualServices
                           editorLink="/namespaces/istio-system/services/reviews"
+                          namespace="istio-system"
                           validations={undefined}
                           virtualServices={
                             Array [
@@ -2680,6 +2699,7 @@ ShallowWrapper {
                             ]
                           }
                           editorLink="/namespaces/istio-system/services/reviews"
+                          namespace="istio-system"
                           validations={
                             Object {
                               "reviews": Object {
@@ -2922,6 +2942,7 @@ ShallowWrapper {
                         >
                           <ServiceInfoVirtualServices
                             editorLink="/namespaces/istio-system/services/reviews"
+                            namespace="istio-system"
                             validations={undefined}
                             virtualServices={
                               Array [
@@ -2988,6 +3009,7 @@ ShallowWrapper {
                               ]
                             }
                             editorLink="/namespaces/istio-system/services/reviews"
+                            namespace="istio-system"
                             validations={
                               Object {
                                 "reviews": Object {
@@ -3473,6 +3495,7 @@ ShallowWrapper {
                         >
                           <ServiceInfoVirtualServices
                             editorLink="/namespaces/istio-system/services/reviews"
+                            namespace="istio-system"
                             validations={undefined}
                             virtualServices={
                               Array [
@@ -3539,6 +3562,7 @@ ShallowWrapper {
                               ]
                             }
                             editorLink="/namespaces/istio-system/services/reviews"
+                            namespace="istio-system"
                             validations={
                               Object {
                                 "reviews": Object {
@@ -3646,6 +3670,7 @@ ShallowWrapper {
                         >
                           <ServiceInfoVirtualServices
                             editorLink="/namespaces/istio-system/services/reviews"
+                            namespace="istio-system"
                             validations={undefined}
                             virtualServices={
                               Array [
@@ -3712,6 +3737,7 @@ ShallowWrapper {
                               ]
                             }
                             editorLink="/namespaces/istio-system/services/reviews"
+                            namespace="istio-system"
                             validations={
                               Object {
                                 "reviews": Object {
@@ -3816,6 +3842,7 @@ ShallowWrapper {
                         >
                           <ServiceInfoVirtualServices
                             editorLink="/namespaces/istio-system/services/reviews"
+                            namespace="istio-system"
                             validations={undefined}
                             virtualServices={
                               Array [
@@ -3882,6 +3909,7 @@ ShallowWrapper {
                               ]
                             }
                             editorLink="/namespaces/istio-system/services/reviews"
+                            namespace="istio-system"
                             validations={
                               Object {
                                 "reviews": Object {
@@ -3981,6 +4009,7 @@ ShallowWrapper {
                           >
                             <ServiceInfoVirtualServices
                               editorLink="/namespaces/istio-system/services/reviews"
+                              namespace="istio-system"
                               validations={undefined}
                               virtualServices={
                                 Array [
@@ -4047,6 +4076,7 @@ ShallowWrapper {
                                 ]
                               }
                               editorLink="/namespaces/istio-system/services/reviews"
+                              namespace="istio-system"
                               validations={
                                 Object {
                                   "reviews": Object {
@@ -4254,6 +4284,7 @@ ShallowWrapper {
                             >
                               <ServiceInfoVirtualServices
                                 editorLink="/namespaces/istio-system/services/reviews"
+                                namespace="istio-system"
                                 validations={undefined}
                                 virtualServices={
                                   Array [
@@ -4320,6 +4351,7 @@ ShallowWrapper {
                                   ]
                                 }
                                 editorLink="/namespaces/istio-system/services/reviews"
+                                namespace="istio-system"
                                 validations={
                                   Object {
                                     "reviews": Object {
@@ -4384,6 +4416,7 @@ ShallowWrapper {
                               "bsClass": "tab-pane",
                               "children": <ServiceInfoVirtualServices
                                 editorLink="/namespaces/istio-system/services/reviews"
+                                namespace="istio-system"
                                 validations={undefined}
                                 virtualServices={
                                   Array [
@@ -4421,6 +4454,7 @@ ShallowWrapper {
                               "nodeType": "class",
                               "props": Object {
                                 "editorLink": "/namespaces/istio-system/services/reviews",
+                                "namespace": "istio-system",
                                 "validations": undefined,
                                 "virtualServices": Array [
                                   Object {
@@ -4492,6 +4526,7 @@ ShallowWrapper {
                                   ]
                                 }
                                 editorLink="/namespaces/istio-system/services/reviews"
+                                namespace="istio-system"
                                 validations={
                                   Object {
                                     "reviews": Object {
@@ -4552,6 +4587,7 @@ ShallowWrapper {
                                   },
                                 ],
                                 "editorLink": "/namespaces/istio-system/services/reviews",
+                                "namespace": "istio-system",
                                 "validations": Object {
                                   "reviews": Object {
                                     "checks": Array [


### PR DESCRIPTION
Jira: [KIALI-1884](https://issues.jboss.org/browse/KIALI-1884)

![link](https://user-images.githubusercontent.com/3019213/49081679-dc742880-f247-11e8-8f2e-c98a7907d227.gif)

Now we let the user delete the istioObject from this view (overview/yaml), I think that we should remove this dropdown actions and let the user make the actions from the istioObject page. What do you think   @lucasponce @jotak ?