### PR TITLE
KIALI-1774 Graph Hide

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -6,7 +6,6 @@ import ReactResizeDetector from 'react-resize-detector';
 
 import Namespace from '../../types/Namespace';
 import { GraphHighlighter } from './graphs/GraphHighlighter';
-import * as LayoutDictionary from './graphs/LayoutDictionary';
 import TrafficRender from './TrafficAnimation/TrafficRenderer';
 import EmptyGraphLayout from '../../containers/EmptyGraphLayoutContainer';
 import { CytoscapeReactWrapper } from './CytoscapeReactWrapper';
@@ -43,7 +42,6 @@ import { NamespaceAppHealth, NamespaceServiceHealth, NamespaceWorkloadHealth } f
 import { makeNodeGraphUrlFromParams, GraphUrlParams } from '../Nav/NavUtils';
 import { NamespaceActions } from '../../actions/NamespaceAction';
 import { DurationInSeconds, PollIntervalInMs } from '../../types/Common';
-import { DagreGraph } from './graphs/DagreGraph';
 import { CyNode } from './CytoscapeGraphUtils';
 import GraphThunkActions from '../../actions/GraphThunkActions';
 import * as MessageCenterUtils from '../../utils/MessageCenter';
@@ -394,22 +392,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
     cy.json({ elements: this.props.elements });
 
     if (updateLayout) {
-      // Enable labels when doing a relayout, layouts can be told to take into account the labels to avoid
-      // overlap, but we need to have them enabled (nodeDimensionsIncludeLabels: true)
-      this.turnNodeLabelsTo(cy, true);
-      const layoutOptions = LayoutDictionary.getLayout(this.props.layout);
-      if (cy.nodes('$node > node').length > 0) {
-        // if there is any parent node, run the group-compound-layout
-        cy.layout({
-          ...layoutOptions,
-          name: 'group-compound-layout',
-          realLayout: this.props.layout.name,
-          // Currently we do not support non discrete layouts for the compounds, but this can be supported if needed.
-          compoundLayoutOptions: LayoutDictionary.getLayout(DagreGraph.getLayout())
-        }).run();
-      } else {
-        cy.layout(layoutOptions).run();
-      }
+      CytoscapeGraphUtils.runLayout(cy, this.props.layout);
     }
 
     // Create and destroy labels

--- a/src/components/CytoscapeGraph/CytoscapeGraphUtils.ts
+++ b/src/components/CytoscapeGraph/CytoscapeGraphUtils.ts
@@ -1,3 +1,8 @@
+import { Layout } from '../../types/GraphFilter';
+import * as LayoutDictionary from './graphs/LayoutDictionary';
+import { CytoscapeGlobalScratchNamespace } from '../../types/Graph';
+import { DagreGraph } from './graphs/DagreGraph';
+
 export const CyEdge = {
   grpc: 'grpc',
   grpcErr: 'grpcErr',
@@ -58,4 +63,27 @@ export const safeFit = (cy: any) => {
     cy.zoom(2.5);
     cy.center();
   }
+};
+
+export const runLayout = (cy: any, layout: Layout) => {
+  // Enable labels when doing a relayout, layouts can be told to take into account the labels to avoid
+  // overlap, but we need to have them enabled (nodeDimensionsIncludeLabels: true)
+  const showNodeLabels = cy.scratch(CytoscapeGlobalScratchNamespace).showNodeLabels;
+  cy.scratch(CytoscapeGlobalScratchNamespace).showNodeLabels = true;
+
+  const layoutOptions = LayoutDictionary.getLayout(layout);
+  if (cy.nodes('$node > node').length > 0) {
+    // if there is any parent node, run the group-compound-layout
+    cy.layout({
+      ...layoutOptions,
+      name: 'group-compound-layout',
+      realLayout: layout.name,
+      // Currently we do not support non discrete layouts for the compounds, but this can be supported if needed.
+      compoundLayoutOptions: LayoutDictionary.getLayout(DagreGraph.getLayout())
+    }).run();
+  } else {
+    cy.layout(layoutOptions).run();
+  }
+
+  cy.scratch(CytoscapeGlobalScratchNamespace).showNodeLabels = showNodeLabels;
 };

--- a/src/components/CytoscapeGraph/TrafficAnimation/TrafficRenderer.ts
+++ b/src/components/CytoscapeGraph/TrafficAnimation/TrafficRenderer.ts
@@ -323,7 +323,7 @@ export default class TrafficRenderer {
       this.layer.setTransform(this.context);
       Object.keys(this.trafficEdges).forEach(edgeId => {
         const trafficEdge = this.trafficEdges[edgeId];
-        // Skip if edge is currently filtered
+        // Skip if edge is currently hidden
         if (trafficEdge.getEdge().visible()) {
           trafficEdge.processStep(step);
           trafficEdge.removeFinishedPoints();

--- a/src/components/CytoscapeGraph/TrafficAnimation/TrafficRenderer.ts
+++ b/src/components/CytoscapeGraph/TrafficAnimation/TrafficRenderer.ts
@@ -323,9 +323,12 @@ export default class TrafficRenderer {
       this.layer.setTransform(this.context);
       Object.keys(this.trafficEdges).forEach(edgeId => {
         const trafficEdge = this.trafficEdges[edgeId];
-        trafficEdge.processStep(step);
-        trafficEdge.removeFinishedPoints();
-        this.render(trafficEdge);
+        // Skip if edge is currently filtered
+        if (trafficEdge.getEdge().visible()) {
+          trafficEdge.processStep(step);
+          trafficEdge.removeFinishedPoints();
+          this.render(trafficEdge);
+        }
       });
       this.previousTimestamp = nextTimestamp;
     } catch (exception) {
@@ -400,7 +403,8 @@ export default class TrafficRenderer {
   private getTrafficEdgeType(edge: any) {
     if (edge.data(CyEdge.http) > 0) {
       return TrafficEdgeType.HTTP;
-    } else if (edge.data(CyEdge.tcp) > 0) {
+    }
+    if (edge.data(CyEdge.tcp) > 0) {
       return TrafficEdgeType.TCP;
     }
     // No TCP or HTTP traffic found

--- a/src/components/GraphFilter/GraphFind.tsx
+++ b/src/components/GraphFilter/GraphFind.tsx
@@ -62,7 +62,6 @@ export class GraphFind extends React.PureComponent<GraphFindProps> {
       this.handleFind();
     }
     if (this.hideValue.length > 0 && this.props.cyData.updateTimestamp !== prevProps.cyData.updateTimestamp) {
-      this.hiddenElements = undefined;
       this.handleHide();
     }
   }

--- a/src/components/GraphFilter/GraphFind.tsx
+++ b/src/components/GraphFilter/GraphFind.tsx
@@ -32,10 +32,10 @@ export class GraphFind extends React.PureComponent<GraphFindProps> {
     router: () => null
   };
 
-  private filterInputRef;
-  private filterInputValue: string;
-  private filterValue: string;
-  private filteredElements: any | undefined;
+  private hideInputRef;
+  private hideInputValue: string;
+  private hideValue: string;
+  private hiddenElements: any | undefined;
   private findInputRef;
   private findInputValue: string;
   private findValue: string;
@@ -47,10 +47,10 @@ export class GraphFind extends React.PureComponent<GraphFindProps> {
       props.toggleFindHelp();
     }
 
-    this.filterInputRef = React.createRef();
-    this.filterInputValue = '';
-    this.filterValue = '';
-    this.filteredElements = undefined;
+    this.hideInputRef = React.createRef();
+    this.hideInputValue = '';
+    this.hideValue = '';
+    this.hiddenElements = undefined;
 
     this.findInputRef = React.createRef();
     this.findInputValue = '';
@@ -61,9 +61,9 @@ export class GraphFind extends React.PureComponent<GraphFindProps> {
     if (this.findValue.length > 0 && this.props.cyData.updateTimestamp !== prevProps.cyData.updateTimestamp) {
       this.handleFind();
     }
-    if (this.filterValue.length > 0 && this.props.cyData.updateTimestamp !== prevProps.cyData.updateTimestamp) {
-      this.filteredElements = undefined;
-      this.handleFilter();
+    if (this.hideValue.length > 0 && this.props.cyData.updateTimestamp !== prevProps.cyData.updateTimestamp) {
+      this.hiddenElements = undefined;
+      this.handleHide();
     }
   }
 
@@ -92,20 +92,20 @@ export class GraphFind extends React.PureComponent<GraphFindProps> {
                 type="text"
                 style={{ width: '18em' }}
                 inputRef={ref => {
-                  this.filterInputRef = ref;
+                  this.hideInputRef = ref;
                 }}
-                onChange={this.updateFilter}
-                onKeyPress={this.checkSubmitFilter}
-                placeholder="Filter..."
+                onChange={this.updateHide}
+                onKeyPress={this.checkSubmitHide}
+                placeholder="Hide..."
               />
               <InputGroup.Button>
-                <Button onClick={this.clearFilter}>
+                <Button onClick={this.clearHide}>
                   <Icon name="close" type="fa" />
                 </Button>
               </InputGroup.Button>
             </InputGroup>
             <Button bsStyle="link" style={{ paddingLeft: '6px' }} onClick={this.toggleFindHelp}>
-              <Icon name="help" type="pf" title="Help Find/Filter..." />
+              <Icon name="help" type="pf" title="Help Find/Hide..." />
             </Button>
           </span>
         </FormGroup>
@@ -118,21 +118,21 @@ export class GraphFind extends React.PureComponent<GraphFindProps> {
     this.props.toggleFindHelp();
   };
 
-  private updateFilter = event => {
-    this.filterInputValue = event.target.value;
+  private updateHide = event => {
+    this.hideInputValue = event.target.value;
   };
 
   private updateFind = event => {
     this.findInputValue = event.target.value;
   };
 
-  private checkSubmitFilter = event => {
+  private checkSubmitHide = event => {
     const keyCode = event.keyCode ? event.keyCode : event.which;
     if (keyCode === 13) {
       event.preventDefault();
-      if (this.filterValue !== this.filterInputValue) {
-        this.filterValue = this.filterInputValue;
-        this.handleFilter();
+      if (this.hideValue !== this.hideInputValue) {
+        this.hideValue = this.hideInputValue;
+        this.handleHide();
       }
     }
   };
@@ -148,12 +148,12 @@ export class GraphFind extends React.PureComponent<GraphFindProps> {
     }
   };
 
-  private clearFilter = () => {
-    this.filterInputValue = '';
-    this.filterValue = '';
-    // note, we don't use filterInputRef.current because <FormControl> deals with refs differently than <input>
-    this.filterInputRef.value = '';
-    this.handleFilter();
+  private clearHide = () => {
+    this.hideInputValue = '';
+    this.hideValue = '';
+    // note, we don't use hideInputRef.current because <FormControl> deals with refs differently than <input>
+    this.hideInputRef.value = '';
+    this.handleHide();
   };
 
   private clearFind = () => {
@@ -164,28 +164,28 @@ export class GraphFind extends React.PureComponent<GraphFindProps> {
     this.handleFind();
   };
 
-  private handleFilter = () => {
+  private handleHide = () => {
     if (!this.props.cyData) {
-      console.debug('Skip Filter: cy not set.');
+      console.debug('Skip Hide: cy not set.');
       return;
     }
     const cy = this.props.cyData.cyRef;
-    const selector = this.parseFindValue(this.filterValue);
+    const selector = this.parseFindValue(this.hideValue);
     cy.startBatch();
     // this could also be done using cy remove/restore but we had better results
     // using visible/hidden.  The latter worked better when hiding animation, and
     // also prevents the need for running layout because visible/hidden maintains
     // the space of the hidden elements.
-    if (this.filteredElements) {
-      // make visible old filter-hits
-      this.filteredElements.style({ visibility: 'visible' });
-      this.filteredElements = undefined;
+    if (this.hiddenElements) {
+      // make visible old hide-hits
+      this.hiddenElements.style({ visibility: 'visible' });
+      this.hiddenElements = undefined;
     }
     if (selector) {
-      // hide new filter-hits
-      this.filteredElements = cy.$(selector);
-      this.filteredElements = this.filteredElements.add(this.filteredElements.connectedEdges());
-      this.filteredElements.style({ visibility: 'hidden' });
+      // hide new hide-hits
+      this.hiddenElements = cy.$(selector);
+      this.hiddenElements = this.hiddenElements.add(this.hiddenElements.connectedEdges());
+      this.hiddenElements.style({ visibility: 'hidden' });
     }
     cy.endBatch();
   };

--- a/src/components/GraphFilter/GraphFind.tsx
+++ b/src/components/GraphFilter/GraphFind.tsx
@@ -186,6 +186,10 @@ export class GraphFind extends React.PureComponent<GraphFindProps> {
       this.hiddenElements = cy.$(selector);
       this.hiddenElements = this.hiddenElements.add(this.hiddenElements.connectedEdges());
       this.hiddenElements.style({ visibility: 'hidden' });
+      // now hide any appboxes that don't have any visible children
+      const hiddenAppBoxes = cy.$('$node[isGroup]').not(cy.$('$node[isGroup] > :visible'));
+      hiddenAppBoxes.style({ visibility: 'hidden' });
+      this.hiddenElements = this.hiddenElements.add(hiddenAppBoxes);
     }
     cy.endBatch();
   };

--- a/src/components/GraphFilter/GraphFind.tsx
+++ b/src/components/GraphFilter/GraphFind.tsx
@@ -10,13 +10,11 @@ import { GraphFilterActions } from '../../actions/GraphFilterActions';
 import { KialiAppAction } from '../../actions/KialiAppAction';
 import * as MessageCenterUtils from '../../utils/MessageCenter';
 import GraphHelpFind from '../../pages/Graph/GraphHelpFind';
-import { CyNode, CyEdge, runLayout } from '../CytoscapeGraph/CytoscapeGraphUtils';
+import { CyNode, CyEdge } from '../CytoscapeGraph/CytoscapeGraphUtils';
 import { CyData } from '../../types/Graph';
-import { Layout } from '../../types/GraphFilter';
 
 type ReduxProps = {
   cyData: CyData;
-  layout: Layout;
   showFindHelp: boolean;
 
   toggleFindHelp: () => void;
@@ -174,15 +172,19 @@ export class GraphFind extends React.PureComponent<GraphFindProps> {
     const cy = this.props.cyData.cyRef;
     const selector = this.parseFindValue(this.filterValue);
     cy.startBatch();
-    // restore old filter-hits
+    // this could also be done useing cy remove/restore but we had better results
+    // using visible/hidden (i.e. display: 'element'/'none' ).  The latter worked
+    // better when hiding animation, and also prevents the need for running
+    // layout after each update (at least in my tests so far..)
     if (this.filteredElements) {
-      this.filteredElements.restore();
+      // make visible old filter-hits
+      this.filteredElements.style({ display: 'element' });
       this.filteredElements = undefined;
-      runLayout(cy, this.props.layout);
     }
     if (selector) {
-      // remove new filter-hits
-      this.filteredElements = cy.remove(selector);
+      // hide new filter-hits
+      this.filteredElements = cy.$(selector);
+      this.filteredElements.style({ display: 'none' });
     }
     cy.endBatch();
   };
@@ -502,7 +504,6 @@ export class GraphFind extends React.PureComponent<GraphFindProps> {
 
 const mapStateToProps = (state: KialiAppState) => ({
   cyData: state.graph.cyData,
-  layout: state.graph.layout,
   showFindHelp: state.graph.filterState.showFindHelp
 });
 

--- a/src/components/GraphFilter/GraphFind.tsx
+++ b/src/components/GraphFilter/GraphFind.tsx
@@ -172,19 +172,20 @@ export class GraphFind extends React.PureComponent<GraphFindProps> {
     const cy = this.props.cyData.cyRef;
     const selector = this.parseFindValue(this.filterValue);
     cy.startBatch();
-    // this could also be done useing cy remove/restore but we had better results
-    // using visible/hidden (i.e. display: 'element'/'none' ).  The latter worked
-    // better when hiding animation, and also prevents the need for running
-    // layout after each update (at least in my tests so far..)
+    // this could also be done using cy remove/restore but we had better results
+    // using visible/hidden.  The latter worked better when hiding animation, and
+    // also prevents the need for running layout because visible/hidden maintains
+    // the space of the hidden elements.
     if (this.filteredElements) {
       // make visible old filter-hits
-      this.filteredElements.style({ display: 'element' });
+      this.filteredElements.style({ visibility: 'visible' });
       this.filteredElements = undefined;
     }
     if (selector) {
       // hide new filter-hits
       this.filteredElements = cy.$(selector);
-      this.filteredElements.style({ display: 'none' });
+      this.filteredElements = this.filteredElements.add(this.filteredElements.connectedEdges());
+      this.filteredElements.style({ visibility: 'hidden' });
     }
     cy.endBatch();
   };

--- a/src/components/GraphFilter/__tests__/GraphFind.test.tsx
+++ b/src/components/GraphFilter/__tests__/GraphFind.test.tsx
@@ -13,7 +13,6 @@ describe('Parse find value test', () => {
     const wrapper = shallow(
       <GraphFind
         cyData={{ updateTimestamp: 123, cyRef: 'dummyRef' }}
-        layout={{ name: 'dagre' }}
         showFindHelp={false}
         toggleFindHelp={testHandler}
       />

--- a/src/components/GraphFilter/__tests__/GraphFind.test.tsx
+++ b/src/components/GraphFilter/__tests__/GraphFind.test.tsx
@@ -13,6 +13,7 @@ describe('Parse find value test', () => {
     const wrapper = shallow(
       <GraphFind
         cyData={{ updateTimestamp: 123, cyRef: 'dummyRef' }}
+        layout={{ name: 'dagre' }}
         showFindHelp={false}
         toggleFindHelp={testHandler}
       />

--- a/src/pages/Graph/GraphHelpFind.tsx
+++ b/src/pages/Graph/GraphHelpFind.tsx
@@ -304,6 +304,7 @@ export default class GraphHelpFind extends React.Component<GraphHelpFindProps> {
                         { id: 'nc100', c: 'outside', n: 'is outside of requested namespaces' },
                         { id: 'nc110', c: 'sidecar' },
                         { id: 'nc130', c: 'serviceentry' },
+                        { id: 'nc135', c: 'trafficsource', n: `has only outgoing edges` },
                         { id: 'nc150', c: 'unused', n: `'Show Unused' option must be enabled` },
                         { id: 'nc160', c: 'virtualservice' }
                       ]}

--- a/src/pages/Graph/GraphHelpFind.tsx
+++ b/src/pages/Graph/GraphHelpFind.tsx
@@ -202,7 +202,7 @@ export default class GraphHelpFind extends React.Component<GraphHelpFindProps> {
             <Button className="close" bsClass="" onClick={this.props.onClose}>
               <Icon title="Close" type="pf" name="close" />
             </Button>
-            <span className="modal-title">Help: Graph Find</span>
+            <span className="modal-title">Help: Graph Find/Hide</span>
           </div>
           <TabContainer id="basic-tabs" defaultActiveKey="examples">
             <div>

--- a/src/store/Selectors/GraphData.ts
+++ b/src/store/Selectors/GraphData.ts
@@ -17,7 +17,7 @@ const decorateGraphData = (graphData: any) => {
       http4xx: '0',
       http5xx: '0',
       httpPercentErr: '0',
-      httpPercentReq: '100',
+      httpPercentReq: '100.0',
       isMTLS: undefined,
       isUnused: undefined,
       responseTime: '0',
@@ -57,7 +57,9 @@ const decorateGraphData = (graphData: any) => {
       graphData.nodes = graphData.nodes.map(node => {
         const decoratedNode = { ...node };
         if (node.data.traffic) {
-          node.data.traffic.map(protocol => {
+          const traffic = node.data.traffic;
+          node.data.traffic = undefined;
+          traffic.map(protocol => {
             decoratedNode.data = { ...protocol.rates, ...decoratedNode.data };
           });
         }
@@ -69,7 +71,9 @@ const decorateGraphData = (graphData: any) => {
       graphData.edges = graphData.edges.map(edge => {
         const decoratedEdge = { ...edge };
         if (edge.data.traffic) {
-          edge.data.traffic.map(protocol => {
+          const traffic = edge.data.traffic;
+          edge.data.traffic = undefined;
+          traffic.map(protocol => {
             decoratedEdge.data = { ...protocol.rates, ...decoratedEdge.data };
           });
         }


### PR DESCRIPTION
- Use the same DSL as Graph Find for filtering.
- Also
  - fixes issue with finding no traffic
  - adds 'trafficsource' operand to node help
  - removes unnecessary 'traffic' field from cy node and edge elements

![image](https://user-images.githubusercontent.com/2104052/51563748-403b5c00-1e5b-11e9-9f04-42cfc81b67f4.png)

@abonas @mwringe There is also a container for this: https://hub.docker.com/r/jshaughn/kiali tag filter.  I'm not sure if we need a UX design issue for this or if it OK from a design perspective.