### PR TITLE
KIALI-2273 Fix SessionTimeout dialog

### DIFF
--- a/src/actions/LoginActions.ts
+++ b/src/actions/LoginActions.ts
@@ -6,7 +6,8 @@ enum LoginActionKeys {
   LOGIN_EXTEND = 'LOGIN_EXTEND',
   LOGIN_SUCCESS = 'LOGIN_SUCCESS',
   LOGIN_FAILURE = 'LOGIN_FAILURE',
-  LOGOUT_SUCCESS = 'LOGOUT_SUCCESS'
+  LOGOUT_SUCCESS = 'LOGOUT_SUCCESS',
+  SESSION_EXPIRED = 'SESSION_EXPIRED'
 }
 
 export interface LoginPayload {
@@ -46,7 +47,8 @@ export const LoginActions = {
       session: undefined,
       error: undefined
     } as LoginPayload)
-  )
+  ),
+  sessionExpired: createAction(LoginActionKeys.SESSION_EXPIRED)
 };
 
 export type LoginAction = ActionType<typeof LoginActions>;

--- a/src/actions/LoginActions.ts
+++ b/src/actions/LoginActions.ts
@@ -1,5 +1,3 @@
-import { RawDate } from '../types/Common';
-
 import { ActionType, createAction } from 'typesafe-actions';
 import { LoginSession, LoginStatus } from '../store/Store';
 
@@ -15,7 +13,6 @@ export interface LoginPayload {
   status: LoginStatus;
   session?: LoginSession;
   error?: any;
-  uiExpiresOn: RawDate;
 }
 
 // synchronous action creators

--- a/src/actions/LoginThunkActions.ts
+++ b/src/actions/LoginThunkActions.ts
@@ -10,10 +10,7 @@ import { MessageCenterActions } from './MessageCenterActions';
 const Dispatcher = new Login.LoginDispatcher();
 
 const shouldRelogin = (state?: LoginState): boolean =>
-  !state ||
-  !state.session ||
-  moment(state.session!.expiresOn).diff(moment()) > 0 ||
-  moment(state.uiExpiresOn).diff(moment()) > 0;
+  !state || !state.session || moment(state.session!.expiresOn).diff(moment()) > 0;
 
 const loginSuccess = async (dispatch: KialiDispatch, session: LoginSession) => {
   dispatch(LoginActions.loginSuccess(session));
@@ -56,9 +53,8 @@ const LoginThunkActions = {
       }
     };
   },
-  extendSession: () => {
-    return (dispatch: KialiDispatch, getState: () => KialiAppState) => {
-      const session = getState().authentication!.session!;
+  extendSession: (session: LoginSession) => {
+    return (dispatch: KialiDispatch) => {
       dispatch(LoginActions.loginExtend(session));
     };
   },

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -13,6 +13,7 @@ import history from './History';
 import InitializingScreen from './InitializingScreen';
 import StartupInitializer from './StartupInitializer';
 import LoginPageConnected from '../containers/LoginPageContainer';
+import { LoginActions } from '../actions/LoginActions';
 
 /**
  * Use the Patternfly RCUE productized css styles if set by the environment
@@ -76,6 +77,11 @@ axios.interceptors.response.use(
   error => {
     // The response was rejected, turn off the spinning
     decrementLoadingCounter();
+
+    if (error.response.status === 401) {
+      store.dispatch(LoginActions.sessionExpired());
+    }
+
     return Promise.reject(error);
   }
 );

--- a/src/components/Nav/UserDropdown.tsx
+++ b/src/components/Nav/UserDropdown.tsx
@@ -11,7 +11,7 @@ import moment from 'moment';
 type UserProps = {
   session: LoginSession;
   logout: () => void;
-  extendSession: () => void;
+  extendSession: (session: LoginSession) => void;
 };
 
 type UserState = {
@@ -19,6 +19,7 @@ type UserState = {
   timeCountDownSeconds: number;
   checkSessionTimerId?: Timer;
   timeLeftTimerId?: Timer;
+  isSessionTimeoutDismissed: boolean;
 };
 
 class UserDropdown extends React.Component<UserProps, UserState> {
@@ -26,6 +27,7 @@ class UserDropdown extends React.Component<UserProps, UserState> {
     super(props);
     this.state = {
       showSessionTimeOut: false,
+      isSessionTimeoutDismissed: false,
       timeCountDownSeconds: this.timeLeft() / MILLISECONDS
     };
   }
@@ -59,7 +61,7 @@ class UserDropdown extends React.Component<UserProps, UserState> {
       this.handleLogout();
     }
 
-    return expiresOn.diff(moment(), 'seconds');
+    return expiresOn.diff(moment());
   };
 
   checkSession = () => {
@@ -72,8 +74,8 @@ class UserDropdown extends React.Component<UserProps, UserState> {
     this.props.logout();
   }
 
-  extendSession = () => {
-    this.props.extendSession();
+  extendSession = (session: LoginSession) => {
+    this.props.extendSession(session);
     this.setState({ showSessionTimeOut: false });
   };
 
@@ -81,9 +83,10 @@ class UserDropdown extends React.Component<UserProps, UserState> {
     return (
       <>
         <SessionTimeout
-          logout={this.props.logout}
-          extendSession={this.extendSession}
-          show={this.state.showSessionTimeOut}
+          onLogout={this.props.logout}
+          onExtendSession={this.extendSession}
+          onDismiss={this.dismissHandler}
+          show={this.state.showSessionTimeOut && !this.state.isSessionTimeoutDismissed}
           timeOutCountDown={this.state.timeCountDownSeconds}
         />
         <Dropdown componentClass="li" id="user">
@@ -99,6 +102,10 @@ class UserDropdown extends React.Component<UserProps, UserState> {
       </>
     );
   }
+
+  private dismissHandler = () => {
+    this.setState({ isSessionTimeoutDismissed: true });
+  };
 }
 
 export default UserDropdown;

--- a/src/components/SessionTimeout/SessionTimeout.tsx
+++ b/src/components/SessionTimeout/SessionTimeout.tsx
@@ -2,10 +2,15 @@ import * as React from 'react';
 import { Modal, Button, Icon, Row, Col } from 'patternfly-react';
 import { config } from '../../config';
 import { UNIT_TIME, MILLISECONDS } from '../../types/Common';
+import AppConfigs from '../../app/AppConfigs';
+import { AuthStrategy } from '../../types/Auth';
+import { LoginSession } from '../../store/Store';
+import * as API from '../../services/Api';
 
 type SessionTimeoutProps = {
-  logout: () => void;
-  extendSession: () => void;
+  onLogout: () => void;
+  onExtendSession: (session: LoginSession) => void;
+  onDismiss: () => void;
   show: boolean;
   timeOutCountDown: number;
 };
@@ -16,14 +21,11 @@ export class SessionTimeout extends React.Component<SessionTimeoutProps, {}> {
   }
 
   render() {
-    const extendedTime = config.session.extendedSessionTimeOut
-      ? config.session.extendedSessionTimeOut / (MILLISECONDS * UNIT_TIME.MINUTE)
-      : 30;
     return (
       <Modal
         className={'message-dialog-pf'}
         show={this.props.show}
-        onHide={this.props.logout}
+        onHide={this.props.onLogout}
         enforceFocus={true}
         aria-modal={true}
       >
@@ -34,25 +36,62 @@ export class SessionTimeout extends React.Component<SessionTimeoutProps, {}> {
               <Icon name="warning-triangle-o" type="pf" style={{ fontSize: '48px' }} />
             </Col>
             <Col xs={12} sm={10} md={10} lg={10}>
-              <p className={'lead'}>
-                Your session will timeout in {this.props.timeOutCountDown.toFixed()} seconds.
-                <br />
-                Would you like to extend your session for another {extendedTime} minutes?
-              </p>
+              {AppConfigs.authenticationConfig!.strategy === AuthStrategy.login
+                ? this.textForLoginStrategy()
+                : this.textForOpenshiftStrategy()}
             </Col>
           </Row>
         </Modal.Body>
         <Modal.Footer>
           <React.Fragment>
-            <Button bsStyle={'default'} onClick={this.props.logout}>
+            <Button bsStyle={'default'} onClick={this.props.onLogout}>
               Log Out
             </Button>
-            <Button autoFocus={true} bsStyle={'primary'} onClick={this.props.extendSession}>
-              Continue Session
-            </Button>
+            {AppConfigs.authenticationConfig!.strategy === AuthStrategy.login ? (
+              <Button autoFocus={true} bsStyle={'primary'} onClick={this.extendSessionHandler}>
+                Continue Session
+              </Button>
+            ) : (
+              <Button autoFocus={true} bsStyle={'primary'} onClick={this.props.onDismiss}>
+                OK
+              </Button>
+            )}
           </React.Fragment>
         </Modal.Footer>
       </Modal>
     );
   }
+
+  private extendSessionHandler = async () => {
+    try {
+      const session = await API.extendSession();
+      this.props.onExtendSession(session.data);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  private textForLoginStrategy = () => {
+    const extendedTime = config.session.extendedSessionTimeOut
+      ? config.session.extendedSessionTimeOut / (MILLISECONDS * UNIT_TIME.MINUTE)
+      : 30;
+
+    return (
+      <p className={'lead'}>
+        Your session will timeout in {this.props.timeOutCountDown.toFixed()} seconds.
+        <br />
+        Would you like to extend your session for another {extendedTime} minutes?
+      </p>
+    );
+  };
+
+  private textForOpenshiftStrategy = () => {
+    return (
+      <p className={'lead'}>
+        Your session will timeout in {this.props.timeOutCountDown.toFixed()} seconds.
+        <br />
+        You will need to re-login with your cluster credentials. Please, save your changes, if any.
+      </p>
+    );
+  };
 }

--- a/src/components/SessionTimeout/SessionTimeout.tsx
+++ b/src/components/SessionTimeout/SessionTimeout.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
 import { Modal, Button, Icon, Row, Col } from 'patternfly-react';
-import { config } from '../../config';
-import { UNIT_TIME, MILLISECONDS } from '../../types/Common';
 import { AuthStrategy } from '../../types/Auth';
 import { LoginSession } from '../../store/Store';
 import * as API from '../../services/Api';
@@ -23,9 +21,9 @@ export class SessionTimeout extends React.Component<SessionTimeoutProps, {}> {
   render() {
     return (
       <Modal
+        backdrop="static"
         className={'message-dialog-pf'}
         show={this.props.show}
-        onHide={this.props.onLogout}
         enforceFocus={true}
         aria-modal={true}
       >
@@ -72,15 +70,11 @@ export class SessionTimeout extends React.Component<SessionTimeoutProps, {}> {
   };
 
   private textForLoginStrategy = () => {
-    const extendedTime = config.session.extendedSessionTimeOut
-      ? config.session.extendedSessionTimeOut / (MILLISECONDS * UNIT_TIME.MINUTE)
-      : 30;
-
     return (
       <p className={'lead'}>
         Your session will timeout in {this.props.timeOutCountDown.toFixed()} seconds.
         <br />
-        Would you like to extend your session for another {extendedTime} minutes?
+        Would you like to extend your session?
       </p>
     );
   };

--- a/src/components/SessionTimeout/SessionTimeout.tsx
+++ b/src/components/SessionTimeout/SessionTimeout.tsx
@@ -2,10 +2,10 @@ import * as React from 'react';
 import { Modal, Button, Icon, Row, Col } from 'patternfly-react';
 import { config } from '../../config';
 import { UNIT_TIME, MILLISECONDS } from '../../types/Common';
-import AppConfigs from '../../app/AppConfigs';
 import { AuthStrategy } from '../../types/Auth';
 import { LoginSession } from '../../store/Store';
 import * as API from '../../services/Api';
+import authenticationConfig from '../../config/authenticationConfig';
 
 type SessionTimeoutProps = {
   onLogout: () => void;
@@ -36,7 +36,7 @@ export class SessionTimeout extends React.Component<SessionTimeoutProps, {}> {
               <Icon name="warning-triangle-o" type="pf" style={{ fontSize: '48px' }} />
             </Col>
             <Col xs={12} sm={10} md={10} lg={10}>
-              {AppConfigs.authenticationConfig!.strategy === AuthStrategy.login
+              {authenticationConfig.strategy === AuthStrategy.login
                 ? this.textForLoginStrategy()
                 : this.textForOpenshiftStrategy()}
             </Col>
@@ -47,7 +47,7 @@ export class SessionTimeout extends React.Component<SessionTimeoutProps, {}> {
             <Button bsStyle={'default'} onClick={this.props.onLogout}>
               Log Out
             </Button>
-            {AppConfigs.authenticationConfig!.strategy === AuthStrategy.login ? (
+            {authenticationConfig.strategy === AuthStrategy.login ? (
               <Button autoFocus={true} bsStyle={'primary'} onClick={this.extendSessionHandler}>
                 Continue Session
               </Button>

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -5,10 +5,6 @@ const conf = {
   version: '0.1',
   /** Configuration related with session */
   session: {
-    /** TimeOut in Minutes default 24 hours */
-    sessionTimeOut: 24 * UNIT_TIME.HOUR * MILLISECONDS,
-    /** Extended Session in Minutes default 30 minutes */
-    extendedSessionTimeOut: 30 * UNIT_TIME.MINUTE * MILLISECONDS,
     /** TimeOut Session remain for warning user default 1 minute */
     timeOutforWarningUser: 1 * UNIT_TIME.MINUTE * MILLISECONDS
   },

--- a/src/containers/UserDropdownContainer.ts
+++ b/src/containers/UserDropdownContainer.ts
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 import { ThunkDispatch } from 'redux-thunk';
 
 import UserDropdown from '../components/Nav/UserDropdown';
-import { KialiAppState } from '../store/Store';
+import { KialiAppState, LoginSession } from '../store/Store';
 import { KialiAppAction } from '../actions/KialiAppAction';
 import LoginThunkActions from '../actions/LoginThunkActions';
 
@@ -12,7 +12,7 @@ const mapStateToProps = (state: KialiAppState) => ({
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<KialiAppState, void, KialiAppAction>) => ({
   logout: () => dispatch(LoginThunkActions.logout()),
-  extendSession: () => dispatch(LoginThunkActions.extendSession()),
+  extendSession: (session: LoginSession) => dispatch(LoginThunkActions.extendSession(session)),
   checkCredentials: () => dispatch(LoginThunkActions.checkCredentials())
 });
 

--- a/src/containers/UserDropdownContainer.ts
+++ b/src/containers/UserDropdownContainer.ts
@@ -12,8 +12,7 @@ const mapStateToProps = (state: KialiAppState) => ({
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<KialiAppState, void, KialiAppAction>) => ({
   logout: () => dispatch(LoginThunkActions.logout()),
-  extendSession: (session: LoginSession) => dispatch(LoginThunkActions.extendSession(session)),
-  checkCredentials: () => dispatch(LoginThunkActions.checkCredentials())
+  extendSession: (session: LoginSession) => dispatch(LoginThunkActions.extendSession(session))
 });
 
 const UserDropdownConnected = connect(

--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Alert, Row, Col, Form, FormGroup, FormControl, Button, HelpBlock } from 'patternfly-react';
+import { Alert, Button, Col, Form, FormControl, FormGroup, HelpBlock, Row } from 'patternfly-react';
 import { KEY_CODES } from '../../types/Common';
-import { LoginStatus, LoginSession } from '../../store/Store';
+import { LoginSession, LoginStatus } from '../../store/Store';
 
 const kialiTitle = require('../../assets/img/logo-login.svg');
 
@@ -69,6 +69,9 @@ export default class LoginPage extends React.Component<LoginProps, LoginState> {
                   <div className={'card-pf'}>
                     <header className={'login-pf-header'} />
                     {this.props.status === LoginStatus.error && <Alert>{this.props.message}</Alert>}
+                    {this.props.status === LoginStatus.expired && (
+                      <Alert type="warning">Your session has expired or was terminated in another window.</Alert>
+                    )}
                     <Form onSubmit={e => this.handleSubmit(e)} id={'kiali-login'}>
                       <FormGroup>
                         <FormControl

--- a/src/pages/Login/__tests__/__snapshots__/LoginPage.test.tsx.snap
+++ b/src/pages/Login/__tests__/__snapshots__/LoginPage.test.tsx.snap
@@ -639,6 +639,7 @@ ShallowWrapper {
                         className="login-pf-header"
                       />,
                       false,
+                      false,
                       <Form
                         bsClass="form"
                         componentClass="form"
@@ -707,6 +708,7 @@ ShallowWrapper {
                       "rendered": null,
                       "type": "header",
                     },
+                    false,
                     false,
                     Object {
                       "instance": null,
@@ -1517,6 +1519,7 @@ ShallowWrapper {
                           className="login-pf-header"
                         />,
                         false,
+                        false,
                         <Form
                           bsClass="form"
                           componentClass="form"
@@ -1585,6 +1588,7 @@ ShallowWrapper {
                         "rendered": null,
                         "type": "header",
                       },
+                      false,
                       false,
                       Object {
                         "instance": null,

--- a/src/reducers/LoginState.ts
+++ b/src/reducers/LoginState.ts
@@ -1,5 +1,3 @@
-import moment from 'moment';
-
 import { getType } from 'typesafe-actions';
 import { LoginState as LoginStateInterface, LoginStatus } from '../store/Store';
 import { KialiAppAction } from '../actions/KialiAppAction';
@@ -8,12 +6,7 @@ import { LoginActions } from '../actions/LoginActions';
 export const INITIAL_LOGIN_STATE: LoginStateInterface = {
   status: LoginStatus.loggedOut,
   session: undefined,
-  message: '',
-  // We define a small expiration date for the UI so it does not block the
-  // session handling on login.
-  uiExpiresOn: moment()
-    .add(10, 'minute')
-    .toISOString()
+  message: ''
 };
 
 // This Reducer allows changes to the 'loginState' portion of Redux Store
@@ -27,8 +20,7 @@ const loginState = (state: LoginStateInterface = INITIAL_LOGIN_STATE, action: Ki
       return {
         ...INITIAL_LOGIN_STATE,
         status: LoginStatus.loggedIn,
-        session: action.payload.session,
-        uiExpiresOn: action.payload.uiExpiresOn
+        session: action.payload.session
       };
     case getType(LoginActions.loginFailure):
       let message = 'Error connecting to Kiali';

--- a/src/reducers/LoginState.ts
+++ b/src/reducers/LoginState.ts
@@ -35,6 +35,11 @@ const loginState = (state: LoginStateInterface = INITIAL_LOGIN_STATE, action: Ki
       return { ...INITIAL_LOGIN_STATE, status: LoginStatus.error, message: message };
     case getType(LoginActions.logoutSuccess):
       return INITIAL_LOGIN_STATE;
+    case getType(LoginActions.sessionExpired):
+      return {
+        ...INITIAL_LOGIN_STATE,
+        status: LoginStatus.expired
+      };
     default:
       return state;
   }

--- a/src/reducers/MessageCenter.ts
+++ b/src/reducers/MessageCenter.ts
@@ -4,6 +4,7 @@ import { KialiAppAction } from '../actions/KialiAppAction';
 import { getType } from 'typesafe-actions';
 import { MessageCenterActions } from '../actions/MessageCenterActions';
 import { updateState } from '../utils/Reducer';
+import { LoginActions } from '../actions/LoginActions';
 
 export const INITIAL_MESSAGE_CENTER_STATE: MessageCenterState = {
   nextId: 0,
@@ -119,7 +120,11 @@ const Messages = (
       const { groupId } = action.payload;
       return updateState(state, { expandedGroupId: groupId });
     }
-
+    case getType(LoginActions.loginRequest): {
+      // Let's clear the message center quen user is loggin-in. This ensures
+      // that messages from a past session won't persist because may be obsolete.
+      return INITIAL_MESSAGE_CENTER_STATE;
+    }
     default:
       return state;
   }

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -65,6 +65,10 @@ interface LoginRequest {
 }
 
 /** Requests */
+export const extendSession = () => {
+  return newRequest<LoginSession>(HTTP_VERBS.GET, urls.authenticate, {}, {});
+};
+
 export const login = async (
   request: LoginRequest = { username: ANONYMOUS_USER, password: 'anonymous' }
 ): Promise<Response<LoginSession>> => {

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -79,7 +79,6 @@ export interface LoginState {
   status: LoginStatus;
   session?: LoginSession;
   message: string;
-  uiExpiresOn: RawDate;
 }
 
 export interface Component {

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -67,7 +67,8 @@ export enum LoginStatus {
   logging,
   loggedIn,
   loggedOut,
-  error
+  error,
+  expired
 }
 
 export interface LoginSession {


### PR DESCRIPTION
https://issues.jboss.org/browse/KIALI-2273
also: https://issues.jboss.org/browse/KIALI-2518

* SessionTimeout was not appearing because of a time unit mismatch (seconds vs milliseconds)
* Extend session feature was not working. UI cannot extend the session by itself; it needs back-end's help. Now the "extend session" button will make the required request to extend the session successfully. *Note:* If Oauth login is configured, the session cannot be extended.
* "Friendly message" (motivation of KIALI-2273)... Instead of displaying an error in the message center, the user will be redirected to the login page:

![image](https://user-images.githubusercontent.com/23639005/54167179-0f74ad80-442e-11e9-83fc-aecc364d531c.png)



**This requires https://github.com/kiali/kiali/pull/903**