### PR TITLE
KIALI-1200 Istio sidecar indicator should be present on pods and not only as summary on service

### DIFF
--- a/src/components/MissingSidecar/MissingSidecar.tsx
+++ b/src/components/MissingSidecar/MissingSidecar.tsx
@@ -1,20 +1,38 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { Icon } from 'patternfly-react';
+import { Icon, OverlayTrigger, Tooltip } from 'patternfly-react';
 import { ICONS } from '../../config';
 
 const MissingSidecar = props => {
-  const { style, text, type, name, color, ...otherProps } = props;
-  return (
+  const { style, text, type, name, color, tooltip, ...otherProps } = props;
+
+  const iconComponent = (
     <span style={style} {...otherProps}>
       <Icon type={type} name={name} style={{ color: color }} />
-      <span style={{ marginLeft: '5px' }}>{text}</span>
+      {!tooltip && <span style={{ marginLeft: '5px' }}>{text}</span>}
     </span>
+  );
+  return tooltip ? (
+    <OverlayTrigger
+      overlay={
+        <Tooltip>
+          <strong>{text}</strong>
+        </Tooltip>
+      }
+      placement="right"
+      trigger={['hover', 'focus']}
+      rootClose={false}
+    >
+      {iconComponent}
+    </OverlayTrigger>
+  ) : (
+    iconComponent
   );
 };
 
 MissingSidecar.propTypes = {
   text: PropTypes.string,
+  tooltip: PropTypes.bool,
   type: PropTypes.string,
   name: PropTypes.string,
   color: PropTypes.string
@@ -22,6 +40,7 @@ MissingSidecar.propTypes = {
 
 MissingSidecar.defaultProps = {
   text: 'Missing Sidecar',
+  tooltip: false,
   type: ICONS().ISTIO.MISSING_SIDECAR.type,
   name: ICONS().ISTIO.MISSING_SIDECAR.name,
   color: ICONS().ISTIO.MISSING_SIDECAR.color

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoWorkload.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoWorkload.tsx
@@ -1,10 +1,13 @@
 import * as React from 'react';
 import { Col, Row, Table } from 'patternfly-react';
-import { WorkloadOverview } from '../../../types/ServiceInfo';
-import Label from '../../../components/Label/Label';
-import LocalTime from '../../../components/Time/LocalTime';
 import { Link } from 'react-router-dom';
 import * as resolve from 'table-resolver';
+
+import { WorkloadOverview } from '../../../types/ServiceInfo';
+
+import Label from '../../../components/Label/Label';
+import LocalTime from '../../../components/Time/LocalTime';
+import MissingSidecar from '../../../components/MissingSidecar/MissingSidecar';
 
 interface ServiceInfoWorkloadProps {
   workloads?: WorkloadOverview[];
@@ -79,12 +82,15 @@ class ServiceInfoWorkload extends React.Component<ServiceInfoWorkloadProps> {
 
   overviewLink(workload: WorkloadOverview) {
     return (
-      <Link
-        to={`/namespaces/${this.props.namespace}/workloads/${workload.name}`}
-        key={'ServiceWorkloadItem_' + this.props.namespace + '_' + workload.name}
-      >
-        {workload.name}
-      </Link>
+      <span>
+        <Link
+          to={`/namespaces/${this.props.namespace}/workloads/${workload.name}`}
+          key={'ServiceWorkloadItem_' + this.props.namespace + '_' + workload.name}
+        >
+          {workload.name}
+        </Link>
+        {!workload.istioSidecar && <MissingSidecar tooltip={true} style={{ marginLeft: '10px' }} />}
+      </span>
     );
   }
 

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/ServiceInfoWorkloads.test.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/ServiceInfoWorkloads.test.tsx
@@ -7,6 +7,7 @@ const workloads: WorkloadOverview[] = [
   {
     name: 'reviews-v2',
     type: 'Deployment',
+    istioSidecar: true,
     resourceVersion: '081020181987',
     createdAt: '2018-03-14T10:17:52Z"',
     labels: { app: 'reviews', version: 'v2' }
@@ -14,6 +15,7 @@ const workloads: WorkloadOverview[] = [
   {
     name: 'reviews-v3',
     type: 'Deployment',
+    istioSidecar: true,
     resourceVersion: '081020181987',
     createdAt: '2018-03-14T10:17:52Z"',
     labels: { app: 'reviews', version: 'v3' }
@@ -21,6 +23,7 @@ const workloads: WorkloadOverview[] = [
   {
     name: 'reviews-v1',
     type: 'Deployment',
+    istioSidecar: true,
     resourceVersion: '081020181987',
     createdAt: '2018-03-14T10:17:52Z"',
     labels: { app: 'reviews', version: 'v1' }

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoCard.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoCard.test.tsx.snap
@@ -73,6 +73,7 @@ ShallowWrapper {
                 color="red"
                 name="blueprint"
                 text="Missing Sidecar"
+                tooltip={false}
                 type="pf"
               />
             </span>
@@ -137,6 +138,7 @@ ShallowWrapper {
                 color="red"
                 name="blueprint"
                 text="Missing Sidecar"
+                tooltip={false}
                 type="pf"
               />
             </span>
@@ -171,6 +173,7 @@ ShallowWrapper {
                   color="red"
                   name="blueprint"
                   text="Missing Sidecar"
+                  tooltip={false}
                   type="pf"
                 />
               </span>,
@@ -204,6 +207,7 @@ ShallowWrapper {
                   color="red"
                   name="blueprint"
                   text="Missing Sidecar"
+                  tooltip={false}
                   type="pf"
                 />,
                 "style": Object {
@@ -219,6 +223,7 @@ ShallowWrapper {
                   "color": "red",
                   "name": "blueprint",
                   "text": "Missing Sidecar",
+                  "tooltip": false,
                   "type": "pf",
                 },
                 "ref": null,
@@ -398,6 +403,7 @@ ShallowWrapper {
                   color="red"
                   name="blueprint"
                   text="Missing Sidecar"
+                  tooltip={false}
                   type="pf"
                 />
               </span>
@@ -462,6 +468,7 @@ ShallowWrapper {
                   color="red"
                   name="blueprint"
                   text="Missing Sidecar"
+                  tooltip={false}
                   type="pf"
                 />
               </span>
@@ -496,6 +503,7 @@ ShallowWrapper {
                     color="red"
                     name="blueprint"
                     text="Missing Sidecar"
+                    tooltip={false}
                     type="pf"
                   />
                 </span>,
@@ -529,6 +537,7 @@ ShallowWrapper {
                     color="red"
                     name="blueprint"
                     text="Missing Sidecar"
+                    tooltip={false}
                     type="pf"
                   />,
                   "style": Object {
@@ -544,6 +553,7 @@ ShallowWrapper {
                     "color": "red",
                     "name": "blueprint",
                     "text": "Missing Sidecar",
+                    "tooltip": false,
                     "type": "pf",
                   },
                   "ref": null,

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoWorkloads.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoWorkloads.test.tsx.snap
@@ -10,6 +10,7 @@ ShallowWrapper {
       Array [
         Object {
           "createdAt": "2018-03-14T10:17:52Z\\"",
+          "istioSidecar": true,
           "labels": Object {
             "app": "reviews",
             "version": "v2",
@@ -20,6 +21,7 @@ ShallowWrapper {
         },
         Object {
           "createdAt": "2018-03-14T10:17:52Z\\"",
+          "istioSidecar": true,
           "labels": Object {
             "app": "reviews",
             "version": "v3",
@@ -30,6 +32,7 @@ ShallowWrapper {
         },
         Object {
           "createdAt": "2018-03-14T10:17:52Z\\"",
+          "istioSidecar": true,
           "labels": Object {
             "app": "reviews",
             "version": "v1",
@@ -265,12 +268,14 @@ ShallowWrapper {
                       value="v2"
                     />
                   </div>,
-                  "name": <Link
-                    replace={false}
-                    to="/namespaces/ns/workloads/reviews-v2"
-                  >
-                    reviews-v2
-                  </Link>,
+                  "name": <span>
+                    <Link
+                      replace={false}
+                      to="/namespaces/ns/workloads/reviews-v2"
+                    >
+                      reviews-v2
+                    </Link>
+                  </span>,
                   "resourceVersion": "081020181987",
                   "type": "Deployment",
                 },
@@ -291,12 +296,14 @@ ShallowWrapper {
                       value="v3"
                     />
                   </div>,
-                  "name": <Link
-                    replace={false}
-                    to="/namespaces/ns/workloads/reviews-v3"
-                  >
-                    reviews-v3
-                  </Link>,
+                  "name": <span>
+                    <Link
+                      replace={false}
+                      to="/namespaces/ns/workloads/reviews-v3"
+                    >
+                      reviews-v3
+                    </Link>
+                  </span>,
                   "resourceVersion": "081020181987",
                   "type": "Deployment",
                 },
@@ -317,12 +324,14 @@ ShallowWrapper {
                       value="v1"
                     />
                   </div>,
-                  "name": <Link
-                    replace={false}
-                    to="/namespaces/ns/workloads/reviews-v1"
-                  >
-                    reviews-v1
-                  </Link>,
+                  "name": <span>
+                    <Link
+                      replace={false}
+                      to="/namespaces/ns/workloads/reviews-v1"
+                    >
+                      reviews-v1
+                    </Link>
+                  </span>,
                   "resourceVersion": "081020181987",
                   "type": "Deployment",
                 },
@@ -546,12 +555,14 @@ ShallowWrapper {
                       value="v2"
                     />
                   </div>,
-                  "name": <Link
-                    replace={false}
-                    to="/namespaces/ns/workloads/reviews-v2"
-                  >
-                    reviews-v2
-                  </Link>,
+                  "name": <span>
+                    <Link
+                      replace={false}
+                      to="/namespaces/ns/workloads/reviews-v2"
+                    >
+                      reviews-v2
+                    </Link>
+                  </span>,
                   "resourceVersion": "081020181987",
                   "type": "Deployment",
                 },
@@ -572,12 +583,14 @@ ShallowWrapper {
                       value="v3"
                     />
                   </div>,
-                  "name": <Link
-                    replace={false}
-                    to="/namespaces/ns/workloads/reviews-v3"
-                  >
-                    reviews-v3
-                  </Link>,
+                  "name": <span>
+                    <Link
+                      replace={false}
+                      to="/namespaces/ns/workloads/reviews-v3"
+                    >
+                      reviews-v3
+                    </Link>
+                  </span>,
                   "resourceVersion": "081020181987",
                   "type": "Deployment",
                 },
@@ -598,12 +611,14 @@ ShallowWrapper {
                       value="v1"
                     />
                   </div>,
-                  "name": <Link
-                    replace={false}
-                    to="/namespaces/ns/workloads/reviews-v1"
-                  >
-                    reviews-v1
-                  </Link>,
+                  "name": <span>
+                    <Link
+                      replace={false}
+                      to="/namespaces/ns/workloads/reviews-v1"
+                    >
+                      reviews-v1
+                    </Link>
+                  </span>,
                   "resourceVersion": "081020181987",
                   "type": "Deployment",
                 },
@@ -740,12 +755,14 @@ ShallowWrapper {
                         value="v2"
                       />
                     </div>,
-                    "name": <Link
-                      replace={false}
-                      to="/namespaces/ns/workloads/reviews-v2"
-                    >
-                      reviews-v2
-                    </Link>,
+                    "name": <span>
+                      <Link
+                        replace={false}
+                        to="/namespaces/ns/workloads/reviews-v2"
+                      >
+                        reviews-v2
+                      </Link>
+                    </span>,
                     "resourceVersion": "081020181987",
                     "type": "Deployment",
                   },
@@ -766,12 +783,14 @@ ShallowWrapper {
                         value="v3"
                       />
                     </div>,
-                    "name": <Link
-                      replace={false}
-                      to="/namespaces/ns/workloads/reviews-v3"
-                    >
-                      reviews-v3
-                    </Link>,
+                    "name": <span>
+                      <Link
+                        replace={false}
+                        to="/namespaces/ns/workloads/reviews-v3"
+                      >
+                        reviews-v3
+                      </Link>
+                    </span>,
                     "resourceVersion": "081020181987",
                     "type": "Deployment",
                   },
@@ -792,12 +811,14 @@ ShallowWrapper {
                         value="v1"
                       />
                     </div>,
-                    "name": <Link
-                      replace={false}
-                      to="/namespaces/ns/workloads/reviews-v1"
-                    >
-                      reviews-v1
-                    </Link>,
+                    "name": <span>
+                      <Link
+                        replace={false}
+                        to="/namespaces/ns/workloads/reviews-v1"
+                      >
+                        reviews-v1
+                      </Link>
+                    </span>,
                     "resourceVersion": "081020181987",
                     "type": "Deployment",
                   },
@@ -1017,12 +1038,14 @@ ShallowWrapper {
                       value="v2"
                     />
                   </div>,
-                  "name": <Link
-                    replace={false}
-                    to="/namespaces/ns/workloads/reviews-v2"
-                  >
-                    reviews-v2
-                  </Link>,
+                  "name": <span>
+                    <Link
+                      replace={false}
+                      to="/namespaces/ns/workloads/reviews-v2"
+                    >
+                      reviews-v2
+                    </Link>
+                  </span>,
                   "resourceVersion": "081020181987",
                   "type": "Deployment",
                 },
@@ -1043,12 +1066,14 @@ ShallowWrapper {
                       value="v3"
                     />
                   </div>,
-                  "name": <Link
-                    replace={false}
-                    to="/namespaces/ns/workloads/reviews-v3"
-                  >
-                    reviews-v3
-                  </Link>,
+                  "name": <span>
+                    <Link
+                      replace={false}
+                      to="/namespaces/ns/workloads/reviews-v3"
+                    >
+                      reviews-v3
+                    </Link>
+                  </span>,
                   "resourceVersion": "081020181987",
                   "type": "Deployment",
                 },
@@ -1069,12 +1094,14 @@ ShallowWrapper {
                       value="v1"
                     />
                   </div>,
-                  "name": <Link
-                    replace={false}
-                    to="/namespaces/ns/workloads/reviews-v1"
-                  >
-                    reviews-v1
-                  </Link>,
+                  "name": <span>
+                    <Link
+                      replace={false}
+                      to="/namespaces/ns/workloads/reviews-v1"
+                    >
+                      reviews-v1
+                    </Link>
+                  </span>,
                   "resourceVersion": "081020181987",
                   "type": "Deployment",
                 },
@@ -1308,12 +1335,14 @@ ShallowWrapper {
                         value="v2"
                       />
                     </div>,
-                    "name": <Link
-                      replace={false}
-                      to="/namespaces/ns/workloads/reviews-v2"
-                    >
-                      reviews-v2
-                    </Link>,
+                    "name": <span>
+                      <Link
+                        replace={false}
+                        to="/namespaces/ns/workloads/reviews-v2"
+                      >
+                        reviews-v2
+                      </Link>
+                    </span>,
                     "resourceVersion": "081020181987",
                     "type": "Deployment",
                   },
@@ -1334,12 +1363,14 @@ ShallowWrapper {
                         value="v3"
                       />
                     </div>,
-                    "name": <Link
-                      replace={false}
-                      to="/namespaces/ns/workloads/reviews-v3"
-                    >
-                      reviews-v3
-                    </Link>,
+                    "name": <span>
+                      <Link
+                        replace={false}
+                        to="/namespaces/ns/workloads/reviews-v3"
+                      >
+                        reviews-v3
+                      </Link>
+                    </span>,
                     "resourceVersion": "081020181987",
                     "type": "Deployment",
                   },
@@ -1360,12 +1391,14 @@ ShallowWrapper {
                         value="v1"
                       />
                     </div>,
-                    "name": <Link
-                      replace={false}
-                      to="/namespaces/ns/workloads/reviews-v1"
-                    >
-                      reviews-v1
-                    </Link>,
+                    "name": <span>
+                      <Link
+                        replace={false}
+                        to="/namespaces/ns/workloads/reviews-v1"
+                      >
+                        reviews-v1
+                      </Link>
+                    </span>,
                     "resourceVersion": "081020181987",
                     "type": "Deployment",
                   },
@@ -1589,12 +1622,14 @@ ShallowWrapper {
                         value="v2"
                       />
                     </div>,
-                    "name": <Link
-                      replace={false}
-                      to="/namespaces/ns/workloads/reviews-v2"
-                    >
-                      reviews-v2
-                    </Link>,
+                    "name": <span>
+                      <Link
+                        replace={false}
+                        to="/namespaces/ns/workloads/reviews-v2"
+                      >
+                        reviews-v2
+                      </Link>
+                    </span>,
                     "resourceVersion": "081020181987",
                     "type": "Deployment",
                   },
@@ -1615,12 +1650,14 @@ ShallowWrapper {
                         value="v3"
                       />
                     </div>,
-                    "name": <Link
-                      replace={false}
-                      to="/namespaces/ns/workloads/reviews-v3"
-                    >
-                      reviews-v3
-                    </Link>,
+                    "name": <span>
+                      <Link
+                        replace={false}
+                        to="/namespaces/ns/workloads/reviews-v3"
+                      >
+                        reviews-v3
+                      </Link>
+                    </span>,
                     "resourceVersion": "081020181987",
                     "type": "Deployment",
                   },
@@ -1641,12 +1678,14 @@ ShallowWrapper {
                         value="v1"
                       />
                     </div>,
-                    "name": <Link
-                      replace={false}
-                      to="/namespaces/ns/workloads/reviews-v1"
-                    >
-                      reviews-v1
-                    </Link>,
+                    "name": <span>
+                      <Link
+                        replace={false}
+                        to="/namespaces/ns/workloads/reviews-v1"
+                      >
+                        reviews-v1
+                      </Link>
+                    </span>,
                     "resourceVersion": "081020181987",
                     "type": "Deployment",
                   },
@@ -1783,12 +1822,14 @@ ShallowWrapper {
                           value="v2"
                         />
                       </div>,
-                      "name": <Link
-                        replace={false}
-                        to="/namespaces/ns/workloads/reviews-v2"
-                      >
-                        reviews-v2
-                      </Link>,
+                      "name": <span>
+                        <Link
+                          replace={false}
+                          to="/namespaces/ns/workloads/reviews-v2"
+                        >
+                          reviews-v2
+                        </Link>
+                      </span>,
                       "resourceVersion": "081020181987",
                       "type": "Deployment",
                     },
@@ -1809,12 +1850,14 @@ ShallowWrapper {
                           value="v3"
                         />
                       </div>,
-                      "name": <Link
-                        replace={false}
-                        to="/namespaces/ns/workloads/reviews-v3"
-                      >
-                        reviews-v3
-                      </Link>,
+                      "name": <span>
+                        <Link
+                          replace={false}
+                          to="/namespaces/ns/workloads/reviews-v3"
+                        >
+                          reviews-v3
+                        </Link>
+                      </span>,
                       "resourceVersion": "081020181987",
                       "type": "Deployment",
                     },
@@ -1835,12 +1878,14 @@ ShallowWrapper {
                           value="v1"
                         />
                       </div>,
-                      "name": <Link
-                        replace={false}
-                        to="/namespaces/ns/workloads/reviews-v1"
-                      >
-                        reviews-v1
-                      </Link>,
+                      "name": <span>
+                        <Link
+                          replace={false}
+                          to="/namespaces/ns/workloads/reviews-v1"
+                        >
+                          reviews-v1
+                        </Link>
+                      </span>,
                       "resourceVersion": "081020181987",
                       "type": "Deployment",
                     },
@@ -2060,12 +2105,14 @@ ShallowWrapper {
                         value="v2"
                       />
                     </div>,
-                    "name": <Link
-                      replace={false}
-                      to="/namespaces/ns/workloads/reviews-v2"
-                    >
-                      reviews-v2
-                    </Link>,
+                    "name": <span>
+                      <Link
+                        replace={false}
+                        to="/namespaces/ns/workloads/reviews-v2"
+                      >
+                        reviews-v2
+                      </Link>
+                    </span>,
                     "resourceVersion": "081020181987",
                     "type": "Deployment",
                   },
@@ -2086,12 +2133,14 @@ ShallowWrapper {
                         value="v3"
                       />
                     </div>,
-                    "name": <Link
-                      replace={false}
-                      to="/namespaces/ns/workloads/reviews-v3"
-                    >
-                      reviews-v3
-                    </Link>,
+                    "name": <span>
+                      <Link
+                        replace={false}
+                        to="/namespaces/ns/workloads/reviews-v3"
+                      >
+                        reviews-v3
+                      </Link>
+                    </span>,
                     "resourceVersion": "081020181987",
                     "type": "Deployment",
                   },
@@ -2112,12 +2161,14 @@ ShallowWrapper {
                         value="v1"
                       />
                     </div>,
-                    "name": <Link
-                      replace={false}
-                      to="/namespaces/ns/workloads/reviews-v1"
-                    >
-                      reviews-v1
-                    </Link>,
+                    "name": <span>
+                      <Link
+                        replace={false}
+                        to="/namespaces/ns/workloads/reviews-v1"
+                      >
+                        reviews-v1
+                      </Link>
+                    </span>,
                     "resourceVersion": "081020181987",
                     "type": "Deployment",
                   },

--- a/src/types/ServiceInfo.ts
+++ b/src/types/ServiceInfo.ts
@@ -17,6 +17,7 @@ interface EndpointAddress {
 export interface WorkloadOverview {
   name: string;
   type: string;
+  istioSidecar: boolean;
   labels?: { [key: string]: string };
   resourceVersion: string;
   createdAt: string;


### PR DESCRIPTION
JIRA: [KIALI-1200](https://issues.jboss.org/browse/KIALI-1200)

The Jira is an old one , now we have not pods in services so after read comments(@lucasponce & @xeviknal ), I did these changes:

- Now we can see in the list of workloads in a service of they have missing Istio Sidecar like @lucasponce proposed. @abonas I set the icon with tooltip (see demo) next to the name of the workload, It's ok in this place under the perspective of UX ?
- Improved component MissingSidecar to let a new attribute "**tooltip**" iff with this we'll have the **text** like a tooltip and not in the right of the icon.
- Added to the types/WorkloadOverview the istioSidecar value.

![sample](https://user-images.githubusercontent.com/3019213/49308948-0b093200-f4da-11e8-9c0b-8b74ec8de574.gif)



