### PR TITLE
KIALI-2076: Upgrade typescript and prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,9 +114,9 @@
     "jest-localstorage-mock": "2.2.0",
     "node-sass-chokidar": "1.3.0",
     "npm-snapshot": "1.0.3",
-    "prettier": "1.13.4",
-    "tslint-no-circular-imports": "0.5.0",
-    "typescript": "3.1.3"
+    "prettier": "1.15.3",
+    "tslint-no-circular-imports": "0.6.1",
+    "typescript": "3.2.1"
   },
   "resolutions": {
     "@types/react": "16.4.17"

--- a/src/components/Filters/StatefulFilters.tsx
+++ b/src/components/Filters/StatefulFilters.tsx
@@ -221,30 +221,29 @@ export class StatefulFilters extends React.Component<StatefulFiltersProps, State
             {this.renderInput()}
           </Filter>
           {this.props.children}
-          {activeFilters &&
-            activeFilters.length > 0 && (
-              <Toolbar.Results>
-                <Filter.ActiveLabel>{'Active Filters:'}</Filter.ActiveLabel>
-                <Filter.List>
-                  {activeFilters.map((item, index) => {
-                    return (
-                      <Filter.Item key={index} onRemove={this.removeFilter} filterData={item}>
-                        {item.category + ': ' + item.value}
-                      </Filter.Item>
-                    );
-                  })}
-                </Filter.List>
-                <a
-                  href="#"
-                  onClick={e => {
-                    e.preventDefault();
-                    this.clearFilters();
-                  }}
-                >
-                  Clear All Filters
-                </a>
-              </Toolbar.Results>
-            )}
+          {activeFilters && activeFilters.length > 0 && (
+            <Toolbar.Results>
+              <Filter.ActiveLabel>{'Active Filters:'}</Filter.ActiveLabel>
+              <Filter.List>
+                {activeFilters.map((item, index) => {
+                  return (
+                    <Filter.Item key={index} onRemove={this.removeFilter} filterData={item}>
+                      {item.category + ': ' + item.value}
+                    </Filter.Item>
+                  );
+                })}
+              </Filter.List>
+              <a
+                href="#"
+                onClick={e => {
+                  e.preventDefault();
+                  this.clearFilters();
+                }}
+              >
+                Clear All Filters
+              </a>
+            </Toolbar.Results>
+          )}
         </Toolbar>
       </div>
     );

--- a/src/components/Health/HealthIndicator.tsx
+++ b/src/components/Health/HealthIndicator.tsx
@@ -60,7 +60,11 @@ export class HealthIndicator extends React.PureComponent<Props, HealthState> {
         <br />
         {this.state.info.length === 1 && this.state.info[0]}
         {this.state.info.length > 1 && (
-          <ul style={{ padding: 0 }}>{this.state.info.map((line, idx) => <li key={idx}>{line}</li>)}</ul>
+          <ul style={{ padding: 0 }}>
+            {this.state.info.map((line, idx) => (
+              <li key={idx}>{line}</li>
+            ))}
+          </ul>
         )}
       </div>
     );

--- a/src/components/MessageCenter/NotificationDrawer.tsx
+++ b/src/components/MessageCenter/NotificationDrawer.tsx
@@ -111,22 +111,21 @@ class NotificationGroupWrapper extends React.PureComponent<NotificationGroupWrap
                 <NotificationWrapper key={message.id} message={message} onClick={this.props.onNotificationClick} />
               ))}
             </PfNotificationDrawer.PanelBody>
-            {group.showActions &&
-              group.messages.length > 0 && (
-                <PfNotificationDrawer.PanelAction>
-                  <PfNotificationDrawer.PanelActionLink className="drawer-pf-action-link">
-                    <Button bsStyle="link" onClick={() => this.props.onMarkGroupAsRead(group)}>
-                      Mark All Read
-                    </Button>
-                  </PfNotificationDrawer.PanelActionLink>
-                  <PfNotificationDrawer.PanelActionLink data-toggle="clear-all">
-                    <Button bsStyle="link" onClick={() => this.props.onClearGroup(group)}>
-                      <Icon type="pf" name="close" />
-                      Clear All
-                    </Button>
-                  </PfNotificationDrawer.PanelActionLink>
-                </PfNotificationDrawer.PanelAction>
-              )}
+            {group.showActions && group.messages.length > 0 && (
+              <PfNotificationDrawer.PanelAction>
+                <PfNotificationDrawer.PanelActionLink className="drawer-pf-action-link">
+                  <Button bsStyle="link" onClick={() => this.props.onMarkGroupAsRead(group)}>
+                    Mark All Read
+                  </Button>
+                </PfNotificationDrawer.PanelActionLink>
+                <PfNotificationDrawer.PanelActionLink data-toggle="clear-all">
+                  <Button bsStyle="link" onClick={() => this.props.onClearGroup(group)}>
+                    <Icon type="pf" name="close" />
+                    Clear All
+                  </Button>
+                </PfNotificationDrawer.PanelActionLink>
+              </PfNotificationDrawer.PanelAction>
+            )}
           </PfNotificationDrawer.PanelCollapse>
         </Collapse>
       </PfNotificationDrawer.Panel>

--- a/src/components/Metrics/__tests__/Metrics.test.tsx
+++ b/src/components/Metrics/__tests__/Metrics.test.tsx
@@ -166,55 +166,51 @@ describe('Metrics for a service', () => {
     );
   });
 
-  it(
-    'mounts and loads full metrics',
-    done => {
-      const allMocksDone = [
-        mockServiceMetrics({
-          metrics: {
-            request_count_in: createMetric('m1')
-          },
-          histograms: {
-            request_size_in: createHistogram('m3'),
-            request_duration_in: createHistogram('m5'),
-            response_size_in: createHistogram('m7')
-          }
+  it('mounts and loads full metrics', done => {
+    const allMocksDone = [
+      mockServiceMetrics({
+        metrics: {
+          request_count_in: createMetric('m1')
+        },
+        histograms: {
+          request_size_in: createHistogram('m3'),
+          request_duration_in: createHistogram('m5'),
+          response_size_in: createHistogram('m7')
+        }
+      })
+        .then(() => {
+          mounted!.update();
+          expect(mounted!.find('LineChart')).toHaveLength(4);
         })
-          .then(() => {
-            mounted!.update();
-            expect(mounted!.find('LineChart')).toHaveLength(4);
-          })
-          .catch(err => done.fail(err))
-      ];
-      Promise.all(allMocksDone).then(() => done());
-      mounted = mount(
-        <Provider store={store}>
-          <MemoryRouter>
-            <Route
-              render={props => (
-                <Metrics
-                  {...props}
-                  namespace="ns"
-                  object="svc"
-                  objectType={MetricsObjectTypes.SERVICE}
-                  direction={MetricsDirection.INBOUND}
-                  grafanaInfo={{
-                    url: 'http://172.30.139.113:3000',
-                    serviceDashboardPath: '/dashboard/db/istio-dashboard',
-                    workloadDashboardPath: '/dashboard/db/istio-dashboard',
-                    varService: 'var-service',
-                    varNamespace: 'var-namespace',
-                    varWorkload: 'var-workload'
-                  }}
-                />
-              )}
-            />
-          </MemoryRouter>
-        </Provider>
-      );
-    },
-    10000
-  ); // Increase timeout for this test
+        .catch(err => done.fail(err))
+    ];
+    Promise.all(allMocksDone).then(() => done());
+    mounted = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <Route
+            render={props => (
+              <Metrics
+                {...props}
+                namespace="ns"
+                object="svc"
+                objectType={MetricsObjectTypes.SERVICE}
+                direction={MetricsDirection.INBOUND}
+                grafanaInfo={{
+                  url: 'http://172.30.139.113:3000',
+                  serviceDashboardPath: '/dashboard/db/istio-dashboard',
+                  workloadDashboardPath: '/dashboard/db/istio-dashboard',
+                  varService: 'var-service',
+                  varNamespace: 'var-namespace',
+                  varWorkload: 'var-workload'
+                }}
+              />
+            )}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+  }, 10000); // Increase timeout for this test
 });
 
 describe('Inbound Metrics for a workload', () => {
@@ -292,55 +288,51 @@ describe('Inbound Metrics for a workload', () => {
     );
   });
 
-  it(
-    'mounts and loads full metrics',
-    done => {
-      const allMocksDone = [
-        mockWorkloadMetrics({
-          metrics: {
-            request_count_in: createMetric('m1')
-          },
-          histograms: {
-            request_size_in: createHistogram('m3'),
-            request_duration_in: createHistogram('m5'),
-            response_size_in: createHistogram('m7')
-          }
+  it('mounts and loads full metrics', done => {
+    const allMocksDone = [
+      mockWorkloadMetrics({
+        metrics: {
+          request_count_in: createMetric('m1')
+        },
+        histograms: {
+          request_size_in: createHistogram('m3'),
+          request_duration_in: createHistogram('m5'),
+          response_size_in: createHistogram('m7')
+        }
+      })
+        .then(() => {
+          mounted!.update();
+          expect(mounted!.find('LineChart')).toHaveLength(4);
         })
-          .then(() => {
-            mounted!.update();
-            expect(mounted!.find('LineChart')).toHaveLength(4);
-          })
-          .catch(err => done.fail(err))
-      ];
-      Promise.all(allMocksDone).then(() => done());
-      mounted = mount(
-        <Provider store={store}>
-          <MemoryRouter>
-            <Route
-              render={props => (
-                <Metrics
-                  {...props}
-                  namespace="ns"
-                  object="svc"
-                  objectType={MetricsObjectTypes.WORKLOAD}
-                  direction={MetricsDirection.INBOUND}
-                  grafanaInfo={{
-                    url: 'http://172.30.139.113:3000',
-                    serviceDashboardPath: '/dashboard/db/istio-dashboard',
-                    workloadDashboardPath: '/dashboard/db/istio-dashboard',
-                    varService: 'var-service',
-                    varNamespace: 'var-namespace',
-                    varWorkload: 'var-workload'
-                  }}
-                />
-              )}
-            />
-          </MemoryRouter>
-        </Provider>
-      );
-    },
-    10000
-  ); // Increase timeout for this test
+        .catch(err => done.fail(err))
+    ];
+    Promise.all(allMocksDone).then(() => done());
+    mounted = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <Route
+            render={props => (
+              <Metrics
+                {...props}
+                namespace="ns"
+                object="svc"
+                objectType={MetricsObjectTypes.WORKLOAD}
+                direction={MetricsDirection.INBOUND}
+                grafanaInfo={{
+                  url: 'http://172.30.139.113:3000',
+                  serviceDashboardPath: '/dashboard/db/istio-dashboard',
+                  workloadDashboardPath: '/dashboard/db/istio-dashboard',
+                  varService: 'var-service',
+                  varNamespace: 'var-namespace',
+                  varWorkload: 'var-workload'
+                }}
+              />
+            )}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+  }, 10000); // Increase timeout for this test
 });
 
 describe('Outbound Metrics for a workload', () => {
@@ -420,53 +412,49 @@ describe('Outbound Metrics for a workload', () => {
     );
   });
 
-  it(
-    'mounts and loads full metrics',
-    done => {
-      const allMocksDone = [
-        mockWorkloadMetrics({
-          metrics: {
-            request_count_out: createMetric('m1')
-          },
-          histograms: {
-            request_size_out: createHistogram('m3'),
-            request_duration_out: createHistogram('m5'),
-            response_size_out: createHistogram('m7')
-          }
+  it('mounts and loads full metrics', done => {
+    const allMocksDone = [
+      mockWorkloadMetrics({
+        metrics: {
+          request_count_out: createMetric('m1')
+        },
+        histograms: {
+          request_size_out: createHistogram('m3'),
+          request_duration_out: createHistogram('m5'),
+          response_size_out: createHistogram('m7')
+        }
+      })
+        .then(() => {
+          mounted!.update();
+          expect(mounted!.find('LineChart')).toHaveLength(4);
         })
-          .then(() => {
-            mounted!.update();
-            expect(mounted!.find('LineChart')).toHaveLength(4);
-          })
-          .catch(err => done.fail(err))
-      ];
-      Promise.all(allMocksDone).then(() => done());
-      mounted = mount(
-        <Provider store={store}>
-          <MemoryRouter>
-            <Route
-              render={props => (
-                <Metrics
-                  {...props}
-                  namespace="ns"
-                  object="svc"
-                  objectType={MetricsObjectTypes.WORKLOAD}
-                  direction={MetricsDirection.OUTBOUND}
-                  grafanaInfo={{
-                    url: 'http://172.30.139.113:3000',
-                    serviceDashboardPath: '/dashboard/db/istio-dashboard',
-                    workloadDashboardPath: '/dashboard/db/istio-dashboard',
-                    varService: 'var-service',
-                    varNamespace: 'var-namespace',
-                    varWorkload: 'var-workload'
-                  }}
-                />
-              )}
-            />
-          </MemoryRouter>
-        </Provider>
-      );
-    },
-    10000
-  ); // Increase timeout for this test
+        .catch(err => done.fail(err))
+    ];
+    Promise.all(allMocksDone).then(() => done());
+    mounted = mount(
+      <Provider store={store}>
+        <MemoryRouter>
+          <Route
+            render={props => (
+              <Metrics
+                {...props}
+                namespace="ns"
+                object="svc"
+                objectType={MetricsObjectTypes.WORKLOAD}
+                direction={MetricsDirection.OUTBOUND}
+                grafanaInfo={{
+                  url: 'http://172.30.139.113:3000',
+                  serviceDashboardPath: '/dashboard/db/istio-dashboard',
+                  workloadDashboardPath: '/dashboard/db/istio-dashboard',
+                  varService: 'var-service',
+                  varNamespace: 'var-namespace',
+                  varWorkload: 'var-workload'
+                }}
+              />
+            )}
+          />
+        </MemoryRouter>
+      </Provider>
+    );
+  }, 10000); // Increase timeout for this test
 });

--- a/src/components/SessionTimeout/SessionTimeout.tsx
+++ b/src/components/SessionTimeout/SessionTimeout.tsx
@@ -35,8 +35,9 @@ export class SessionTimeout extends React.Component<SessionTimeoutProps, {}> {
             </Col>
             <Col xs={12} sm={10} md={10} lg={10}>
               <p className={'lead'}>
-                Your session will timeout in {this.props.timeOutCountDown.toFixed()} seconds.<br />Would you like to
-                extend your session for another {extendedTime} minutes?
+                Your session will timeout in {this.props.timeOutCountDown.toFixed()} seconds.
+                <br />
+                Would you like to extend your session for another {extendedTime} minutes?
               </p>
             </Col>
           </Row>

--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -153,7 +153,8 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
       <span style={{ float: 'right' }}>
         <Button onClick={this.fetchIstioObjectDetails}>
           <Icon name="refresh" />
-        </Button>&nbsp;
+        </Button>
+        &nbsp;
         <IstioActionDropdown
           objectName={this.props.match.params.object}
           canDelete={canDelete}

--- a/src/pages/IstioConfigList/FiltersAndSorts.ts
+++ b/src/pages/IstioConfigList/FiltersAndSorts.ts
@@ -8,8 +8,8 @@ export namespace IstioConfigListFilters {
     return item.type === 'adapter'
       ? item.type + '_' + item.adapter!.adapter
       : item.type === 'template'
-        ? item.type + '_' + item.template!.template
-        : item.type;
+      ? item.type + '_' + item.template!.template
+      : item.type;
   };
   export const sortFields: SortField<IstioConfigItem>[] = [
     {

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDestinationRules.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDestinationRules.tsx
@@ -177,7 +177,9 @@ class ServiceInfoDestinationRules extends React.Component<ServiceInfoDestination
               <span style={{ paddingRight: '10px', paddingTop: '3px' }}>{subset.name}</span>{' '}
             </Col>
             <Col xs={4}>
-              {Object.keys(subset.labels).map((key, _) => <Label key={key} name={key} value={subset.labels[key]} />)}
+              {Object.keys(subset.labels).map((key, _) => (
+                <Label key={key} name={key} value={subset.labels[key]} />
+              ))}
             </Col>
             <Col xs={4}>
               <DetailObject name={subset.trafficPolicy ? 'trafficPolicy' : ''} detail={subset.trafficPolicy} />

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPods.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPods.tsx
@@ -154,7 +154,9 @@ class WorkloadPods extends React.Component<WorkloadPodsProps, WorkloadPodsState>
   renderLabels(labels: { [key: string]: string }, u: Number) {
     return (
       <div key="labels" className="label-collection">
-        {Object.keys(labels).map((key, i) => <Label key={'pod_' + u + '_' + i} name={key} value={labels[key]} />)}
+        {Object.keys(labels).map((key, i) => (
+          <Label key={'pod_' + u + '_' + i} name={key} value={labels[key]} />
+        ))}
       </div>
     );
   }

--- a/src/services/__mockData__/getServiceDetail.json
+++ b/src/services/__mockData__/getServiceDetail.json
@@ -204,8 +204,7 @@
     {
       "name": "reviews-v1",
       "templateAnnotations": {
-        "sidecar.istio.io/status":
-          "{\"version\":\"ead37a825b2e46228909b05014a7c281345a42a86033d92bf5c12b4f1cb2d9f4\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":null}"
+        "sidecar.istio.io/status": "{\"version\":\"ead37a825b2e46228909b05014a7c281345a42a86033d92bf5c12b4f1cb2d9f4\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":null}"
       },
       "labels": {
         "app": "reviews",
@@ -230,8 +229,7 @@
     {
       "name": "reviews-v2",
       "templateAnnotations": {
-        "sidecar.istio.io/status":
-          "{\"version\":\"ead37a825b2e46228909b05014a7c281345a42a86033d92bf5c12b4f1cb2d9f4\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":null}"
+        "sidecar.istio.io/status": "{\"version\":\"ead37a825b2e46228909b05014a7c281345a42a86033d92bf5c12b4f1cb2d9f4\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":null}"
       },
       "labels": {
         "app": "reviews",
@@ -256,8 +254,7 @@
     {
       "name": "reviews-v3",
       "templateAnnotations": {
-        "sidecar.istio.io/status":
-          "{\"version\":\"ead37a825b2e46228909b05014a7c281345a42a86033d92bf5c12b4f1cb2d9f4\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":null}"
+        "sidecar.istio.io/status": "{\"version\":\"ead37a825b2e46228909b05014a7c281345a42a86033d92bf5c12b4f1cb2d9f4\",\"initContainers\":[\"istio-init\"],\"containers\":[\"istio-proxy\"],\"volumes\":[\"istio-envoy\",\"istio-certs\"],\"imagePullSecrets\":null}"
       },
       "labels": {
         "app": "reviews",

--- a/src/store/Selectors.ts
+++ b/src/store/Selectors.ts
@@ -15,8 +15,9 @@ export const activeNamespacesSelector = createSelector(
  * Gets a comma separated list of the namespaces for displaying
  * @type {OutputSelector<KialiAppState, any, (res: Namespace[]) => any>}
  */
-export const activeNamespacesAsStringSelector = createSelector(activeNamespaces, namespaces =>
-  namespaces.map(namespace => namespace.name).join(', ')
+export const activeNamespacesAsStringSelector = createSelector(
+  activeNamespaces,
+  namespaces => namespaces.map(namespace => namespace.name).join(', ')
 );
 
 const duration = (state: KialiAppState) => state.userSettings.duration;

--- a/src/types/ServiceInfo.ts
+++ b/src/types/ServiceInfo.ts
@@ -125,10 +125,10 @@ export const validationToSeverity = (object: ObjectValidation): string => {
   return object && object.valid
     ? 'correct'
     : object && !object.valid && errChecks > 0
-      ? 'error'
-      : object && !object.valid && warnChecks > 0
-        ? 'warning'
-        : 'correct';
+    ? 'error'
+    : object && !object.valid && warnChecks > 0
+    ? 'warning'
+    : 'correct';
 };
 
 export const validationToIconName = (object: ObjectValidation): string => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1520,22 +1520,6 @@ bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
   integrity sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==
 
-body-parser@1.18.2:
-  version "1.18.2"
-  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.18.2.tgz#87678a19d84b47d859b83199bd59bce222b10454"
-  integrity sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=
-  dependencies:
-    bytes "3.0.0"
-    content-type "~1.0.4"
-    debug "2.6.9"
-    depd "~1.1.1"
-    http-errors "~1.6.2"
-    iconv-lite "0.4.19"
-    on-finished "~2.3.0"
-    qs "6.5.1"
-    raw-body "2.3.2"
-    type-is "~1.6.15"
-
 body-parser@1.18.3:
   version "1.18.3"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.18.3.tgz#5b292198ffdd553b3a0f20ded0592b956955c8b4"
@@ -2896,12 +2880,7 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
-depd@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.1.tgz#5783b4e1c459f06fa5ca27f991f3d06e7a310359"
-  integrity sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=
-
-depd@~1.1.1, depd@~1.1.2:
+depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
@@ -3527,42 +3506,6 @@ expect@^22.4.0:
     jest-matcher-utils "^22.4.3"
     jest-message-util "^22.4.3"
     jest-regex-util "^22.4.3"
-
-express@4.16.3:
-  version "4.16.3"
-  resolved "https://registry.yarnpkg.com/express/-/express-4.16.3.tgz#6af8a502350db3246ecc4becf6b5a34d22f7ed53"
-  integrity sha1-avilAjUNsyRuzEvs9rWjTSL37VM=
-  dependencies:
-    accepts "~1.3.5"
-    array-flatten "1.1.1"
-    body-parser "1.18.2"
-    content-disposition "0.5.2"
-    content-type "~1.0.4"
-    cookie "0.3.1"
-    cookie-signature "1.0.6"
-    debug "2.6.9"
-    depd "~1.1.2"
-    encodeurl "~1.0.2"
-    escape-html "~1.0.3"
-    etag "~1.8.1"
-    finalhandler "1.1.1"
-    fresh "0.5.2"
-    merge-descriptors "1.0.1"
-    methods "~1.1.2"
-    on-finished "~2.3.0"
-    parseurl "~1.3.2"
-    path-to-regexp "0.1.7"
-    proxy-addr "~2.0.3"
-    qs "6.5.1"
-    range-parser "~1.2.0"
-    safe-buffer "5.1.1"
-    send "0.16.2"
-    serve-static "1.13.2"
-    setprototypeof "1.1.0"
-    statuses "~1.4.0"
-    type-is "~1.6.16"
-    utils-merge "1.0.1"
-    vary "~1.1.2"
 
 express@^4.13.3:
   version "4.16.4"
@@ -4466,16 +4409,6 @@ http-deceiver@^1.2.7:
   resolved "https://registry.yarnpkg.com/http-deceiver/-/http-deceiver-1.2.7.tgz#fa7168944ab9a519d337cb0bec7284dc3e723d87"
   integrity sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=
 
-http-errors@1.6.2:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.2.tgz#0a002cc85707192a7e7946ceedc11155f60ec736"
-  integrity sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=
-  dependencies:
-    depd "1.1.1"
-    inherits "2.0.3"
-    setprototypeof "1.0.3"
-    statuses ">= 1.3.1 < 2"
-
 http-errors@1.6.3, http-errors@~1.6.2, http-errors@~1.6.3:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.3.tgz#8b55680bb4be283a0b5bf4ea2e38580be1d9320d"
@@ -4491,16 +4424,6 @@ http-parser-js@>=0.4.0:
   resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.5.0.tgz#d65edbede84349d0dc30320815a15d39cc3cbbd8"
   integrity sha512-cZdEF7r4gfRIq7ezX9J0T+kQmJNOub71dWbgAXVHDct80TKP4MCETtZQ31xyv38UwgzkWPYF/Xc0ge55dW9Z9w==
 
-http-proxy-middleware@0.19.0:
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-0.19.0.tgz#40992b5901dc44bc7bc3795da81b0b248eca02d8"
-  integrity sha512-Ab/zKDy2B0404mz83bgki0HHv/xqpYKAyFXhopAiJaVAUSJfLYrpBYynTl4ZSUJ7TqrAgjarTsxdX5yBb4unRQ==
-  dependencies:
-    http-proxy "^1.17.0"
-    is-glob "^4.0.0"
-    lodash "^4.17.10"
-    micromatch "^3.1.10"
-
 http-proxy-middleware@~0.17.4:
   version "0.17.4"
   resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz#642e8848851d66f09d4f124912846dbaeb41b833"
@@ -4511,7 +4434,7 @@ http-proxy-middleware@~0.17.4:
     lodash "^4.17.2"
     micromatch "^2.3.11"
 
-http-proxy@^1.16.2, http-proxy@^1.17.0:
+http-proxy@^1.16.2:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.17.0.tgz#7ad38494658f84605e2f6db4436df410f4e5be9a"
   integrity sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==
@@ -4542,11 +4465,6 @@ husky@0.14.3:
     is-ci "^1.0.10"
     normalize-path "^1.0.0"
     strip-indent "^2.0.0"
-
-iconv-lite@0.4.19:
-  version "0.4.19"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
-  integrity sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==
 
 iconv-lite@0.4.23:
   version "0.4.23"
@@ -7512,10 +7430,10 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
-prettier@1.13.4:
-  version "1.13.4"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.13.4.tgz#31bbae6990f13b1093187c731766a14036fa72e6"
-  integrity sha512-emsEZ2bAigL1lq6ssgkpPm1MIBqgeTvcp90NxOP5XDqprub/V/WS2Hfgih3mS7/1dqTUvhG+sxx1Dv8crnVexA==
+prettier@1.15.3:
+  version "1.15.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.15.3.tgz#1feaac5bdd181237b54dbe65d874e02a1472786a"
+  integrity sha512-gAU9AGAPMaKb3NNSUUuhhFAS7SCO4ALTN4nRIn6PJ075Qd28Yn2Ig2ahEJWdJwJmlEBTUfC7mMUSFy8MwsOCfg==
 
 pretty-bytes@^4.0.2:
   version "4.0.2"
@@ -7588,7 +7506,7 @@ prop-types@^15.5.10, prop-types@^15.5.6, prop-types@^15.5.8, prop-types@^15.6.0,
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-proxy-addr@~2.0.3, proxy-addr@~2.0.4:
+proxy-addr@~2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.4.tgz#ecfc733bf22ff8c6f407fa275327b9ab67e48b93"
   integrity sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==
@@ -7659,11 +7577,6 @@ q@^1.1.2:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
-
-qs@6.5.1:
-  version "6.5.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
-  integrity sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==
 
 qs@6.5.2, qs@~6.5.2:
   version "6.5.2"
@@ -7741,16 +7654,6 @@ range-parser@^1.0.3, range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
   integrity sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=
-
-raw-body@2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.3.2.tgz#bcd60c77d3eb93cde0050295c3f379389bc88f89"
-  integrity sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=
-  dependencies:
-    bytes "3.0.0"
-    http-errors "1.6.2"
-    iconv-lite "0.4.19"
-    unpipe "1.0.0"
 
 raw-body@2.3.3:
   version "2.3.3"
@@ -8606,11 +8509,6 @@ rx-lite@*, rx-lite@^4.0.8:
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
   integrity sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=
 
-safe-buffer@5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
-  integrity sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==
-
 safe-buffer@5.1.2, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
@@ -8799,11 +8697,6 @@ setimmediate@^1.0.4, setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
-
-setprototypeof@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.0.3.tgz#66567e37043eeb4f04d91bd658c0cbefb55b8e04"
-  integrity sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=
 
 setprototypeof@1.1.0:
   version "1.1.0"
@@ -9093,7 +8986,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"statuses@>= 1.3.1 < 2", "statuses@>= 1.4.0 < 2":
+"statuses@>= 1.4.0 < 2":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
@@ -9568,10 +9461,10 @@ tslint-config-prettier@^1.10.0:
   resolved "https://registry.yarnpkg.com/tslint-config-prettier/-/tslint-config-prettier-1.15.0.tgz#76b9714399004ab6831fdcf76d89b73691c812cf"
   integrity sha512-06CgrHJxJmNYVgsmeMoa1KXzQRoOdvfkqnJth6XUkNeOz707qxN0WfxfhYwhL5kXHHbYJRby2bqAPKwThlZPhw==
 
-tslint-no-circular-imports@0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/tslint-no-circular-imports/-/tslint-no-circular-imports-0.5.0.tgz#dce659c024165fc1bdd39a6f01479eb4be33cffe"
-  integrity sha1-3OZZwCQWX8G905pvAUeetL4zz/4=
+tslint-no-circular-imports@0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/tslint-no-circular-imports/-/tslint-no-circular-imports-0.6.1.tgz#a91358395a81c067bf104a641f269655057715cd"
+  integrity sha512-XuRgHZKFu6dv7fm/tuilmvynLHgtCTd63/p3744dYVEpnMExp2Jd9IwTiBOGmy5bUDlpTy117vtBcLd028RsBA==
 
 tslint-react@^3.2.0:
   version "3.6.0"
@@ -9629,7 +9522,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-is@~1.6.15, type-is@~1.6.16:
+type-is@~1.6.16:
   version "1.6.16"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.16.tgz#f89ce341541c672b25ee7ae3c73dee3b2be50194"
   integrity sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==
@@ -9657,10 +9550,10 @@ typesafe-actions@2.0.4:
   resolved "https://registry.yarnpkg.com/typesafe-actions/-/typesafe-actions-2.0.4.tgz#31c8f8df3566d549eb52edb64a75997e970c17d0"
   integrity sha512-3qnSDBNtH3mfekmM9w/IVlsqiUT4I5m+mpLp5tV2Ua/28BfaehqUg6eQNC8+cTk+oufbXcubLiWvKS/61qgleQ==
 
-typescript@3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.3.tgz#01b70247a6d3c2467f70c45795ef5ea18ce191d5"
-  integrity sha512-+81MUSyX+BaSo+u2RbozuQk/UWx6hfG0a5gHu4ANEM4sU96XbuIyAB+rWBW1u70c6a5QuZfuYICn3s2UjuHUpA==
+typescript@3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.1.tgz#0b7a04b8cf3868188de914d9568bd030f0c56192"
+  integrity sha512-jw7P2z/h6aPT4AENXDGjcfHTu5CSqzsbZc6YlUIebTyBAq8XaKp78x7VcSh30xwSCcsu5irZkYZUSFP1MrAMbg==
 
 typestyle@2.0.1:
   version "2.0.1"


### PR DESCRIPTION

** Describe the change **
Update the more _compile-time_ oriented packages:

- prettier                      1.13.4  →    1.15.3
-  tslint-no-circular-imports     0.5.0  →     0.6.1
-  typescript                     3.1.3  →     3.2.1


** Issue reference **
https://issues.jboss.org/browse/KIALI-2076

** Backwards compatible? **
Yes

[ ] Is your pull-request introducing changes in behaviour?
No new behaviour
