### PR TITLE
KIALI-2334 Fix legend sizing for Firefox

### DIFF
--- a/src/assets/img/graph-legend.svg
+++ b/src/assets/img/graph-legend.svg
@@ -7,7 +7,7 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="1040"
+   width="1060"
    height="143"
    version="1.1"
    id="svg220"


### PR DESCRIPTION
https://issues.jboss.org/browse/KIALI-2334

Each browser may render SVG differently, because of available fonts. This fixes size issue for Firefox. Chrome will show more white space at the right of the legend.

Before:

![image](https://user-images.githubusercontent.com/23639005/52676272-3c957500-2eef-11e9-84d8-4fffeb99d270.png)

After:

![image](https://user-images.githubusercontent.com/23639005/52676287-44edb000-2eef-11e9-8019-1a945e5cfb6a.png)
