### PR TITLE
KIALI-2318 Debounce resize detection events to avoid the flickering-loop

### DIFF
--- a/src/components/Tour/Tour.tsx
+++ b/src/components/Tour/Tour.tsx
@@ -127,7 +127,14 @@ export default class Tour extends React.PureComponent<TourProps> {
 
     return (
       <>
-        {this.props.show && <ReactResizeDetector handleWidth={true} handleHeight={true} onResize={this.onResize} />}
+        <ReactResizeDetector
+          refreshMode={'debounce'}
+          refreshRate={100}
+          skipOnMount={true}
+          handleWidth={true}
+          handleHeight={true}
+          onResize={this.onResize}
+        />
         <Floater
           getPopper={popper => {
             this.popperRef = popper;


### PR DESCRIPTION
** Describe the change **

I was using a resize callback to know if the pointed element moved from place, to refresh. 
When opening the popperjs element on the "edge" before the browser pushed the refresh section to the bottom it caused the browser to push and pull the refresh section, triggering resize events (of the dom element) and requesting an update to the popperjs element (which looped this).

Adding debounce to group these events into one and avoiding the re-trigger.

There is still a small flicker when starting, probably something from popperjs or Floater (or maybe even us, not sure), but is way more usable now.

Notice that this only happens if the window width is so that if is slighly less, it will cause the refresh to be pushed down.

** Screenshot **

![peek 2019-02-12 17-13](https://user-images.githubusercontent.com/3845764/52674551-8d09d400-2ee9-11e9-8daf-c2f7ec0fcb67.gif)
