### PR TITLE
KIALI-2369 Fix style on Service Details:

### DIFF
--- a/src/actions/JaegerActions.ts
+++ b/src/actions/JaegerActions.ts
@@ -14,7 +14,7 @@ export const JaegerActions = {
       url: url
     })
   ),
-  setEnableIntegration: createStandardAction(JaegerActionKeys.SET_ENABLE_INTEGRATION)<boolean>(),
+  setEnableIntegration: createStandardAction(JaegerActionKeys.SET_ENABLE_INTEGRATION)<boolean>()
 };
 
 export type JaegerAction = ActionType<typeof JaegerActions>;

--- a/src/components/Health/__tests__/__snapshots__/HealthDetails.test.tsx.snap
+++ b/src/components/Health/__tests__/__snapshots__/HealthDetails.test.tsx.snap
@@ -18,8 +18,8 @@ ShallowWrapper {
               "priority": 0,
               "text": "N/A",
             },
-            "text": "No requests over last 1m",
-            "title": "Error Rate",
+            "text": "No requests",
+            "title": "Error Rate over last 1m",
           },
         ],
         "requests": Object {
@@ -54,9 +54,9 @@ ShallowWrapper {
           >
             N/A
           </span>
-           Error Rate: 
+           Error Rate over last 1m: 
         </strong>,
-        "No requests over last 1m",
+        "No requests",
         undefined,
       ],
     },
@@ -77,7 +77,7 @@ ShallowWrapper {
             >
               N/A
             </span>,
-            " Error Rate: ",
+            " Error Rate over last 1m: ",
           ],
         },
         "ref": null,
@@ -96,11 +96,11 @@ ShallowWrapper {
             "rendered": "N/A",
             "type": "span",
           },
-          " Error Rate: ",
+          " Error Rate over last 1m: ",
         ],
         "type": "strong",
       },
-      "No requests over last 1m",
+      "No requests",
       undefined,
     ],
     "type": "div",
@@ -122,9 +122,9 @@ ShallowWrapper {
             >
               N/A
             </span>
-             Error Rate: 
+             Error Rate over last 1m: 
           </strong>,
-          "No requests over last 1m",
+          "No requests",
           undefined,
         ],
       },
@@ -145,7 +145,7 @@ ShallowWrapper {
               >
                 N/A
               </span>,
-              " Error Rate: ",
+              " Error Rate over last 1m: ",
             ],
           },
           "ref": null,
@@ -164,11 +164,11 @@ ShallowWrapper {
               "rendered": "N/A",
               "type": "span",
             },
-            " Error Rate: ",
+            " Error Rate over last 1m: ",
           ],
           "type": "strong",
         },
-        "No requests over last 1m",
+        "No requests",
         undefined,
       ],
       "type": "div",
@@ -212,8 +212,8 @@ ShallowWrapper {
               "priority": 0,
               "text": "N/A",
             },
-            "text": "No requests over last 1m",
-            "title": "Error Rate",
+            "text": "No requests",
+            "title": "Error Rate over last 1m",
           },
         ],
         "requests": Object {
@@ -248,9 +248,9 @@ ShallowWrapper {
           >
             N/A
           </span>
-           Error Rate: 
+           Error Rate over last 1m: 
         </strong>,
-        "No requests over last 1m",
+        "No requests",
         undefined,
       ],
     },
@@ -271,7 +271,7 @@ ShallowWrapper {
             >
               N/A
             </span>,
-            " Error Rate: ",
+            " Error Rate over last 1m: ",
           ],
         },
         "ref": null,
@@ -290,11 +290,11 @@ ShallowWrapper {
             "rendered": "N/A",
             "type": "span",
           },
-          " Error Rate: ",
+          " Error Rate over last 1m: ",
         ],
         "type": "strong",
       },
-      "No requests over last 1m",
+      "No requests",
       undefined,
     ],
     "type": "div",
@@ -316,9 +316,9 @@ ShallowWrapper {
             >
               N/A
             </span>
-             Error Rate: 
+             Error Rate over last 1m: 
           </strong>,
-          "No requests over last 1m",
+          "No requests",
           undefined,
         ],
       },
@@ -339,7 +339,7 @@ ShallowWrapper {
               >
                 N/A
               </span>,
-              " Error Rate: ",
+              " Error Rate over last 1m: ",
             ],
           },
           "ref": null,
@@ -358,11 +358,11 @@ ShallowWrapper {
               "rendered": "N/A",
               "type": "span",
             },
-            " Error Rate: ",
+            " Error Rate over last 1m: ",
           ],
           "type": "strong",
         },
-        "No requests over last 1m",
+        "No requests",
         undefined,
       ],
       "type": "div",

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
@@ -7,6 +7,7 @@ import { ServiceHealth } from '../../../types/Health';
 import { Endpoints } from '../../../types/ServiceInfo';
 import { Port } from '../../../types/IstioObjects';
 import PfInfoCard from '../../../components/Pf/PfInfoCard';
+import { style } from 'typestyle';
 
 import './ServiceInfoDescription.css';
 
@@ -22,6 +23,11 @@ interface ServiceInfoDescriptionProps {
   endpoints?: Endpoints[];
   health?: ServiceHealth;
 }
+
+const listStyle = style({
+  listStyleType: 'none',
+  padding: 0
+});
 
 class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps> {
   constructor(props: ServiceInfoDescriptionProps) {
@@ -65,7 +71,7 @@ class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps
               <div className="progress-description">
                 <strong>Ports</strong>
               </div>
-              <ul style={{ listStyleType: 'none' }}>
+              <ul className={listStyle}>
                 {(this.props.ports || []).map((port, i) => (
                   <li key={'port_' + i}>
                     {port.protocol} {port.name} ({port.port})
@@ -73,14 +79,14 @@ class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps
                 ))}
               </ul>
             </Col>
-            <Col xs={12} sm={6} md={3} lg={3}>
+            <Col xs={12} sm={6} md={2} lg={2}>
               <div className="progress-description">
                 <strong>Endpoints</strong>
               </div>
               {(this.props.endpoints || []).map((endpoint, i) => (
                 <Row key={'endpoint_' + i}>
                   <Col xs={12} sm={12} md={12} lg={12}>
-                    <ul style={{ listStyleType: 'none' }}>
+                    <ul className={listStyle}>
                       {(endpoint.addresses || []).map((address, u) => (
                         <li key={'endpoint_' + i + '_address_' + u}>
                           <strong>{address.ip} </strong>: {address.name}
@@ -91,7 +97,7 @@ class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps
                 </Row>
               ))}
             </Col>
-            <Col xs={12} sm={6} md={2} lg={2}>
+            <Col xs={12} sm={6} md={3} lg={3}>
               <div className="progress-description">
                 <strong>Health</strong>
               </div>

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
@@ -137,18 +137,14 @@ ShallowWrapper {
             </strong>
           </div>
           <ul
-            style={
-              Object {
-                "listStyleType": "none",
-              }
-            }
+            className="fza38k8"
           />
         </Col>
         <Col
           bsClass="col"
           componentClass="div"
-          lg={3}
-          md={3}
+          lg={2}
+          md={2}
           sm={6}
           xs={12}
         >
@@ -172,11 +168,7 @@ ShallowWrapper {
               xs={12}
             >
               <ul
-                style={
-                  Object {
-                    "listStyleType": "none",
-                  }
-                }
+                className="fza38k8"
               >
                 <li>
                   <strong>
@@ -209,8 +201,8 @@ ShallowWrapper {
         <Col
           bsClass="col"
           componentClass="div"
-          lg={2}
-          md={2}
+          lg={3}
+          md={3}
           sm={6}
           xs={12}
         >
@@ -320,18 +312,14 @@ ShallowWrapper {
               </strong>
             </div>
             <ul
-              style={
-                Object {
-                  "listStyleType": "none",
-                }
-              }
+              className="fza38k8"
             />
           </Col>
           <Col
             bsClass="col"
             componentClass="div"
-            lg={3}
-            md={3}
+            lg={2}
+            md={2}
             sm={6}
             xs={12}
           >
@@ -355,11 +343,7 @@ ShallowWrapper {
                 xs={12}
               >
                 <ul
-                  style={
-                    Object {
-                      "listStyleType": "none",
-                    }
-                  }
+                  className="fza38k8"
                 >
                   <li>
                     <strong>
@@ -392,8 +376,8 @@ ShallowWrapper {
           <Col
             bsClass="col"
             componentClass="div"
-            lg={2}
-            md={2}
+            lg={3}
+            md={3}
             sm={6}
             xs={12}
           >

--- a/src/types/Health.ts
+++ b/src/types/Health.ts
@@ -167,9 +167,9 @@ export class ServiceHealth extends Health {
         const reqErrorsRatio = getRequestErrorsStatus(requests.errorRatio);
         const reqErrorsText = reqErrorsRatio.status === NA ? 'No requests' : reqErrorsRatio.value.toFixed(2) + '%';
         const item: HealthItem = {
-          title: 'Error Rate',
+          title: 'Error Rate over ' + getName(ctx.rateInterval).toLowerCase(),
           status: reqErrorsRatio.status,
-          text: reqErrorsText + ' over ' + getName(ctx.rateInterval).toLowerCase()
+          text: reqErrorsText
         };
         items.push(item);
       } else {


### PR DESCRIPTION
- Same col span for Health in App/Workload/Service
- Align Ports/Endpoints

https://issues.jboss.org/browse/KIALI-2369

Using same wording and grid/col(3) for Health in all pages:
![image](https://user-images.githubusercontent.com/1662329/54603790-80771f00-4a45-11e9-898b-2d5305714e38.png)

![image](https://user-images.githubusercontent.com/1662329/54603800-8b31b400-4a45-11e9-9475-db38eefc7fcf.png)

![image](https://user-images.githubusercontent.com/1662329/54603831-9d135700-4a45-11e9-823e-959e59b9977f.png)
