### PR TITLE
KIALI-2560 Add expanded mode for overview cards

### DIFF
--- a/src/pages/Overview/NamespaceInfo.ts
+++ b/src/pages/Overview/NamespaceInfo.ts
@@ -1,9 +1,11 @@
 import { TLSStatus } from '../../types/TLSStatus';
+import { TimeSeries } from '../../types/Metrics';
 
 export type NamespaceInfo = {
   name: string;
   status?: NamespaceStatus;
   tlsStatus?: TLSStatus;
+  metrics?: TimeSeries[];
 };
 
 export type NamespaceStatus = {

--- a/src/pages/Overview/OverviewCardContent.tsx
+++ b/src/pages/Overview/OverviewCardContent.tsx
@@ -12,10 +12,9 @@ type Props = {
   name: string;
   type: OverviewType;
   status: NamespaceStatus;
-  tlsStatus: boolean;
 };
 
-class OverviewStatuses extends React.Component<Props> {
+class OverviewCardContent extends React.Component<Props> {
   constructor(props: Props) {
     super(props);
   }
@@ -70,4 +69,4 @@ class OverviewStatuses extends React.Component<Props> {
   }
 }
 
-export default OverviewStatuses;
+export default OverviewCardContent;

--- a/src/pages/Overview/OverviewCardContentExpanded.tsx
+++ b/src/pages/Overview/OverviewCardContentExpanded.tsx
@@ -22,11 +22,10 @@ type Props = {
   type: OverviewType;
   duration: DurationInSeconds;
   status: NamespaceStatus;
-  tlsStatus: boolean;
   metrics?: TimeSeries[];
 };
 
-class OverviewStatusesExpanded extends React.Component<Props> {
+class OverviewCardContentExpanded extends React.Component<Props> {
   constructor(props: Props) {
     super(props);
   }
@@ -98,7 +97,7 @@ class OverviewStatusesExpanded extends React.Component<Props> {
           bar={{ width: 20 }}
           legend={{ hide: true }}
         />
-        <AggregateStatusNotifications style={{ marginTop: -30 }}>
+        <AggregateStatusNotifications style={{ marginTop: -20, position: 'relative' }}>
           {status.inError.length > 0 && (
             <OverviewStatus
               id={name + '-failure'}
@@ -152,4 +151,4 @@ class OverviewStatusesExpanded extends React.Component<Props> {
   }
 }
 
-export default OverviewStatusesExpanded;
+export default OverviewCardContentExpanded;

--- a/src/pages/Overview/OverviewCardLinks.tsx
+++ b/src/pages/Overview/OverviewCardLinks.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { Icon } from 'patternfly-react';
+import { Paths } from '../../config';
+
+type Props = {
+  name: string;
+};
+
+class OverviewCardLinks extends React.Component<Props> {
+  constructor(props: Props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <div>
+        <Link to={`/graph/namespaces?namespaces=` + this.props.name} title="Graph">
+          <Icon type="pf" name="topology" style={{ paddingLeft: 10, paddingRight: 10 }} />
+        </Link>
+        <Link to={`/${Paths.APPLICATIONS}?namespaces=` + this.props.name} title="Applications list">
+          <Icon type="pf" name="applications" style={{ paddingLeft: 10, paddingRight: 10 }} />
+        </Link>
+        <Link to={`/${Paths.WORKLOADS}?namespaces=` + this.props.name} title="Workloads list">
+          <Icon type="pf" name="bundle" style={{ paddingLeft: 10, paddingRight: 10 }} />
+        </Link>
+        <Link to={`/${Paths.SERVICES}?namespaces=` + this.props.name} title="Services list">
+          <Icon type="pf" name="service" style={{ paddingLeft: 10, paddingRight: 10 }} />
+        </Link>
+        <Link to={`/${Paths.ISTIO}?namespaces=` + this.props.name} title="Istio Config list">
+          <Icon type="pf" name="template" style={{ paddingLeft: 10, paddingRight: 10 }} />
+        </Link>
+      </div>
+    );
+  }
+}
+
+export default OverviewCardLinks;

--- a/src/pages/Overview/OverviewHelper.ts
+++ b/src/pages/Overview/OverviewHelper.ts
@@ -1,5 +1,43 @@
 import { OverviewType } from './OverviewToolbar';
+import { FilterSelected } from '../../components/Filters/StatefulFilters';
+import { FiltersAndSorts } from './FiltersAndSorts';
+import { FAILURE, DEGRADED, HEALTHY } from '../../types/Health';
 
 export const switchType = <T, U, V>(type: OverviewType, caseApp: T, caseService: U, caseWorkload: V): T | U | V => {
   return type === 'app' ? caseApp : type === 'service' ? caseService : caseWorkload;
+};
+
+export const summarizeHealthFilters = () => {
+  const healthFilters = FilterSelected.getSelected().filter(f => f.category === FiltersAndSorts.healthFilter.title);
+  if (healthFilters.length === 0) {
+    return {
+      noFilter: true,
+      showInError: true,
+      showInWarning: true,
+      showInSuccess: true
+    };
+  }
+  let showInError = false,
+    showInWarning = false,
+    showInSuccess = false;
+  healthFilters.forEach(f => {
+    switch (f.value) {
+      case FAILURE.name:
+        showInError = true;
+        break;
+      case DEGRADED.name:
+        showInWarning = true;
+        break;
+      case HEALTHY.name:
+        showInSuccess = true;
+        break;
+      default:
+    }
+  });
+  return {
+    noFilter: false,
+    showInError: showInError,
+    showInWarning: showInWarning,
+    showInSuccess: showInSuccess
+  };
 };

--- a/src/pages/Overview/OverviewPage.tsx
+++ b/src/pages/Overview/OverviewPage.tsx
@@ -23,11 +23,11 @@ import { PromisesRegistry } from '../../utils/CancelablePromises';
 import { FiltersAndSorts } from './FiltersAndSorts';
 import OverviewToolbarContainer, { OverviewToolbar, OverviewType, OverviewDisplayMode } from './OverviewToolbar';
 import NamespaceInfo, { NamespaceStatus } from './NamespaceInfo';
-import OverviewStatuses from './OverviewStatuses';
+import OverviewCardContent from './OverviewCardContent';
 import { switchType } from './OverviewHelper';
 import { Paths } from '../../config';
 import { default as NamespaceMTLSStatusContainer } from '../../components/MTls/NamespaceMTLSStatus';
-import OverviewStatusesExpanded from './OverviewStatusesExpanded';
+import OverviewCardContentExpanded from './OverviewCardContentExpanded';
 import { MetricsOptions } from '../../types/MetricsOptions';
 import { computePrometheusRateParams } from '../../services/Prometheus';
 
@@ -118,7 +118,8 @@ class OverviewPage extends React.Component<OverviewProps, State> {
             return {
               name: ns.name,
               status: previous ? previous.status : undefined,
-              tlsStatus: previous ? previous.tlsStatus : undefined
+              tlsStatus: previous ? previous.tlsStatus : undefined,
+              metrics: previous ? previous.metrics : undefined
             };
           });
         const isAscending = ListPagesHelper.isCurrentSortAscending();
@@ -348,18 +349,15 @@ class OverviewPage extends React.Component<OverviewProps, State> {
   renderStatuses(ns: NamespaceInfo): JSX.Element {
     if (ns.status) {
       if (this.state.displayMode === OverviewDisplayMode.COMPACT) {
-        return (
-          <OverviewStatuses key={ns.name} name={ns.name} status={ns.status} type={this.state.type} tlsStatus={true} />
-        );
+        return <OverviewCardContent key={ns.name} name={ns.name} status={ns.status} type={this.state.type} />;
       }
       return (
-        <OverviewStatusesExpanded
+        <OverviewCardContentExpanded
           key={ns.name}
           name={ns.name}
           duration={ListPagesHelper.currentDuration()}
           status={ns.status}
           type={this.state.type}
-          tlsStatus={true}
           metrics={ns.metrics}
         />
       );

--- a/src/pages/Overview/OverviewStatusesExpanded.tsx
+++ b/src/pages/Overview/OverviewStatusesExpanded.tsx
@@ -1,0 +1,155 @@
+import * as React from 'react';
+import {
+  AggregateStatusNotification,
+  AggregateStatusNotifications,
+  StackedBarChart,
+  SparklineChart
+} from 'patternfly-react';
+import { Link } from 'react-router-dom';
+import { DEGRADED, FAILURE, HEALTHY } from '../../types/Health';
+import OverviewStatus from './OverviewStatus';
+import { OverviewType } from './OverviewToolbar';
+import { NamespaceStatus } from './NamespaceInfo';
+import { switchType } from './OverviewHelper';
+import { Paths } from '../../config';
+import { TimeSeries } from '../../types/Metrics';
+import graphUtils from '../../utils/Graphing';
+import { DurationInSeconds } from '../../types/Common';
+import { getName } from '../../utils/RateIntervals';
+
+type Props = {
+  name: string;
+  type: OverviewType;
+  duration: DurationInSeconds;
+  status: NamespaceStatus;
+  tlsStatus: boolean;
+  metrics?: TimeSeries[];
+};
+
+class OverviewStatusesExpanded extends React.Component<Props> {
+  constructor(props: Props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <>
+        <div style={{ width: '50%', display: 'inline-block', height: 90 }}>{this.renderLeft()}</div>
+        <div
+          style={{
+            width: '50%',
+            display: 'inline-block',
+            height: 90,
+            borderLeft: '1px solid #d1d1d1',
+            paddingLeft: 10,
+            verticalAlign: 'top'
+          }}
+        >
+          {this.renderRight()}
+        </div>
+      </>
+    );
+  }
+
+  renderLeft(): JSX.Element {
+    const targetPage = switchType(this.props.type, Paths.APPLICATIONS, Paths.SERVICES, Paths.WORKLOADS);
+    const name = this.props.name;
+    const status = this.props.status;
+    const nbItems =
+      status.inError.length + status.inWarning.length + status.inSuccess.length + status.notAvailable.length;
+    let text: string;
+    if (nbItems === 1) {
+      text = switchType(this.props.type, '1 Application', '1 Service', '1 Workload');
+    } else {
+      text = nbItems + switchType(this.props.type, ' Applications', ' Services', ' Workloads');
+    }
+    const mainLink = <Link to={`/${targetPage}?namespaces=${name}`}>{text}</Link>;
+    if (nbItems === status.notAvailable.length) {
+      return (
+        <>
+          {mainLink}
+          <AggregateStatusNotifications>
+            <AggregateStatusNotification>N/A</AggregateStatusNotification>
+          </AggregateStatusNotifications>
+        </>
+      );
+    }
+    return (
+      <>
+        {mainLink}
+        <StackedBarChart
+          style={{ paddingLeft: 13 }}
+          id={'card-barchart-' + name}
+          size={{ height: 50 }}
+          axis={{ rotated: true, x: { show: false, categories: ['Health'], type: 'category' }, y: { show: false } }}
+          grid={{ x: { show: false }, y: { show: false } }}
+          tooltip={{ show: false }}
+          data={{
+            groups: [[FAILURE.name, DEGRADED.name, HEALTHY.name]],
+            columns: [
+              [FAILURE.name, status.inError.length],
+              [DEGRADED.name, status.inWarning.length],
+              [HEALTHY.name, status.inSuccess.length]
+            ],
+            order: null,
+            type: 'bar'
+          }}
+          color={{ pattern: [FAILURE.color, DEGRADED.color, HEALTHY.color] }}
+          bar={{ width: 20 }}
+          legend={{ hide: true }}
+        />
+        <AggregateStatusNotifications style={{ marginTop: -30 }}>
+          {status.inError.length > 0 && (
+            <OverviewStatus
+              id={name + '-failure'}
+              namespace={name}
+              status={FAILURE}
+              items={status.inError}
+              targetPage={targetPage}
+            />
+          )}
+          {status.inWarning.length > 0 && (
+            <OverviewStatus
+              id={name + '-degraded'}
+              namespace={name}
+              status={DEGRADED}
+              items={status.inWarning}
+              targetPage={targetPage}
+            />
+          )}
+          {status.inSuccess.length > 0 && (
+            <OverviewStatus
+              id={name + '-healthy'}
+              namespace={name}
+              status={HEALTHY}
+              items={status.inSuccess}
+              targetPage={targetPage}
+            />
+          )}
+        </AggregateStatusNotifications>
+      </>
+    );
+  }
+
+  renderRight(): JSX.Element {
+    if (this.props.metrics && this.props.metrics.length > 0) {
+      return (
+        <>
+          {'Traffic, ' + getName(this.props.duration).toLowerCase()}
+          <SparklineChart
+            id={'card-sparkline-' + name}
+            data={{ x: 'x', columns: graphUtils.toC3Columns(this.props.metrics, 'RPS'), type: 'area' }}
+            tooltip={{}}
+            axis={{
+              x: { show: false, type: 'timeseries', tick: { format: '%H:%M:%S' } },
+              y: { show: false }
+            }}
+          />
+        </>
+      );
+    }
+    return <div style={{ marginTop: 20 }}>No traffic</div>;
+  }
+}
+
+export default OverviewStatusesExpanded;

--- a/src/pages/Overview/OverviewToolbar.tsx
+++ b/src/pages/Overview/OverviewToolbar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FormGroup, Sort, ToolbarRightContent } from 'patternfly-react';
+import { Button, ButtonGroup, FormGroup, Sort, ToolbarRightContent } from 'patternfly-react';
 import { connect } from 'react-redux';
 import { ThunkDispatch } from 'redux-thunk';
 
@@ -31,7 +31,14 @@ type Props = ReduxProps & {
   onError: (msg: string) => void;
   onRefresh: () => void;
   sort: (sortField: SortField<NamespaceInfo>, isAscending: boolean) => void;
+  displayMode: OverviewDisplayMode;
+  setDisplayMode: (mode: OverviewDisplayMode) => void;
 };
+
+export enum OverviewDisplayMode {
+  COMPACT,
+  EXPAND
+}
 
 const overviewTypes = {
   app: 'Apps',
@@ -71,7 +78,7 @@ export class OverviewToolbar extends React.Component<Props, State> {
     this.state = {
       isSortAscending: ListPagesHelper.isCurrentSortAscending(),
       overviewType: OverviewToolbar.currentOverviewType(),
-      sortField: ListPagesHelper.currentSortField(FiltersAndSorts.sortFields)
+      sortField: ListPagesHelper.currentSortField(FiltersAndSorts.sortFields),
     };
   }
 
@@ -146,6 +153,24 @@ export class OverviewToolbar extends React.Component<Props, State> {
             label={overviewTypes[this.state.overviewType]}
             options={overviewTypes}
           />
+        </FormGroup>
+        <FormGroup>
+          <ButtonGroup id="toolbar_layout_group">
+            <Button
+              onClick={() => this.props.setDisplayMode(OverviewDisplayMode.COMPACT)}
+              title="Compact mode"
+              active={this.props.displayMode === OverviewDisplayMode.COMPACT}
+            >
+              Compact
+            </Button>
+            <Button
+              onClick={() => this.props.setDisplayMode(OverviewDisplayMode.EXPAND)}
+              title="Expanded mode"
+              active={this.props.displayMode === OverviewDisplayMode.EXPAND}
+            >
+              Expand
+            </Button>
+          </ButtonGroup>
         </FormGroup>
         <ToolbarRightContent style={{ ...AlignRightStyle }}>
           <ToolbarDropdown

--- a/src/pages/Overview/__tests__/OverviewPage.test.tsx
+++ b/src/pages/Overview/__tests__/OverviewPage.test.tsx
@@ -9,6 +9,8 @@ import * as API from '../../../services/Api';
 import { AppHealth, NamespaceAppHealth, HEALTHY, FAILURE, DEGRADED } from '../../../types/Health';
 import { store } from '../../../store/ConfigStore';
 
+window['SVGPathElement'] = a => a;
+
 const mockAPIToPromise = (func: keyof typeof API, obj: any, encapsData: boolean): Promise<void> => {
   return new Promise((resolve, reject) => {
     jest.spyOn(API, func).mockImplementation(() => {

--- a/src/pages/Overview/__tests__/__snapshots__/OverviewPage.test.tsx.snap
+++ b/src/pages/Overview/__tests__/__snapshots__/OverviewPage.test.tsx.snap
@@ -28,8 +28,10 @@ ShallowWrapper {
           </BreadcrumbItem>
         </Breadcrumb>,
         <Connect(OverviewToolbar)
+          displayMode={1}
           onError={[Function]}
           onRefresh={[Function]}
+          setDisplayMode={[Function]}
           sort={[Function]}
         />,
         <div
@@ -87,8 +89,10 @@ ShallowWrapper {
         "key": undefined,
         "nodeType": "class",
         "props": Object {
+          "displayMode": 1,
           "onError": [Function],
           "onRefresh": [Function],
+          "setDisplayMode": [Function],
           "sort": [Function],
         },
         "ref": null,
@@ -178,8 +182,10 @@ ShallowWrapper {
             </BreadcrumbItem>
           </Breadcrumb>,
           <Connect(OverviewToolbar)
+            displayMode={1}
             onError={[Function]}
             onRefresh={[Function]}
+            setDisplayMode={[Function]}
             sort={[Function]}
           />,
           <div
@@ -237,8 +243,10 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "class",
           "props": Object {
+            "displayMode": 1,
             "onError": [Function],
             "onRefresh": [Function],
+            "setDisplayMode": [Function],
             "sort": [Function],
           },
           "ref": null,


### PR DESCRIPTION
See https://github.com/kiali/kiali-design/issues/57

- Fetch metrics in overview when mode is expanded
- Add toggle button to switch expanded/compact
- Horizontal bar chart (for health) and sparkline (for RPS)

JIRA: https://issues.jboss.org/browse/KIALI-2560