### PR TITLE
KIALI-2438 Metrics dashboards to manage non-SI underscaling like bytes

### DIFF
--- a/src/components/Metrics/MetricsChartBase.tsx
+++ b/src/components/Metrics/MetricsChartBase.tsx
@@ -75,7 +75,45 @@ abstract class MetricsChartBase<Props extends MetricsChartBaseProps> extends Rea
     };
   }
 
-  formatYAxis = (val: any): string => {
+  formatYAxis = (val: number): string => {
+    switch (this.props.unit) {
+      case 'bytes':
+      case 'bytes-si':
+        return this.formatDataSI(val, 'B');
+      case 'bytes-iec':
+        return this.formatDataIEC(val, 'B');
+      case 'bitrate':
+      case 'bitrate-si':
+        return this.formatDataSI(val, 'bit/s');
+      case 'bitrate-iec':
+        return this.formatDataIEC(val, 'bit/s');
+      default:
+        // Fallback to default SI scaler:
+        return this.formatSI(val);
+    }
+  };
+
+  formatDataSI = (val: number, suffix: string): string => {
+    return this.formatData(val, 1000, ['k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y']) + suffix;
+  };
+
+  formatDataIEC = (val: number, suffix: string): string => {
+    return this.formatData(val, 1024, ['Ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'Zi', 'Yi']) + suffix;
+  };
+
+  formatData = (val: number, threshold: number, units: string[]): string => {
+    if (Math.abs(val) < threshold) {
+      return val + ' ';
+    }
+    let u = -1;
+    do {
+      val /= threshold;
+      ++u;
+    } while (Math.abs(val) >= threshold && u < units.length - 1);
+    return val.toFixed(1) + ' ' + units[u];
+  };
+
+  formatSI = (val: number): string => {
     const fmt = format('~s')(val);
     let si = '';
     // Insert space before SI

--- a/src/components/Metrics/MetricsChartBase.tsx
+++ b/src/components/Metrics/MetricsChartBase.tsx
@@ -77,6 +77,8 @@ abstract class MetricsChartBase<Props extends MetricsChartBaseProps> extends Rea
 
   formatYAxis = (val: number): string => {
     switch (this.props.unit) {
+      case 'seconds':
+        return this.formatSI(val, 's');
       case 'bytes':
       case 'bytes-si':
         return this.formatDataSI(val, 'B');
@@ -89,7 +91,7 @@ abstract class MetricsChartBase<Props extends MetricsChartBaseProps> extends Rea
         return this.formatDataIEC(val, 'bit/s');
       default:
         // Fallback to default SI scaler:
-        return this.formatSI(val);
+        return this.formatDataSI(val, this.props.unit);
     }
   };
 
@@ -113,7 +115,7 @@ abstract class MetricsChartBase<Props extends MetricsChartBaseProps> extends Rea
     return val.toFixed(1) + ' ' + units[u];
   };
 
-  formatSI = (val: number): string => {
+  formatSI = (val: number, suffix: string): string => {
     const fmt = format('~s')(val);
     let si = '';
     // Insert space before SI
@@ -123,12 +125,12 @@ abstract class MetricsChartBase<Props extends MetricsChartBaseProps> extends Rea
     for (let i = fmt.length - 1; i >= 0; i--) {
       const c = fmt.charAt(i);
       if (c >= '0' && c <= '9') {
-        return fmt.substr(0, i + 1) + ' ' + si + this.props.unit;
+        return fmt.substr(0, i + 1) + ' ' + si + suffix;
       }
       si = c + si;
     }
     // Weird: no number found?
-    return fmt + this.props.unit;
+    return fmt + suffix;
   };
 
   protected onExpandHandler = (event: React.MouseEvent<HTMLAnchorElement>) => {

--- a/src/components/Metrics/MetricsChartBase.tsx
+++ b/src/components/Metrics/MetricsChartBase.tsx
@@ -76,6 +76,8 @@ abstract class MetricsChartBase<Props extends MetricsChartBaseProps> extends Rea
   }
 
   formatYAxis = (val: number): string => {
+    // Round to dismiss float imprecision
+    val = Math.round(val * 10000) / 10000;
     switch (this.props.unit) {
       case 'seconds':
         return this.formatSI(val, 's');
@@ -112,7 +114,7 @@ abstract class MetricsChartBase<Props extends MetricsChartBaseProps> extends Rea
       val /= threshold;
       ++u;
     } while (Math.abs(val) >= threshold && u < units.length - 1);
-    return val.toFixed(1) + ' ' + units[u];
+    return format('~r')(val) + ' ' + units[u];
   };
 
   formatSI = (val: number, suffix: string): string => {


### PR DESCRIPTION
This is to prevent some data types (currently bytes and bitrates) to be downscaled as "milli-bytes" / "µbps" which are quite uncommon. At the same time, introducing IEC-based versus SI-based data units.

Now, some unit types are recognized from the dashboards renderer and processed in a specific way.
Other units / non-recognized ones continue to fall under the standard SI scaler

JIRA: https://issues.jboss.org/browse/KIALI-2438

Backend PR: https://github.com/kiali/kiali/pull/925