### PR TITLE
KIALI-2110 Updates to cytoscape 3.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "axios": "0.18.0",
     "csstips": "0.3.0",
     "csx": "9.0.0",
-    "cytoscape": "3.2.22",
+    "cytoscape": "3.3.1",
     "cytoscape-canvas": "3.0.1",
     "cytoscape-cola": "2.3.0",
     "cytoscape-cose-bilkent": "4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2671,10 +2671,10 @@ cytoscape-dagre@2.2.2:
   dependencies:
     dagre "^0.8.2"
 
-cytoscape@3.2.22:
-  version "3.2.22"
-  resolved "https://registry.yarnpkg.com/cytoscape/-/cytoscape-3.2.22.tgz#5a46c88c760cc733ea8c66dd348e4da08e5956b5"
-  integrity sha512-0eHGQWuE6UTTZ0T3L/p1gYBfAkq/+PAFJWq79PL2qDexPSLnbYi6JivSid31TLIRwxe29MW6TPqZZ6ynMXPK8A==
+cytoscape@3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/cytoscape/-/cytoscape-3.3.1.tgz#fd393d92725ae6c8f38eb64e85f143fc0144815f"
+  integrity sha512-3IIh63Oz/dtiO1ibPb9CWHBPo90JZg/74EI+vDL/hamaP01bQ7Yx1r9oiS4AyTedvlUCio5j7Bu3NtRWxJHryw==
   dependencies:
     heap "^0.2.6"
     lodash.debounce "^4.0.8"


### PR DESCRIPTION
 Fixes a bug that prevents some nodes from being removed when adding
 and removing the unused nodes

