### PR TITLE
KIALI-2552 Don't use request_protocol metrics option with TCP

### DIFF
--- a/src/pages/Graph/SummaryPanelEdge.tsx
+++ b/src/pages/Graph/SummaryPanelEdge.tsx
@@ -263,7 +263,7 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
         filtersTCP,
         'inbound',
         reporterTCP,
-        'tcp',
+        undefined, // tcp metrics use dedicated metrics (i.e. no request_protocol label)
         quantiles,
         byLabels
       );


### PR DESCRIPTION
It is not valid to specify 'tcp' as the request_protocol when calling for
metrics because request_protocol applies only to request count metrics (I.e. istio_requests_total)
