### PR TITLE
KIALI-2086 More optimized metrics API

### DIFF
--- a/src/components/Metrics/__tests__/Metrics.test.tsx
+++ b/src/components/Metrics/__tests__/Metrics.test.tsx
@@ -5,7 +5,7 @@ import { MemoryRouter, Route } from 'react-router';
 
 import Metrics from '../Metrics';
 import * as API from '../../../services/Api';
-import { MetricsDirection, MetricsObjectTypes } from '../../../types/Metrics';
+import { MetricsObjectTypes } from '../../../types/Metrics';
 import { store } from '../../../store/ConfigStore';
 
 window['SVGPathElement'] = a => a;
@@ -29,11 +29,11 @@ const mockAPIToPromise = (func: keyof typeof API, obj: any): Promise<void> => {
 };
 
 const mockServiceMetrics = (metrics: any): Promise<void> => {
-  return mockAPIToPromise('getServiceMetrics', { source: metrics, dest: metrics });
+  return mockAPIToPromise('getServiceMetrics', metrics);
 };
 
 const mockWorkloadMetrics = (metrics: any): Promise<void> => {
-  return mockAPIToPromise('getWorkloadMetrics', { source: metrics, dest: metrics });
+  return mockAPIToPromise('getWorkloadMetrics', metrics);
 };
 
 const mockGrafanaInfo = (info: any): Promise<any> => {
@@ -110,7 +110,7 @@ describe('Metrics for a service', () => {
                 namespace="ns"
                 object="svc"
                 objectType={MetricsObjectTypes.SERVICE}
-                direction={MetricsDirection.INBOUND}
+                direction={'inbound'}
                 grafanaInfo={{
                   url: 'http://172.30.139.113:3000',
                   serviceDashboardPath: '/dashboard/db/istio-dashboard',
@@ -149,7 +149,7 @@ describe('Metrics for a service', () => {
                 namespace="ns"
                 object="svc"
                 objectType={MetricsObjectTypes.SERVICE}
-                direction={MetricsDirection.INBOUND}
+                direction={'inbound'}
                 grafanaInfo={{
                   url: 'http://172.30.139.113:3000',
                   serviceDashboardPath: '/dashboard/db/istio-dashboard',
@@ -170,12 +170,12 @@ describe('Metrics for a service', () => {
     const allMocksDone = [
       mockServiceMetrics({
         metrics: {
-          request_count_in: createMetric('m1')
+          request_count: createMetric('m1')
         },
         histograms: {
-          request_size_in: createHistogram('m3'),
-          request_duration_in: createHistogram('m5'),
-          response_size_in: createHistogram('m7')
+          request_size: createHistogram('m3'),
+          request_duration: createHistogram('m5'),
+          response_size: createHistogram('m7')
         }
       })
         .then(() => {
@@ -195,7 +195,7 @@ describe('Metrics for a service', () => {
                 namespace="ns"
                 object="svc"
                 objectType={MetricsObjectTypes.SERVICE}
-                direction={MetricsDirection.INBOUND}
+                direction={'inbound'}
                 grafanaInfo={{
                   url: 'http://172.30.139.113:3000',
                   serviceDashboardPath: '/dashboard/db/istio-dashboard',
@@ -233,7 +233,7 @@ describe('Inbound Metrics for a workload', () => {
               namespace="ns"
               object="svc"
               objectType={MetricsObjectTypes.WORKLOAD}
-              direction={MetricsDirection.INBOUND}
+              direction={'inbound'}
               grafanaInfo={{
                 url: 'http://172.30.139.113:3000',
                 serviceDashboardPath: '/dashboard/db/istio-dashboard',
@@ -271,7 +271,7 @@ describe('Inbound Metrics for a workload', () => {
                 namespace="ns"
                 object="svc"
                 objectType={MetricsObjectTypes.WORKLOAD}
-                direction={MetricsDirection.INBOUND}
+                direction={'inbound'}
                 grafanaInfo={{
                   url: 'http://172.30.139.113:3000',
                   serviceDashboardPath: '/dashboard/db/istio-dashboard',
@@ -292,12 +292,12 @@ describe('Inbound Metrics for a workload', () => {
     const allMocksDone = [
       mockWorkloadMetrics({
         metrics: {
-          request_count_in: createMetric('m1')
+          request_count: createMetric('m1')
         },
         histograms: {
-          request_size_in: createHistogram('m3'),
-          request_duration_in: createHistogram('m5'),
-          response_size_in: createHistogram('m7')
+          request_size: createHistogram('m3'),
+          request_duration: createHistogram('m5'),
+          response_size: createHistogram('m7')
         }
       })
         .then(() => {
@@ -317,7 +317,7 @@ describe('Inbound Metrics for a workload', () => {
                 namespace="ns"
                 object="svc"
                 objectType={MetricsObjectTypes.WORKLOAD}
-                direction={MetricsDirection.INBOUND}
+                direction={'inbound'}
                 grafanaInfo={{
                   url: 'http://172.30.139.113:3000',
                   serviceDashboardPath: '/dashboard/db/istio-dashboard',
@@ -356,7 +356,7 @@ describe('Outbound Metrics for a workload', () => {
                 namespace="ns"
                 object="svc"
                 objectType={MetricsObjectTypes.WORKLOAD}
-                direction={MetricsDirection.INBOUND}
+                direction={'inbound'}
                 grafanaInfo={{
                   url: 'http://172.30.139.113:3000',
                   serviceDashboardPath: '/dashboard/db/istio-dashboard',
@@ -395,7 +395,7 @@ describe('Outbound Metrics for a workload', () => {
                 namespace="ns"
                 object="svc"
                 objectType={MetricsObjectTypes.WORKLOAD}
-                direction={MetricsDirection.INBOUND}
+                direction={'inbound'}
                 grafanaInfo={{
                   url: 'http://172.30.139.113:3000',
                   serviceDashboardPath: '/dashboard/db/istio-dashboard',
@@ -416,12 +416,12 @@ describe('Outbound Metrics for a workload', () => {
     const allMocksDone = [
       mockWorkloadMetrics({
         metrics: {
-          request_count_out: createMetric('m1')
+          request_count: createMetric('m1')
         },
         histograms: {
-          request_size_out: createHistogram('m3'),
-          request_duration_out: createHistogram('m5'),
-          response_size_out: createHistogram('m7')
+          request_size: createHistogram('m3'),
+          request_duration: createHistogram('m5'),
+          response_size: createHistogram('m7')
         }
       })
         .then(() => {
@@ -441,7 +441,7 @@ describe('Outbound Metrics for a workload', () => {
                 namespace="ns"
                 object="svc"
                 objectType={MetricsObjectTypes.WORKLOAD}
-                direction={MetricsDirection.OUTBOUND}
+                direction={'outbound'}
                 grafanaInfo={{
                   url: 'http://172.30.139.113:3000',
                   serviceDashboardPath: '/dashboard/db/istio-dashboard',

--- a/src/components/MetricsOptions/__tests__/MetricsOptionsBar.test.tsx
+++ b/src/components/MetricsOptions/__tests__/MetricsOptionsBar.test.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { mount, shallow } from 'enzyme';
 import { Provider } from 'react-redux';
 import MetricsOptionsBar from '../MetricsOptionsBar';
-import { MetricsDirection } from '../../../types/Metrics';
 import { store } from '../../../store/ConfigStore';
 
 const optionsChanged = jest.fn();
@@ -14,10 +13,8 @@ describe('MetricsOptionsBar', () => {
         <MetricsOptionsBar
           onOptionsChanged={jest.fn()}
           onRefresh={jest.fn()}
-          onReporterChanged={jest.fn()}
           onLabelsFiltersChanged={jest.fn()}
-          metricReporter={'destination'}
-          direction={MetricsDirection.INBOUND}
+          direction={'inbound'}
           labelValues={new Map()}
         />
       </Provider>
@@ -31,10 +28,8 @@ describe('MetricsOptionsBar', () => {
         <MetricsOptionsBar
           onOptionsChanged={optionsChanged}
           onRefresh={jest.fn()}
-          onReporterChanged={jest.fn()}
           onLabelsFiltersChanged={jest.fn()}
-          metricReporter={'destination'}
-          direction={MetricsDirection.INBOUND}
+          direction={'inbound'}
           labelValues={new Map()}
         />
       </Provider>

--- a/src/components/MetricsOptions/__tests__/__snapshots__/MetricsOptionsBar.test.tsx.snap
+++ b/src/components/MetricsOptions/__tests__/__snapshots__/MetricsOptionsBar.test.tsx.snap
@@ -16,13 +16,11 @@ ShallowWrapper {
     }
   >
     <MetricsOptionsBar
-      direction={0}
+      direction="inbound"
       labelValues={Map {}}
-      metricReporter="destination"
       onLabelsFiltersChanged={[MockFunction]}
       onOptionsChanged={[MockFunction]}
       onRefresh={[MockFunction]}
-      onReporterChanged={[MockFunction]}
     />
   </Provider>,
   Symbol(enzyme.__renderer__): Object {
@@ -38,13 +36,11 @@ ShallowWrapper {
     "key": undefined,
     "nodeType": "class",
     "props": Object {
-      "direction": 0,
+      "direction": "inbound",
       "labelValues": Map {},
-      "metricReporter": "destination",
       "onLabelsFiltersChanged": [MockFunction],
       "onOptionsChanged": [MockFunction],
       "onRefresh": [MockFunction],
-      "onReporterChanged": [MockFunction],
     },
     "ref": null,
     "rendered": null,
@@ -56,13 +52,11 @@ ShallowWrapper {
       "key": undefined,
       "nodeType": "class",
       "props": Object {
-        "direction": 0,
+        "direction": "inbound",
         "labelValues": Map {},
-        "metricReporter": "destination",
         "onLabelsFiltersChanged": [MockFunction],
         "onOptionsChanged": [MockFunction],
         "onRefresh": [MockFunction],
-        "onReporterChanged": [MockFunction],
       },
       "ref": null,
       "rendered": null,

--- a/src/pages/AppDetails/AppDetailsPage.tsx
+++ b/src/pages/AppDetails/AppDetailsPage.tsx
@@ -9,7 +9,7 @@ import * as MessageCenter from '../../utils/MessageCenter';
 import AppMetricsContainer from '../../containers/AppMetricsContainer';
 import { AppHealth } from '../../types/Health';
 import { ListPageLink, TargetPage } from '../../components/ListPage/ListPageLink';
-import { MetricsObjectTypes, MetricsDirection } from '../../types/Metrics';
+import { MetricsObjectTypes } from '../../types/Metrics';
 
 type AppDetailsState = {
   app: App;
@@ -128,7 +128,7 @@ class AppDetails extends React.Component<RouteComponentProps<AppId>, AppDetailsS
                   namespace={this.props.match.params.namespace}
                   object={this.props.match.params.app}
                   objectType={MetricsObjectTypes.APP}
-                  direction={MetricsDirection.INBOUND}
+                  direction={'inbound'}
                 />
               </TabPane>
               <TabPane eventKey="out_metrics" mountOnEnter={true} unmountOnExit={true}>
@@ -136,7 +136,7 @@ class AppDetails extends React.Component<RouteComponentProps<AppId>, AppDetailsS
                   namespace={this.props.match.params.namespace}
                   object={this.props.match.params.app}
                   objectType={MetricsObjectTypes.APP}
-                  direction={MetricsDirection.OUTBOUND}
+                  direction={'outbound'}
                 />
               </TabPane>
             </TabContent>

--- a/src/pages/Graph/SummaryPanelGraph.tsx
+++ b/src/pages/Graph/SummaryPanelGraph.tsx
@@ -136,10 +136,17 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
       reporter: 'destination'
     };
     const promiseHTTP = API.getNamespaceMetrics(authentication(), props.namespaces[0].name, options);
-    options.filters = ['tcp_sent', 'tcp_received'];
     // TCP metrics are only available for reporter="source"
-    options.reporter = 'source';
-    const promiseTCP = API.getNamespaceMetrics(authentication(), props.namespaces[0].name, options);
+    const optionsTCP: MetricsOptions = {
+      filters: ['tcp_sent', 'tcp_received'],
+      queryTime: props.queryTime,
+      duration: props.duration,
+      step: props.step,
+      rateInterval: props.rateInterval,
+      direction: 'inbound',
+      reporter: 'source'
+    };
+    const promiseTCP = API.getNamespaceMetrics(authentication(), props.namespaces[0].name, optionsTCP);
     this.metricsPromise = makeCancelablePromise(mergeMetricsResponses([promiseHTTP, promiseTCP]));
 
     this.metricsPromise.promise

--- a/src/pages/Graph/SummaryPanelGraph.tsx
+++ b/src/pages/Graph/SummaryPanelGraph.tsx
@@ -7,10 +7,11 @@ import * as API from '../../services/Api';
 import { ListPageLink, TargetPage } from '../../components/ListPage/ListPageLink';
 import { Icon } from 'patternfly-react';
 import { authentication } from '../../utils/Authentication';
-import { shouldRefreshData, getDatapoints } from './SummaryPanelCommon';
+import { shouldRefreshData, getDatapoints, mergeMetricsResponses } from './SummaryPanelCommon';
 import { Response } from '../../services/Api';
 import { Metrics } from '../../types/Metrics';
 import { CancelablePromise, makeCancelablePromise } from '../../utils/CancelablePromises';
+import MetricsOptions from 'src/types/MetricsOptions';
 
 type SummaryPanelGraphState = {
   loading: boolean;
@@ -125,25 +126,28 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
   }
 
   private updateRpsChart = (props: SummaryPanelPropType) => {
-    const options = {
+    const options: MetricsOptions = {
+      filters: ['request_count', 'request_error_count'],
       queryTime: props.queryTime,
       duration: props.duration,
       step: props.step,
-      rateInterval: props.rateInterval
+      rateInterval: props.rateInterval,
+      direction: 'inbound',
+      reporter: 'destination'
     };
-    const promise = API.getNamespaceMetrics(authentication(), props.namespaces[0].name, options);
-    this.metricsPromise = makeCancelablePromise(promise);
+    const promiseHTTP = API.getNamespaceMetrics(authentication(), props.namespaces[0].name, options);
+    options.filters = ['tcp_sent', 'tcp_received'];
+    // TCP metrics are only available for reporter="source"
+    options.reporter = 'source';
+    const promiseTCP = API.getNamespaceMetrics(authentication(), props.namespaces[0].name, options);
+    this.metricsPromise = makeCancelablePromise(mergeMetricsResponses([promiseHTTP, promiseTCP]));
 
     this.metricsPromise.promise
       .then(response => {
-        let metrics = response.data.dest.metrics;
-        const reqRates = getDatapoints(metrics['request_count_in'], 'RPS');
-        const errRates = getDatapoints(metrics['request_error_count_in'], 'Error');
-
-        // TCP metrics are only available for reporter="source"
-        metrics = response.data.source.metrics;
-        const tcpSent = getDatapoints(metrics['tcp_sent_in'], 'Sent');
-        const tcpReceived = getDatapoints(metrics['tcp_received_in'], 'Received');
+        const reqRates = getDatapoints(response.data.metrics['request_count'], 'RPS');
+        const errRates = getDatapoints(response.data.metrics['request_error_count'], 'Error');
+        const tcpSent = getDatapoints(response.data.metrics['tcp_sent'], 'Sent');
+        const tcpReceived = getDatapoints(response.data.metrics['tcp_received'], 'Received');
 
         this.setState({
           loading: false,

--- a/src/pages/Graph/SummaryPanelGroup.tsx
+++ b/src/pages/Graph/SummaryPanelGroup.tsx
@@ -172,7 +172,6 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
         const ecOut = metricsOut['request_error_count'];
         const tcpSentOut = metricsOut['tcp_sent'];
         const tcpReceivedOut = metricsOut['tcp_received'];
-        // use dest metrics for incoming
         const rcIn = metricsIn['request_count'];
         const ecIn = metricsIn['request_error_count'];
         const tcpSentIn = metricsIn['tcp_sent'];

--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -12,7 +12,7 @@ import IstioObjectDetails from './IstioObjectDetails';
 import ServiceMetricsContainer from '../../containers/ServiceMetricsContainer';
 import ServiceInfo from './ServiceInfo';
 import { TargetPage, ListPageLink } from '../../components/ListPage/ListPageLink';
-import { MetricsObjectTypes, MetricsDirection } from '../../types/Metrics';
+import { MetricsObjectTypes } from '../../types/Metrics';
 
 type ServiceDetailsState = {
   serviceDetailsInfo: ServiceDetailsInfo;
@@ -268,7 +268,7 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
                     namespace={this.props.match.params.namespace}
                     object={this.props.match.params.service}
                     objectType={MetricsObjectTypes.SERVICE}
-                    direction={MetricsDirection.INBOUND}
+                    direction={'inbound'}
                   />
                 </TabPane>
               </TabContent>

--- a/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -10,7 +10,7 @@ import * as MessageCenter from '../../utils/MessageCenter';
 import WorkloadMetricsContainer from '../../containers/WorkloadMetricsContainer';
 import { WorkloadHealth } from '../../types/Health';
 import { ListPageLink, TargetPage } from '../../components/ListPage/ListPageLink';
-import { MetricsObjectTypes, MetricsDirection } from '../../types/Metrics';
+import { MetricsObjectTypes } from '../../types/Metrics';
 
 type WorkloadDetailsState = {
   workload: Workload;
@@ -184,7 +184,7 @@ class WorkloadDetails extends React.Component<RouteComponentProps<WorkloadId>, W
                   namespace={this.props.match.params.namespace}
                   object={this.props.match.params.workload}
                   objectType={MetricsObjectTypes.WORKLOAD}
-                  direction={MetricsDirection.INBOUND}
+                  direction={'inbound'}
                 />
               </TabPane>
               <TabPane eventKey="out_metrics" mountOnEnter={true} unmountOnExit={true}>
@@ -192,7 +192,7 @@ class WorkloadDetails extends React.Component<RouteComponentProps<WorkloadId>, W
                   namespace={this.props.match.params.namespace}
                   object={this.props.match.params.workload}
                   objectType={MetricsObjectTypes.WORKLOAD}
-                  direction={MetricsDirection.OUTBOUND}
+                  direction={'outbound'}
                 />
               </TabPane>
             </TabContent>

--- a/src/services/__mocks__/Api.ts
+++ b/src/services/__mocks__/Api.ts
@@ -87,8 +87,8 @@ export const getNamespaceMetrics = (namespace: string, params: any) => {
   return Promise.resolve({
     data: {
       metrics: {
-        request_count_in: { matrix: [] },
-        request_error_count_in: { matrix: [] }
+        request_count: { matrix: [] },
+        request_error_count: { matrix: [] }
       }
     }
   });

--- a/src/services/__tests__/ApiMethods.test.tsx.ts
+++ b/src/services/__tests__/ApiMethods.test.tsx.ts
@@ -1,6 +1,7 @@
 import * as API from '../Api';
 import { AxiosError } from 'axios';
 import { authentication } from '../../utils/Authentication';
+import MetricsOptions from 'src/types/MetricsOptions';
 
 describe('#GetErrorMessage', () => {
   const errormsg = 'Error sample';
@@ -78,7 +79,7 @@ describe('#Test Methods return a Promise', () => {
   });
 
   it('#getNamespaceMetrics', () => {
-    const result = API.getNamespaceMetrics(authentication(), 'istio-system', {});
+    const result = API.getNamespaceMetrics(authentication(), 'istio-system', {} as MetricsOptions);
     evaluatePromise(result);
   });
 
@@ -88,7 +89,7 @@ describe('#Test Methods return a Promise', () => {
   });
 
   it('#getAppMetrics', () => {
-    const result = API.getAppMetrics(authentication(), 'istio-system', 'book-info', {});
+    const result = API.getAppMetrics(authentication(), 'istio-system', 'book-info', {} as MetricsOptions);
     evaluatePromise(result);
   });
 

--- a/src/types/Metrics.ts
+++ b/src/types/Metrics.ts
@@ -1,9 +1,4 @@
 export interface Metrics {
-  source: ReporterMetrics;
-  dest: ReporterMetrics;
-}
-
-export interface ReporterMetrics {
   metrics: { [key: string]: MetricGroup };
   histograms: { [key: string]: Histogram };
 }
@@ -26,11 +21,6 @@ export interface TimeSeries {
 
 // First is timestamp, second is value
 export type Datapoint = [number, number];
-
-export enum MetricsDirection {
-  INBOUND,
-  OUTBOUND
-}
 
 export enum MetricsObjectTypes {
   SERVICE,

--- a/src/types/MetricsOptions.ts
+++ b/src/types/MetricsOptions.ts
@@ -8,8 +8,12 @@ interface MetricsOptions {
   filters?: string[];
   quantiles?: string[];
   avg?: boolean;
-  byLabelsIn?: string[];
-  byLabelsOut?: string[];
+  byLabels?: string[];
+  reporter: Reporter;
+  direction: Direction;
 }
+
+export type Reporter = 'source' | 'destination';
+export type Direction = 'inbound' | 'outbound';
 
 export default MetricsOptions;


### PR DESCRIPTION
Reporter and Direction now have to be provided in the query, to avoid fetching too many unnecessary metrics
As a consequence, response model doesn't include them anymore

No functional change expected.

JIRA: https://issues.jboss.org/browse/KIALI-2086
backend PR: https://github.com/kiali/kiali/pull/710