### PR TITLE
KIALI-1185 Implement Openshift OAuth support

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "@kiali/kiali-ui",
   "version": "0.15.0",
   "description": "React UI for [Kiali](https://github.com/kiali/kiali).",
-  "proxy": "https://kiali-istio-system.10.7.0.11.nip.io",
   "keywords": [
     "istio service mesh",
     "kiali",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@kiali/kiali-ui",
   "version": "0.15.0",
   "description": "React UI for [Kiali](https://github.com/kiali/kiali).",
+  "proxy": "https://kiali-istio-system.10.7.0.11.nip.io",
   "keywords": [
     "istio service mesh",
     "kiali",
@@ -72,6 +73,7 @@
     "json-beautify": "1.0.1",
     "lodash": "4.17.11",
     "logfmt": "^1.2.1",
+    "moment": "2.23.0",
     "patternfly": "3.59.1",
     "patternfly-react": "2.25.3",
     "patternfly-react-extensions": "2.16.8",

--- a/src/actions/JaegerThunkActions.ts
+++ b/src/actions/JaegerThunkActions.ts
@@ -63,7 +63,7 @@ export const JaegerThunkActions = {
         return Promise.resolve();
       }
       /** Get the token storage in redux-store */
-      const token = getState().authentication.token!.token;
+      const token = getState().authentication.session!.token;
       /** generate Token */
       const auth = `Bearer ${token}`;
 

--- a/src/actions/LoginActions.ts
+++ b/src/actions/LoginActions.ts
@@ -1,3 +1,5 @@
+import { RawDate } from '../types/Common';
+
 import { ActionType, createAction } from 'typesafe-actions';
 import { LoginSession, LoginStatus } from '../store/Store';
 
@@ -13,6 +15,7 @@ export interface LoginPayload {
   status: LoginStatus;
   session?: LoginSession;
   error?: any;
+  uiExpiresOn: RawDate;
 }
 
 // synchronous action creators
@@ -29,7 +32,8 @@ export const LoginActions = {
     resolve({
       status: LoginStatus.loggedIn,
       session: session,
-      error: undefined
+      error: undefined,
+      uiExpiresOn: session.expiresOn
     } as LoginPayload)
   ),
   loginFailure: createAction(LoginActionKeys.LOGIN_FAILURE, resolve => (error: any) =>

--- a/src/actions/LoginActions.ts
+++ b/src/actions/LoginActions.ts
@@ -1,5 +1,5 @@
 import { ActionType, createAction } from 'typesafe-actions';
-import { Session, LoginStatus } from '../store/Store';
+import { LoginSession, LoginStatus } from '../store/Store';
 
 enum LoginActionKeys {
   LOGIN_REQUEST = 'LOGIN_REQUEST',
@@ -11,21 +11,21 @@ enum LoginActionKeys {
 
 export interface LoginPayload {
   status: LoginStatus;
-  session?: Session;
+  session?: LoginSession;
   error?: any;
 }
 
 // synchronous action creators
 export const LoginActions = {
   loginRequest: createAction(LoginActionKeys.LOGIN_REQUEST),
-  loginExtend: createAction(LoginActionKeys.LOGIN_EXTEND, resolve => (session: Session) =>
+  loginExtend: createAction(LoginActionKeys.LOGIN_EXTEND, resolve => (session: LoginSession) =>
     resolve({
       status: LoginStatus.loggedIn,
       session: session,
       error: undefined
     } as LoginPayload)
   ),
-  loginSuccess: createAction(LoginActionKeys.LOGIN_SUCCESS, resolve => (session: Session) =>
+  loginSuccess: createAction(LoginActionKeys.LOGIN_SUCCESS, resolve => (session: LoginSession) =>
     resolve({
       status: LoginStatus.loggedIn,
       session: session,

--- a/src/actions/LoginActions.ts
+++ b/src/actions/LoginActions.ts
@@ -21,13 +21,15 @@ export const LoginActions = {
   loginExtend: createAction(LoginActionKeys.LOGIN_EXTEND, resolve => (session: Session) =>
     resolve({
       status: LoginStatus.loggedIn,
-      session: session
+      session: session,
+      error: undefined
     } as LoginPayload)
   ),
   loginSuccess: createAction(LoginActionKeys.LOGIN_SUCCESS, resolve => (session: Session) =>
     resolve({
       status: LoginStatus.loggedIn,
-      session: session
+      session: session,
+      error: undefined
     } as LoginPayload)
   ),
   loginFailure: createAction(LoginActionKeys.LOGIN_FAILURE, resolve => (error: any) =>
@@ -40,7 +42,8 @@ export const LoginActions = {
   logoutSuccess: createAction(LoginActionKeys.LOGOUT_SUCCESS, resolve => () =>
     resolve({
       status: LoginStatus.loggedOut,
-      session: undefined
+      session: undefined,
+      error: undefined
     } as LoginPayload)
   )
 };

--- a/src/actions/LoginActions.ts
+++ b/src/actions/LoginActions.ts
@@ -1,6 +1,5 @@
 import { ActionType, createAction } from 'typesafe-actions';
-import { Token } from '../store/Store';
-import { config } from '../config/config';
+import { Session, LoginStatus } from '../store/Store';
 
 enum LoginActionKeys {
   LOGIN_REQUEST = 'LOGIN_REQUEST',
@@ -11,43 +10,38 @@ enum LoginActionKeys {
 }
 
 export interface LoginPayload {
-  logged?: boolean;
-  sessionTimeOut?: number;
-  token: Token;
-  username: string;
-}
-
-export interface LoginFailurePayload {
-  error: any;
+  status: LoginStatus;
+  session?: Session;
+  error?: any;
 }
 
 // synchronous action creators
 export const LoginActions = {
   loginRequest: createAction(LoginActionKeys.LOGIN_REQUEST),
-  loginExtend: createAction(
-    LoginActionKeys.LOGIN_EXTEND,
-    resolve => (token: Token, username: string, currentTimeOut: number) =>
-      resolve({
-        token: token,
-        username: username,
-        sessionTimeOut: currentTimeOut + config.session.extendedSessionTimeOut
-      } as LoginPayload)
+  loginExtend: createAction(LoginActionKeys.LOGIN_EXTEND, resolve => (session: Session) =>
+    resolve({
+      status: LoginStatus.loggedIn,
+      session: session
+    } as LoginPayload)
   ),
-  loginSuccess: createAction(
-    LoginActionKeys.LOGIN_SUCCESS,
-    resolve => (token: Token, username: string, currentTimeOut?: number) =>
-      resolve({
-        token: token,
-        username: username,
-        logged: true,
-        sessionTimeOut: currentTimeOut || new Date().getTime() + config.session.sessionTimeOut
-      } as LoginPayload)
+  loginSuccess: createAction(LoginActionKeys.LOGIN_SUCCESS, resolve => (session: Session) =>
+    resolve({
+      status: LoginStatus.loggedIn,
+      session: session
+    } as LoginPayload)
   ),
   loginFailure: createAction(LoginActionKeys.LOGIN_FAILURE, resolve => (error: any) =>
-    resolve({ error: error } as LoginFailurePayload)
+    resolve({
+      status: LoginStatus.error,
+      session: undefined,
+      error: error
+    } as LoginPayload)
   ),
   logoutSuccess: createAction(LoginActionKeys.LOGOUT_SUCCESS, resolve => () =>
-    resolve({ logged: false } as LoginPayload)
+    resolve({
+      status: LoginStatus.loggedOut,
+      session: undefined
+    } as LoginPayload)
   )
 };
 

--- a/src/actions/LoginThunkActions.ts
+++ b/src/actions/LoginThunkActions.ts
@@ -45,8 +45,8 @@ const loginSuccess = async (dispatch: KialiDispatch, session: LoginSession) => {
 // The `data` argument is defined as `any` because the dispatchers receive
 // different kinds of data (such as e-mail/password, tokens).
 const performLogin = (dispatch: KialiDispatch, state: KialiAppState, data?: any) => {
-  const bail = (error: Login.LoginResult) =>
-    data ? dispatch(LoginActions.loginFailure(error)) : dispatch(LoginActions.logoutSuccess());
+  const bail = (loginResult: Login.LoginResult) =>
+    data ? dispatch(LoginActions.loginFailure(loginResult.error)) : dispatch(LoginActions.logoutSuccess());
 
   Dispatcher.prepare().then((result: AuthResult) => {
     if (result === AuthResult.CONTINUE) {

--- a/src/actions/LoginThunkActions.ts
+++ b/src/actions/LoginThunkActions.ts
@@ -17,7 +17,10 @@ type KialiDispatch = ThunkDispatch<KialiAppState, void, KialiAppAction>;
 const Dispatcher = new Login.LoginDispatcher();
 
 const shouldRelogin = (state?: LoginState): boolean =>
-  !state || !state.session || moment(state.session!.expiresOn).diff(moment()) > 0;
+  !state ||
+  !state.session ||
+  moment(state.session!.expiresOn).diff(moment()) > 0 ||
+  moment(state.uiExpiresOn).diff(moment()) > 0;
 
 const loginSuccess = async (dispatch: KialiDispatch, session: LoginSession) => {
   const authHeader = `Bearer ${session.token}`;

--- a/src/actions/LoginThunkActions.ts
+++ b/src/actions/LoginThunkActions.ts
@@ -10,7 +10,7 @@ import * as API from '../services/Api';
 import { ServerConfigActions } from './ServerConfigActions';
 
 import * as Login from '../services/Login';
-import { AuthResult } from 'src/types/Auth';
+import { AuthResult } from '../types/Auth';
 
 type KialiDispatch = ThunkDispatch<KialiAppState, void, KialiAppAction>;
 

--- a/src/actions/NamespaceThunkActions.ts
+++ b/src/actions/NamespaceThunkActions.ts
@@ -32,11 +32,14 @@ const NamespaceThunkActions = {
     // a cached value is already available.
     return (dispatch: ThunkDispatch<KialiAppState, void, KialiAppAction>, getState: () => KialiAppState) => {
       if (shouldFetchNamespaces(getState())) {
-        if (getState()['authentication']['token'] === undefined) {
+        const state = getState().authentication;
+
+        if (!state || !state.session) {
           return Promise.resolve();
         }
+
         // Dispatch a thunk from thunk!
-        return dispatch(NamespaceThunkActions.asyncFetchNamespaces(getState().authentication.session!.token));
+        return dispatch(NamespaceThunkActions.asyncFetchNamespaces(state.session.token));
       } else {
         // Let the calling code know there's nothing to wait for.
         return Promise.resolve();

--- a/src/actions/NamespaceThunkActions.ts
+++ b/src/actions/NamespaceThunkActions.ts
@@ -35,9 +35,8 @@ const NamespaceThunkActions = {
         if (getState()['authentication']['token'] === undefined) {
           return Promise.resolve();
         }
-        const auth = 'Bearer ' + getState().authentication.token!.token;
         // Dispatch a thunk from thunk!
-        return dispatch(NamespaceThunkActions.asyncFetchNamespaces(auth));
+        return dispatch(NamespaceThunkActions.asyncFetchNamespaces(getState().authentication.session!.token));
       } else {
         // Let the calling code know there's nothing to wait for.
         return Promise.resolve();

--- a/src/actions/NamespaceThunkActions.ts
+++ b/src/actions/NamespaceThunkActions.ts
@@ -3,6 +3,7 @@ import { KialiAppState } from '../store/Store';
 import * as Api from '../services/Api';
 import { KialiAppAction } from './KialiAppAction';
 import { NamespaceActions } from './NamespaceAction';
+import { authenticationToken } from '../utils/AuthenticationToken';
 
 const shouldFetchNamespaces = (state: KialiAppState) => {
   if (!state) {
@@ -39,7 +40,7 @@ const NamespaceThunkActions = {
         }
 
         // Dispatch a thunk from thunk!
-        return dispatch(NamespaceThunkActions.asyncFetchNamespaces(state.session.token));
+        return dispatch(NamespaceThunkActions.asyncFetchNamespaces(authenticationToken(getState())));
       } else {
         // Let the calling code know there's nothing to wait for.
         return Promise.resolve();

--- a/src/actions/__tests__/LoginAction.test.ts
+++ b/src/actions/__tests__/LoginAction.test.ts
@@ -1,6 +1,6 @@
 import { getType } from 'typesafe-actions';
 import { LoginActions } from '../LoginActions';
-import { LoginStatus } from 'src/store/Store';
+import { LoginStatus } from '../../store/Store';
 
 const session = {
   token:
@@ -20,7 +20,7 @@ describe('LoginActions', () => {
 
   it('Login action failure', () => {
     const error = 'Error with username or password';
-    const expectedAction = { error: error };
+    const expectedAction = { error: error, status: LoginStatus.error, session: undefined };
     expect(LoginActions.loginFailure(error).payload).toEqual(expectedAction);
   });
 

--- a/src/actions/__tests__/LoginAction.test.ts
+++ b/src/actions/__tests__/LoginAction.test.ts
@@ -1,23 +1,21 @@
 import { getType } from 'typesafe-actions';
 import { LoginActions } from '../LoginActions';
+import { LoginStatus } from 'src/store/Store';
 
-const token =
-  'eyJ3bGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyr1c2VybmFtZSI6ImFkbWluIiwiZXhwIjoxNTI3NjIzNTAwfQ.klBh7tDeuMgZbsNWsUJWAqOBkRG30vURzKF6sZ8soB4';
-const expiredAt = '018-05-29 21:51:40.186179601 +0200 CEST m=+36039.431579761';
-const username = 'admin';
+const session = {
+  token:
+    'eyJ3bGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyr1c2VybmFtZSI6ImFkbWluIiwiZXhwIjoxNTI3NjIzNTAwfQ.klBh7tDeuMgZbsNWsUJWAqOBkRG30vURzKF6sZ8soB4',
+  expiresOn: '018-05-29 21:51:40.186179601 +0200 CEST m=+36039.431579761',
+  username: 'admin'
+};
 
 describe('LoginActions', () => {
   it('Login action success', () => {
-    const expectedAction = {
-      token: { token: token, expired_at: expiredAt },
-      username: username,
-      logged: true
-    };
-    const result = LoginActions.loginSuccess({ token: token, expired_at: expiredAt }, username);
+    const result = LoginActions.loginSuccess(session);
+
     expect(result.type).toEqual(getType(LoginActions.loginSuccess));
-    expect(result.payload.token).toEqual(expectedAction.token);
-    expect(result.payload.username).toEqual(expectedAction.username);
-    expect(result.payload.logged).toEqual(expectedAction.logged);
+    expect(result.payload.session).toEqual(session);
+    expect(result.payload.status).toEqual(LoginStatus.loggedIn);
   });
 
   it('Login action failure', () => {
@@ -28,9 +26,10 @@ describe('LoginActions', () => {
 
   it('Login action logout', () => {
     const expectedAction = {
-      user: undefined,
-      logged: false
+      status: LoginStatus.loggedOut,
+      session: undefined
     };
+
     expect(LoginActions.logoutSuccess().payload).toEqual(expectedAction);
   });
 });

--- a/src/components/Nav/UserDropdown.tsx
+++ b/src/components/Nav/UserDropdown.tsx
@@ -4,12 +4,14 @@ import { SessionTimeout } from '../SessionTimeout/SessionTimeout';
 import { config } from '../../config';
 import { MILLISECONDS } from '../../types/Common';
 import Timer = NodeJS.Timer;
+import { Session } from 'src/store/Store';
+
+import moment from 'moment';
 
 type UserProps = {
-  username: string;
+  session: Session;
   logout: () => void;
   extendSession: () => void;
-  sessionTimeOut: number;
 };
 
 type UserState = {
@@ -51,11 +53,13 @@ class UserDropdown extends React.Component<UserProps, UserState> {
   }
 
   timeLeft = (): number => {
-    const nowDate = new Date().getTime();
-    if (this.props.sessionTimeOut - nowDate < 1) {
+    const expiresOn = moment(this.props.session.expiresOn).toDate();
+
+    if (expiresOn <= new Date()) {
       this.handleLogout();
     }
-    return this.props.sessionTimeOut - nowDate;
+
+    return expiresOn.getTime() - new Date().getTime();
   };
 
   checkSession = () => {
@@ -88,7 +92,7 @@ class UserDropdown extends React.Component<UserProps, UserState> {
         />
         <Dropdown componentClass="li" id="user">
           <Dropdown.Toggle useAnchor={true} className="nav-item-iconic">
-            <Icon type="pf" name="user" /> {this.props.username}
+            <Icon type="pf" name="user" /> {this.props.session.username}
           </Dropdown.Toggle>
           <Dropdown.Menu>
             <MenuItem id="usermenu_logout" onClick={() => this.handleLogout()}>

--- a/src/components/Nav/UserDropdown.tsx
+++ b/src/components/Nav/UserDropdown.tsx
@@ -4,12 +4,12 @@ import { SessionTimeout } from '../SessionTimeout/SessionTimeout';
 import { config } from '../../config';
 import { MILLISECONDS } from '../../types/Common';
 import Timer = NodeJS.Timer;
-import { Session } from 'src/store/Store';
+import { LoginSession } from 'src/store/Store';
 
 import moment from 'moment';
 
 type UserProps = {
-  session: Session;
+  session: LoginSession;
   logout: () => void;
   extendSession: () => void;
   checkCredentials: () => void;
@@ -54,13 +54,13 @@ class UserDropdown extends React.Component<UserProps, UserState> {
   }
 
   timeLeft = (): number => {
-    const expiresOn = moment(this.props.session.expiresOn).toDate();
+    const expiresOn = moment(this.props.session.expiresOn);
 
-    if (expiresOn <= new Date()) {
+    if (expiresOn <= moment()) {
       this.handleLogout();
     }
 
-    return expiresOn.getTime() - new Date().getTime();
+    return expiresOn.diff(moment(), 'seconds');
   };
 
   checkSession = () => {

--- a/src/components/Nav/UserDropdown.tsx
+++ b/src/components/Nav/UserDropdown.tsx
@@ -12,6 +12,7 @@ type UserProps = {
   session: Session;
   logout: () => void;
   extendSession: () => void;
+  checkCredentials: () => void;
 };
 
 type UserState = {
@@ -70,6 +71,10 @@ class UserDropdown extends React.Component<UserProps, UserState> {
 
   handleLogout() {
     this.props.logout();
+
+    // Force login dispatcher to run
+    this.props.checkCredentials();
+
     const el = document.documentElement;
     if (el) {
       el.className = 'login-pf';

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -74,6 +74,7 @@ const conf = {
   /** API configuration */
   api: {
     urls: {
+      authInfo: 'api/auth/info',
       apps: (namespace: string) => `api/namespaces/${namespace}/apps`,
       app: (namespace: string, app: string) => `api/namespaces/${namespace}/apps/${app}`,
       appGraphElements: (namespace: string, app: string, version?: string) => {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -75,6 +75,7 @@ const conf = {
   api: {
     urls: {
       authInfo: 'api/auth/info',
+      checkOpenshiftAuth: 'api/auth/openshift-token',
       apps: (namespace: string) => `api/namespaces/${namespace}/apps`,
       app: (namespace: string, app: string) => `api/namespaces/${namespace}/apps/${app}`,
       appGraphElements: (namespace: string, app: string, version?: string) => {

--- a/src/containers/LoginPageContainer.ts
+++ b/src/containers/LoginPageContainer.ts
@@ -7,7 +7,7 @@ import LoginThunkActions from '../actions/LoginThunkActions';
 
 const mapStateToProps = (state: KialiAppState) => ({
   status: state.authentication.status,
-  error: state.authentication.error
+  message: state.authentication.message
 });
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<KialiAppState, void, KialiAppAction>) => ({

--- a/src/containers/LoginPageContainer.ts
+++ b/src/containers/LoginPageContainer.ts
@@ -6,11 +6,8 @@ import { KialiAppAction } from '../actions/KialiAppAction';
 import LoginThunkActions from '../actions/LoginThunkActions';
 
 const mapStateToProps = (state: KialiAppState) => ({
-  token: state.authentication.token,
-  username: state.authentication.username,
-  logging: state.authentication.logging,
-  error: state.authentication.error,
-  message: state.authentication.message
+  status: state.authentication.status,
+  error: state.authentication.error
 });
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<KialiAppState, void, KialiAppAction>) => ({

--- a/src/containers/NavigationContainer.ts
+++ b/src/containers/NavigationContainer.ts
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import { ThunkDispatch } from 'redux-thunk';
 import Navigation from '../components/Nav/Navigation';
-import { KialiAppState, Component } from '../store/Store';
+import { KialiAppState, Component, LoginStatus } from '../store/Store';
 import { KialiAppAction } from '../actions/KialiAppAction';
 import LoginThunkActions from '../actions/LoginThunkActions';
 import UserSettingsThunkActions from '../actions/UserSettingsThunkActions';
@@ -12,7 +12,7 @@ const getJaegerUrl = (components: Component[]) => {
 };
 
 const mapStateToProps = (state: KialiAppState) => ({
-  authenticated: state.authentication.logged,
+  authenticated: state.authentication.status === LoginStatus.loggedIn,
   navCollapsed: state.userSettings.interface.navCollapse,
   jaegerUrl: getJaegerUrl(state.statusState.components)
 });

--- a/src/containers/UserDropdownContainer.ts
+++ b/src/containers/UserDropdownContainer.ts
@@ -8,8 +8,7 @@ import { LoginActions } from '../actions/LoginActions';
 import LoginThunkActions from '../actions/LoginThunkActions';
 
 const mapStateToProps = (state: KialiAppState) => ({
-  username: state.authentication.username,
-  sessionTimeOut: state.authentication.sessionTimeOut
+  session: state.authentication.session!
 });
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<KialiAppState, void, KialiAppAction>) => ({

--- a/src/containers/UserDropdownContainer.ts
+++ b/src/containers/UserDropdownContainer.ts
@@ -13,7 +13,8 @@ const mapStateToProps = (state: KialiAppState) => ({
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<KialiAppState, void, KialiAppAction>) => ({
   logout: () => dispatch(LoginActions.logoutSuccess()),
-  extendSession: () => dispatch(LoginThunkActions.extendSession())
+  extendSession: () => dispatch(LoginThunkActions.extendSession()),
+  checkCredentials: () => dispatch(LoginThunkActions.checkCredentials())
 });
 
 const UserDropdownConnected = connect(

--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -72,7 +72,7 @@ export default class LoginPage extends React.Component<LoginProps, LoginState> {
                 <Col sm={10} smOffset={1} md={8} mdOffset={2} lg={8} lgOffset={2}>
                   <div className={'card-pf'}>
                     <header className={'login-pf-header'} />
-                    {this.props.error && <Alert>{this.props.error}</Alert>}
+                    {this.props.status === LoginStatus.error && <Alert>{this.props.message}</Alert>}
                     <Form onSubmit={e => this.handleSubmit(e)} id={'kiali-login'}>
                       <FormGroup>
                         <FormControl

--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { Alert, Row, Col, Form, FormGroup, FormControl, Button, HelpBlock } from 'patternfly-react';
 import { KEY_CODES } from '../../types/Common';
-import { LoginStatus, Session } from 'src/store/Store';
+import { LoginStatus, LoginSession } from 'src/store/Store';
 
 const kialiTitle = require('../../assets/img/logo-login.svg');
 
 type LoginProps = {
   status: LoginStatus;
-  session?: Session;
+  session?: LoginSession;
   message?: string;
   error?: any;
   authenticate: (username: string, password: string) => void;

--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Alert, Row, Col, Form, FormGroup, FormControl, Button, HelpBlock } from 'patternfly-react';
 import { KEY_CODES } from '../../types/Common';
-import { LoginStatus, LoginSession } from 'src/store/Store';
+import { LoginStatus, LoginSession } from '../../store/Store';
 
 const kialiTitle = require('../../assets/img/logo-login.svg');
 

--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import { Alert, Row, Col, Form, FormGroup, FormControl, Button, HelpBlock } from 'patternfly-react';
 import { KEY_CODES } from '../../types/Common';
+import { LoginStatus, Session } from 'src/store/Store';
 
 const kialiTitle = require('../../assets/img/logo-login.svg');
 
 type LoginProps = {
-  logging: boolean;
-  error: any;
-  message: string;
+  status: LoginStatus;
+  session?: Session;
+  message?: string;
+  error?: any;
   authenticate: (username: string, password: string) => void;
 };
 
@@ -70,7 +72,7 @@ export default class LoginPage extends React.Component<LoginProps, LoginState> {
                 <Col sm={10} smOffset={1} md={8} mdOffset={2} lg={8} lgOffset={2}>
                   <div className={'card-pf'}>
                     <header className={'login-pf-header'} />
-                    {this.props.error && <Alert>{this.props.message}</Alert>}
+                    {this.props.error && <Alert>{this.props.error}</Alert>}
                     <Form onSubmit={e => this.handleSubmit(e)} id={'kiali-login'}>
                       <FormGroup>
                         <FormControl
@@ -83,7 +85,9 @@ export default class LoginPage extends React.Component<LoginProps, LoginState> {
                           required={true}
                           onKeyPress={this.handleKeyPress}
                         />
-                        {this.props.logging && !this.state.username && <HelpBlock>Username is required</HelpBlock>}
+                        {this.props.status === LoginStatus.logging && !this.state.username && (
+                          <HelpBlock>Username is required</HelpBlock>
+                        )}
                       </FormGroup>
                       <FormGroup>
                         <FormControl
@@ -95,7 +99,9 @@ export default class LoginPage extends React.Component<LoginProps, LoginState> {
                           required={true}
                           onKeyPress={this.handleKeyPress}
                         />
-                        {this.props.logging && !this.state.password && <HelpBlock>Password is required</HelpBlock>}
+                        {this.props.status === LoginStatus.logging && !this.state.password && (
+                          <HelpBlock>Password is required</HelpBlock>
+                        )}
                       </FormGroup>
                       <Button
                         type="submit"

--- a/src/pages/Login/__tests__/LoginPage.test.tsx
+++ b/src/pages/Login/__tests__/LoginPage.test.tsx
@@ -2,12 +2,10 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import LoginPage from '../LoginPage';
 import { KEY_CODES } from '../../../types/Common';
+import { LoginStatus } from 'src/store/Store';
 
 const LoginProps = {
-  user: undefined,
-  logging: false,
-  error: undefined,
-  message: '',
+  status: LoginStatus.loggedOut,
   authenticate: jest.fn()
 };
 

--- a/src/pages/Login/__tests__/LoginPage.test.tsx
+++ b/src/pages/Login/__tests__/LoginPage.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import LoginPage from '../LoginPage';
 import { KEY_CODES } from '../../../types/Common';
-import { LoginStatus } from 'src/store/Store';
+import { LoginStatus } from '../../../store/Store';
 
 const LoginProps = {
   status: LoginStatus.loggedOut,

--- a/src/pages/Login/__tests__/__snapshots__/LoginPage.test.tsx.snap
+++ b/src/pages/Login/__tests__/__snapshots__/LoginPage.test.tsx.snap
@@ -5,10 +5,7 @@ ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <LoginPage
     authenticate={[MockFunction]}
-    error={undefined}
-    logging={false}
-    message=""
-    user={undefined}
+    status={2}
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],

--- a/src/pages/Login/__tests__/__snapshots__/LoginPage.test.tsx.snap
+++ b/src/pages/Login/__tests__/__snapshots__/LoginPage.test.tsx.snap
@@ -631,7 +631,7 @@ ShallowWrapper {
                       <header
                         className="login-pf-header"
                       />,
-                      undefined,
+                      false,
                       <Form
                         bsClass="form"
                         componentClass="form"
@@ -700,7 +700,7 @@ ShallowWrapper {
                       "rendered": null,
                       "type": "header",
                     },
-                    undefined,
+                    false,
                     Object {
                       "instance": null,
                       "key": undefined,
@@ -1509,7 +1509,7 @@ ShallowWrapper {
                         <header
                           className="login-pf-header"
                         />,
-                        undefined,
+                        false,
                         <Form
                           bsClass="form"
                           componentClass="form"
@@ -1578,7 +1578,7 @@ ShallowWrapper {
                         "rendered": null,
                         "type": "header",
                       },
-                      undefined,
+                      false,
                       Object {
                         "instance": null,
                         "key": undefined,

--- a/src/reducers/LoginState.ts
+++ b/src/reducers/LoginState.ts
@@ -24,12 +24,14 @@ const loginState = (state: LoginState = INITIAL_LOGIN_STATE, action: KialiAppAct
       });
     case getType(LoginActions.loginFailure):
       let message = 'Error connecting to Kiali';
+
       if (action.payload.error.request.status === 401) {
         message = 'Unauthorized. Error in username or password';
       } else if (action.payload.error.request.status === 520) {
         message =
           'The Kiali secret is missing. Users are prohibited from accessing Kiali until an administrator creates a valid secret and restarts Kiali. Please refer to the Kiali documentation for more details.';
       }
+
       return Object.assign({}, INITIAL_LOGIN_STATE, {
         status: LoginStatus.error,
         message: message

--- a/src/reducers/LoginState.ts
+++ b/src/reducers/LoginState.ts
@@ -9,7 +9,7 @@ export const INITIAL_LOGIN_STATE: LoginStateInterface = {
 };
 
 // This Reducer allows changes to the 'loginState' portion of Redux Store
-const loginState = (state: LoginState = INITIAL_LOGIN_STATE, action: KialiAppAction): LoginState => {
+const loginState = (state: LoginStateInterface = INITIAL_LOGIN_STATE, action: KialiAppAction): LoginStateInterface => {
   switch (action.type) {
     case getType(LoginActions.loginRequest):
       return Object.assign({}, INITIAL_LOGIN_STATE, {

--- a/src/reducers/LoginState.ts
+++ b/src/reducers/LoginState.ts
@@ -1,16 +1,11 @@
 import { getType } from 'typesafe-actions';
-import { LoginState } from '../store/Store';
+import { LoginState as LoginStateInterface, LoginStatus } from '../store/Store';
 import { KialiAppAction } from '../actions/KialiAppAction';
 import { LoginActions } from '../actions/LoginActions';
 
-export const INITIAL_LOGIN_STATE: LoginState = {
-  token: undefined,
-  username: undefined,
-  error: false,
-  message: '',
-  logged: false,
-  logging: false,
-  sessionTimeOut: undefined
+export const INITIAL_LOGIN_STATE: LoginStateInterface = {
+  status: LoginStatus.loggedOut,
+  session: undefined
 };
 
 // This Reducer allows changes to the 'loginState' portion of Redux Store
@@ -18,21 +13,14 @@ const loginState = (state: LoginState = INITIAL_LOGIN_STATE, action: KialiAppAct
   switch (action.type) {
     case getType(LoginActions.loginRequest):
       return Object.assign({}, INITIAL_LOGIN_STATE, {
-        logging: true
+        status: LoginStatus.logging
       });
     case getType(LoginActions.loginSuccess):
-      return Object.assign({}, INITIAL_LOGIN_STATE, {
-        logged: true,
-        token: action.payload.token,
-        username: action.payload.username,
-        sessionTimeOut: action.payload.sessionTimeOut
-      });
+      return Object.assign({}, INITIAL_LOGIN_STATE, action.payload);
     case getType(LoginActions.loginExtend):
       return Object.assign({}, INITIAL_LOGIN_STATE, {
-        logged: true,
-        token: action.payload.token,
-        username: action.payload.username,
-        sessionTimeOut: action.payload.sessionTimeOut
+        status: LoginStatus.loggedIn,
+        session: action.payload.session
       });
     case getType(LoginActions.loginFailure):
       let message = 'Error connecting to Kiali';
@@ -43,7 +31,7 @@ const loginState = (state: LoginState = INITIAL_LOGIN_STATE, action: KialiAppAct
           'The Kiali secret is missing. Users are prohibited from accessing Kiali until an administrator creates a valid secret and restarts Kiali. Please refer to the Kiali documentation for more details.';
       }
       return Object.assign({}, INITIAL_LOGIN_STATE, {
-        error: true,
+        status: LoginStatus.error,
         message: message
       });
     case getType(LoginActions.logoutSuccess):

--- a/src/reducers/LoginState.ts
+++ b/src/reducers/LoginState.ts
@@ -1,3 +1,5 @@
+import moment from 'moment';
+
 import { getType } from 'typesafe-actions';
 import { LoginState as LoginStateInterface, LoginStatus } from '../store/Store';
 import { KialiAppAction } from '../actions/KialiAppAction';
@@ -5,7 +7,13 @@ import { LoginActions } from '../actions/LoginActions';
 
 export const INITIAL_LOGIN_STATE: LoginStateInterface = {
   status: LoginStatus.loggedOut,
-  session: undefined
+  session: undefined,
+
+  // We define a small expiration date for the UI so it does not block the
+  // session handling on login.
+  uiExpiresOn: moment()
+    .add(10, 'minute')
+    .toISOString()
 };
 
 // This Reducer allows changes to the 'loginState' portion of Redux Store
@@ -20,7 +28,8 @@ const loginState = (state: LoginStateInterface = INITIAL_LOGIN_STATE, action: Ki
     case getType(LoginActions.loginExtend):
       return Object.assign({}, INITIAL_LOGIN_STATE, {
         status: LoginStatus.loggedIn,
-        session: action.payload.session
+        session: action.payload.session,
+        uiExpiresOn: action.payload.uiExpiresOn
       });
     case getType(LoginActions.loginFailure):
       let message = 'Error connecting to Kiali';

--- a/src/reducers/LoginState.ts
+++ b/src/reducers/LoginState.ts
@@ -8,7 +8,7 @@ import { LoginActions } from '../actions/LoginActions';
 export const INITIAL_LOGIN_STATE: LoginStateInterface = {
   status: LoginStatus.loggedOut,
   session: undefined,
-
+  message: '',
   // We define a small expiration date for the UI so it does not block the
   // session handling on login.
   uiExpiresOn: moment()

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -77,9 +77,11 @@ export const login = async (
 };
 
 export const getAuthInfo = async () => {
-  let response = await newRequest<any>(HTTP_VERBS.GET, urls.authInfo, {}, {});
+  return newRequest<AuthInfo>(HTTP_VERBS.GET, urls.authInfo, {}, {});
+};
 
-  return response as Response<AuthInfo>;
+export const checkOpenshiftAuth = async (data: any): Promise<Response<Session>> => {
+  return newRequest<Session>(HTTP_VERBS.POST, urls.checkOpenshiftAuth, {}, data);
 };
 
 export const getStatus = () => {

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -7,7 +7,7 @@ import { IstioConfigList } from '../types/IstioConfigList';
 import { Workload, WorkloadNamespaceResponse } from '../types/Workload';
 import { ServiceDetailsInfo } from '../types/ServiceInfo';
 import JaegerInfo from '../types/JaegerInfo';
-import { GrafanaInfo, LoginSession } from '../store/Store';
+import { GrafanaInfo, LoginSession, ServerConfig } from '../store/Store';
 import {
   AppHealth,
   ServiceHealth,
@@ -22,8 +22,7 @@ import { AppList } from '../types/AppList';
 import { App } from '../types/App';
 import { NodeParamsType, NodeType, GraphDefinition } from '../types/Graph';
 import { config } from '../config';
-import { AuthToken, HTTP_VERBS } from '../types/Common';
-import { ServerConfig } from '../config/Config';
+import { AuthToken, HTTP_VERBS, UserName, Password } from '../types/Common';
 
 export interface Response<T> {
   data: T;

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -7,7 +7,7 @@ import { IstioConfigList } from '../types/IstioConfigList';
 import { Workload, WorkloadNamespaceResponse } from '../types/Workload';
 import { ServiceDetailsInfo } from '../types/ServiceInfo';
 import JaegerInfo from '../types/JaegerInfo';
-import { GrafanaInfo, ServerConfig } from '../store/Store';
+import { GrafanaInfo, Session } from '../store/Store';
 import {
   AppHealth,
   ServiceHealth,
@@ -17,6 +17,7 @@ import {
   NamespaceWorkloadHealth
 } from '../types/Health';
 import { ServiceList } from '../types/ServiceList';
+import { AuthInfo } from '../types/Auth';
 import { AppList } from '../types/AppList';
 import { App } from '../types/App';
 import { NodeParamsType, NodeType, GraphDefinition } from '../types/Graph';
@@ -58,22 +59,27 @@ export const newRequest = <P>(method: HTTP_VERBS, url: string, queryParams: any,
     params: queryParams
   });
 
+interface LoginRequest {
+  username: string;
+  password: string;
+}
+
 /** Requests */
-export const login = (username: string, password: string) => {
-  return new Promise((resolve, reject) => {
-    axios({
-      method: HTTP_VERBS.GET,
-      url: urls.token,
-      headers: getHeaders(),
-      auth: basicAuth(username, password)
-    })
-      .then(response => {
-        resolve(response);
-      })
-      .catch(error => {
-        reject(error);
-      });
+export const login = async (
+  request: LoginRequest = { username: 'anonymous', password: 'anonymous' }
+): Promise<Response<Session>> => {
+  return axios({
+    method: HTTP_VERBS.GET,
+    url: urls.token,
+    headers: getHeaders(),
+    auth: basicAuth(request.username, request.password)
   });
+};
+
+export const getAuthInfo = async () => {
+  let response = await newRequest<any>(HTTP_VERBS.GET, urls.authInfo, {}, {});
+
+  return response as Response<AuthInfo>;
 };
 
 export const getStatus = () => {

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -7,7 +7,7 @@ import { IstioConfigList } from '../types/IstioConfigList';
 import { Workload, WorkloadNamespaceResponse } from '../types/Workload';
 import { ServiceDetailsInfo } from '../types/ServiceInfo';
 import JaegerInfo from '../types/JaegerInfo';
-import { GrafanaInfo, Session } from '../store/Store';
+import { GrafanaInfo, LoginSession } from '../store/Store';
 import {
   AppHealth,
   ServiceHealth,
@@ -23,6 +23,7 @@ import { App } from '../types/App';
 import { NodeParamsType, NodeType, GraphDefinition } from '../types/Graph';
 import { config } from '../config';
 import { AuthToken, HTTP_VERBS } from '../types/Common';
+import { ServerConfig } from '../config/Config';
 
 export interface Response<T> {
   data: T;
@@ -46,7 +47,7 @@ const getHeaders = (auth?: AuthToken) => {
   return { ...loginHeaders, ...authHeader(auth) };
 };
 
-const basicAuth = (username: string, password: string) => {
+const basicAuth = (username: UserName, password: Password) => {
   return { username: username, password: password };
 };
 
@@ -60,14 +61,14 @@ export const newRequest = <P>(method: HTTP_VERBS, url: string, queryParams: any,
   });
 
 interface LoginRequest {
-  username: string;
-  password: string;
+  username: UserName;
+  password: Password;
 }
 
 /** Requests */
 export const login = async (
   request: LoginRequest = { username: 'anonymous', password: 'anonymous' }
-): Promise<Response<Session>> => {
+): Promise<Response<LoginSession>> => {
   return axios({
     method: HTTP_VERBS.GET,
     url: urls.token,
@@ -80,8 +81,8 @@ export const getAuthInfo = async () => {
   return newRequest<AuthInfo>(HTTP_VERBS.GET, urls.authInfo, {}, {});
 };
 
-export const checkOpenshiftAuth = async (data: any): Promise<Response<Session>> => {
-  return newRequest<Session>(HTTP_VERBS.POST, urls.checkOpenshiftAuth, {}, data);
+export const checkOpenshiftAuth = async (data: any): Promise<Response<LoginSession>> => {
+  return newRequest<LoginSession>(HTTP_VERBS.POST, urls.checkOpenshiftAuth, {}, data);
 };
 
 export const getStatus = () => {

--- a/src/services/Login.ts
+++ b/src/services/Login.ts
@@ -90,8 +90,6 @@ class OpenshiftLogin implements LoginStrategy {
   public async perform(request: DispatchRequest<any>): Promise<LoginResult> {
     const session = (await API.checkOpenshiftAuth(window.location.hash.substring(1))).data;
 
-    console.log(`Session: ${JSON.stringify(session)}`);
-
     return {
       status: Result.success,
       session: session

--- a/src/services/Login.ts
+++ b/src/services/Login.ts
@@ -1,0 +1,109 @@
+import * as API from './Api';
+
+import { AuthInfo, AuthStrategy } from '../types/Auth';
+import { Session } from 'src/store/Store';
+
+// We just mock the types for state for now, to avoid injecting more
+// dependencies on the service.
+type Dispatch = any;
+type AppState = any;
+
+enum Result {
+  continue,
+  success,
+  failure
+}
+
+interface LoginResult {
+  status: Result;
+  session?: Session;
+  error?: any;
+}
+
+interface LoginStrategy<T = {}> {
+  prepare: () => Promise<Result>;
+  perform: (request: DispatchRequest<T>) => Promise<LoginResult>;
+}
+
+interface DispatchRequest<T> {
+  dispatch: Dispatch;
+  getState: () => AppState;
+  data: T;
+}
+
+class AnonymousLogin implements LoginStrategy {
+  public async prepare() {
+    return Result.continue;
+  }
+
+  public async perform(request: DispatchRequest<{}>): Promise<LoginResult> {
+    const session: Session = (await API.login()).data;
+
+    return {
+      status: Result.success,
+      session: session
+    };
+  }
+}
+
+interface WebLoginData {
+  username: string;
+  password: string;
+}
+
+class WebLogin implements LoginStrategy<WebLoginData> {
+  public async prepare() {
+    return Result.continue;
+  }
+
+  public async perform(request: DispatchRequest<WebLoginData>): Promise<LoginResult> {
+    const session = (await API.login(request.data)).data;
+
+    return {
+      status: Result.success,
+      session: session
+    };
+  }
+}
+
+export class LoginDispatcher implements LoginStrategy<any> {
+  strategyMapping: Map<AuthStrategy, LoginStrategy>;
+  info?: AuthInfo;
+
+  constructor() {
+    this.strategyMapping = new Map<AuthStrategy, LoginStrategy>();
+
+    this.strategyMapping.set(AuthStrategy.anonymous, new AnonymousLogin());
+    this.strategyMapping.set(AuthStrategy.login, new WebLogin());
+  }
+
+  public async prepare(): Promise<Result> {
+    const strategy = this.strategyMapping.get((await this.getInfo()).strategy)!;
+
+    try {
+      return await strategy.prepare();
+    } catch (error) {
+      return Promise.reject({ status: Result.failure, error });
+    }
+  }
+
+  public async perform(request: DispatchRequest<any>): Promise<LoginResult> {
+    const strategy = this.strategyMapping.get((await this.getInfo()).strategy)!;
+
+    try {
+      return await strategy.perform(request);
+    } catch (error) {
+      return Promise.reject({ status: Result.failure, error });
+    }
+  }
+
+  private async getInfo(): Promise<AuthInfo> {
+    if (this.info) {
+      return this.info;
+    }
+
+    this.info = await (await API.getAuthInfo()).data;
+
+    return this.info;
+  }
+}

--- a/src/services/__tests__/ApiMethods.test.tsx.ts
+++ b/src/services/__tests__/ApiMethods.test.tsx.ts
@@ -64,7 +64,7 @@ describe('#Test Methods return a Promise', () => {
   };
 
   it('#login', () => {
-    const result = API.login('admin', 'admin');
+    const result = API.login({ username: 'admin', password: 'admin' });
     evaluatePromise(result);
   });
 

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -63,18 +63,23 @@ export interface GraphState {
   summaryData: SummaryData | null;
 }
 
-export interface Token {
-  token: string;
-  expired_at: string;
+export enum LoginStatus {
+  logging,
+  loggedIn,
+  loggedOut,
+  error
 }
+
+export interface Session {
+  token: string;
+  expiresOn: string;
+  username: string;
+}
+
 export interface LoginState {
-  token?: Token;
-  username?: string;
-  error: any;
-  message: string;
-  logged: boolean;
-  logging: boolean;
-  sessionTimeOut?: number;
+  status: LoginStatus;
+  session?: Session;
+  error?: any;
 }
 
 export interface Component {

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -1,6 +1,6 @@
 import { NotificationGroup } from '../types/MessageCenter';
 import Namespace from '../types/Namespace';
-import { DurationInSeconds, PollIntervalInMs, TimeInSeconds } from '../types/Common';
+import { DurationInSeconds, PollIntervalInMs, TimeInSeconds, UserName, RawDate, AuthToken } from '../types/Common';
 import { EdgeLabelMode, Layout } from '../types/GraphFilter';
 import { GraphType, NodeParamsType, SummaryData, CyData, GraphElements } from '../types/Graph';
 
@@ -70,15 +70,15 @@ export enum LoginStatus {
   error
 }
 
-export interface Session {
-  token: string;
-  expiresOn: string;
-  username: string;
+export interface LoginSession {
+  token: AuthToken;
+  expiresOn: RawDate;
+  username: UserName;
 }
 
 export interface LoginState {
   status: LoginStatus;
-  session?: Session;
+  session?: LoginSession;
   error?: any;
 }
 

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -79,7 +79,7 @@ export interface LoginSession {
 export interface LoginState {
   status: LoginStatus;
   session?: LoginSession;
-  error?: any;
+  message: string;
   uiExpiresOn: RawDate;
 }
 

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -80,6 +80,7 @@ export interface LoginState {
   status: LoginStatus;
   session?: LoginSession;
   error?: any;
+  uiExpiresOn: RawDate;
 }
 
 export interface Component {

--- a/src/types/Auth.ts
+++ b/src/types/Auth.ts
@@ -1,0 +1,9 @@
+export enum AuthStrategy {
+  login = 'login',
+  anonymous = 'anonymous'
+}
+
+export interface AuthInfo {
+  strategy: AuthStrategy;
+  authorizationEndpoint?: string;
+}

--- a/src/types/Auth.ts
+++ b/src/types/Auth.ts
@@ -1,6 +1,7 @@
 export enum AuthStrategy {
   login = 'login',
-  anonymous = 'anonymous'
+  anonymous = 'anonymous',
+  openshift = 'openshift'
 }
 
 export interface AuthInfo {

--- a/src/types/Auth.ts
+++ b/src/types/Auth.ts
@@ -8,3 +8,15 @@ export interface AuthInfo {
   strategy: AuthStrategy;
   authorizationEndpoint?: string;
 }
+
+// Stores the result of a computation:
+// hold = stop all computation and wait for a side-effect, such as a redirect
+// continue = continue...
+// success = authentication was a success, session is available
+// failure = authentication failed, session is undefined but error is available
+export enum AuthResult {
+  HOLD = 'hold',
+  CONTINUE = 'continue',
+  SUCCESS = 'success',
+  FAILURE = 'failure'
+}

--- a/src/types/Common.ts
+++ b/src/types/Common.ts
@@ -8,6 +8,10 @@ export type AuthToken = string;
 
 export type AppenderString = string;
 
+export type UserName = string;
+export type Password = string;
+export type RawDate = string;
+
 export const HTTP_CODES = {
   OK: 200,
   ACCEPTED: 202,

--- a/src/utils/AuthenticationToken.ts
+++ b/src/utils/AuthenticationToken.ts
@@ -2,8 +2,9 @@ import { KialiAppState } from '../store/Store';
 import { AuthToken } from '../types/Common';
 
 export const authenticationToken = (state: KialiAppState): AuthToken => {
-  if (state.authentication.token !== undefined) {
-    return 'Bearer ' + state.authentication.token.token;
+  if (state.authentication.session !== undefined) {
+    return 'Bearer ' + state.authentication.session.token;
   }
+
   return '';
 };

--- a/src/utils/__tests__/Authentication.test.ts
+++ b/src/utils/__tests__/Authentication.test.ts
@@ -2,10 +2,12 @@ import { authentication } from '../Authentication';
 import { store } from '../../store/ConfigStore';
 import { LoginActions } from '../../actions/LoginActions';
 
-const token =
-  'eyJ3bGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyr1c2VybmFtZSI6ImFkbWluIiwiZXhwIjoxNTI3NjIzNTAwfQ.klBh7tDeuMgZbsNWsUJWAqOBkRG30vURzKF6sZ8soB4';
-const expiredAt = '018-05-29 21:51:40.186179601 +0200 CEST m=+36039.431579761';
-const username = 'admin';
+const session = {
+  token:
+    'eyJ3bGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyr1c2VybmFtZSI6ImFkbWluIiwiZXhwIjoxNTI3NjIzNTAwfQ.klBh7tDeuMgZbsNWsUJWAqOBkRG30vURzKF6sZ8soB4',
+  expiresOn: '018-05-29 21:51:40.186179601 +0200 CEST m=+36039.431579761',
+  username: 'admin'
+};
 
 describe('Authentication', () => {
   it('should return empty object without store', () => {
@@ -13,7 +15,7 @@ describe('Authentication', () => {
   });
 
   it('should return username and password object ', () => {
-    store.dispatch(LoginActions.loginSuccess({ token: token, expired_at: expiredAt }, username));
-    expect(authentication()).toEqual('Bearer ' + token);
+    store.dispatch(LoginActions.loginSuccess(session));
+    expect(authentication()).toEqual('Bearer ' + session.token);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6575,6 +6575,11 @@ moment-timezone@^0.4.0, moment-timezone@^0.4.1:
   dependencies:
     moment ">= 2.6.0"
 
+moment@2.23.0:
+  version "2.23.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.23.0.tgz#759ea491ac97d54bac5ad776996e2a58cc1bc225"
+  integrity sha512-3IE39bHVqFbWWaPOMHZF98Q9c3LDKGTmypMiTM2QygGXXElkFWIH7GxfmlwmY2vwa+wmNsoYZmG2iusf1ZjJoA==
+
 "moment@>= 2.6.0", moment@^2.10, moment@^2.19.1:
   version "2.23.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.23.0.tgz#759ea491ac97d54bac5ad776996e2a58cc1bc225"


### PR DESCRIPTION
This is a big one, and touch many parts of the system, so it should be reviewed with care.

The main idea here is to enable Openshift users to authorize themselves using the OAuth interface provided, and as doing so, also simplifying the task of adding new behaviours and protocols for the user to authorize from.

Following [Kent Beck's](https://twitter.com/kentbeck/status/250733358307500032) advice, to do something hard, you refactor the code until it becomes easy, then do the easy change.

## What changed:

1. All endpoints for authentication (generating tokens, validating tokens) now return the same interface:

```typescript
export interface Session {
  token: string;
  expiresOn: string;
  username: string;
}
```
The usual expiration time calculation was removed, so now the endpoint returns when the token is going to expire, and we just check with that.

2. [https://momentjs.com](MomentJS) is being used to have more robust time calculations and parsing.
3. All login strategies are now defined on `src/services/Login.ts`, with separated classes implementing the same interface:

```typescript
interface LoginStrategy<T = {}> {
  prepare: (info: AuthInfo) => Promise<Result>;
  perform: (request: DispatchRequest<T>) => Promise<LoginResult>;
}
```

The `prepare()` method process some authorization information with the interface:

```typescript
interface AuthInfo {
  strategy: 'login' | 'anonymous' | 'openshift';
  authorizationEndpoint?: string;
}
```
And returns one of those values:

```typescript
enum Result {
  hold = 'hold',
  continue = 'continue',
  failure = 'failure'
}
```

1. `hold` means to stop the authorization flow to wait for some external processing that at some point is going to close the page. Examples: redirecting to an authorization endpoint.
2. `continue` means to continue the authorization flow.
3. `failure` short-circuits the process and force logging out the user.

For `perform()`, it does the meat of the authorization process. The implementation should be straightforward, with an example:

```typescript
class AnonymousLogin implements LoginStrategy {
  public async prepare(info: AuthInfo) {
    return Result.continue;
  }

  public async perform(request: DispatchRequest<{}>): Promise<LoginResult> {
    const session: Session = (await API.login()).data;

    return {
      status: Result.success,
      session: session
    };
  }
}
```

### How to test

1. Update the branches on both repositories (core and UI).
2. Build the UI.
3. Compile with: `AUTH_STRATEGY=<strategy> CONSOLE_VERSION=local CONSOLE_LOCAL_DIR=<ui dir> make build docker-build openshift-deploy`, where `<strategy>` is one of `openshift`, `login`, `anonymous`.