### PR TITLE
[Minor] Fix warning about accessibility issue

### DIFF
--- a/src/components/ToolbarDropdown/ToolbarDropdown.tsx
+++ b/src/components/ToolbarDropdown/ToolbarDropdown.tsx
@@ -60,7 +60,7 @@ export class ToolbarDropdown extends React.Component<ToolbarDropdownProps, Toolb
           <OverlayTrigger
             key={'ot-' + this.props.id}
             placement="top"
-            trigger="hover"
+            trigger={['hover', 'focus']}
             delayShow={1000}
             overlay={<Tooltip id={'tt-' + this.props.id}>{this.props.tooltip}</Tooltip>}
           >


### PR DESCRIPTION
Warning message was: 

Warning: [react-bootstrap] Specifying only the `"hover"` trigger limits the visibility of the overlay to just mouse users. Consider also including the `"focus"` trigger so that touch and keyboard only users can see the overlay as well.
