### PR TITLE
KIALI-1469 Do not report "no requests" in health on missing sidecar

### DIFF
--- a/src/components/Health/__tests__/HealthDetails.test.tsx
+++ b/src/components/Health/__tests__/HealthDetails.test.tsx
@@ -6,14 +6,20 @@ import { ServiceHealth } from '../../../types/Health';
 
 describe('HealthDetails', () => {
   it('renders healthy', () => {
-    const health = new ServiceHealth({ errorRatio: -1, inboundErrorRatio: -1, outboundErrorRatio: -1 }, 60);
+    const health = new ServiceHealth(
+      { errorRatio: -1, inboundErrorRatio: -1, outboundErrorRatio: -1 },
+      { rateInterval: 60, hasSidecar: true }
+    );
 
     const wrapper = shallow(<HealthDetails health={health} />);
     expect(wrapper).toMatchSnapshot();
   });
 
   it('renders deployments failure', () => {
-    const health = new ServiceHealth({ errorRatio: -1, inboundErrorRatio: -1, outboundErrorRatio: -1 }, 60);
+    const health = new ServiceHealth(
+      { errorRatio: -1, inboundErrorRatio: -1, outboundErrorRatio: -1 },
+      { rateInterval: 60, hasSidecar: true }
+    );
 
     const wrapper = shallow(<HealthDetails health={health} />);
     expect(wrapper).toMatchSnapshot();

--- a/src/components/Health/__tests__/HealthIndicator.test.tsx
+++ b/src/components/Health/__tests__/HealthIndicator.test.tsx
@@ -19,7 +19,7 @@ describe('HealthIndicator', () => {
     const health = new AppHealth(
       [{ name: 'A', available: 1, replicas: 1 }, { name: 'B', available: 2, replicas: 2 }],
       { errorRatio: -1, inboundErrorRatio: -1, outboundErrorRatio: -1 },
-      600
+      { rateInterval: 600, hasSidecar: true }
     );
 
     // SMALL
@@ -38,7 +38,7 @@ describe('HealthIndicator', () => {
     const health = new AppHealth(
       [{ name: 'A', available: 1, replicas: 10 }, { name: 'B', available: 2, replicas: 2 }],
       { errorRatio: -1, inboundErrorRatio: -1, outboundErrorRatio: -1 },
-      600
+      { rateInterval: 600, hasSidecar: true }
     );
 
     // SMALL
@@ -57,7 +57,7 @@ describe('HealthIndicator', () => {
     const health = new AppHealth(
       [{ name: 'A', available: 0, replicas: 0 }, { name: 'B', available: 2, replicas: 2 }],
       { errorRatio: -1, inboundErrorRatio: -1, outboundErrorRatio: -1 },
-      600
+      { rateInterval: 600, hasSidecar: true }
     );
 
     // SMALL
@@ -76,7 +76,7 @@ describe('HealthIndicator', () => {
     const health = new AppHealth(
       [{ name: 'A', available: 0, replicas: 0 }, { name: 'B', available: 0, replicas: 0 }],
       { errorRatio: -1, inboundErrorRatio: -1, outboundErrorRatio: -1 },
-      600
+      { rateInterval: 600, hasSidecar: true }
     );
 
     // SMALL
@@ -94,7 +94,7 @@ describe('HealthIndicator', () => {
     const health = new AppHealth(
       [{ name: 'A', available: 1, replicas: 1 }],
       { errorRatio: 0.3, inboundErrorRatio: 0.1, outboundErrorRatio: 0.2 },
-      600
+      { rateInterval: 600, hasSidecar: true }
     );
 
     // SMALL

--- a/src/components/Health/__tests__/__snapshots__/HealthDetails.test.tsx.snap
+++ b/src/components/Health/__tests__/__snapshots__/HealthDetails.test.tsx.snap
@@ -6,6 +6,10 @@ ShallowWrapper {
   Symbol(enzyme.__unrendered__): <HealthDetails
     health={
       ServiceHealth {
+        "ctx": Object {
+          "hasSidecar": true,
+          "rateInterval": 60,
+        },
         "items": Array [
           Object {
             "status": Object {
@@ -18,7 +22,6 @@ ShallowWrapper {
             "title": "Error Rate",
           },
         ],
-        "rateInterval": 60,
         "requests": Object {
           "errorRatio": -1,
           "inboundErrorRatio": -1,
@@ -197,6 +200,10 @@ ShallowWrapper {
   Symbol(enzyme.__unrendered__): <HealthDetails
     health={
       ServiceHealth {
+        "ctx": Object {
+          "hasSidecar": true,
+          "rateInterval": 60,
+        },
         "items": Array [
           Object {
             "status": Object {
@@ -209,7 +216,6 @@ ShallowWrapper {
             "title": "Error Rate",
           },
         ],
-        "rateInterval": 60,
         "requests": Object {
           "errorRatio": -1,
           "inboundErrorRatio": -1,

--- a/src/components/Health/__tests__/__snapshots__/HealthIndicator.test.tsx.snap
+++ b/src/components/Health/__tests__/__snapshots__/HealthIndicator.test.tsx.snap
@@ -6,6 +6,10 @@ ShallowWrapper {
   Symbol(enzyme.__unrendered__): <HealthIndicator
     health={
       AppHealth {
+        "ctx": Object {
+          "hasSidecar": true,
+          "rateInterval": 600,
+        },
         "items": Array [
           Object {
             "children": Array [
@@ -66,7 +70,6 @@ ShallowWrapper {
             "title": "Error Rate over last 10 min",
           },
         ],
-        "rateInterval": 600,
         "requests": Object {
           "errorRatio": -1,
           "inboundErrorRatio": -1,
@@ -123,6 +126,10 @@ ShallowWrapper {
         <HealthDetails
           health={
             AppHealth {
+              "ctx": Object {
+                "hasSidecar": true,
+                "rateInterval": 600,
+              },
               "items": Array [
                 Object {
                   "children": Array [
@@ -183,7 +190,6 @@ ShallowWrapper {
                   "title": "Error Rate over last 10 min",
                 },
               ],
-              "rateInterval": 600,
               "requests": Object {
                 "errorRatio": -1,
                 "inboundErrorRatio": -1,
@@ -259,6 +265,10 @@ ShallowWrapper {
           <HealthDetails
             health={
               AppHealth {
+                "ctx": Object {
+                  "hasSidecar": true,
+                  "rateInterval": 600,
+                },
                 "items": Array [
                   Object {
                     "children": Array [
@@ -319,7 +329,6 @@ ShallowWrapper {
                     "title": "Error Rate over last 10 min",
                   },
                 ],
-                "rateInterval": 600,
                 "requests": Object {
                   "errorRatio": -1,
                   "inboundErrorRatio": -1,

--- a/src/pages/AppList/AppListClass.tsx
+++ b/src/pages/AppList/AppListClass.tsx
@@ -14,7 +14,7 @@ export namespace AppListClass {
         namespace: data.namespace.name,
         name: app.name,
         istioSidecar: app.istioSidecar,
-        healthPromise: API.getAppHealth(authentication(), data.namespace.name, app.name, rateInterval)
+        healthPromise: API.getAppHealth(authentication(), data.namespace.name, app.name, rateInterval, app.istioSidecar)
       }));
     }
     return [];

--- a/src/pages/ServiceList/ServiceListComponent.tsx
+++ b/src/pages/ServiceList/ServiceListComponent.tsx
@@ -134,7 +134,13 @@ class ServiceListComponent extends ListComponent.Component<
         name: service.name,
         istioSidecar: service.istioSidecar,
         namespace: data.namespace.name,
-        healthPromise: API.getServiceHealth(authentication(), data.namespace.name, service.name, rateInterval)
+        healthPromise: API.getServiceHealth(
+          authentication(),
+          data.namespace.name,
+          service.name,
+          rateInterval,
+          service.istioSidecar
+        )
       }));
     }
     return [];

--- a/src/pages/ServiceList/__tests__/ItemDescription.test.tsx
+++ b/src/pages/ServiceList/__tests__/ItemDescription.test.tsx
@@ -4,7 +4,10 @@ import ItemDescription from '../ItemDescription';
 import { ServiceHealth } from '../../../types/Health';
 import { ServiceListItem } from '../../../types/ServiceList';
 
-const health = new ServiceHealth({ errorRatio: 0.1, inboundErrorRatio: 0.17, outboundErrorRatio: -1 }, 60);
+const health = new ServiceHealth(
+  { errorRatio: 0.1, inboundErrorRatio: 0.17, outboundErrorRatio: -1 },
+  { rateInterval: 60, hasSidecar: true }
+);
 
 describe('ItemDescription', () => {
   let resolver;

--- a/src/pages/ServiceList/__tests__/ServiceListComponent.test.ts
+++ b/src/pages/ServiceList/__tests__/ServiceListComponent.test.ts
@@ -4,7 +4,10 @@ import { ServiceListFilters } from '../FiltersAndSorts';
 
 const makeService = (name: string, errRatio: number): ServiceListItem & { health: ServiceHealth } => {
   const reqErrs: RequestHealth = { errorRatio: errRatio, inboundErrorRatio: errRatio, outboundErrorRatio: -1 };
-  return { name: name, health: new ServiceHealth(reqErrs, 60) } as ServiceListItem & {
+  return {
+    name: name,
+    health: new ServiceHealth(reqErrs, { rateInterval: 60, hasSidecar: true })
+  } as ServiceListItem & {
     health: ServiceHealth;
   };
 };

--- a/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -129,28 +129,22 @@ class WorkloadDetails extends React.Component<RouteComponentProps<WorkloadId>, W
   };
 
   fetchWorkload = () => {
-    const promiseDetails = API.getWorkload(
-      authentication(),
-      this.props.match.params.namespace,
-      this.props.match.params.workload
-    );
-
-    const promiseHealth = API.getWorkloadHealth(
-      authentication(),
-      this.props.match.params.namespace,
-      this.props.match.params.workload,
-      600
-    );
-
-    Promise.all([promiseDetails, promiseHealth])
-      .then(([resultDetails, resultHealth]) => {
+    API.getWorkload(authentication(), this.props.match.params.namespace, this.props.match.params.workload)
+      .then(details => {
         this.setState({
-          workload: resultDetails.data,
-          validations: this.workloadValidations(resultDetails.data),
-          istioEnabled: resultDetails.data.istioSidecar,
-          health: resultHealth
+          workload: details.data,
+          validations: this.workloadValidations(details.data),
+          istioEnabled: details.data.istioSidecar
         });
+        return API.getWorkloadHealth(
+          authentication(),
+          this.props.match.params.namespace,
+          this.props.match.params.workload,
+          600,
+          details.data.istioSidecar
+        );
       })
+      .then(health => this.setState({ health: health }))
       .catch(error => {
         MessageCenter.add(API.getErrorMsg('Could not fetch Workload', error));
       });

--- a/src/pages/WorkloadList/WorkloadListComponent.tsx
+++ b/src/pages/WorkloadList/WorkloadListComponent.tsx
@@ -118,7 +118,8 @@ class WorkloadListComponent extends ListComponent.Component<
           authentication(),
           data.namespace.name,
           deployment.name,
-          this.state.rateInterval
+          this.state.rateInterval,
+          deployment.istioSidecar
         )
       }));
     }

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -250,11 +250,12 @@ export const getServiceHealth = (
   auth: AuthToken,
   namespace: string,
   service: string,
-  durationSec: number
+  durationSec: number,
+  hasSidecar: boolean
 ): Promise<ServiceHealth> => {
   const params = durationSec ? { rateInterval: String(durationSec) + 's' } : {};
   return newRequest(HTTP_VERBS.GET, urls.serviceHealth(namespace, service), params, {}, auth).then(response =>
-    ServiceHealth.fromJson(response.data, durationSec)
+    ServiceHealth.fromJson(response.data, { rateInterval: durationSec, hasSidecar: hasSidecar })
   );
 };
 
@@ -262,11 +263,12 @@ export const getAppHealth = (
   auth: AuthToken,
   namespace: string,
   app: string,
-  durationSec: number
+  durationSec: number,
+  hasSidecar: boolean
 ): Promise<AppHealth> => {
   const params = durationSec ? { rateInterval: String(durationSec) + 's' } : {};
   return newRequest(HTTP_VERBS.GET, urls.appHealth(namespace, app), params, {}, auth).then(response =>
-    AppHealth.fromJson(response.data, durationSec)
+    AppHealth.fromJson(response.data, { rateInterval: durationSec, hasSidecar: hasSidecar })
   );
 };
 
@@ -274,11 +276,12 @@ export const getWorkloadHealth = (
   auth: AuthToken,
   namespace: string,
   workload: string,
-  durationSec: number
+  durationSec: number,
+  hasSidecar: boolean
 ): Promise<WorkloadHealth> => {
   const params = durationSec ? { rateInterval: String(durationSec) + 's' } : {};
   return newRequest(HTTP_VERBS.GET, urls.workloadHealth(namespace, workload), params, {}, auth).then(response =>
-    WorkloadHealth.fromJson(response.data, durationSec)
+    WorkloadHealth.fromJson(response.data, { rateInterval: durationSec, hasSidecar: hasSidecar })
   );
 };
 
@@ -296,7 +299,7 @@ export const getNamespaceAppHealth = (
   return newRequest(HTTP_VERBS.GET, urls.namespaceHealth(namespace), params, {}, auth).then(response => {
     const ret: NamespaceAppHealth = {};
     Object.keys(response.data).forEach(k => {
-      ret[k] = AppHealth.fromJson(response.data[k], durationSec);
+      ret[k] = AppHealth.fromJson(response.data[k], { rateInterval: durationSec, hasSidecar: true });
     });
     return ret;
   });
@@ -316,7 +319,7 @@ export const getNamespaceServiceHealth = (
   return newRequest(HTTP_VERBS.GET, urls.namespaceHealth(namespace), params, {}, auth).then(response => {
     const ret: NamespaceServiceHealth = {};
     Object.keys(response.data).forEach(k => {
-      ret[k] = ServiceHealth.fromJson(response.data[k], durationSec);
+      ret[k] = ServiceHealth.fromJson(response.data[k], { rateInterval: durationSec, hasSidecar: true });
     });
     return ret;
   });
@@ -336,7 +339,7 @@ export const getNamespaceWorkloadHealth = (
   return newRequest(HTTP_VERBS.GET, urls.namespaceHealth(namespace), params, {}, auth).then(response => {
     const ret: NamespaceWorkloadHealth = {};
     Object.keys(response.data).forEach(k => {
-      ret[k] = WorkloadHealth.fromJson(response.data[k], durationSec);
+      ret[k] = WorkloadHealth.fromJson(response.data[k], { rateInterval: durationSec, hasSidecar: true });
     });
     return ret;
   });
@@ -404,7 +407,7 @@ export const getServiceDetail = (
     const info: ServiceDetailsInfo = r.data;
     if (info.health) {
       // Default rate interval in backend = 600s
-      info.health = ServiceHealth.fromJson(info.health, 600);
+      info.health = ServiceHealth.fromJson(info.health, { rateInterval: 600, hasSidecar: info.istioSidecar });
     }
     return info;
   });

--- a/src/services/__tests__/ApiMethods.test.tsx.ts
+++ b/src/services/__tests__/ApiMethods.test.tsx.ts
@@ -94,7 +94,7 @@ describe('#Test Methods return a Promise', () => {
   });
 
   it('#getServiceHealth', () => {
-    const result = API.getServiceHealth(authentication(), 'istio-system', 'book-info', 60);
+    const result = API.getServiceHealth(authentication(), 'istio-system', 'book-info', 60, true);
     evaluatePromise(result);
   });
 

--- a/src/types/__tests__/Health.test.ts
+++ b/src/types/__tests__/Health.test.ts
@@ -96,4 +96,20 @@ describe('Health', () => {
     );
     expect(health.getGlobalStatus()).toEqual(H.FAILURE);
   });
+  it('should not ignore error rates when has sidecar', () => {
+    const health = new H.AppHealth(
+      [{ available: 1, replicas: 1, name: 'a' }],
+      { errorRatio: 0, inboundErrorRatio: 0, outboundErrorRatio: 0 },
+      { rateInterval: 60, hasSidecar: true }
+    );
+    expect(health.items).toHaveLength(2);
+  });
+  it('should ignore error rates when no sidecar', () => {
+    const health = new H.AppHealth(
+      [{ available: 1, replicas: 1, name: 'a' }],
+      { errorRatio: 0, inboundErrorRatio: 0, outboundErrorRatio: 0 },
+      { rateInterval: 60, hasSidecar: false }
+    );
+    expect(health.items).toHaveLength(1);
+  });
 });

--- a/src/types/__tests__/Health.test.ts
+++ b/src/types/__tests__/Health.test.ts
@@ -60,7 +60,7 @@ describe('Health', () => {
     const health = new H.AppHealth(
       [{ available: 0, replicas: 1, name: 'a' }],
       { errorRatio: 1, inboundErrorRatio: 1, outboundErrorRatio: 1 },
-      60
+      { rateInterval: 60, hasSidecar: true }
     );
     expect(health.getGlobalStatus()).toEqual(H.FAILURE);
   });
@@ -68,7 +68,7 @@ describe('Health', () => {
     const health = new H.AppHealth(
       [{ available: 1, replicas: 1, name: 'a' }, { available: 2, replicas: 2, name: 'b' }],
       { errorRatio: 0, inboundErrorRatio: 0, outboundErrorRatio: 0 },
-      60
+      { rateInterval: 60, hasSidecar: true }
     );
     expect(health.getGlobalStatus()).toEqual(H.HEALTHY);
   });
@@ -76,7 +76,7 @@ describe('Health', () => {
     const health = new H.AppHealth(
       [{ available: 1, replicas: 1, name: 'a' }, { available: 1, replicas: 2, name: 'b' }],
       { errorRatio: 0, inboundErrorRatio: 0, outboundErrorRatio: 0 },
-      60
+      { rateInterval: 60, hasSidecar: true }
     );
     expect(health.getGlobalStatus()).toEqual(H.DEGRADED);
   });
@@ -84,7 +84,7 @@ describe('Health', () => {
     const health = new H.AppHealth(
       [{ available: 1, replicas: 1, name: 'a' }, { available: 2, replicas: 2, name: 'b' }],
       { errorRatio: 0.2, inboundErrorRatio: 0.3, outboundErrorRatio: 0.1 },
-      60
+      { rateInterval: 60, hasSidecar: true }
     );
     expect(health.getGlobalStatus()).toEqual(H.FAILURE);
   });
@@ -92,7 +92,7 @@ describe('Health', () => {
     const health = new H.AppHealth(
       [{ available: 0, replicas: 0, name: 'a' }, { available: 0, replicas: 0, name: 'b' }],
       { errorRatio: 0.2, inboundErrorRatio: 0.3, outboundErrorRatio: 0.1 },
-      60
+      { rateInterval: 60, hasSidecar: true }
     );
     expect(health.getGlobalStatus()).toEqual(H.FAILURE);
   });


### PR DESCRIPTION
When pods are not istio-sidecared, just omit requests errors in health
(or in case of ServiceHealth where this is the only item checked, just write n/a - no sidecar)

JIRA: https://issues.jboss.org/browse/KIALI-1469
