### PR TITLE
KIALI-2481 filter empty runtimes (minor change)

### DIFF
--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadDescription.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadDescription.tsx
@@ -68,6 +68,7 @@ class WorkloadDescription extends React.Component<WorkloadDescriptionProps, Work
                 <div>
                   <br />
                   {workload.runtimes
+                    .filter(r => r.name !== '')
                     .map((rt, idx) => this.renderLogo(rt.name, idx))
                     .reduce(
                       (list: JSX.Element[], elem) => (list ? [...list, <span key="sep"> | </span>, elem] : [elem]),


### PR DESCRIPTION
This change allows a user to not provide a runtime for a given dashboard (ex: an application-specific dashboard) so that it won't appear in runtimes list

JIRA: https://issues.jboss.org/browse/KIALI-2481