### PR TITLE
KIALI-1390 Multiple namespace filter on the graph

### DIFF
--- a/src/actions/GraphDataThunkActions.ts
+++ b/src/actions/GraphDataThunkActions.ts
@@ -102,11 +102,6 @@ const GraphDataThunkActions = {
         );
       }
 
-      // Todo: Remove this when we are finally getting rid of 'all' namespace
-      if (namespaces.length === 1 && namespaces[0].name === 'all') {
-        namespaces = getState().namespaces.activeNamespaces.filter(namespace => namespace.name !== 'all');
-      }
-
       restParams['namespaces'] = namespaces.map(namespace => namespace.name).join(',');
       return setCurrentRequest(API.getGraphElements(authenticationToken(getState()), restParams)).then(
         response => {

--- a/src/actions/NamespaceThunkActions.ts
+++ b/src/actions/NamespaceThunkActions.ts
@@ -1,5 +1,4 @@
 import { ThunkDispatch } from 'redux-thunk';
-import Namespace from '../types/Namespace';
 import { KialiAppState } from '../store/Store';
 import * as Api from '../services/Api';
 import { KialiAppAction } from './KialiAppAction';
@@ -20,11 +19,7 @@ const NamespaceThunkActions = {
       return Api.getNamespaces(auth)
         .then(response => response['data'])
         .then(data => {
-          let namespaceList: Namespace[] = [{ name: 'all' }];
-          data.forEach((aNamespace: Namespace) => {
-            namespaceList.push(aNamespace);
-          });
-          dispatch(NamespaceActions.receiveList(namespaceList, new Date()));
+          dispatch(NamespaceActions.receiveList([...data], new Date()));
         })
         .catch(() => dispatch(NamespaceActions.requestFailed()));
     };

--- a/src/actions/__tests__/NamespaceAction.test.ts
+++ b/src/actions/__tests__/NamespaceAction.test.ts
@@ -43,7 +43,7 @@ describe('NamespaceActions', () => {
     mockDate(currentDate);
     const expectedActions = [
       NamespaceActions.requestStarted(),
-      NamespaceActions.receiveList([{ name: 'all' }, { name: 'a' }, { name: 'b' }, { name: 'c' }], currentDate)
+      NamespaceActions.receiveList([{ name: 'a' }, { name: 'b' }, { name: 'c' }], currentDate)
     ];
     const axiosMock = new axiosMockAdapter(axios);
     axiosMock.onGet('/api/namespaces').reply(200, [{ name: 'a' }, { name: 'b' }, { name: 'c' }]);

--- a/src/components/GraphFilter/GraphFilter.tsx
+++ b/src/components/GraphFilter/GraphFilter.tsx
@@ -107,7 +107,7 @@ export class GraphFilter extends React.PureComponent<GraphFilterProps> {
   componentDidUpdate() {
     // ensure redux state and URL are aligned
     const activeNamespacesString = namespacesToString(this.props.activeNamespaces);
-    if (!this.props.activeNamespaces) {
+    if (this.props.activeNamespaces.length === 0) {
       HistoryManager.deleteParam(URLParams.NAMESPACES, true);
     } else {
       HistoryManager.setParam(URLParams.NAMESPACES, activeNamespacesString);

--- a/src/components/GraphFilter/GraphFilter.tsx
+++ b/src/components/GraphFilter/GraphFilter.tsx
@@ -100,16 +100,14 @@ export class GraphFilter extends React.PureComponent<GraphFilterProps> {
       }
     } else {
       const activeNamespacesString = namespacesToString(props.activeNamespaces);
-      if ('all' !== activeNamespacesString) {
-        HistoryManager.setParam(URLParams.NAMESPACES, activeNamespacesString);
-      }
+      HistoryManager.setParam(URLParams.NAMESPACES, activeNamespacesString);
     }
   }
 
   componentDidUpdate() {
     // ensure redux state and URL are aligned
     const activeNamespacesString = namespacesToString(this.props.activeNamespaces);
-    if (!this.props.activeNamespaces || activeNamespacesString === 'all') {
+    if (!this.props.activeNamespaces) {
       HistoryManager.deleteParam(URLParams.NAMESPACES, true);
     } else {
       HistoryManager.setParam(URLParams.NAMESPACES, activeNamespacesString);

--- a/src/components/NamespaceDropdown.tsx
+++ b/src/components/NamespaceDropdown.tsx
@@ -7,15 +7,17 @@ import { KialiAppAction } from '../actions/KialiAppAction';
 import { GraphActions } from '../actions/GraphActions';
 import { NamespaceActions } from '../actions/NamespaceAction';
 import NamespaceThunkActions from '../actions/NamespaceThunkActions';
-import Namespace, { namespaceFromString } from '../types/Namespace';
-import ToolbarDropdown from './ToolbarDropdown/ToolbarDropdown';
+import { Button, Icon, OverlayTrigger, Popover } from 'patternfly-react';
+import Namespace from '../types/Namespace';
+import { style } from 'typestyle';
 
 interface NamespaceListType {
   disabled: boolean;
-  activeNamespace: Namespace;
+  activeNamespaces: Namespace[];
   items: Namespace[];
-  setActiveNamespace: (namespace: string) => void;
+  toggleNamespace: (namespace: Namespace) => void;
   refresh: () => void;
+  clearAll: () => void;
 }
 
 export class NamespaceDropdown extends React.PureComponent<NamespaceListType, {}> {
@@ -27,28 +29,65 @@ export class NamespaceDropdown extends React.PureComponent<NamespaceListType, {}
     this.props.refresh();
   }
 
+  onNamespaceToggled = (a: any) => {
+    this.props.toggleNamespace({ name: a.target.value });
+  };
+
+  namespaceButtonText() {
+    if (this.props.activeNamespaces.length === 0) {
+      return 'Select a namespace';
+    } else if (this.props.activeNamespaces.length === 1) {
+      return this.props.activeNamespaces[0].name;
+    } else {
+      return `${this.props.activeNamespaces.length} namespaces`;
+    }
+  }
+
   handleToggle = (isOpen: boolean) => isOpen && this.props.refresh();
 
+  getPopoverContent() {
+    if (this.props.items.length > 0) {
+      const activeMap = this.props.activeNamespaces.reduce((map, namespace) => {
+        map[namespace.name] = namespace.name;
+        return map;
+      }, {});
+      const checkboxStyle = style({ marginLeft: 5 });
+      const namespaces = this.props.items.map((namespace: Namespace) => (
+        <div id={`namespace-list-item[${namespace.name}]`} key={`namespace-list-item[${namespace.name}]`}>
+          <label>
+            <input
+              type="checkbox"
+              value={namespace.name}
+              checked={!!activeMap[namespace.name]}
+              onChange={this.onNamespaceToggled}
+            />
+            <span className={checkboxStyle}>{namespace.name}</span>
+          </label>
+        </div>
+      ));
+
+      return (
+        <>
+          <div className="text-right">
+            <Button disabled={this.props.activeNamespaces.length === 0} bsStyle="link" onClick={this.props.clearAll}>
+              Clear all
+            </Button>
+          </div>
+          <div>{namespaces}</div>
+        </>
+      );
+    }
+    return <div>No namespaces found or they haven't loaded yet</div>;
+  }
+
   render() {
-    const disabled = this.props.disabled;
-
-    // convert namespace array to an object {"ns1": "ns1"} to make it compatible with <ToolbarDropdown />
-    const items: { [key: string]: string } = this.props.items.reduce((list, item) => {
-      list[item.name] = item.name;
-      return list;
-    }, {});
-
+    const popover = <Popover id="namespace-list-layers-popover">{this.getPopoverContent()}</Popover>;
     return (
-      <ToolbarDropdown
-        id="namespace-selector"
-        disabled={disabled}
-        options={items}
-        value={this.props.activeNamespace.name}
-        label={this.props.activeNamespace.name}
-        useName={true}
-        handleSelect={this.props.setActiveNamespace}
-        onToggle={this.handleToggle}
-      />
+      <OverlayTrigger overlay={popover} placement="bottom" trigger={['click']} rootClose={true}>
+        <Button id="graph_settings">
+          {this.namespaceButtonText()} <Icon name="angle-down" />
+        </Button>
+      </OverlayTrigger>
     );
   }
 }
@@ -56,7 +95,7 @@ export class NamespaceDropdown extends React.PureComponent<NamespaceListType, {}
 const mapStateToProps = (state: KialiAppState) => {
   return {
     items: namespaceItemsSelector(state)!,
-    activeNamespace: activeNamespacesSelector(state)[0]
+    activeNamespaces: activeNamespacesSelector(state)
   };
 };
 
@@ -65,10 +104,14 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<KialiAppState, void, KialiAp
     refresh: () => {
       dispatch(NamespaceThunkActions.fetchNamespacesIfNeeded());
     },
-    setActiveNamespace: (namespace: string) => {
+    toggleNamespace: (namespace: Namespace) => {
       // TODO: This needs to be a single update
       dispatch(GraphActions.changed());
-      dispatch(NamespaceActions.setActiveNamespaces([namespaceFromString(namespace)]));
+      dispatch(NamespaceActions.toggleActiveNamespace(namespace));
+    },
+    clearAll: () => {
+      dispatch(GraphActions.changed());
+      dispatch(NamespaceActions.setActiveNamespaces([]));
     }
   };
 };

--- a/src/components/NamespaceDropdown.tsx
+++ b/src/components/NamespaceDropdown.tsx
@@ -43,8 +43,6 @@ export class NamespaceDropdown extends React.PureComponent<NamespaceListType, {}
     }
   }
 
-  handleToggle = (isOpen: boolean) => isOpen && this.props.refresh();
-
   getPopoverContent() {
     if (this.props.items.length > 0) {
       const activeMap = this.props.activeNamespaces.reduce((map, namespace) => {
@@ -83,7 +81,13 @@ export class NamespaceDropdown extends React.PureComponent<NamespaceListType, {}
   render() {
     const popover = <Popover id="namespace-list-layers-popover">{this.getPopoverContent()}</Popover>;
     return (
-      <OverlayTrigger overlay={popover} placement="bottom" trigger={['click']} rootClose={true}>
+      <OverlayTrigger
+        onEnter={this.props.refresh}
+        overlay={popover}
+        placement="bottom"
+        trigger={['click']}
+        rootClose={true}
+      >
         <Button id="graph_settings">
           {this.namespaceButtonText()} <Icon name="angle-down" />
         </Button>

--- a/src/components/Nav/NavUtils.tsx
+++ b/src/components/Nav/NavUtils.tsx
@@ -26,9 +26,11 @@ const buildCommonQueryParams = (params: GraphUrlParams): string => {
 };
 
 export const makeNamespacesGraphUrlFromParams = (params: GraphUrlParams): string => {
-  const namespaces = params.activeNamespaces.map(namespace => namespace.name).join(', ');
   let queryParams = buildCommonQueryParams(params);
-  queryParams += `&${URLParams.NAMESPACES}=${namespaces}`;
+  if (params.activeNamespaces.length > 0) {
+    const namespaces = params.activeNamespaces.map(namespace => namespace.name).join(',');
+    queryParams += `&${URLParams.NAMESPACES}=${namespaces}`;
+  }
   return `/graph/namespaces?` + queryParams;
 };
 

--- a/src/pages/Graph/SummaryPanelGraph.tsx
+++ b/src/pages/Graph/SummaryPanelGraph.tsx
@@ -44,7 +44,7 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
   }
 
   componentDidMount() {
-    if (this.props.namespaces.length === 1) {
+    if (this.shouldShowRPSChart()) {
       this.updateRpsChart(this.props);
     }
   }
@@ -58,9 +58,7 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
     }
 
     if (shouldRefreshData(prevProps, this.props)) {
-      // TODO (maybe) we omit the rps chart when dealing with multiple namespaces. There is no backend
-      // API support to gather the data. The whole-graph chart is of nominal value, it will likely be OK.
-      if (this.props.namespaces.length === 1) {
+      if (this.shouldShowRPSChart()) {
         this.updateRpsChart(this.props);
       }
     }
@@ -108,7 +106,7 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
               rate4xx={trafficRate.rate4xx}
               rate5xx={trafficRate.rate5xx}
             />
-            {this.props.namespaces.length === 1 && (
+            {this.shouldShowRPSChart() && (
               <div>
                 <hr />
                 {this.renderRpsChart()}
@@ -118,6 +116,12 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
         </div>
       </div>
     );
+  }
+
+  private shouldShowRPSChart() {
+    // TODO we omit the rps chart when dealing with multiple namespaces. There is no backend
+    // API support to gather the data. The whole-graph chart is of nominal value, it will likely be OK.
+    return this.props.namespaces.length === 1;
   }
 
   private updateRpsChart = (props: SummaryPanelPropType) => {

--- a/src/pages/Graph/SummaryPanelGraph.tsx
+++ b/src/pages/Graph/SummaryPanelGraph.tsx
@@ -11,7 +11,6 @@ import { shouldRefreshData, getDatapoints } from './SummaryPanelCommon';
 import { Response } from '../../services/Api';
 import { Metrics } from '../../types/Metrics';
 import { CancelablePromise, makeCancelablePromise } from '../../utils/CancelablePromises';
-import { namespacesToString } from '../../types/Namespace';
 
 type SummaryPanelGraphState = {
   loading: boolean;
@@ -45,7 +44,7 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
   }
 
   componentDidMount() {
-    if ('all' !== namespacesToString(this.props.namespaces)) {
+    if (this.props.namespaces.length === 1) {
       this.updateRpsChart(this.props);
     }
   }
@@ -61,7 +60,7 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
     if (shouldRefreshData(prevProps, this.props)) {
       // TODO (maybe) we omit the rps chart when dealing with multiple namespaces. There is no backend
       // API support to gather the data. The whole-graph chart is of nominal value, it will likely be OK.
-      if ('all' !== namespacesToString(this.props.namespaces)) {
+      if (this.props.namespaces.length === 1) {
         this.updateRpsChart(this.props);
       }
     }
@@ -109,7 +108,7 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
               rate4xx={trafficRate.rate4xx}
               rate5xx={trafficRate.rate5xx}
             />
-            {'all' !== namespacesToString(this.props.namespaces) && (
+            {this.props.namespaces.length === 1 && (
               <div>
                 <hr />
                 {this.renderRpsChart()}

--- a/src/reducers/NamespaceState.ts
+++ b/src/reducers/NamespaceState.ts
@@ -5,7 +5,7 @@ import { KialiAppAction } from '../actions/KialiAppAction';
 import { NamespaceActions } from '../actions/NamespaceAction';
 
 export const INITIAL_NAMESPACE_STATE: NamespaceState = {
-  activeNamespaces: [{ name: 'all' }],
+  activeNamespaces: [],
   isFetching: false,
   items: [],
   lastUpdated: undefined

--- a/src/reducers/__tests__/NamespacesReducer.test.ts
+++ b/src/reducers/__tests__/NamespacesReducer.test.ts
@@ -6,7 +6,7 @@ describe('Namespaces reducer', () => {
   it('should return the initial state', () => {
     expect(namespaceState(undefined, GlobalActions.unknown())).toEqual({
       isFetching: false,
-      activeNamespaces: [{ name: 'all' }],
+      activeNamespaces: [],
       items: [],
       lastUpdated: undefined
     });


### PR DESCRIPTION
KIALI-1724 Removes the 'all' namespace

Allows to select multiple namespaces instead of only one or all.
This allows a more fine-grained selection of the namespaces that we care in a single view.

This PR only focuses on having the component in the graph page but it could very well be used in other pages. 

** Screenshot **

![namespace-selector](https://user-images.githubusercontent.com/3845764/49315465-65db6300-f4b3-11e8-81b0-05f0eb2b195f.gif)

![namespace-full](https://user-images.githubusercontent.com/3845764/49315467-683dbd00-f4b3-11e8-9cd8-3819a8535cc5.gif)

