### PR TITLE
KIALI-2463 Block Wizard Create button until it has finished

### DIFF
--- a/src/components/IstioWizards/IstioWizard.tsx
+++ b/src/components/IstioWizards/IstioWizard.tsx
@@ -247,12 +247,17 @@ class IstioWizard extends React.Component<Props, State> {
     const [dr, vr] = this.createIstioTraffic();
     const createDR = API.createIstioConfigDetail(this.props.namespace, 'destinationrules', JSON.stringify(dr));
     const createVS = API.createIstioConfigDetail(this.props.namespace, 'virtualservices', JSON.stringify(vr));
+    // Disable button before promise is completed. Then Wizard is closed.
+    this.setState({
+      valid: false
+    });
     Promise.all([createDR, createVS])
       .then(results => {
         this.props.onClose(true);
       })
       .catch(error => {
         MessageCenter.add(API.getErrorMsg('Could not create Istio config objects', error));
+        this.props.onClose(true);
       });
   };
 


### PR DESCRIPTION
Minor change.
When onCreate is invoked, disable the "Create" button to avoid multiple clicks.

https://issues.jboss.org/browse/KIALI-2463