### PR TITLE
KIALI-2437 Show "n/a" when there is an error reading the error tr…

### DIFF
--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
-import { Nav, NavItem, TabContainer, TabContent, TabPane, Icon } from 'patternfly-react';
+import { Nav, NavItem, TabContainer, TabContent, TabPane, Icon, OverlayTrigger, Tooltip } from 'patternfly-react';
 import ServiceId from '../../types/ServiceId';
 import * as API from '../../services/Api';
 import * as MessageCenter from '../../utils/MessageCenter';
@@ -177,7 +177,23 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
                   <div>
                     Error Traces{' '}
                     <span>
-                      ({errorTraces}
+                      (
+                      {errorTraces !== -1 ? (
+                        errorTraces
+                      ) : (
+                        <OverlayTrigger
+                          overlay={
+                            <Tooltip id="error-trace-unknown-tooltip">
+                              There was a problem loading the <b>Error Trace</b> count from the server
+                            </Tooltip>
+                          }
+                          placement="top"
+                          trigger={['hover', 'focus']}
+                          rootClose={false}
+                        >
+                          <span>Unknown</span>
+                        </OverlayTrigger>
+                      )}
                       {errorTraces > 0 && (
                         <Icon type={'fa'} name={'exclamation-circle'} style={{ color: 'red', marginLeft: '2px' }} />
                       )}

--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -191,7 +191,7 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
                           trigger={['hover', 'focus']}
                           rootClose={false}
                         >
-                          <span>Unknown</span>
+                          <span>n/a</span>
                         </OverlayTrigger>
                       )}
                       {errorTraces > 0 && (


### PR DESCRIPTION
…ace count

** Describe the change **

Shows `n/a` instead of `-1` in the UI when there was an error reading the "error trace" count.

I'm not sure if we want to give more context about the error or if is fine as is for now.

** Screenshot **

![peek 25-02-2019 09-54](https://user-images.githubusercontent.com/3845764/53349721-56698b80-38e3-11e9-8948-81a4f3b089a2.gif)
