### PR TITLE
Trivial: Remove old unused kiali-browser-test.png from .gitignore. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@
 
 # testing
 /coverage
-kiali-browser-test.png
 
 # production
 /build


### PR DESCRIPTION
** Describe the change **
Remove old unused `kiali-browser-test.png` from `.gitignore`. This is old from when we were saving the browser image snapshots.

** Backwards compatible? **
Yes.
[ ] Is your pull-request introducing changes in behaviour?
No new behaviour.
