### PR TITLE
KIALI-2495 Do not create VS/DR when Matching Wizard is empty

### DIFF
--- a/src/components/IstioWizards/IstioWizard.tsx
+++ b/src/components/IstioWizards/IstioWizard.tsx
@@ -61,11 +61,23 @@ class IstioWizard extends React.Component<Props, State> {
 
   componentDidUpdate(prevProps: Props) {
     if (prevProps.show !== this.props.show || !this.compareWorkloads(prevProps.workloads, this.props.workloads)) {
+      let isValid: boolean;
+      switch (this.props.type) {
+        // By default the rule of Weighted routing should be valid
+        case WIZARD_WEIGHTED_ROUTING:
+          isValid = true;
+          break;
+        // By default no rules is a no valid scenario
+        case WIZARD_MATCHING_ROUTING:
+        default:
+          isValid = false;
+          break;
+      }
       this.setState({
         showWizard: this.props.show,
         workloads: [],
         rules: [],
-        valid: true,
+        valid: isValid,
         mtlsMode: NONE,
         loadBalancer: NONE,
         modified: false

--- a/src/components/IstioWizards/MatchingRouting.tsx
+++ b/src/components/IstioWizards/MatchingRouting.tsx
@@ -171,6 +171,10 @@ class MatchingRouting extends React.Component<Props, State> {
   };
 
   isValid = (rules: Rule[]): boolean => {
+    // Corner case, an empty rules shouldn't be a valid scenario to create a VS/DR
+    if (rules.length === 0) {
+      return false;
+    }
     const matchAll: number = this.matchAllIndex(rules);
     let isValid: boolean = true;
     for (let index = 0; index < this.state.rules.length; index++) {


### PR DESCRIPTION
** Describe the change **

When Matching Wizard is empty and Galley is not working/configured propery. Wizard has "Create" button enabled and it can create an incompleted pair of VS/DR.

With this PR, Matching Wizard only can create VS/DR when matching rules are defined.

** Issue reference **

https://issues.jboss.org/browse/KIALI-2495

** Some screenshots **

![image](https://user-images.githubusercontent.com/1662329/53750813-0d00d980-3eab-11e9-9317-0abca42843c1.png)

