### PR TITLE
KIALI-2352 Update prom rate query param calculation given change in scrape interval

### DIFF
--- a/src/components/Metrics/Helper.ts
+++ b/src/components/Metrics/Helper.ts
@@ -13,7 +13,7 @@ import { BaseMetricsOptions } from '../../types/MetricsOptions';
 import { MetricsSettingsDropdown, MetricsSettings } from '../MetricsOptions/MetricsSettings';
 import MetricsDuration from '../MetricsOptions/MetricsDuration';
 import { DurationInSeconds } from '../../types/Common';
-import { computePrometheusQueryInterval } from '../../services/Prometheus';
+import { computePrometheusRateParams } from '../../services/Prometheus';
 
 namespace MetricsHelper {
   export const extractLabelValuesOnSeries = (
@@ -120,7 +120,7 @@ namespace MetricsHelper {
 
   export const durationToOptions = (duration: DurationInSeconds, opts: BaseMetricsOptions) => {
     opts.duration = duration;
-    const intervalOpts = computePrometheusQueryInterval(duration);
+    const intervalOpts = computePrometheusRateParams(duration);
     opts.step = intervalOpts.step;
     opts.rateInterval = intervalOpts.rateInterval;
   };

--- a/src/pages/Graph/GraphPage.tsx
+++ b/src/pages/Graph/GraphPage.tsx
@@ -8,7 +8,7 @@ import { DurationInSeconds, PollIntervalInMs, TimeInSeconds, TimeInMilliseconds 
 import Namespace from '../../types/Namespace';
 import { SummaryData, NodeParamsType, NodeType, GraphType } from '../../types/Graph';
 import { Layout, EdgeLabelMode } from '../../types/GraphFilter';
-import { computePrometheusQueryInterval } from '../../services/Prometheus';
+import { computePrometheusRateParams } from '../../services/Prometheus';
 import { CancelablePromise, makeCancelablePromise } from '../../utils/CancelablePromises';
 import * as MessageCenterUtils from '../../utils/MessageCenter';
 import CytoscapeGraphContainer from '../../components/CytoscapeGraph/CytoscapeGraph';
@@ -330,7 +330,7 @@ export default class GraphPage extends React.Component<GraphPageProps, GraphPage
                 queryTime={this.props.graphTimestamp}
                 duration={this.props.graphDuration}
                 isPageVisible={this.props.isPageVisible}
-                {...computePrometheusQueryInterval(this.props.duration, NUMBER_OF_DATAPOINTS)}
+                {...computePrometheusRateParams(this.props.duration, NUMBER_OF_DATAPOINTS)}
               />
             )}
             {this.props.showLegend && (

--- a/src/pages/Overview/OverviewStatuses.tsx
+++ b/src/pages/Overview/OverviewStatuses.tsx
@@ -33,9 +33,7 @@ class OverviewStatuses extends React.Component<Props> {
     }
     return (
       <>
-        <Link to={`/${targetPage}?namespaces=${name}`} >
-          {text}
-        </Link>
+        <Link to={`/${targetPage}?namespaces=${name}`}>{text}</Link>
         <AggregateStatusNotifications>
           {status.inError.length > 0 && (
             <OverviewStatus

--- a/src/services/Prometheus.ts
+++ b/src/services/Prometheus.ts
@@ -1,11 +1,11 @@
 import { DurationInSeconds } from '../types/Common';
-import { serverConfig } from '../config';
 
 // The step needs to minimally cover 2 datapoints to get any sort of average. So 2*scrape is the bare
 // minimum.  We set rateInterval=step which basically gives us the rate() of each disjoint set.
 // (note, another approach could be to set rateInterval=step+scrape, the overlap could produce some
 // smoothing). The rateInterval should typically not be < step or you're just omitting datapoints.
 const defaultDataPoints = 50;
+const defaultScrapeInterval = 15; // seconds
 const minDataPoints = 2;
 
 export interface PrometheusRateParams {
@@ -23,7 +23,7 @@ export const computePrometheusRateParams = (
     actualDataPoints = defaultDataPoints;
   }
   // TODO: should the scrape interval really be in serverConfig?
-  const actualScrapeInterval = scrapeInterval || serverConfig().istioScrapeInterval || 15;
+  const actualScrapeInterval = scrapeInterval || defaultScrapeInterval;
   const minStep = 2 * actualScrapeInterval;
   let step = Math.floor(duration / actualDataPoints);
   step = step < minStep ? minStep : step;

--- a/src/services/__tests__/Prometheus.test.ts
+++ b/src/services/__tests__/Prometheus.test.ts
@@ -1,21 +1,27 @@
-import { computePrometheusQueryInterval } from '../Prometheus';
+import { computePrometheusRateParams } from '../Prometheus';
 
 describe('Prometheus service', () => {
-  it('should compute prometheus query interval default', () => {
-    const res = computePrometheusQueryInterval(3600);
+  it('should compute prometheus rate interval default', () => {
+    const res = computePrometheusRateParams(3600);
     expect(res.step).toBe(72);
     expect(res.rateInterval).toBe('72s');
   });
 
-  it('should compute prometheus query interval with expected datapoints', () => {
-    const res = computePrometheusQueryInterval(3600, 10);
+  it('should compute prometheus rate interval with expected datapoints', () => {
+    const res = computePrometheusRateParams(3600, 10);
     expect(res.step).toBe(360);
     expect(res.rateInterval).toBe('360s');
   });
 
-  it('should compute prometheus query interval minimized', () => {
-    const res = computePrometheusQueryInterval(3600, 1000);
-    expect(res.step).toBe(20);
-    expect(res.rateInterval).toBe('20s');
+  it('should compute prometheus rate interval minimized', () => {
+    const res = computePrometheusRateParams(60, 30);
+    expect(res.step).toBe(30);
+    expect(res.rateInterval).toBe('30s');
+  });
+
+  it('should compute prometheus rate interval minimized for custom scrape', () => {
+    const res = computePrometheusRateParams(60, 30, 5);
+    expect(res.step).toBe(10);
+    expect(res.rateInterval).toBe('10s');
   });
 });


### PR DESCRIPTION
Istio 1.1 has updated the scrape interval for relevant metrics from 5s to
15s, presumably to reduce metric collection intensity.  This affects the
rateInterval/step param calculation we do in the UI, resulting in "single-dot"
sparklines for "Last Minute" durations, and affects other calls as well.

The change increases the minimum step to include 2 data points (making rate()
for short durations basically the same as irate()).  This provides us with at
least a minimal sparkline graph of 3 points.

Additionally, do a little refactoring for this compute method and set things
up for a possible follow-on that adds scrap interval to the server config.

The new 3-dot sparklines for a 1 minute duration:

![image](https://user-images.githubusercontent.com/2104052/52383483-9dcccc80-2a47-11e9-9142-63c48c9b6f07.png)
