### PR TITLE
KIALI-2191 KIALI-2210 Updates cytoscape to 3.3.2 to receive bug fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "axios": "0.18.0",
     "csstips": "0.3.0",
     "csx": "9.0.0",
-    "cytoscape": "3.3.1",
+    "cytoscape": "3.3.2",
     "cytoscape-canvas": "3.0.1",
     "cytoscape-cola": "2.3.0",
     "cytoscape-cose-bilkent": "4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2721,10 +2721,10 @@ cytoscape-dagre@2.2.2:
   dependencies:
     dagre "^0.8.2"
 
-cytoscape@3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/cytoscape/-/cytoscape-3.3.1.tgz#fd393d92725ae6c8f38eb64e85f143fc0144815f"
-  integrity sha512-3IIh63Oz/dtiO1ibPb9CWHBPo90JZg/74EI+vDL/hamaP01bQ7Yx1r9oiS4AyTedvlUCio5j7Bu3NtRWxJHryw==
+cytoscape@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/cytoscape/-/cytoscape-3.3.2.tgz#7c81a5a07ddbe573044ad2a176b10e6350f58cc3"
+  integrity sha512-DkLcpbxZ1tHCT6x9RevtYuFWdxvc8ZvLXAktgBf++YGWOdkwH/6qE25Omzk2vnbZnYjf2dy81gIYay+wF0z1RQ==
   dependencies:
     heap "^0.2.6"
     lodash.debounce "^4.0.8"


### PR DESCRIPTION
  - Unused compound nodes were not removed on update
  - App box labels were getting father away from the box

** Issue reference **

[KIALI-2191](https://issues.jboss.org/browse/KIALI-2191)
[KIALI-2210](https://issues.jboss.org/browse/KIALI-2210)


** Screenshot **

![peek 2019-01-15 10-16](https://user-images.githubusercontent.com/3845764/51193682-0ee8ec00-18af-11e9-9c71-5bc243e78b67.gif)
