### PR TITLE
KIALI-2311 Add support to display MeshPolicies items

### DIFF
--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -222,6 +222,8 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
         istioObject = this.state.istioObjectDetails.quotaSpecBinding;
       } else if (this.state.istioObjectDetails.policy) {
         istioObject = this.state.istioObjectDetails.policy;
+      } else if (this.state.istioObjectDetails.meshPolicy) {
+        istioObject = this.state.istioObjectDetails.meshPolicy;
       }
     }
     return istioObject ? jsYaml.safeDump(istioObject, safeDumpOptions) : '';

--- a/src/pages/IstioConfigList/FiltersAndSorts.ts
+++ b/src/pages/IstioConfigList/FiltersAndSorts.ts
@@ -128,6 +128,10 @@ export namespace IstioConfigListFilters {
       {
         id: 'Policy',
         title: 'Policy'
+      },
+      {
+        id: 'MeshPolicy',
+        title: 'MeshPolicy'
       }
     ]
   };

--- a/src/pages/IstioConfigList/IstioConfigListComponent.tsx
+++ b/src/pages/IstioConfigList/IstioConfigListComponent.tsx
@@ -229,7 +229,12 @@ class IstioConfigListComponent extends ListComponent.Component<
       iconName = 'locked';
       iconType = 'pf';
       type = 'Policy';
+    } else if (istioItem.type === 'meshpolicy') {
+      iconName = 'locked';
+      iconType = 'pf';
+      type = 'MeshPolicy';
     }
+
     // Adapters and Templates need to pass subtype
     if (istioItem.type === 'adapter' || istioItem.type === 'template') {
       // Build a /adapters/<adapter_type_plural>/<adapter_name> or

--- a/src/pages/IstioConfigList/__tests__/IstioConfigListComponent.test.ts
+++ b/src/pages/IstioConfigList/__tests__/IstioConfigListComponent.test.ts
@@ -17,6 +17,7 @@ const mockIstioConfigList = (names: string[]): IstioConfigList => {
     quotaSpecs: [],
     quotaSpecBindings: [],
     policies: [],
+    meshPolicies: [],
     validations: {},
     permissions: {}
   };
@@ -40,7 +41,8 @@ const mockIstioConfigList = (names: string[]): IstioConfigList => {
     });
     testData.quotaSpecs.push({ metadata: { name: name + '7' }, spec: {} });
     testData.quotaSpecBindings.push({ metadata: { name: name + '8' }, spec: {} });
-    testData.policies.push({ metadata: { name: name + '8' }, spec: {} });
+    testData.policies.push({ metadata: { name: name + '9' }, spec: {} });
+    testData.meshPolicies.push({ metadata: { name: name + '10' }, spec: {} });
   });
   return testData;
 };
@@ -60,6 +62,8 @@ describe('IstioConfigListComponent#filterByName', () => {
     expect(filtered.templates.length).toBe(2);
     expect(filtered.quotaSpecs.length).toBe(2);
     expect(filtered.quotaSpecBindings.length).toBe(2);
+    expect(filtered.policies.length).toBe(2);
+    expect(filtered.meshPolicies.length).toBe(2);
 
     expect(filtered.virtualServices.items[0].metadata.name).toBe('white1');
     expect(filtered.destinationRules.items[0].metadata.name).toBe('white2');
@@ -69,6 +73,8 @@ describe('IstioConfigListComponent#filterByName', () => {
     expect(filtered.templates[0].metadata.name).toBe('white6');
     expect(filtered.quotaSpecs[0].metadata.name).toBe('white7');
     expect(filtered.quotaSpecBindings[0].metadata.name).toBe('white8');
+    expect(filtered.policies[0].metadata.name).toBe('white9');
+    expect(filtered.meshPolicies[0].metadata.name).toBe('white10');
 
     filtered = filterByName(unfiltered, ['bad']);
     expect(filtered).toBeDefined();
@@ -81,6 +87,8 @@ describe('IstioConfigListComponent#filterByName', () => {
     expect(filtered.templates.length).toBe(0);
     expect(filtered.quotaSpecs.length).toBe(0);
     expect(filtered.quotaSpecBindings.length).toBe(0);
+    expect(filtered.policies.length).toBe(0);
+    expect(filtered.meshPolicies.length).toBe(0);
   });
 });
 
@@ -89,7 +97,7 @@ describe('IstioConfigListComponent#toIstioItems', () => {
     const istioItems = toIstioItems(unfiltered);
 
     expect(istioItems).toBeDefined();
-    expect(istioItems.length).toBe(30);
+    expect(istioItems.length).toBe(33);
     expect(istioItems[0].gateway).toBeDefined();
     expect(istioItems[0].destinationRule).toBeUndefined();
     expect(istioItems[3].virtualService).toBeDefined();
@@ -107,7 +115,7 @@ describe('IstioConfigComponent#sortIstioItems', () => {
 
     IstioConfigListFilters.sortIstioItems(istioItems, sortField, isAscending).then(sorted => {
       expect(sorted).toBeDefined();
-      expect(sorted.length).toBe(30);
+      expect(sorted.length).toBe(33);
 
       const first = sorted[0];
       expect(first.gateway).toBeDefined();
@@ -131,7 +139,7 @@ describe('IstioConfigComponent#sortIstioItems', () => {
     // Descending
     IstioConfigListFilters.sortIstioItems(istioItems, sortField, isAscending).then(sorted => {
       expect(sorted).toBeDefined();
-      expect(sorted.length).toBe(30);
+      expect(sorted.length).toBe(33);
 
       const first = sorted[0];
       expect(first.quotaSpecBinding).toBeDefined();
@@ -150,7 +158,7 @@ describe('IstioConfigComponent#sortIstioItems', () => {
 
     IstioConfigListFilters.sortIstioItems(istioItems, sortField, isAscending).then(sorted => {
       expect(sorted).toBeDefined();
-      expect(sorted.length).toBe(30);
+      expect(sorted.length).toBe(33);
 
       const first = sorted[0];
       expect(first.adapter).toBeDefined();
@@ -173,7 +181,7 @@ describe('IstioConfigComponent#sortIstioItems', () => {
 
     IstioConfigListFilters.sortIstioItems(istioItems, sortField, isAscending).then(sorted => {
       expect(sorted).toBeDefined();
-      expect(sorted.length).toBe(30);
+      expect(sorted.length).toBe(33);
 
       const first = sorted[0];
       expect(first.virtualService).toBeDefined();

--- a/src/types/IstioConfigDetails.ts
+++ b/src/types/IstioConfigDetails.ts
@@ -38,6 +38,7 @@ export interface IstioConfigDetails {
   quotaSpec: QuotaSpec;
   quotaSpecBinding: QuotaSpecBinding;
   policy: Policy;
+  meshPolicy: Policy;
   permissions: ResourcePermissions;
   validation: ObjectValidation;
 }

--- a/src/types/IstioConfigList.ts
+++ b/src/types/IstioConfigList.ts
@@ -31,6 +31,7 @@ export interface IstioConfigItem {
   quotaSpec?: QuotaSpec;
   quotaSpecBinding?: QuotaSpecBinding;
   policy?: Policy;
+  meshPolicy?: Policy;
   validation?: ObjectValidation;
 }
 
@@ -46,6 +47,7 @@ export interface IstioConfigList {
   quotaSpecs: QuotaSpec[];
   quotaSpecBindings: QuotaSpecBinding[];
   policies: Policy[];
+  meshPolicies: Policy[];
   permissions: { [key: string]: ResourcePermissions };
   validations: Validations;
 }
@@ -69,6 +71,7 @@ export const dicIstioType = {
   QuotaSpec: 'quotaspecs',
   QuotaSpecBinding: 'quotaspecbindings',
   Policy: 'policies',
+  MeshPolicy: 'meshpolicies',
   gateways: 'Gateway',
   virtualservices: 'VirtualService',
   destinationrules: 'DestinationRule',
@@ -80,7 +83,8 @@ export const dicIstioType = {
   quotaspecbindings: 'QuotaSpecBinding',
   instance: 'Instance',
   handler: 'Handler',
-  policies: 'Policy'
+  policies: 'Policy',
+  meshpolicies: 'MeshPolicy'
 };
 
 const includeName = (name: string, names: string[]) => {
@@ -114,6 +118,7 @@ export const filterByName = (unfiltered: IstioConfigList, names: string[]): Isti
     quotaSpecs: unfiltered.quotaSpecs.filter(qs => includeName(qs.metadata.name, names)),
     quotaSpecBindings: unfiltered.quotaSpecBindings.filter(qsb => includeName(qsb.metadata.name, names)),
     policies: unfiltered.policies.filter(p => includeName(p.metadata.name, names)),
+    meshPolicies: unfiltered.meshPolicies.filter(p => includeName(p.metadata.name, names)),
     validations: unfiltered.validations,
     permissions: unfiltered.permissions
   };
@@ -229,6 +234,14 @@ export const toIstioItems = (istioConfigList: IstioConfigList): IstioConfigItem[
     istioItems.push({
       namespace: istioConfigList.namespace.name,
       type: 'policy',
+      name: p.metadata.name,
+      policy: p
+    })
+  );
+  istioConfigList.meshPolicies.forEach(p =>
+    istioItems.push({
+      namespace: istioConfigList.namespace.name,
+      type: 'meshpolicy',
       name: p.metadata.name,
       policy: p
     })


### PR DESCRIPTION
** Describe the change **
MeshPolicies are now listed and detailed into Istio Config section.
Requires PR: https://github.com/kiali/kiali/pull/831

** Issue reference **
https://issues.jboss.org/browse/KIALI-2311

** Backwards incompatible? **
yes

** Screenshots **
![screenshot of kiali console 31](https://user-images.githubusercontent.com/613814/52411727-0914ae00-2add-11e9-83a7-915f3773da36.png)

![screenshot of kiali console 32](https://user-images.githubusercontent.com/613814/52411730-0ade7180-2add-11e9-8a85-e468ee34d059.png)
