### PR TITLE
KIALI-2248 Prevent to show multiple Prompts when abandon the editor page

### DIFF
--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -116,6 +116,11 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
     }
   }
 
+  componentWillUnmount() {
+    // Reset ask confirmation flag
+    window.onbeforeunload = null;
+  }
+
   backToList = () => {
     // Back to list page
     ListPageLink.navigateTo(TargetPage.ISTIO, [{ name: this.props.match.params.namespace }]);

--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -36,11 +36,13 @@ interface IstioConfigDetailsState {
 
 class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioConfigId>, IstioConfigDetailsState> {
   aceEditorRef: React.RefObject<AceEditor>;
+  promptTo: string;
 
   constructor(props: RouteComponentProps<IstioConfigId>) {
     super(props);
     this.state = { isModified: false };
     this.aceEditorRef = React.createRef();
+    this.promptTo = '';
   }
 
   updateTypeFilter = () => {
@@ -101,6 +103,8 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
     } else {
       window.onbeforeunload = null;
     }
+    // This will reset the flag to prevent ask multiple times the confirmnation to leave with unsaved changed
+    this.promptTo = '';
     // Hack to force redisplay of annotations after update
     // See https://github.com/securingsincity/react-ace/issues/300
     if (this.aceEditorRef.current) {
@@ -404,7 +408,19 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
         {this.renderBreadcrumbs()}
         {this.renderRightToolbar()}
         {this.renderTabs()}
-        <Prompt when={this.state.isModified} message="You have unsaved changes, are you sure you want to leave?" />
+        <Prompt
+          message={location => {
+            if (this.state.isModified) {
+              // Check if Prompt is invoked multiple times
+              if (this.promptTo === location.pathname) {
+                return true;
+              }
+              this.promptTo = location.pathname;
+              return 'You have unsaved changes, are you sure you want to leave?';
+            }
+            return true;
+          }}
+        />
       </>
     );
   }


### PR DESCRIPTION
** Describe the change **

Save a flag to prevent multiple Prompt invocations on Istio Config editor

** Issue reference **

https://issues.jboss.org/browse/KIALI-2248
