### PR TITLE
KIALI-2206 Fetch grafana information on login

### DIFF
--- a/src/actions/LoginThunkActions.ts
+++ b/src/actions/LoginThunkActions.ts
@@ -22,7 +22,9 @@ const performLogin = (
   API.login(loginUser, loginPass).then(
     token => {
       dispatch(LoginActions.loginSuccess(token['data'], loginUser));
+      const auth = `Bearer ${token['data']['token']}`;
       dispatch(HelpDropdownThunkActions.refresh());
+      dispatch(GrafanaThunkActions.getInfo(auth));
     },
     error => {
       if (anonymous) {


### PR DESCRIPTION
** Describe the change **

Loads the grafana details on login instead of just when we verify the credentials on subsequent requests.

Fix for the v0.11 branch. Master is already doing something similar (https://github.com/kiali/kiali-ui/blob/master/src/actions/LoginThunkActions.ts#L25)

** Issue reference **

https://issues.jboss.org/browse/KIALI-2206

** Backwards compatible? **

Yes, everything else should work as expected. This should only fix the broken links for grafana
