### PR TITLE
Add new tslint rule: 'no-literal-string' to clean up type-safe issues…

### DIFF
--- a/src/actions/GraphDataThunkActions.ts
+++ b/src/actions/GraphDataThunkActions.ts
@@ -37,17 +37,17 @@ const GraphDataThunkActions = {
         return Promise.resolve();
       }
       dispatch(GraphDataActions.getGraphDataStart());
-      const restParams = {
+      const restParams: any = {
         duration: duration + 's',
         graphType: graphType,
         injectServiceNodes: injectServiceNodes
       };
       if (namespaces.find(namespace => namespace.name === serverConfig.istioNamespace)) {
-        restParams['includeIstio'] = true;
+        restParams.includeIstio = true;
       }
 
       if (graphType === GraphType.APP || graphType === GraphType.VERSIONED_APP) {
-        restParams['groupBy'] = GroupByType.APP;
+        restParams.groupBy = GroupByType.APP;
       }
 
       // Some appenders are expensive so only specify an appender if needed.
@@ -74,13 +74,13 @@ const GraphDataThunkActions = {
         default:
           break;
       }
-      restParams['appenders'] = appenders;
+      restParams.appenders = appenders;
       console.debug('Fetching graph with appenders: ' + appenders);
 
       if (node) {
         return setCurrentRequest(API.getNodeGraphElements(node, restParams)).then(
           response => {
-            const responseData: any = response['data'];
+            const responseData: any = response.data;
             const graphData = responseData && responseData.elements ? responseData.elements : EMPTY_GRAPH_DATA;
             const timestamp = responseData && responseData.timestamp ? responseData.timestamp : 0;
             const graphDuration = responseData && responseData.duration ? responseData.duration : 0;
@@ -102,10 +102,10 @@ const GraphDataThunkActions = {
         );
       }
 
-      restParams['namespaces'] = namespaces.map(namespace => namespace.name).join(',');
+      restParams.namespaces = namespaces.map(namespace => namespace.name).join(',');
       return setCurrentRequest(API.getGraphElements(restParams)).then(
         response => {
-          const responseData: any = response['data'];
+          const responseData: any = response.data;
           const graphData = responseData && responseData.elements ? responseData.elements : EMPTY_GRAPH_DATA;
           const timestamp = responseData && responseData.timestamp ? responseData.timestamp : 0;
           const graphDuration = responseData && responseData.duration ? responseData.duration : 0;

--- a/src/actions/NamespaceThunkActions.ts
+++ b/src/actions/NamespaceThunkActions.ts
@@ -17,7 +17,7 @@ const NamespaceThunkActions = {
     return (dispatch: ThunkDispatch<KialiAppState, void, KialiAppAction>) => {
       dispatch(NamespaceActions.requestStarted());
       return Api.getNamespaces()
-        .then(response => response['data'])
+        .then(response => response.data)
         .then(data => {
           dispatch(NamespaceActions.receiveList([...data], new Date()));
         })

--- a/src/app/AuthenticationController.tsx
+++ b/src/app/AuthenticationController.tsx
@@ -119,7 +119,7 @@ const processServerStatus = (dispatch: KialiDispatch, serverStatus: ServerStatus
   );
 
   // Get the jaeger URL
-  const hasJaeger = serverStatus.externalServices.filter(item => item['name'] === 'Jaeger');
+  const hasJaeger = serverStatus.externalServices.filter(item => item.name === 'Jaeger');
   if (hasJaeger.length === 1 && hasJaeger[0].url) {
     dispatch(JaegerActions.setUrl(hasJaeger[0].url));
     // If same protocol enable integration

--- a/src/components/CytoscapeGraph/__tests__/CytoscapeGraph.test.tsx
+++ b/src/components/CytoscapeGraph/__tests__/CytoscapeGraph.test.tsx
@@ -59,7 +59,7 @@ describe('CytoscapeGraph component test', () => {
     );
     const emptyGraphLayoutWrapper = wrapper.find(EmptyGraphLayout);
     const emptyGraphDecorated = decorateGraphData(GRAPH_DATA[testNamespace].elements);
-    expect(emptyGraphLayoutWrapper.prop('elements')['nodes']).toEqual(emptyGraphDecorated.nodes);
-    expect(emptyGraphLayoutWrapper.prop('elements')['edges']).toEqual(emptyGraphDecorated.edges);
+    expect(emptyGraphLayoutWrapper.prop('elements').nodes).toEqual(emptyGraphDecorated.nodes);
+    expect(emptyGraphLayoutWrapper.prop('elements').edges).toEqual(emptyGraphDecorated.edges);
   });
 });

--- a/src/components/JaegerIntegration/ServiceDropdown.tsx
+++ b/src/components/JaegerIntegration/ServiceDropdown.tsx
@@ -43,8 +43,8 @@ export class ServiceDropdown extends React.PureComponent<ServiceDropdownProps, S
         .then(responses => {
           const serviceListItems: string[] = [];
           responses.forEach(response => {
-            const ns = response['data']['namespace']['name'];
-            response['data']['services'].forEach((service: ServiceOverview) => {
+            const ns = response.data.namespace.name;
+            response.data.services.forEach((service: ServiceOverview) => {
               serviceListItems.push(`${service.name}.${ns}`);
             });
           });

--- a/src/components/JaegerIntegration/__tests__/JaegerToolbar.test.tsx
+++ b/src/components/JaegerIntegration/__tests__/JaegerToolbar.test.tsx
@@ -33,11 +33,11 @@ describe('LookBack', () => {
   describe('Form', () => {
     it('FormControl should be disabled', () => {
       wrapper.find(FormControl).forEach(f => {
-        expect(f.props()['disabled']).toBeFalsy();
+        expect(f.props().disabled).toBeFalsy();
       });
       wrapper.setProps({ disabled: true });
       wrapper.find(FormControl).forEach(f => {
-        expect(f.props()['disabled']).toBeTruthy();
+        expect(f.props().disabled).toBeTruthy();
       });
     });
   });

--- a/src/components/JaegerIntegration/__tests__/LookBack.test.tsx
+++ b/src/components/JaegerIntegration/__tests__/LookBack.test.tsx
@@ -46,14 +46,14 @@ describe('LookBack', () => {
       wrapper
         .find(ToolbarDropdown)
         .first()
-        .props()['disabled']
+        .props().disabled
     ).toBeFalsy();
     wrapper.setProps({ disabled: true });
     expect(
       wrapper
         .find(ToolbarDropdown)
         .first()
-        .props()['disabled']
+        .props().disabled
     ).toBeTruthy();
   });
 
@@ -62,7 +62,7 @@ describe('LookBack', () => {
       wrapper
         .find(ToolbarDropdown)
         .first()
-        .props()['options']
+        .props().options
     ).toEqual(lookBackOptions);
   });
 
@@ -72,7 +72,7 @@ describe('LookBack', () => {
       wrapper
         .find(ToolbarDropdown)
         .first()
-        .props()['value']
+        .props().value
     ).toEqual('1h');
   });
 
@@ -81,7 +81,7 @@ describe('LookBack', () => {
       wrapper
         .find(ToolbarDropdown)
         .first()
-        .props()['handleSelect']
+        .props().handleSelect
     ).toBe(setLookback);
   });
 });

--- a/src/components/JaegerIntegration/__tests__/RightToolbar.test.tsx
+++ b/src/components/JaegerIntegration/__tests__/RightToolbar.test.tsx
@@ -25,10 +25,10 @@ describe('RightToolbar', () => {
     it('RightToolbar have Search button', () => {
       let buttonProps = wrapper.find({ title: 'Search' }).props();
       expect(buttonProps).toBeDefined();
-      expect(buttonProps['onClick']).toBeDefined();
+      expect(buttonProps.onClick).toBeDefined();
       wrapper.setProps({ disabled: true });
       buttonProps = wrapper.find({ title: 'Search' }).props();
-      expect(buttonProps['disabled']).toBeTruthy();
+      expect(buttonProps.disabled).toBeTruthy();
     });
   });
 });

--- a/src/components/JaegerIntegration/__tests__/ServiceDropdown.test.tsx
+++ b/src/components/JaegerIntegration/__tests__/ServiceDropdown.test.tsx
@@ -20,7 +20,7 @@ describe('NamespaceDropdown', () => {
       wrapper
         .find(ToolbarDropdown)
         .first()
-        .props()['value']
+        .props().value
     ).toBe('');
   });
 
@@ -31,7 +31,7 @@ describe('NamespaceDropdown', () => {
       wrapper
         .find(ToolbarDropdown)
         .first()
-        .props()['label']
+        .props().label
     ).toBe(service);
   });
 
@@ -40,7 +40,7 @@ describe('NamespaceDropdown', () => {
       wrapper
         .find(ToolbarDropdown)
         .first()
-        .props()['handleSelect']
+        .props().handleSelect
     ).toBe(setService);
   });
 });

--- a/src/components/JaegerIntegration/__tests__/TagsControl.test.tsx
+++ b/src/components/JaegerIntegration/__tests__/TagsControl.test.tsx
@@ -26,7 +26,7 @@ describe('TagsControls', () => {
         wrapper
           .find(FormControl)
           .first()
-          .props()['disabled']
+          .props().disabled
       ).toBeFalsy();
     });
 
@@ -37,7 +37,7 @@ describe('TagsControls', () => {
         wrapper
           .find(FormControl)
           .first()
-          .props()['disabled']
+          .props().disabled
       ).toBeTruthy();
     });
 
@@ -47,7 +47,7 @@ describe('TagsControls', () => {
         wrapper
           .find(FormControl)
           .first()
-          .props()['defaultValue']
+          .props().defaultValue
       ).toBe('');
     });
 
@@ -58,7 +58,7 @@ describe('TagsControls', () => {
         wrapper
           .find(FormControl)
           .first()
-          .props()['defaultValue']
+          .props().defaultValue
       ).toBe('{error: true}');
     });
 

--- a/src/components/Metrics/__tests__/CustomMetrics.test.tsx
+++ b/src/components/Metrics/__tests__/CustomMetrics.test.tsx
@@ -8,7 +8,7 @@ import * as API from '../../../services/Api';
 import { MonitoringDashboard } from '../../../types/Metrics';
 import { store } from '../../../store/ConfigStore';
 
-window['SVGPathElement'] = a => a;
+(window as any).SVGPathElement = a => a;
 let mounted: ReactWrapper<any, any> | null;
 
 const mockAPIToPromise = (func: keyof typeof API, obj: any): Promise<void> => {

--- a/src/components/Metrics/__tests__/IstioMetrics.test.tsx
+++ b/src/components/Metrics/__tests__/IstioMetrics.test.tsx
@@ -8,7 +8,7 @@ import * as API from '../../../services/Api';
 import { MetricsObjectTypes, MonitoringDashboard, Chart } from '../../../types/Metrics';
 import { store } from '../../../store/ConfigStore';
 
-window['SVGPathElement'] = a => a;
+(window as any).SVGPathElement = a => a;
 let mounted: ReactWrapper<any, any> | null;
 
 const mockAPIToPromise = (func: keyof typeof API, obj: any): Promise<void> => {

--- a/src/components/Nav/__tests__/Navigation.test.tsx
+++ b/src/components/Nav/__tests__/Navigation.test.tsx
@@ -60,7 +60,7 @@ const _tester = (path: string, expectedMenuPath: string) => {
   );
 
   const navWrapper = wrapper.find(VerticalNav.Item).findWhere(el => el.key() === path);
-  expect(navWrapper.props()['active']).toBeTruthy();
+  expect(navWrapper.props().active).toBeTruthy();
 };
 
 describe('Navigation test', () => {

--- a/src/components/SummaryPanel/ResponseTable.tsx
+++ b/src/components/SummaryPanel/ResponseTable.tsx
@@ -1,14 +1,22 @@
 import * as React from 'react';
 import { Responses } from '../../types/Graph';
+import _ from 'lodash';
 
 type ResponseTableProps = {
   responses: Responses;
   title: string;
 };
 
+interface Row {
+  code: string;
+  flags: string;
+  key: string;
+  val: string;
+}
+
 // The Envoy flags can be found here:
 // https://github.com/envoyproxy/envoy/blob/master/source/common/stream_info/utility.cc
-const FLAGS = Object.freeze({
+const Flags: object = {
   DC: { code: '500', help: 'Downstream Connection Termination' },
   DI: { help: 'Delayed via fault injection' },
   FI: { help: 'Aborted via fault injection' },
@@ -26,7 +34,7 @@ const FLAGS = Object.freeze({
   UR: { code: '503', help: 'Upstream remote reset' },
   URX: { code: '503', help: 'Upstream retry limit exceeded' },
   UT: { code: '504', help: 'Upstream request timeout' }
-});
+};
 
 export class ResponseTable extends React.PureComponent<ResponseTableProps> {
   constructor(props: ResponseTableProps) {
@@ -47,10 +55,10 @@ export class ResponseTable extends React.PureComponent<ResponseTableProps> {
           </thead>
           <tbody>
             {this.getRows(this.props.responses).map(row => (
-              <tr key={row['key']}>
-                <td>{row['code']}</td>
-                <td title={this.getTitle(row['flags'])}>{row['flags']}</td>
-                <td>{row['val']}</td>
+              <tr key={row.key}>
+                <td>{row.code}</td>
+                <td title={this.getTitle(row.flags)}>{row.flags}</td>
+                <td>{row.val}</td>
               </tr>
             ))}
           </tbody>
@@ -59,10 +67,10 @@ export class ResponseTable extends React.PureComponent<ResponseTableProps> {
     );
   }
 
-  private getRows = (responses: Responses): Object[] => {
-    const rows: Object[] = [];
-    Object.keys(responses).map(code => {
-      Object.keys(responses[code]).map(f => {
+  private getRows = (responses: Responses): Row[] => {
+    const rows: Row[] = [];
+    _.keys(responses).map(code => {
+      _.keys(responses[code]).map(f => {
         rows.push({ key: `${code} ${f}`, code: code, flags: f, val: responses[code][f] });
       });
     });
@@ -74,7 +82,7 @@ export class ResponseTable extends React.PureComponent<ResponseTableProps> {
       .split(',')
       .map(flagToken => {
         flagToken = flagToken.trim();
-        const flag = FLAGS[flagToken];
+        const flag = Flags[flagToken];
         return flagToken === '-' ? '' : `[${flagToken}] ${flag ? flag.help : 'Unknown Flag'}`;
       })
       .join('\n');

--- a/src/pages/AppList/AppListComponent.tsx
+++ b/src/pages/AppList/AppListComponent.tsx
@@ -85,7 +85,7 @@ class AppListComponent extends ListComponent.Component<AppListComponentProps, Ap
       this.promises
         .register('namespaces', API.getNamespaces())
         .then(namespacesResponse => {
-          const namespaces: Namespace[] = namespacesResponse['data'];
+          const namespaces: Namespace[] = namespacesResponse.data;
           this.fetchApps(
             namespaces.map(namespace => namespace.name),
             activeFilters,

--- a/src/pages/Graph/SummaryPanelEdge.tsx
+++ b/src/pages/Graph/SummaryPanelEdge.tsx
@@ -229,7 +229,7 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
     }
     const comparator = (metric: Metric) => {
       if (this.isSpecialServiceDest(destMetricType)) {
-        return metric[sourceLabel] === sourceValue && metric['destination_workload'] === 'unknown';
+        return metric[sourceLabel] === sourceValue && metric.destination_workload === 'unknown';
       }
       return metric[sourceLabel] === sourceValue;
     };
@@ -316,43 +316,37 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
         const histograms = response.data.histograms;
         let { reqRates, errRates, rtAvg, rtMed, rt95, rt99, tcpSent, tcpReceived } = defaultSummaryPanelState;
         if (isGrpc || isHttp) {
-          reqRates = this.getNodeDataPoints(
-            metrics['request_count'],
-            'RPS',
-            sourceMetricType,
-            destMetricType,
-            sourceData
-          );
+          reqRates = this.getNodeDataPoints(metrics.request_count, 'RPS', sourceMetricType, destMetricType, sourceData);
           errRates = this.getNodeDataPoints(
-            metrics['request_error_count'],
+            metrics.request_error_count,
             'Error',
             sourceMetricType,
             destMetricType,
             sourceData
           );
           rtAvg = this.getNodeDataPoints(
-            histograms['request_duration']['avg'],
+            histograms.request_duration.avg,
             'Average',
             sourceMetricType,
             destMetricType,
             sourceData
           );
           rtMed = this.getNodeDataPoints(
-            histograms['request_duration']['0.5'],
+            histograms.request_duration['0.5'],
             'Median',
             sourceMetricType,
             destMetricType,
             sourceData
           );
           rt95 = this.getNodeDataPoints(
-            histograms['request_duration']['0.95'],
+            histograms.request_duration['0.95'],
             '95th',
             sourceMetricType,
             destMetricType,
             sourceData
           );
           rt99 = this.getNodeDataPoints(
-            histograms['request_duration']['0.99'],
+            histograms.request_duration['0.99'],
             '99th',
             sourceMetricType,
             destMetricType,
@@ -360,9 +354,9 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
           );
         } else {
           // TCP
-          tcpSent = this.getNodeDataPoints(metrics['tcp_sent'], 'Sent', sourceMetricType, destMetricType, sourceData);
+          tcpSent = this.getNodeDataPoints(metrics.tcp_sent, 'Sent', sourceMetricType, destMetricType, sourceData);
           tcpReceived = this.getNodeDataPoints(
-            metrics['tcp_received'],
+            metrics.tcp_received,
             'Received',
             sourceMetricType,
             destMetricType,

--- a/src/pages/Graph/SummaryPanelGraph.tsx
+++ b/src/pages/Graph/SummaryPanelGraph.tsx
@@ -157,10 +157,10 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
 
     this.metricsPromise.promise
       .then(response => {
-        const reqRates = getDatapoints(response.data.metrics['request_count'], 'RPS');
-        const errRates = getDatapoints(response.data.metrics['request_error_count'], 'Error');
-        const tcpSent = getDatapoints(response.data.metrics['tcp_sent'], 'Sent');
-        const tcpReceived = getDatapoints(response.data.metrics['tcp_received'], 'Received');
+        const reqRates = getDatapoints(response.data.metrics.request_count, 'RPS');
+        const errRates = getDatapoints(response.data.metrics.request_error_count, 'Error');
+        const tcpSent = getDatapoints(response.data.metrics.tcp_sent, 'Sent');
+        const tcpReceived = getDatapoints(response.data.metrics.tcp_received, 'Received');
 
         this.setState({
           loading: false,

--- a/src/pages/Graph/SummaryPanelGroup.tsx
+++ b/src/pages/Graph/SummaryPanelGroup.tsx
@@ -180,14 +180,14 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
       .then(responses => {
         const metricsOut = responses[0].data.metrics;
         const metricsIn = responses[1].data.metrics;
-        const rcOut = metricsOut['request_count'];
-        const ecOut = metricsOut['request_error_count'];
-        const tcpSentOut = metricsOut['tcp_sent'];
-        const tcpReceivedOut = metricsOut['tcp_received'];
-        const rcIn = metricsIn['request_count'];
-        const ecIn = metricsIn['request_error_count'];
-        const tcpSentIn = metricsIn['tcp_sent'];
-        const tcpReceivedIn = metricsIn['tcp_received'];
+        const rcOut = metricsOut.request_count;
+        const ecOut = metricsOut.request_error_count;
+        const tcpSentOut = metricsOut.tcp_sent;
+        const tcpReceivedOut = metricsOut.tcp_received;
+        const rcIn = metricsIn.request_count;
+        const ecIn = metricsIn.request_error_count;
+        const tcpSentIn = metricsIn.tcp_sent;
+        const tcpReceivedIn = metricsIn.tcp_received;
         this.setState({
           loading: false,
           requestCountIn: graphUtils.toC3Columns(rcIn.matrix, 'RPS'),

--- a/src/pages/Graph/SummaryPanelNode.tsx
+++ b/src/pages/Graph/SummaryPanelNode.tsx
@@ -219,30 +219,28 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
 
   showRequestCountMetrics(outbound: Metrics, inbound: Metrics, data: NodeData, nodeMetricType: NodeMetricType) {
     let comparator = (metric: Metric, protocol?: Protocol) => {
-      return protocol ? metric['request_protocol'] === protocol : true;
+      return protocol ? metric.request_protocol === protocol : true;
     };
     if (this.isServiceDestCornerCase(nodeMetricType)) {
       comparator = (metric: Metric, protocol?: Protocol) => {
-        return (
-          (protocol ? metric['request_protocol'] === protocol : true) && metric['destination_workload'] === 'unknown'
-        );
+        return (protocol ? metric.request_protocol === protocol : true) && metric.destination_workload === 'unknown';
       };
     } else if (data.isRoot) {
       comparator = (metric: Metric, protocol?: Protocol) => {
         return (
-          (protocol ? metric['request_protocol'] === protocol : true) &&
-          this.isActiveNamespace(metric['destination_service_namespace'])
+          (protocol ? metric.request_protocol === protocol : true) &&
+          this.isActiveNamespace(metric.destination_service_namespace)
         );
       };
     }
-    const rcOut = outbound.metrics['request_count'];
-    const ecOut = outbound.metrics['request_error_count'];
-    const tcpSentOut = outbound.metrics['tcp_sent'];
-    const tcpReceivedOut = outbound.metrics['tcp_received'];
-    const rcIn = inbound.metrics['request_count'];
-    const ecIn = inbound.metrics['request_error_count'];
-    const tcpSentIn = inbound.metrics['tcp_sent'];
-    const tcpReceivedIn = inbound.metrics['tcp_received'];
+    const rcOut = outbound.metrics.request_count;
+    const ecOut = outbound.metrics.request_error_count;
+    const tcpSentOut = outbound.metrics.tcp_sent;
+    const tcpReceivedOut = outbound.metrics.tcp_received;
+    const rcIn = inbound.metrics.request_count;
+    const ecIn = inbound.metrics.request_error_count;
+    const tcpSentIn = inbound.metrics.tcp_sent;
+    const tcpReceivedIn = inbound.metrics.tcp_received;
     this.setState({
       loading: false,
       grpcRequestCountOut: getDatapoints(rcOut, 'RPS', comparator, Protocol.GRPC),

--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -79,11 +79,12 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
     } else {
       window.onbeforeunload = null;
     }
-    // This will reset the flag to prevent ask multiple times the confirmnation to leave with unsaved changed
+    // This will reset the flag to prevent ask multiple times the confirmation to leave with unsaved changed
     this.promptTo = '';
     // Hack to force redisplay of annotations after update
     // See https://github.com/securingsincity/react-ace/issues/300
     if (this.aceEditorRef.current) {
+      // tslint:disable-next-line
       this.aceEditorRef.current!['editor'].onChangeAnnotation();
     }
 

--- a/src/pages/IstioConfigList/IstioConfigListComponent.tsx
+++ b/src/pages/IstioConfigList/IstioConfigListComponent.tsx
@@ -109,7 +109,7 @@ class IstioConfigListComponent extends ListComponent.Component<
       this.promises
         .register('namespaces', API.getNamespaces())
         .then(namespacesResponse => {
-          const namespaces: Namespace[] = namespacesResponse['data'];
+          const namespaces: Namespace[] = namespacesResponse.data;
           this.fetchConfigs(
             namespaces.map(namespace => namespace.name),
             istioTypeFilters,

--- a/src/pages/Login/__tests__/LoginPage.test.tsx
+++ b/src/pages/Login/__tests__/LoginPage.test.tsx
@@ -29,9 +29,9 @@ describe('#LoginPage render correctly', () => {
   it('handleChange should change state', () => {
     const instance = wrapper.instance() as LoginPage;
     instance.handleChange({ target: { name: 'username', value: username } });
-    expect(instance.state['username']).toBe(username);
+    expect(instance.state.username).toBe(username);
     instance.handleChange({ target: { name: 'password', value: password } });
-    expect(instance.state['password']).toBe(password);
+    expect(instance.state.password).toBe(password);
   });
 
   it('handleKeyPress should call handleSubmit if enterkey', () => {

--- a/src/pages/Overview/OverviewPage.tsx
+++ b/src/pages/Overview/OverviewPage.tsx
@@ -80,7 +80,7 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
       .register('namespaces', API.getNamespaces())
       .then(namespacesResponse => {
         const nameFilters = FilterSelected.getSelected().filter(f => f.category === Filters.nameFilter.title);
-        const allNamespaces: NamespaceInfo[] = namespacesResponse['data']
+        const allNamespaces: NamespaceInfo[] = namespacesResponse.data
           .filter(ns => {
             return nameFilters.length === 0 || nameFilters.some(f => ns.name.includes(f.value));
           })
@@ -210,7 +210,7 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
         return API.getNamespaceMetrics(nsInfo.name, optionsIn).then(rs => {
           nsInfo.metrics = undefined;
           if (rs.data.metrics.hasOwnProperty('request_count')) {
-            nsInfo.metrics = rs.data.metrics['request_count'].matrix;
+            nsInfo.metrics = rs.data.metrics.request_count.matrix;
           }
           return nsInfo;
         });

--- a/src/pages/Overview/__tests__/OverviewPage.test.tsx
+++ b/src/pages/Overview/__tests__/OverviewPage.test.tsx
@@ -11,7 +11,7 @@ import { AppHealth, NamespaceAppHealth, HEALTHY, FAILURE, DEGRADED } from '../..
 import { store } from '../../../store/ConfigStore';
 import { MTLSStatuses } from '../../../types/TLSStatus';
 
-window['SVGPathElement'] = a => a;
+(window as any).SVGPathElement = a => a;
 
 const mockAPIToPromise = (func: keyof typeof API, obj: any, encapsData: boolean): Promise<void> => {
   return new Promise((resolve, reject) => {

--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -193,8 +193,8 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
       const dr = new DestinationRuleValidator(destinationRule);
       const formatValidation = dr.formatValidation();
 
-      if (validations['destinationrule']) {
-        const objectValidations = validations['destinationrule'][destinationRule.metadata.name];
+      if (validations.destinationrule) {
+        const objectValidations = validations.destinationrule[destinationRule.metadata.name];
         if (
           formatValidation !== null &&
           !objectValidations.checks.some(check => check.message === formatValidation.message)

--- a/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -63,17 +63,17 @@ class ServiceInfo extends React.Component<ServiceDetails, ServiceInfoState> {
     const validations = this.props.validations || {};
     validationChecks.hasVirtualServiceChecks = this.props.serviceDetails.virtualServices.items.some(
       virtualService =>
-        validations['virtualservice'] &&
-        validations['virtualservice'][virtualService.metadata.name] &&
-        validations['virtualservice'][virtualService.metadata.name].checks.length > 0
+        validations.virtualservice &&
+        validations.virtualservice[virtualService.metadata.name] &&
+        validations.virtualservice[virtualService.metadata.name].checks.length > 0
     );
 
     validationChecks.hasDestinationRuleChecks = this.props.serviceDetails.destinationRules.items.some(
       destinationRule =>
-        validations['destinationrule'] &&
+        validations.destinationrule &&
         destinationRule.metadata &&
-        validations['destinationrule'][destinationRule.metadata.name] &&
-        validations['destinationrule'][destinationRule.metadata.name].checks.length > 0
+        validations.destinationrule[destinationRule.metadata.name] &&
+        validations.destinationrule[destinationRule.metadata.name].checks.length > 0
     );
 
     return validationChecks;
@@ -198,7 +198,7 @@ class ServiceInfo extends React.Component<ServiceDetails, ServiceInfoState> {
                       {(virtualServices.items.length > 0 || this.props.serviceDetails.istioSidecar) && (
                         <ServiceInfoVirtualServices
                           virtualServices={virtualServices.items}
-                          validations={validations!['virtualservice']}
+                          validations={validations!.virtualservice}
                         />
                       )}
                     </TabPaneWithErrorBoundary>
@@ -209,7 +209,7 @@ class ServiceInfo extends React.Component<ServiceDetails, ServiceInfoState> {
                       {(destinationRules.items.length > 0 || this.props.serviceDetails.istioSidecar) && (
                         <ServiceInfoDestinationRules
                           destinationRules={destinationRules.items}
-                          validations={validations!['destinationrule']}
+                          validations={validations!.destinationrule}
                         />
                       )}
                     </TabPaneWithErrorBoundary>

--- a/src/pages/ServiceList/ServiceListComponent.tsx
+++ b/src/pages/ServiceList/ServiceListComponent.tsx
@@ -103,7 +103,7 @@ class ServiceListComponent extends ListComponent.Component<
       this.promises
         .register('namespaces', API.getNamespaces())
         .then(namespacesResponse => {
-          const namespaces: Namespace[] = namespacesResponse['data'];
+          const namespaces: Namespace[] = namespacesResponse.data;
           this.fetchServices(
             namespaces.map(namespace => namespace.name),
             activeFilters,

--- a/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -65,29 +65,29 @@ class WorkloadDetails extends React.Component<RouteComponentProps<WorkloadId>, W
 
     const validations: Validations = {};
     if (workload.pods.length > 0) {
-      validations['pod'] = {};
+      validations.pod = {};
       workload.pods.forEach(pod => {
-        validations['pod'][pod.name] = {
+        validations.pod[pod.name] = {
           name: pod.name,
           objectType: 'pod',
           valid: true,
           checks: []
         };
         if (!pod.istioContainers || pod.istioContainers.length === 0) {
-          validations['pod'][pod.name].checks.push(noIstiosidecar);
+          validations.pod[pod.name].checks.push(noIstiosidecar);
         }
         if (!pod.labels) {
-          validations['pod'][pod.name].checks.push(noAppLabel);
-          validations['pod'][pod.name].checks.push(noVersionLabel);
+          validations.pod[pod.name].checks.push(noAppLabel);
+          validations.pod[pod.name].checks.push(noVersionLabel);
         } else {
           if (!pod.appLabel) {
-            validations['pod'][pod.name].checks.push(noAppLabel);
+            validations.pod[pod.name].checks.push(noAppLabel);
           }
           if (!pod.versionLabel) {
-            validations['pod'][pod.name].checks.push(noVersionLabel);
+            validations.pod[pod.name].checks.push(noVersionLabel);
           }
         }
-        validations['pod'][pod.name].valid = validations['pod'][pod.name].checks.length === 0;
+        validations.pod[pod.name].valid = validations.pod[pod.name].checks.length === 0;
       });
     }
     return validations;

--- a/src/pages/WorkloadDetails/WorkloadInfo.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo.tsx
@@ -46,9 +46,9 @@ class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInfoState>
 
     validationChecks.hasPodsChecks = pods.some(
       pod =>
-        this.props.validations['pod'] &&
-        this.props.validations['pod'][pod.name] &&
-        this.props.validations['pod'][pod.name].checks.length > 0
+        this.props.validations.pod &&
+        this.props.validations.pod[pod.name] &&
+        this.props.validations.pod[pod.name].checks.length > 0
     );
 
     return validationChecks;
@@ -116,7 +116,7 @@ class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInfoState>
                   </Nav>
                   <TabContent>
                     <TabPane eventKey={'pods'}>
-                      {pods.length > 0 && <WorkloadPods pods={pods} validations={this.props.validations!['pod']} />}
+                      {pods.length > 0 && <WorkloadPods pods={pods} validations={this.props.validations!.pod} />}
                     </TabPane>
                     <TabPane eventKey={'services'}>
                       {services.length > 0 && <WorkloadServices services={services} namespace={this.props.namespace} />}

--- a/src/pages/WorkloadList/WorkloadListComponent.tsx
+++ b/src/pages/WorkloadList/WorkloadListComponent.tsx
@@ -90,7 +90,7 @@ class WorkloadListComponent extends ListComponent.Component<
       this.promises
         .register('namespaces', API.getNamespaces())
         .then(namespacesResponse => {
-          const namespaces: Namespace[] = namespacesResponse['data'];
+          const namespaces: Namespace[] = namespacesResponse.data;
           this.fetchWorkloads(namespaces.map(namespace => namespace.name), activeFilters, resetPagination);
         })
         .catch(namespacesError => {

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -110,9 +110,9 @@ export const getNamespaceTls = (namespace: string) => {
 };
 
 export const getIstioConfig = (namespace: string, objects: string[], validate: boolean) => {
-  const params = objects && objects.length > 0 ? { objects: objects.join(',') } : {};
+  const params: any = objects && objects.length > 0 ? { objects: objects.join(',') } : {};
   if (validate) {
-    params['validate'] = validate;
+    params.validate = validate;
   }
   return newRequest<IstioConfigList>(HTTP_VERBS.GET, urls.istioConfig(namespace), params, {});
 };
@@ -376,9 +376,9 @@ export const getServiceDetail = (
   service: string,
   validate: boolean
 ): Promise<ServiceDetailsInfo> => {
-  const params = {};
+  const params: any = {};
   if (validate) {
-    params['validate'] = true;
+    params.validate = true;
   }
   return newRequest<ServiceDetailsInfo>(HTTP_VERBS.GET, urls.service(namespace, service), params, {}).then(r => {
     const info: ServiceDetailsInfo = r.data;
@@ -401,8 +401,8 @@ export const getWorkload = (namespace: string, name: string) => {
 export const getErrorMsg = (msg: string, error: AxiosError) => {
   let errorMessage = msg;
   if (error && error.response) {
-    if (error.response.data && error.response.data['error']) {
-      errorMessage = `${msg}, Error: [ ${error.response.data['error']} ]`;
+    if (error.response.data && error.response.data.error) {
+      errorMessage = `${msg}, Error: [ ${error.response.data.error} ]`;
     } else if (error.response.statusText) {
       errorMessage = `${msg}, Error: [ ${error.response.statusText} ]`;
       if (error.response.status === 401) {

--- a/src/types/Graph.ts
+++ b/src/types/Graph.ts
@@ -93,7 +93,7 @@ export interface CytoscapeMouseOutEvent extends CytoscapeBaseEvent {}
 //     flags0: %traffic,
 //     flags1: %traffic
 //   }}
-export type Responses = Object;
+export type Responses = object;
 
 export type ProtocolTrafficNoData = {
   protocol: '';

--- a/tslint.json
+++ b/tslint.json
@@ -28,7 +28,7 @@
     "no-empty": true,
     "no-eval": true,
     "no-shadowed-variable": true,
-    "no-string-literal": false,
+    "no-string-literal": true,
     "no-switch-case-fall-through": true,
     "no-trailing-whitespace": false,
     "no-unused-expression": true,


### PR DESCRIPTION
…. Disallows obj["property"] (which has no type safety) in favor of obj.property. We are totally bypassing Typescript's type-safety here.

WDYT? This open to the team to comment.