### PR TITLE
KIALI-1962 Suspend Traffic Wizard

### DIFF
--- a/src/components/IstioWizards/IstioWizard.tsx
+++ b/src/components/IstioWizards/IstioWizard.tsx
@@ -16,6 +16,7 @@ import WeightedRouting, { WorkloadWeight } from './WeightedRouting';
 import TrafficPolicyConnected from '../../containers/TrafficPolicyContainer';
 import { DISABLE, ROUND_ROBIN } from './TrafficPolicy';
 import { TLSStatus } from '../../types/TLSStatus';
+import SuspendTraffic, { SuspendedRoute } from './SuspendTraffic';
 
 type Props = {
   show: boolean;
@@ -31,6 +32,7 @@ type State = {
   showWizard: boolean;
   workloads: WorkloadWeight[];
   rules: Rule[];
+  suspendedRoutes: SuspendedRoute[];
   valid: boolean;
   mtlsMode: string;
   tlsModified: boolean;
@@ -40,11 +42,15 @@ type State = {
 
 export const WIZARD_WEIGHTED_ROUTING = 'create_weighted_routing';
 export const WIZARD_MATCHING_ROUTING = 'create_matching_routing';
+export const WIZARD_SUSPEND_TRAFFIC = 'suspend_traffic';
 
 export const WIZARD_TITLES = {
   [WIZARD_WEIGHTED_ROUTING]: 'Create Weighted Routing',
-  [WIZARD_MATCHING_ROUTING]: 'Create Matching Routing'
+  [WIZARD_MATCHING_ROUTING]: 'Create Matching Routing',
+  [WIZARD_SUSPEND_TRAFFIC]: 'Suspend Traffic'
 };
+
+const SERVICE_UNAVAILABLE = 503;
 
 class IstioWizard extends React.Component<Props, State> {
   constructor(props: Props) {
@@ -53,6 +59,7 @@ class IstioWizard extends React.Component<Props, State> {
       showWizard: false,
       workloads: [],
       rules: [],
+      suspendedRoutes: [],
       valid: true,
       mtlsMode: DISABLE,
       tlsModified: false,
@@ -71,8 +78,11 @@ class IstioWizard extends React.Component<Props, State> {
           break;
         // By default no rules is a no valid scenario
         case WIZARD_MATCHING_ROUTING:
-        default:
           isValid = false;
+          break;
+        case WIZARD_SUSPEND_TRAFFIC:
+        default:
+          isValid = true;
           break;
       }
       this.setState({
@@ -216,6 +226,63 @@ class IstioWizard extends React.Component<Props, State> {
         };
         break;
       }
+      case WIZARD_SUSPEND_TRAFFIC: {
+        // VirtualService from the suspendedRoutes
+        const httpRoute: HTTPRoute = {
+          route: []
+        };
+        // Let's use the # os suspended notes to create weights
+        const totalRoutes = this.state.suspendedRoutes.length;
+        const closeRoutes = this.state.suspendedRoutes.filter(s => s.suspended).length;
+        const openRoutes = totalRoutes - closeRoutes;
+        let firstValue = true;
+        // If we have some suspended routes, we need to use weights
+        if (closeRoutes < totalRoutes) {
+          for (let i = 0; i < this.state.suspendedRoutes.length; i++) {
+            const suspendedRoute = this.state.suspendedRoutes[i];
+            const destW: DestinationWeight = {
+              destination: {
+                host: this.props.serviceName
+              }
+            };
+            if (suspendedRoute.suspended) {
+              destW.destination.subset = wkdNameVersion[suspendedRoute.workload];
+              // A suspended route has a 0 weight
+              destW.weight = 0;
+            } else {
+              destW.weight = Math.floor(100 / openRoutes);
+              // We need to adjust the rest
+              if (firstValue) {
+                destW.weight += 100 % openRoutes;
+                firstValue = false;
+              }
+            }
+            httpRoute.route!.push(destW);
+          }
+        } else {
+          // All routes are suspended, so we use an fault/abort rule
+          httpRoute.route = [
+            {
+              destination: {
+                host: this.props.serviceName
+              }
+            }
+          ];
+          httpRoute.fault = {
+            abort: {
+              httpStatus: SERVICE_UNAVAILABLE,
+              percentage: {
+                value: 100
+              }
+            }
+          };
+        }
+        wizardVS.spec = {
+          hosts: [this.props.serviceName],
+          http: [httpRoute]
+        };
+        break;
+      }
       default:
         console.log('Unrecognized type');
     }
@@ -289,6 +356,13 @@ class IstioWizard extends React.Component<Props, State> {
     });
   };
 
+  onSuspendedChange = (valid: boolean, suspendedRoutes: SuspendedRoute[]) => {
+    this.setState({
+      valid: valid,
+      suspendedRoutes: suspendedRoutes
+    });
+  };
+
   render() {
     return (
       <Wizard show={this.state.showWizard} onHide={this.onClose}>
@@ -309,6 +383,13 @@ class IstioWizard extends React.Component<Props, State> {
                     serviceName={this.props.serviceName}
                     workloads={this.props.workloads}
                     onChange={this.onRulesChange}
+                  />
+                )}
+                {this.props.type === WIZARD_SUSPEND_TRAFFIC && (
+                  <SuspendTraffic
+                    serviceName={this.props.serviceName}
+                    workloads={this.props.workloads}
+                    onChange={this.onSuspendedChange}
                   />
                 )}
                 <TrafficPolicyConnected

--- a/src/components/IstioWizards/IstioWizard.tsx
+++ b/src/components/IstioWizards/IstioWizard.tsx
@@ -242,11 +242,11 @@ class IstioWizard extends React.Component<Props, State> {
             const suspendedRoute = this.state.suspendedRoutes[i];
             const destW: DestinationWeight = {
               destination: {
-                host: this.props.serviceName
+                host: this.props.serviceName,
+                subset: wkdNameVersion[suspendedRoute.workload]
               }
             };
             if (suspendedRoute.suspended) {
-              destW.destination.subset = wkdNameVersion[suspendedRoute.workload];
               // A suspended route has a 0 weight
               destW.weight = 0;
             } else {

--- a/src/components/IstioWizards/IstioWizardDropdown.tsx
+++ b/src/components/IstioWizards/IstioWizardDropdown.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react';
 import { DropdownButton, MenuItem, MessageDialog, OverlayTrigger, Tooltip } from 'patternfly-react';
-import IstioWizard, { WIZARD_MATCHING_ROUTING, WIZARD_TITLES, WIZARD_WEIGHTED_ROUTING } from './IstioWizard';
+import IstioWizard, {
+  WIZARD_MATCHING_ROUTING,
+  WIZARD_TITLES,
+  WIZARD_WEIGHTED_ROUTING,
+  WIZARD_SUSPEND_TRAFFIC
+} from './IstioWizard';
 import { WorkloadOverview } from '../../types/ServiceInfo';
 import { DestinationRules, VirtualServices } from '../../types/IstioObjects';
 import * as MessageCenter from '../../utils/MessageCenter';
@@ -50,7 +55,8 @@ class IstioWizardDropdown extends React.Component<Props, State> {
   onAction = (key: string) => {
     switch (key) {
       case WIZARD_WEIGHTED_ROUTING:
-      case WIZARD_MATCHING_ROUTING: {
+      case WIZARD_MATCHING_ROUTING:
+      case WIZARD_SUSPEND_TRAFFIC: {
         this.setState({ showWizard: true, wizardType: key });
         break;
       }
@@ -110,6 +116,7 @@ class IstioWizardDropdown extends React.Component<Props, State> {
     switch (eventKey) {
       case WIZARD_WEIGHTED_ROUTING:
       case WIZARD_MATCHING_ROUTING:
+      case WIZARD_SUSPEND_TRAFFIC:
         const menuItem = (
           <MenuItem disabled={this.hasTrafficRouting()} key={eventKey} eventKey={eventKey}>
             {WIZARD_TITLES[eventKey]}
@@ -172,6 +179,7 @@ class IstioWizardDropdown extends React.Component<Props, State> {
         <DropdownButton id="service_actions" title="Actions" onSelect={this.onAction} pullRight={true}>
           {this.canCreate() && this.renderMenuItem(WIZARD_WEIGHTED_ROUTING)}
           {this.canCreate() && this.renderMenuItem(WIZARD_MATCHING_ROUTING)}
+          {this.canCreate() && this.renderMenuItem(WIZARD_SUSPEND_TRAFFIC)}
           <MenuItem divider={true} />
           {this.canDelete() && this.renderMenuItem(DELETE_TRAFFIC_ROUTING)}
         </DropdownButton>

--- a/src/components/IstioWizards/SuspendTraffic.tsx
+++ b/src/components/IstioWizards/SuspendTraffic.tsx
@@ -136,7 +136,7 @@ class SuspendTraffic extends React.Component<Props, State> {
                   <Row>
                     <Col xs={12} sm={12} md={4} lg={4} />
                     <Col xs={12} sm={12} md={2} lg={2}>
-                      {route.suspended ? 'Suspended' : 'Open'}
+                      {route.suspended ? 'Suspended' : 'Connected'}
                     </Col>
                     <Col xs={12} sm={12} md={2} lg={2}>
                       <Button bsSize="xsmall" onClick={() => this.updateRoute(route.workload, !route.suspended)}>
@@ -153,7 +153,7 @@ class SuspendTraffic extends React.Component<Props, State> {
         {this.props.workloads.length > 1 && (
           <div className={evenlyButtonStyle}>
             <Button className={allButtonStyle} onClick={() => this.resetState()}>
-              Open All
+              Connect All
             </Button>
             <Button className={allButtonStyle} onClick={() => this.suspendAll()}>
               Suspend All

--- a/src/components/IstioWizards/SuspendTraffic.tsx
+++ b/src/components/IstioWizards/SuspendTraffic.tsx
@@ -1,0 +1,168 @@
+import * as React from 'react';
+import { Button, Col, Icon, ListView, ListViewIcon, ListViewItem, Row } from 'patternfly-react';
+import { WorkloadOverview } from '../../types/ServiceInfo';
+import { style } from 'typestyle';
+
+type Props = {
+  serviceName: string;
+  workloads: WorkloadOverview[];
+  onChange: (valid: boolean, suspendedRoutes: SuspendedRoute[]) => void;
+};
+
+export type SuspendedRoute = {
+  workload: string;
+  suspended: boolean;
+  httpStatus: number;
+};
+
+type State = {
+  suspendedRoutes: SuspendedRoute[];
+};
+
+const wkIconType = 'pf';
+const wkIconName = 'bundle';
+
+const SERVICE_UNAVAILABLE = 503;
+
+const listStyle = style({
+  marginTop: 10
+});
+
+const listHeaderStyle = style({
+  textTransform: 'uppercase',
+  fontSize: '12px',
+  fontWeight: 300,
+  color: '#72767b',
+  borderTop: '0px !important',
+  $nest: {
+    ['.list-view-pf-main-info']: {
+      padding: 5
+    },
+    ['.list-group-item-heading']: {
+      fontWeight: 300,
+      textAlign: 'center'
+    },
+    ['.list-group-item-text']: {
+      textAlign: 'center'
+    }
+  }
+});
+
+const evenlyButtonStyle = style({
+  width: '100%',
+  textAlign: 'right'
+});
+
+const allButtonStyle = style({
+  marginBottom: 20,
+  marginLeft: 5
+});
+
+class SuspendTraffic extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      suspendedRoutes: []
+    };
+  }
+
+  componentDidMount(): void {
+    this.resetState();
+  }
+
+  resetState = () => {
+    this.setState(
+      {
+        suspendedRoutes: this.props.workloads.map(workload => {
+          return {
+            workload: workload.name,
+            suspended: false,
+            httpStatus: SERVICE_UNAVAILABLE
+          };
+        })
+      },
+      () => this.props.onChange(true, this.state.suspendedRoutes)
+    );
+  };
+
+  suspendAll = () => {
+    this.setState(
+      {
+        suspendedRoutes: this.props.workloads.map(workload => {
+          return {
+            workload: workload.name,
+            suspended: true,
+            httpStatus: SERVICE_UNAVAILABLE
+          };
+        })
+      },
+      () => this.props.onChange(true, this.state.suspendedRoutes)
+    );
+  };
+
+  updateRoute = (workload: string, suspended: boolean) => {
+    this.setState(
+      prevState => {
+        return {
+          suspendedRoutes: prevState.suspendedRoutes.map(route => {
+            if (route.workload === workload) {
+              return {
+                workload: route.workload,
+                suspended: suspended,
+                // Note that in a future version we might want to let user to choose the httpStatus
+                httpStatus: SERVICE_UNAVAILABLE
+              };
+            }
+            return route;
+          })
+        };
+      },
+      () => this.props.onChange(true, this.state.suspendedRoutes)
+    );
+  };
+
+  render() {
+    return (
+      <>
+        <ListView className={listStyle}>
+          <ListViewItem className={listHeaderStyle} heading={'Workload'} description={'Suspended Status'} />
+          {this.state.suspendedRoutes.map((route, id) => {
+            return (
+              <ListViewItem
+                key={'workload-' + id}
+                leftContent={<ListViewIcon type={wkIconType} name={wkIconName} />}
+                heading={route.workload}
+                description={
+                  <Row>
+                    <Col xs={12} sm={12} md={4} lg={4} />
+                    <Col xs={12} sm={12} md={2} lg={2}>
+                      {route.suspended ? 'Suspended' : 'Open'}
+                    </Col>
+                    <Col xs={12} sm={12} md={2} lg={2}>
+                      <Button bsSize="xsmall" onClick={() => this.updateRoute(route.workload, !route.suspended)}>
+                        <Icon type="pf" name={route.suspended ? 'unplugged' : 'plugged'} />
+                      </Button>
+                    </Col>
+                    <Col xs={12} sm={12} md={4} lg={4} />
+                  </Row>
+                }
+              />
+            );
+          })}
+        </ListView>
+        {this.props.workloads.length > 1 && (
+          <div className={evenlyButtonStyle}>
+            <Button className={allButtonStyle} onClick={() => this.resetState()}>
+              Open All
+            </Button>
+            <Button className={allButtonStyle} onClick={() => this.suspendAll()}>
+              Suspend All
+            </Button>
+          </div>
+        )}
+      </>
+    );
+  }
+}
+
+export default SuspendTraffic;

--- a/src/types/IstioObjects.ts
+++ b/src/types/IstioObjects.ts
@@ -210,8 +210,8 @@ export interface SimpleRetryPolicy {
 }
 
 export interface HTTPFaultInjection {
-  delay: Delay;
-  abort: Abort;
+  delay?: Delay;
+  abort?: Abort;
 }
 
 export interface Delay {
@@ -221,12 +221,14 @@ export interface Delay {
   overrideHeaderName: string;
 }
 
+export interface Percent {
+  value: number;
+}
+
 export interface Abort {
-  percent: number;
-  grpcStatus: string;
-  http2Error: string;
-  httpStatus: string;
-  overrideHeaderName: string;
+  percent?: number;
+  httpStatus?: number;
+  percentage?: Percent;
 }
 
 export interface L4FaultInjection {
@@ -402,6 +404,7 @@ export interface HTTPRoute {
   websocketUpgrade?: boolean;
   timeout?: string;
   retries?: HTTPRetry;
+  fault?: HTTPFaultInjection;
   mirror?: Destination;
   corsPolicy?: CorsPolicy;
   appendHeaders?: { [key: string]: string };


### PR DESCRIPTION
This PR introduces a new use-case Wizard for suspend traffic.
This operation might require different low level Istio configuration, depending if we want to stop traffic for a particular workload or whole service.

I.e. when more than one workload, typically a suspended traffic means to redirect traffic to pending workloads with weights. When all workloads are stopped, then a fault injection is generated.

The UI hides the complexity to the user and try to offer a one-click operation simplifying all steps around it.

https://issues.jboss.org/browse/KIALI-1962

![image](https://user-images.githubusercontent.com/1662329/54750954-afbe9500-4bd9-11e9-9e7c-d798e5f61946.png)

![image](https://user-images.githubusercontent.com/1662329/54751071-12b02c00-4bda-11e9-85b1-109b273268ed.png)

![image](https://user-images.githubusercontent.com/1662329/54750976-c2d16500-4bd9-11e9-990f-07dc975b47ce.png)

![image](https://user-images.githubusercontent.com/1662329/54751043-ff04c580-4bd9-11e9-86f3-04b2df9475f3.png)



