### PR TITLE
KIALI-2150 Fix VirtualService Route graph

### DIFF
--- a/src/pages/ServiceDetails/ServiceInfo/IstioObjectDetails/VirtualServiceRoute.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/IstioObjectDetails/VirtualServiceRoute.tsx
@@ -220,11 +220,15 @@ class VirtualServiceRoute extends React.Component<VirtualServiceRouteProps> {
 
   destinationFrom(destinationWeight: DestinationWeight, i: number, isValid: boolean) {
     const destination = destinationWeight.destination;
-    return {
-      host: this.serviceLink(this.props.namespace, destination.host, isValid),
-      subset: destination.subset || '-',
-      port: destination.port ? destination.port.number || '-' : '-'
-    };
+    if (destination) {
+      return {
+        host: this.serviceLink(this.props.namespace, destination.host, isValid),
+        subset: destination.subset || '-',
+        port: destination.port ? destination.port.number || '-' : '-'
+      };
+    } else {
+      return { host: '-', subset: '-', port: '-' };
+    }
   }
 
   infotipContent(checks: ObjectCheck[]) {
@@ -267,13 +271,17 @@ class VirtualServiceRoute extends React.Component<VirtualServiceRouteProps> {
   }
 
   renderDestination(destination: Destination) {
-    return (
-      <ul style={{ listStyleType: 'none', paddingLeft: '15px' }}>
-        <li>Host: {destination.host || '-'} </li>
-        <li>Subset: {destination.subset || '-'} </li>
-        <li>Port: {destination.port ? destination.port.number : '-'} </li>
-      </ul>
-    );
+    if (destination) {
+      return (
+        <ul style={{ listStyleType: 'none', paddingLeft: '15px' }}>
+          <li>Host: {destination.host || '-'} </li>
+          <li>Subset: {destination.subset || '-'} </li>
+          <li>Port: {destination.port ? destination.port.number : '-'} </li>
+        </ul>
+      );
+    } else {
+      return undefined;
+    }
   }
 
   renderTable(route: any, i: number) {


### PR DESCRIPTION
** Describe the change **
Wrong formatted Virtual Service now doesn't break the console.
This is just a quick patch bc we accorded to strong type the backend (and also rely on Galley) to ensure that all the data from backend have proper formats.

** Issue reference **
https://issues.jboss.org/browse/KIALI-2150

** Screenshot **
![screenshot of kiali console 49](https://user-images.githubusercontent.com/613814/53247121-d1982b00-36b2-11e9-84b3-902b1d550951.png)

![screenshot of kiali console 50](https://user-images.githubusercontent.com/613814/53247151-ed033600-36b2-11e9-8997-e716c56c841c.png)

![screenshot of kiali console 51](https://user-images.githubusercontent.com/613814/53247154-eeccf980-36b2-11e9-994d-ff654cc14353.png)
