### PR TITLE
KIALI-2362 Allow different operators than "sum" for raw metrics

### DIFF
--- a/src/app/History.ts
+++ b/src/app/History.ts
@@ -7,7 +7,7 @@ const history = createBrowserHistory({ basename: baseName });
 export default history;
 
 export enum URLParams {
-  AGG_OPERATOR = 'aggOperator',
+  AGGREGATOR = 'aggregator',
   BY_LABELS = 'bylbl',
   DIRECTION = 'direction',
   DURATION = 'duration',

--- a/src/app/History.ts
+++ b/src/app/History.ts
@@ -7,6 +7,7 @@ const history = createBrowserHistory({ basename: baseName });
 export default history;
 
 export enum URLParams {
+  AGG_OPERATOR = 'aggOperator',
   BY_LABELS = 'bylbl',
   DIRECTION = 'direction',
   DURATION = 'duration',

--- a/src/components/Metrics/CustomMetrics.tsx
+++ b/src/components/Metrics/CustomMetrics.tsx
@@ -8,7 +8,7 @@ import * as API from '../../services/Api';
 import { KialiAppState } from '../../store/Store';
 import { DurationInSeconds } from '../../types/Common';
 import * as M from '../../types/Metrics';
-import { CustomMetricsOptions, AggregationOperator } from '../../types/MetricsOptions';
+import { CustomMetricsOptions, Aggregator } from '../../types/MetricsOptions';
 import { authentication } from '../../utils/Authentication';
 import * as MessageCenter from '../../utils/MessageCenter';
 
@@ -90,8 +90,8 @@ class CustomMetrics extends React.Component<CustomMetricsProps, MetricsState> {
     this.fetchMetrics();
   };
 
-  onRawAggregationChanged = (operator: AggregationOperator) => {
-    this.options.rawAggregationOperator = operator;
+  onRawAggregationChanged = (aggregator: Aggregator) => {
+    this.options.rawDataAggregator = aggregator;
     this.fetchMetrics();
   };
 

--- a/src/components/Metrics/CustomMetrics.tsx
+++ b/src/components/Metrics/CustomMetrics.tsx
@@ -8,7 +8,7 @@ import * as API from '../../services/Api';
 import { KialiAppState } from '../../store/Store';
 import { DurationInSeconds } from '../../types/Common';
 import * as M from '../../types/Metrics';
-import { CustomMetricsOptions } from '../../types/MetricsOptions';
+import { CustomMetricsOptions, AggregationOperator } from '../../types/MetricsOptions';
 import { authentication } from '../../utils/Authentication';
 import * as MessageCenter from '../../utils/MessageCenter';
 
@@ -16,6 +16,7 @@ import { Dashboard } from './Dashboard';
 import MetricsHelper from './Helper';
 import { MetricsSettingsDropdown, MetricsSettings } from '../MetricsOptions/MetricsSettings';
 import MetricsDuration from '../MetricsOptions/MetricsDuration';
+import MetricsRawAggregation from '../MetricsOptions/MetricsRawAggregation';
 
 type MetricsState = {
   dashboard?: M.MonitoringDashboard;
@@ -89,6 +90,11 @@ class CustomMetrics extends React.Component<CustomMetricsProps, MetricsState> {
     this.fetchMetrics();
   };
 
+  onRawAggregationChanged = (operator: AggregationOperator) => {
+    this.options.rawAggregationOperator = operator;
+    this.fetchMetrics();
+  };
+
   render() {
     if (!this.props.isPageVisible) {
       return null;
@@ -118,6 +124,9 @@ class CustomMetrics extends React.Component<CustomMetricsProps, MetricsState> {
             onLabelsFiltersChanged={this.onLabelsFiltersChanged}
             labelValues={this.state.labelValues}
           />
+        </FormGroup>
+        <FormGroup>
+          <MetricsRawAggregation onChanged={this.onRawAggregationChanged} />
         </FormGroup>
         <ToolbarRightContent>
           <MetricsDuration onChanged={this.onDurationChanged} />

--- a/src/components/MetricsOptions/MetricsRawAggregation.tsx
+++ b/src/components/MetricsOptions/MetricsRawAggregation.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+
+import history, { URLParams, HistoryManager } from '../../app/History';
+import { ToolbarDropdown } from '../ToolbarDropdown/ToolbarDropdown';
+import { AggregationOperator } from '../../types/MetricsOptions';
+
+interface Props {
+  onChanged: (operator: AggregationOperator) => void;
+}
+
+export default class MetricsRawAggregation extends React.Component<Props> {
+  static Operators: { [key: string]: string } = {
+    sum: 'Sum',
+    avg: 'Average',
+    min: 'Min',
+    max: 'Max',
+    stddev: 'Standard deviation',
+    stdvar: 'Standard variance'
+  };
+
+  private shouldReportOptions: boolean;
+  private operator: AggregationOperator;
+
+  static initialOperator = (): AggregationOperator => {
+    const urlParams = new URLSearchParams(history.location.search);
+    const opParam = urlParams.get(URLParams.AGG_OPERATOR);
+    if (opParam != null) {
+      return opParam as AggregationOperator;
+    }
+    return 'sum';
+  };
+
+  constructor(props: Props) {
+    super(props);
+  }
+
+  componentDidUpdate() {
+    if (this.shouldReportOptions) {
+      this.shouldReportOptions = false;
+      this.props.onChanged(this.operator);
+    }
+  }
+
+  onOperatorChanged = (operator: string) => {
+    HistoryManager.setParam(URLParams.AGG_OPERATOR, operator);
+  };
+
+  render() {
+    this.processUrlParams();
+    return (
+      <ToolbarDropdown
+        id={'metrics_filter_operator'}
+        disabled={false}
+        handleSelect={this.onOperatorChanged}
+        nameDropdown={'Pods aggregation'}
+        value={this.operator}
+        initialLabel={MetricsRawAggregation.Operators[this.operator]}
+        options={MetricsRawAggregation.Operators}
+      />
+    );
+  }
+
+  processUrlParams() {
+    const op = MetricsRawAggregation.initialOperator();
+    this.shouldReportOptions = op !== this.operator;
+    this.operator = op;
+  }
+}

--- a/src/components/MetricsOptions/MetricsRawAggregation.tsx
+++ b/src/components/MetricsOptions/MetricsRawAggregation.tsx
@@ -2,14 +2,14 @@ import * as React from 'react';
 
 import history, { URLParams, HistoryManager } from '../../app/History';
 import { ToolbarDropdown } from '../ToolbarDropdown/ToolbarDropdown';
-import { AggregationOperator } from '../../types/MetricsOptions';
+import { Aggregator } from '../../types/MetricsOptions';
 
 interface Props {
-  onChanged: (operator: AggregationOperator) => void;
+  onChanged: (aggregator: Aggregator) => void;
 }
 
 export default class MetricsRawAggregation extends React.Component<Props> {
-  static Operators: { [key: string]: string } = {
+  static Aggregators: { [key: string]: string } = {
     sum: 'Sum',
     avg: 'Average',
     min: 'Min',
@@ -19,13 +19,13 @@ export default class MetricsRawAggregation extends React.Component<Props> {
   };
 
   private shouldReportOptions: boolean;
-  private operator: AggregationOperator;
+  private aggregator: Aggregator;
 
-  static initialOperator = (): AggregationOperator => {
+  static initialAggregator = (): Aggregator => {
     const urlParams = new URLSearchParams(history.location.search);
-    const opParam = urlParams.get(URLParams.AGG_OPERATOR);
+    const opParam = urlParams.get(URLParams.AGGREGATOR);
     if (opParam != null) {
-      return opParam as AggregationOperator;
+      return opParam as Aggregator;
     }
     return 'sum';
   };
@@ -37,32 +37,32 @@ export default class MetricsRawAggregation extends React.Component<Props> {
   componentDidUpdate() {
     if (this.shouldReportOptions) {
       this.shouldReportOptions = false;
-      this.props.onChanged(this.operator);
+      this.props.onChanged(this.aggregator);
     }
   }
 
-  onOperatorChanged = (operator: string) => {
-    HistoryManager.setParam(URLParams.AGG_OPERATOR, operator);
+  onAggregatorChanged = (aggregator: string) => {
+    HistoryManager.setParam(URLParams.AGGREGATOR, aggregator);
   };
 
   render() {
     this.processUrlParams();
     return (
       <ToolbarDropdown
-        id={'metrics_filter_operator'}
+        id={'metrics_filter_aggregator'}
         disabled={false}
-        handleSelect={this.onOperatorChanged}
+        handleSelect={this.onAggregatorChanged}
         nameDropdown={'Pods aggregation'}
-        value={this.operator}
-        initialLabel={MetricsRawAggregation.Operators[this.operator]}
-        options={MetricsRawAggregation.Operators}
+        value={this.aggregator}
+        initialLabel={MetricsRawAggregation.Aggregators[this.aggregator]}
+        options={MetricsRawAggregation.Aggregators}
       />
     );
   }
 
   processUrlParams() {
-    const op = MetricsRawAggregation.initialOperator();
-    this.shouldReportOptions = op !== this.operator;
-    this.operator = op;
+    const op = MetricsRawAggregation.initialAggregator();
+    this.shouldReportOptions = op !== this.aggregator;
+    this.aggregator = op;
   }
 }

--- a/src/types/MetricsOptions.ts
+++ b/src/types/MetricsOptions.ts
@@ -18,7 +18,9 @@ export interface MetricsOptions extends BaseMetricsOptions {
 
 export interface CustomMetricsOptions extends BaseMetricsOptions {
   version?: string;
+  rawAggregationOperator?: AggregationOperator;
 }
 
 export type Reporter = 'source' | 'destination';
 export type Direction = 'inbound' | 'outbound';
+export type AggregationOperator = 'sum' | 'avg' | 'min' | 'max' | 'stddev' | 'stdvar';

--- a/src/types/MetricsOptions.ts
+++ b/src/types/MetricsOptions.ts
@@ -18,9 +18,9 @@ export interface MetricsOptions extends BaseMetricsOptions {
 
 export interface CustomMetricsOptions extends BaseMetricsOptions {
   version?: string;
-  rawAggregationOperator?: AggregationOperator;
+  rawDataAggregator?: Aggregator;
 }
 
 export type Reporter = 'source' | 'destination';
 export type Direction = 'inbound' | 'outbound';
-export type AggregationOperator = 'sum' | 'avg' | 'min' | 'max' | 'stddev' | 'stdvar';
+export type Aggregator = 'sum' | 'avg' | 'min' | 'max' | 'stddev' | 'stdvar';


### PR DESCRIPTION
Add an operator dropdown for custom dashboards to allow different aggregations across pods.
Possible values: min, max, sum, avg, standard deviation, standard variance.

Backend PR: https://github.com/kiali/kiali/pull/829

![sshot](https://screenshotscdn.firefoxusercontent.com/images/35349189-105b-4f7f-b54f-c4b28556e8d7.png)
