### PR TITLE
KIALI-2057 Istio sidecar indicator should be present on Workloads and not only as summary on Application

### DIFF
--- a/src/components/MissingSidecar/MissingSidecar.tsx
+++ b/src/components/MissingSidecar/MissingSidecar.tsx
@@ -4,7 +4,7 @@ import { Icon, OverlayTrigger, Tooltip } from 'patternfly-react';
 import { ICONS } from '../../config';
 
 const MissingSidecar = props => {
-  const { style, text, type, name, color, tooltip, ...otherProps } = props;
+  const { style, text, textTooltip, type, name, color, tooltip, ...otherProps } = props;
 
   const iconComponent = (
     <span style={style} {...otherProps}>
@@ -16,7 +16,7 @@ const MissingSidecar = props => {
     <OverlayTrigger
       overlay={
         <Tooltip>
-          <strong>{text}</strong>
+          <strong>{textTooltip}</strong>
         </Tooltip>
       }
       placement="right"
@@ -32,6 +32,7 @@ const MissingSidecar = props => {
 
 MissingSidecar.propTypes = {
   text: PropTypes.string,
+  textTooltip: PropTypes.string,
   tooltip: PropTypes.bool,
   type: PropTypes.string,
   name: PropTypes.string,
@@ -40,6 +41,7 @@ MissingSidecar.propTypes = {
 
 MissingSidecar.defaultProps = {
   text: 'Missing Sidecar',
+  textTooltip: 'Missing Sidecar',
   tooltip: false,
   type: ICONS().ISTIO.MISSING_SIDECAR.type,
   name: ICONS().ISTIO.MISSING_SIDECAR.name,

--- a/src/pages/AppDetails/AppInfo/AppDescription.tsx
+++ b/src/pages/AppDetails/AppInfo/AppDescription.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Row, Col, ListView, ListViewItem, ListViewIcon, Icon } from 'patternfly-react';
 import PfInfoCard from '../../../components/Pf/PfInfoCard';
 import { DisplayMode, HealthIndicator } from '../../../components/Health/HealthIndicator';
+import MissingSidecar from '../../../components/MissingSidecar/MissingSidecar';
 import { AppHealth } from '../../../types/Health';
 import { App, AppWorkload } from '../../../types/App';
 import { WorkloadIcon } from '../../../types/Workload';
@@ -56,7 +57,10 @@ class AppDescription extends React.Component<AppDescriptionProps, AppDescription
     const heading = (
       <div className="ServiceList-Heading">
         <div className="ServiceList-Title">
-          <div className="component-label">Workload</div>
+          <div className="component-label">
+            Workload{' '}
+            {!workload.istioSidecar && <MissingSidecar style={{ marginLeft: '10px' }} tooltip={true} text={''} />}
+          </div>
           <Link to={this.workloadLink(namespace, workload.workloadName)}>{workload.workloadName}</Link>
         </div>
       </div>

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoCard.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoCard.test.tsx.snap
@@ -72,6 +72,7 @@ ShallowWrapper {
                 color="red"
                 name="blueprint"
                 text="Missing Sidecar"
+                textTooltip="Missing Sidecar"
                 tooltip={false}
                 type="pf"
               />
@@ -137,6 +138,7 @@ ShallowWrapper {
                 color="red"
                 name="blueprint"
                 text="Missing Sidecar"
+                textTooltip="Missing Sidecar"
                 tooltip={false}
                 type="pf"
               />
@@ -172,6 +174,7 @@ ShallowWrapper {
                   color="red"
                   name="blueprint"
                   text="Missing Sidecar"
+                  textTooltip="Missing Sidecar"
                   tooltip={false}
                   type="pf"
                 />
@@ -206,6 +209,7 @@ ShallowWrapper {
                   color="red"
                   name="blueprint"
                   text="Missing Sidecar"
+                  textTooltip="Missing Sidecar"
                   tooltip={false}
                   type="pf"
                 />,
@@ -222,6 +226,7 @@ ShallowWrapper {
                   "color": "red",
                   "name": "blueprint",
                   "text": "Missing Sidecar",
+                  "textTooltip": "Missing Sidecar",
                   "tooltip": false,
                   "type": "pf",
                 },
@@ -402,6 +407,7 @@ ShallowWrapper {
                   color="red"
                   name="blueprint"
                   text="Missing Sidecar"
+                  textTooltip="Missing Sidecar"
                   tooltip={false}
                   type="pf"
                 />
@@ -467,6 +473,7 @@ ShallowWrapper {
                   color="red"
                   name="blueprint"
                   text="Missing Sidecar"
+                  textTooltip="Missing Sidecar"
                   tooltip={false}
                   type="pf"
                 />
@@ -502,6 +509,7 @@ ShallowWrapper {
                     color="red"
                     name="blueprint"
                     text="Missing Sidecar"
+                    textTooltip="Missing Sidecar"
                     tooltip={false}
                     type="pf"
                   />
@@ -536,6 +544,7 @@ ShallowWrapper {
                     color="red"
                     name="blueprint"
                     text="Missing Sidecar"
+                    textTooltip="Missing Sidecar"
                     tooltip={false}
                     type="pf"
                   />,
@@ -552,6 +561,7 @@ ShallowWrapper {
                     "color": "red",
                     "name": "blueprint",
                     "text": "Missing Sidecar",
+                    "textTooltip": "Missing Sidecar",
                     "tooltip": false,
                     "type": "pf",
                   },


### PR DESCRIPTION
[KIALI-2057](https://issues.jboss.org/browse/KIALI-2057)

Added missing istio sidecar when worklaods not have istio sidecar deployed with a tooltip.

![peek 2019-01-30 11-43](https://user-images.githubusercontent.com/3019213/51976312-9f652600-2484-11e9-85c2-5ada936d2af2.gif)
