### PR TITLE
KIALI-2357 Fetch data when a new workload (URL) is requested

### DIFF
--- a/src/pages/AppDetails/AppDetailsPage.tsx
+++ b/src/pages/AppDetails/AppDetailsPage.tsx
@@ -17,19 +17,34 @@ type AppDetailsState = {
   health?: AppHealth;
 };
 
+const emptyApp = {
+  namespace: { name: '' },
+  name: '',
+  workloads: [],
+  serviceNames: [],
+  runtimes: []
+};
+
 class AppDetails extends React.Component<RouteComponentProps<AppId>, AppDetailsState> {
   constructor(props: RouteComponentProps<AppId>) {
     super(props);
     this.state = {
-      app: {
-        namespace: { name: '' },
-        name: '',
-        workloads: [],
-        serviceNames: [],
-        runtimes: []
-      }
+      app: emptyApp
     };
     this.fetchApp();
+  }
+
+  componentDidUpdate(prevProps: RouteComponentProps<AppId>) {
+    if (
+      this.props.match.params.namespace !== prevProps.match.params.namespace ||
+      this.props.match.params.app !== prevProps.match.params.app
+    ) {
+      this.setState({
+        app: emptyApp,
+        health: undefined
+      });
+      this.fetchApp();
+    }
   }
 
   fetchApp = () => {

--- a/src/pages/Overview/OverviewStatuses.tsx
+++ b/src/pages/Overview/OverviewStatuses.tsx
@@ -33,9 +33,7 @@ class OverviewStatuses extends React.Component<Props> {
     }
     return (
       <>
-        <Link to={`/${targetPage}?namespaces=${name}`} >
-          {text}
-        </Link>
+        <Link to={`/${targetPage}?namespaces=${name}`}>{text}</Link>
         <AggregateStatusNotifications>
           {status.inError.length > 0 && (
             <OverviewStatus

--- a/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -32,6 +32,21 @@ class WorkloadDetails extends React.Component<RouteComponentProps<WorkloadId>, W
     this.fetchWorkload();
   }
 
+  componentDidUpdate(prevProps: RouteComponentProps<WorkloadId>) {
+    if (
+      this.props.match.params.namespace !== prevProps.match.params.namespace ||
+      this.props.match.params.workload !== prevProps.match.params.workload
+    ) {
+      this.setState({
+        workload: emptyWorkload,
+        validations: {},
+        istioEnabled: false,
+        health: undefined
+      });
+      this.fetchWorkload();
+    }
+  }
+
   // All information for validations is fetched in the workload, no need to add another call
   workloadValidations(workload: Workload): Validations {
     const noIstiosidecar: ObjectCheck = { message: 'Pod has no Istio sidecar', severity: 'warning', path: '' };


### PR DESCRIPTION
This fixes an issue when user navigates to another workload from Kiali.
The URL updates and the page should fetch the data of the newly
requested workload.

https://issues.jboss.org/browse/KIALI-2357

Before:

![before-2019-02-06 11-51](https://user-images.githubusercontent.com/23639005/52363049-8110a480-2a07-11e9-8b17-58a75ebe6c48.gif)

After:

![after-2019-02-06 11-49](https://user-images.githubusercontent.com/23639005/52363025-76560f80-2a07-11e9-8532-8b565dee67b2.gif)
