### PR TITLE
KIALI-2381 Adding support to RbacConfig, ServiceRole and ServiceRoleBindings to IstioConfig

### DIFF
--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -228,6 +228,8 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
         istioObject = this.state.istioObjectDetails.rbacConfig;
       } else if (this.state.istioObjectDetails.serviceRole) {
         istioObject = this.state.istioObjectDetails.serviceRole;
+      } else if (this.state.istioObjectDetails.serviceRoleBinding) {
+        istioObject = this.state.istioObjectDetails.serviceRoleBinding;
       }
     }
     return istioObject ? jsYaml.safeDump(istioObject, safeDumpOptions) : '';

--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -224,6 +224,8 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
         istioObject = this.state.istioObjectDetails.policy;
       } else if (this.state.istioObjectDetails.meshPolicy) {
         istioObject = this.state.istioObjectDetails.meshPolicy;
+      } else if (this.state.istioObjectDetails.rbacConfig) {
+        istioObject = this.state.istioObjectDetails.rbacConfig;
       }
     }
     return istioObject ? jsYaml.safeDump(istioObject, safeDumpOptions) : '';

--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -224,8 +224,8 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
         istioObject = this.state.istioObjectDetails.policy;
       } else if (this.state.istioObjectDetails.meshPolicy) {
         istioObject = this.state.istioObjectDetails.meshPolicy;
-      } else if (this.state.istioObjectDetails.rbacConfig) {
-        istioObject = this.state.istioObjectDetails.rbacConfig;
+      } else if (this.state.istioObjectDetails.clusterRbacConfig) {
+        istioObject = this.state.istioObjectDetails.clusterRbacConfig;
       } else if (this.state.istioObjectDetails.serviceRole) {
         istioObject = this.state.istioObjectDetails.serviceRole;
       } else if (this.state.istioObjectDetails.serviceRoleBinding) {

--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -226,6 +226,8 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
         istioObject = this.state.istioObjectDetails.meshPolicy;
       } else if (this.state.istioObjectDetails.rbacConfig) {
         istioObject = this.state.istioObjectDetails.rbacConfig;
+      } else if (this.state.istioObjectDetails.serviceRole) {
+        istioObject = this.state.istioObjectDetails.serviceRole;
       }
     }
     return istioObject ? jsYaml.safeDump(istioObject, safeDumpOptions) : '';

--- a/src/pages/IstioConfigList/FiltersAndSorts.ts
+++ b/src/pages/IstioConfigList/FiltersAndSorts.ts
@@ -134,8 +134,8 @@ export namespace IstioConfigListFilters {
         title: 'MeshPolicy'
       },
       {
-        id: 'RbacConfig',
-        title: 'RbacConfig'
+        id: 'ClusterRbacConfig',
+        title: 'ClusterRbacConfig'
       },
       {
         id: 'ServiceRole',

--- a/src/pages/IstioConfigList/FiltersAndSorts.ts
+++ b/src/pages/IstioConfigList/FiltersAndSorts.ts
@@ -132,6 +132,18 @@ export namespace IstioConfigListFilters {
       {
         id: 'MeshPolicy',
         title: 'MeshPolicy'
+      },
+      {
+        id: 'RbacConfig',
+        title: 'RbacConfig'
+      },
+      {
+        id: 'ServiceRole',
+        title: 'ServiceRole'
+      },
+      {
+        id: 'ServiceRoleBinding',
+        title: 'ServiceRoleBinding'
       }
     ]
   };

--- a/src/pages/IstioConfigList/IstioConfigListComponent.tsx
+++ b/src/pages/IstioConfigList/IstioConfigListComponent.tsx
@@ -233,6 +233,18 @@ class IstioConfigListComponent extends ListComponent.Component<
       iconName = 'locked';
       iconType = 'pf';
       type = 'MeshPolicy';
+    } else if (istioItem.type === 'rbacconfig') {
+      iconName = 'locked';
+      iconType = 'pf';
+      type = 'RbacConfig';
+    } else if (istioItem.type === 'servicerole') {
+      iconName = 'locked';
+      iconType = 'pf';
+      type = 'ServiceRole';
+    } else if (istioItem.type === 'servicerolebinding') {
+      iconName = 'locked';
+      iconType = 'pf';
+      type = 'ServiceRoleBinding';
     }
 
     // Adapters and Templates need to pass subtype

--- a/src/pages/IstioConfigList/IstioConfigListComponent.tsx
+++ b/src/pages/IstioConfigList/IstioConfigListComponent.tsx
@@ -233,10 +233,10 @@ class IstioConfigListComponent extends ListComponent.Component<
       iconName = 'locked';
       iconType = 'pf';
       type = 'MeshPolicy';
-    } else if (istioItem.type === 'rbacconfig') {
+    } else if (istioItem.type === 'clusterrbacconfig') {
       iconName = 'locked';
       iconType = 'pf';
-      type = 'RbacConfig';
+      type = 'ClusterRbacConfig';
     } else if (istioItem.type === 'servicerole') {
       iconName = 'locked';
       iconType = 'pf';
@@ -245,6 +245,12 @@ class IstioConfigListComponent extends ListComponent.Component<
       iconName = 'locked';
       iconType = 'pf';
       type = 'ServiceRoleBinding';
+    } else {
+      console.warn('Istio Object ' + istioItem.type + ' not supported');
+    }
+
+    if (type === 'No type found') {
+      return undefined;
     }
 
     // Adapters and Templates need to pass subtype

--- a/src/pages/IstioConfigList/__tests__/IstioConfigListComponent.test.ts
+++ b/src/pages/IstioConfigList/__tests__/IstioConfigListComponent.test.ts
@@ -19,6 +19,7 @@ const mockIstioConfigList = (names: string[]): IstioConfigList => {
     policies: [],
     meshPolicies: [],
     rbacConfigs: [],
+    serviceRoles: [],
     validations: {},
     permissions: {}
   };
@@ -45,6 +46,7 @@ const mockIstioConfigList = (names: string[]): IstioConfigList => {
     testData.policies.push({ metadata: { name: name + '9' }, spec: {} });
     testData.meshPolicies.push({ metadata: { name: name + '10' }, spec: {} });
     testData.rbacConfigs.push({ metadata: { name: name + '11' }, spec: {} });
+    testData.serviceRoles.push({ metadata: { name: name + '12' }, spec: {} });
   });
   return testData;
 };
@@ -79,6 +81,7 @@ describe('IstioConfigListComponent#filterByName', () => {
     expect(filtered.policies[0].metadata.name).toBe('white9');
     expect(filtered.meshPolicies[0].metadata.name).toBe('white10');
     expect(filtered.rbacConfigs[0].metadata.name).toBe('white11');
+    expect(filtered.serviceRoles[0].metadata.name).toBe('white12');
 
     filtered = filterByName(unfiltered, ['bad']);
     expect(filtered).toBeDefined();
@@ -94,6 +97,7 @@ describe('IstioConfigListComponent#filterByName', () => {
     expect(filtered.policies.length).toBe(0);
     expect(filtered.meshPolicies.length).toBe(0);
     expect(filtered.rbacConfigs.length).toBe(0);
+    expect(filtered.serviceRoles.length).toBe(0);
   });
 });
 
@@ -102,7 +106,7 @@ describe('IstioConfigListComponent#toIstioItems', () => {
     const istioItems = toIstioItems(unfiltered);
 
     expect(istioItems).toBeDefined();
-    expect(istioItems.length).toBe(36);
+    expect(istioItems.length).toBe(39);
     expect(istioItems[0].gateway).toBeDefined();
     expect(istioItems[0].destinationRule).toBeUndefined();
     expect(istioItems[3].virtualService).toBeDefined();
@@ -120,7 +124,7 @@ describe('IstioConfigComponent#sortIstioItems', () => {
 
     return IstioConfigListFilters.sortIstioItems(istioItems, sortField, isAscending).then(sorted => {
       expect(sorted).toBeDefined();
-      expect(sorted.length).toBe(36);
+      expect(sorted.length).toBe(39);
 
       const first = sorted[0];
       expect(first.gateway).toBeDefined();
@@ -130,7 +134,7 @@ describe('IstioConfigComponent#sortIstioItems', () => {
       expect(second.virtualService).toBeDefined();
       expect(second.virtualService!.metadata.name).toBe('blue1');
 
-      const last = sorted[35];
+      const last = sorted[38];
       expect(last.policy).toBeDefined();
       expect(last.policy!.metadata.name).toBe('white9');
     });
@@ -144,13 +148,13 @@ describe('IstioConfigComponent#sortIstioItems', () => {
     // Descending
     return IstioConfigListFilters.sortIstioItems(istioItems, sortField, isAscending).then(sorted => {
       expect(sorted).toBeDefined();
-      expect(sorted.length).toBe(36);
+      expect(sorted.length).toBe(39);
 
       const first = sorted[0];
       expect(first.policy).toBeDefined();
       expect(first.policy!.metadata.name).toBe('white9');
 
-      const last = sorted[35];
+      const last = sorted[38];
       expect(last.gateway).toBeDefined();
       expect(last.gateway!.metadata.name).toBe('blue0');
     });
@@ -163,7 +167,7 @@ describe('IstioConfigComponent#sortIstioItems', () => {
 
     return IstioConfigListFilters.sortIstioItems(istioItems, sortField, isAscending).then(sorted => {
       expect(sorted).toBeDefined();
-      expect(sorted.length).toBe(36);
+      expect(sorted.length).toBe(39);
 
       const first = sorted[0];
       expect(first.adapter).toBeDefined();
@@ -173,7 +177,7 @@ describe('IstioConfigComponent#sortIstioItems', () => {
       expect(second.destinationRule).toBeDefined();
       expect(second.destinationRule!.metadata.name).toBe('blue2');
 
-      const last = sorted[35];
+      const last = sorted[38];
       expect(last.virtualService).toBeDefined();
       expect(last.virtualService!.metadata.name).toBe('white1');
     });
@@ -186,7 +190,7 @@ describe('IstioConfigComponent#sortIstioItems', () => {
 
     return IstioConfigListFilters.sortIstioItems(istioItems, sortField, isAscending).then(sorted => {
       expect(sorted).toBeDefined();
-      expect(sorted.length).toBe(36);
+      expect(sorted.length).toBe(39);
 
       const first = sorted[0];
       expect(first.virtualService).toBeDefined();

--- a/src/pages/IstioConfigList/__tests__/IstioConfigListComponent.test.ts
+++ b/src/pages/IstioConfigList/__tests__/IstioConfigListComponent.test.ts
@@ -20,6 +20,7 @@ const mockIstioConfigList = (names: string[]): IstioConfigList => {
     meshPolicies: [],
     rbacConfigs: [],
     serviceRoles: [],
+    serviceRoleBindings: [],
     validations: {},
     permissions: {}
   };
@@ -47,6 +48,7 @@ const mockIstioConfigList = (names: string[]): IstioConfigList => {
     testData.meshPolicies.push({ metadata: { name: name + '10' }, spec: {} });
     testData.rbacConfigs.push({ metadata: { name: name + '11' }, spec: {} });
     testData.serviceRoles.push({ metadata: { name: name + '12' }, spec: {} });
+    testData.serviceRoleBindings.push({ metadata: { name: name + '13' }, spec: {} });
   });
   return testData;
 };
@@ -69,6 +71,8 @@ describe('IstioConfigListComponent#filterByName', () => {
     expect(filtered.policies.length).toBe(2);
     expect(filtered.meshPolicies.length).toBe(2);
     expect(filtered.rbacConfigs.length).toBe(2);
+    expect(filtered.serviceRoles.length).toBe(2);
+    expect(filtered.serviceRoleBindings.length).toBe(2);
 
     expect(filtered.virtualServices.items[0].metadata.name).toBe('white1');
     expect(filtered.destinationRules.items[0].metadata.name).toBe('white2');
@@ -82,6 +86,7 @@ describe('IstioConfigListComponent#filterByName', () => {
     expect(filtered.meshPolicies[0].metadata.name).toBe('white10');
     expect(filtered.rbacConfigs[0].metadata.name).toBe('white11');
     expect(filtered.serviceRoles[0].metadata.name).toBe('white12');
+    expect(filtered.serviceRoleBindings[0].metadata.name).toBe('white13');
 
     filtered = filterByName(unfiltered, ['bad']);
     expect(filtered).toBeDefined();
@@ -106,7 +111,7 @@ describe('IstioConfigListComponent#toIstioItems', () => {
     const istioItems = toIstioItems(unfiltered);
 
     expect(istioItems).toBeDefined();
-    expect(istioItems.length).toBe(39);
+    expect(istioItems.length).toBe(42);
     expect(istioItems[0].gateway).toBeDefined();
     expect(istioItems[0].destinationRule).toBeUndefined();
     expect(istioItems[3].virtualService).toBeDefined();
@@ -124,7 +129,7 @@ describe('IstioConfigComponent#sortIstioItems', () => {
 
     return IstioConfigListFilters.sortIstioItems(istioItems, sortField, isAscending).then(sorted => {
       expect(sorted).toBeDefined();
-      expect(sorted.length).toBe(39);
+      expect(sorted.length).toBe(42);
 
       const first = sorted[0];
       expect(first.gateway).toBeDefined();
@@ -134,7 +139,7 @@ describe('IstioConfigComponent#sortIstioItems', () => {
       expect(second.virtualService).toBeDefined();
       expect(second.virtualService!.metadata.name).toBe('blue1');
 
-      const last = sorted[38];
+      const last = sorted[41];
       expect(last.policy).toBeDefined();
       expect(last.policy!.metadata.name).toBe('white9');
     });
@@ -148,13 +153,13 @@ describe('IstioConfigComponent#sortIstioItems', () => {
     // Descending
     return IstioConfigListFilters.sortIstioItems(istioItems, sortField, isAscending).then(sorted => {
       expect(sorted).toBeDefined();
-      expect(sorted.length).toBe(39);
+      expect(sorted.length).toBe(42);
 
       const first = sorted[0];
       expect(first.policy).toBeDefined();
       expect(first.policy!.metadata.name).toBe('white9');
 
-      const last = sorted[38];
+      const last = sorted[41];
       expect(last.gateway).toBeDefined();
       expect(last.gateway!.metadata.name).toBe('blue0');
     });
@@ -167,7 +172,7 @@ describe('IstioConfigComponent#sortIstioItems', () => {
 
     return IstioConfigListFilters.sortIstioItems(istioItems, sortField, isAscending).then(sorted => {
       expect(sorted).toBeDefined();
-      expect(sorted.length).toBe(39);
+      expect(sorted.length).toBe(42);
 
       const first = sorted[0];
       expect(first.adapter).toBeDefined();
@@ -177,7 +182,7 @@ describe('IstioConfigComponent#sortIstioItems', () => {
       expect(second.destinationRule).toBeDefined();
       expect(second.destinationRule!.metadata.name).toBe('blue2');
 
-      const last = sorted[38];
+      const last = sorted[41];
       expect(last.virtualService).toBeDefined();
       expect(last.virtualService!.metadata.name).toBe('white1');
     });
@@ -190,7 +195,7 @@ describe('IstioConfigComponent#sortIstioItems', () => {
 
     return IstioConfigListFilters.sortIstioItems(istioItems, sortField, isAscending).then(sorted => {
       expect(sorted).toBeDefined();
-      expect(sorted.length).toBe(39);
+      expect(sorted.length).toBe(42);
 
       const first = sorted[0];
       expect(first.virtualService).toBeDefined();

--- a/src/pages/IstioConfigList/__tests__/IstioConfigListComponent.test.ts
+++ b/src/pages/IstioConfigList/__tests__/IstioConfigListComponent.test.ts
@@ -18,6 +18,7 @@ const mockIstioConfigList = (names: string[]): IstioConfigList => {
     quotaSpecBindings: [],
     policies: [],
     meshPolicies: [],
+    rbacConfigs: [],
     validations: {},
     permissions: {}
   };
@@ -43,6 +44,7 @@ const mockIstioConfigList = (names: string[]): IstioConfigList => {
     testData.quotaSpecBindings.push({ metadata: { name: name + '8' }, spec: {} });
     testData.policies.push({ metadata: { name: name + '9' }, spec: {} });
     testData.meshPolicies.push({ metadata: { name: name + '10' }, spec: {} });
+    testData.rbacConfigs.push({ metadata: { name: name + '11' }, spec: {} });
   });
   return testData;
 };
@@ -64,6 +66,7 @@ describe('IstioConfigListComponent#filterByName', () => {
     expect(filtered.quotaSpecBindings.length).toBe(2);
     expect(filtered.policies.length).toBe(2);
     expect(filtered.meshPolicies.length).toBe(2);
+    expect(filtered.rbacConfigs.length).toBe(2);
 
     expect(filtered.virtualServices.items[0].metadata.name).toBe('white1');
     expect(filtered.destinationRules.items[0].metadata.name).toBe('white2');
@@ -75,6 +78,7 @@ describe('IstioConfigListComponent#filterByName', () => {
     expect(filtered.quotaSpecBindings[0].metadata.name).toBe('white8');
     expect(filtered.policies[0].metadata.name).toBe('white9');
     expect(filtered.meshPolicies[0].metadata.name).toBe('white10');
+    expect(filtered.rbacConfigs[0].metadata.name).toBe('white11');
 
     filtered = filterByName(unfiltered, ['bad']);
     expect(filtered).toBeDefined();
@@ -89,6 +93,7 @@ describe('IstioConfigListComponent#filterByName', () => {
     expect(filtered.quotaSpecBindings.length).toBe(0);
     expect(filtered.policies.length).toBe(0);
     expect(filtered.meshPolicies.length).toBe(0);
+    expect(filtered.rbacConfigs.length).toBe(0);
   });
 });
 
@@ -97,7 +102,7 @@ describe('IstioConfigListComponent#toIstioItems', () => {
     const istioItems = toIstioItems(unfiltered);
 
     expect(istioItems).toBeDefined();
-    expect(istioItems.length).toBe(33);
+    expect(istioItems.length).toBe(36);
     expect(istioItems[0].gateway).toBeDefined();
     expect(istioItems[0].destinationRule).toBeUndefined();
     expect(istioItems[3].virtualService).toBeDefined();
@@ -115,7 +120,7 @@ describe('IstioConfigComponent#sortIstioItems', () => {
 
     return IstioConfigListFilters.sortIstioItems(istioItems, sortField, isAscending).then(sorted => {
       expect(sorted).toBeDefined();
-      expect(sorted.length).toBe(33);
+      expect(sorted.length).toBe(36);
 
       const first = sorted[0];
       expect(first.gateway).toBeDefined();
@@ -125,7 +130,7 @@ describe('IstioConfigComponent#sortIstioItems', () => {
       expect(second.virtualService).toBeDefined();
       expect(second.virtualService!.metadata.name).toBe('blue1');
 
-      const last = sorted[32];
+      const last = sorted[35];
       expect(last.policy).toBeDefined();
       expect(last.policy!.metadata.name).toBe('white9');
     });
@@ -139,13 +144,13 @@ describe('IstioConfigComponent#sortIstioItems', () => {
     // Descending
     return IstioConfigListFilters.sortIstioItems(istioItems, sortField, isAscending).then(sorted => {
       expect(sorted).toBeDefined();
-      expect(sorted.length).toBe(33);
+      expect(sorted.length).toBe(36);
 
       const first = sorted[0];
       expect(first.policy).toBeDefined();
       expect(first.policy!.metadata.name).toBe('white9');
 
-      const last = sorted[32];
+      const last = sorted[35];
       expect(last.gateway).toBeDefined();
       expect(last.gateway!.metadata.name).toBe('blue0');
     });
@@ -158,7 +163,7 @@ describe('IstioConfigComponent#sortIstioItems', () => {
 
     return IstioConfigListFilters.sortIstioItems(istioItems, sortField, isAscending).then(sorted => {
       expect(sorted).toBeDefined();
-      expect(sorted.length).toBe(33);
+      expect(sorted.length).toBe(36);
 
       const first = sorted[0];
       expect(first.adapter).toBeDefined();
@@ -168,7 +173,7 @@ describe('IstioConfigComponent#sortIstioItems', () => {
       expect(second.destinationRule).toBeDefined();
       expect(second.destinationRule!.metadata.name).toBe('blue2');
 
-      const last = sorted[32];
+      const last = sorted[35];
       expect(last.virtualService).toBeDefined();
       expect(last.virtualService!.metadata.name).toBe('white1');
     });
@@ -181,7 +186,7 @@ describe('IstioConfigComponent#sortIstioItems', () => {
 
     return IstioConfigListFilters.sortIstioItems(istioItems, sortField, isAscending).then(sorted => {
       expect(sorted).toBeDefined();
-      expect(sorted.length).toBe(33);
+      expect(sorted.length).toBe(36);
 
       const first = sorted[0];
       expect(first.virtualService).toBeDefined();

--- a/src/pages/IstioConfigList/__tests__/IstioConfigListComponent.test.ts
+++ b/src/pages/IstioConfigList/__tests__/IstioConfigListComponent.test.ts
@@ -18,7 +18,7 @@ const mockIstioConfigList = (names: string[]): IstioConfigList => {
     quotaSpecBindings: [],
     policies: [],
     meshPolicies: [],
-    rbacConfigs: [],
+    clusterRbacConfigs: [],
     serviceRoles: [],
     serviceRoleBindings: [],
     validations: {},
@@ -46,7 +46,7 @@ const mockIstioConfigList = (names: string[]): IstioConfigList => {
     testData.quotaSpecBindings.push({ metadata: { name: name + '8' }, spec: {} });
     testData.policies.push({ metadata: { name: name + '9' }, spec: {} });
     testData.meshPolicies.push({ metadata: { name: name + '10' }, spec: {} });
-    testData.rbacConfigs.push({ metadata: { name: name + '11' }, spec: {} });
+    testData.clusterRbacConfigs.push({ metadata: { name: name + '11' }, spec: {} });
     testData.serviceRoles.push({ metadata: { name: name + '12' }, spec: {} });
     testData.serviceRoleBindings.push({ metadata: { name: name + '13' }, spec: {} });
   });
@@ -70,7 +70,7 @@ describe('IstioConfigListComponent#filterByName', () => {
     expect(filtered.quotaSpecBindings.length).toBe(2);
     expect(filtered.policies.length).toBe(2);
     expect(filtered.meshPolicies.length).toBe(2);
-    expect(filtered.rbacConfigs.length).toBe(2);
+    expect(filtered.clusterRbacConfigs.length).toBe(2);
     expect(filtered.serviceRoles.length).toBe(2);
     expect(filtered.serviceRoleBindings.length).toBe(2);
 
@@ -84,7 +84,7 @@ describe('IstioConfigListComponent#filterByName', () => {
     expect(filtered.quotaSpecBindings[0].metadata.name).toBe('white8');
     expect(filtered.policies[0].metadata.name).toBe('white9');
     expect(filtered.meshPolicies[0].metadata.name).toBe('white10');
-    expect(filtered.rbacConfigs[0].metadata.name).toBe('white11');
+    expect(filtered.clusterRbacConfigs[0].metadata.name).toBe('white11');
     expect(filtered.serviceRoles[0].metadata.name).toBe('white12');
     expect(filtered.serviceRoleBindings[0].metadata.name).toBe('white13');
 
@@ -101,7 +101,7 @@ describe('IstioConfigListComponent#filterByName', () => {
     expect(filtered.quotaSpecBindings.length).toBe(0);
     expect(filtered.policies.length).toBe(0);
     expect(filtered.meshPolicies.length).toBe(0);
-    expect(filtered.rbacConfigs.length).toBe(0);
+    expect(filtered.clusterRbacConfigs.length).toBe(0);
     expect(filtered.serviceRoles.length).toBe(0);
   });
 });
@@ -179,8 +179,8 @@ describe('IstioConfigComponent#sortIstioItems', () => {
       expect(first.adapter!.metadata.name).toBe('blue5');
 
       const second = sorted[3];
-      expect(second.destinationRule).toBeDefined();
-      expect(second.destinationRule!.metadata.name).toBe('blue2');
+      expect(second.clusterRbacConfig).toBeDefined();
+      expect(second.clusterRbacConfig!.metadata.name).toBe('blue11');
 
       const last = sorted[41];
       expect(last.virtualService).toBeDefined();

--- a/src/types/IstioConfigDetails.ts
+++ b/src/types/IstioConfigDetails.ts
@@ -14,7 +14,8 @@ import {
   RouteRule,
   ServiceEntry,
   VirtualService,
-  ObjectValidation
+  ObjectValidation,
+  RbacConfig
 } from './IstioObjects';
 
 export interface IstioConfigId {
@@ -39,6 +40,7 @@ export interface IstioConfigDetails {
   quotaSpecBinding: QuotaSpecBinding;
   policy: Policy;
   meshPolicy: Policy;
+  rbacConfig: RbacConfig;
   permissions: ResourcePermissions;
   validation: ObjectValidation;
 }

--- a/src/types/IstioConfigDetails.ts
+++ b/src/types/IstioConfigDetails.ts
@@ -15,7 +15,8 @@ import {
   ServiceEntry,
   VirtualService,
   ObjectValidation,
-  RbacConfig
+  RbacConfig,
+  ServiceRole
 } from './IstioObjects';
 
 export interface IstioConfigId {
@@ -41,6 +42,7 @@ export interface IstioConfigDetails {
   policy: Policy;
   meshPolicy: Policy;
   rbacConfig: RbacConfig;
+  serviceRole: ServiceRole;
   permissions: ResourcePermissions;
   validation: ObjectValidation;
 }

--- a/src/types/IstioConfigDetails.ts
+++ b/src/types/IstioConfigDetails.ts
@@ -16,7 +16,8 @@ import {
   VirtualService,
   ObjectValidation,
   RbacConfig,
-  ServiceRole
+  ServiceRole,
+  ServiceRoleBinding
 } from './IstioObjects';
 
 export interface IstioConfigId {
@@ -43,6 +44,7 @@ export interface IstioConfigDetails {
   meshPolicy: Policy;
   rbacConfig: RbacConfig;
   serviceRole: ServiceRole;
+  serviceRoleBinding: ServiceRoleBinding;
   permissions: ResourcePermissions;
   validation: ObjectValidation;
 }

--- a/src/types/IstioConfigDetails.ts
+++ b/src/types/IstioConfigDetails.ts
@@ -15,7 +15,7 @@ import {
   ServiceEntry,
   VirtualService,
   ObjectValidation,
-  RbacConfig,
+  ClusterRbacConfig,
   ServiceRole,
   ServiceRoleBinding
 } from './IstioObjects';
@@ -42,7 +42,7 @@ export interface IstioConfigDetails {
   quotaSpecBinding: QuotaSpecBinding;
   policy: Policy;
   meshPolicy: Policy;
-  rbacConfig: RbacConfig;
+  clusterRbacConfig: ClusterRbacConfig;
   serviceRole: ServiceRole;
   serviceRoleBinding: ServiceRoleBinding;
   permissions: ResourcePermissions;

--- a/src/types/IstioConfigList.ts
+++ b/src/types/IstioConfigList.ts
@@ -14,7 +14,7 @@ import {
   VirtualService,
   VirtualServices,
   Validations,
-  RbacConfig,
+  ClusterRbacConfig,
   ServiceRole,
   ServiceRoleBinding
 } from './IstioObjects';
@@ -35,7 +35,7 @@ export interface IstioConfigItem {
   quotaSpecBinding?: QuotaSpecBinding;
   policy?: Policy;
   meshPolicy?: Policy;
-  rbacConfig?: RbacConfig;
+  clusterRbacConfig?: ClusterRbacConfig;
   serviceRole?: ServiceRole;
   serviceRoleBinding?: ServiceRoleBinding;
   validation?: ObjectValidation;
@@ -54,7 +54,7 @@ export interface IstioConfigList {
   quotaSpecBindings: QuotaSpecBinding[];
   policies: Policy[];
   meshPolicies: Policy[];
-  rbacConfigs: RbacConfig[];
+  clusterRbacConfigs: ClusterRbacConfig[];
   serviceRoles: ServiceRole[];
   serviceRoleBindings: ServiceRoleBinding[];
   permissions: { [key: string]: ResourcePermissions };
@@ -81,7 +81,7 @@ export const dicIstioType = {
   QuotaSpecBinding: 'quotaspecbindings',
   Policy: 'policies',
   MeshPolicy: 'meshpolicies',
-  RbacConfig: 'rbacconfigs',
+  ClusterRbacConfig: 'clusterrbacconfigs',
   ServiceRole: 'serviceroles',
   ServiceRoleBinding: 'servicerolebindings',
   gateways: 'Gateway',
@@ -97,7 +97,7 @@ export const dicIstioType = {
   handler: 'Handler',
   policies: 'Policy',
   meshpolicies: 'MeshPolicy',
-  rbacconfigs: 'RbacConfig',
+  clusterrbacconfigs: 'ClusterRbacConfig',
   serviceroles: 'ServiceRole',
   servicerolebindings: 'ServiceRoleBinding'
 };
@@ -134,7 +134,7 @@ export const filterByName = (unfiltered: IstioConfigList, names: string[]): Isti
     quotaSpecBindings: unfiltered.quotaSpecBindings.filter(qsb => includeName(qsb.metadata.name, names)),
     policies: unfiltered.policies.filter(p => includeName(p.metadata.name, names)),
     meshPolicies: unfiltered.meshPolicies.filter(p => includeName(p.metadata.name, names)),
-    rbacConfigs: unfiltered.rbacConfigs.filter(rc => includeName(rc.metadata.name, names)),
+    clusterRbacConfigs: unfiltered.clusterRbacConfigs.filter(rc => includeName(rc.metadata.name, names)),
     serviceRoles: unfiltered.serviceRoles.filter(sr => includeName(sr.metadata.name, names)),
     serviceRoleBindings: unfiltered.serviceRoleBindings.filter(srb => includeName(srb.metadata.name, names)),
     validations: unfiltered.validations,
@@ -264,12 +264,12 @@ export const toIstioItems = (istioConfigList: IstioConfigList): IstioConfigItem[
       policy: p
     })
   );
-  istioConfigList.rbacConfigs.forEach(rc =>
+  istioConfigList.clusterRbacConfigs.forEach(rc =>
     istioItems.push({
       namespace: istioConfigList.namespace.name,
-      type: 'rbacconfig',
+      type: 'clusterrbacconfig',
       name: rc.metadata.name,
-      rbacConfig: rc
+      clusterRbacConfig: rc
     })
   );
   istioConfigList.serviceRoles.forEach(sr =>

--- a/src/types/IstioConfigList.ts
+++ b/src/types/IstioConfigList.ts
@@ -13,7 +13,8 @@ import {
   ServiceEntry,
   VirtualService,
   VirtualServices,
-  Validations
+  Validations,
+  RbacConfig
 } from './IstioObjects';
 import { ResourcePermissions } from './Permissions';
 
@@ -32,6 +33,7 @@ export interface IstioConfigItem {
   quotaSpecBinding?: QuotaSpecBinding;
   policy?: Policy;
   meshPolicy?: Policy;
+  rbacConfig?: RbacConfig;
   validation?: ObjectValidation;
 }
 
@@ -48,6 +50,7 @@ export interface IstioConfigList {
   quotaSpecBindings: QuotaSpecBinding[];
   policies: Policy[];
   meshPolicies: Policy[];
+  rbacConfigs: RbacConfig[];
   permissions: { [key: string]: ResourcePermissions };
   validations: Validations;
 }
@@ -72,6 +75,9 @@ export const dicIstioType = {
   QuotaSpecBinding: 'quotaspecbindings',
   Policy: 'policies',
   MeshPolicy: 'meshpolicies',
+  RbacConfig: 'rbacconfigs',
+  ServiceRole: 'serviceroles',
+  ServiceRoleBinding: 'servicerolebindings',
   gateways: 'Gateway',
   virtualservices: 'VirtualService',
   destinationrules: 'DestinationRule',
@@ -84,7 +90,10 @@ export const dicIstioType = {
   instance: 'Instance',
   handler: 'Handler',
   policies: 'Policy',
-  meshpolicies: 'MeshPolicy'
+  meshpolicies: 'MeshPolicy',
+  rbacconfigs: 'RbacConfig',
+  serviceroles: 'ServiceRole',
+  servicerolebindings: 'ServiceRoleBinding'
 };
 
 const includeName = (name: string, names: string[]) => {
@@ -119,6 +128,7 @@ export const filterByName = (unfiltered: IstioConfigList, names: string[]): Isti
     quotaSpecBindings: unfiltered.quotaSpecBindings.filter(qsb => includeName(qsb.metadata.name, names)),
     policies: unfiltered.policies.filter(p => includeName(p.metadata.name, names)),
     meshPolicies: unfiltered.meshPolicies.filter(p => includeName(p.metadata.name, names)),
+    rbacConfigs: unfiltered.rbacConfigs.filter(p => includeName(p.metadata.name, names)),
     validations: unfiltered.validations,
     permissions: unfiltered.permissions
   };
@@ -244,6 +254,14 @@ export const toIstioItems = (istioConfigList: IstioConfigList): IstioConfigItem[
       type: 'meshpolicy',
       name: p.metadata.name,
       policy: p
+    })
+  );
+  istioConfigList.rbacConfigs.forEach(rc =>
+    istioItems.push({
+      namespace: istioConfigList.namespace.name,
+      type: 'rbacconfig',
+      name: rc.metadata.name,
+      rbacConfig: rc
     })
   );
   return istioItems;

--- a/src/types/IstioConfigList.ts
+++ b/src/types/IstioConfigList.ts
@@ -14,7 +14,8 @@ import {
   VirtualService,
   VirtualServices,
   Validations,
-  RbacConfig
+  RbacConfig,
+  ServiceRole
 } from './IstioObjects';
 import { ResourcePermissions } from './Permissions';
 
@@ -34,6 +35,7 @@ export interface IstioConfigItem {
   policy?: Policy;
   meshPolicy?: Policy;
   rbacConfig?: RbacConfig;
+  serviceRole?: ServiceRole;
   validation?: ObjectValidation;
 }
 
@@ -51,6 +53,7 @@ export interface IstioConfigList {
   policies: Policy[];
   meshPolicies: Policy[];
   rbacConfigs: RbacConfig[];
+  serviceRoles: ServiceRole[];
   permissions: { [key: string]: ResourcePermissions };
   validations: Validations;
 }
@@ -128,7 +131,8 @@ export const filterByName = (unfiltered: IstioConfigList, names: string[]): Isti
     quotaSpecBindings: unfiltered.quotaSpecBindings.filter(qsb => includeName(qsb.metadata.name, names)),
     policies: unfiltered.policies.filter(p => includeName(p.metadata.name, names)),
     meshPolicies: unfiltered.meshPolicies.filter(p => includeName(p.metadata.name, names)),
-    rbacConfigs: unfiltered.rbacConfigs.filter(p => includeName(p.metadata.name, names)),
+    rbacConfigs: unfiltered.rbacConfigs.filter(rc => includeName(rc.metadata.name, names)),
+    serviceRoles: unfiltered.serviceRoles.filter(sr => includeName(sr.metadata.name, names)),
     validations: unfiltered.validations,
     permissions: unfiltered.permissions
   };
@@ -262,6 +266,14 @@ export const toIstioItems = (istioConfigList: IstioConfigList): IstioConfigItem[
       type: 'rbacconfig',
       name: rc.metadata.name,
       rbacConfig: rc
+    })
+  );
+  istioConfigList.serviceRoles.forEach(sr =>
+    istioItems.push({
+      namespace: istioConfigList.namespace.name,
+      type: 'servicerole',
+      name: sr.metadata.name,
+      serviceRole: sr
     })
   );
   return istioItems;

--- a/src/types/IstioConfigList.ts
+++ b/src/types/IstioConfigList.ts
@@ -15,7 +15,8 @@ import {
   VirtualServices,
   Validations,
   RbacConfig,
-  ServiceRole
+  ServiceRole,
+  ServiceRoleBinding
 } from './IstioObjects';
 import { ResourcePermissions } from './Permissions';
 
@@ -36,6 +37,7 @@ export interface IstioConfigItem {
   meshPolicy?: Policy;
   rbacConfig?: RbacConfig;
   serviceRole?: ServiceRole;
+  serviceRoleBinding?: ServiceRoleBinding;
   validation?: ObjectValidation;
 }
 
@@ -54,6 +56,7 @@ export interface IstioConfigList {
   meshPolicies: Policy[];
   rbacConfigs: RbacConfig[];
   serviceRoles: ServiceRole[];
+  serviceRoleBindings: ServiceRoleBinding[];
   permissions: { [key: string]: ResourcePermissions };
   validations: Validations;
 }
@@ -133,6 +136,7 @@ export const filterByName = (unfiltered: IstioConfigList, names: string[]): Isti
     meshPolicies: unfiltered.meshPolicies.filter(p => includeName(p.metadata.name, names)),
     rbacConfigs: unfiltered.rbacConfigs.filter(rc => includeName(rc.metadata.name, names)),
     serviceRoles: unfiltered.serviceRoles.filter(sr => includeName(sr.metadata.name, names)),
+    serviceRoleBindings: unfiltered.serviceRoleBindings.filter(srb => includeName(srb.metadata.name, names)),
     validations: unfiltered.validations,
     permissions: unfiltered.permissions
   };
@@ -274,6 +278,14 @@ export const toIstioItems = (istioConfigList: IstioConfigList): IstioConfigItem[
       type: 'servicerole',
       name: sr.metadata.name,
       serviceRole: sr
+    })
+  );
+  istioConfigList.serviceRoleBindings.forEach(srb =>
+    istioItems.push({
+      namespace: istioConfigList.namespace.name,
+      type: 'servicerolebinding',
+      name: srb.metadata.name,
+      serviceRoleBinding: srb
     })
   );
   return istioItems;

--- a/src/types/IstioObjects.ts
+++ b/src/types/IstioObjects.ts
@@ -596,12 +596,12 @@ export interface Policy {
   spec: PolicySpec;
 }
 
-export interface RbacConfig {
+export interface ClusterRbacConfig {
   metadata: K8sMetadata;
-  spec: RbacConfigSpec;
+  spec: ClusterRbacConfigSpec;
 }
 
-export interface RbacConfigSpec {
+export interface ClusterRbacConfigSpec {
   mode?: string;
   inclusion?: RbacConfigTarget;
   exclusion?: RbacConfigTarget;

--- a/src/types/IstioObjects.ts
+++ b/src/types/IstioObjects.ts
@@ -632,3 +632,18 @@ export interface AccessRuleConstraint {
   key: string;
   values: string[];
 }
+
+export interface ServiceRoleBinding {
+  metadata: K8sMetadata;
+  spec: ServiceRoleBindingSpec;
+}
+
+export interface ServiceRoleBindingSpec {
+  subjects?: ServiceRoleBindingSubject[];
+  roleRef?: Reference;
+}
+
+export interface ServiceRoleBindingSubject {
+  user: string;
+  properties: Map<string, string>;
+}

--- a/src/types/IstioObjects.ts
+++ b/src/types/IstioObjects.ts
@@ -611,3 +611,24 @@ export interface RbacConfigTarget {
   services: string[];
   namespaces: string[];
 }
+
+export interface ServiceRole {
+  metadata: K8sMetadata;
+  spec: ServiceRoleSpec;
+}
+
+export interface ServiceRoleSpec {
+  rules?: AccessRules[];
+}
+
+export interface AccessRules {
+  service: string[];
+  path: string[];
+  methods: string[];
+  constraints: AccessRuleConstraint;
+}
+
+export interface AccessRuleConstraint {
+  key: string;
+  values: string[];
+}

--- a/src/types/IstioObjects.ts
+++ b/src/types/IstioObjects.ts
@@ -595,3 +595,19 @@ export interface Policy {
   metadata: K8sMetadata;
   spec: PolicySpec;
 }
+
+export interface RbacConfig {
+  metadata: K8sMetadata;
+  spec: RbacConfigSpec;
+}
+
+export interface RbacConfigSpec {
+  mode?: string;
+  inclusion?: RbacConfigTarget;
+  exclusion?: RbacConfigTarget;
+}
+
+export interface RbacConfigTarget {
+  services: string[];
+  namespaces: string[];
+}


### PR DESCRIPTION
** Describe the change **
Adding support to RbacConfig, ServiceRole and ServiceRoleBindings to IstioConfig.
It allows list, view, update and delete.

Backend: https://github.com/kiali/kiali/pull/842

** Issue reference **
https://issues.jboss.org/browse/KIALI-2381

** Backwards compatible? **
yes.

** Screenshot **
![screen recording 9](https://user-images.githubusercontent.com/613814/52796321-e30a8300-3073-11e9-8bd2-725bf80dbc54.gif)

