### PR TITLE
Add new tslint rule to eliminate the old Object.assign() syntax with ES6+

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeReactWrapper.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeReactWrapper.tsx
@@ -70,15 +70,13 @@ export class CytoscapeReactWrapper extends React.Component<CytoscapeReactWrapper
     if (this.cy) {
       this.destroy();
     }
-    const opts = Object.assign(
-      {
-        container: this.divParentRef.current,
-        boxSelectionEnabled: false,
-        autounselectify: true,
-        style: GraphStyles.styles()
-      },
-      GraphStyles.options()
-    );
+    const opts = {
+      container: this.divParentRef.current,
+      boxSelectionEnabled: false,
+      autounselectify: true,
+      style: GraphStyles.styles(),
+      ...GraphStyles.options()
+    };
 
     this.cy = cytoscape(opts);
   }

--- a/src/components/Metrics/CustomMetrics.tsx
+++ b/src/components/Metrics/CustomMetrics.tsx
@@ -115,12 +115,14 @@ class CustomMetrics extends React.Component<CustomMetricsProps, MetricsState> {
   }
 
   renderOptionsBar() {
-    const hasHistograms = this.state.dashboard !== undefined && this.state.dashboard.charts.some(chart => {
-      if (chart.histogram) {
-        return Object.keys(chart.histogram).length > 0;
-      }
-      return false;
-    });
+    const hasHistograms =
+      this.state.dashboard !== undefined &&
+      this.state.dashboard.charts.some(chart => {
+        if (chart.histogram) {
+          return Object.keys(chart.histogram).length > 0;
+        }
+        return false;
+      });
     return (
       <Toolbar>
         <FormGroup>

--- a/src/reducers/GrafanaState.ts
+++ b/src/reducers/GrafanaState.ts
@@ -16,6 +16,8 @@ const GrafanaState = (
         // Ex: in case of response 204
         return null;
       }
+      // Spread types can only be created from object types so need to use Object.assign here
+      // tslint:disable-next-line
       return Object.assign({}, INITIAL_GRAFANA_STATE, {
         url: action.payload.url,
         serviceDashboardPath: action.payload.serviceDashboardPath,

--- a/src/reducers/HelpDropdownState.ts
+++ b/src/reducers/HelpDropdownState.ts
@@ -13,11 +13,12 @@ export const INITIAL_STATUS_STATE: StatusState = {
 const HelpDropdownState = (state: StatusState = INITIAL_STATUS_STATE, action: KialiAppAction): StatusState => {
   switch (action.type) {
     case getType(HelpDropdownActions.statusRefresh):
-      return Object.assign({}, INITIAL_STATUS_STATE, {
+      return {
+        ...INITIAL_STATUS_STATE,
         status: action.payload.status,
         components: action.payload.components,
         warningMessages: action.payload.warningMessages
-      });
+      };
     default:
       return state;
   }

--- a/src/reducers/LoginState.ts
+++ b/src/reducers/LoginState.ts
@@ -20,17 +20,16 @@ export const INITIAL_LOGIN_STATE: LoginStateInterface = {
 const loginState = (state: LoginStateInterface = INITIAL_LOGIN_STATE, action: KialiAppAction): LoginStateInterface => {
   switch (action.type) {
     case getType(LoginActions.loginRequest):
-      return Object.assign({}, INITIAL_LOGIN_STATE, {
-        status: LoginStatus.logging
-      });
+      return { ...INITIAL_LOGIN_STATE, status: LoginStatus.logging };
     case getType(LoginActions.loginSuccess):
-      return Object.assign({}, INITIAL_LOGIN_STATE, action.payload);
+      return { ...INITIAL_LOGIN_STATE, ...action.payload };
     case getType(LoginActions.loginExtend):
-      return Object.assign({}, INITIAL_LOGIN_STATE, {
+      return {
+        ...INITIAL_LOGIN_STATE,
         status: LoginStatus.loggedIn,
         session: action.payload.session,
         uiExpiresOn: action.payload.uiExpiresOn
-      });
+      };
     case getType(LoginActions.loginFailure):
       let message = 'Error connecting to Kiali';
 
@@ -41,10 +40,7 @@ const loginState = (state: LoginStateInterface = INITIAL_LOGIN_STATE, action: Ki
           'The Kiali secret is missing. Users are prohibited from accessing Kiali until an administrator creates a valid secret and restarts Kiali. Please refer to the Kiali documentation for more details.';
       }
 
-      return Object.assign({}, INITIAL_LOGIN_STATE, {
-        status: LoginStatus.error,
-        message: message
-      });
+      return { ...INITIAL_LOGIN_STATE, status: LoginStatus.error, message: message };
     case getType(LoginActions.logoutSuccess):
       return INITIAL_LOGIN_STATE;
     default:

--- a/src/reducers/MessageCenter.ts
+++ b/src/reducers/MessageCenter.ts
@@ -43,14 +43,15 @@ const createMessage = (id: number, content: string, type: MessageType) => {
 // returns the updated state
 const updateMessage = (state: MessageCenterState, messageIds: number[], updater) => {
   const groups = state.groups.map(group => {
-    group = Object.assign({}, group, {
+    group = {
+      ...group,
       messages: group.messages.map(message => {
         if (messageIds.includes(message.id)) {
           message = updater(message);
         }
         return message;
       })
-    });
+    };
     return group;
   });
   return updateState(state, { groups });
@@ -65,9 +66,7 @@ const Messages = (
       const { groupId, content, messageType } = action.payload;
       const groups = state.groups.map(group => {
         if (group.id === groupId) {
-          group = Object.assign({}, group, {
-            messages: group.messages.concat([createMessage(state.nextId, content, messageType)])
-          });
+          group = { ...group, messages: group.messages.concat([createMessage(state.nextId, content, messageType)]) };
           return group;
         }
         return group;
@@ -77,11 +76,12 @@ const Messages = (
     case getType(MessageCenterActions.removeMessage): {
       const messageId = action.payload.messageId;
       const groups = state.groups.map(group => {
-        group = Object.assign({}, group, {
+        group = {
+          ...group,
           messages: group.messages.filter(message => {
             return !messageId.includes(message.id);
           })
-        });
+        };
         return group;
       });
       return updateState(state, { groups });

--- a/src/utils/Reducer.ts
+++ b/src/utils/Reducer.ts
@@ -1,3 +1,3 @@
 export const updateState = <S>(oldState: S, updatedState: Partial<S>): S => {
-  return Object.assign({}, oldState, updatedState);
+  return { ...oldState, ...updatedState };
 };

--- a/tslint.json
+++ b/tslint.json
@@ -37,6 +37,7 @@
     "one-line": [true, "check-catch", "check-else", "check-open-brace", "check-whitespace"],
     "only-arrow-functions": true,
     "prefer-const": [true, { "destructuring": "all" }],
+    "prefer-object-spread": true,
     "quotemark": [true, "single", "jsx-double", "avoid-escape"],
     "radix": true,
     "semicolon": [true, "always", "ignore-bound-class-methods"],


### PR DESCRIPTION
** Describe the change **
Let's replace this old javascript Object.assign() syntax with the current object spread syntax. It's just more descriptive and therefore easier to grok.

This adds the tslint rules to enforce this.

** Documentation **

- https://palantir.github.io/tslint/rules/prefer-object-spread/
- https://redux.js.org/recipes/using-object-spread-operator
- https://davidwalsh.name/merge-objects