### PR TITLE
KIALI-2588 Fix headers without name

### DIFF
--- a/src/components/IstioWizards/MatchingRouting.tsx
+++ b/src/components/IstioWizards/MatchingRouting.tsx
@@ -5,6 +5,7 @@ import {
   DropdownKebab,
   Form,
   FormControl,
+  FormGroup,
   Icon,
   Label,
   ListView,
@@ -73,6 +74,7 @@ const matchStyle = style({
 });
 
 const createStyle = style({
+  marginTop: 70,
   marginLeft: 20
 });
 
@@ -269,13 +271,22 @@ class MatchingRouting extends React.Component<Props, State> {
 
   onHeaderNameChange = (event: any) => {
     this.setState({
-      headerName: event.target.value
+      headerName: event.target.value,
+      validationMsg: ''
     });
   };
 
   onMatchValueChange = (event: any) => {
+    let validationMsg = '';
+    if (this.state.category === HEADERS && this.state.headerName === '') {
+      validationMsg = 'Header name must be non empty';
+    }
+    if (event.target.value === '') {
+      validationMsg = '';
+    }
     this.setState({
-      matchValue: event.target.value
+      matchValue: event.target.value,
+      validationMsg: validationMsg
     });
   };
 
@@ -307,6 +318,10 @@ class MatchingRouting extends React.Component<Props, State> {
     return matchAll;
   };
 
+  matchBuilderValidation = (): string => {
+    return 'success';
+  };
+
   renderRuleBuilder = () => {
     return (
       <ListView>
@@ -328,7 +343,12 @@ class MatchingRouting extends React.Component<Props, State> {
           }
           // tslint:disable
           actions={
-            <Button bsStyle="primary" className={createStyle} onClick={this.onAddRule}>
+            <Button
+              bsStyle="primary"
+              className={createStyle}
+              disabled={this.state.validationMsg !== ''}
+              onClick={this.onAddRule}
+            >
               Add Rule
             </Button>
           }
@@ -350,41 +370,48 @@ class MatchingRouting extends React.Component<Props, State> {
     ));
     return (
       <Form inline={true}>
-        <DropdownButton
-          bsStyle="default"
-          title={this.state.category}
-          id="match-dropdown"
-          onSelect={this.onSelectCategory}
-        >
-          {matchItems}
-        </DropdownButton>
-        {this.state.category === HEADERS && (
+        <FormGroup validationState={this.matchBuilderValidation()}>
+          <DropdownButton
+            bsStyle="default"
+            title={this.state.category}
+            id="match-dropdown"
+            onSelect={this.onSelectCategory}
+          >
+            {matchItems}
+          </DropdownButton>
+          {this.state.category === HEADERS && (
+            <FormControl
+              type="text"
+              id="header-name-text"
+              placeholder={'Header name...'}
+              value={this.state.headerName}
+              onChange={this.onHeaderNameChange}
+            />
+          )}
+          <DropdownButton
+            bsStyle="default"
+            title={this.state.operator}
+            id="operator-dropdown"
+            onSelect={this.onSelectOperator}
+          >
+            {opItems}
+          </DropdownButton>
           <FormControl
             type="text"
-            id="header-name-text"
-            placeholder={'Header name...'}
-            value={this.state.headerName}
-            onChange={this.onHeaderNameChange}
+            id="header-value-text"
+            placeholder={placeholderText[this.state.category]}
+            value={this.state.matchValue}
+            onChange={this.onMatchValueChange}
           />
-        )}
-        <DropdownButton
-          bsStyle="default"
-          title={this.state.operator}
-          id="operator-dropdown"
-          onSelect={this.onSelectOperator}
-        >
-          {opItems}
-        </DropdownButton>
-        <FormControl
-          type="text"
-          id="header-value-text"
-          placeholder={placeholderText[this.state.category]}
-          value={this.state.matchValue}
-          onChange={this.onMatchValueChange}
-        />
-        <Button bsStyle="default" className={matchStyle} onClick={this.onAddMatch}>
-          Add Match
-        </Button>
+          <Button
+            bsStyle="default"
+            className={matchStyle}
+            disabled={this.state.validationMsg !== ''}
+            onClick={this.onAddMatch}
+          >
+            Add Match
+          </Button>
+        </FormGroup>
       </Form>
     );
   };

--- a/src/components/IstioWizards/MatchingRouting.tsx
+++ b/src/components/IstioWizards/MatchingRouting.tsx
@@ -106,7 +106,7 @@ const ruleItemStyle = style({
 });
 
 const matchValueStyle = style({
-  fontWeight: 300,
+  fontWeight: 'normal',
   whiteSpace: 'nowrap',
   overflow: 'hidden',
   textOverflow: 'ellipsis'

--- a/src/components/IstioWizards/MatchingRouting.tsx
+++ b/src/components/IstioWizards/MatchingRouting.tsx
@@ -6,7 +6,6 @@ import {
   Form,
   FormControl,
   FormGroup,
-  Icon,
   Label,
   ListView,
   ListViewIcon,
@@ -97,6 +96,22 @@ const validationStyle = style({
   color: PfColors.Red100
 });
 
+const ruleItemStyle = style({
+  $nest: {
+    ['.list-group-item-heading']: {
+      flexBasis: 'calc(50% - 20px)',
+      width: 'calc(50% - 20px)'
+    }
+  }
+});
+
+const matchValueStyle = style({
+  fontWeight: 300,
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis'
+});
+
 enum MOVE_TYPE {
   UP,
   DOWN
@@ -110,9 +125,6 @@ const svcIconName = 'service';
 
 const wkIconType = 'pf';
 const wkIconName = 'bundle';
-
-const valIconType = 'pf';
-const valIconName = 'error-circle-o';
 
 class MatchingRouting extends React.Component<Props, State> {
   constructor(props: Props) {
@@ -319,7 +331,7 @@ class MatchingRouting extends React.Component<Props, State> {
   };
 
   matchBuilderValidation = (): string => {
-    return 'success';
+    return this.state.validationMsg === '' ? 'success' : 'error';
   };
 
   renderRuleBuilder = () => {
@@ -468,7 +480,11 @@ class MatchingRouting extends React.Component<Props, State> {
       const rule = this.state.rules[index];
       isValid = matchAll === -1 || index <= matchAll;
       const matches: any[] = rule.matches.map((map, index) => {
-        return <small key={'match-' + map + '-' + index}>{map}</small>;
+        return (
+          <div key={'match-' + map + '-' + index} className={matchValueStyle}>
+            {map}
+          </div>
+        );
       });
       const ruleActions = (
         <div>
@@ -486,11 +502,12 @@ class MatchingRouting extends React.Component<Props, State> {
       ruleItems.push(
         <ListViewItem
           key={'match-rule-' + index}
+          className={ruleItemStyle}
           leftContent={<ListViewIcon type={vsIconType} name={vsIconName} />}
           heading={
             <div>
               Matches:
-              {rule.matches.length === 0 && <small>Any request</small>}
+              {rule.matches.length === 0 && <div className={matchValueStyle}>Any request</div>}
               {rule.matches.length !== 0 && matches}
             </div>
           }
@@ -508,8 +525,9 @@ class MatchingRouting extends React.Component<Props, State> {
               </div>
               {!isValid && (
                 <div className={validationStyle}>
-                  <Icon type={valIconType} name={valIconName} /> Match 'Any request' is defined in a previous rule. This
-                  rule is not accessible.
+                  Match 'Any request' is defined in a previous rule.
+                  <br />
+                  This rule is not accessible.
                 </div>
               )}
             </div>


### PR DESCRIPTION
Fix style of matching rule

https://issues.jboss.org/browse/KIALI-2588
https://issues.jboss.org/browse/KIALI-2576

Buttons are disabled in case there is a validation message:
![image](https://user-images.githubusercontent.com/1662329/54631200-c949ca80-4a7b-11e9-9f09-a6d81ba87b1c.png)

Text of matching rule is changed to address KIALI-2576, minor adjustments in style to support large header names.

![image](https://user-images.githubusercontent.com/1662329/54631248-e67e9900-4a7b-11e9-903c-c50b549d2c2f.png)

![image](https://user-images.githubusercontent.com/1662329/54631277-f39b8800-4a7b-11e9-9723-ce4f12e92d8c.png)


