### PR TITLE
KIALI-2504 Don't show the lock icon on the grouping box

### DIFF
--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -152,11 +152,11 @@ export class GraphStyles {
     const getNodeBackgroundImage = (ele: any): string => {
       const isInaccessible = ele.data(CyNode.isInaccessible);
       const isServiceEntry = ele.data(CyNode.isServiceEntry);
-      if (isInaccessible && !isServiceEntry) {
+      const isGroup = ele.data(CyNode.isGroup);
+      if (isInaccessible && !isServiceEntry && !isGroup) {
         return NodeImageKey;
       }
       const isOutside = ele.data(CyNode.isOutside);
-      const isGroup = ele.data(CyNode.isGroup);
       if (isOutside && !isGroup) {
         return NodeImageTopology;
       }


### PR DESCRIPTION
** Describe the change **

Removes the giant lock icon from the application grouping box.

** Issue reference **

https://issues.jboss.org/browse/KIALI-2504

** Screenshot **

Before:

![screenshot from 2019-03-05 16-05-20](https://user-images.githubusercontent.com/691166/53898608-6cbfc780-4006-11e9-8584-81f4a337f0c6.png)

After:

![screenshot from 2019-03-06 11-51-45](https://user-images.githubusercontent.com/691166/53898618-71847b80-4006-11e9-858d-9785e77fd31c.png)