### PR TITLE
KIALI-2256 Wizard for creating traffic rules 

### DIFF
--- a/src/components/IstioWizards/IstioWizard.tsx
+++ b/src/components/IstioWizards/IstioWizard.tsx
@@ -211,6 +211,10 @@ class IstioWizard extends React.Component<Props, State> {
               label={'Traffic Weight'}
               value={workload.traffic}
               onSlide={value => {
+                console.log('onSlide value: ' + value);
+                if (value > 100) {
+                  value = 100;
+                }
                 this.onWeight(workload.name, value as number);
               }}
             />

--- a/src/components/IstioWizards/IstioWizard.tsx
+++ b/src/components/IstioWizards/IstioWizard.tsx
@@ -39,8 +39,8 @@ class IstioWizard extends React.Component<Props, State> {
     if (this.props.workloads.length === 0) {
       return;
     }
-    const wkTraffic = Math.round(100 / this.props.workloads.length);
-    const remainTraffic = 100 % this.props.workloads.length;
+    const wkTraffic = this.props.workloads.length < 100 ? Math.round(100 / this.props.workloads.length) : 0;
+    const remainTraffic = this.props.workloads.length < 100 ? 100 % this.props.workloads.length : 0;
     const workloads: WorkloadTraffic[] = this.props.workloads.map(workload => ({
       name: workload.name,
       traffic: wkTraffic

--- a/src/components/IstioWizards/IstioWizard.tsx
+++ b/src/components/IstioWizards/IstioWizard.tsx
@@ -238,7 +238,7 @@ class IstioWizard extends React.Component<Props, State> {
   render() {
     return (
       <Wizard show={this.state.showWizard} onHide={this.onClose}>
-        <Wizard.Header onClose={this.onClose} title="Create A/B Traffic Routing" />
+        <Wizard.Header onClose={this.onClose} title="Create Traffic Routing" />
         <Wizard.Body>
           <Wizard.Row>
             <Wizard.Main>{this.renderContent()}</Wizard.Main>

--- a/src/components/IstioWizards/IstioWizard.tsx
+++ b/src/components/IstioWizards/IstioWizard.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, ListView, ListViewIcon, ListViewItem, Wizard } from 'patternfly-react';
+import { Button, Label, ListView, ListViewIcon, ListViewItem, Wizard } from 'patternfly-react';
 import { WorkloadOverview } from '../../types/ServiceInfo';
 import Slider from './Slider/Slider';
 import { DestinationRule, VirtualService } from '../../types/IstioObjects';
@@ -245,6 +245,11 @@ class IstioWizard extends React.Component<Props, State> {
           </Wizard.Row>
         </Wizard.Body>
         <Wizard.Footer>
+          {!this.checkWeight() && (
+            <Label style={{ margin: '0 15px 0 0', paddingTop: '6px' }} bsStyle="danger">
+              Traffic Weights must sum 100%
+            </Label>
+          )}
           <Button bsStyle="default" className="btn-cancel" onClick={this.onClose}>
             Cancel
           </Button>

--- a/src/components/IstioWizards/IstioWizard.tsx
+++ b/src/components/IstioWizards/IstioWizard.tsx
@@ -1,0 +1,253 @@
+import * as React from 'react';
+import { Button, ListView, ListViewIcon, ListViewItem, Wizard } from 'patternfly-react';
+import { WorkloadOverview } from '../../types/ServiceInfo';
+import Slider from './Slider/Slider';
+import { DestinationRule, VirtualService } from '../../types/IstioObjects';
+import { serverConfig } from '../../config';
+import { authentication } from '../../utils/Authentication';
+import * as API from '../../services/Api';
+import * as MessageCenter from '../../utils/MessageCenter';
+
+type Props = {
+  show: boolean;
+  namespace: string;
+  serviceName: string;
+  workloads: WorkloadOverview[];
+  onClose: (changed: boolean) => void;
+};
+
+type WorkloadTraffic = {
+  name: string;
+  traffic: number;
+};
+
+type State = {
+  showWizard: boolean;
+  workloads: WorkloadTraffic[];
+};
+
+class IstioWizard extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      showWizard: false,
+      workloads: []
+    };
+  }
+
+  resetState = () => {
+    if (this.props.workloads.length === 0) {
+      return;
+    }
+    const wkTraffic = Math.round(100 / this.props.workloads.length);
+    const remainTraffic = 100 % this.props.workloads.length;
+    const workloads: WorkloadTraffic[] = this.props.workloads.map(workload => ({
+      name: workload.name,
+      traffic: wkTraffic
+    }));
+    if (remainTraffic > 0) {
+      workloads[workloads.length - 1].traffic = workloads[workloads.length - 1].traffic + remainTraffic;
+    }
+    this.setState({
+      showWizard: this.props.show,
+      workloads: workloads
+    });
+  };
+
+  compareWorkloads = (prev: WorkloadOverview[], current: WorkloadOverview[]): boolean => {
+    if (prev.length !== current.length) {
+      return false;
+    }
+    for (let i = 0; i < prev.length; i++) {
+      if (!current.includes(prev[i])) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  componentDidMount() {
+    this.resetState();
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps.show !== this.props.show || !this.compareWorkloads(prevProps.workloads, this.props.workloads)) {
+      this.resetState();
+    }
+  }
+
+  createIstioTraffic = (): [DestinationRule, VirtualService] => {
+    const wkdNameVersion: { [key: string]: string } = {};
+
+    // DestinationRule from the labels
+    const wizardDR: DestinationRule = {
+      metadata: {
+        namespace: this.props.namespace,
+        name: this.props.serviceName
+      },
+      spec: {
+        host: this.props.serviceName,
+        subsets: this.props.workloads.map(workload => {
+          // Using version
+          const versionLabelName = serverConfig().istioLabels.VersionLabelName;
+          const versionValue = workload.labels![versionLabelName];
+          const labels: { [key: string]: string } = {};
+          labels[versionLabelName] = versionValue;
+          // Populate helper table
+          wkdNameVersion[workload.name] = versionValue;
+          return {
+            name: versionValue,
+            labels: labels
+          };
+        })
+      }
+    };
+
+    // VirtualService from the weights
+    const wizardVS: VirtualService = {
+      metadata: {
+        namespace: this.props.namespace,
+        name: this.props.serviceName
+      },
+      spec: {
+        hosts: [this.props.serviceName],
+        http: [
+          {
+            route: this.state.workloads.map(workload => {
+              return {
+                destination: {
+                  host: this.props.serviceName,
+                  subset: wkdNameVersion[workload.name]
+                },
+                weight: workload.traffic
+              };
+            })
+          }
+        ]
+      }
+    };
+    return [wizardDR, wizardVS];
+  };
+
+  onClose = () => {
+    this.setState({ showWizard: false });
+    this.props.onClose(false);
+  };
+
+  onCreate = () => {
+    const [dr, vr] = this.createIstioTraffic();
+    const createDR = API.createIstioConfigDetail(
+      authentication(),
+      this.props.namespace,
+      'destinationrules',
+      JSON.stringify(dr)
+    );
+    const createVS = API.createIstioConfigDetail(
+      authentication(),
+      this.props.namespace,
+      'virtualservices',
+      JSON.stringify(vr)
+    );
+    Promise.all([createDR, createVS])
+      .then(results => {
+        this.props.onClose(true);
+      })
+      .catch(error => {
+        MessageCenter.add(API.getErrorMsg('Could not create Istio config objects', error));
+      });
+  };
+
+  onWeight = (workloadName: string, newWeight: number) => {
+    this.setState(prevState => {
+      const nodeId: number[] = [];
+      // Set new weight, remember rest of the list
+      for (let i = 0; i < prevState.workloads.length; i++) {
+        if (prevState.workloads[i].name === workloadName) {
+          prevState.workloads[i].traffic = newWeight;
+        } else {
+          nodeId.push(i);
+        }
+      }
+      // Distribute pending weights
+      const maxWeights = 100 - newWeight;
+      let sumWeights = 0;
+      for (let j = 0; j < nodeId.length; j++) {
+        if (sumWeights + prevState.workloads[nodeId[j]].traffic > maxWeights) {
+          prevState.workloads[nodeId[j]].traffic = maxWeights - sumWeights;
+        }
+        sumWeights += prevState.workloads[nodeId[j]].traffic;
+      }
+      // Adjust last element
+      if (nodeId.length > 0 && sumWeights < maxWeights) {
+        prevState.workloads[nodeId[nodeId.length - 1]].traffic += maxWeights - sumWeights;
+      }
+      return {
+        workloads: prevState.workloads
+      };
+    });
+  };
+
+  checkWeight = (): boolean => {
+    // Check all weights are equal to 100
+    return this.state.workloads.map(w => w.traffic).reduce((a, b) => a + b, 0) === 100;
+  };
+
+  renderWorkloads = () => {
+    const iconType = 'pf';
+    const iconName = 'bundle';
+    return this.state.workloads.map((workload, id) => {
+      return (
+        <ListViewItem
+          key={'workload-' + id}
+          leftContent={<ListViewIcon type={iconType} name={iconName} />}
+          heading={workload.name}
+          description={
+            <Slider
+              id={'slider-' + workload.name}
+              key={'slider-' + workload.name}
+              tooltip={true}
+              input={true}
+              inputFormat="%"
+              label={'Traffic Weight'}
+              value={workload.traffic}
+              onSlide={value => {
+                this.onWeight(workload.name, value as number);
+              }}
+            />
+          }
+        />
+      );
+    });
+  };
+
+  renderContent = () => {
+    return (
+      <Wizard.Contents stepIndex={0} activeStepIndex={0}>
+        <ListView>{this.renderWorkloads()}</ListView>
+      </Wizard.Contents>
+    );
+  };
+
+  render() {
+    return (
+      <Wizard show={this.state.showWizard} onHide={this.onClose}>
+        <Wizard.Header onClose={this.onClose} title="Create A/B Traffic Routing" />
+        <Wizard.Body>
+          <Wizard.Row>
+            <Wizard.Main>{this.renderContent()}</Wizard.Main>
+          </Wizard.Row>
+        </Wizard.Body>
+        <Wizard.Footer>
+          <Button bsStyle="default" className="btn-cancel" onClick={this.onClose}>
+            Cancel
+          </Button>
+          <Button disabled={!this.checkWeight()} bsStyle="primary" onClick={this.onCreate}>
+            Create
+          </Button>
+        </Wizard.Footer>
+      </Wizard>
+    );
+  }
+}
+
+export default IstioWizard;

--- a/src/components/IstioWizards/IstioWizard.tsx
+++ b/src/components/IstioWizards/IstioWizard.tsx
@@ -211,9 +211,12 @@ class IstioWizard extends React.Component<Props, State> {
               label={'Traffic Weight'}
               value={workload.traffic}
               onSlide={value => {
-                console.log('onSlide value: ' + value);
+                value = Math.round((value as number) || 0);
                 if (value > 100) {
                   value = 100;
+                }
+                if (value < 0) {
+                  value = 0;
                 }
                 this.onWeight(workload.name, value as number);
               }}

--- a/src/components/IstioWizards/IstioWizardDropdown.tsx
+++ b/src/components/IstioWizards/IstioWizardDropdown.tsx
@@ -1,0 +1,141 @@
+import * as React from 'react';
+import { DropdownButton, MenuItem, MessageDialog } from 'patternfly-react';
+import IstioWizard from './IstioWizard';
+import { WorkloadOverview } from '../../types/ServiceInfo';
+import { DestinationRules, VirtualServices } from '../../types/IstioObjects';
+import { authentication } from '../../utils/Authentication';
+import * as MessageCenter from '../../utils/MessageCenter';
+import * as API from '../../services/Api';
+
+type Props = {
+  namespace: string;
+  serviceName: string;
+  show: boolean;
+  workloads: WorkloadOverview[];
+  virtualServices: VirtualServices;
+  destinationRules: DestinationRules;
+  onChange: () => void;
+};
+
+type State = {
+  showWizard: boolean;
+  showConfirmDelete: boolean;
+};
+
+class IstioWizardDropdown extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { showWizard: props.show, showConfirmDelete: false };
+  }
+
+  // Wizard can be opened when there are not existing VS & DR and there are update permissions
+  canCreate = () => {
+    return (
+      this.props.virtualServices.permissions.update &&
+      this.props.destinationRules.permissions.update &&
+      this.props.virtualServices.items.length === 0 &&
+      this.props.destinationRules.items.length === 0
+    );
+  };
+
+  canDelete = () => {
+    return (
+      this.props.virtualServices.permissions.delete &&
+      this.props.destinationRules.permissions.delete &&
+      (this.props.virtualServices.items.length > 0 || this.props.destinationRules.items.length > 0)
+    );
+  };
+
+  onAction = (key: string) => {
+    if (key === 'create_traffic_routing') {
+      this.setState({ showWizard: true });
+    }
+    if (key === 'delete_traffic_routing') {
+      this.setState({ showConfirmDelete: true });
+    }
+  };
+
+  onDelete = () => {
+    const deletePromises: Promise<any>[] = [];
+    this.props.virtualServices.items.forEach(vs => {
+      deletePromises.push(
+        API.deleteIstioConfigDetail(authentication(), vs.metadata.namespace || '', 'virtualservices', vs.metadata.name)
+      );
+    });
+    this.props.destinationRules.items.forEach(dr => {
+      deletePromises.push(
+        API.deleteIstioConfigDetail(authentication(), dr.metadata.namespace || '', 'destinationrules', dr.metadata.name)
+      );
+    });
+    Promise.all(deletePromises)
+      .then(results => {
+        this.hideConfirmDelete();
+        this.props.onChange();
+      })
+      .catch(error => {
+        MessageCenter.add(API.getErrorMsg('Could not delete Istio config objects', error));
+      });
+  };
+
+  hideConfirmDelete = () => {
+    this.setState({ showConfirmDelete: false });
+  };
+
+  onClose = (changed: boolean) => {
+    this.setState({ showWizard: false });
+    if (changed) {
+      this.props.onChange();
+    }
+  };
+
+  render() {
+    let deleteMessage = 'Are you sure you want to delete ';
+    deleteMessage +=
+      this.props.virtualServices.items.length > 0
+        ? `VirtualServices: '${this.props.virtualServices.items.map(vs => vs.metadata.name)}'`
+        : '';
+    deleteMessage +=
+      this.props.virtualServices.items.length > 0 && this.props.destinationRules.items.length > 0 ? ' and ' : '';
+    deleteMessage +=
+      this.props.destinationRules.items.length > 0
+        ? `DestinationRules : '${this.props.destinationRules.items.map(dr => dr.metadata.name)}'`
+        : '';
+    deleteMessage += ' ?.  ';
+    return (
+      <>
+        <DropdownButton id="service_actions" title="Actions" onSelect={this.onAction} pullRight={true}>
+          <MenuItem disabled={!this.canCreate()} key="create_traffic_routing" eventKey="create_traffic_routing">
+            Create A/B Traffic Routing
+          </MenuItem>
+          <MenuItem divider={true} />
+          <MenuItem disabled={!this.canDelete()} key="delete_traffic_routing" eventKey="delete_traffic_routing">
+            Delete ALL Traffic Routing
+          </MenuItem>
+        </DropdownButton>
+        <IstioWizard
+          show={this.state.showWizard}
+          namespace={this.props.namespace}
+          serviceName={this.props.serviceName}
+          workloads={this.props.workloads}
+          onClose={this.onClose}
+        />
+        <MessageDialog
+          show={this.state.showConfirmDelete}
+          primaryAction={this.onDelete}
+          secondaryAction={this.hideConfirmDelete}
+          onHide={this.hideConfirmDelete}
+          primaryActionButtonContent="Delete"
+          secondaryActionButtonContent="Cancel"
+          primaryActionButtonBsStyle="danger"
+          title="Confirm Delete"
+          primaryContent={deleteMessage}
+          secondaryContent="It cannot be undone. Make sure this is something you really want to do!"
+          accessibleName="deleteConfirmationDialog"
+          accessibleDescription="deleteConfirmationDialogContent"
+        />
+      </>
+    );
+  }
+}
+
+export default IstioWizardDropdown;

--- a/src/components/IstioWizards/IstioWizardDropdown.tsx
+++ b/src/components/IstioWizards/IstioWizardDropdown.tsx
@@ -105,7 +105,7 @@ class IstioWizardDropdown extends React.Component<Props, State> {
       <>
         <DropdownButton id="service_actions" title="Actions" onSelect={this.onAction} pullRight={true}>
           <MenuItem disabled={!this.canCreate()} key="create_traffic_routing" eventKey="create_traffic_routing">
-            Create A/B Traffic Routing
+            Create Traffic Routing
           </MenuItem>
           <MenuItem divider={true} />
           <MenuItem disabled={!this.canDelete()} key="delete_traffic_routing" eventKey="delete_traffic_routing">

--- a/src/components/IstioWizards/IstioWizardDropdown.tsx
+++ b/src/components/IstioWizards/IstioWizardDropdown.tsx
@@ -31,8 +31,8 @@ class IstioWizardDropdown extends React.Component<Props, State> {
   // Wizard can be opened when there are not existing VS & DR and there are update permissions
   canCreate = () => {
     return (
-      this.props.virtualServices.permissions.update &&
-      this.props.destinationRules.permissions.update &&
+      this.props.virtualServices.permissions.create &&
+      this.props.destinationRules.permissions.create &&
       this.props.virtualServices.items.length === 0 &&
       this.props.destinationRules.items.length === 0
     );

--- a/src/components/IstioWizards/Slider/BootstrapSlider.tsx
+++ b/src/components/IstioWizards/Slider/BootstrapSlider.tsx
@@ -1,0 +1,75 @@
+// Clone of Slider component to workaround issue https://github.com/patternfly/patternfly-react/issues/1221
+
+import React from 'react';
+import Slider from 'bootstrap-slider-without-jquery';
+
+const orientation = {
+  horizontal: 'horizontal',
+  vertical: 'vertical'
+};
+
+type Props = {
+  value: number[] | number;
+  formatter: (value: any) => any;
+  onSlide: (event: any) => any;
+  orientation: string;
+  ticks_labels: [];
+};
+
+class BootstrapSlider extends React.Component<Props> {
+  static defaultProps = {
+    formatter: value => value,
+    onSlide: event => event,
+    orientation: 'horizontal',
+    ticks_labels: []
+  };
+  slider: Slider;
+  sliderDiv: any;
+
+  componentDidMount() {
+    this.slider = new Slider(this.sliderDiv, {
+      ...this.props
+    });
+
+    const onSlide = value => {
+      this.props.onSlide(value);
+      this.slider.setValue(value);
+    };
+
+    this.slider.on('slide', onSlide);
+    this.slider.on('slideStop', onSlide);
+  }
+
+  // Instead of rendering the slider element again and again,
+  // we took advantage of the bootstrap-slider library
+  // and only update the new value or format when new props arrive.
+  componentWillReceiveProps(nextProps: Props) {
+    this.slider.setValue(nextProps.value);
+    // Sets the tooltip format.
+    this.slider.setAttribute('formatter', nextProps.formatter);
+    // Adjust the tooltip to "sit" ontop of the slider's handle. #LibraryBug
+    // check
+    if (this.props && this.props.orientation === orientation.horizontal) {
+      this.slider.tooltip.style.marginLeft = `-${this.slider.tooltip.offsetWidth / 2}px`;
+      if (this.props.ticks_labels && this.slider.tickLabelContainer) {
+        this.slider.tickLabelContainer.style.marginTop = '0px';
+      }
+    } else {
+      this.slider.tooltip.style.marginTop = `-${this.slider.tooltip.offsetHeight / 2}px`;
+    }
+  }
+
+  render() {
+    return (
+      <input
+        className="slider-pf"
+        type="range"
+        ref={input => {
+          this.sliderDiv = input;
+        }}
+      />
+    );
+  }
+}
+
+export default BootstrapSlider;

--- a/src/components/IstioWizards/Slider/Boundaries.tsx
+++ b/src/components/IstioWizards/Slider/Boundaries.tsx
@@ -1,0 +1,49 @@
+// Clone of Slider component to workaround issue https://github.com/patternfly/patternfly-react/issues/1221
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Boundaries = props => {
+  const { children, min, max, reversed, showBoundaries, slider } = props;
+  const minElement = <b>{min}</b>;
+  const maxElement = <b>{max}</b>;
+  let leftBoundary: any = null;
+  let rightBoundary: any = null;
+  if (showBoundaries) {
+    if (reversed) {
+      leftBoundary = maxElement;
+      rightBoundary = minElement;
+    } else {
+      leftBoundary = minElement;
+      rightBoundary = maxElement;
+    }
+  }
+
+  return (
+    <div className="slider-pf">
+      {leftBoundary}
+      {slider}
+      {rightBoundary}
+      {children}
+    </div>
+  );
+};
+
+Boundaries.propTypes = {
+  children: PropTypes.array,
+  min: PropTypes.number,
+  max: PropTypes.number,
+  reversed: PropTypes.bool,
+  showBoundaries: PropTypes.bool,
+  slider: PropTypes.object.isRequired
+};
+
+Boundaries.defaultProps = {
+  children: [],
+  min: 0,
+  max: 100,
+  reversed: false,
+  showBoundaries: false
+};
+
+export default Boundaries;

--- a/src/components/IstioWizards/Slider/DropdownMenu.tsx
+++ b/src/components/IstioWizards/Slider/DropdownMenu.tsx
@@ -1,0 +1,40 @@
+// Clone of Slider component to workaround issue https://github.com/patternfly/patternfly-react/issues/1221
+
+import React from 'react';
+import { Dropdown, MenuItem } from 'patternfly-react';
+
+type Props = {
+  dropup: boolean;
+  dropdownList: string[];
+  onFormatChange: (event: string) => void;
+  title: string;
+};
+
+class DropdownMenu extends React.Component<Props> {
+  static defaultProps = {
+    dropup: false,
+    dropdownList: null,
+    onFormatChange: null,
+    title: null
+  };
+
+  render() {
+    const { dropup, dropdownList, onFormatChange, title } = this.props;
+    const menuItems = dropdownList.map((item, index) => (
+      <MenuItem bsClass="slider_menuitem" onClick={event => onFormatChange(event.target.text)} key={index} value={item}>
+        {item}
+      </MenuItem>
+    ));
+
+    return (
+      <Dropdown id="slider_dropdown" dropup={dropup} pullRight={true}>
+        <Dropdown.Toggle>
+          <span>{title || dropdownList[0]}</span>
+        </Dropdown.Toggle>
+        <Dropdown.Menu>{menuItems}</Dropdown.Menu>
+      </Dropdown>
+    );
+  }
+}
+
+export default DropdownMenu;

--- a/src/components/IstioWizards/Slider/Slider.tsx
+++ b/src/components/IstioWizards/Slider/Slider.tsx
@@ -60,7 +60,7 @@ class Slider extends React.Component<Props, State> {
   }
 
   componentDidUpdate(prevProps: Readonly<Props>): void {
-    if (prevProps.value !== this.props.value) {
+    if (prevProps.value !== this.props.value || this.state.value !== this.props.value) {
       this.setState({ value: this.props.value });
     }
   }

--- a/src/components/IstioWizards/Slider/Slider.tsx
+++ b/src/components/IstioWizards/Slider/Slider.tsx
@@ -1,0 +1,139 @@
+// Clone of Slider component to workaround issue https://github.com/patternfly/patternfly-react/issues/1221
+
+import React from 'react';
+import BootstrapSlider from './BootstrapSlider';
+import { Icon, ControlLabel, FormControl } from 'patternfly-react';
+import Boundaries from './Boundaries';
+import DropdownMenu from './DropdownMenu';
+
+export const noop = Function.prototype;
+
+type Props = {
+  id: string;
+  orientation: string;
+  min: number;
+  max: number;
+  step: number;
+  value: number[] | number;
+  tooltip: boolean;
+  onSlide: (value: number[] | number) => void;
+  label: string;
+  labelClass: string;
+  icon: Icon;
+  input: boolean;
+  sliderClass: string;
+  dropdownList: string[];
+  inputFormat: string;
+};
+
+type State = {
+  value: number[] | number;
+  tooltipFormat: string;
+};
+
+class Slider extends React.Component<Props, State> {
+  static defaultProps = {
+    id: null,
+    orientation: 'horizontal',
+    min: 0,
+    max: 100,
+    value: 0,
+    step: 1,
+    toolTip: false,
+    onSlide: noop,
+    label: null,
+    labelClass: null,
+    input: false,
+    sliderClass: null,
+    icon: null,
+    dropdownList: null,
+    inputFormat: ''
+  };
+
+  constructor(props: Props) {
+    super(props);
+
+    this.state = {
+      value: this.props.value,
+      tooltipFormat: (this.props.dropdownList && this.props.dropdownList[0]) || this.props.inputFormat
+    };
+  }
+
+  componentDidUpdate(prevProps: Readonly<Props>): void {
+    if (prevProps.value !== this.props.value) {
+      this.setState({ value: this.props.value });
+    }
+  }
+
+  onSlide = value => {
+    this.setState({ value }, () => this.props.onSlide(value));
+  };
+
+  onInputChange = event => {
+    const newValue = Number(event.target.value || 0);
+    this.setState({ value: newValue }, () => this.props.onSlide(newValue));
+  };
+
+  onFormatChange = format => {
+    this.setState({ tooltipFormat: format });
+  };
+
+  formatter = value => `${value} ${this.state.tooltipFormat}`;
+
+  render() {
+    let label: any = null;
+    let sliderClass = 'col-xs-12 col-sm-12 col-md-12';
+    const labelClass = 'col-xs-2 col-sm-2 col-md-2';
+    if (this.props.label || this.props.icon) {
+      sliderClass = 'col-xs-10 col-sm-10 col-md-10';
+      label = this.props.icon ? (
+        <Icon className={labelClass} {...this.props.icon} />
+      ) : (
+        <ControlLabel htmlFor={this.props.id} bsClass={labelClass}>
+          {this.props.label}
+        </ControlLabel>
+      );
+    }
+
+    let formatElement;
+
+    if (this.props.inputFormat) {
+      formatElement = <span>{this.props.inputFormat}</span>;
+    }
+
+    if (this.props.dropdownList) {
+      formatElement = (
+        <DropdownMenu {...this.props} onFormatChange={this.onFormatChange} title={this.state.tooltipFormat} />
+      );
+    }
+
+    const inputElement = this.props.input && (
+      <FormControl
+        bsClass="slider-input-pf"
+        type="number"
+        value={this.state.value}
+        min={this.props.min}
+        max={this.props.max}
+        onChange={this.onInputChange}
+      />
+    );
+
+    const BSSlider = (
+      <BootstrapSlider {...this.props} formatter={this.formatter} value={this.state.value} onSlide={this.onSlide} />
+    );
+
+    return (
+      <div>
+        {label}
+        <div className={sliderClass}>
+          <Boundaries slider={BSSlider} {...this.props}>
+            {inputElement}
+            {formatElement}
+          </Boundaries>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default Slider;

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -87,6 +87,9 @@ const conf = {
       appDashboard: (namespace: string, app: string) => `api/namespaces/${namespace}/apps/${app}/dashboard`,
       grafana: 'api/grafana',
       istioConfig: (namespace: string) => `api/namespaces/${namespace}/istio`,
+      istioConfigCreate: (namespace: string, objectType: string) => `api/namespaces/${namespace}/istio/${objectType}`,
+      istioConfigCreateSubtype: (namespace: string, objectType: string, objectSubtype: string) =>
+        `api/namespaces/${namespace}/istio/${objectType}/${objectSubtype}`,
       istioConfigDetail: (namespace: string, objectType: string, object: string) =>
         `api/namespaces/${namespace}/istio/${objectType}/${object}`,
       istioConfigDetailSubtype: (namespace: string, objectType: string, objectSubtype: string, object: string) =>

--- a/src/pages/IstioConfigList/__tests__/IstioConfigListComponent.test.ts
+++ b/src/pages/IstioConfigList/__tests__/IstioConfigListComponent.test.ts
@@ -8,8 +8,8 @@ const mockIstioConfigList = (names: string[]): IstioConfigList => {
       name: 'test'
     },
     gateways: [],
-    virtualServices: { items: [], permissions: { update: false, delete: false } },
-    destinationRules: { items: [], permissions: { update: false, delete: false } },
+    virtualServices: { items: [], permissions: { create: false, update: false, delete: false } },
+    destinationRules: { items: [], permissions: { create: false, update: false, delete: false } },
     serviceEntries: [],
     rules: [],
     adapters: [],

--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -43,6 +43,7 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
         virtualServices: {
           items: [],
           permissions: {
+            create: false,
             update: false,
             delete: false
           }
@@ -50,6 +51,7 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
         destinationRules: {
           items: [],
           permissions: {
+            create: false,
             update: false,
             delete: false
           }

--- a/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -24,6 +24,7 @@ import { Validations } from '../../types/IstioObjects';
 import { ServiceInfoRoutes } from '../../components/InfoRoutes/ServiceInfoRoutes';
 import { Route } from '../../components/InfoRoutes/InfoRoutes';
 import WithErrorBoundary from '../../components/ErrorBoundary/WithErrorBoundary';
+import IstioWizardDropdown from '../../components/IstioWizards/IstioWizardDropdown';
 
 interface ServiceDetails extends ServiceId {
   serviceDetails: ServiceDetailsInfo;
@@ -137,9 +138,21 @@ class ServiceInfo extends React.Component<ServiceDetails, ServiceInfoState> {
         <div className="container-fluid container-cards-pf">
           <Row className="row-cards-pf">
             <Col xs={12} sm={12} md={12} lg={12}>
-              <Button onClick={this.props.onRefresh} style={{ float: 'right' }}>
-                <Icon name="refresh" />
-              </Button>
+              <span style={{ float: 'right' }}>
+                <Button onClick={this.props.onRefresh}>
+                  <Icon name="refresh" />
+                </Button>
+                &nbsp;
+                <IstioWizardDropdown
+                  namespace={this.props.namespace}
+                  serviceName={this.props.serviceDetails.service.name}
+                  show={false}
+                  workloads={workloads}
+                  virtualServices={virtualServices}
+                  destinationRules={destinationRules}
+                  onChange={this.props.onRefresh}
+                />
+              </span>
             </Col>
           </Row>
           <Row className="row-cards-pf">

--- a/src/pages/ServiceDetails/__tests__/__snapshots__/ServiceInfo.test.tsx.snap
+++ b/src/pages/ServiceDetails/__tests__/__snapshots__/ServiceInfo.test.tsx.snap
@@ -258,24 +258,112 @@ ShallowWrapper {
               sm={12}
               xs={12}
             >
-              <Button
-                active={false}
-                block={false}
-                bsClass="btn"
-                bsStyle="default"
-                disabled={false}
-                onClick={[MockFunction]}
+              <span
                 style={
                   Object {
                     "float": "right",
                   }
                 }
               >
-                <Icon
-                  name="refresh"
-                  type="fa"
+                <Button
+                  active={false}
+                  block={false}
+                  bsClass="btn"
+                  bsStyle="default"
+                  disabled={false}
+                  onClick={[MockFunction]}
+                >
+                  <Icon
+                    name="refresh"
+                    type="fa"
+                  />
+                </Button>
+                 
+                <IstioWizardDropdown
+                  destinationRules={
+                    Object {
+                      "items": Array [
+                        Object {
+                          "metadata": Object {
+                            "createdTimestamp": "2018-07-02T13:44:01+02:00",
+                            "name": "reviews",
+                            "resourceVersion": "393061",
+                          },
+                          "spec": Object {
+                            "host": "reviews",
+                            "subsets": Array [
+                              Object {
+                                "labels": Object {
+                                  "version": "v1",
+                                },
+                                "name": "v1",
+                              },
+                              Object {
+                                "labels": Object {
+                                  "version": "v2",
+                                },
+                                "name": "v2",
+                              },
+                              Object {
+                                "labels": Object {
+                                  "version": "v3",
+                                },
+                                "name": "v3",
+                              },
+                            ],
+                            "trafficPolicy": null,
+                          },
+                        },
+                      ],
+                      "permissions": Object {
+                        "delete": false,
+                        "update": false,
+                      },
+                    }
+                  }
+                  namespace="istio-system"
+                  onChange={[MockFunction]}
+                  serviceName="reviews"
+                  show={false}
+                  virtualServices={
+                    Object {
+                      "items": Array [
+                        Object {
+                          "metadata": Object {
+                            "creationTimestamp": "2018-07-02T13:44:01+02:00",
+                            "name": "reviews",
+                            "resourceVersion": "393057",
+                          },
+                          "spec": Object {
+                            "gateways": null,
+                            "hosts": Array [
+                              "reviews",
+                            ],
+                            "http": Array [
+                              Object {
+                                "route": Array [
+                                  Object {
+                                    "destination": Object {
+                                      "host": "reviews",
+                                      "subset": "v1",
+                                    },
+                                  },
+                                ],
+                              },
+                            ],
+                            "tcp": null,
+                          },
+                        },
+                      ],
+                      "permissions": Object {
+                        "delete": false,
+                        "update": false,
+                      },
+                    }
+                  }
+                  workloads={Array []}
                 />
-              </Button>
+              </span>
             </Col>
           </Row>
           <Row
@@ -593,24 +681,112 @@ ShallowWrapper {
                 sm={12}
                 xs={12}
               >
-                <Button
-                  active={false}
-                  block={false}
-                  bsClass="btn"
-                  bsStyle="default"
-                  disabled={false}
-                  onClick={[MockFunction]}
+                <span
                   style={
                     Object {
                       "float": "right",
                     }
                   }
                 >
-                  <Icon
-                    name="refresh"
-                    type="fa"
+                  <Button
+                    active={false}
+                    block={false}
+                    bsClass="btn"
+                    bsStyle="default"
+                    disabled={false}
+                    onClick={[MockFunction]}
+                  >
+                    <Icon
+                      name="refresh"
+                      type="fa"
+                    />
+                  </Button>
+                   
+                  <IstioWizardDropdown
+                    destinationRules={
+                      Object {
+                        "items": Array [
+                          Object {
+                            "metadata": Object {
+                              "createdTimestamp": "2018-07-02T13:44:01+02:00",
+                              "name": "reviews",
+                              "resourceVersion": "393061",
+                            },
+                            "spec": Object {
+                              "host": "reviews",
+                              "subsets": Array [
+                                Object {
+                                  "labels": Object {
+                                    "version": "v1",
+                                  },
+                                  "name": "v1",
+                                },
+                                Object {
+                                  "labels": Object {
+                                    "version": "v2",
+                                  },
+                                  "name": "v2",
+                                },
+                                Object {
+                                  "labels": Object {
+                                    "version": "v3",
+                                  },
+                                  "name": "v3",
+                                },
+                              ],
+                              "trafficPolicy": null,
+                            },
+                          },
+                        ],
+                        "permissions": Object {
+                          "delete": false,
+                          "update": false,
+                        },
+                      }
+                    }
+                    namespace="istio-system"
+                    onChange={[MockFunction]}
+                    serviceName="reviews"
+                    show={false}
+                    virtualServices={
+                      Object {
+                        "items": Array [
+                          Object {
+                            "metadata": Object {
+                              "creationTimestamp": "2018-07-02T13:44:01+02:00",
+                              "name": "reviews",
+                              "resourceVersion": "393057",
+                            },
+                            "spec": Object {
+                              "gateways": null,
+                              "hosts": Array [
+                                "reviews",
+                              ],
+                              "http": Array [
+                                Object {
+                                  "route": Array [
+                                    Object {
+                                      "destination": Object {
+                                        "host": "reviews",
+                                        "subset": "v1",
+                                      },
+                                    },
+                                  ],
+                                },
+                              ],
+                              "tcp": null,
+                            },
+                          },
+                        ],
+                        "permissions": Object {
+                          "delete": false,
+                          "update": false,
+                        },
+                      }
+                    }
+                    workloads={Array []}
                   />
-                </Button>
+                </span>
               </Col>
             </Row>,
             <Row
@@ -922,24 +1098,112 @@ ShallowWrapper {
                 sm={12}
                 xs={12}
               >
-                <Button
-                  active={false}
-                  block={false}
-                  bsClass="btn"
-                  bsStyle="default"
-                  disabled={false}
-                  onClick={[MockFunction]}
+                <span
                   style={
                     Object {
                       "float": "right",
                     }
                   }
                 >
-                  <Icon
-                    name="refresh"
-                    type="fa"
+                  <Button
+                    active={false}
+                    block={false}
+                    bsClass="btn"
+                    bsStyle="default"
+                    disabled={false}
+                    onClick={[MockFunction]}
+                  >
+                    <Icon
+                      name="refresh"
+                      type="fa"
+                    />
+                  </Button>
+                   
+                  <IstioWizardDropdown
+                    destinationRules={
+                      Object {
+                        "items": Array [
+                          Object {
+                            "metadata": Object {
+                              "createdTimestamp": "2018-07-02T13:44:01+02:00",
+                              "name": "reviews",
+                              "resourceVersion": "393061",
+                            },
+                            "spec": Object {
+                              "host": "reviews",
+                              "subsets": Array [
+                                Object {
+                                  "labels": Object {
+                                    "version": "v1",
+                                  },
+                                  "name": "v1",
+                                },
+                                Object {
+                                  "labels": Object {
+                                    "version": "v2",
+                                  },
+                                  "name": "v2",
+                                },
+                                Object {
+                                  "labels": Object {
+                                    "version": "v3",
+                                  },
+                                  "name": "v3",
+                                },
+                              ],
+                              "trafficPolicy": null,
+                            },
+                          },
+                        ],
+                        "permissions": Object {
+                          "delete": false,
+                          "update": false,
+                        },
+                      }
+                    }
+                    namespace="istio-system"
+                    onChange={[MockFunction]}
+                    serviceName="reviews"
+                    show={false}
+                    virtualServices={
+                      Object {
+                        "items": Array [
+                          Object {
+                            "metadata": Object {
+                              "creationTimestamp": "2018-07-02T13:44:01+02:00",
+                              "name": "reviews",
+                              "resourceVersion": "393057",
+                            },
+                            "spec": Object {
+                              "gateways": null,
+                              "hosts": Array [
+                                "reviews",
+                              ],
+                              "http": Array [
+                                Object {
+                                  "route": Array [
+                                    Object {
+                                      "destination": Object {
+                                        "host": "reviews",
+                                        "subset": "v1",
+                                      },
+                                    },
+                                  ],
+                                },
+                              ],
+                              "tcp": null,
+                            },
+                          },
+                        ],
+                        "permissions": Object {
+                          "delete": false,
+                          "update": false,
+                        },
+                      }
+                    }
+                    workloads={Array []}
                   />
-                </Button>
+                </span>
               </Col>,
               "className": "row-cards-pf",
               "componentClass": "div",
@@ -951,24 +1215,112 @@ ShallowWrapper {
               "nodeType": "class",
               "props": Object {
                 "bsClass": "col",
-                "children": <Button
-                  active={false}
-                  block={false}
-                  bsClass="btn"
-                  bsStyle="default"
-                  disabled={false}
-                  onClick={[MockFunction]}
+                "children": <span
                   style={
                     Object {
                       "float": "right",
                     }
                   }
                 >
-                  <Icon
-                    name="refresh"
-                    type="fa"
+                  <Button
+                    active={false}
+                    block={false}
+                    bsClass="btn"
+                    bsStyle="default"
+                    disabled={false}
+                    onClick={[MockFunction]}
+                  >
+                    <Icon
+                      name="refresh"
+                      type="fa"
+                    />
+                  </Button>
+                   
+                  <IstioWizardDropdown
+                    destinationRules={
+                      Object {
+                        "items": Array [
+                          Object {
+                            "metadata": Object {
+                              "createdTimestamp": "2018-07-02T13:44:01+02:00",
+                              "name": "reviews",
+                              "resourceVersion": "393061",
+                            },
+                            "spec": Object {
+                              "host": "reviews",
+                              "subsets": Array [
+                                Object {
+                                  "labels": Object {
+                                    "version": "v1",
+                                  },
+                                  "name": "v1",
+                                },
+                                Object {
+                                  "labels": Object {
+                                    "version": "v2",
+                                  },
+                                  "name": "v2",
+                                },
+                                Object {
+                                  "labels": Object {
+                                    "version": "v3",
+                                  },
+                                  "name": "v3",
+                                },
+                              ],
+                              "trafficPolicy": null,
+                            },
+                          },
+                        ],
+                        "permissions": Object {
+                          "delete": false,
+                          "update": false,
+                        },
+                      }
+                    }
+                    namespace="istio-system"
+                    onChange={[MockFunction]}
+                    serviceName="reviews"
+                    show={false}
+                    virtualServices={
+                      Object {
+                        "items": Array [
+                          Object {
+                            "metadata": Object {
+                              "creationTimestamp": "2018-07-02T13:44:01+02:00",
+                              "name": "reviews",
+                              "resourceVersion": "393057",
+                            },
+                            "spec": Object {
+                              "gateways": null,
+                              "hosts": Array [
+                                "reviews",
+                              ],
+                              "http": Array [
+                                Object {
+                                  "route": Array [
+                                    Object {
+                                      "destination": Object {
+                                        "host": "reviews",
+                                        "subset": "v1",
+                                      },
+                                    },
+                                  ],
+                                },
+                              ],
+                              "tcp": null,
+                            },
+                          },
+                        ],
+                        "permissions": Object {
+                          "delete": false,
+                          "update": false,
+                        },
+                      }
+                    }
+                    workloads={Array []}
                   />
-                </Button>,
+                </span>,
                 "componentClass": "div",
                 "lg": 12,
                 "md": 12,
@@ -979,36 +1331,236 @@ ShallowWrapper {
               "rendered": Object {
                 "instance": null,
                 "key": undefined,
-                "nodeType": "class",
+                "nodeType": "host",
                 "props": Object {
-                  "active": false,
-                  "block": false,
-                  "bsClass": "btn",
-                  "bsStyle": "default",
-                  "children": <Icon
-                    name="refresh"
-                    type="fa"
-                  />,
-                  "disabled": false,
-                  "onClick": [MockFunction],
+                  "children": Array [
+                    <Button
+                      active={false}
+                      block={false}
+                      bsClass="btn"
+                      bsStyle="default"
+                      disabled={false}
+                      onClick={[MockFunction]}
+                    >
+                      <Icon
+                        name="refresh"
+                        type="fa"
+                      />
+                    </Button>,
+                    " ",
+                    <IstioWizardDropdown
+                      destinationRules={
+                        Object {
+                          "items": Array [
+                            Object {
+                              "metadata": Object {
+                                "createdTimestamp": "2018-07-02T13:44:01+02:00",
+                                "name": "reviews",
+                                "resourceVersion": "393061",
+                              },
+                              "spec": Object {
+                                "host": "reviews",
+                                "subsets": Array [
+                                  Object {
+                                    "labels": Object {
+                                      "version": "v1",
+                                    },
+                                    "name": "v1",
+                                  },
+                                  Object {
+                                    "labels": Object {
+                                      "version": "v2",
+                                    },
+                                    "name": "v2",
+                                  },
+                                  Object {
+                                    "labels": Object {
+                                      "version": "v3",
+                                    },
+                                    "name": "v3",
+                                  },
+                                ],
+                                "trafficPolicy": null,
+                              },
+                            },
+                          ],
+                          "permissions": Object {
+                            "delete": false,
+                            "update": false,
+                          },
+                        }
+                      }
+                      namespace="istio-system"
+                      onChange={[MockFunction]}
+                      serviceName="reviews"
+                      show={false}
+                      virtualServices={
+                        Object {
+                          "items": Array [
+                            Object {
+                              "metadata": Object {
+                                "creationTimestamp": "2018-07-02T13:44:01+02:00",
+                                "name": "reviews",
+                                "resourceVersion": "393057",
+                              },
+                              "spec": Object {
+                                "gateways": null,
+                                "hosts": Array [
+                                  "reviews",
+                                ],
+                                "http": Array [
+                                  Object {
+                                    "route": Array [
+                                      Object {
+                                        "destination": Object {
+                                          "host": "reviews",
+                                          "subset": "v1",
+                                        },
+                                      },
+                                    ],
+                                  },
+                                ],
+                                "tcp": null,
+                              },
+                            },
+                          ],
+                          "permissions": Object {
+                            "delete": false,
+                            "update": false,
+                          },
+                        }
+                      }
+                      workloads={Array []}
+                    />,
+                  ],
                   "style": Object {
                     "float": "right",
                   },
                 },
                 "ref": null,
-                "rendered": Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "function",
-                  "props": Object {
-                    "name": "refresh",
-                    "type": "fa",
+                "rendered": Array [
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "class",
+                    "props": Object {
+                      "active": false,
+                      "block": false,
+                      "bsClass": "btn",
+                      "bsStyle": "default",
+                      "children": <Icon
+                        name="refresh"
+                        type="fa"
+                      />,
+                      "disabled": false,
+                      "onClick": [MockFunction],
+                    },
+                    "ref": null,
+                    "rendered": Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "function",
+                      "props": Object {
+                        "name": "refresh",
+                        "type": "fa",
+                      },
+                      "ref": null,
+                      "rendered": null,
+                      "type": [Function],
+                    },
+                    "type": [Function],
                   },
-                  "ref": null,
-                  "rendered": null,
-                  "type": [Function],
-                },
-                "type": [Function],
+                  " ",
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "class",
+                    "props": Object {
+                      "destinationRules": Object {
+                        "items": Array [
+                          Object {
+                            "metadata": Object {
+                              "createdTimestamp": "2018-07-02T13:44:01+02:00",
+                              "name": "reviews",
+                              "resourceVersion": "393061",
+                            },
+                            "spec": Object {
+                              "host": "reviews",
+                              "subsets": Array [
+                                Object {
+                                  "labels": Object {
+                                    "version": "v1",
+                                  },
+                                  "name": "v1",
+                                },
+                                Object {
+                                  "labels": Object {
+                                    "version": "v2",
+                                  },
+                                  "name": "v2",
+                                },
+                                Object {
+                                  "labels": Object {
+                                    "version": "v3",
+                                  },
+                                  "name": "v3",
+                                },
+                              ],
+                              "trafficPolicy": null,
+                            },
+                          },
+                        ],
+                        "permissions": Object {
+                          "delete": false,
+                          "update": false,
+                        },
+                      },
+                      "namespace": "istio-system",
+                      "onChange": [MockFunction],
+                      "serviceName": "reviews",
+                      "show": false,
+                      "virtualServices": Object {
+                        "items": Array [
+                          Object {
+                            "metadata": Object {
+                              "creationTimestamp": "2018-07-02T13:44:01+02:00",
+                              "name": "reviews",
+                              "resourceVersion": "393057",
+                            },
+                            "spec": Object {
+                              "gateways": null,
+                              "hosts": Array [
+                                "reviews",
+                              ],
+                              "http": Array [
+                                Object {
+                                  "route": Array [
+                                    Object {
+                                      "destination": Object {
+                                        "host": "reviews",
+                                        "subset": "v1",
+                                      },
+                                    },
+                                  ],
+                                },
+                              ],
+                              "tcp": null,
+                            },
+                          },
+                        ],
+                        "permissions": Object {
+                          "delete": false,
+                          "update": false,
+                        },
+                      },
+                      "workloads": Array [],
+                    },
+                    "ref": null,
+                    "rendered": null,
+                    "type": [Function],
+                  },
+                ],
+                "type": "span",
               },
               "type": [Function],
             },
@@ -2618,24 +3170,112 @@ ShallowWrapper {
                 sm={12}
                 xs={12}
               >
-                <Button
-                  active={false}
-                  block={false}
-                  bsClass="btn"
-                  bsStyle="default"
-                  disabled={false}
-                  onClick={[MockFunction]}
+                <span
                   style={
                     Object {
                       "float": "right",
                     }
                   }
                 >
-                  <Icon
-                    name="refresh"
-                    type="fa"
+                  <Button
+                    active={false}
+                    block={false}
+                    bsClass="btn"
+                    bsStyle="default"
+                    disabled={false}
+                    onClick={[MockFunction]}
+                  >
+                    <Icon
+                      name="refresh"
+                      type="fa"
+                    />
+                  </Button>
+                   
+                  <IstioWizardDropdown
+                    destinationRules={
+                      Object {
+                        "items": Array [
+                          Object {
+                            "metadata": Object {
+                              "createdTimestamp": "2018-07-02T13:44:01+02:00",
+                              "name": "reviews",
+                              "resourceVersion": "393061",
+                            },
+                            "spec": Object {
+                              "host": "reviews",
+                              "subsets": Array [
+                                Object {
+                                  "labels": Object {
+                                    "version": "v1",
+                                  },
+                                  "name": "v1",
+                                },
+                                Object {
+                                  "labels": Object {
+                                    "version": "v2",
+                                  },
+                                  "name": "v2",
+                                },
+                                Object {
+                                  "labels": Object {
+                                    "version": "v3",
+                                  },
+                                  "name": "v3",
+                                },
+                              ],
+                              "trafficPolicy": null,
+                            },
+                          },
+                        ],
+                        "permissions": Object {
+                          "delete": false,
+                          "update": false,
+                        },
+                      }
+                    }
+                    namespace="istio-system"
+                    onChange={[MockFunction]}
+                    serviceName="reviews"
+                    show={false}
+                    virtualServices={
+                      Object {
+                        "items": Array [
+                          Object {
+                            "metadata": Object {
+                              "creationTimestamp": "2018-07-02T13:44:01+02:00",
+                              "name": "reviews",
+                              "resourceVersion": "393057",
+                            },
+                            "spec": Object {
+                              "gateways": null,
+                              "hosts": Array [
+                                "reviews",
+                              ],
+                              "http": Array [
+                                Object {
+                                  "route": Array [
+                                    Object {
+                                      "destination": Object {
+                                        "host": "reviews",
+                                        "subset": "v1",
+                                      },
+                                    },
+                                  ],
+                                },
+                              ],
+                              "tcp": null,
+                            },
+                          },
+                        ],
+                        "permissions": Object {
+                          "delete": false,
+                          "update": false,
+                        },
+                      }
+                    }
+                    workloads={Array []}
                   />
-                </Button>
+                </span>
               </Col>
             </Row>
             <Row
@@ -2953,24 +3593,112 @@ ShallowWrapper {
                   sm={12}
                   xs={12}
                 >
-                  <Button
-                    active={false}
-                    block={false}
-                    bsClass="btn"
-                    bsStyle="default"
-                    disabled={false}
-                    onClick={[MockFunction]}
+                  <span
                     style={
                       Object {
                         "float": "right",
                       }
                     }
                   >
-                    <Icon
-                      name="refresh"
-                      type="fa"
+                    <Button
+                      active={false}
+                      block={false}
+                      bsClass="btn"
+                      bsStyle="default"
+                      disabled={false}
+                      onClick={[MockFunction]}
+                    >
+                      <Icon
+                        name="refresh"
+                        type="fa"
+                      />
+                    </Button>
+                     
+                    <IstioWizardDropdown
+                      destinationRules={
+                        Object {
+                          "items": Array [
+                            Object {
+                              "metadata": Object {
+                                "createdTimestamp": "2018-07-02T13:44:01+02:00",
+                                "name": "reviews",
+                                "resourceVersion": "393061",
+                              },
+                              "spec": Object {
+                                "host": "reviews",
+                                "subsets": Array [
+                                  Object {
+                                    "labels": Object {
+                                      "version": "v1",
+                                    },
+                                    "name": "v1",
+                                  },
+                                  Object {
+                                    "labels": Object {
+                                      "version": "v2",
+                                    },
+                                    "name": "v2",
+                                  },
+                                  Object {
+                                    "labels": Object {
+                                      "version": "v3",
+                                    },
+                                    "name": "v3",
+                                  },
+                                ],
+                                "trafficPolicy": null,
+                              },
+                            },
+                          ],
+                          "permissions": Object {
+                            "delete": false,
+                            "update": false,
+                          },
+                        }
+                      }
+                      namespace="istio-system"
+                      onChange={[MockFunction]}
+                      serviceName="reviews"
+                      show={false}
+                      virtualServices={
+                        Object {
+                          "items": Array [
+                            Object {
+                              "metadata": Object {
+                                "creationTimestamp": "2018-07-02T13:44:01+02:00",
+                                "name": "reviews",
+                                "resourceVersion": "393057",
+                              },
+                              "spec": Object {
+                                "gateways": null,
+                                "hosts": Array [
+                                  "reviews",
+                                ],
+                                "http": Array [
+                                  Object {
+                                    "route": Array [
+                                      Object {
+                                        "destination": Object {
+                                          "host": "reviews",
+                                          "subset": "v1",
+                                        },
+                                      },
+                                    ],
+                                  },
+                                ],
+                                "tcp": null,
+                              },
+                            },
+                          ],
+                          "permissions": Object {
+                            "delete": false,
+                            "update": false,
+                          },
+                        }
+                      }
+                      workloads={Array []}
                     />
-                  </Button>
+                  </span>
                 </Col>
               </Row>,
               <Row
@@ -3282,24 +4010,112 @@ ShallowWrapper {
                   sm={12}
                   xs={12}
                 >
-                  <Button
-                    active={false}
-                    block={false}
-                    bsClass="btn"
-                    bsStyle="default"
-                    disabled={false}
-                    onClick={[MockFunction]}
+                  <span
                     style={
                       Object {
                         "float": "right",
                       }
                     }
                   >
-                    <Icon
-                      name="refresh"
-                      type="fa"
+                    <Button
+                      active={false}
+                      block={false}
+                      bsClass="btn"
+                      bsStyle="default"
+                      disabled={false}
+                      onClick={[MockFunction]}
+                    >
+                      <Icon
+                        name="refresh"
+                        type="fa"
+                      />
+                    </Button>
+                     
+                    <IstioWizardDropdown
+                      destinationRules={
+                        Object {
+                          "items": Array [
+                            Object {
+                              "metadata": Object {
+                                "createdTimestamp": "2018-07-02T13:44:01+02:00",
+                                "name": "reviews",
+                                "resourceVersion": "393061",
+                              },
+                              "spec": Object {
+                                "host": "reviews",
+                                "subsets": Array [
+                                  Object {
+                                    "labels": Object {
+                                      "version": "v1",
+                                    },
+                                    "name": "v1",
+                                  },
+                                  Object {
+                                    "labels": Object {
+                                      "version": "v2",
+                                    },
+                                    "name": "v2",
+                                  },
+                                  Object {
+                                    "labels": Object {
+                                      "version": "v3",
+                                    },
+                                    "name": "v3",
+                                  },
+                                ],
+                                "trafficPolicy": null,
+                              },
+                            },
+                          ],
+                          "permissions": Object {
+                            "delete": false,
+                            "update": false,
+                          },
+                        }
+                      }
+                      namespace="istio-system"
+                      onChange={[MockFunction]}
+                      serviceName="reviews"
+                      show={false}
+                      virtualServices={
+                        Object {
+                          "items": Array [
+                            Object {
+                              "metadata": Object {
+                                "creationTimestamp": "2018-07-02T13:44:01+02:00",
+                                "name": "reviews",
+                                "resourceVersion": "393057",
+                              },
+                              "spec": Object {
+                                "gateways": null,
+                                "hosts": Array [
+                                  "reviews",
+                                ],
+                                "http": Array [
+                                  Object {
+                                    "route": Array [
+                                      Object {
+                                        "destination": Object {
+                                          "host": "reviews",
+                                          "subset": "v1",
+                                        },
+                                      },
+                                    ],
+                                  },
+                                ],
+                                "tcp": null,
+                              },
+                            },
+                          ],
+                          "permissions": Object {
+                            "delete": false,
+                            "update": false,
+                          },
+                        }
+                      }
+                      workloads={Array []}
                     />
-                  </Button>
+                  </span>
                 </Col>,
                 "className": "row-cards-pf",
                 "componentClass": "div",
@@ -3311,24 +4127,112 @@ ShallowWrapper {
                 "nodeType": "class",
                 "props": Object {
                   "bsClass": "col",
-                  "children": <Button
-                    active={false}
-                    block={false}
-                    bsClass="btn"
-                    bsStyle="default"
-                    disabled={false}
-                    onClick={[MockFunction]}
+                  "children": <span
                     style={
                       Object {
                         "float": "right",
                       }
                     }
                   >
-                    <Icon
-                      name="refresh"
-                      type="fa"
+                    <Button
+                      active={false}
+                      block={false}
+                      bsClass="btn"
+                      bsStyle="default"
+                      disabled={false}
+                      onClick={[MockFunction]}
+                    >
+                      <Icon
+                        name="refresh"
+                        type="fa"
+                      />
+                    </Button>
+                     
+                    <IstioWizardDropdown
+                      destinationRules={
+                        Object {
+                          "items": Array [
+                            Object {
+                              "metadata": Object {
+                                "createdTimestamp": "2018-07-02T13:44:01+02:00",
+                                "name": "reviews",
+                                "resourceVersion": "393061",
+                              },
+                              "spec": Object {
+                                "host": "reviews",
+                                "subsets": Array [
+                                  Object {
+                                    "labels": Object {
+                                      "version": "v1",
+                                    },
+                                    "name": "v1",
+                                  },
+                                  Object {
+                                    "labels": Object {
+                                      "version": "v2",
+                                    },
+                                    "name": "v2",
+                                  },
+                                  Object {
+                                    "labels": Object {
+                                      "version": "v3",
+                                    },
+                                    "name": "v3",
+                                  },
+                                ],
+                                "trafficPolicy": null,
+                              },
+                            },
+                          ],
+                          "permissions": Object {
+                            "delete": false,
+                            "update": false,
+                          },
+                        }
+                      }
+                      namespace="istio-system"
+                      onChange={[MockFunction]}
+                      serviceName="reviews"
+                      show={false}
+                      virtualServices={
+                        Object {
+                          "items": Array [
+                            Object {
+                              "metadata": Object {
+                                "creationTimestamp": "2018-07-02T13:44:01+02:00",
+                                "name": "reviews",
+                                "resourceVersion": "393057",
+                              },
+                              "spec": Object {
+                                "gateways": null,
+                                "hosts": Array [
+                                  "reviews",
+                                ],
+                                "http": Array [
+                                  Object {
+                                    "route": Array [
+                                      Object {
+                                        "destination": Object {
+                                          "host": "reviews",
+                                          "subset": "v1",
+                                        },
+                                      },
+                                    ],
+                                  },
+                                ],
+                                "tcp": null,
+                              },
+                            },
+                          ],
+                          "permissions": Object {
+                            "delete": false,
+                            "update": false,
+                          },
+                        }
+                      }
+                      workloads={Array []}
                     />
-                  </Button>,
+                  </span>,
                   "componentClass": "div",
                   "lg": 12,
                   "md": 12,
@@ -3339,36 +4243,236 @@ ShallowWrapper {
                 "rendered": Object {
                   "instance": null,
                   "key": undefined,
-                  "nodeType": "class",
+                  "nodeType": "host",
                   "props": Object {
-                    "active": false,
-                    "block": false,
-                    "bsClass": "btn",
-                    "bsStyle": "default",
-                    "children": <Icon
-                      name="refresh"
-                      type="fa"
-                    />,
-                    "disabled": false,
-                    "onClick": [MockFunction],
+                    "children": Array [
+                      <Button
+                        active={false}
+                        block={false}
+                        bsClass="btn"
+                        bsStyle="default"
+                        disabled={false}
+                        onClick={[MockFunction]}
+                      >
+                        <Icon
+                          name="refresh"
+                          type="fa"
+                        />
+                      </Button>,
+                      " ",
+                      <IstioWizardDropdown
+                        destinationRules={
+                          Object {
+                            "items": Array [
+                              Object {
+                                "metadata": Object {
+                                  "createdTimestamp": "2018-07-02T13:44:01+02:00",
+                                  "name": "reviews",
+                                  "resourceVersion": "393061",
+                                },
+                                "spec": Object {
+                                  "host": "reviews",
+                                  "subsets": Array [
+                                    Object {
+                                      "labels": Object {
+                                        "version": "v1",
+                                      },
+                                      "name": "v1",
+                                    },
+                                    Object {
+                                      "labels": Object {
+                                        "version": "v2",
+                                      },
+                                      "name": "v2",
+                                    },
+                                    Object {
+                                      "labels": Object {
+                                        "version": "v3",
+                                      },
+                                      "name": "v3",
+                                    },
+                                  ],
+                                  "trafficPolicy": null,
+                                },
+                              },
+                            ],
+                            "permissions": Object {
+                              "delete": false,
+                              "update": false,
+                            },
+                          }
+                        }
+                        namespace="istio-system"
+                        onChange={[MockFunction]}
+                        serviceName="reviews"
+                        show={false}
+                        virtualServices={
+                          Object {
+                            "items": Array [
+                              Object {
+                                "metadata": Object {
+                                  "creationTimestamp": "2018-07-02T13:44:01+02:00",
+                                  "name": "reviews",
+                                  "resourceVersion": "393057",
+                                },
+                                "spec": Object {
+                                  "gateways": null,
+                                  "hosts": Array [
+                                    "reviews",
+                                  ],
+                                  "http": Array [
+                                    Object {
+                                      "route": Array [
+                                        Object {
+                                          "destination": Object {
+                                            "host": "reviews",
+                                            "subset": "v1",
+                                          },
+                                        },
+                                      ],
+                                    },
+                                  ],
+                                  "tcp": null,
+                                },
+                              },
+                            ],
+                            "permissions": Object {
+                              "delete": false,
+                              "update": false,
+                            },
+                          }
+                        }
+                        workloads={Array []}
+                      />,
+                    ],
                     "style": Object {
                       "float": "right",
                     },
                   },
                   "ref": null,
-                  "rendered": Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "function",
-                    "props": Object {
-                      "name": "refresh",
-                      "type": "fa",
+                  "rendered": Array [
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "class",
+                      "props": Object {
+                        "active": false,
+                        "block": false,
+                        "bsClass": "btn",
+                        "bsStyle": "default",
+                        "children": <Icon
+                          name="refresh"
+                          type="fa"
+                        />,
+                        "disabled": false,
+                        "onClick": [MockFunction],
+                      },
+                      "ref": null,
+                      "rendered": Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "function",
+                        "props": Object {
+                          "name": "refresh",
+                          "type": "fa",
+                        },
+                        "ref": null,
+                        "rendered": null,
+                        "type": [Function],
+                      },
+                      "type": [Function],
                     },
-                    "ref": null,
-                    "rendered": null,
-                    "type": [Function],
-                  },
-                  "type": [Function],
+                    " ",
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "class",
+                      "props": Object {
+                        "destinationRules": Object {
+                          "items": Array [
+                            Object {
+                              "metadata": Object {
+                                "createdTimestamp": "2018-07-02T13:44:01+02:00",
+                                "name": "reviews",
+                                "resourceVersion": "393061",
+                              },
+                              "spec": Object {
+                                "host": "reviews",
+                                "subsets": Array [
+                                  Object {
+                                    "labels": Object {
+                                      "version": "v1",
+                                    },
+                                    "name": "v1",
+                                  },
+                                  Object {
+                                    "labels": Object {
+                                      "version": "v2",
+                                    },
+                                    "name": "v2",
+                                  },
+                                  Object {
+                                    "labels": Object {
+                                      "version": "v3",
+                                    },
+                                    "name": "v3",
+                                  },
+                                ],
+                                "trafficPolicy": null,
+                              },
+                            },
+                          ],
+                          "permissions": Object {
+                            "delete": false,
+                            "update": false,
+                          },
+                        },
+                        "namespace": "istio-system",
+                        "onChange": [MockFunction],
+                        "serviceName": "reviews",
+                        "show": false,
+                        "virtualServices": Object {
+                          "items": Array [
+                            Object {
+                              "metadata": Object {
+                                "creationTimestamp": "2018-07-02T13:44:01+02:00",
+                                "name": "reviews",
+                                "resourceVersion": "393057",
+                              },
+                              "spec": Object {
+                                "gateways": null,
+                                "hosts": Array [
+                                  "reviews",
+                                ],
+                                "http": Array [
+                                  Object {
+                                    "route": Array [
+                                      Object {
+                                        "destination": Object {
+                                          "host": "reviews",
+                                          "subset": "v1",
+                                        },
+                                      },
+                                    ],
+                                  },
+                                ],
+                                "tcp": null,
+                              },
+                            },
+                          ],
+                          "permissions": Object {
+                            "delete": false,
+                            "update": false,
+                          },
+                        },
+                        "workloads": Array [],
+                      },
+                      "ref": null,
+                      "rendered": null,
+                      "type": [Function],
+                    },
+                  ],
+                  "type": "span",
                 },
                 "type": [Function],
               },

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -176,6 +176,31 @@ export const updateIstioConfigDetailSubtype = (
   );
 };
 
+export const createIstioConfigDetail = (
+  auth: AuthToken,
+  namespace: string,
+  objectType: string,
+  json: string
+): Promise<Response<string>> => {
+  return newRequest(HTTP_VERBS.POST, urls.istioConfigCreate(namespace, objectType), {}, json, auth);
+};
+
+export const createIstioConfigDetailSubtype = (
+  auth: AuthToken,
+  namespace: string,
+  objectType: string,
+  objectSubtype: string,
+  json: string
+): Promise<Response<string>> => {
+  return newRequest(
+    HTTP_VERBS.POST,
+    urls.istioConfigCreateSubtype(namespace, objectType, objectSubtype),
+    {},
+    json,
+    auth
+  );
+};
+
 export const getServices = (auth: AuthToken, namespace: string) => {
   return newRequest<ServiceList>(HTTP_VERBS.GET, urls.services(namespace), {}, {}, auth);
 };

--- a/src/types/IstioConfigList.ts
+++ b/src/types/IstioConfigList.ts
@@ -115,7 +115,7 @@ export const filterByName = (unfiltered: IstioConfigList, names: string[]): Isti
     quotaSpecBindings: unfiltered.quotaSpecBindings.filter(qsb => includeName(qsb.metadata.name, names)),
     policies: unfiltered.policies.filter(p => includeName(p.metadata.name, names)),
     validations: unfiltered.validations,
-    permissions: unfiltered.permissions,
+    permissions: unfiltered.permissions
   };
 };
 

--- a/src/types/IstioObjects.ts
+++ b/src/types/IstioObjects.ts
@@ -297,7 +297,7 @@ export interface TrafficPolicy {
 export interface Subset {
   name: string;
   labels: { [key: string]: string };
-  trafficPolicy: TrafficPolicy;
+  trafficPolicy?: TrafficPolicy;
 }
 
 export interface DestinationRuleSpec {

--- a/src/types/Permissions.ts
+++ b/src/types/Permissions.ts
@@ -1,4 +1,5 @@
 export interface ResourcePermissions {
+  create: boolean;
   update: boolean;
   delete: boolean;
 }


### PR DESCRIPTION
This PR enables two operations at Service detail level:
- Create A/B Traffic Routing.
- Delete ALL Traffic Routing.

Basically to not need to go into individual configs to delete all Istio linked with a particular service.

![image](https://user-images.githubusercontent.com/1662329/51753943-56475780-20bb-11e9-8c9a-4dfc98b3f679.png)

The Wizard only performs a "Create" operation, and it's enabled when service has not defined any prior configuration (for existing configuration, standard YAML edition is enabled).

The A/B patter is extended in a generic way, meaning that it works for 1..N cases, the wizard will control the weights between the workloads and it will create a basic DestinationRule/VirtualService pair.

![image](https://user-images.githubusercontent.com/1662329/51753979-7119cc00-20bb-11e9-889a-738caa8aaf09.png)

![image](https://user-images.githubusercontent.com/1662329/51753957-6101ec80-20bb-11e9-81d7-5c6bf4ecf0be.png)

