### PR TITLE
KIALI-2303 - provide a user-friendly message indicating that the Kiali secret is missing

### DIFF
--- a/src/reducers/LoginState.ts
+++ b/src/reducers/LoginState.ts
@@ -38,6 +38,9 @@ const loginState = (state: LoginState = INITIAL_LOGIN_STATE, action: KialiAppAct
       let message = 'Error connecting to Kiali';
       if (action.payload.error.request.status === 401) {
         message = 'Unauthorized. Error in username or password';
+      } else if (action.payload.error.request.status === 520) {
+        message =
+          'The Kiali secret is missing. Users are prohibited from accessing Kiali until an administrator creates a valid secret and restarts Kiali. Please refer to the Kiali documentation for more details.';
       }
       return Object.assign({}, INITIAL_LOGIN_STATE, {
         error: true,


### PR DESCRIPTION
This requires kiali PR https://github.com/kiali/kiali/pull/811

Once that PR and this PR are built and running, if the Kiali secret is missing, the user will see this message on the login screen:

![screenshot from 2019-01-25 15-44-47](https://user-images.githubusercontent.com/2029470/51771862-66116c80-20b8-11e9-8834-71e50f572676.png)
