### PR TITLE
KIALI-2132 Only show valid version label for app box children

### DIFF
--- a/src/pages/Graph/SummaryPanelGroup.tsx
+++ b/src/pages/Graph/SummaryPanelGroup.tsx
@@ -206,7 +206,7 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
 
   private renderVersionBadges = () => {
     return this.props.data.summaryTarget
-      .children()
+      .children('node[version]')
       .toArray()
       .map((c, i) => (
         <Label
@@ -231,7 +231,7 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
   };
 
   private renderHttpRates = group => {
-    const nonServiceChildren = group.children('[nodeType != "service"]');
+    const nonServiceChildren = group.children('node[nodeType != "' + NodeType.SERVICE + '"]');
     const incoming = getAccumulatedTrafficRate(nonServiceChildren);
     const outgoing = getAccumulatedTrafficRate(nonServiceChildren.edgesTo('*'));
 
@@ -317,13 +317,10 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
   private renderWorkloadList = (group): any[] => {
     let workloadList: any[] = [];
 
-    group.children().forEach((node, index) => {
+    group.children('node[workload]').forEach((node, index) => {
       const data = nodeData(node);
-
-      if (data.workload) {
-        workloadList.push(<RenderLink key={`node-${index}`} data={data} nodeType={NodeType.WORKLOAD} />);
-        workloadList.push(<span key={`node-comma-${index}`}>, </span>);
-      }
+      workloadList.push(<RenderLink key={`node-${index}`} data={data} nodeType={NodeType.WORKLOAD} />);
+      workloadList.push(<span key={`node-comma-${index}`}>, </span>);
     });
 
     if (workloadList.length > 0) {


### PR DESCRIPTION
- now that app boxes can contain service nodes we can not assume all
  app box child nodes have a version.

![image](https://user-images.githubusercontent.com/2104052/49808079-a9429680-fd29-11e8-8f02-8040516876e0.png)
