### PR TITLE
KIALI-2359 Utilize the new prom config in ServerConfig

### DIFF
--- a/src/actions/GraphDataThunkActions.ts
+++ b/src/actions/GraphDataThunkActions.ts
@@ -10,7 +10,7 @@ import { GraphDataActions } from './GraphDataActions';
 import { MessageCenterActions } from './MessageCenterActions';
 import { EdgeLabelMode } from '../types/GraphFilter';
 import * as API from '../services/Api';
-import { serverConfig } from '../config';
+import { serverConfig } from '../config/ServerConfig';
 import { PromisesRegistry } from '../utils/CancelablePromises';
 
 const EMPTY_GRAPH_DATA = { nodes: [], edges: [] };

--- a/src/actions/KialiAppAction.ts
+++ b/src/actions/KialiAppAction.ts
@@ -8,6 +8,7 @@ import { LoginAction } from './LoginActions';
 import { MessageCenterAction } from './MessageCenterActions';
 import { NamespaceAction } from './NamespaceAction';
 import { UserSettingsAction } from './UserSettingsActions';
+import { ServerConfigAction } from './ServerConfigActions';
 
 export type KialiAppAction =
   | GlobalAction
@@ -19,4 +20,5 @@ export type KialiAppAction =
   | LoginAction
   | MessageCenterAction
   | NamespaceAction
+  | ServerConfigAction
   | UserSettingsAction;

--- a/src/actions/LoginActions.ts
+++ b/src/actions/LoginActions.ts
@@ -1,6 +1,6 @@
 import { ActionType, createAction } from 'typesafe-actions';
 import { Token } from '../store/Store';
-import { config } from '../config';
+import { config } from '../config/Config';
 
 enum LoginActionKeys {
   LOGIN_REQUEST = 'LOGIN_REQUEST',

--- a/src/actions/ServerConfigActions.ts
+++ b/src/actions/ServerConfigActions.ts
@@ -1,0 +1,13 @@
+import { ActionType, createStandardAction } from 'typesafe-actions';
+import { ServerConfig } from '../store/Store';
+
+enum ServerConfigActionKeys {
+  SET_SERVER_CONFIG = 'SET_SERVER_CONFIG'
+}
+
+// synchronous action creators
+export const ServerConfigActions = {
+  setServerConfig: createStandardAction(ServerConfigActionKeys.SET_SERVER_CONFIG)<ServerConfig | null>()
+};
+
+export type ServerConfigAction = ActionType<typeof ServerConfigActions>;

--- a/src/actions/__tests__/ServerConfigAction.test.ts
+++ b/src/actions/__tests__/ServerConfigAction.test.ts
@@ -1,0 +1,20 @@
+import { ServerConfigActions } from '../ServerConfigActions';
+import { ServerConfig } from '../../store/Store';
+import { serverConfig } from '../../config/ServerConfig';
+import { store } from '../../store/ConfigStore';
+
+const config: ServerConfig = {
+  istioNamespace: 'istio-system',
+  istioLabels: { appLabelname: 'app', versionLabelName: 'version' },
+  prometheus: { globalScrapeInterval: 15, storageTsdbRetention: 21600 }
+};
+
+describe('ServerConfigActions', () => {
+  it('Set ServerConfig action success', () => {
+    store.dispatch(ServerConfigActions.setServerConfig(config));
+    expect(serverConfig().istioNamespace).toEqual(config.istioNamespace);
+    expect(serverConfig().istioLabels).toEqual(config.istioLabels);
+    expect(serverConfig().prometheus.globalScrapeInterval).toEqual(config.prometheus.globalScrapeInterval);
+    expect(serverConfig().prometheus.storageTsdbRetention).toEqual(config.prometheus.storageTsdbRetention);
+  });
+});

--- a/src/actions/__tests__/ServerConfigAction.test.ts
+++ b/src/actions/__tests__/ServerConfigAction.test.ts
@@ -5,7 +5,7 @@ import { store } from '../../store/ConfigStore';
 
 const config: ServerConfig = {
   istioNamespace: 'istio-system',
-  istioLabels: { appLabelname: 'app', versionLabelName: 'version' },
+  istioLabels: { AppLabelName: 'app', VersionLabelName: 'version' },
   prometheus: { globalScrapeInterval: 15, storageTsdbRetention: 21600 }
 };
 

--- a/src/components/GraphFilter/GraphRefresh.tsx
+++ b/src/components/GraphFilter/GraphRefresh.tsx
@@ -5,17 +5,18 @@ import { connect } from 'react-redux';
 import { ThunkDispatch } from 'redux-thunk';
 import { bindActionCreators } from 'redux';
 
-import { KialiAppState } from '../../store/Store';
-import { durationSelector, refreshIntervalSelector } from '../../store/Selectors';
+import { KialiAppState, ServerConfig } from '../../store/Store';
+import { durationSelector, refreshIntervalSelector, serverConfigSelector } from '../../store/Selectors';
 import { KialiAppAction } from '../../actions/KialiAppAction';
 import { UserSettingsActions } from '../../actions/UserSettingsActions';
 
 import { DurationInSeconds, PollIntervalInMs } from '../../types/Common';
 
-import { config } from '../../config';
+import { config } from '../../config/Config';
 import { HistoryManager, URLParams } from '../../app/History';
 import { ListPagesHelper } from '../../components/ListPage/ListPagesHelper';
 import ToolbarDropdown from '../ToolbarDropdown/ToolbarDropdown';
+import { pickBy } from 'lodash';
 
 //
 // GraphRefresh actually handles the Duration dropdown, the RefreshInterval dropdown and the Refresh button.
@@ -24,6 +25,7 @@ import ToolbarDropdown from '../ToolbarDropdown/ToolbarDropdown';
 type ReduxProps = {
   duration: DurationInSeconds;
   refreshInterval: PollIntervalInMs;
+  serverConfig: ServerConfig;
 
   setDuration: (duration: DurationInSeconds) => void;
   setRefreshInterval: (refreshInterval: PollIntervalInMs) => void;
@@ -71,6 +73,11 @@ export class GraphRefresh extends React.PureComponent<GraphRefreshProps> {
   }
 
   render() {
+    const retention = this.props.serverConfig.prometheus.storageTsdbRetention;
+    const validDurations = pickBy(GraphRefresh.DURATION_LIST, (value, key) => {
+      return !retention || Number(key) <= retention;
+    });
+
     return (
       <>
         <label className={GraphRefresh.durationLabelStyle}>Fetching</label>
@@ -79,8 +86,8 @@ export class GraphRefresh extends React.PureComponent<GraphRefreshProps> {
           disabled={this.props.disabled}
           handleSelect={this.props.setDuration}
           value={this.props.duration}
-          label={String(GraphRefresh.DURATION_LIST[this.props.duration])}
-          options={GraphRefresh.DURATION_LIST}
+          label={String(validDurations[this.props.duration])}
+          options={validDurations}
         />
         <DropdownButton
           id="graph_refresh_dropdown"
@@ -112,7 +119,8 @@ export class GraphRefresh extends React.PureComponent<GraphRefreshProps> {
 
 const mapStateToProps = (state: KialiAppState) => ({
   duration: durationSelector(state),
-  refreshInterval: refreshIntervalSelector(state)
+  refreshInterval: refreshIntervalSelector(state),
+  serverConfig: serverConfigSelector(state)
 });
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<KialiAppState, void, KialiAppAction>) => {

--- a/src/components/GraphFilter/GraphRefresh.tsx
+++ b/src/components/GraphFilter/GraphRefresh.tsx
@@ -16,7 +16,7 @@ import { config } from '../../config/Config';
 import { HistoryManager, URLParams } from '../../app/History';
 import { ListPagesHelper } from '../../components/ListPage/ListPagesHelper';
 import ToolbarDropdown from '../ToolbarDropdown/ToolbarDropdown';
-import { pickBy } from 'lodash';
+import { getValidDurations, getValidDuration } from '../../config/ServerConfig';
 
 //
 // GraphRefresh actually handles the Duration dropdown, the RefreshInterval dropdown and the Refresh button.
@@ -74,9 +74,8 @@ export class GraphRefresh extends React.PureComponent<GraphRefreshProps> {
 
   render() {
     const retention = this.props.serverConfig.prometheus.storageTsdbRetention;
-    const validDurations = pickBy(GraphRefresh.DURATION_LIST, (value, key) => {
-      return !retention || Number(key) <= retention;
-    });
+    const validDurations = getValidDurations(GraphRefresh.DURATION_LIST, retention);
+    const validDuration = getValidDuration(validDurations, this.props.duration);
 
     return (
       <>
@@ -85,8 +84,8 @@ export class GraphRefresh extends React.PureComponent<GraphRefreshProps> {
           id={'graph_filter_duration'}
           disabled={this.props.disabled}
           handleSelect={this.props.setDuration}
-          value={this.props.duration}
-          label={String(validDurations[this.props.duration])}
+          value={validDuration}
+          label={String(validDurations[validDuration])}
           options={validDurations}
         />
         <DropdownButton

--- a/src/components/IstioWizards/IstioWizard.tsx
+++ b/src/components/IstioWizards/IstioWizard.tsx
@@ -15,7 +15,7 @@ import {
 import { WorkloadOverview } from '../../types/ServiceInfo';
 import Slider from './Slider/Slider';
 import { DestinationRule, VirtualService } from '../../types/IstioObjects';
-import { serverConfig } from '../../config';
+import { serverConfig } from '../../config/ServerConfig';
 import { authentication } from '../../utils/Authentication';
 import * as API from '../../services/Api';
 import * as MessageCenter from '../../utils/MessageCenter';

--- a/src/components/Metrics/CustomMetrics.tsx
+++ b/src/components/Metrics/CustomMetrics.tsx
@@ -15,8 +15,8 @@ import * as MessageCenter from '../../utils/MessageCenter';
 import { Dashboard } from './Dashboard';
 import MetricsHelper from './Helper';
 import { MetricsSettingsDropdown, MetricsSettings } from '../MetricsOptions/MetricsSettings';
-import MetricsDuration from '../MetricsOptions/MetricsDuration';
 import MetricsRawAggregation from '../MetricsOptions/MetricsRawAggregation';
+import MetricsDurationContainer from '../MetricsOptions/MetricsDuration';
 
 type MetricsState = {
   dashboard?: M.MonitoringDashboard;
@@ -129,7 +129,7 @@ class CustomMetrics extends React.Component<CustomMetricsProps, MetricsState> {
           <MetricsRawAggregation onChanged={this.onRawAggregationChanged} />
         </FormGroup>
         <ToolbarRightContent>
-          <MetricsDuration onChanged={this.onDurationChanged} />
+          <MetricsDurationContainer onChanged={this.onDurationChanged} />
           <RefreshContainer id="metrics-refresh" handleRefresh={this.fetchMetrics} hideLabel={true} />
         </ToolbarRightContent>
       </Toolbar>

--- a/src/components/Metrics/Helper.ts
+++ b/src/components/Metrics/Helper.ts
@@ -11,7 +11,7 @@ import {
 } from '../../types/Metrics';
 import { BaseMetricsOptions } from '../../types/MetricsOptions';
 import { MetricsSettingsDropdown, MetricsSettings } from '../MetricsOptions/MetricsSettings';
-import MetricsDuration from '../MetricsOptions/MetricsDuration';
+import { MetricsDuration } from '../MetricsOptions/MetricsDuration';
 import { DurationInSeconds } from '../../types/Common';
 import { computePrometheusRateParams } from '../../services/Prometheus';
 

--- a/src/components/Metrics/IstioMetrics.tsx
+++ b/src/components/Metrics/IstioMetrics.tsx
@@ -14,8 +14,8 @@ import * as MessageCenter from '../../utils/MessageCenter';
 import { Dashboard } from './Dashboard';
 import MetricsHelper from './Helper';
 import { MetricsSettings, MetricsSettingsDropdown } from '../MetricsOptions/MetricsSettings';
-import MetricsDuration from '../MetricsOptions/MetricsDuration';
 import MetricsReporter from '../MetricsOptions/MetricsReporter';
+import MetricsDurationContainer from '../MetricsOptions/MetricsDuration';
 
 type MetricsState = {
   dashboard?: M.MonitoringDashboard;
@@ -176,7 +176,7 @@ class IstioMetrics extends React.Component<IstioMetricsProps, MetricsState> {
           </FormGroup>
         )}
         <ToolbarRightContent>
-          <MetricsDuration onChanged={this.onDurationChanged} />
+          <MetricsDurationContainer onChanged={this.onDurationChanged} />
           <RefreshContainer id="metrics-refresh" handleRefresh={this.fetchMetrics} hideLabel={true} />
         </ToolbarRightContent>
       </Toolbar>

--- a/src/components/Metrics/__tests__/CustomMetrics.test.tsx
+++ b/src/components/Metrics/__tests__/CustomMetrics.test.tsx
@@ -36,8 +36,8 @@ const mockCustomDashboard = (dashboard: MonitoringDashboard): Promise<void> => {
 
 const mockServerConfig = () => {
   const config: ServerConfig = {
-    istioNamespace: 'foo',
-    istioLabels: {},
+    istioNamespace: 'istio-system',
+    istioLabels: { AppLabelName: 'app', VersionLabelName: 'version' },
     prometheus: { storageTsdbRetention: 31 * 24 * 60 * 60 }
   };
   store.dispatch(ServerConfigActions.setServerConfig(config));

--- a/src/components/Metrics/__tests__/CustomMetrics.test.tsx
+++ b/src/components/Metrics/__tests__/CustomMetrics.test.tsx
@@ -7,6 +7,8 @@ import CustomMetrics from '../CustomMetrics';
 import * as API from '../../../services/Api';
 import { MonitoringDashboard } from '../../../types/Metrics';
 import { store } from '../../../store/ConfigStore';
+import { ServerConfig } from '../../../store/Store';
+import { ServerConfigActions } from '../../../actions/ServerConfigActions';
 
 window['SVGPathElement'] = a => a;
 let mounted: ReactWrapper<any, any> | null;
@@ -32,6 +34,15 @@ const mockCustomDashboard = (dashboard: MonitoringDashboard): Promise<void> => {
   return mockAPIToPromise('getCustomDashboard', dashboard);
 };
 
+const mockServerConfig = () => {
+  const config: ServerConfig = {
+    istioNamespace: 'foo',
+    istioLabels: {},
+    prometheus: { storageTsdbRetention: 31 * 24 * 60 * 60 }
+  };
+  store.dispatch(ServerConfigActions.setServerConfig(config));
+};
+
 describe('Custom metrics', () => {
   beforeEach(() => {
     mounted = null;
@@ -43,6 +54,7 @@ describe('Custom metrics', () => {
   });
 
   it('mounts and loads empty metrics', done => {
+    mockServerConfig();
     mockCustomDashboard({ title: 'foo', aggregations: [], charts: [] })
       .then(() => {
         mounted!.update();

--- a/src/components/Metrics/__tests__/IstioMetrics.test.tsx
+++ b/src/components/Metrics/__tests__/IstioMetrics.test.tsx
@@ -7,6 +7,8 @@ import IstioMetrics from '../IstioMetrics';
 import * as API from '../../../services/Api';
 import { MetricsObjectTypes, MonitoringDashboard, Chart } from '../../../types/Metrics';
 import { store } from '../../../store/ConfigStore';
+import { ServerConfig } from '../../../store/Store';
+import { ServerConfigActions } from '../../../actions/ServerConfigActions';
 
 window['SVGPathElement'] = a => a;
 let mounted: ReactWrapper<any, any> | null;
@@ -38,6 +40,15 @@ const mockWorkloadDashboard = (dashboard: MonitoringDashboard): Promise<void> =>
 
 const mockGrafanaInfo = (info: any): Promise<any> => {
   return mockAPIToPromise('getGrafanaInfo', info);
+};
+
+const mockServerConfig = () => {
+  const config: ServerConfig = {
+    istioNamespace: 'foo',
+    istioLabels: {},
+    prometheus: { storageTsdbRetention: 31 * 24 * 60 * 60 }
+  };
+  store.dispatch(ServerConfigActions.setServerConfig(config));
 };
 
 const createMetricChart = (name: string): Chart => {
@@ -114,6 +125,7 @@ describe('Metrics for a service', () => {
   });
 
   it('renders initial layout', () => {
+    mockServerConfig();
     mockGrafanaInfo({});
     const wrapper = shallow(
       <Provider store={store}>
@@ -145,6 +157,7 @@ describe('Metrics for a service', () => {
 
   it('mounts and loads empty metrics', done => {
     const allMocksDone = [
+      mockServerConfig(),
       mockServiceDashboard({ title: 'foo', aggregations: [], charts: [] })
         .then(() => {
           mounted!.update();
@@ -183,6 +196,7 @@ describe('Metrics for a service', () => {
 
   it('mounts and loads full metrics', done => {
     const allMocksDone = [
+      mockServerConfig(),
       mockServiceDashboard({
         title: 'foo',
         aggregations: [],
@@ -267,6 +281,7 @@ describe('Inbound Metrics for a workload', () => {
 
   it('mounts and loads empty metrics', done => {
     const allMocksDone = [
+      mockServerConfig(),
       mockWorkloadDashboard({ title: 'foo', aggregations: [], charts: [] })
         .then(() => {
           mounted!.update();
@@ -305,6 +320,7 @@ describe('Inbound Metrics for a workload', () => {
 
   it('mounts and loads full metrics', done => {
     const allMocksDone = [
+      mockServerConfig(),
       mockWorkloadDashboard({
         title: 'foo',
         aggregations: [],

--- a/src/components/Metrics/__tests__/IstioMetrics.test.tsx
+++ b/src/components/Metrics/__tests__/IstioMetrics.test.tsx
@@ -44,8 +44,8 @@ const mockGrafanaInfo = (info: any): Promise<any> => {
 
 const mockServerConfig = () => {
   const config: ServerConfig = {
-    istioNamespace: 'foo',
-    istioLabels: {},
+    istioNamespace: 'istio-system',
+    istioLabels: { AppLabelName: 'app', VersionLabelName: 'version' },
     prometheus: { storageTsdbRetention: 31 * 24 * 60 * 60 }
   };
   store.dispatch(ServerConfigActions.setServerConfig(config));

--- a/src/components/MetricsOptions/MetricsDuration.tsx
+++ b/src/components/MetricsOptions/MetricsDuration.tsx
@@ -7,7 +7,7 @@ import { ToolbarDropdown } from '../ToolbarDropdown/ToolbarDropdown';
 import { KialiAppState, ServerConfig } from '../../store/Store';
 import { serverConfigSelector } from '../../store/Selectors';
 import { connect } from 'react-redux';
-import { pickBy } from 'lodash';
+import { getValidDurations, getValidDuration } from '../../config/ServerConfig';
 
 type ReduxProps = {
   serverConfig: ServerConfig;
@@ -55,17 +55,17 @@ export class MetricsDuration extends React.Component<Props> {
   render() {
     this.processUrlParams();
     const retention = this.props.serverConfig.prometheus.storageTsdbRetention;
-    const validDurations = pickBy(MetricsDuration.Durations, (value, key) => {
-      return !retention || Number(key) <= retention;
-    });
+    const validDurations = getValidDurations(MetricsDuration.Durations, retention);
+    const validDuration = getValidDuration(validDurations, this.duration);
+
     return (
       <ToolbarDropdown
         id={'metrics_filter_interval_duration'}
         disabled={false}
         handleSelect={this.onDurationChanged}
         nameDropdown={'Fetching'}
-        initialValue={this.duration}
-        initialLabel={validDurations[this.duration]}
+        initialValue={validDuration}
+        initialLabel={validDurations[validDuration]}
         options={validDurations}
       />
     );

--- a/src/components/MetricsOptions/MetricsDuration.tsx
+++ b/src/components/MetricsOptions/MetricsDuration.tsx
@@ -4,12 +4,20 @@ import history, { URLParams, HistoryManager } from '../../app/History';
 import { config } from '../../config';
 import { DurationInSeconds } from '../../types/Common';
 import { ToolbarDropdown } from '../ToolbarDropdown/ToolbarDropdown';
+import { KialiAppState, ServerConfig } from '../../store/Store';
+import { serverConfigSelector } from '../../store/Selectors';
+import { connect } from 'react-redux';
+import { pickBy } from 'lodash';
 
-interface Props {
+type ReduxProps = {
+  serverConfig: ServerConfig;
+};
+
+type Props = ReduxProps & {
   onChanged: (duration: DurationInSeconds) => void;
-}
+};
 
-export default class MetricsDuration extends React.Component<Props> {
+export class MetricsDuration extends React.Component<Props> {
   static Durations = config().toolbar.intervalDuration;
   // Default to 10 minutes. Showing timeseries to only 1 minute doesn't make so much sense.
   static DefaultDuration = 600;
@@ -46,6 +54,10 @@ export default class MetricsDuration extends React.Component<Props> {
 
   render() {
     this.processUrlParams();
+    const retention = this.props.serverConfig.prometheus.storageTsdbRetention;
+    const validDurations = pickBy(MetricsDuration.Durations, (value, key) => {
+      return !retention || Number(key) <= retention;
+    });
     return (
       <ToolbarDropdown
         id={'metrics_filter_interval_duration'}
@@ -53,8 +65,8 @@ export default class MetricsDuration extends React.Component<Props> {
         handleSelect={this.onDurationChanged}
         nameDropdown={'Fetching'}
         initialValue={this.duration}
-        initialLabel={MetricsDuration.Durations[this.duration]}
-        options={MetricsDuration.Durations}
+        initialLabel={validDurations[this.duration]}
+        options={validDurations}
       />
     );
   }
@@ -65,3 +77,14 @@ export default class MetricsDuration extends React.Component<Props> {
     this.duration = duration;
   }
 }
+
+const mapStateToProps = (state: KialiAppState) => ({
+  serverConfig: serverConfigSelector(state)
+});
+
+const MetricsDurationContainer = connect(
+  mapStateToProps,
+  null
+)(MetricsDuration);
+
+export default MetricsDurationContainer;

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -129,24 +129,3 @@ const conf = {
 export const config = () => {
   return deepFreeze(conf) as typeof conf;
 };
-
-export interface ServerConfig {
-  istioNamespace: string;
-  istioLabels: { [key: string]: string };
-}
-
-let serverConf: ServerConfig = {
-  istioNamespace: 'istio-system',
-  istioLabels: {
-    AppLabelName: 'app',
-    VersionLabelName: 'version'
-  }
-};
-
-export const setServerConfig = (newServerConf: ServerConfig) => {
-  serverConf = newServerConf;
-};
-
-export const serverConfig = (): ServerConfig => {
-  return deepFreeze(serverConf);
-};

--- a/src/config/ServerConfig.ts
+++ b/src/config/ServerConfig.ts
@@ -2,10 +2,41 @@ import deepFreeze from 'deep-freeze';
 import { store } from '../store/ConfigStore';
 import { KialiAppState, ServerConfig } from '../store/Store';
 import { PersistPartial } from 'redux-persist';
+import { DurationInSeconds } from '../types/Common';
+import { forOwn, pickBy } from 'lodash';
 
 // It's not great to access the store directly for convenience but the alternative is
 // a huge code ripple just to access some server config. better to just have this one utility.
 export const serverConfig = (): ServerConfig => {
   const actualState = store.getState() || ({} as KialiAppState & PersistPartial);
   return deepFreeze(actualState.serverConfig);
+};
+
+// getValidDurations returns a new object with only the durations <= retention
+export const getValidDurations = (
+  durations: { [key: string]: string },
+  retention?: DurationInSeconds
+): { [key: string]: string } => {
+  const validDurations = pickBy(durations, (_, key) => {
+    return !retention || Number(key) <= retention;
+  });
+  return validDurations;
+};
+
+// getValidDuration returns duration if it is a valid property key in durations, otherwise it return the first property
+// key in durations.  It is assumed that durations has at least one property.
+export const getValidDuration = (
+  durations: { [key: string]: string },
+  duration: DurationInSeconds
+): DurationInSeconds => {
+  let validDuration = 0;
+  forOwn(durations, (value, key) => {
+    const d = Number(key);
+    if (d === duration) {
+      validDuration = d;
+    } else if (!validDuration) {
+      validDuration = d;
+    }
+  });
+  return validDuration;
 };

--- a/src/config/ServerConfig.ts
+++ b/src/config/ServerConfig.ts
@@ -1,0 +1,11 @@
+import deepFreeze from 'deep-freeze';
+import { store } from '../store/ConfigStore';
+import { KialiAppState, ServerConfig } from '../store/Store';
+import { PersistPartial } from 'redux-persist';
+
+// It's not great to access the store directly for convenience but the alternative is
+// a huge code ripple just to access some server config. better to just have this one utility.
+export const serverConfig = (): ServerConfig => {
+  const actualState = store.getState() || ({} as KialiAppState & PersistPartial);
+  return deepFreeze(actualState.serverConfig);
+};

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,6 +1,6 @@
 // Configuration
 
-import { config, serverConfig, setServerConfig } from './Config';
+import { config } from './Config';
 
 // Icons
 
@@ -13,4 +13,4 @@ import { IstioLogo, KialiLogo } from './Logos';
 
 import { Paths } from './Paths';
 
-export { config, Paths, serverConfig, setServerConfig, ICONS, IstioLogo, KialiLogo };
+export { config, Paths, ICONS, IstioLogo, KialiLogo };

--- a/src/pages/Graph/SummaryPanelCommon.tsx
+++ b/src/pages/Graph/SummaryPanelCommon.tsx
@@ -10,7 +10,7 @@ import graphUtils from '../../utils/Graphing';
 import { Metric } from '../../types/Metrics';
 import { Response } from '../../services/Api';
 import Label from '../../components/Label/Label';
-import { serverConfig } from '../../config';
+import { serverConfig } from '../../config/ServerConfig';
 import { CyNode } from '../../components/CytoscapeGraph/CytoscapeGraphUtils';
 
 export interface NodeData {

--- a/src/pages/Graph/SummaryPanelEdge.tsx
+++ b/src/pages/Graph/SummaryPanelEdge.tsx
@@ -19,7 +19,7 @@ import {
 import { MetricGroup, Metric, Metrics } from '../../types/Metrics';
 import { Response } from '../../services/Api';
 import { CancelablePromise, makeCancelablePromise } from '../../utils/CancelablePromises';
-import { serverConfig } from '../../config';
+import { serverConfig } from '../../config/ServerConfig';
 import { CyEdge } from '../../components/CytoscapeGraph/CytoscapeGraphUtils';
 
 type SummaryPanelEdgeState = {

--- a/src/pages/Graph/SummaryPanelGroup.tsx
+++ b/src/pages/Graph/SummaryPanelGroup.tsx
@@ -22,7 +22,7 @@ import { Response } from '../../services/Api';
 import { Metrics } from '../../types/Metrics';
 import { Reporter } from '../../types/MetricsOptions';
 import { CancelablePromise, makeCancelablePromise } from '../../utils/CancelablePromises';
-import { serverConfig } from '../../config';
+import { serverConfig } from '../../config/ServerConfig';
 import { CyNode } from '../../components/CytoscapeGraph/CytoscapeGraphUtils';
 
 type SummaryPanelGroupState = {

--- a/src/pages/Graph/SummaryPanelNode.tsx
+++ b/src/pages/Graph/SummaryPanelNode.tsx
@@ -30,7 +30,8 @@ import { Health } from '../../types/Health';
 import { CancelablePromise, makeCancelablePromise } from '../../utils/CancelablePromises';
 import { Response } from '../../services/Api';
 import { Reporter } from '../../types/MetricsOptions';
-import { serverConfig, ICONS } from '../../config';
+import { ICONS } from '../../config/Icons';
+import { serverConfig } from '../../config/ServerConfig';
 import { CyNode } from '../../components/CytoscapeGraph/CytoscapeGraphUtils';
 
 type SummaryPanelStateType = {

--- a/src/pages/Overview/OverviewToolbar.tsx
+++ b/src/pages/Overview/OverviewToolbar.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 import { FormGroup, Sort, ToolbarRightContent } from 'patternfly-react';
 import { connect } from 'react-redux';
 
-import { KialiAppState } from '../../store/Store';
-import { durationSelector, refreshIntervalSelector } from '../../store/Selectors';
+import { KialiAppState, ServerConfig } from '../../store/Store';
+import { durationSelector, refreshIntervalSelector, serverConfigSelector } from '../../store/Selectors';
 import { UserSettingsActions } from '../../actions/UserSettingsActions';
 
 import { StatefulFilters } from '../../components/Filters/StatefulFilters';
@@ -20,10 +20,12 @@ import { HistoryManager, URLParams } from '../../app/History';
 import RefreshContainer from '../../containers/RefreshContainer';
 import { KialiAppAction } from '../../actions/KialiAppAction';
 import { ThunkDispatch } from 'redux-thunk';
+import { pickBy } from 'lodash';
 
 type ReduxProps = {
   duration: DurationInSeconds;
   refreshInterval: PollIntervalInMs;
+  serverConfig: ServerConfig;
   setDuration: (duration: DurationInSeconds) => void;
   setRefreshInterval: (refresh: PollIntervalInMs) => void;
 };
@@ -125,6 +127,10 @@ export class OverviewToolbar extends React.Component<Props, State> {
   };
 
   render() {
+    const retention = this.props.serverConfig.prometheus.storageTsdbRetention;
+    const validDurations = pickBy(DURATIONS, (value, key) => {
+      return !retention || Number(key) <= retention;
+    });
     return (
       <StatefulFilters initialFilters={FiltersAndSorts.availableFilters} onFilterChange={this.props.onRefresh}>
         <Sort>
@@ -155,8 +161,8 @@ export class OverviewToolbar extends React.Component<Props, State> {
             handleSelect={this.updateDuration}
             nameDropdown="Displaying"
             value={this.props.duration}
-            label={DURATIONS[this.props.duration]}
-            options={DURATIONS}
+            label={validDurations[this.props.duration]}
+            options={validDurations}
           />
         </FormGroup>
         <ToolbarRightContent>
@@ -169,7 +175,8 @@ export class OverviewToolbar extends React.Component<Props, State> {
 
 const mapStateToProps = (state: KialiAppState) => ({
   duration: durationSelector(state),
-  refreshInterval: refreshIntervalSelector(state)
+  refreshInterval: refreshIntervalSelector(state),
+  serverConfig: serverConfigSelector(state)
 });
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<KialiAppState, void, KialiAppAction>) => {

--- a/src/pages/Overview/OverviewToolbar.tsx
+++ b/src/pages/Overview/OverviewToolbar.tsx
@@ -20,7 +20,7 @@ import { HistoryManager, URLParams } from '../../app/History';
 import RefreshContainer from '../../containers/RefreshContainer';
 import { KialiAppAction } from '../../actions/KialiAppAction';
 import { ThunkDispatch } from 'redux-thunk';
-import { pickBy } from 'lodash';
+import { getValidDurations, getValidDuration } from '../../config/ServerConfig';
 
 type ReduxProps = {
   duration: DurationInSeconds;
@@ -128,9 +128,9 @@ export class OverviewToolbar extends React.Component<Props, State> {
 
   render() {
     const retention = this.props.serverConfig.prometheus.storageTsdbRetention;
-    const validDurations = pickBy(DURATIONS, (value, key) => {
-      return !retention || Number(key) <= retention;
-    });
+    const validDurations = getValidDurations(DURATIONS, retention);
+    const validDuration = getValidDuration(validDurations, this.props.duration);
+
     return (
       <StatefulFilters initialFilters={FiltersAndSorts.availableFilters} onFilterChange={this.props.onRefresh}>
         <Sort>
@@ -160,8 +160,8 @@ export class OverviewToolbar extends React.Component<Props, State> {
             disabled={false}
             handleSelect={this.updateDuration}
             nameDropdown="Displaying"
-            value={this.props.duration}
-            label={validDurations[this.props.duration]}
+            value={validDuration}
+            label={validDurations[validDuration]}
             options={validDurations}
           />
         </FormGroup>

--- a/src/pages/Overview/__tests__/OverviewPage.test.tsx
+++ b/src/pages/Overview/__tests__/OverviewPage.test.tsx
@@ -8,6 +8,8 @@ import { FilterSelected } from '../../../components/Filters/StatefulFilters';
 import * as API from '../../../services/Api';
 import { AppHealth, NamespaceAppHealth, HEALTHY, FAILURE, DEGRADED } from '../../../types/Health';
 import { store } from '../../../store/ConfigStore';
+import { ServerConfigActions } from '../../../actions/ServerConfigActions';
+import { ServerConfig } from '../../../store/Store';
 
 const mockAPIToPromise = (func: keyof typeof API, obj: any, encapsData: boolean): Promise<void> => {
   return new Promise((resolve, reject) => {
@@ -36,6 +38,15 @@ const mockNamespaces = (names: string[]): Promise<void> => {
 
 const mockNamespaceHealth = (obj: NamespaceAppHealth): Promise<void> => {
   return mockAPIToPromise('getNamespaceAppHealth', obj, false);
+};
+
+const mockServerConfig = () => {
+  const config: ServerConfig = {
+    istioNamespace: 'foo',
+    istioLabels: {},
+    prometheus: { storageTsdbRetention: 31 * 24 * 60 * 60 }
+  };
+  store.dispatch(ServerConfigActions.setServerConfig(config));
 };
 
 let mounted: ReactWrapper<any, any> | null;
@@ -68,6 +79,7 @@ describe('Overview page', () => {
   it('renders all without filters', done => {
     FilterSelected.setSelected([]);
     Promise.all([
+      mockServerConfig(),
       mockNamespaces(['a', 'b', 'c']),
       mockNamespaceHealth({
         app1: {

--- a/src/pages/Overview/__tests__/OverviewPage.test.tsx
+++ b/src/pages/Overview/__tests__/OverviewPage.test.tsx
@@ -42,8 +42,8 @@ const mockNamespaceHealth = (obj: NamespaceAppHealth): Promise<void> => {
 
 const mockServerConfig = () => {
   const config: ServerConfig = {
-    istioNamespace: 'foo',
-    istioLabels: {},
+    istioNamespace: 'istio-system',
+    istioLabels: { AppLabelName: 'app', VersionLabelName: 'version' },
     prometheus: { storageTsdbRetention: 31 * 24 * 60 * 60 }
   };
   store.dispatch(ServerConfigActions.setServerConfig(config));

--- a/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -11,7 +11,7 @@ import WorkloadMetricsContainer from '../../containers/WorkloadMetricsContainer'
 import { WorkloadHealth } from '../../types/Health';
 import { MetricsObjectTypes } from '../../types/Metrics';
 import CustomMetricsContainer from '../../components/Metrics/CustomMetrics';
-import { serverConfig } from '../../config';
+import { serverConfig } from '../../config/ServerConfig';
 import BreadcrumbView from '../../components/BreadcrumbView/BreadcrumbView';
 import { GraphDefinition, GraphType, NodeParamsType, NodeType } from '../../types/Graph';
 import { fetchTrafficDetails } from '../../helpers/TrafficDetailsHelper';

--- a/src/reducers/ServerConfigState.ts
+++ b/src/reducers/ServerConfigState.ts
@@ -1,0 +1,21 @@
+import { ServerConfig } from '../store/Store';
+import { KialiAppAction } from '../actions/KialiAppAction';
+import { getType } from 'typesafe-actions';
+import { ServerConfigActions } from '../actions/ServerConfigActions';
+
+export const INITIAL_SERVER_CONFIG: ServerConfig | null = null;
+
+// This Reducer allows changes to the 'serverConfig' portion of Redux Store
+const serverConfig = (
+  state: ServerConfig | null = INITIAL_SERVER_CONFIG,
+  action: KialiAppAction
+): ServerConfig | null => {
+  switch (action.type) {
+    case getType(ServerConfigActions.setServerConfig):
+      return action.payload;
+    default:
+      return state;
+  }
+};
+
+export default serverConfig;

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -7,19 +7,21 @@ import HelpDropdownState from './HelpDropdownState';
 import graphDataState from './GraphDataState';
 import globalState from './GlobalState';
 import namespaceState from './NamespaceState';
+import serverConfig from './ServerConfigState';
 import UserSettingsState from './UserSettingsState';
 import GrafanaState from './GrafanaState';
 import { KialiAppAction } from '../actions/KialiAppAction';
 
 const rootReducer = combineReducers<KialiAppState, KialiAppAction>({
   authentication: loginState,
-  statusState: HelpDropdownState,
+  globalState: globalState,
+  grafanaInfo: GrafanaState,
+  graph: graphDataState,
   messageCenter,
   namespaces: namespaceState,
-  globalState: globalState,
-  graph: graphDataState,
-  userSettings: UserSettingsState,
-  grafanaInfo: GrafanaState
+  serverConfig: serverConfig,
+  statusState: HelpDropdownState,
+  userSettings: UserSettingsState
 });
 
 export default rootReducer;

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -7,7 +7,7 @@ import { IstioConfigList } from '../types/IstioConfigList';
 import { Workload, WorkloadNamespaceResponse } from '../types/Workload';
 import { ServiceDetailsInfo } from '../types/ServiceInfo';
 import JaegerInfo from '../types/JaegerInfo';
-import { GrafanaInfo } from '../store/Store';
+import { GrafanaInfo, ServerConfig } from '../store/Store';
 import {
   AppHealth,
   ServiceHealth,
@@ -22,7 +22,6 @@ import { App } from '../types/App';
 import { NodeParamsType, NodeType, GraphDefinition } from '../types/Graph';
 import { config } from '../config';
 import { AuthToken, HTTP_VERBS } from '../types/Common';
-import { ServerConfig } from '../config/Config';
 
 export interface Response<T> {
   data: T;

--- a/src/services/Prometheus.ts
+++ b/src/services/Prometheus.ts
@@ -1,4 +1,5 @@
 import { DurationInSeconds } from '../types/Common';
+import { serverConfig } from '../config/ServerConfig';
 
 // The step needs to minimally cover 2 datapoints to get any sort of average. So 2*scrape is the bare
 // minimum.  We set rateInterval=step which basically gives us the rate() of each disjoint set.
@@ -22,8 +23,9 @@ export const computePrometheusRateParams = (
   if (actualDataPoints < minDataPoints) {
     actualDataPoints = defaultDataPoints;
   }
-  // TODO: should the scrape interval really be in serverConfig?
-  const actualScrapeInterval = scrapeInterval || defaultScrapeInterval;
+
+  const actualScrapeInterval =
+    scrapeInterval || serverConfig().prometheus.globalScrapeInterval || defaultScrapeInterval;
   const minStep = 2 * actualScrapeInterval;
   let step = Math.floor(duration / actualDataPoints);
   step = step < minStep ? minStep : step;

--- a/src/services/Prometheus.ts
+++ b/src/services/Prometheus.ts
@@ -24,8 +24,8 @@ export const computePrometheusRateParams = (
     actualDataPoints = defaultDataPoints;
   }
 
-  const actualScrapeInterval =
-    scrapeInterval || serverConfig().prometheus.globalScrapeInterval || defaultScrapeInterval;
+  const configuredScrapeInterval = serverConfig() && serverConfig().prometheus.globalScrapeInterval;
+  const actualScrapeInterval = scrapeInterval || configuredScrapeInterval || defaultScrapeInterval;
   const minStep = 2 * actualScrapeInterval;
   let step = Math.floor(duration / actualDataPoints);
   step = step < minStep ? minStep : step;

--- a/src/services/__tests__/Prometheus.test.ts
+++ b/src/services/__tests__/Prometheus.test.ts
@@ -4,8 +4,8 @@ import { ServerConfig } from '../../store/Store';
 import { store } from '../../store/ConfigStore';
 
 const mockServerConfig: ServerConfig = {
-  istioNamespace: 'foo',
-  istioLabels: {},
+  istioNamespace: 'istio-system',
+  istioLabels: { AppLabelName: 'app', VersionLabelName: 'version' },
   prometheus: { globalScrapeInterval: 15 }
 };
 

--- a/src/services/__tests__/Prometheus.test.ts
+++ b/src/services/__tests__/Prometheus.test.ts
@@ -1,25 +1,38 @@
 import { computePrometheusRateParams } from '../Prometheus';
+import { ServerConfigActions } from '../../actions/ServerConfigActions';
+import { ServerConfig } from '../../store/Store';
+import { store } from '../../store/ConfigStore';
+
+const mockServerConfig: ServerConfig = {
+  istioNamespace: 'foo',
+  istioLabels: {},
+  prometheus: { globalScrapeInterval: 15 }
+};
 
 describe('Prometheus service', () => {
   it('should compute prometheus rate interval default', () => {
+    store.dispatch(ServerConfigActions.setServerConfig(mockServerConfig));
     const res = computePrometheusRateParams(3600);
     expect(res.step).toBe(72);
     expect(res.rateInterval).toBe('72s');
   });
 
   it('should compute prometheus rate interval with expected datapoints', () => {
+    store.dispatch(ServerConfigActions.setServerConfig(mockServerConfig));
     const res = computePrometheusRateParams(3600, 10);
     expect(res.step).toBe(360);
     expect(res.rateInterval).toBe('360s');
   });
 
   it('should compute prometheus rate interval minimized', () => {
+    store.dispatch(ServerConfigActions.setServerConfig(mockServerConfig));
     const res = computePrometheusRateParams(60, 30);
     expect(res.step).toBe(30);
     expect(res.rateInterval).toBe('30s');
   });
 
   it('should compute prometheus rate interval minimized for custom scrape', () => {
+    store.dispatch(ServerConfigActions.setServerConfig(mockServerConfig));
     const res = computePrometheusRateParams(60, 30, 5);
     expect(res.step).toBe(10);
     expect(res.rateInterval).toBe('10s');

--- a/src/store/ConfigStore.ts
+++ b/src/store/ConfigStore.ts
@@ -17,6 +17,7 @@ import { INITIAL_MESSAGE_CENTER_STATE } from '../reducers/MessageCenter';
 import { INITIAL_STATUS_STATE } from '../reducers/HelpDropdownState';
 import { INITIAL_NAMESPACE_STATE } from '../reducers/NamespaceState';
 import { INITIAL_GRAFANA_STATE } from '../reducers/GrafanaState';
+import { INITIAL_SERVER_CONFIG } from '../reducers/ServerConfigState';
 
 declare const window;
 
@@ -40,7 +41,7 @@ const namespacePersistFilter = whitelistInputWithInitialState(
 const persistConfig = {
   key: persistKey,
   storage: storage,
-  whitelist: ['authentication', 'statusState', 'namespaces'],
+  whitelist: ['authentication', 'statusState', 'namespaces', 'serverConfig'],
   transforms: [namespacePersistFilter]
 };
 
@@ -69,7 +70,8 @@ const initialStore: KialiAppState = {
   messageCenter: INITIAL_MESSAGE_CENTER_STATE,
   graph: INITIAL_GRAPH_STATE,
   userSettings: INITIAL_USER_SETTINGS_STATE,
-  grafanaInfo: INITIAL_GRAFANA_STATE
+  grafanaInfo: INITIAL_GRAFANA_STATE,
+  serverConfig: INITIAL_SERVER_CONFIG
 };
 
 // pass an optional param to rehydrate state on app start

--- a/src/store/Selectors.ts
+++ b/src/store/Selectors.ts
@@ -56,6 +56,13 @@ const refreshInterval = (state: KialiAppState) => state.userSettings.refreshInte
 
 export const refreshIntervalSelector = createIdentitySelector(refreshInterval);
 
+const serverConfig = (state: KialiAppState) => state.serverConfig;
+
+export const serverConfigSelector = createSelector(
+  serverConfig,
+  x => x // identity function
+);
+
 const showServiceNodes = (state: KialiAppState) => state.graph.filterState.showServiceNodes;
 
 export const showServiceNodesSelector = createIdentitySelector(showServiceNodes);

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -108,9 +108,11 @@ export interface GrafanaInfo {
   varWorkload: string;
 }
 
+export type IstioLabelKey = 'AppLabelName' | 'VersionLabelName';
+
 export interface ServerConfig {
   istioNamespace: string;
-  istioLabels: { [key: string]: string };
+  istioLabels: { [key in IstioLabelKey]: string };
   prometheus: {
     globalScrapeInterval?: DurationInSeconds;
     storageTsdbRetention?: DurationInSeconds;

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -108,12 +108,22 @@ export interface GrafanaInfo {
   varWorkload: string;
 }
 
+export interface ServerConfig {
+  istioNamespace: string;
+  istioLabels: { [key: string]: string };
+  prometheus: {
+    globalScrapeInterval?: DurationInSeconds;
+    storageTsdbRetention?: DurationInSeconds;
+  };
+}
+
 // This defines the Kiali Global Application State
 export interface KialiAppState {
   // Global state === across multiple pages
   // could also be session state
   globalState: GlobalState;
   grafanaInfo: GrafanaInfo | null;
+  serverConfig: ServerConfig | null;
   statusState: StatusState;
   /** Page Settings */
   authentication: LoginState;


### PR DESCRIPTION
- use scrapeInterval when computing rate params
- use retention to determine valid "Fetch Duration" dropdown values.
   - GraphRefresh, OverviewToolbar, MetricsDuration
- Replace static/default serverConfig with actual serverConfig
   - fetched at login/checkCred time
- Move serverConfig into persisted redux
   - it needs persistence because checkCreds is async (not sure why this is a thunk actually, it seems it should block) and because we may start rendering prior to the serverConfig being updated, we need something in the store. Note that this is not an issue at login time.
- update serverConfig() to actually get the info from the store.
- make config imports more explicit for clarity and to avoid cyclic imports
   - also, break ServerConfig into its own file (from Config)

@jotak @israel-hdez Sorry, this is a relatively large PR although it's not really bigger than it needs to be, I think.   @mattmahoneyrh, While validating that the dropdowns are properly filtered also try various navigations with logouts/logins and F5s from various pages.   The duration dropdowns are on Overview, Graph, and Metrics (inbound/outbound) pages.  The dropdowns should be filtered based on the prometheus retention (probably 6h given the prom config I've seen for our installs, see the prom container's start command for the actual retention setting).

*** THIS PR REQUIRES SERVER PR: https://github.com/kiali/kiali/pull/836 ***  !!! MERGED, use master !!!