### PR TITLE
KIALI-2192 Avoid propagation of layout events up to cy for the local …

### DIFF
--- a/src/components/CytoscapeGraph/Layout/GroupCompoundLayout.ts
+++ b/src/components/CytoscapeGraph/Layout/GroupCompoundLayout.ts
@@ -126,6 +126,10 @@ export default class GroupCompoundLayout {
 
       // We expect a discrete layout here
       const compoundLayout = targetElements.layout(compoundLayoutOptions);
+      compoundLayout.on('layoutstart layoutready layoutstop', evt => {
+        // Avoid to propagate any local layout events up to cy, this would yield a global operation when not all nodes are ready.
+        return false;
+      });
       compoundLayout.run();
 
       const boundingBox = targetElements.boundingBox();


### PR DESCRIPTION
…layout

** Describe the change **

It avoids propagation of the local layout events (the layout used for the compound nodes) to cy.

It was a problem, because the layout stop triggered a fit operation on all nodes, that required all nodes to have a proper position (no overlaps), this wasn't the case when only a subset was in place.
