### PR TITLE
KIALI-2200 Changes the label order of non-parent nodes

### DIFF
--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -177,30 +177,32 @@ export class GraphStyles {
               content = '';
           }
         } else {
+          let contentArray: string[] = [];
+          if ((isMultiNamespace || ele.data('isOutside')) && !(isServiceEntry || nodeType === NodeType.UNKNOWN)) {
+            contentArray.push(namespace);
+          }
           switch (nodeType) {
             case NodeType.APP:
               if (cyGlobal.graphType === GraphType.APP || ele.data('isGroup') || version === 'unknown') {
-                content = app;
+                contentArray.unshift(app);
               } else {
-                content = app + `\n${version}`;
+                contentArray.unshift(app);
+                contentArray.push(version);
               }
               break;
             case NodeType.SERVICE:
-              content = service;
+              contentArray.unshift(service);
               break;
             case NodeType.UNKNOWN:
-              content = 'unknown';
+              contentArray.unshift('unknown');
               break;
             case NodeType.WORKLOAD:
-              content = workload;
+              contentArray.unshift(workload);
               break;
             default:
-              content = 'error';
+              contentArray.unshift('error');
           }
-
-          if ((isMultiNamespace || ele.data('isOutside')) && !(isServiceEntry || nodeType === NodeType.UNKNOWN)) {
-            content += `\n${namespace}`;
-          }
+          content = contentArray.join('\n');
         }
       }
 


### PR DESCRIPTION
  from: $app \n $version \n $namespace (if any)
  to:   $app \n $namespace (if any) \n $version

** Screenshot **

Before:
![before-kiali-2200](https://user-images.githubusercontent.com/3845764/50799775-17d03100-12a3-11e9-8b18-1f1dce1b055f.png)

After:
![after-kiali-2200](https://user-images.githubusercontent.com/3845764/50799778-1dc61200-12a3-11e9-81e5-991463d25eb2.png)


