### PR TITLE
KIALI-2547 JS warnings in App/Workload/Service details

### DIFF
--- a/src/pages/AppDetails/AppDetailsPage.tsx
+++ b/src/pages/AppDetails/AppDetailsPage.tsx
@@ -36,6 +36,9 @@ class AppDetails extends React.Component<RouteComponentProps<AppId>, AppDetailsS
       app: emptyApp,
       trafficData: null
     };
+  }
+
+  componentDidMount(): void {
     this.doRefresh();
   }
 

--- a/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -9,7 +9,6 @@ import {
   Row,
   TabContainer,
   TabContent,
-  TabPane,
   ToastNotification,
   ToastNotificationList
 } from 'patternfly-react';
@@ -204,26 +203,17 @@ class ServiceInfo extends React.Component<ServiceDetails, ServiceInfoState> {
                     </NavItem>
                   </Nav>
                   <TabContent>
-                    <WithErrorBoundary
-                      component={TabPane}
-                      eventKey={'workloads'}
-                      message={this.errorBoundaryMessage('Workloads')}
-                    >
+                    <WithErrorBoundary eventKey={'workloads'} message={this.errorBoundaryMessage('Workloads')}>
                       {(Object.keys(workloads).length > 0 || this.props.serviceDetails.istioSidecar) && (
                         <ServiceInfoWorkload workloads={workloads} namespace={this.props.namespace} />
                       )}
                     </WithErrorBoundary>
-                    <WithErrorBoundary
-                      component={TabPane}
-                      eventKey={'sources'}
-                      message={this.errorBoundaryMessage('Sources')}
-                    >
+                    <WithErrorBoundary eventKey={'sources'} message={this.errorBoundaryMessage('Sources')}>
                       {(Object.keys(dependencies).length > 0 || this.props.serviceDetails.istioSidecar) && (
                         <ServiceInfoRoutes dependencies={dependencies} />
                       )}
                     </WithErrorBoundary>
                     <WithErrorBoundary
-                      component={TabPane}
                       eventKey={'virtualservices'}
                       message={this.errorBoundaryMessage('Virtual Services')}
                     >
@@ -235,7 +225,6 @@ class ServiceInfo extends React.Component<ServiceDetails, ServiceInfoState> {
                       )}
                     </WithErrorBoundary>
                     <WithErrorBoundary
-                      component={TabPane}
                       eventKey={'destinationrules'}
                       message={this.errorBoundaryMessage('Destination Rules')}
                     >

--- a/src/pages/ServiceDetails/__tests__/__snapshots__/ServiceInfo.test.tsx.snap
+++ b/src/pages/ServiceDetails/__tests__/__snapshots__/ServiceInfo.test.tsx.snap
@@ -540,17 +540,14 @@ ShallowWrapper {
                     unmountOnExit={false}
                   >
                     <WithErrorBoundary
-                      component={[Function]}
                       eventKey="workloads"
                       message="One of the Workloads associated to this service has an invalid format"
                     />
                     <WithErrorBoundary
-                      component={[Function]}
                       eventKey="sources"
                       message="One of the Sources associated to this service has an invalid format"
                     />
                     <WithErrorBoundary
-                      component={[Function]}
                       eventKey="virtualservices"
                       message="One of the Virtual Services associated to this service has an invalid format"
                     >
@@ -589,7 +586,6 @@ ShallowWrapper {
                       />
                     </WithErrorBoundary>
                     <WithErrorBoundary
-                      component={[Function]}
                       eventKey="destinationrules"
                       message="One of the Destination Rules associated to this service has an invalid format"
                     >
@@ -964,17 +960,14 @@ ShallowWrapper {
                       unmountOnExit={false}
                     >
                       <WithErrorBoundary
-                        component={[Function]}
                         eventKey="workloads"
                         message="One of the Workloads associated to this service has an invalid format"
                       />
                       <WithErrorBoundary
-                        component={[Function]}
                         eventKey="sources"
                         message="One of the Sources associated to this service has an invalid format"
                       />
                       <WithErrorBoundary
-                        component={[Function]}
                         eventKey="virtualservices"
                         message="One of the Virtual Services associated to this service has an invalid format"
                       >
@@ -1013,7 +1006,6 @@ ShallowWrapper {
                         />
                       </WithErrorBoundary>
                       <WithErrorBoundary
-                        component={[Function]}
                         eventKey="destinationrules"
                         message="One of the Destination Rules associated to this service has an invalid format"
                       >
@@ -1939,17 +1931,14 @@ ShallowWrapper {
                       unmountOnExit={false}
                     >
                       <WithErrorBoundary
-                        component={[Function]}
                         eventKey="workloads"
                         message="One of the Workloads associated to this service has an invalid format"
                       />
                       <WithErrorBoundary
-                        component={[Function]}
                         eventKey="sources"
                         message="One of the Sources associated to this service has an invalid format"
                       />
                       <WithErrorBoundary
-                        component={[Function]}
                         eventKey="virtualservices"
                         message="One of the Virtual Services associated to this service has an invalid format"
                       >
@@ -1988,7 +1977,6 @@ ShallowWrapper {
                         />
                       </WithErrorBoundary>
                       <WithErrorBoundary
-                        component={[Function]}
                         eventKey="destinationrules"
                         message="One of the Destination Rules associated to this service has an invalid format"
                       >
@@ -2124,17 +2112,14 @@ ShallowWrapper {
                       unmountOnExit={false}
                     >
                       <WithErrorBoundary
-                        component={[Function]}
                         eventKey="workloads"
                         message="One of the Workloads associated to this service has an invalid format"
                       />
                       <WithErrorBoundary
-                        component={[Function]}
                         eventKey="sources"
                         message="One of the Sources associated to this service has an invalid format"
                       />
                       <WithErrorBoundary
-                        component={[Function]}
                         eventKey="virtualservices"
                         message="One of the Virtual Services associated to this service has an invalid format"
                       >
@@ -2173,7 +2158,6 @@ ShallowWrapper {
                         />
                       </WithErrorBoundary>
                       <WithErrorBoundary
-                        component={[Function]}
                         eventKey="destinationrules"
                         message="One of the Destination Rules associated to this service has an invalid format"
                       >
@@ -2306,17 +2290,14 @@ ShallowWrapper {
                       unmountOnExit={false}
                     >
                       <WithErrorBoundary
-                        component={[Function]}
                         eventKey="workloads"
                         message="One of the Workloads associated to this service has an invalid format"
                       />
                       <WithErrorBoundary
-                        component={[Function]}
                         eventKey="sources"
                         message="One of the Sources associated to this service has an invalid format"
                       />
                       <WithErrorBoundary
-                        component={[Function]}
                         eventKey="virtualservices"
                         message="One of the Virtual Services associated to this service has an invalid format"
                       >
@@ -2355,7 +2336,6 @@ ShallowWrapper {
                         />
                       </WithErrorBoundary>
                       <WithErrorBoundary
-                        component={[Function]}
                         eventKey="destinationrules"
                         message="One of the Destination Rules associated to this service has an invalid format"
                       >
@@ -2483,17 +2463,14 @@ ShallowWrapper {
                         unmountOnExit={false}
                       >
                         <WithErrorBoundary
-                          component={[Function]}
                           eventKey="workloads"
                           message="One of the Workloads associated to this service has an invalid format"
                         />
                         <WithErrorBoundary
-                          component={[Function]}
                           eventKey="sources"
                           message="One of the Sources associated to this service has an invalid format"
                         />
                         <WithErrorBoundary
-                          component={[Function]}
                           eventKey="virtualservices"
                           message="One of the Virtual Services associated to this service has an invalid format"
                         >
@@ -2532,7 +2509,6 @@ ShallowWrapper {
                           />
                         </WithErrorBoundary>
                         <WithErrorBoundary
-                          component={[Function]}
                           eventKey="destinationrules"
                           message="One of the Destination Rules associated to this service has an invalid format"
                         >
@@ -2771,17 +2747,14 @@ ShallowWrapper {
                         "bsClass": "tab",
                         "children": Array [
                           <WithErrorBoundary
-                            component={[Function]}
                             eventKey="workloads"
                             message="One of the Workloads associated to this service has an invalid format"
                           />,
                           <WithErrorBoundary
-                            component={[Function]}
                             eventKey="sources"
                             message="One of the Sources associated to this service has an invalid format"
                           />,
                           <WithErrorBoundary
-                            component={[Function]}
                             eventKey="virtualservices"
                             message="One of the Virtual Services associated to this service has an invalid format"
                           >
@@ -2820,7 +2793,6 @@ ShallowWrapper {
                             />
                           </WithErrorBoundary>,
                           <WithErrorBoundary
-                            component={[Function]}
                             eventKey="destinationrules"
                             message="One of the Destination Rules associated to this service has an invalid format"
                           >
@@ -2896,7 +2868,6 @@ ShallowWrapper {
                           "nodeType": "class",
                           "props": Object {
                             "children": false,
-                            "component": [Function],
                             "eventKey": "workloads",
                             "message": "One of the Workloads associated to this service has an invalid format",
                           },
@@ -2910,7 +2881,6 @@ ShallowWrapper {
                           "nodeType": "class",
                           "props": Object {
                             "children": false,
-                            "component": [Function],
                             "eventKey": "sources",
                             "message": "One of the Sources associated to this service has an invalid format",
                           },
@@ -2956,7 +2926,6 @@ ShallowWrapper {
                                 ]
                               }
                             />,
-                            "component": [Function],
                             "eventKey": "virtualservices",
                             "message": "One of the Virtual Services associated to this service has an invalid format",
                           },
@@ -3065,7 +3034,6 @@ ShallowWrapper {
                                 }
                               }
                             />,
-                            "component": [Function],
                             "eventKey": "destinationrules",
                             "message": "One of the Destination Rules associated to this service has an invalid format",
                           },
@@ -3458,17 +3426,14 @@ ShallowWrapper {
                       unmountOnExit={false}
                     >
                       <WithErrorBoundary
-                        component={[Function]}
                         eventKey="workloads"
                         message="One of the Workloads associated to this service has an invalid format"
                       />
                       <WithErrorBoundary
-                        component={[Function]}
                         eventKey="sources"
                         message="One of the Sources associated to this service has an invalid format"
                       />
                       <WithErrorBoundary
-                        component={[Function]}
                         eventKey="virtualservices"
                         message="One of the Virtual Services associated to this service has an invalid format"
                       >
@@ -3507,7 +3472,6 @@ ShallowWrapper {
                         />
                       </WithErrorBoundary>
                       <WithErrorBoundary
-                        component={[Function]}
                         eventKey="destinationrules"
                         message="One of the Destination Rules associated to this service has an invalid format"
                       >
@@ -3882,17 +3846,14 @@ ShallowWrapper {
                         unmountOnExit={false}
                       >
                         <WithErrorBoundary
-                          component={[Function]}
                           eventKey="workloads"
                           message="One of the Workloads associated to this service has an invalid format"
                         />
                         <WithErrorBoundary
-                          component={[Function]}
                           eventKey="sources"
                           message="One of the Sources associated to this service has an invalid format"
                         />
                         <WithErrorBoundary
-                          component={[Function]}
                           eventKey="virtualservices"
                           message="One of the Virtual Services associated to this service has an invalid format"
                         >
@@ -3931,7 +3892,6 @@ ShallowWrapper {
                           />
                         </WithErrorBoundary>
                         <WithErrorBoundary
-                          component={[Function]}
                           eventKey="destinationrules"
                           message="One of the Destination Rules associated to this service has an invalid format"
                         >
@@ -4857,17 +4817,14 @@ ShallowWrapper {
                         unmountOnExit={false}
                       >
                         <WithErrorBoundary
-                          component={[Function]}
                           eventKey="workloads"
                           message="One of the Workloads associated to this service has an invalid format"
                         />
                         <WithErrorBoundary
-                          component={[Function]}
                           eventKey="sources"
                           message="One of the Sources associated to this service has an invalid format"
                         />
                         <WithErrorBoundary
-                          component={[Function]}
                           eventKey="virtualservices"
                           message="One of the Virtual Services associated to this service has an invalid format"
                         >
@@ -4906,7 +4863,6 @@ ShallowWrapper {
                           />
                         </WithErrorBoundary>
                         <WithErrorBoundary
-                          component={[Function]}
                           eventKey="destinationrules"
                           message="One of the Destination Rules associated to this service has an invalid format"
                         >
@@ -5042,17 +4998,14 @@ ShallowWrapper {
                         unmountOnExit={false}
                       >
                         <WithErrorBoundary
-                          component={[Function]}
                           eventKey="workloads"
                           message="One of the Workloads associated to this service has an invalid format"
                         />
                         <WithErrorBoundary
-                          component={[Function]}
                           eventKey="sources"
                           message="One of the Sources associated to this service has an invalid format"
                         />
                         <WithErrorBoundary
-                          component={[Function]}
                           eventKey="virtualservices"
                           message="One of the Virtual Services associated to this service has an invalid format"
                         >
@@ -5091,7 +5044,6 @@ ShallowWrapper {
                           />
                         </WithErrorBoundary>
                         <WithErrorBoundary
-                          component={[Function]}
                           eventKey="destinationrules"
                           message="One of the Destination Rules associated to this service has an invalid format"
                         >
@@ -5224,17 +5176,14 @@ ShallowWrapper {
                         unmountOnExit={false}
                       >
                         <WithErrorBoundary
-                          component={[Function]}
                           eventKey="workloads"
                           message="One of the Workloads associated to this service has an invalid format"
                         />
                         <WithErrorBoundary
-                          component={[Function]}
                           eventKey="sources"
                           message="One of the Sources associated to this service has an invalid format"
                         />
                         <WithErrorBoundary
-                          component={[Function]}
                           eventKey="virtualservices"
                           message="One of the Virtual Services associated to this service has an invalid format"
                         >
@@ -5273,7 +5222,6 @@ ShallowWrapper {
                           />
                         </WithErrorBoundary>
                         <WithErrorBoundary
-                          component={[Function]}
                           eventKey="destinationrules"
                           message="One of the Destination Rules associated to this service has an invalid format"
                         >
@@ -5401,17 +5349,14 @@ ShallowWrapper {
                           unmountOnExit={false}
                         >
                           <WithErrorBoundary
-                            component={[Function]}
                             eventKey="workloads"
                             message="One of the Workloads associated to this service has an invalid format"
                           />
                           <WithErrorBoundary
-                            component={[Function]}
                             eventKey="sources"
                             message="One of the Sources associated to this service has an invalid format"
                           />
                           <WithErrorBoundary
-                            component={[Function]}
                             eventKey="virtualservices"
                             message="One of the Virtual Services associated to this service has an invalid format"
                           >
@@ -5450,7 +5395,6 @@ ShallowWrapper {
                             />
                           </WithErrorBoundary>
                           <WithErrorBoundary
-                            component={[Function]}
                             eventKey="destinationrules"
                             message="One of the Destination Rules associated to this service has an invalid format"
                           >
@@ -5689,17 +5633,14 @@ ShallowWrapper {
                           "bsClass": "tab",
                           "children": Array [
                             <WithErrorBoundary
-                              component={[Function]}
                               eventKey="workloads"
                               message="One of the Workloads associated to this service has an invalid format"
                             />,
                             <WithErrorBoundary
-                              component={[Function]}
                               eventKey="sources"
                               message="One of the Sources associated to this service has an invalid format"
                             />,
                             <WithErrorBoundary
-                              component={[Function]}
                               eventKey="virtualservices"
                               message="One of the Virtual Services associated to this service has an invalid format"
                             >
@@ -5738,7 +5679,6 @@ ShallowWrapper {
                               />
                             </WithErrorBoundary>,
                             <WithErrorBoundary
-                              component={[Function]}
                               eventKey="destinationrules"
                               message="One of the Destination Rules associated to this service has an invalid format"
                             >
@@ -5814,7 +5754,6 @@ ShallowWrapper {
                             "nodeType": "class",
                             "props": Object {
                               "children": false,
-                              "component": [Function],
                               "eventKey": "workloads",
                               "message": "One of the Workloads associated to this service has an invalid format",
                             },
@@ -5828,7 +5767,6 @@ ShallowWrapper {
                             "nodeType": "class",
                             "props": Object {
                               "children": false,
-                              "component": [Function],
                               "eventKey": "sources",
                               "message": "One of the Sources associated to this service has an invalid format",
                             },
@@ -5874,7 +5812,6 @@ ShallowWrapper {
                                   ]
                                 }
                               />,
-                              "component": [Function],
                               "eventKey": "virtualservices",
                               "message": "One of the Virtual Services associated to this service has an invalid format",
                             },
@@ -5983,7 +5920,6 @@ ShallowWrapper {
                                   }
                                 }
                               />,
-                              "component": [Function],
                               "eventKey": "destinationrules",
                               "message": "One of the Destination Rules associated to this service has an invalid format",
                             },

--- a/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -34,6 +34,9 @@ class WorkloadDetails extends React.Component<RouteComponentProps<WorkloadId>, W
       istioEnabled: false,
       trafficData: null
     };
+  }
+
+  componentDidMount(): void {
     this.doRefresh();
   }
 


### PR DESCRIPTION
The two first fixes are trivial.
@xeviknal the WithErrorBoundary class doesn't seem to need the component attribute, as it uses the TabPane inside:

```
const TabPaneWithErrorBoundary = withErrorBoundary<TabPane.propTypes>(TabPane);
export default TabPaneWithErrorBoundary;
```

So I think it's safe, but just take a look and let me how it looks there.