### PR TITLE
KIALI-2230 Reduce charts height and do not adjust anymore

### DIFF
--- a/src/components/Metrics/MetricsChartBase.tsx
+++ b/src/components/Metrics/MetricsChartBase.tsx
@@ -93,11 +93,6 @@ abstract class MetricsChartBase<Props extends MetricsChartBaseProps> extends Rea
     return fmt + this.props.unit;
   };
 
-  adjustHeight(columns: any[]): number {
-    const series = columns.length - 1;
-    return 350 + series * 23;
-  }
-
   protected onExpandHandler = (event: React.MouseEvent<HTMLAnchorElement>) => {
     event.preventDefault();
     this.props.onExpandRequested!();
@@ -138,7 +133,7 @@ abstract class MetricsChartBase<Props extends MetricsChartBaseProps> extends Rea
   render() {
     const data = this.getSeriesData();
     this.checkUnload(data);
-    const height = this.adjustHeight(data.columns);
+    const height = 350;
     // Note: if any direct interaction is needed with the C3 chart,
     //  use "oninit" hook and reference "this" as the C3 chart object.
     //  see commented code


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/KIALI-2230

![two columns](https://screenshotscdn.firefoxusercontent.com/images/052a5efe-2d1f-4cf1-94b9-dc08f1ee0a2b.png)

Note: backend PR is also part of the work to split in two columns, but can be merged independently: https://github.com/kiali/kiali/pull/780