### PR TITLE
KIALI-2036 fix inaccurate wording and redesign health report

### DIFF
--- a/src/components/Health/HealthDetails.tsx
+++ b/src/components/Health/HealthDetails.tsx
@@ -1,30 +1,14 @@
 import * as React from 'react';
-import { Icon, OverlayTrigger, Popover } from 'patternfly-react';
+import { Icon } from 'patternfly-react';
 import * as H from '../../types/Health';
 
 interface Props {
-  id: string;
   health: H.Health;
-  headline: string;
-  placement?: string;
 }
 
 export class HealthDetails extends React.PureComponent<Props, {}> {
   constructor(props: Props) {
     super(props);
-  }
-
-  render() {
-    return (
-      <OverlayTrigger
-        placement={this.props.placement || 'right'}
-        overlay={this.renderPopover()}
-        trigger={['hover', 'focus']}
-        rootClose={false}
-      >
-        {this.props.children}
-      </OverlayTrigger>
-    );
   }
 
   renderStatus(status: H.Status) {
@@ -35,33 +19,29 @@ export class HealthDetails extends React.PureComponent<Props, {}> {
     }
   }
 
-  renderPopover() {
+  render() {
     const health = this.props.health;
-    return (
-      <Popover id={this.props.id + '-health-tooltip'} title={this.props.headline}>
-        {health.items.map((item, idx) => {
-          return (
-            <div key={idx}>
-              <strong>
-                {this.renderStatus(item.status)}
-                {' ' + item.title + ': '}
-              </strong>
-              {item.text}
-              {item.children && (
-                <ul style={{ listStyleType: 'none', paddingLeft: 12 }}>
-                  {item.children.map((sub, subIdx) => {
-                    return (
-                      <li key={subIdx}>
-                        {this.renderStatus(sub.status)} {sub.text}
-                      </li>
-                    );
-                  })}
-                </ul>
-              )}
-            </div>
-          );
-        })}
-      </Popover>
-    );
+    return health.items.map((item, idx) => {
+      return (
+        <div key={idx}>
+          <strong>
+            {this.renderStatus(item.status)}
+            {' ' + item.title + ': '}
+          </strong>
+          {item.text}
+          {item.children && (
+            <ul style={{ listStyleType: 'none', paddingLeft: 12 }}>
+              {item.children.map((sub, subIdx) => {
+                return (
+                  <li key={subIdx}>
+                    {this.renderStatus(sub.status)} {sub.text}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      );
+    });
   }
 }

--- a/src/components/Health/HealthIndicator.tsx
+++ b/src/components/Health/HealthIndicator.tsx
@@ -56,13 +56,13 @@ export class HealthIndicator extends React.PureComponent<Props, HealthState> {
       left: 10
     };
     return (
-      <div>
+      <>
         {this.renderIcon('35px', '24px')}
         <span style={spanStyle}>{this.state.globalStatus.name}</span>
         <br />
         <br />
         <HealthDetails health={health} />
-      </div>
+      </>
     );
   }
 

--- a/src/components/Health/HealthIndicator.tsx
+++ b/src/components/Health/HealthIndicator.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Icon } from 'patternfly-react';
+import { Icon, OverlayTrigger, Popover } from 'patternfly-react';
 import { HealthDetails } from './HealthDetails';
 import * as H from '../../types/Health';
 
@@ -17,25 +17,18 @@ interface Props {
 
 interface HealthState {
   globalStatus: H.Status;
-  info: string[];
 }
 
 export class HealthIndicator extends React.PureComponent<Props, HealthState> {
-  static updateHealth = (health?: H.Health) => {
-    if (health) {
-      return { info: health.getReport(), globalStatus: health.getGlobalStatus() };
-    } else {
-      return { info: [], globalStatus: H.NA };
-    }
-  };
-
-  static getDerivedStateFromProps(props: Props, state: HealthState) {
-    return HealthIndicator.updateHealth(props.health);
+  static getDerivedStateFromProps(props: Props) {
+    return {
+      globalStatus: props.health ? props.health.getGlobalStatus() : H.NA
+    };
   }
 
   constructor(props: Props) {
     super(props);
-    this.state = HealthIndicator.updateHealth(props.health);
+    this.state = HealthIndicator.getDerivedStateFromProps(props);
   }
 
   render() {
@@ -50,43 +43,62 @@ export class HealthIndicator extends React.PureComponent<Props, HealthState> {
   }
 
   renderSmall(health: H.Health) {
-    return <span>{this.renderIndicator(health, '18px', '12px', this.state.globalStatus.name)}</span>;
+    const icon = this.renderIcon('18px', '12px');
+    return this.renderPopover(health, icon);
   }
 
   renderLarge(health: H.Health) {
+    const spanStyle: React.CSSProperties = {
+      color: this.state.globalStatus.color,
+      fontWeight: 'bold',
+      position: 'relative',
+      top: -9,
+      left: 10
+    };
     return (
-      <div style={{ color: this.state.globalStatus.color }}>
-        {this.renderIndicator(health, '35px', '24px', this.state.globalStatus.name)}
+      <div>
+        {this.renderIcon('35px', '24px')}
+        <span style={spanStyle}>{this.state.globalStatus.name}</span>
         <br />
-        {this.state.info.length === 1 && this.state.info[0]}
-        {this.state.info.length > 1 && (
-          <ul style={{ padding: 0 }}>
-            {this.state.info.map((line, idx) => (
-              <li key={idx}>{line}</li>
-            ))}
-          </ul>
-        )}
+        <br />
+        <HealthDetails health={health} />
       </div>
     );
   }
 
-  renderIndicator(health: H.Health, iconSize: string, textSize: string, title: string) {
+  renderIcon(iconSize: string, textSize: string) {
     if (this.state.globalStatus.icon) {
       return (
-        <HealthDetails id={this.props.id} health={health} headline={title} placement={this.props.tooltipPlacement}>
-          <Icon
-            type="pf"
-            name={this.state.globalStatus.icon}
-            style={{ fontSize: iconSize }}
-            className="health-icon"
-            tabIndex="0"
-          />
-        </HealthDetails>
+        <Icon
+          type="pf"
+          name={this.state.globalStatus.icon}
+          style={{ fontSize: iconSize }}
+          className="health-icon"
+          tabIndex="0"
+        />
       );
     } else {
       return (
         <span style={{ color: this.state.globalStatus.color, fontSize: textSize }}>{this.state.globalStatus.text}</span>
       );
     }
+  }
+
+  renderPopover(health: H.Health, icon: JSX.Element) {
+    const popover = (
+      <Popover id={this.props.id + '-health-tooltip'} title={this.state.globalStatus.name}>
+        <HealthDetails health={health} />
+      </Popover>
+    );
+    return (
+      <OverlayTrigger
+        placement={this.props.tooltipPlacement || 'right'}
+        overlay={popover}
+        trigger={['hover', 'focus']}
+        rootClose={false}
+      >
+        {icon}
+      </OverlayTrigger>
+    );
   }
 }

--- a/src/components/Health/__tests__/HealthDetails.test.tsx
+++ b/src/components/Health/__tests__/HealthDetails.test.tsx
@@ -8,14 +8,14 @@ describe('HealthDetails', () => {
   it('renders healthy', () => {
     const health = new ServiceHealth({ errorRatio: -1, inboundErrorRatio: -1, outboundErrorRatio: -1 }, 60);
 
-    const wrapper = shallow(<HealthDetails id="svc" health={health} headline="" />);
+    const wrapper = shallow(<HealthDetails health={health} />);
     expect(wrapper).toMatchSnapshot();
   });
 
   it('renders deployments failure', () => {
     const health = new ServiceHealth({ errorRatio: -1, inboundErrorRatio: -1, outboundErrorRatio: -1 }, 60);
 
-    const wrapper = shallow(<HealthDetails id="svc" health={health} headline="" />);
+    const wrapper = shallow(<HealthDetails health={health} />);
     expect(wrapper).toMatchSnapshot();
   });
 });

--- a/src/components/Health/__tests__/HealthIndicator.test.tsx
+++ b/src/components/Health/__tests__/HealthIndicator.test.tsx
@@ -50,7 +50,7 @@ describe('HealthIndicator', () => {
     wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} />);
     html = wrapper.html();
     expect(html).toContain('pficon-warning');
-    expect(html).toContain('Pod workload degraded');
+    expect(html).toContain('1 / 10');
   });
 
   it('renders some scaled down workload', () => {
@@ -69,7 +69,7 @@ describe('HealthIndicator', () => {
     wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} />);
     html = wrapper.html();
     expect(html).toContain('pficon-ok');
-    expect(html).toContain('inactive workload');
+    expect(html).toContain('0 / 0');
   });
 
   it('renders all workloads down', () => {
@@ -88,7 +88,6 @@ describe('HealthIndicator', () => {
     wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} />);
     html = wrapper.html();
     expect(html).toContain('pficon-error');
-    expect(html).toContain('No active workload');
   });
 
   it('renders error rate failure', () => {
@@ -107,7 +106,7 @@ describe('HealthIndicator', () => {
     wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} />);
     html = wrapper.html();
     expect(html).toContain('pficon-error');
-    expect(html).toContain('Outbound errors failure');
-    expect(html).toContain('Inbound errors degraded');
+    expect(html).toContain('Outbound: 20.00%');
+    expect(html).toContain('Inbound: 10.00%');
   });
 });

--- a/src/components/Health/__tests__/__snapshots__/HealthDetails.test.tsx.snap
+++ b/src/components/Health/__tests__/__snapshots__/HealthDetails.test.tsx.snap
@@ -4,7 +4,6 @@ exports[`HealthDetails renders deployments failure 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <HealthDetails
-    headline=""
     health={
       ServiceHealth {
         "items": Array [
@@ -27,7 +26,6 @@ ShallowWrapper {
         },
       }
     }
-    id="svc"
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -39,18 +37,78 @@ ShallowWrapper {
   },
   Symbol(enzyme.__node__): Object {
     "instance": null,
-    "key": undefined,
-    "nodeType": "class",
+    "key": "0",
+    "nodeType": "host",
     "props": Object {
-      "children": undefined,
-      "defaultOverlayShown": false,
-      "overlay": <Popover
-        bsClass="popover"
-        id="svc-health-tooltip"
-        placement="right"
-        title=""
-      >
-        <div>
+      "children": Array [
+        <strong>
+          <span
+            style={
+              Object {
+                "color": "#72767b",
+              }
+            }
+          >
+            N/A
+          </span>
+           Error Rate: 
+        </strong>,
+        "No requests over last min",
+        undefined,
+      ],
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            <span
+              style={
+                Object {
+                  "color": "#72767b",
+                }
+              }
+            >
+              N/A
+            </span>,
+            " Error Rate: ",
+          ],
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": "N/A",
+              "style": Object {
+                "color": "#72767b",
+              },
+            },
+            "ref": null,
+            "rendered": "N/A",
+            "type": "span",
+          },
+          " Error Rate: ",
+        ],
+        "type": "strong",
+      },
+      "No requests over last min",
+      undefined,
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": "0",
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
           <strong>
             <span
               style={
@@ -62,37 +120,19 @@ ShallowWrapper {
               N/A
             </span>
              Error Rate: 
-          </strong>
-          No requests over last min
-        </div>
-      </Popover>,
-      "placement": "right",
-      "rootClose": false,
-      "trigger": Array [
-        "hover",
-        "focus",
-      ],
-    },
-    "ref": null,
-    "rendered": null,
-    "type": [Function],
-  },
-  Symbol(enzyme.__nodes__): Array [
-    Object {
-      "instance": null,
-      "key": undefined,
-      "nodeType": "class",
-      "props": Object {
-        "children": undefined,
-        "defaultOverlayShown": false,
-        "overlay": <Popover
-          bsClass="popover"
-          id="svc-health-tooltip"
-          placement="right"
-          title=""
-        >
-          <div>
-            <strong>
+          </strong>,
+          "No requests over last min",
+          undefined,
+        ],
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
               <span
                 style={
                   Object {
@@ -101,22 +141,34 @@ ShallowWrapper {
                 }
               >
                 N/A
-              </span>
-               Error Rate: 
-            </strong>
-            No requests over last min
-          </div>
-        </Popover>,
-        "placement": "right",
-        "rootClose": false,
-        "trigger": Array [
-          "hover",
-          "focus",
-        ],
-      },
-      "ref": null,
-      "rendered": null,
-      "type": [Function],
+              </span>,
+              " Error Rate: ",
+            ],
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": "N/A",
+                "style": Object {
+                  "color": "#72767b",
+                },
+              },
+              "ref": null,
+              "rendered": "N/A",
+              "type": "span",
+            },
+            " Error Rate: ",
+          ],
+          "type": "strong",
+        },
+        "No requests over last min",
+        undefined,
+      ],
+      "type": "div",
     },
   ],
   Symbol(enzyme.__options__): Object {
@@ -143,7 +195,6 @@ exports[`HealthDetails renders healthy 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <HealthDetails
-    headline=""
     health={
       ServiceHealth {
         "items": Array [
@@ -166,7 +217,6 @@ ShallowWrapper {
         },
       }
     }
-    id="svc"
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
@@ -178,18 +228,78 @@ ShallowWrapper {
   },
   Symbol(enzyme.__node__): Object {
     "instance": null,
-    "key": undefined,
-    "nodeType": "class",
+    "key": "0",
+    "nodeType": "host",
     "props": Object {
-      "children": undefined,
-      "defaultOverlayShown": false,
-      "overlay": <Popover
-        bsClass="popover"
-        id="svc-health-tooltip"
-        placement="right"
-        title=""
-      >
-        <div>
+      "children": Array [
+        <strong>
+          <span
+            style={
+              Object {
+                "color": "#72767b",
+              }
+            }
+          >
+            N/A
+          </span>
+           Error Rate: 
+        </strong>,
+        "No requests over last min",
+        undefined,
+      ],
+    },
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            <span
+              style={
+                Object {
+                  "color": "#72767b",
+                }
+              }
+            >
+              N/A
+            </span>,
+            " Error Rate: ",
+          ],
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": "N/A",
+              "style": Object {
+                "color": "#72767b",
+              },
+            },
+            "ref": null,
+            "rendered": "N/A",
+            "type": "span",
+          },
+          " Error Rate: ",
+        ],
+        "type": "strong",
+      },
+      "No requests over last min",
+      undefined,
+    ],
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": "0",
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
           <strong>
             <span
               style={
@@ -201,37 +311,19 @@ ShallowWrapper {
               N/A
             </span>
              Error Rate: 
-          </strong>
-          No requests over last min
-        </div>
-      </Popover>,
-      "placement": "right",
-      "rootClose": false,
-      "trigger": Array [
-        "hover",
-        "focus",
-      ],
-    },
-    "ref": null,
-    "rendered": null,
-    "type": [Function],
-  },
-  Symbol(enzyme.__nodes__): Array [
-    Object {
-      "instance": null,
-      "key": undefined,
-      "nodeType": "class",
-      "props": Object {
-        "children": undefined,
-        "defaultOverlayShown": false,
-        "overlay": <Popover
-          bsClass="popover"
-          id="svc-health-tooltip"
-          placement="right"
-          title=""
-        >
-          <div>
-            <strong>
+          </strong>,
+          "No requests over last min",
+          undefined,
+        ],
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
               <span
                 style={
                   Object {
@@ -240,22 +332,34 @@ ShallowWrapper {
                 }
               >
                 N/A
-              </span>
-               Error Rate: 
-            </strong>
-            No requests over last min
-          </div>
-        </Popover>,
-        "placement": "right",
-        "rootClose": false,
-        "trigger": Array [
-          "hover",
-          "focus",
-        ],
-      },
-      "ref": null,
-      "rendered": null,
-      "type": [Function],
+              </span>,
+              " Error Rate: ",
+            ],
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": "N/A",
+                "style": Object {
+                  "color": "#72767b",
+                },
+              },
+              "ref": null,
+              "rendered": "N/A",
+              "type": "span",
+            },
+            " Error Rate: ",
+          ],
+          "type": "strong",
+        },
+        "No requests over last min",
+        undefined,
+      ],
+      "type": "div",
     },
   ],
   Symbol(enzyme.__options__): Object {

--- a/src/components/Health/__tests__/__snapshots__/HealthIndicator.test.tsx.snap
+++ b/src/components/Health/__tests__/__snapshots__/HealthIndicator.test.tsx.snap
@@ -100,239 +100,27 @@ ShallowWrapper {
   Symbol(enzyme.__node__): Object {
     "instance": null,
     "key": undefined,
-    "nodeType": "host",
+    "nodeType": "class",
     "props": Object {
-      "children": <HealthDetails
-        headline="Healthy"
-        health={
-          AppHealth {
-            "items": Array [
-              Object {
-                "children": Array [
-                  Object {
-                    "status": Object {
-                      "color": "#3f9c35",
-                      "icon": "ok",
-                      "name": "Healthy",
-                      "priority": 1,
-                    },
-                    "text": "A: 1 / 1",
-                  },
-                  Object {
-                    "status": Object {
-                      "color": "#3f9c35",
-                      "icon": "ok",
-                      "name": "Healthy",
-                      "priority": 1,
-                    },
-                    "text": "B: 2 / 2",
-                  },
-                ],
-                "status": Object {
-                  "color": "#3f9c35",
-                  "icon": "ok",
-                  "name": "Healthy",
-                  "priority": 1,
-                },
-                "title": "Workload Status",
-              },
-              Object {
-                "children": Array [
-                  Object {
-                    "status": Object {
-                      "color": "#72767b",
-                      "name": "No health information",
-                      "priority": 0,
-                      "text": "N/A",
-                    },
-                    "text": "Inbound: No requests",
-                  },
-                  Object {
-                    "status": Object {
-                      "color": "#72767b",
-                      "name": "No health information",
-                      "priority": 0,
-                      "text": "N/A",
-                    },
-                    "text": "Outbound: No requests",
-                  },
-                ],
-                "status": Object {
-                  "color": "#72767b",
-                  "name": "No health information",
-                  "priority": 0,
-                  "text": "N/A",
-                },
-                "title": "Error Rate over last 10 min",
-              },
-            ],
-            "rateInterval": 600,
-            "requests": Object {
-              "errorRatio": -1,
-              "inboundErrorRatio": -1,
-              "outboundErrorRatio": -1,
-            },
-            "workloadStatuses": Array [
-              Object {
-                "available": 1,
-                "name": "A",
-                "replicas": 1,
-              },
-              Object {
-                "available": 2,
-                "name": "B",
-                "replicas": 2,
-              },
-            ],
+      "children": <Icon
+        className="health-icon"
+        name="ok"
+        style={
+          Object {
+            "fontSize": "18px",
           }
         }
-        id="svc"
-        placement={undefined}
+        tabIndex="0"
+        type="pf"
+      />,
+      "defaultOverlayShown": false,
+      "overlay": <Popover
+        bsClass="popover"
+        id="svc-health-tooltip"
+        placement="right"
+        title="Healthy"
       >
-        <Icon
-          className="health-icon"
-          name="ok"
-          style={
-            Object {
-              "fontSize": "18px",
-            }
-          }
-          tabIndex="0"
-          type="pf"
-        />
-      </HealthDetails>,
-    },
-    "ref": null,
-    "rendered": Object {
-      "instance": null,
-      "key": undefined,
-      "nodeType": "class",
-      "props": Object {
-        "children": <Icon
-          className="health-icon"
-          name="ok"
-          style={
-            Object {
-              "fontSize": "18px",
-            }
-          }
-          tabIndex="0"
-          type="pf"
-        />,
-        "headline": "Healthy",
-        "health": AppHealth {
-          "items": Array [
-            Object {
-              "children": Array [
-                Object {
-                  "status": Object {
-                    "color": "#3f9c35",
-                    "icon": "ok",
-                    "name": "Healthy",
-                    "priority": 1,
-                  },
-                  "text": "A: 1 / 1",
-                },
-                Object {
-                  "status": Object {
-                    "color": "#3f9c35",
-                    "icon": "ok",
-                    "name": "Healthy",
-                    "priority": 1,
-                  },
-                  "text": "B: 2 / 2",
-                },
-              ],
-              "status": Object {
-                "color": "#3f9c35",
-                "icon": "ok",
-                "name": "Healthy",
-                "priority": 1,
-              },
-              "title": "Workload Status",
-            },
-            Object {
-              "children": Array [
-                Object {
-                  "status": Object {
-                    "color": "#72767b",
-                    "name": "No health information",
-                    "priority": 0,
-                    "text": "N/A",
-                  },
-                  "text": "Inbound: No requests",
-                },
-                Object {
-                  "status": Object {
-                    "color": "#72767b",
-                    "name": "No health information",
-                    "priority": 0,
-                    "text": "N/A",
-                  },
-                  "text": "Outbound: No requests",
-                },
-              ],
-              "status": Object {
-                "color": "#72767b",
-                "name": "No health information",
-                "priority": 0,
-                "text": "N/A",
-              },
-              "title": "Error Rate over last 10 min",
-            },
-          ],
-          "rateInterval": 600,
-          "requests": Object {
-            "errorRatio": -1,
-            "inboundErrorRatio": -1,
-            "outboundErrorRatio": -1,
-          },
-          "workloadStatuses": Array [
-            Object {
-              "available": 1,
-              "name": "A",
-              "replicas": 1,
-            },
-            Object {
-              "available": 2,
-              "name": "B",
-              "replicas": 2,
-            },
-          ],
-        },
-        "id": "svc",
-        "placement": undefined,
-      },
-      "ref": null,
-      "rendered": Object {
-        "instance": null,
-        "key": undefined,
-        "nodeType": "function",
-        "props": Object {
-          "className": "health-icon",
-          "name": "ok",
-          "style": Object {
-            "fontSize": "18px",
-          },
-          "tabIndex": "0",
-          "type": "pf",
-        },
-        "ref": null,
-        "rendered": null,
-        "type": [Function],
-      },
-      "type": [Function],
-    },
-    "type": "span",
-  },
-  Symbol(enzyme.__nodes__): Array [
-    Object {
-      "instance": null,
-      "key": undefined,
-      "nodeType": "host",
-      "props": Object {
-        "children": <HealthDetails
-          headline="Healthy"
+        <HealthDetails
           health={
             AppHealth {
               "items": Array [
@@ -415,144 +203,170 @@ ShallowWrapper {
               ],
             }
           }
-          id="svc"
-          placement={undefined}
+        />
+      </Popover>,
+      "placement": "right",
+      "rootClose": false,
+      "trigger": Array [
+        "hover",
+        "focus",
+      ],
+    },
+    "ref": null,
+    "rendered": Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "function",
+      "props": Object {
+        "className": "health-icon",
+        "name": "ok",
+        "style": Object {
+          "fontSize": "18px",
+        },
+        "tabIndex": "0",
+        "type": "pf",
+      },
+      "ref": null,
+      "rendered": null,
+      "type": [Function],
+    },
+    "type": [Function],
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "class",
+      "props": Object {
+        "children": <Icon
+          className="health-icon"
+          name="ok"
+          style={
+            Object {
+              "fontSize": "18px",
+            }
+          }
+          tabIndex="0"
+          type="pf"
+        />,
+        "defaultOverlayShown": false,
+        "overlay": <Popover
+          bsClass="popover"
+          id="svc-health-tooltip"
+          placement="right"
+          title="Healthy"
         >
-          <Icon
-            className="health-icon"
-            name="ok"
-            style={
-              Object {
-                "fontSize": "18px",
+          <HealthDetails
+            health={
+              AppHealth {
+                "items": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "status": Object {
+                          "color": "#3f9c35",
+                          "icon": "ok",
+                          "name": "Healthy",
+                          "priority": 1,
+                        },
+                        "text": "A: 1 / 1",
+                      },
+                      Object {
+                        "status": Object {
+                          "color": "#3f9c35",
+                          "icon": "ok",
+                          "name": "Healthy",
+                          "priority": 1,
+                        },
+                        "text": "B: 2 / 2",
+                      },
+                    ],
+                    "status": Object {
+                      "color": "#3f9c35",
+                      "icon": "ok",
+                      "name": "Healthy",
+                      "priority": 1,
+                    },
+                    "title": "Workload Status",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "status": Object {
+                          "color": "#72767b",
+                          "name": "No health information",
+                          "priority": 0,
+                          "text": "N/A",
+                        },
+                        "text": "Inbound: No requests",
+                      },
+                      Object {
+                        "status": Object {
+                          "color": "#72767b",
+                          "name": "No health information",
+                          "priority": 0,
+                          "text": "N/A",
+                        },
+                        "text": "Outbound: No requests",
+                      },
+                    ],
+                    "status": Object {
+                      "color": "#72767b",
+                      "name": "No health information",
+                      "priority": 0,
+                      "text": "N/A",
+                    },
+                    "title": "Error Rate over last 10 min",
+                  },
+                ],
+                "rateInterval": 600,
+                "requests": Object {
+                  "errorRatio": -1,
+                  "inboundErrorRatio": -1,
+                  "outboundErrorRatio": -1,
+                },
+                "workloadStatuses": Array [
+                  Object {
+                    "available": 1,
+                    "name": "A",
+                    "replicas": 1,
+                  },
+                  Object {
+                    "available": 2,
+                    "name": "B",
+                    "replicas": 2,
+                  },
+                ],
               }
             }
-            tabIndex="0"
-            type="pf"
           />
-        </HealthDetails>,
+        </Popover>,
+        "placement": "right",
+        "rootClose": false,
+        "trigger": Array [
+          "hover",
+          "focus",
+        ],
       },
       "ref": null,
       "rendered": Object {
         "instance": null,
         "key": undefined,
-        "nodeType": "class",
+        "nodeType": "function",
         "props": Object {
-          "children": <Icon
-            className="health-icon"
-            name="ok"
-            style={
-              Object {
-                "fontSize": "18px",
-              }
-            }
-            tabIndex="0"
-            type="pf"
-          />,
-          "headline": "Healthy",
-          "health": AppHealth {
-            "items": Array [
-              Object {
-                "children": Array [
-                  Object {
-                    "status": Object {
-                      "color": "#3f9c35",
-                      "icon": "ok",
-                      "name": "Healthy",
-                      "priority": 1,
-                    },
-                    "text": "A: 1 / 1",
-                  },
-                  Object {
-                    "status": Object {
-                      "color": "#3f9c35",
-                      "icon": "ok",
-                      "name": "Healthy",
-                      "priority": 1,
-                    },
-                    "text": "B: 2 / 2",
-                  },
-                ],
-                "status": Object {
-                  "color": "#3f9c35",
-                  "icon": "ok",
-                  "name": "Healthy",
-                  "priority": 1,
-                },
-                "title": "Workload Status",
-              },
-              Object {
-                "children": Array [
-                  Object {
-                    "status": Object {
-                      "color": "#72767b",
-                      "name": "No health information",
-                      "priority": 0,
-                      "text": "N/A",
-                    },
-                    "text": "Inbound: No requests",
-                  },
-                  Object {
-                    "status": Object {
-                      "color": "#72767b",
-                      "name": "No health information",
-                      "priority": 0,
-                      "text": "N/A",
-                    },
-                    "text": "Outbound: No requests",
-                  },
-                ],
-                "status": Object {
-                  "color": "#72767b",
-                  "name": "No health information",
-                  "priority": 0,
-                  "text": "N/A",
-                },
-                "title": "Error Rate over last 10 min",
-              },
-            ],
-            "rateInterval": 600,
-            "requests": Object {
-              "errorRatio": -1,
-              "inboundErrorRatio": -1,
-              "outboundErrorRatio": -1,
-            },
-            "workloadStatuses": Array [
-              Object {
-                "available": 1,
-                "name": "A",
-                "replicas": 1,
-              },
-              Object {
-                "available": 2,
-                "name": "B",
-                "replicas": 2,
-              },
-            ],
+          "className": "health-icon",
+          "name": "ok",
+          "style": Object {
+            "fontSize": "18px",
           },
-          "id": "svc",
-          "placement": undefined,
+          "tabIndex": "0",
+          "type": "pf",
         },
         "ref": null,
-        "rendered": Object {
-          "instance": null,
-          "key": undefined,
-          "nodeType": "function",
-          "props": Object {
-            "className": "health-icon",
-            "name": "ok",
-            "style": Object {
-              "fontSize": "18px",
-            },
-            "tabIndex": "0",
-            "type": "pf",
-          },
-          "ref": null,
-          "rendered": null,
-          "type": [Function],
-        },
+        "rendered": null,
         "type": [Function],
       },
-      "type": "span",
+      "type": [Function],
     },
   ],
   Symbol(enzyme.__options__): Object {

--- a/src/components/Health/__tests__/__snapshots__/HealthIndicator.test.tsx.snap
+++ b/src/components/Health/__tests__/__snapshots__/HealthIndicator.test.tsx.snap
@@ -34,7 +34,7 @@ ShallowWrapper {
               "name": "Healthy",
               "priority": 1,
             },
-            "title": "Workload Status",
+            "title": "Pods Status",
           },
           Object {
             "children": Array [
@@ -151,7 +151,7 @@ ShallowWrapper {
                     "name": "Healthy",
                     "priority": 1,
                   },
-                  "title": "Workload Status",
+                  "title": "Pods Status",
                 },
                 Object {
                   "children": Array [
@@ -287,7 +287,7 @@ ShallowWrapper {
                       "name": "Healthy",
                       "priority": 1,
                     },
-                    "title": "Workload Status",
+                    "title": "Pods Status",
                   },
                   Object {
                     "children": Array [

--- a/src/pages/AppDetails/AppInfo/AppDescription.tsx
+++ b/src/pages/AppDetails/AppInfo/AppDescription.tsx
@@ -127,13 +127,14 @@ class AppDescription extends React.Component<AppDescriptionProps, AppDescription
         istio={this.istioSidecar()}
         items={
           <Row>
-            <Col xs={12} sm={6} md={5} lg={5}>
+            <Col xs={12} sm={6} md={4} lg={4}>
               <ListView>{this.workloadList()}</ListView>
             </Col>
-            <Col xs={12} sm={6} md={5} lg={5}>
+            <Col xs={12} sm={6} md={4} lg={4}>
               <ListView>{this.serviceList()}</ListView>
             </Col>
-            <Col xs={12} sm={6} md={2} lg={2}>
+            <Col xs={0} sm={0} md={1} lg={1} />
+            <Col xs={12} sm={6} md={3} lg={3}>
               <div className="progress-description">
                 <strong>Health</strong>
               </div>

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadDescription.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadDescription.tsx
@@ -61,8 +61,8 @@ class WorkloadDescription extends React.Component<WorkloadDescriptionProps, Work
                 </div>
               )}
             </Col>
-            <Col xs={12} sm={4} md={4} lg={4} />
-            <Col xs={12} sm={4} md={2} lg={2}>
+            <Col xs={12} sm={4} md={3} lg={3} />
+            <Col xs={12} sm={4} md={3} lg={3}>
               <div className="progress-description">
                 <strong>Health</strong>
               </div>

--- a/src/types/Health.ts
+++ b/src/types/Health.ts
@@ -6,7 +6,6 @@ interface HealthItem {
   title: string;
   text?: string;
   children?: HealthSubItem[];
-  report?: string;
 }
 
 interface HealthSubItem {
@@ -132,10 +131,10 @@ export const getRequestErrorsSubItem = (thresholdStatus: ThresholdStatus, prefix
 export const getRequestErrorsViolations = (reqIn: ThresholdStatus, reqOut: ThresholdStatus): string => {
   const violations: string[] = [];
   if (reqIn.violation) {
-    violations.push(`Inbound errors ${reqIn.status.name.toLowerCase()}: ${reqIn.violation}`);
+    violations.push(`Inbound errors: ${reqIn.violation}`);
   }
   if (reqOut.violation) {
-    violations.push(`Outbound errors ${reqOut.status.name.toLowerCase()}: ${reqOut.violation}`);
+    violations.push(`Outbound errors: ${reqOut.violation}`);
   }
   return violations.join(', ');
 };
@@ -149,10 +148,6 @@ export abstract class Health {
 
   getGlobalStatus(): Status {
     return this.items.map(i => i.status).reduce((prev, cur) => mergeStatus(prev, cur), NA);
-  }
-
-  getReport(): string[] {
-    return this.items.filter(i => i.report !== undefined).map(i => i.report!);
   }
 }
 
@@ -170,9 +165,6 @@ export class ServiceHealth extends Health {
         status: reqErrorsRatio.status,
         text: reqErrorsText + ' over ' + getName(rateInterval).toLowerCase()
       };
-      if (reqErrorsRatio.violation) {
-        item.report = `Error rate ${reqErrorsRatio.status.name.toLowerCase()}: ${reqErrorsRatio.violation}`;
-      }
       items.push(item);
     }
     return items;
@@ -214,14 +206,7 @@ export class AppHealth extends Health {
       };
       if (countInactive > 0 && countInactive === workloadStatuses.length) {
         // No active deployment => special case for failure
-        item.report = 'No active workload!';
         item.status = FAILURE;
-      } else if (workloadStatus === FAILURE || workloadStatus === DEGRADED) {
-        item.report = 'Pod workload ' + workloadStatus.name.toLowerCase();
-      } else if (countInactive === 1) {
-        item.report = 'One inactive workload';
-      } else if (countInactive > 1) {
-        item.report = `${countInactive} inactive workloads`;
       }
       items.push(item);
     }
@@ -235,10 +220,6 @@ export class AppHealth extends Health {
         status: both,
         children: [getRequestErrorsSubItem(reqIn, 'Inbound'), getRequestErrorsSubItem(reqOut, 'Outbound')]
       };
-      const violations = getRequestErrorsViolations(reqIn, reqOut);
-      if (violations.length > 0) {
-        item.report = violations;
-      }
       items.push(item);
     }
     return items;
@@ -267,9 +248,6 @@ export class WorkloadHealth extends Health {
         status: workStatus,
         text: String(workloadStatus.available + ' / ' + workloadStatus.replicas)
       };
-      if (workStatus === FAILURE || workStatus === DEGRADED) {
-        item.report = 'Pod workload ' + workStatus.name.toLowerCase();
-      }
       items.push(item);
     }
     {
@@ -282,10 +260,6 @@ export class WorkloadHealth extends Health {
         status: both,
         children: [getRequestErrorsSubItem(reqIn, 'Inbound'), getRequestErrorsSubItem(reqOut, 'Outbound')]
       };
-      const violations = getRequestErrorsViolations(reqIn, reqOut);
-      if (violations.length > 0) {
-        item.report = violations;
-      }
       items.push(item);
     }
     return items;

--- a/src/types/Health.ts
+++ b/src/types/Health.ts
@@ -198,10 +198,10 @@ export class AppHealth extends Health {
           status: status
         };
       });
-      const workloadStatus = children.map(i => i.status).reduce((prev, cur) => mergeStatus(prev, cur), NA);
+      const podsStatus = children.map(i => i.status).reduce((prev, cur) => mergeStatus(prev, cur), NA);
       const item: HealthItem = {
-        title: 'Workload Status',
-        status: workloadStatus,
+        title: 'Pods Status',
+        status: podsStatus,
         children: children
       };
       if (countInactive > 0 && countInactive === workloadStatuses.length) {
@@ -242,10 +242,10 @@ export class WorkloadHealth extends Health {
     const items: HealthItem[] = [];
     {
       // Pods
-      const workStatus = ratioCheck(workloadStatus.available, workloadStatus.replicas);
+      const podsStatus = ratioCheck(workloadStatus.available, workloadStatus.replicas);
       const item: HealthItem = {
-        title: 'Workloads Status',
-        status: workStatus,
+        title: 'Pods Status',
+        status: podsStatus,
         text: String(workloadStatus.available + ' / ' + workloadStatus.replicas)
       };
       items.push(item);

--- a/src/types/__tests__/Health.test.ts
+++ b/src/types/__tests__/Health.test.ts
@@ -71,7 +71,6 @@ describe('Health', () => {
       60
     );
     expect(health.getGlobalStatus()).toEqual(H.HEALTHY);
-    expect(health.getReport()).toEqual([]);
   });
   it('should aggregate degraded workload', () => {
     const health = new H.AppHealth(
@@ -80,7 +79,6 @@ describe('Health', () => {
       60
     );
     expect(health.getGlobalStatus()).toEqual(H.DEGRADED);
-    expect(health.getReport()).toEqual(['Pod workload degraded']);
   });
   it('should aggregate failing requests', () => {
     const health = new H.AppHealth(
@@ -89,7 +87,6 @@ describe('Health', () => {
       60
     );
     expect(health.getGlobalStatus()).toEqual(H.FAILURE);
-    expect(health.getReport()).toEqual(['Inbound errors failure: 30.00%>=20%, Outbound errors degraded: 10.00%>=0.1%']);
   });
   it('should aggregate multiple issues', () => {
     const health = new H.AppHealth(
@@ -98,9 +95,5 @@ describe('Health', () => {
       60
     );
     expect(health.getGlobalStatus()).toEqual(H.FAILURE);
-    expect(health.getReport()).toEqual([
-      'No active workload!',
-      'Inbound errors failure: 30.00%>=20%, Outbound errors degraded: 10.00%>=0.1%'
-    ]);
   });
 });


### PR DESCRIPTION
Now tooltip content is displayed right below the big health indicator, not as a tooltip anymore.
It replaces the previous "report" text.
For small indicator (in list views) it's unchanged, still as a tooltip

Moving popover & overlay components from HealthDetails to HealthIndicator

![screenshot](https://screenshotscdn.firefoxusercontent.com/images/26a3b978-0589-4bb7-942b-c5e6a39b3df3.png)
