### PR TITLE
KIALI-2221 Remove 0 on graph screen when no namespace is selected

### DIFF
--- a/src/pages/Graph/GraphPage.tsx
+++ b/src/pages/Graph/GraphPage.tsx
@@ -291,7 +291,7 @@ export default class GraphPage extends React.Component<GraphPageProps, GraphPage
                   <Icon title="Help" type="pf" name="help" />
                 </Button>
               </Breadcrumb.Item>
-              {this.props.graphTimestamp && (
+              {this.props.graphTimestamp > 0 && (
                 <span className={'pull-right'}>
                   {new Date(graphStart).toLocaleDateString(undefined, timeDisplayOptions)}
                   {' ... '}


### PR DESCRIPTION
 - We need to use booleans when doing conditional rendering to avoid
   passing the raw values to react.

The zero was appearing because `this.props.graphTimestamp` has the value `0`, that value is given to the renderer. 
