### PR TITLE
KIALI-2195 Fix issue with the first graph tour element

### DIFF
--- a/src/components/NamespaceDropdown.tsx
+++ b/src/components/NamespaceDropdown.tsx
@@ -107,7 +107,7 @@ export class NamespaceDropdown extends React.PureComponent<NamespaceListType, {}
         trigger={['click']}
         rootClose={true}
       >
-        <Button bsClass={`btn btn-link btn-lg  ${namespaceButtonStyle}`} id="graph_settings">
+        <Button bsClass={`btn btn-link btn-lg  ${namespaceButtonStyle}`} id="namespace-selector">
           {this.namespaceButtonText()} <Icon name="angle-down" />
         </Button>
       </OverlayTrigger>


### PR DESCRIPTION
** Describe the change **

Fixes an issue where the incorrect id was being used in the page.

Since there was two components with the same id on the page, the tour component wasn't properly selecting the right one.

The tour component was also expecting a component to be named 'namespace-selector' to be available. Since this id didn't exist, the tour component would get confused and cause a failure when trying to access this id.

** Issue reference **

https://issues.jboss.org/browse/KIALI-2195