### PR TITLE
KIALI-2484 fix console log error for NA health use case

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -642,15 +642,20 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
     promise
       .then(nsHealth => {
         const health = nsHealth[key];
-        const status = health.getGlobalStatus();
-        ele.removeClass(H.DEGRADED.name + ' ' + H.FAILURE.name);
-        if (status === H.DEGRADED || status === H.FAILURE) {
-          ele.addClass(status.name);
+        if (health) {
+          const status = health.getGlobalStatus();
+          ele.removeClass(H.DEGRADED.name + ' ' + H.FAILURE.name);
+          if (status === H.DEGRADED || status === H.FAILURE) {
+            ele.addClass(status.name);
+          }
+        } else {
+          ele.removeClass(`${H.DEGRADED.name}  ${H.FAILURE.name} ${H.HEALTHY.name}`);
+          console.debug(`No health found for [${ele.data(CyNode.nodeType)}] [${key}]`);
         }
       })
       .catch(err => {
-        ele.removeClass(H.DEGRADED.name + ' ' + H.FAILURE.name);
-        console.error(API.getErrorMsg('Could not fetch health [' + key + ']', err));
+        ele.removeClass(`${H.DEGRADED.name}  ${H.FAILURE.name} ${H.HEALTHY.name}`);
+        console.error(API.getErrorMsg(`Could not fetch health for [${ele.data(CyNode.nodeType)}] [${key}]`, err));
       });
   }
 }


### PR DESCRIPTION
The call to get health information may not return health for every node. There
are valid use cases for no health (like no traffic for the health calc period).
Change to log no health at debug level and only log an error if the call to the
backend fails.
