### PR TITLE
KIALI-2612 Fix non-clickable remove button

### DIFF
--- a/src/components/IstioWizards/MatchingRouting.tsx
+++ b/src/components/IstioWizards/MatchingRouting.tsx
@@ -101,6 +101,9 @@ const ruleItemStyle = style({
     ['.list-group-item-heading']: {
       flexBasis: 'calc(50% - 20px)',
       width: 'calc(50% - 20px)'
+    },
+    ['.list-view-pf-actions']: {
+      zIndex: 10
     }
   }
 });


### PR DESCRIPTION
The "Route to" div could overlap the floating "actions" layer and make the button non clickable.

This is a fix to put the floating layer always on top.

![image](https://user-images.githubusercontent.com/1662329/54813519-02f21f80-4c8e-11e9-937d-83289fceb66a.png)

https://issues.jboss.org/browse/KIALI-2612