### PR TITLE
KIALI-2606 Using TabPaneWithErrorBoundary instead of plain implicit WithErrorBoundary

### DIFF
--- a/src/components/ErrorBoundary/WithErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/WithErrorBoundary.tsx
@@ -25,5 +25,4 @@ const withErrorBoundary = <P extends object>(WrappedComponent: React.ComponentCl
     }
   };
 
-const TabPaneWithErrorBoundary = withErrorBoundary<TabPane.propTypes>(TabPane);
-export default TabPaneWithErrorBoundary;
+export const TabPaneWithErrorBoundary = withErrorBoundary<TabPane.propTypes>(TabPane);

--- a/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -20,7 +20,7 @@ import ServiceInfoVirtualServices from './ServiceInfo/ServiceInfoVirtualServices
 import ServiceInfoDestinationRules from './ServiceInfo/ServiceInfoDestinationRules';
 import ServiceInfoWorkload from './ServiceInfo/ServiceInfoWorkload';
 import { Validations } from '../../types/IstioObjects';
-import WithErrorBoundary from '../../components/ErrorBoundary/WithErrorBoundary';
+import { TabPaneWithErrorBoundary } from '../../components/ErrorBoundary/WithErrorBoundary';
 import IstioWizardDropdown from '../../components/IstioWizards/IstioWizardDropdown';
 
 interface ServiceDetails extends ServiceId {
@@ -186,12 +186,12 @@ class ServiceInfo extends React.Component<ServiceDetails, ServiceInfoState> {
                     </NavItem>
                   </Nav>
                   <TabContent>
-                    <WithErrorBoundary eventKey={'workloads'} message={this.errorBoundaryMessage('Workloads')}>
+                    <TabPaneWithErrorBoundary eventKey={'workloads'} message={this.errorBoundaryMessage('Workloads')}>
                       {(Object.keys(workloads).length > 0 || this.props.serviceDetails.istioSidecar) && (
                         <ServiceInfoWorkload workloads={workloads} namespace={this.props.namespace} />
                       )}
-                    </WithErrorBoundary>
-                    <WithErrorBoundary
+                    </TabPaneWithErrorBoundary>
+                    <TabPaneWithErrorBoundary
                       eventKey={'virtualservices'}
                       message={this.errorBoundaryMessage('Virtual Services')}
                     >
@@ -201,8 +201,8 @@ class ServiceInfo extends React.Component<ServiceDetails, ServiceInfoState> {
                           validations={validations!['virtualservice']}
                         />
                       )}
-                    </WithErrorBoundary>
-                    <WithErrorBoundary
+                    </TabPaneWithErrorBoundary>
+                    <TabPaneWithErrorBoundary
                       eventKey={'destinationrules'}
                       message={this.errorBoundaryMessage('Destination Rules')}
                     >
@@ -212,7 +212,7 @@ class ServiceInfo extends React.Component<ServiceDetails, ServiceInfoState> {
                           validations={validations!['destinationrule']}
                         />
                       )}
-                    </WithErrorBoundary>
+                    </TabPaneWithErrorBoundary>
                   </TabContent>
                 </div>
               </TabContainer>


### PR DESCRIPTION
** Describe the change **
Use TabPaneWithErrorBoundary instead of WithErrorBounday. This last one doesn't show which Component was rendering for real.

https://issues.jboss.org/browse/KIALI-2606
