### PR TITLE
KIALI-2492 Fix changing duration in metrics page

### DIFF
--- a/src/components/MetricsOptions/MetricsDuration.tsx
+++ b/src/components/MetricsOptions/MetricsDuration.tsx
@@ -22,7 +22,6 @@ export class MetricsDuration extends React.Component<Props> {
   // Default to 10 minutes. Showing timeseries to only 1 minute doesn't make so much sense.
   static DefaultDuration = 600;
 
-  private shouldReportOptions: boolean;
   private duration: DurationInSeconds;
 
   static initialDuration = (): DurationInSeconds => {
@@ -38,22 +37,17 @@ export class MetricsDuration extends React.Component<Props> {
 
   constructor(props: Props) {
     super(props);
-  }
-
-  componentDidUpdate() {
-    if (this.shouldReportOptions) {
-      this.shouldReportOptions = false;
-      this.props.onChanged(this.duration);
-    }
+    this.duration = MetricsDuration.initialDuration();
   }
 
   onDurationChanged = (key: string) => {
     sessionStorage.setItem(URLParams.DURATION, key);
     HistoryManager.setParam(URLParams.DURATION, key);
+    this.duration = Number(key);
+    this.props.onChanged(this.duration);
   };
 
   render() {
-    this.processUrlParams();
     const retention = this.props.serverConfig.prometheus.storageTsdbRetention;
     const validDurations = getValidDurations(MetricsDuration.Durations, retention);
     const validDuration = getValidDuration(validDurations, this.duration);
@@ -69,12 +63,6 @@ export class MetricsDuration extends React.Component<Props> {
         options={validDurations}
       />
     );
-  }
-
-  processUrlParams() {
-    const duration = MetricsDuration.initialDuration();
-    this.shouldReportOptions = duration !== this.duration;
-    this.duration = duration;
   }
 }
 

--- a/src/components/MetricsOptions/MetricsRawAggregation.tsx
+++ b/src/components/MetricsOptions/MetricsRawAggregation.tsx
@@ -18,7 +18,6 @@ export default class MetricsRawAggregation extends React.Component<Props> {
     stdvar: 'Standard variance'
   };
 
-  private shouldReportOptions: boolean;
   private aggregator: Aggregator;
 
   static initialAggregator = (): Aggregator => {
@@ -32,21 +31,16 @@ export default class MetricsRawAggregation extends React.Component<Props> {
 
   constructor(props: Props) {
     super(props);
-  }
-
-  componentDidUpdate() {
-    if (this.shouldReportOptions) {
-      this.shouldReportOptions = false;
-      this.props.onChanged(this.aggregator);
-    }
+    this.aggregator = MetricsRawAggregation.initialAggregator();
   }
 
   onAggregatorChanged = (aggregator: string) => {
     HistoryManager.setParam(URLParams.AGGREGATOR, aggregator);
+    this.aggregator = aggregator as Aggregator;
+    this.props.onChanged(this.aggregator);
   };
 
   render() {
-    this.processUrlParams();
     return (
       <ToolbarDropdown
         id={'metrics_filter_aggregator'}
@@ -58,11 +52,5 @@ export default class MetricsRawAggregation extends React.Component<Props> {
         options={MetricsRawAggregation.Aggregators}
       />
     );
-  }
-
-  processUrlParams() {
-    const op = MetricsRawAggregation.initialAggregator();
-    this.shouldReportOptions = op !== this.aggregator;
-    this.aggregator = op;
   }
 }

--- a/src/components/MetricsOptions/MetricsReporter.tsx
+++ b/src/components/MetricsOptions/MetricsReporter.tsx
@@ -15,7 +15,6 @@ export default class MetricsReporter extends React.Component<Props> {
     source: 'Source'
   };
 
-  private shouldReportOptions: boolean;
   private reporter: Reporter;
 
   static initialReporter = (direction: Direction): Reporter => {
@@ -29,21 +28,16 @@ export default class MetricsReporter extends React.Component<Props> {
 
   constructor(props: Props) {
     super(props);
-  }
-
-  componentDidUpdate() {
-    if (this.shouldReportOptions) {
-      this.shouldReportOptions = false;
-      this.props.onChanged(this.reporter);
-    }
+    this.reporter = MetricsReporter.initialReporter(props.direction);
   }
 
   onReporterChanged = (reporter: string) => {
     HistoryManager.setParam(URLParams.REPORTER, reporter);
+    this.reporter = reporter as Reporter;
+    this.props.onChanged(this.reporter);
   };
 
   render() {
-    this.processUrlParams();
     return (
       <ToolbarDropdown
         id={'metrics_filter_reporter'}
@@ -55,11 +49,5 @@ export default class MetricsReporter extends React.Component<Props> {
         options={MetricsReporter.ReporterOptions}
       />
     );
-  }
-
-  processUrlParams() {
-    const reporter = MetricsReporter.initialReporter(this.props.direction);
-    this.shouldReportOptions = reporter !== this.reporter;
-    this.reporter = reporter;
   }
 }


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/KIALI-2492

We should not expect changes to be caught on re-rendering, we can deal with it before (as soon as the change hook is called)