### PR TITLE
[PoC] context-menu pie 

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@kiali/kiali-ui",
   "version": "0.14.0",
   "description": "React UI for [Kiali](https://github.com/kiali/kiali).",
+  "proxy": "https://kiali-istio-system.ose.os310-kprod.osoos.centralci.eng.rdu2.redhat.com",
   "keywords": [
     "istio service mesh",
     "kiali",
@@ -66,6 +67,7 @@
     "cytoscape-canvas": "3.0.1",
     "cytoscape-cola": "2.3.0",
     "cytoscape-cose-bilkent": "4.0.0",
+    "cytoscape-cxtmenu": "^3.0.2",
     "cytoscape-dagre": "2.2.2",
     "d3-format": "1.3.2",
     "deep-freeze": "0.0.1",

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -315,6 +315,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
         }, CytoscapeGraph.doubleTapMs);
       }
     });
+
     cy.on('mouseover', 'node,edge', (evt: any) => {
       const cytoscapeEvent = getCytoscapeBaseEvent(evt);
       if (cytoscapeEvent) {

--- a/src/components/CytoscapeGraph/CytoscapeReactWrapper.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeReactWrapper.tsx
@@ -8,11 +8,14 @@ import cycola from 'cytoscape-cola';
 import dagre from 'cytoscape-dagre';
 import coseBilkent from 'cytoscape-cose-bilkent';
 import GroupCompoundLayout from './Layout/GroupCompoundLayout';
+import cxtmenu from 'cytoscape-cxtmenu';
+import { GraphContextMenu } from './graphs/GraphContextMenu';
 
 cytoscape.use(canvas);
 cytoscape.use(cycola);
 cytoscape.use(dagre);
 cytoscape.use(coseBilkent);
+cytoscape.use(cxtmenu);
 cytoscape('layout', 'group-compound-layout', GroupCompoundLayout);
 
 type CytoscapeReactWrapperProps = {};
@@ -32,6 +35,7 @@ type CytoscapeReactWrapperState = {};
  */
 export class CytoscapeReactWrapper extends React.Component<CytoscapeReactWrapperProps, CytoscapeReactWrapperState> {
   cy: any;
+  contextMenu: any;
   divParentRef: any;
 
   constructor(props: CytoscapeReactWrapperProps) {
@@ -81,12 +85,17 @@ export class CytoscapeReactWrapper extends React.Component<CytoscapeReactWrapper
     );
 
     this.cy = cytoscape(opts);
+    this.contextMenu = this.cy.cxtmenu(GraphContextMenu.menuOptions());
   }
 
   destroy() {
     if (this.cy) {
       this.cy.destroy();
       this.cy = null;
+    }
+    if (this.contextMenu) {
+      this.contextMenu.destroy();
+      this.contextMenu = null;
     }
   }
 }

--- a/src/components/CytoscapeGraph/graphs/GraphContextMenu.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphContextMenu.ts
@@ -1,0 +1,78 @@
+import history from '../../../app/History';
+
+export class GraphContextMenu {
+  static menuOptions() {
+    return {
+      menuRadius: 100, // the radius of the circular menu in pixels
+      selector: 'node', // elements matching this Cytoscape.js selector will trigger cxtmenus
+      commands: [
+        // an array of commands to list in the menu or a function that returns the array
+        {
+          fillColor: 'rgba(200, 200, 200, 0.75)', // optional: custom background color for item
+          content: 'Detailed View',
+          contentStyle: {}, // css key:value pairs to set the command's css in js if you want
+          select: ele => {
+            // a function to execute when the command is selected
+            console.log('Context Menu Detailed view tap and hold on:' + ele.id());
+            this.showDetailsPage(ele);
+          },
+          enabled: true // whether the command is selectable
+        },
+        {
+          fillColor: 'rgba(200, 200, 200, 0.75)', // optional: custom background color for item
+          content: 'Zoom In',
+          contentStyle: {}, // css key:value pairs to set the command's css in js if you want
+          select: ele => {
+            // a function to execute when the command is selected
+            console.log('Context Menu Zoom In tap and hold');
+          },
+          enabled: true // whether the command is selectable
+        },
+        {
+          fillColor: 'rgba(200, 200, 200, 0.75)', // optional: custom background color for item
+          content: 'Hide',
+          contentStyle: {}, // css key:value pairs to set the command's css in js if you want
+          select: ele => {
+            // a function to execute when the command is selected
+            console.log('Context Menu Hide tap and hold');
+          },
+          enabled: false // whether the command is selectable
+        }
+      ], // function( ele ){ return [ /*...*/ ] }, // example function for commands
+      fillColor: 'rgba(0, 0, 0, 0.75)', // the background colour of the menu
+      activeFillColor: 'rgba(1, 105, 217, 0.75)', // the colour used to indicate the selected command
+      activePadding: 20, // additional size in pixels for the active command
+      indicatorSize: 24, // the size in pixels of the pointer to the active command
+      separatorWidth: 3, // the empty spacing in pixels between successive commands
+      spotlightPadding: 4, // extra spacing in pixels between the element and the spotlight
+      minSpotlightRadius: 24, // the minimum radius in pixels of the spotlight
+      maxSpotlightRadius: 38, // the maximum radius in pixels of the spotlight
+      openMenuEvents: 'cxttapstart taphold', // space-separated cytoscape events that will open the menu; only `cxttapstart` and/or `taphold` work here
+      itemColor: 'white', // the colour of text in the command's content
+      itemTextShadowColor: 'transparent', // the text shadow colour of the command's content
+      zIndex: 9999, // the z-index of the ui div
+      atMouse: false // draw menu at mouse position
+    };
+  }
+
+  private static showDetailsPage(element: any) {
+    const data = element._private.data;
+    const namespace = data.namespace;
+    const nodeType = data.nodeType;
+    const workload = data.workload;
+    let app = data.app;
+    let urlNodeType = app;
+
+    if (nodeType === 'app') {
+      urlNodeType = 'applications';
+    } else if (nodeType === 'service') {
+      urlNodeType = 'services';
+    } else if (workload) {
+      urlNodeType = 'workloads';
+      app = workload;
+    }
+    const detailsPageUrl = `/namespaces/${namespace}/${urlNodeType}/${app}`;
+    console.info(`Routing to details page: ${detailsPageUrl}`);
+    history.push(detailsPageUrl);
+  }
+}

--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -52,7 +52,11 @@ const NodeWidth = NodeHeight;
 
 export class GraphStyles {
   static options() {
-    return { wheelSensitivity: 0.1, autounselectify: false, autoungrabify: true };
+    return {
+      wheelSensitivity: 0.1,
+      autounselectify: false,
+      autoungrabify: true
+    };
   }
 
   static styles() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2726,6 +2726,11 @@ cytoscape-cose-bilkent@4.0.0:
   resolved "https://registry.yarnpkg.com/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.0.0.tgz#5f0afbe5c55a7a026442b756ca388ce77c262967"
   integrity sha1-Xwr75cVaegJkQrdWyjiM53wmKWc=
 
+cytoscape-cxtmenu@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/cytoscape-cxtmenu/-/cytoscape-cxtmenu-3.0.2.tgz#dcf3fc5b02511384537f40a1768f8ec2ba0db725"
+  integrity sha512-UJIH1BT98MlotUfPgw7r/1V/RXfEHS0EGZy38lu56+OUw5NSBXArSlfHIVZzwrQAmHKIhfnzqJOkajB06IEzAQ==
+
 cytoscape-dagre@2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/cytoscape-dagre/-/cytoscape-dagre-2.2.2.tgz#5f32a85c0ba835f167efee531df9e89ac58ff411"


### PR DESCRIPTION
** Describe the change **

This is a PoC of the context pie menu. Current PoC is Node-only, but we can put different menus on different type of node and/or edges. Obviously, the rules for node/edge types and what kind of capabilities are still undetermined. This is more about establishing a UX mechanism for accessing the capabilities of graph items. But obviously, this gives us the more documented capability of what we can do on a graph item.

** Issue reference **

https://issues.jboss.org/browse/KIALI-2271

** Backwards compatible? **
Yes

** Screenshot **
![pie-context-menu](https://user-images.githubusercontent.com/1312165/52062567-98422480-2525-11e9-892d-b39625eabf2c.gif)

EDIT: I updated the pointer in the video to be the mouse pointer; I was using a weird finger-like pointer before that was confusing.

BTW: the red clicks don't actually show up on the screen they are to identify clicks.