### PR TITLE
Trivial: Remove the @types/node from package.json 

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
     "@types/enzyme": "3.1.14",
     "@types/jest": "23.3.5",
     "@types/lodash": "4.14.116",
-    "@types/node": "10.9.4",
     "@types/react": "16.4.17",
     "@types/react-dom": "16.0.9",
     "@types/react-redux": "6.0.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -298,11 +298,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.0.tgz#ea6dcbddbc5b584c83f06c60e82736d8fbb0c235"
   integrity sha512-3TUHC3jsBAB7qVRGxT6lWyYo2v96BMmD2PTcl47H25Lu7UXtFH/2qqmKiVrnel6Ne//0TFYf6uvNX+HW2FRkLQ==
 
-"@types/node@10.9.4":
-  version "10.9.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.9.4.tgz#0f4cb2dc7c1de6096055357f70179043c33e9897"
-  integrity sha512-fCHV45gS+m3hH17zgkgADUSi2RR1Vht6wOZ0jyHP8rjiQra9f+mIcgwPQHllmDocYOstIEbKlxbFDYlgrTPYqw==
-
 "@types/prop-types@*":
   version "15.5.6"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.6.tgz#9c03d3fed70a8d517c191b7734da2879b50ca26c"


### PR DESCRIPTION
** Describe the change **

Remove the `@types/node` from package.json since we don't do any node.js server-side stuff. So no need for the node typing libs.
