### PR TITLE
KIALI-2500 Fix rendering hide/show tab when no graph

### DIFF
--- a/src/pages/Graph/SummaryPanel.tsx
+++ b/src/pages/Graph/SummaryPanel.tsx
@@ -59,7 +59,7 @@ export default class SummaryPanel extends React.Component<MainSummaryPanelPropTy
   }
 
   render() {
-    if (!this.props.isPageVisible) {
+    if (!this.props.isPageVisible || !this.props.data.summaryTarget) {
       return null;
     }
     return (


### PR DESCRIPTION
https://issues.jboss.org/browse/KIALI-2500

This will properly avoid rendering of the hide/show tab of the side panel when there is no side panel rendered.
