### PR TITLE
KIALI-2486 Adding Policy and MeshPolicy validations to IstioConfigList

### DIFF
--- a/src/types/IstioConfigList.ts
+++ b/src/types/IstioConfigList.ts
@@ -223,6 +223,28 @@ export const toIstioItems = (istioConfigList: IstioConfigList): IstioConfigItem[
         : undefined
     })
   );
+  istioConfigList.meshPolicies.forEach(p =>
+    istioItems.push({
+      namespace: istioConfigList.namespace.name,
+      type: 'meshpolicy',
+      name: p.metadata.name,
+      policy: p,
+      validation: hasValidations('meshpolicy', p.metadata.name)
+        ? istioConfigList.validations['meshpolicy'][p.metadata.name]
+        : undefined
+    })
+  );
+  istioConfigList.policies.forEach(p =>
+    istioItems.push({
+      namespace: istioConfigList.namespace.name,
+      type: 'policy',
+      name: p.metadata.name,
+      policy: p,
+      validation: hasValidations('policy', p.metadata.name)
+        ? istioConfigList.validations['policy'][p.metadata.name]
+        : undefined
+    })
+  );
   istioConfigList.rules.forEach(r =>
     istioItems.push({ namespace: istioConfigList.namespace.name, type: 'rule', name: r.metadata.name, rule: r })
   );
@@ -246,22 +268,6 @@ export const toIstioItems = (istioConfigList: IstioConfigList): IstioConfigItem[
       type: 'quotaspecbinding',
       name: qsb.metadata.name,
       quotaSpecBinding: qsb
-    })
-  );
-  istioConfigList.policies.forEach(p =>
-    istioItems.push({
-      namespace: istioConfigList.namespace.name,
-      type: 'policy',
-      name: p.metadata.name,
-      policy: p
-    })
-  );
-  istioConfigList.meshPolicies.forEach(p =>
-    istioItems.push({
-      namespace: istioConfigList.namespace.name,
-      type: 'meshpolicy',
-      name: p.metadata.name,
-      policy: p
     })
   );
   istioConfigList.clusterRbacConfigs.forEach(rc =>


### PR DESCRIPTION
** Describe the change **

IstioConfig list now shows validations for:

- MeshPolicy
- Policy
- ClusterRbacConfig
- ServiceRole
- ServiceRoleBinding

There are only validations for MeshPolicy at the moment. However, KIALI-2392 should add validations for the latest 4 config types.

** Issue reference **
https://issues.jboss.org/browse/KIALI-2486

** Backwards compatible? **
yes

** Screenshot **

![screenshot of kiali console 61](https://user-images.githubusercontent.com/613814/53814126-54e13880-3f5f-11e9-8e8d-db59ad38e05b.png)

![screenshot of kiali console 60](https://user-images.githubusercontent.com/613814/53814134-57dc2900-3f5f-11e9-9ae3-2f5ab3a338e9.png)



