### PR TITLE
[POC] Kiali 1775 - Graph Search

### DIFF
--- a/src/actions/GraphFilterActions.ts
+++ b/src/actions/GraphFilterActions.ts
@@ -6,6 +6,7 @@ import { EdgeLabelMode } from '../types/GraphFilter';
 enum GraphFilterActionKeys {
   SET_EDGE_LABEL_MODE = 'SET_EDGE_LABEL_MODE',
   SET_GRAPH_TYPE = 'SET_GRAPH_TYPE',
+  SET_SEARCH = 'SET_SEARCH',
   // Toggle Actions
   TOGGLE_GRAPH_NODE_LABEL = 'TOGGLE_GRAPH_NODE_LABEL',
   TOGGLE_GRAPH_CIRCUIT_BREAKERS = 'TOGGLE_GRAPH_CIRCUIT_BREAKERS',
@@ -13,6 +14,7 @@ enum GraphFilterActionKeys {
   TOGGLE_GRAPH_MISSING_SIDECARS = 'TOGGLE_GRAPH_MISSING_SIDECARS',
   TOGGLE_GRAPH_SECURITY = 'TOGGLE_GRAPH_SECURITY',
   TOGGLE_LEGEND = 'TOGGLE_LEGEND',
+  TOGGLE_SEARCH_HELP = 'TOGGLE_SEARCH_HELP',
   TOGGLE_SERVICE_NODES = 'TOGGLE_SERVICE_NODES',
   TOGGLE_TRAFFIC_ANIMATION = 'TOGGLE_TRAFFIC_ANIMATION',
   TOGGLE_UNUSED_NODES = 'TOGGLE_UNUSED_NODES',
@@ -23,6 +25,7 @@ enum GraphFilterActionKeys {
 export const GraphFilterActions = {
   setEdgelLabelMode: createStandardAction(GraphFilterActionKeys.SET_EDGE_LABEL_MODE)<EdgeLabelMode>(),
   setGraphType: createStandardAction(GraphFilterActionKeys.SET_GRAPH_TYPE)<GraphType>(),
+  setSearch: createStandardAction(GraphFilterActionKeys.SET_SEARCH)<string>(),
   // Toggle actions
   showGraphFilters: createStandardAction(GraphFilterActionKeys.ENABLE_GRAPH_FILTERS)<boolean>(),
   toggleGraphNodeLabel: createAction(GraphFilterActionKeys.TOGGLE_GRAPH_NODE_LABEL),
@@ -31,6 +34,7 @@ export const GraphFilterActions = {
   toggleGraphCircuitBreakers: createAction(GraphFilterActionKeys.TOGGLE_GRAPH_CIRCUIT_BREAKERS),
   toggleGraphMissingSidecars: createAction(GraphFilterActionKeys.TOGGLE_GRAPH_MISSING_SIDECARS),
   toggleGraphSecurity: createAction(GraphFilterActionKeys.TOGGLE_GRAPH_SECURITY),
+  toggleSearchHelp: createAction(GraphFilterActionKeys.TOGGLE_SEARCH_HELP),
   toggleServiceNodes: createAction(GraphFilterActionKeys.TOGGLE_SERVICE_NODES),
   toggleTrafficAnimation: createAction(GraphFilterActionKeys.TOGGLE_TRAFFIC_ANIMATION),
   toggleUnusedNodes: createAction(GraphFilterActionKeys.TOGGLE_UNUSED_NODES)

--- a/src/actions/GraphFilterActions.ts
+++ b/src/actions/GraphFilterActions.ts
@@ -6,7 +6,6 @@ import { EdgeLabelMode } from '../types/GraphFilter';
 enum GraphFilterActionKeys {
   SET_EDGE_LABEL_MODE = 'SET_EDGE_LABEL_MODE',
   SET_GRAPH_TYPE = 'SET_GRAPH_TYPE',
-  SET_SEARCH = 'SET_SEARCH',
   // Toggle Actions
   TOGGLE_GRAPH_NODE_LABEL = 'TOGGLE_GRAPH_NODE_LABEL',
   TOGGLE_GRAPH_CIRCUIT_BREAKERS = 'TOGGLE_GRAPH_CIRCUIT_BREAKERS',
@@ -25,7 +24,6 @@ enum GraphFilterActionKeys {
 export const GraphFilterActions = {
   setEdgelLabelMode: createStandardAction(GraphFilterActionKeys.SET_EDGE_LABEL_MODE)<EdgeLabelMode>(),
   setGraphType: createStandardAction(GraphFilterActionKeys.SET_GRAPH_TYPE)<GraphType>(),
-  setSearch: createStandardAction(GraphFilterActionKeys.SET_SEARCH)<string>(),
   // Toggle actions
   showGraphFilters: createStandardAction(GraphFilterActionKeys.ENABLE_GRAPH_FILTERS)<boolean>(),
   toggleGraphNodeLabel: createAction(GraphFilterActionKeys.TOGGLE_GRAPH_NODE_LABEL),

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -460,6 +460,8 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
       return;
     }
 
+    console.log('Node: ' + JSON.stringify(target.json()));
+
     const namespace = target.data('namespace');
     const nodeType = target.data('nodeType');
     const workload = target.data('workload');

--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -306,7 +306,7 @@ export class GraphStyles {
         style: nodeSelectedStyle
       },
       {
-        // version group
+        // app box
         selector: `$node > node, node.${COMPOUND_PARENT_NODE_CLASS}`,
         css: {
           'text-valign': 'top',
@@ -405,6 +405,22 @@ export class GraphStyles {
         selector: 'edge.' + DimClass,
         style: {
           opacity: '0.3'
+        }
+      },
+      {
+        selector: 'node.search[^isGroup]',
+        style: {
+          'overlay-color': PfColors.Blue,
+          'overlay-padding': '8px',
+          'overlay-opacity': '0.5'
+        }
+      },
+      {
+        selector: 'edge.search',
+        style: {
+          'overlay-color': PfColors.Blue,
+          'overlay-padding': '8px',
+          'overlay-opacity': '0.5'
         }
       }
     ];

--- a/src/components/GraphFilter/GraphFilter.tsx
+++ b/src/components/GraphFilter/GraphFilter.tsx
@@ -31,14 +31,12 @@ type ReduxProps = {
   edgeLabelMode: EdgeLabelMode;
   graphType: GraphType;
   node?: NodeParamsType;
-  search: string;
   showSearchHelp: boolean;
 
   setActiveNamespaces: (activeNamespaces: Namespace[]) => void;
   setEdgeLabelMode: (edgeLabelMode: EdgeLabelMode) => void;
   setGraphType: (graphType: GraphType) => void;
   setNode: (node?: NodeParamsType) => void;
-  setSearch: (search: string) => void;
   toggleSearchHelp: () => void;
 };
 
@@ -118,9 +116,6 @@ export class GraphFilter extends React.PureComponent<GraphFilterProps> {
       HistoryManager.setParam(URLParams.NAMESPACES, activeNamespacesString);
     }
 
-    if (props.search) {
-      props.setSearch('');
-    }
     if (props.showSearchHelp) {
       props.toggleSearchHelp();
     }
@@ -498,7 +493,6 @@ const mapStateToProps = (state: KialiAppState) => ({
   edgeLabelMode: edgeLabelModeSelector(state),
   graphType: graphTypeSelector(state),
   node: state.graph.node,
-  search: state.graph.filterState.search,
   showSearchHelp: state.graph.filterState.showSearchHelp
 });
 
@@ -508,7 +502,6 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<KialiAppState, void, KialiAp
     setEdgeLabelMode: bindActionCreators(GraphFilterActions.setEdgelLabelMode, dispatch),
     setGraphType: bindActionCreators(GraphFilterActions.setGraphType, dispatch),
     setNode: bindActionCreators(GraphActions.setNode, dispatch),
-    setSearch: bindActionCreators(GraphFilterActions.setSearch, dispatch),
     toggleSearchHelp: bindActionCreators(GraphFilterActions.toggleSearchHelp, dispatch)
   };
 };

--- a/src/components/GraphFilter/GraphSettings.tsx
+++ b/src/components/GraphFilter/GraphSettings.tsx
@@ -13,7 +13,7 @@ import { GraphType } from '../../types/Graph';
 import { PfColors } from '../Pf/PfColors';
 import { Omit } from 'lodash';
 
-type ReduxProps = Omit<Omit<Omit<GraphFilterState, 'search'>, 'showLegend'>, 'showSearchHelp'> & {
+type ReduxProps = Omit<Omit<GraphFilterState, 'showLegend'>, 'showSearchHelp'> & {
   // Dispatch methods
   toggleGraphCircuitBreakers(): void;
   toggleGraphMissingSidecars(): void;

--- a/src/components/GraphFilter/GraphSettings.tsx
+++ b/src/components/GraphFilter/GraphSettings.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { ThunkDispatch } from 'redux-thunk';
 import { bindActionCreators } from 'redux';
-import { Omit } from 'react-router';
 import { HistoryManager, URLParams } from '../../app/History';
 import { ListPagesHelper } from '../../components/ListPage/ListPagesHelper';
 import { GraphFilterState, KialiAppState } from '../../store/Store';
@@ -12,8 +11,9 @@ import { KialiAppAction } from '../../actions/KialiAppAction';
 import { GraphFilterActions } from '../../actions/GraphFilterActions';
 import { GraphType } from '../../types/Graph';
 import { PfColors } from '../Pf/PfColors';
+import { Omit } from 'lodash';
 
-type ReduxProps = Omit<GraphFilterState, 'showLegend'> & {
+type ReduxProps = Omit<Omit<Omit<GraphFilterState, 'search'>, 'showLegend'>, 'showSearchHelp'> & {
   // Dispatch methods
   toggleGraphCircuitBreakers(): void;
   toggleGraphMissingSidecars(): void;

--- a/src/pages/Graph/GraphHelpSearch.tsx
+++ b/src/pages/Graph/GraphHelpSearch.tsx
@@ -1,0 +1,304 @@
+import * as React from 'react';
+import Draggable from 'react-draggable';
+import {
+  Button,
+  Icon,
+  Nav,
+  NavItem,
+  TabContainer,
+  TabContent,
+  TabPane,
+  Table,
+  TablePfProvider
+} from 'patternfly-react';
+import * as resolve from 'table-resolver';
+
+export interface GraphHelpSearchProps {
+  onClose: () => void;
+  className?: string;
+}
+
+export default class GraphHelpSearch extends React.Component<GraphHelpSearchProps> {
+  headerFormat = (label, { column }) => <Table.Heading className={column.property}>{label}</Table.Heading>;
+  cellFormat = (value, { column }) => {
+    const props = column.cell.props;
+    const className = props ? props.align : '';
+
+    return <Table.Cell className={className}>{value}</Table.Cell>;
+  };
+
+  constructor(props: GraphHelpSearchProps) {
+    super(props);
+  }
+
+  edgeColumns = () => {
+    return {
+      columns: [
+        {
+          property: 'c',
+          header: {
+            label: 'Criteria',
+            formatters: [this.headerFormat]
+          },
+          cell: {
+            formatters: [this.cellFormat],
+            props: {
+              align: 'text-left'
+            }
+          }
+        }
+      ]
+    };
+  };
+
+  exampleColumns = () => {
+    return {
+      columns: [
+        {
+          property: 'e',
+          header: {
+            label: 'Expression',
+            formatters: [this.headerFormat]
+          },
+          cell: {
+            formatters: [this.cellFormat],
+            props: {
+              align: 'text-left'
+            }
+          }
+        },
+        {
+          property: 'd',
+          header: {
+            label: 'Description',
+            formatters: [this.headerFormat]
+          },
+          cell: {
+            formatters: [this.cellFormat],
+            props: {
+              align: 'text-left'
+            }
+          }
+        }
+      ]
+    };
+  };
+
+  nodeColumns = () => {
+    return {
+      columns: [
+        {
+          property: 'c',
+          header: {
+            label: 'Criteria',
+            formatters: [this.headerFormat]
+          },
+          cell: {
+            formatters: [this.cellFormat],
+            props: {
+              align: 'text-left'
+            }
+          }
+        }
+      ]
+    };
+  };
+
+  operatorColumns = () => {
+    return {
+      columns: [
+        {
+          property: 'o',
+          header: {
+            label: 'Operator',
+            formatters: [this.headerFormat]
+          },
+          cell: {
+            formatters: [this.cellFormat],
+            props: {
+              align: 'text-center'
+            }
+          }
+        },
+        {
+          property: 'd',
+          header: {
+            label: 'Description',
+            formatters: [this.headerFormat]
+          },
+          cell: {
+            formatters: [this.cellFormat],
+            props: {
+              align: 'text-left'
+            }
+          }
+        }
+      ]
+    };
+  };
+
+  render() {
+    console.log('Render Help!');
+    const className = this.props.className ? this.props.className : '';
+    return (
+      <Draggable>
+        <div
+          className={`modal-content ${className}`}
+          style={{
+            width: '600px',
+            height: '500px',
+            right: '0',
+            top: '10px',
+            zIndex: 9999,
+            position: 'absolute'
+          }}
+        >
+          <div className="modal-header">
+            <Button className="close" bsClass="" onClick={this.props.onClose}>
+              <Icon title="Close" type="pf" name="close" />
+            </Button>
+            <span className="modal-title">Help: Graph Search</span>
+          </div>
+          <TabContainer id="basic-tabs" defaultActiveKey="examples">
+            <div>
+              <Nav bsClass="nav nav-tabs nav-tabs-pf">
+                <NavItem eventKey="examples">
+                  <div>Examples</div>
+                </NavItem>
+                <NavItem eventKey="nodes">
+                  <div>Nodes</div>
+                </NavItem>
+                <NavItem eventKey="edges">
+                  <div>Edges</div>
+                </NavItem>
+                <NavItem eventKey="operators">
+                  <div>Operators</div>
+                </NavItem>
+              </Nav>
+              <TabContent>
+                <TabPane eventKey="examples">
+                  <TablePfProvider
+                    striped={true}
+                    bordered={true}
+                    hover={true}
+                    dataTable={true}
+                    columns={this.exampleColumns().columns}
+                  >
+                    <Table.Header headerRows={resolve.headerRows(this.exampleColumns())} />
+                    <Table.Body
+                      rowKey="id"
+                      rows={[
+                        { id: 'e0', e: 'product', d: `"name search": app, service or workloads containing  'product'` },
+                        { id: 'e1', e: 'app *= product', d: `apps containing 'product'` },
+                        {
+                          id: 'e2',
+                          e: 'app = details and version=v1',
+                          d: `apps named 'details' and having version 'v1'`
+                        },
+                        { id: 'e3', e: '!sc', d: `nodes without a sidecar` },
+                        { id: 'e4', e: 'httpin > 0.5', d: `nodes with incoming http rate > 0.5 rps` },
+                        { id: 'e5', e: 'tcpout > 1000', d: `nodes with outgoing tcp rates > 1000 bps` },
+                        { id: 'e6', e: 'http > 0.5', d: `edges with http rate > 0.5 rps` },
+                        {
+                          id: 'e7',
+                          e: 'rt > 500  (requires response time edge labels)',
+                          d: `edges with response time > 500ms`
+                        },
+                        { id: 'e8', e: 'Hint #1', d: 'Expressions can not combine "and" with "or"' },
+                        { id: 'e9', e: 'Hint #2', d: 'Expressions can not combine "and" with a name search' }
+                      ]}
+                    />
+                  </TablePfProvider>
+                </TabPane>
+                <TabPane eventKey="nodes" mountOnEnter={true} unmountOnExit={true}>
+                  <TablePfProvider
+                    striped={true}
+                    bordered={true}
+                    hover={true}
+                    dataTable={true}
+                    columns={this.nodeColumns().columns}
+                  >
+                    <Table.Header headerRows={resolve.headerRows(this.nodeColumns())} />
+                    <Table.Body
+                      rowKey="id"
+                      rows={[
+                        { id: 'nc0', c: 'httpin <op> <val> (requests per sec)' },
+                        { id: 'nc1', c: 'httpout <op> <val> (requests per sec)' },
+                        { id: 'nc2', c: 'ns | namespace <op> <val>' },
+                        { id: 'nc3', c: 'svc | service <op> <val>' },
+                        { id: 'nc4', c: 'version <op> <val>' },
+                        { id: 'nc5', c: 'tcpin <op> <val> (bytes per sec)' },
+                        { id: 'nc6', c: 'tcpout <op> <val> (bytes per sec)' },
+                        { id: 'nc7', c: 'wl | workload <op> <val>' },
+                        { id: 'nc8', c: 'appnode' },
+                        { id: 'nc9', c: 'cb | circuitbreaker' },
+                        { id: 'nc10', c: 'outside | outsider' },
+                        { id: 'nc11', c: 'sc | sidecar' },
+                        { id: 'nc12', c: 'svcnode | servicenode' },
+                        { id: 'nc13', c: 'serviceentry' },
+                        { id: 'nc14', c: 'unknown' },
+                        { id: 'nc15', c: 'unused' },
+                        { id: 'nc16', c: 'vs | virtualservice' },
+                        { id: 'nc17', c: 'wlnode | workloadnode' }
+                      ]}
+                    />
+                  </TablePfProvider>
+                </TabPane>
+                <TabPane eventKey="edges" mountOnEnter={true} unmountOnExit={true}>
+                  <TablePfProvider
+                    striped={true}
+                    bordered={true}
+                    hover={true}
+                    dataTable={true}
+                    columns={this.edgeColumns().columns}
+                  >
+                    <Table.Header headerRows={resolve.headerRows(this.edgeColumns())} />
+                    <Table.Body
+                      rowKey="id"
+                      rows={[
+                        { id: 'ec0', c: 'http <op> <val> (requests per sec)' },
+                        { id: 'ec1', c: '%err | percenterr <op> <val>' },
+                        { id: 'ec2', c: '%traffic | percenttraffic <op> <val>' },
+                        { id: 'ec3', c: 'rt | responsetime <op> <val> (millis)' },
+                        { id: 'ec4', c: 'tcp <op> <val> (bytes per sec)' },
+                        { id: 'ec5', c: 'tcpout <op> <val> (bytes per sec)' },
+                        { id: 'ec6', c: 'wl | workload <op> <val>' },
+                        { id: 'ec7', c: 'mtls' }
+                      ]}
+                    />
+                  </TablePfProvider>
+                </TabPane>
+                <TabPane eventKey="operators" mountOnEnter={true} unmountOnExit={true}>
+                  <TablePfProvider
+                    striped={true}
+                    bordered={true}
+                    hover={true}
+                    dataTable={true}
+                    columns={this.operatorColumns().columns}
+                  >
+                    <Table.Header headerRows={resolve.headerRows(this.operatorColumns())} />
+                    <Table.Body
+                      rows={[
+                        { id: 'o0', o: '!', d: `negation, unary expressions only` },
+                        { id: 'o1', o: '=', d: `equals` },
+                        { id: 'o2', o: '!=', d: `not equals` },
+                        { id: 'o3', o: '^=', d: `starts with, strings only` },
+                        { id: 'o4', o: '$=', d: `ends with, strings only` },
+                        { id: 'o5', o: '*=', d: 'contains, strings only' },
+                        { id: 'o6', o: '>', d: `greater than, numbers only` },
+                        { id: 'o7', o: '>=', d: `greater than or equals, numbers only` },
+                        { id: 'o8', o: '<', d: `less than, numbers only` },
+                        { id: 'o9', o: '<=', d: `less than or equals, numbers only` }
+                      ]}
+                      rowKey="id"
+                    />
+                  </TablePfProvider>
+                </TabPane>
+              </TabContent>
+            </div>
+          </TabContainer>
+        </div>
+      </Draggable>
+    );
+  }
+}

--- a/src/pages/Graph/GraphPage.tsx
+++ b/src/pages/Graph/GraphPage.tsx
@@ -281,7 +281,11 @@ export default class GraphPage extends React.Component<GraphPageProps, GraphPage
           </Breadcrumb>
           <div>
             {/* Use empty div to reset the flex, this component doesn't seem to like that. It renders all its contents in the center */}
-            <GraphFilterContainer disabled={this.props.isLoading} onRefresh={this.handleRefreshClick} />
+            <GraphFilterContainer
+              cytoscapeGraphRef={this.cytoscapeGraphRef}
+              disabled={this.props.isLoading}
+              onRefresh={this.handleRefreshClick}
+            />
           </div>
           <FlexView grow={true} className={cytoscapeGraphWrapperDivStyle}>
             <ErrorBoundary

--- a/src/reducers/GraphDataState.ts
+++ b/src/reducers/GraphDataState.ts
@@ -20,10 +20,12 @@ export const INITIAL_GRAPH_STATE: GraphState = {
   filterState: {
     edgeLabelMode: EdgeLabelMode.HIDE,
     graphType: GraphType.VERSIONED_APP,
+    search: '',
     showCircuitBreakers: true,
     showLegend: false,
     showMissingSidecars: true,
     showNodeLabels: true,
+    showSearchHelp: false,
     showSecurity: false,
     showServiceNodes: true,
     showTrafficAnimation: false,
@@ -76,6 +78,7 @@ const graphDataState = (state: GraphState = INITIAL_GRAPH_STATE, action: KialiAp
       newState.sidePanelInfo = INITIAL_GRAPH_STATE.sidePanelInfo;
       break;
     // Filter actions
+    //
     case getType(GraphFilterActions.setEdgelLabelMode):
       newState.filterState.edgeLabelMode = action.payload;
       break;
@@ -85,6 +88,9 @@ const graphDataState = (state: GraphState = INITIAL_GRAPH_STATE, action: KialiAp
       newState.graphData = INITIAL_GRAPH_STATE.graphData;
       newState.graphDataTimestamp = INITIAL_GRAPH_STATE.graphDataTimestamp;
       newState.sidePanelInfo = INITIAL_GRAPH_STATE.sidePanelInfo;
+      break;
+    case getType(GraphFilterActions.setSearch):
+      newState.filterState.search = action.payload;
       break;
     case getType(GraphFilterActions.toggleLegend):
       newState.filterState.showLegend = !state.filterState.showLegend;
@@ -103,6 +109,9 @@ const graphDataState = (state: GraphState = INITIAL_GRAPH_STATE, action: KialiAp
       break;
     case getType(GraphFilterActions.toggleGraphSecurity):
       newState.filterState.showSecurity = !state.filterState.showSecurity;
+      break;
+    case getType(GraphFilterActions.toggleSearchHelp):
+      newState.filterState.showSearchHelp = !state.filterState.showSearchHelp;
       break;
     case getType(GraphFilterActions.toggleServiceNodes):
       newState.filterState.showServiceNodes = !state.filterState.showServiceNodes;

--- a/src/reducers/GraphDataState.ts
+++ b/src/reducers/GraphDataState.ts
@@ -20,7 +20,6 @@ export const INITIAL_GRAPH_STATE: GraphState = {
   filterState: {
     edgeLabelMode: EdgeLabelMode.HIDE,
     graphType: GraphType.VERSIONED_APP,
-    search: '',
     showCircuitBreakers: true,
     showLegend: false,
     showMissingSidecars: true,
@@ -88,9 +87,6 @@ const graphDataState = (state: GraphState = INITIAL_GRAPH_STATE, action: KialiAp
       newState.graphData = INITIAL_GRAPH_STATE.graphData;
       newState.graphDataTimestamp = INITIAL_GRAPH_STATE.graphDataTimestamp;
       newState.sidePanelInfo = INITIAL_GRAPH_STATE.sidePanelInfo;
-      break;
-    case getType(GraphFilterActions.setSearch):
-      newState.filterState.search = action.payload;
       break;
     case getType(GraphFilterActions.toggleLegend):
       newState.filterState.showLegend = !state.filterState.showLegend;

--- a/src/reducers/__tests__/GraphDataState.test.ts
+++ b/src/reducers/__tests__/GraphDataState.test.ts
@@ -19,6 +19,7 @@ describe('GraphDataState', () => {
         showLegend: false,
         showMissingSidecars: true,
         showNodeLabels: true,
+        showSearchHelp: false,
         showSecurity: false,
         showServiceNodes: true,
         showTrafficAnimation: false,

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -24,7 +24,6 @@ export interface GraphFilterState {
   edgeLabelMode: EdgeLabelMode;
   graphType: GraphType;
   // search props
-  search: string;
   showSearchHelp: boolean;
   // Toggle props
   showCircuitBreakers: boolean;

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -23,6 +23,9 @@ export interface GraphFilterState {
   // dropdown props
   edgeLabelMode: EdgeLabelMode;
   graphType: GraphType;
+  // search props
+  search: string;
+  showSearchHelp: boolean;
   // Toggle props
   showCircuitBreakers: boolean;
   showLegend: boolean;


### PR DESCRIPTION
This adds a new DSL-based search to the graph, allowing for node or edge highlighting for the match criteria.  It can help locate items too small to distinguish via label, badge, icon, etc,  or identify usage patterns, distinguish a namespace, and other various things.

It is currently POC as it is not yet reviewed by UX.