### PR TITLE
KIALI-2555 Return to the OpenShift login page on error

### DIFF
--- a/src/actions/LoginThunkActions.ts
+++ b/src/actions/LoginThunkActions.ts
@@ -21,8 +21,13 @@ const loginSuccess = async (dispatch: KialiDispatch, session: LoginSession) => {
 // The `data` argument is defined as `any` because the dispatchers receive
 // different kinds of data (such as e-mail/password, tokens).
 const performLogin = (dispatch: KialiDispatch, state: KialiAppState, data?: any) => {
-  const bail = (loginResult: Login.LoginResult) =>
-    data ? dispatch(LoginActions.loginFailure(loginResult.error)) : dispatch(LoginActions.logoutSuccess());
+  const bail = (loginResult: Login.LoginResult) => {
+    if (authenticationConfig.strategy === AuthStrategy.openshift) {
+      dispatch(LoginActions.loginFailure(loginResult.error));
+    } else {
+      data ? dispatch(LoginActions.loginFailure(loginResult.error)) : dispatch(LoginActions.logoutSuccess());
+    }
+  };
 
   Dispatcher.prepare().then((result: AuthResult) => {
     if (result === AuthResult.CONTINUE) {

--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { Alert, Button, Col, Form, FormControl, FormGroup, HelpBlock, Row } from 'patternfly-react';
 import { KEY_CODES } from '../../types/Common';
 import { LoginSession, LoginStatus } from '../../store/Store';
+import { AuthStrategy } from '../../types/Auth';
+import authenticationConfig from '../../config/authenticationConfig';
 
 const kialiTitle = require('../../assets/img/logo-login.svg');
 
@@ -44,8 +46,13 @@ export default class LoginPage extends React.Component<LoginProps, LoginState> {
 
   handleSubmit = (e: any) => {
     e.preventDefault();
-    if (this.state.username.length > 0 && this.state.password.length > 0 && this.props.authenticate) {
-      this.props.authenticate(this.state.username, this.state.password);
+    if (authenticationConfig.strategy === AuthStrategy.openshift) {
+      // If we are using OpenShift OAuth, take the user back to the OpenShift OAuth login
+      window.location.href = authenticationConfig.authorizationEndpoint!;
+    } else {
+      if (this.state.username.length > 0 && this.state.password.length > 0 && this.props.authenticate) {
+        this.props.authenticate(this.state.username, this.state.password);
+      }
     }
   };
 
@@ -56,6 +63,10 @@ export default class LoginPage extends React.Component<LoginProps, LoginState> {
   };
 
   render() {
+    let loginLabel = 'Log In';
+    if (authenticationConfig.strategy === AuthStrategy.openshift) {
+      loginLabel = 'Log In With OpenShift';
+    }
     return (
       <div className={'login-pf-page'}>
         <div className={'container-fluid'}>
@@ -73,41 +84,45 @@ export default class LoginPage extends React.Component<LoginProps, LoginState> {
                       <Alert type="warning">Your session has expired or was terminated in another window.</Alert>
                     )}
                     <Form onSubmit={e => this.handleSubmit(e)} id={'kiali-login'}>
-                      <FormGroup>
-                        <FormControl
-                          id="username"
-                          type="text"
-                          name="username"
-                          onChange={this.handleChange}
-                          placeholder={'Username'}
-                          disabled={false}
-                          required={true}
-                          onKeyPress={this.handleKeyPress}
-                        />
-                        {this.props.status === LoginStatus.logging && !this.state.username && (
-                          <HelpBlock>Username is required</HelpBlock>
-                        )}
-                      </FormGroup>
-                      <FormGroup>
-                        <FormControl
-                          type="password"
-                          name="password"
-                          onChange={this.handleChange}
-                          placeholder={'Password'}
-                          disabled={false}
-                          required={true}
-                          onKeyPress={this.handleKeyPress}
-                        />
-                        {this.props.status === LoginStatus.logging && !this.state.password && (
-                          <HelpBlock>Password is required</HelpBlock>
-                        )}
-                      </FormGroup>
+                      {authenticationConfig.strategy === AuthStrategy.login && (
+                        <FormGroup>
+                          <FormControl
+                            id="username"
+                            type="text"
+                            name="username"
+                            onChange={this.handleChange}
+                            placeholder={'Username'}
+                            disabled={false}
+                            required={true}
+                            onKeyPress={this.handleKeyPress}
+                          />
+                          {this.props.status === LoginStatus.logging && !this.state.username && (
+                            <HelpBlock>Username is required</HelpBlock>
+                          )}
+                        </FormGroup>
+                      )}
+                      {authenticationConfig.strategy === AuthStrategy.login && (
+                        <FormGroup>
+                          <FormControl
+                            type="password"
+                            name="password"
+                            onChange={this.handleChange}
+                            placeholder={'Password'}
+                            disabled={false}
+                            required={true}
+                            onKeyPress={this.handleKeyPress}
+                          />
+                          {this.props.status === LoginStatus.logging && !this.state.password && (
+                            <HelpBlock>Password is required</HelpBlock>
+                          )}
+                        </FormGroup>
+                      )}
                       <Button
                         type="submit"
                         onKeyPress={this.handleKeyPress}
                         className="btn btn-primary btn-block btn-lg"
                       >
-                        Log In
+                        {loginLabel}
                       </Button>
                     </Form>
                   </div>

--- a/src/reducers/LoginState.ts
+++ b/src/reducers/LoginState.ts
@@ -26,7 +26,8 @@ const loginState = (state: LoginStateInterface = INITIAL_LOGIN_STATE, action: Ki
       let message = 'Error connecting to Kiali';
 
       if (action.payload.error.request.status === 401) {
-        message = 'Unauthorized. Error in username or password';
+        message =
+          'Unauthorized. The provided credentials are not valid to access Kiali. Please check your credentials and try again.';
       } else if (action.payload.error.request.status === 520) {
         message =
           'The Kiali secret is missing. Users are prohibited from accessing Kiali until an administrator creates a valid secret and restarts Kiali. Please refer to the Kiali documentation for more details.';

--- a/src/services/Login.ts
+++ b/src/services/Login.ts
@@ -83,7 +83,12 @@ class OpenshiftLogin implements LoginStrategy<any> {
   }
 
   public async perform(_request: NullDispatch): Promise<LoginResult> {
+    // get the data from the url that was passed by the OAuth login.
     const session = (await API.checkOpenshiftAuth(window.location.hash.substring(1))).data;
+
+    // remove the data that was passed by the OAuth login. In certain error situations this can cause the
+    // page to enter a refresh loop since it tries to reload the page which then tries to reuse the bad token again.
+    history.replaceState('', document.title, window.location.pathname + window.location.search);
 
     return {
       status: AuthResult.SUCCESS,


### PR DESCRIPTION
** Describe the change **

Adds in some better error handling when dealing with OpenShift OAuth logins.

If we encounter a problem during login it will be bring the user back to the OAuth login page so that the user can start the login process again. Otherwise they can get stuck on the main username/password login screen.

I was not able to exactly recreate the issue mention in KIALI-2555, but spent some time modifying the code to do things like setup cookies with invalid tokens, expired OpenShift tokens, etc. So I can't verify it this fixes the exact problem reported.

** Issue reference **

https://issues.jboss.org/browse/KIALI-2555