### PR TITLE
KIALI-2075 Move namespace selector to a secondary masthead

### DIFF
--- a/src/components/DefaultSecondaryMasthead/DefaultSecondaryMasthead.tsx
+++ b/src/components/DefaultSecondaryMasthead/DefaultSecondaryMasthead.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import SecondaryMasthead from '../Nav/SecondaryMasthead';
+import NamespaceDropdownContainer from '../../components/NamespaceDropdown';
+
+export default class DefaultSecondaryMasthead extends React.PureComponent {
+  render() {
+    return (
+      <SecondaryMasthead>
+        <NamespaceDropdownContainer disabled={false} />
+      </SecondaryMasthead>
+    );
+  }
+}

--- a/src/components/GraphFilter/GraphFilter.tsx
+++ b/src/components/GraphFilter/GraphFilter.tsx
@@ -17,7 +17,6 @@ import GraphRefreshContainer from './GraphRefresh';
 import GraphSettingsContainer from './GraphSettings';
 import { HistoryManager, URLParams } from '../../app/History';
 import { ListPagesHelper } from '../../components/ListPage/ListPagesHelper';
-import NamespaceDropdownContainer from '../../components/NamespaceDropdown';
 import { ToolbarDropdown } from '../ToolbarDropdown/ToolbarDropdown';
 import Namespace, { namespacesToString, namespacesFromString } from '../../types/Namespace';
 import { NamespaceActions } from '../../actions/NamespaceAction';
@@ -133,15 +132,10 @@ export class GraphFilter extends React.PureComponent<GraphFilterProps> {
       <>
         <Toolbar>
           <FormGroup className={zeroPaddingLeft}>
-            {this.props.node ? (
+            {this.props.node && (
               <Button className={namespaceStyle} onClick={this.handleNamespaceReturn}>
                 Back to Full Graph...
               </Button>
-            ) : (
-              <>
-                <label className={namespaceStyle}>Namespace</label>
-                <NamespaceDropdownContainer disabled={this.props.disabled} />
-              </>
             )}
           </FormGroup>
           <FormGroup className={zeroPaddingLeft}>

--- a/src/components/NamespaceDropdown.tsx
+++ b/src/components/NamespaceDropdown.tsx
@@ -10,6 +10,26 @@ import NamespaceThunkActions from '../actions/NamespaceThunkActions';
 import { Button, Icon, OverlayTrigger, Popover } from 'patternfly-react';
 import Namespace from '../types/Namespace';
 import { style } from 'typestyle';
+import { PfColors } from './Pf/PfColors';
+
+const namespaceButtonStyle = style({
+  color: PfColors.Black,
+  outline: 'none',
+  $nest: {
+    '&:hover': {
+      textDecoration: 'none',
+      color: PfColors.Black,
+      outline: 'none',
+      boxShadow: 'none'
+    },
+    '&:focus': {
+      textDecoration: 'none',
+      color: PfColors.Black,
+      outline: 'none',
+      boxShadow: 'none'
+    }
+  }
+});
 
 interface NamespaceListType {
   disabled: boolean;
@@ -37,9 +57,9 @@ export class NamespaceDropdown extends React.PureComponent<NamespaceListType, {}
     if (this.props.activeNamespaces.length === 0) {
       return 'Select a namespace';
     } else if (this.props.activeNamespaces.length === 1) {
-      return this.props.activeNamespaces[0].name;
+      return `Namespace: ${this.props.activeNamespaces[0].name}`;
     } else {
-      return `${this.props.activeNamespaces.length} namespaces`;
+      return `Namespaces: ${this.props.activeNamespaces.length} namespaces`;
     }
   }
 
@@ -88,7 +108,7 @@ export class NamespaceDropdown extends React.PureComponent<NamespaceListType, {}
         trigger={['click']}
         rootClose={true}
       >
-        <Button id="graph_settings">
+        <Button bsClass={`btn btn-link btn-lg  ${namespaceButtonStyle}`} id="graph_settings">
           {this.namespaceButtonText()} <Icon name="angle-down" />
         </Button>
       </OverlayTrigger>

--- a/src/components/Nav/RenderPage.tsx
+++ b/src/components/Nav/RenderPage.tsx
@@ -1,25 +1,39 @@
 import React from 'react';
 import { Redirect, Route } from 'react-router-dom';
 import SwitchErrorBoundary from '../SwitchErrorBoundary/SwitchErrorBoundary';
-import { pathRoutes, defaultRoute } from '../../routes';
+import { pathRoutes, defaultRoute, secondaryMastheadRoutes } from '../../routes';
 import PfContainerNavVertical from '../Pf/PfContainerNavVertical';
+import { Path } from '../../types/Routes';
 
 class RenderPage extends React.Component {
-  renderPaths() {
-    return pathRoutes.map((item, index) => {
+  renderPaths(paths: Path[]) {
+    return paths.map((item, index) => {
       return <Route key={index} path={item.path} component={item.component} />;
     });
+  }
+
+  renderPathRoutes() {
+    return this.renderPaths(pathRoutes);
+  }
+
+  renderSecondaryMastheadRoutes() {
+    return this.renderPaths(secondaryMastheadRoutes);
   }
 
   render() {
     return (
       <PfContainerNavVertical>
-        <SwitchErrorBoundary
-          fallBackComponent={() => <h2>Sorry, there was a problem. Try a refresh or navigate to a different page.</h2>}
-        >
-          {this.renderPaths()}
-          <Redirect from="/" to={defaultRoute} />
-        </SwitchErrorBoundary>
+        <div>{this.renderSecondaryMastheadRoutes()}</div>
+        <div className="container-fluid">
+          <SwitchErrorBoundary
+            fallBackComponent={() => (
+              <h2>Sorry, there was a problem. Try a refresh or navigate to a different page.</h2>
+            )}
+          >
+            {this.renderPathRoutes()}
+            <Redirect from="/" to={defaultRoute} />
+          </SwitchErrorBoundary>
+        </div>
       </PfContainerNavVertical>
     );
   }

--- a/src/components/Nav/SecondaryMasthead.tsx
+++ b/src/components/Nav/SecondaryMasthead.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { style } from 'typestyle';
+
+const secondaryMastheadStyle = style({
+  borderBottom: '1px solid #d1d1d1',
+  padding: '10px 15px'
+});
+
+export default class SecondaryMasthead extends React.PureComponent {
+  render() {
+    return <div className={`container-fluid ${secondaryMastheadStyle}`}>{this.props.children}</div>;
+  }
+}

--- a/src/components/Pf/PfContainerNavVertical.tsx
+++ b/src/components/Pf/PfContainerNavVertical.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const PfContainerNavVertical = props => {
-  return <div className="container-fluid container-pf-nav-pf-vertical">{props.children}</div>;
+  return <div className="container-pf-nav-pf-vertical">{props.children}</div>;
 };
 
 export default PfContainerNavVertical;

--- a/src/pages/Graph/GraphPage.tsx
+++ b/src/pages/Graph/GraphPage.tsx
@@ -79,7 +79,8 @@ const NUMBER_OF_DATAPOINTS = 30;
 
 const containerStyle = style({
   minHeight: '350px',
-  height: 'calc(100vh - 60px)' // View height minus top bar height
+  // TODO: try flexbox to remove this calc
+  height: 'calc(100vh - 113px)' // View height minus top bar height minus secondary masthead
 });
 
 const cytoscapeGraphContainerStyle = style({ flex: '1', minWidth: '350px', zIndex: 0, paddingRight: '5px' });

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -11,6 +11,7 @@ import { MenuItem, Path } from './types/Routes';
 import GraphPageContainer from './containers/GraphPageContainer';
 import { ICONS } from './config';
 import ServiceDetailsPageContainer from './containers/ServiceDetailsPageContainer';
+import DefaultSecondaryMasthead from './components/DefaultSecondaryMasthead/DefaultSecondaryMasthead';
 
 /**
  * Return array of objects that describe vertical menu
@@ -130,4 +131,11 @@ const pathRoutes: Path[] = [
   }
 ];
 
-export { defaultRoute, navItems, pathRoutes };
+const secondaryMastheadRoutes: Path[] = [
+  {
+    path: '/graph',
+    component: DefaultSecondaryMasthead
+  }
+];
+
+export { defaultRoute, navItems, pathRoutes, secondaryMastheadRoutes };


### PR DESCRIPTION
 This is only for the graph page, but it prepares for other pages
 to use it.

** Describe the change **

Moves the namespace selector to a secondary masthead in the GraphPage

** Backwards compatible? **

[ ] Is your pull-request introducing changes in behaviour?

Moving the namespace of place, but still works as before

** Screenshot **

![namespace-selector-2-masthead](https://user-images.githubusercontent.com/3845764/49479766-d0f5a400-f7e9-11e8-9e6a-d0a806e55fcc.gif)
