### PR TITLE
KIALI-2144 Fix About modal when git commits are unknown or malformed

### DIFF
--- a/src/components/About/AboutUIModal.tsx
+++ b/src/components/About/AboutUIModal.tsx
@@ -31,11 +31,13 @@ class AboutUIModal extends React.Component<AboutUIModalProps, AboutUIModalState>
 
   render() {
     const uiVersion =
-      process.env.REACT_APP_GIT_HASH === ''
+      process.env.REACT_APP_GIT_HASH === '' ||
+      process.env.REACT_APP_GIT_HASH === 'unknown'
         ? process.env.REACT_APP_VERSION
         : `${process.env.REACT_APP_VERSION} (${process.env.REACT_APP_GIT_HASH})`;
     const coreVersion =
-      this.props.status[KIALI_CORE_COMMIT_HASH] === ''
+      this.props.status[KIALI_CORE_COMMIT_HASH] === '' ||
+      this.props.status[KIALI_CORE_COMMIT_HASH] === 'unknown'
         ? this.props.status[KIALI_CORE_VERSION]
         : `${this.props.status[KIALI_CORE_VERSION]} (${this.props.status[KIALI_CORE_COMMIT_HASH]})`;
 


### PR DESCRIPTION
** Describe the change **

When the commit hash is not available for either the UI or core, hide the commit hash from the about page.

** Issue reference **

https://issues.jboss.org/browse/KIALI-2144

** Backwards compatible? **

Yes.

** Screenshot **

![](https://i.imgur.com/UxhnTKb.png)