### PR TITLE
KIALI-2388 Prevent filter and hide fields from reseting on refresh

### DIFF
--- a/src/components/GraphFilter/GraphFind.tsx
+++ b/src/components/GraphFilter/GraphFind.tsx
@@ -57,14 +57,18 @@ export class GraphFind extends React.PureComponent<GraphFindProps> {
   // that applying the find/hide on update is sufficient because  we will be updated after the cy is loaded
   // due to a change notification for this.props.cyData.
   componentDidUpdate(prevProps: GraphFindProps) {
-    // make sure the input box reflects the redux value
-    this.findInputRef.value = this.props.findValue;
-    this.hideInputRef.value = this.props.hideValue;
-
     const findChanged = this.props.findValue !== prevProps.findValue;
     const hideChanged = this.props.hideValue !== prevProps.hideValue;
     const graphChanged =
       this.props.cyData && prevProps.cyData && this.props.cyData.updateTimestamp !== prevProps.cyData.updateTimestamp;
+
+    // make sure the value is updated if there was a change
+    if (findChanged) {
+      this.findInputValue = this.props.findValue;
+    }
+    if (hideChanged) {
+      this.hideInputValue = this.props.hideValue;
+    }
 
     if (findChanged || (graphChanged && this.props.findValue)) {
       this.handleFind();
@@ -87,6 +91,7 @@ export class GraphFind extends React.PureComponent<GraphFindProps> {
                   this.findInputRef = ref;
                 }}
                 onChange={this.updateFind}
+                defaultValue={this.findInputValue !== undefined ? this.findInputValue : this.props.findValue}
                 onKeyPress={this.checkSubmitFind}
                 placeholder="Find..."
               />
@@ -102,6 +107,7 @@ export class GraphFind extends React.PureComponent<GraphFindProps> {
                   this.hideInputRef = ref;
                 }}
                 onChange={this.updateHide}
+                defaultValue={this.hideInputValue !== undefined ? this.hideInputValue : this.props.hideValue}
                 onKeyPress={this.checkSubmitHide}
                 placeholder="Hide..."
               />


### PR DESCRIPTION
** Describe the change **

Instead of always using the redux property, it checks if we already started any typing and uses that value.

** Screenshot **

![peek 19-02-2019 16-33](https://user-images.githubusercontent.com/3845764/53052347-137f6200-3464-11e9-965c-62e98ef75917.gif)


Add a screenshot of the UI after your changes.

