### PR TITLE
KIALI-2047 Ensure the cy canvas is resized when mounting

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -193,7 +193,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
   render() {
     return (
       <div id="cytoscape-container" className={this.props.containerClassName}>
-        <ReactResizeDetector handleWidth={true} handleHeight={true} skipOnMount={true} onResize={this.onResize} />
+        <ReactResizeDetector handleWidth={true} handleHeight={true} skipOnMount={false} onResize={this.onResize} />
         <EmptyGraphLayout
           elements={this.props.elements}
           namespaces={this.props.activeNamespaces}


### PR DESCRIPTION
When navigating trough pages, is required to resize the canvas upon mounting the components.


** Backwards compatible? **

Is backwards compatible