### PR TITLE
Add tippy.js for cytoscape context menu on Nodes/Edges

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "cytoscape-cola": "2.3.0",
     "cytoscape-cose-bilkent": "4.0.0",
     "cytoscape-dagre": "2.2.2",
+    "cytoscape-popper": "1.0.2",
     "d3-format": "1.3.2",
     "deep-freeze": "0.0.1",
     "js-yaml": "3.13.1",
@@ -99,6 +100,7 @@
     "redux-thunk": "2.3.0",
     "reselect": "4.0.0",
     "ssri": "6.0.1",
+    "tippy.js": "3.4.1",
     "typesafe-actions": "3.2.1",
     "typestyle": "2.0.1",
     "visibilityjs": "2.0.2"

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -13,6 +13,8 @@ import InitializingScreen from './InitializingScreen';
 import StartupInitializer from './StartupInitializer';
 import LoginPageContainer from '../pages/Login/LoginPage';
 import { LoginActions } from '../actions/LoginActions';
+import 'tippy.js/dist/tippy.css';
+import 'tippy.js/dist/themes/light-border.css';
 
 /**
  * Use the Patternfly RCUE productized css styles if set by the environment

--- a/src/components/CytoscapeGraph/CytoscapeGraph.scss
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.scss
@@ -1,0 +1,26 @@
+/**
+ * Right-click Context menu styles for graph (using Tippy.js)
+ */
+.kiali-graph-context-menu-container {
+  text-align: left;
+}
+
+.kiali-graph-context-menu-title {
+  text-align: center;
+  font-size: 12px;
+}
+
+.kiali-graph-context-menu-item {
+  text-align: center;
+  font-size: 12px;
+  text-decoration: none;
+  color: #363636;
+  &:hover {
+    background-color: #def3ff;
+    color: #4d5258;
+  }
+}
+
+.kiali-graph-context-menu-item-link {
+  color: #363636;
+}

--- a/src/components/CytoscapeGraph/CytoscapeReactWrapper.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeReactWrapper.tsx
@@ -8,16 +8,29 @@ import cycola from 'cytoscape-cola';
 import dagre from 'cytoscape-dagre';
 import coseBilkent from 'cytoscape-cose-bilkent';
 import GroupCompoundLayout from './Layout/GroupCompoundLayout';
+import popper from 'cytoscape-popper';
+import tippy from 'tippy.js';
 
 cytoscape.use(canvas);
 cytoscape.use(cycola);
 cytoscape.use(dagre);
 cytoscape.use(coseBilkent);
+cytoscape.use(popper);
 cytoscape('layout', 'group-compound-layout', GroupCompoundLayout);
 
-type CytoscapeReactWrapperProps = {};
+type CytoscapeReactWrapperProps = any;
 
 type CytoscapeReactWrapperState = {};
+
+const styleContainer = {
+  height: '100%'
+};
+
+// Keep the browser right-click menu from popping up since have our own context menu
+// @todo: Should turn off browser right-click menus only on Graph page
+window.oncontextmenu = () => {
+  return false;
+};
 
 /**
  * The purpose of this wrapper is very simple and minimal - to provide a long-lived <div> element that can be used
@@ -34,13 +47,32 @@ export class CytoscapeReactWrapper extends React.Component<CytoscapeReactWrapper
   cy: any;
   divParentRef: any;
 
+  // @todo: We need take care of this at global app level
+  private static makeDetailsPageUrl(element: any) {
+    const data = element.data();
+    const namespace = data.namespace;
+    const nodeType = data.nodeType;
+    const workload = data.workload;
+    let app = data.app;
+    let urlNodeType = app;
+    if (nodeType === 'app') {
+      urlNodeType = 'applications';
+    } else if (nodeType === 'service') {
+      urlNodeType = 'services';
+    } else if (workload) {
+      urlNodeType = 'workloads';
+      app = workload;
+    }
+    return `/namespaces/${namespace}/${urlNodeType}/${app}`;
+  }
+
   constructor(props: CytoscapeReactWrapperProps) {
     super(props);
     this.cy = null;
     this.divParentRef = React.createRef();
   }
 
-  // For other components to be able to maniuplate the cy graph.
+  // For other components to be able to manipulate the cy graph.
   getCy() {
     return this.cy;
   }
@@ -60,9 +92,6 @@ export class CytoscapeReactWrapper extends React.Component<CytoscapeReactWrapper
   }
 
   render() {
-    const styleContainer = {
-      height: '100%'
-    };
     return <div id="cy" className="graph" style={styleContainer} ref={this.divParentRef} />;
   }
 
@@ -79,6 +108,11 @@ export class CytoscapeReactWrapper extends React.Component<CytoscapeReactWrapper
     };
 
     this.cy = cytoscape(opts);
+
+    // the context menus need a little bit of time for the DOM to settle down before they are added
+    setTimeout(() => {
+      this.buildContextMenus();
+    }, 50);
   }
 
   destroy() {
@@ -86,6 +120,105 @@ export class CytoscapeReactWrapper extends React.Component<CytoscapeReactWrapper
       this.cy.destroy();
       this.cy = null;
     }
+  }
+
+  // Build right-click menus for the graph
+  private buildContextMenus() {
+    const makeTippyForNode: any = (node: any) => {
+      return tippy(node.popperRef(), {
+        content: (() => {
+          // Remember we on Tippy.js which is html over the cytoscape canvas -- not React JSX
+          // @todo: Refactor this to ReactDOM.render() to use JSX
+          const tippyDiv = document.createElement('div');
+          tippyDiv.setAttribute('align', 'left');
+          const divTitle = document.createElement('div');
+          divTitle.setAttribute('align', 'center');
+          divTitle.setAttribute('style', 'font-size: 12px');
+          const nodeData = node.data();
+          const version = nodeData.version ? `:${nodeData.version}` : '';
+          divTitle.innerHTML = `<strong>${nodeData.app}</strong>:${version}`;
+
+          const detailsPageUrl = CytoscapeReactWrapper.makeDetailsPageUrl(node);
+          const divDetails = document.createElement('div');
+          divDetails.setAttribute('style', 'color: #363636; text-decoration: none; font-size: 12px');
+          divDetails.innerHTML = `<a style='color: #363636' href="${detailsPageUrl}" >Show Details</a>`;
+
+          tippyDiv.append(divTitle);
+          tippyDiv.append(divDetails);
+
+          return tippyDiv;
+        })(),
+        trigger: 'manual',
+        arrow: true,
+        placement: 'bottom',
+        hideOnClick: true,
+        multiple: false,
+        sticky: false,
+        interactive: true,
+        theme: 'light-border',
+        size: 'large'
+      });
+    };
+
+    // add the 'tap' events to trigger tippy context menus for each node
+    this.cy.nodes().each(appNode => {
+      // ignore events if its is coming from a group node
+      if (!appNode.data().isGroup) {
+        appNode.on('cxttapstart taphold', (event: any) => {
+          event.preventDefault();
+          if (event.target) {
+            const tipNode = makeTippyForNode(appNode).instances[0];
+            // hide the tip after 6 seconds otherwise we can get a bunch of persistent tips
+            setTimeout(() => {
+              tipNode./**/ hide();
+            }, 6000);
+            tipNode.show();
+          }
+        });
+      }
+    });
+
+    /**
+     * Uncomment for Edge Context Menus; currently we don't have any use for edge menus
+     */
+    // const makeTippyForEdge: any = (node: any) => {
+    //   return tippy(node.popperRef(), {
+    //     content: (() => {
+    //       const tippyDiv = document.createElement('div');
+    //       tippyDiv.align = 'left';
+    //       const divTitle = document.createElement('div');
+    //       divTitle.setAttribute('align', 'center');
+    //       divTitle.innerHTML = `<strong>Edge Properties</strong>`;
+    //       const divProtocol = document.createElement('div');
+    //       const nodeData = node.data();
+    //       divProtocol.innerHTML = `<strong>Protocol:</strong> ${nodeData.protocol}`;
+    //       tippyDiv.append(divTitle);
+    //       tippyDiv.append(divProtocol);
+    //       return tippyDiv;
+    //     })(),
+    //     trigger: 'manual',
+    //     arrow: true,
+    //     followCursor: true,
+    //     placement: 'bottom',
+    //     distance: -45, // shouldn't have to do this but you do or else the tip is a couple cm below the edge
+    //     hideOnClick: true,
+    //     multiple: false,
+    //     sticky: false,
+    //     interactive: false,
+    //     theme: 'light-border',
+    //     size: 'large'
+    //   });
+    // };
+    //
+    // // add the 'tap' events to trigger tippy context menus for each edge
+    // this.cy.edges().each(edgeNode => {
+    //   edgeNode.on('cxttapstart taphold', (event: any) => {
+    //     if (event.target) {
+    //       const tipNode = makeTippyForEdge(edgeNode).instances[0];
+    //       tipNode.show();
+    //     }
+    //   });
+    // });
   }
 }
 

--- a/src/components/CytoscapeGraph/CytoscapeReactWrapper.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeReactWrapper.tsx
@@ -22,12 +22,12 @@ type CytoscapeReactWrapperProps = any;
 
 type CytoscapeReactWrapperState = {};
 
-const styleContainer = {
+const styleContainer: React.CSSProperties = {
   height: '100%'
 };
 
 // Keep the browser right-click menu from popping up since have our own context menu
-// @todo: Should turn off browser right-click menus only on Graph page
+// @todo: Should turn off browser right-click menus on Graph page only?
 window.oncontextmenu = () => {
   return false;
 };
@@ -42,6 +42,10 @@ window.oncontextmenu = () => {
  * Other than creating and initializing the cy graph, this component should do nothing else. Parent components
  * should get a ref to this component can call getCy() in order to perform additional processing on the graph.
  * It is the job of the parent component to manipulate and update the cy graph during runtime.
+ *
+ * NOTE: The context menu stuff is defined in the CytoscapeReactWrapper because that is
+ * where the cytoscape plugins are defined. And the context menu functions are defined in
+ * here because they are not normal Cytoscape defined functions like those found in CytoscapeGraph.
  */
 export class CytoscapeReactWrapper extends React.Component<CytoscapeReactWrapperProps, CytoscapeReactWrapperState> {
   cy: any;
@@ -130,21 +134,20 @@ export class CytoscapeReactWrapper extends React.Component<CytoscapeReactWrapper
           // Remember we on Tippy.js which is html over the cytoscape canvas -- not React JSX
           // @todo: Refactor this to ReactDOM.render() to use JSX
           const tippyDiv = document.createElement('div');
-          tippyDiv.setAttribute('align', 'left');
+          tippyDiv.setAttribute('class', 'kiali-graph-context-menu-container');
           const divTitle = document.createElement('div');
-          divTitle.setAttribute('align', 'center');
-          divTitle.setAttribute('style', 'font-size: 12px');
+          divTitle.setAttribute('class', 'kiali-graph-context-menu-title');
           const nodeData = node.data();
-          const version = nodeData.version ? `:${nodeData.version}` : '';
+          const version = nodeData.version ? `${nodeData.version}` : '';
           divTitle.innerHTML = `<strong>${nodeData.app}</strong>:${version}`;
 
           const detailsPageUrl = CytoscapeReactWrapper.makeDetailsPageUrl(node);
-          const divDetails = document.createElement('div');
-          divDetails.setAttribute('style', 'color: #363636; text-decoration: none; font-size: 12px');
-          divDetails.innerHTML = `<a style='color: #363636' href="${detailsPageUrl}" >Show Details</a>`;
+          const divDetailsItem = document.createElement('div');
+          divDetailsItem.setAttribute('class', 'kiali-graph-context-menu-item');
+          divDetailsItem.innerHTML = `<a class='kiali-graph-context-menu-item-link' href="${detailsPageUrl}" >Show Details</a>`;
 
           tippyDiv.append(divTitle);
-          tippyDiv.append(divDetails);
+          tippyDiv.append(divDetailsItem);
 
           return tippyDiv;
         })(),
@@ -170,7 +173,7 @@ export class CytoscapeReactWrapper extends React.Component<CytoscapeReactWrapper
             const tipNode = makeTippyForNode(appNode).instances[0];
             // hide the tip after 6 seconds otherwise we can get a bunch of persistent tips
             setTimeout(() => {
-              tipNode./**/ hide();
+              tipNode.hide();
             }, 6000);
             tipNode.show();
           }

--- a/src/components/CytoscapeGraph/CytoscapeReactWrapper.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeReactWrapper.tsx
@@ -27,9 +27,9 @@ const styleContainer: React.CSSProperties = {
 };
 
 // Keep the browser right-click menu from popping up since have our own context menu
-// @todo: Should turn off browser right-click menus on Graph page only?
 window.oncontextmenu = () => {
-  return false;
+  // turn off browser right-click menus on Graph page only
+  return !window.location.pathname.includes('graph');
 };
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -3085,6 +3085,13 @@ cytoscape-dagre@2.2.2:
   dependencies:
     dagre "^0.8.2"
 
+cytoscape-popper@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/cytoscape-popper/-/cytoscape-popper-1.0.2.tgz#0c2bab6cf5ca504144c7eb42fe44638ff0e3bb9c"
+  integrity sha512-1ihKND9OTgG24U/vBzUuOEsMem9gAek83b98QjP7piKkyRdpPwwxZFVDuDCsjWendNocAKFOsxHDF7RD3J5/Pw==
+  dependencies:
+    popper.js "^1.0.0"
+
 cytoscape@3.6.1:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/cytoscape/-/cytoscape-3.6.1.tgz#96cfc9c60b7147b043a4a47bd55bde2cc6d333eb"
@@ -8170,6 +8177,11 @@ pn@^1.1.0:
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
   integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
 
+popper.js@^1.0.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.15.0.tgz#5560b99bbad7647e9faa475c6b8056621f5a4ff2"
+  integrity sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA==
+
 popper.js@^1.14.4:
   version "1.14.6"
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.14.6.tgz#ab20dd4edf9288b8b3b6531c47c361107b60b4b0"
@@ -10973,7 +10985,7 @@ tiny-warning@^1.0.0:
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.2.tgz#1dfae771ee1a04396bdfde27a3adcebc6b648b28"
   integrity sha512-rru86D9CpQRLvsFG5XFdy0KdLAvjdQDyZCsRcuu60WtzFylDM3eAWSxEVz5kzL2Gp544XiUvPbVKtOA/txLi9Q==
 
-tippy.js@^3.2.0:
+tippy.js@3.4.1, tippy.js@^3.2.0:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/tippy.js/-/tippy.js-3.4.1.tgz#f0eb3081824ad6c5d364336451ad77ae2f543da8"
   integrity sha512-ZiyGP9WZyCCcjxKM4G88cm4U1r1ytjeMDGa5FSKPaPzwc/3yZJVZsb1ffcmqUMCpryRp5LNxRNGKLzbs11sb/Q==


### PR DESCRIPTION
** Describe the change **
This PoC uses tippy.js to add a right-click context menu to the graph for extended functionality

- [x] Right click action menu for Nodes/Services
- [x] For nodes/services add **Show Detail** Action as a shortcut to that screen
- [x] Move style information into SASS
- [x] Globally turn off right click so that we don’t get a menu from the browser 
- [x] Add a 6 second timeout so that the context menus goes away in 6 seconds (or else you can have multiple context menus open on the screen which looks very strange)
- [x] Since we have to override the browser right-click capability and that is a global change off of `window` it effectively **disabled** right-clicking to get the browser context menu everywhere in the app. I have overcome this by only disabling the right-click on the graph page (which the whole canvas has right click disabled anyway).

** Issue reference **
https://issues.jboss.org/browse/KIALI-2271
https://github.com/kiali/kiali-design/issues/104

** Backwards compatible? **
Yes
[ ] Is your pull-request introducing changes in behaviour?

_Describe the changes if appropriate. E.g. a new link, a change on what a click does, etc_

** Screenshot **
For a node:
![context-click](https://user-images.githubusercontent.com/1312165/55591071-79a90700-56e9-11e9-8aad-828d1e4a0487.gif)


** Documentation **

https://atomiks.github.io/tippyjs/

