### PR TITLE
KIALI-1987 Add installation tag to serverConfig

### DIFF
--- a/src/components/Nav/Navigation.tsx
+++ b/src/components/Nav/Navigation.tsx
@@ -10,7 +10,7 @@ import HelpDropdown from '../../containers/HelpDropdownContainer';
 import UserDropdown from '../../containers/UserDropdownContainer';
 import PfSpinnerContainer from '../../containers/PfSpinnerContainer';
 import { default as MeshMTLSStatus } from '../../components/MTls/MeshMTLSStatus';
-import { kialiLogo } from '../../config';
+import { kialiLogo, serverConfig } from '../../config';
 
 export const istioConfigTitle = 'Istio Config';
 export const servicesTitle = 'Services';
@@ -39,6 +39,10 @@ class Navigation extends React.Component<PropsType> {
 
   goTojaeger() {
     window.open(this.props.jaegerUrl, '_blank');
+  }
+
+  componentDidMount() {
+    document.title = serverConfig.installationTag ? serverConfig.installationTag : 'Kiali Console';
   }
 
   renderMenuItems() {

--- a/src/config/serverConfig.ts
+++ b/src/config/serverConfig.ts
@@ -43,6 +43,7 @@ const computeValidDurations = (cfg: ComputedServerConfig) => {
 // Set some defaults. Mainly used in tests, because
 // these will be overwritten on user login.
 let serverConfig: ComputedServerConfig = {
+  installationTag: 'Kiali Console',
   istioNamespace: 'istio-system',
   istioLabels: {
     appLabelName: 'app',

--- a/src/types/ServerConfig.ts
+++ b/src/types/ServerConfig.ts
@@ -3,6 +3,7 @@ import { DurationInSeconds } from './Common';
 export type IstioLabelKey = 'appLabelName' | 'versionLabelName';
 
 export interface ServerConfig {
+  installationTag?: string;
   istioNamespace: string;
   istioLabels: { [key in IstioLabelKey]: string };
   prometheus: {


### PR DESCRIPTION
**Describe the change**
Add the new installation tag var to the server config and set that as the tab title on login. Default will be "Kiali Console".
Related server PR - [#926](https://github.com/kiali/kiali/pull/926)
**Issue reference**
[JIRA KIALI-1987](https://issues.jboss.org/browse/KIALI-1987)
**Backwards compatible?**
Yes