### PR TITLE
KIALI-2023 Make aceValidation parseMaker skip the metadata part 

### DIFF
--- a/src/types/AceValidations.ts
+++ b/src/types/AceValidations.ts
@@ -99,8 +99,15 @@ const parseMarker = (
     position: -1
   };
 
+  let tokenPos = startsFrom;
+
+  // Find start of the spec part first, this should skip the whole metadata part
+  if (startsFrom < 0) {
+    tokenPos = yaml.indexOf('spec:', tokenPos);
+  }
+
   // Find initial token position
-  let tokenPos = yaml.indexOf(token, startsFrom);
+  tokenPos = yaml.indexOf(token, tokenPos);
   if (tokenPos < 0) {
     return aceMarker;
   }


### PR DESCRIPTION
** Describe the change **

Makes the ACE Editor's validation errors part skip the metadata part when evaluating yaml paths for validation error markers. This is because the marker does not really understand yaml but parses matching words in the strings / lines and the metadata part can include the same matching words as part of the kubernetes annotations.

** Issue reference **

KIALI-2023
