### PR TITLE
Kiali-907: Error messages pile up infinitely.

### DIFF
--- a/src/components/MessageCenter/NotificationDrawer.tsx
+++ b/src/components/MessageCenter/NotificationDrawer.tsx
@@ -12,6 +12,7 @@ import {
 } from 'patternfly-react';
 
 import { MessageType, NotificationMessage, NotificationGroup } from '../../types/MessageCenter';
+import * as moment from 'moment';
 
 const typeForPfIcon = (type: MessageType) => {
   switch (type) {
@@ -59,7 +60,14 @@ class NotificationWrapper extends React.PureComponent<NotificationWrapperPropsTy
       <Notification seen={this.props.message.seen} onClick={() => this.props.onClick(this.props.message)}>
         <Icon className="pull-left" type="pf" name={typeForPfIcon(this.props.message.type)} />
         <Notification.Content>
-          <Notification.Message>{this.props.message.content}</Notification.Message>
+          <Notification.Message>
+            {this.props.message.content}
+            {this.props.message.count > 1 && (
+              <div>
+                {this.props.message.count} {moment().from(this.props.message.firstTriggered)}
+              </div>
+            )}
+          </Notification.Message>
           <Notification.Info
             leftText={this.props.message.created.toLocaleDateString()}
             rightText={this.props.message.created.toLocaleTimeString()}

--- a/src/components/MessageCenter/__tests__/MessageCenter.test.tsx
+++ b/src/components/MessageCenter/__tests__/MessageCenter.test.tsx
@@ -18,6 +18,7 @@ describe('MessageCenter', () => {
           seen: false,
           content: 'show me',
           type: MessageType.ERROR,
+          count: 0,
           show_notification: true,
           created: new Date()
         },
@@ -26,6 +27,7 @@ describe('MessageCenter', () => {
           seen: false,
           content: 'hide me',
           type: MessageType.ERROR,
+          count: 0,
           created: new Date()
         }
       ]
@@ -41,6 +43,7 @@ describe('MessageCenter', () => {
           seen: true,
           content: 'show me too',
           type: MessageType.SUCCESS,
+          count: 0,
           show_notification: true,
           created: new Date()
         }

--- a/src/reducers/__tests__/MessageCenterReducer.test.ts
+++ b/src/reducers/__tests__/MessageCenterReducer.test.ts
@@ -39,6 +39,7 @@ describe('MessageCenter reducer', () => {
       nextId: 0
     });
   });
+
   it('should handle ADD_MESSAGE', () => {
     const date = mockDate(new Date());
     expect(
@@ -73,6 +74,8 @@ describe('MessageCenter reducer', () => {
               show_notification: true,
               content: 'my new message',
               type: MessageType.WARNING,
+              count: 1,
+              firstTriggered: undefined,
               created: date
             }
           ],
@@ -85,6 +88,67 @@ describe('MessageCenter reducer', () => {
       nextId: 1
     });
   });
+
+  it('should handle Duplicate Messages', () => {
+    const date = mockDate(new Date());
+    expect(
+      MessageCenter(
+        {
+          expanded: false,
+          expandedGroupId: 'default',
+          groups: [
+            {
+              id: 'default',
+              messages: [
+                {
+                  id: 0,
+                  seen: false,
+                  show_notification: true,
+                  content: 'my new message',
+                  type: MessageType.WARNING,
+                  count: 1,
+                  firstTriggered: undefined,
+                  created: date
+                }
+              ],
+              title: 'Default',
+              showActions: true,
+              hideIfEmpty: false
+            }
+          ],
+          hidden: true,
+          nextId: 0
+        },
+        MessageCenterActions.addMessage('my new message', 'default', MessageType.WARNING)
+      )
+    ).toEqual({
+      expanded: false,
+      expandedGroupId: 'default',
+      groups: [
+        {
+          id: 'default',
+          messages: [
+            {
+              id: 0,
+              seen: false,
+              show_notification: true,
+              content: 'my new message',
+              type: MessageType.WARNING,
+              count: 2,
+              firstTriggered: date,
+              created: date
+            }
+          ],
+          title: 'Default',
+          showActions: true,
+          hideIfEmpty: false
+        }
+      ],
+      hidden: true,
+      nextId: 1
+    });
+  });
+
   it('should handle REMOVE_MESSAGE', () => {
     const date = mockDate(new Date());
     expect(
@@ -104,6 +168,7 @@ describe('MessageCenter reducer', () => {
                   show_notification: true,
                   content: 'my new message',
                   type: MessageType.WARNING,
+                  count: 1,
                   created: date
                 },
                 {
@@ -112,6 +177,7 @@ describe('MessageCenter reducer', () => {
                   show_notification: false,
                   content: 'other message',
                   type: MessageType.ERROR,
+                  count: 1,
                   created: date
                 },
                 {
@@ -120,6 +186,7 @@ describe('MessageCenter reducer', () => {
                   show_notification: false,
                   content: 'other',
                   type: MessageType.INFO,
+                  count: 1,
                   created: date
                 }
               ],
@@ -144,6 +211,7 @@ describe('MessageCenter reducer', () => {
               show_notification: false,
               content: 'other message',
               type: MessageType.ERROR,
+              count: 1,
               created: date
             }
           ],
@@ -156,6 +224,7 @@ describe('MessageCenter reducer', () => {
       nextId: 1
     });
   });
+
   it('should handle MARK_MESSAGE_AS_READ', () => {
     const date = mockDate(new Date());
     expect(
@@ -175,6 +244,7 @@ describe('MessageCenter reducer', () => {
                   show_notification: true,
                   content: 'my new message',
                   type: MessageType.WARNING,
+                  count: 1,
                   created: date
                 },
                 {
@@ -183,6 +253,7 @@ describe('MessageCenter reducer', () => {
                   show_notification: false,
                   content: 'other message',
                   type: MessageType.ERROR,
+                  count: 1,
                   created: date
                 },
                 {
@@ -191,6 +262,7 @@ describe('MessageCenter reducer', () => {
                   show_notification: false,
                   content: 'other',
                   type: MessageType.INFO,
+                  count: 1,
                   created: date
                 }
               ],
@@ -215,6 +287,7 @@ describe('MessageCenter reducer', () => {
               show_notification: false,
               content: 'my new message',
               type: MessageType.WARNING,
+              count: 1,
               created: date
             },
             {
@@ -223,6 +296,7 @@ describe('MessageCenter reducer', () => {
               show_notification: false,
               content: 'other message',
               type: MessageType.ERROR,
+              count: 1,
               created: date
             },
             {
@@ -231,6 +305,7 @@ describe('MessageCenter reducer', () => {
               show_notification: false,
               content: 'other',
               type: MessageType.INFO,
+              count: 1,
               created: date
             }
           ],
@@ -243,6 +318,7 @@ describe('MessageCenter reducer', () => {
       nextId: 1
     });
   });
+
   it('should handle HIDE_NOTIFICATION', () => {
     const date = mockDate(new Date());
     expect(
@@ -262,6 +338,7 @@ describe('MessageCenter reducer', () => {
                   show_notification: true,
                   content: 'my new message',
                   type: MessageType.WARNING,
+                  count: 1,
                   created: date
                 },
                 {
@@ -270,6 +347,7 @@ describe('MessageCenter reducer', () => {
                   show_notification: true,
                   content: 'other message',
                   type: MessageType.ERROR,
+                  count: 1,
                   created: date
                 }
               ],
@@ -294,6 +372,7 @@ describe('MessageCenter reducer', () => {
               show_notification: false,
               content: 'my new message',
               type: MessageType.WARNING,
+              count: 1,
               created: date
             },
             {
@@ -302,6 +381,7 @@ describe('MessageCenter reducer', () => {
               show_notification: true,
               content: 'other message',
               type: MessageType.ERROR,
+              count: 1,
               created: date
             }
           ],
@@ -314,6 +394,7 @@ describe('MessageCenter reducer', () => {
       nextId: 1
     });
   });
+
   it('should handle SHOW', () => {
     expect(
       MessageCenter(
@@ -386,6 +467,7 @@ describe('MessageCenter reducer', () => {
       nextId: 0
     });
   });
+
   it('should handle TOGGLE_EXPAND', () => {
     expect(
       MessageCenter(
@@ -422,6 +504,7 @@ describe('MessageCenter reducer', () => {
       nextId: 0
     });
   });
+
   it('should handle TOGGLE_GROUP to hide a group', () => {
     expect(
       MessageCenter(
@@ -458,6 +541,7 @@ describe('MessageCenter reducer', () => {
       nextId: 0
     });
   });
+
   it('should handle TOGGLE_GROUP to show a group', () => {
     expect(
       MessageCenter(

--- a/src/types/MessageCenter.ts
+++ b/src/types/MessageCenter.ts
@@ -11,6 +11,8 @@ export interface NotificationMessage {
   type: MessageType;
   content: string;
   created: Date;
+  firstTriggered?: Date; // when was it first triggered
+  count: number; // how many times did this message occur
 
   show_notification?: boolean;
   groupId?: string;


### PR DESCRIPTION
** Describe the change **
This keeps repeating error messages from piling up in the message drawer.
It now works like the Openshift messages with a count of how many times the notification message is repeated and for how long the same notification has been going on.


** Issue reference **
https://issues.jboss.org/browse/KIALI-907

** Backwards compatible? **
yes

[ ] Is your pull-request introducing changes in behaviour?
no, just changes the way the messages are presented

** Screenshot **

**Old**:

![_KIALI-907__Error_Messages_Pile_up_infinitely_-_JBoss_Issue_Tracker](https://user-images.githubusercontent.com/1312165/54691934-6723b080-4ae1-11e9-94ec-dbc062ca0718.png)

**New**:

![error-msg](https://user-images.githubusercontent.com/1312165/54695819-e74d1480-4ae7-11e9-87d2-4a39ead2ea7f.png)

** Documentation **

