### PR TITLE
Add multiple destinations on Matching Wizard

### DIFF
--- a/src/components/IstioWizards/MatchingRouting.tsx
+++ b/src/components/IstioWizards/MatchingRouting.tsx
@@ -1,20 +1,8 @@
 import * as React from 'react';
-import {
-  Button,
-  DropdownButton,
-  DropdownKebab,
-  Form,
-  FormControl,
-  FormGroup,
-  Label,
-  ListView,
-  ListViewIcon,
-  ListViewItem,
-  MenuItem
-} from 'patternfly-react';
 import { WorkloadOverview } from '../../types/ServiceInfo';
-import { style } from 'typestyle';
-import { PfColors } from '../Pf/PfColors';
+import Rules, { MOVE_TYPE, Rule } from './MatchingRouting/Rules';
+import RuleBuilder from './MatchingRouting/RuleBuilder';
+import { EXACT, HEADERS } from './MatchingRouting/MatchBuilder';
 
 type Props = {
   serviceName: string;
@@ -22,22 +10,10 @@ type Props = {
   onChange: (valid: boolean, rules: Rule[]) => void;
 };
 
-export enum ROUTE_TYPE {
-  SERVICE = 'service-',
-  WORKLOAD = 'workload-'
-}
-
-export type Rule = {
-  matches: string[];
-  routeType: ROUTE_TYPE;
-  route: string;
-};
-
 type State = {
   category: string;
   operator: string;
-  route: string;
-  routeType: ROUTE_TYPE;
+  routes: string[];
   matches: string[];
   headerName: string;
   matchValue: string;
@@ -45,98 +21,13 @@ type State = {
   validationMsg: string;
 };
 
-const HEADERS = 'headers';
-const URI = 'uri';
-const SCHEME = 'scheme';
-const METHOD = 'method';
-const AUTHORITY = 'authority';
-
-const matchOptions: string[] = [HEADERS, URI, SCHEME, METHOD, AUTHORITY];
-
-const EXACT = 'exact';
-const PREFIX = 'prefix';
-const REGEX = 'regex';
-
-const opOptions: string[] = [EXACT, PREFIX, REGEX];
-
-const placeholderText = {
-  [HEADERS]: 'Header value...',
-  [URI]: 'Uri value...',
-  [SCHEME]: 'Scheme value...',
-  [METHOD]: 'Method value...',
-  [AUTHORITY]: 'Authority value...'
-};
-
-const matchStyle = style({
-  marginLeft: 20,
-  marginRight: 20
-});
-
-const createStyle = style({
-  marginTop: 70,
-  marginLeft: 20
-});
-
-const labelContainerStyle = style({
-  marginTop: 5
-});
-
-const labelMatchStyle = style({});
-
-const routeStyle = style({
-  marginTop: 15
-});
-
-const routeToStyle = style({
-  marginLeft: 10
-});
-
-const validationStyle = style({
-  marginTop: 15,
-  color: PfColors.Red100
-});
-
-const ruleItemStyle = style({
-  $nest: {
-    ['.list-group-item-heading']: {
-      flexBasis: 'calc(50% - 20px)',
-      width: 'calc(50% - 20px)'
-    },
-    ['.list-view-pf-actions']: {
-      zIndex: 10
-    }
-  }
-});
-
-const matchValueStyle = style({
-  fontWeight: 'normal',
-  whiteSpace: 'nowrap',
-  overflow: 'hidden',
-  textOverflow: 'ellipsis'
-});
-
-enum MOVE_TYPE {
-  UP,
-  DOWN
-}
-
-const vsIconType = 'fa';
-const vsIconName = 'code-fork';
-
-const svcIconType = 'pf';
-const svcIconName = 'service';
-
-const wkIconType = 'pf';
-const wkIconName = 'bundle';
-
 class MatchingRouting extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {
       category: HEADERS,
       operator: EXACT,
-      routeType: props.workloads.length > 0 ? ROUTE_TYPE.WORKLOAD : ROUTE_TYPE.SERVICE,
-      route: props.workloads.length > 0 ? props.workloads[0].name : props.serviceName,
+      routes: [],
       matches: [],
       headerName: '',
       matchValue: '',
@@ -144,34 +35,6 @@ class MatchingRouting extends React.Component<Props, State> {
       validationMsg: ''
     };
   }
-
-  onSelectCategory = (category: string) => {
-    this.setState({
-      category: category
-    });
-  };
-
-  onSelectOperator = (operator: string) => {
-    this.setState({
-      operator: operator
-    });
-  };
-
-  onSelectRoute = (routeName: string) => {
-    let route = '';
-    let routeType: ROUTE_TYPE;
-    if (routeName.startsWith(ROUTE_TYPE.SERVICE.toString())) {
-      routeType = ROUTE_TYPE.SERVICE;
-      route = routeName.substring(ROUTE_TYPE.SERVICE.toString().length);
-    } else {
-      routeType = ROUTE_TYPE.WORKLOAD;
-      route = routeName.substring(ROUTE_TYPE.WORKLOAD.toString().length);
-    }
-    this.setState({
-      route: route,
-      routeType: routeType
-    });
-  };
 
   isMatchesIncluded = (rules: Rule[], rule: Rule) => {
     let found = false;
@@ -238,8 +101,7 @@ class MatchingRouting extends React.Component<Props, State> {
         }
         const newRule: Rule = {
           matches: prevState.matches,
-          routeType: prevState.routeType,
-          route: prevState.route
+          routes: prevState.routes
         };
         if (!this.isMatchesIncluded(prevState.rules, newRule)) {
           prevState.rules.push(newRule);
@@ -284,13 +146,6 @@ class MatchingRouting extends React.Component<Props, State> {
     );
   };
 
-  onHeaderNameChange = (event: any) => {
-    this.setState({
-      headerName: event.target.value,
-      validationMsg: ''
-    });
-  };
-
   onMatchValueChange = (event: any) => {
     let validationMsg = '';
     if (this.state.category === HEADERS && this.state.headerName === '') {
@@ -333,228 +188,29 @@ class MatchingRouting extends React.Component<Props, State> {
     return matchAll;
   };
 
-  matchBuilderValidation = (): string => {
-    return this.state.validationMsg === '' ? 'success' : 'error';
-  };
-
-  renderRuleBuilder = () => {
-    return (
-      <ListView>
-        <ListViewItem
-          key={'match-builder'}
-          description={
-            <div>
-              <div>
-                Matches:
-                {this.renderMatchBuilder()}
-                {this.renderMatches()}
-              </div>
-              <div className={routeStyle}>
-                Route:
-                {this.renderRouteBuilder()}
-              </div>
-              {this.state.validationMsg !== '' && <div className={validationStyle}>{this.state.validationMsg}</div>}
-            </div>
-          }
-          // tslint:disable
-          actions={
-            <Button
-              bsStyle="primary"
-              className={createStyle}
-              disabled={this.state.validationMsg !== ''}
-              onClick={this.onAddRule}
-            >
-              Add Rule
-            </Button>
-          }
-        />
-      </ListView>
-    );
-  };
-
-  renderMatchBuilder = () => {
-    const matchItems: any[] = matchOptions.map((mode, index) => (
-      <MenuItem key={mode + '-' + index} eventKey={mode} active={mode === this.state.category}>
-        {mode}
-      </MenuItem>
-    ));
-    const opItems: any[] = opOptions.map((op, index) => (
-      <MenuItem key={op + '-' + index} eventKey={op} active={op === this.state.operator}>
-        {op}
-      </MenuItem>
-    ));
-    return (
-      <Form inline={true}>
-        <FormGroup validationState={this.matchBuilderValidation()}>
-          <DropdownButton
-            bsStyle="default"
-            title={this.state.category}
-            id="match-dropdown"
-            onSelect={this.onSelectCategory}
-          >
-            {matchItems}
-          </DropdownButton>
-          {this.state.category === HEADERS && (
-            <FormControl
-              type="text"
-              id="header-name-text"
-              placeholder={'Header name...'}
-              value={this.state.headerName}
-              onChange={this.onHeaderNameChange}
-            />
-          )}
-          <DropdownButton
-            bsStyle="default"
-            title={this.state.operator}
-            id="operator-dropdown"
-            onSelect={this.onSelectOperator}
-          >
-            {opItems}
-          </DropdownButton>
-          <FormControl
-            type="text"
-            id="header-value-text"
-            placeholder={placeholderText[this.state.category]}
-            value={this.state.matchValue}
-            onChange={this.onMatchValueChange}
-          />
-          <Button
-            bsStyle="default"
-            className={matchStyle}
-            disabled={this.state.validationMsg !== ''}
-            onClick={this.onAddMatch}
-          >
-            Add Match
-          </Button>
-        </FormGroup>
-      </Form>
-    );
-  };
-
-  renderRouteBuilder = () => {
-    const routeItems: any[] = this.props.workloads.map(wk => (
-      <MenuItem
-        key={'workload-' + wk.name}
-        eventKey={'workload-' + wk.name}
-        active={wk.name === this.state.route && this.state.routeType === ROUTE_TYPE.WORKLOAD}
-      >
-        Workload: {wk.name}
-      </MenuItem>
-    ));
-    routeItems.push(
-      <MenuItem
-        key={'service-' + this.props.serviceName}
-        eventKey={'service-' + this.props.serviceName}
-        active={this.props.serviceName === this.state.route && this.state.routeType === ROUTE_TYPE.SERVICE}
-      >
-        Service: {this.props.serviceName}
-      </MenuItem>
-    );
-    return (
-      <Form inline={true}>
-        <DropdownButton
-          bsStyle="default"
-          title={(this.state.routeType === ROUTE_TYPE.SERVICE ? 'Service: ' : 'Workload: ') + this.state.route}
-          id="route-dropdown"
-          onSelect={this.onSelectRoute}
-        >
-          {routeItems}
-        </DropdownButton>
-      </Form>
-    );
-  };
-
-  renderMatches = () => {
-    const matches: any[] = this.state.matches.map((match, index) => (
-      <span key={match + '-' + index}>
-        <Label className={labelMatchStyle} type="primary" onRemoveClick={() => this.onRemoveMatch(match)}>
-          {match}
-        </Label>{' '}
-      </span>
-    ));
-    return (
-      <div className={labelContainerStyle}>
-        Matching selected: {matches.length > 0 ? matches : <b>Match any request</b>}
-      </div>
-    );
-  };
-
-  renderRules = () => {
-    let ruleItems: any[] = [];
-    let isValid: boolean = true;
-    let matchAll: number = this.matchAllIndex(this.state.rules);
-    for (let index = 0; index < this.state.rules.length; index++) {
-      const rule = this.state.rules[index];
-      isValid = matchAll === -1 || index <= matchAll;
-      const matches: any[] = rule.matches.map((map, index) => {
-        return (
-          <div key={'match-' + map + '-' + index} className={matchValueStyle}>
-            {map}
-          </div>
-        );
-      });
-      const ruleActions = (
-        <div>
-          <Button onClick={() => this.onRemoveRule(index)}>Remove</Button>
-          {this.state.rules.length > 1 && (
-            <DropdownKebab key={'move-rule-actions-' + index} id={'move-rule-actions-' + index} pullRight={true}>
-              {index > 0 && <MenuItem onClick={() => this.onMoveRule(index, MOVE_TYPE.UP)}>Move Up</MenuItem>}
-              {index + 1 < this.state.rules.length && (
-                <MenuItem onClick={() => this.onMoveRule(index, MOVE_TYPE.DOWN)}>Move Down</MenuItem>
-              )}
-            </DropdownKebab>
-          )}
-        </div>
-      );
-      ruleItems.push(
-        <ListViewItem
-          key={'match-rule-' + index}
-          className={ruleItemStyle}
-          leftContent={<ListViewIcon type={vsIconType} name={vsIconName} />}
-          heading={
-            <div>
-              Matches:
-              {rule.matches.length === 0 && <div className={matchValueStyle}>Any request</div>}
-              {rule.matches.length !== 0 && matches}
-            </div>
-          }
-          description={
-            <div>
-              <b>Route to:</b>
-              <div>
-                <span>
-                  <ListViewIcon
-                    type={rule.routeType === ROUTE_TYPE.SERVICE ? svcIconType : wkIconType}
-                    name={rule.routeType === ROUTE_TYPE.SERVICE ? svcIconName : wkIconName}
-                  />
-                  <span className={routeToStyle}>{rule.route}</span>
-                </span>
-              </div>
-              {!isValid && (
-                <div className={validationStyle}>
-                  Match 'Any request' is defined in a previous rule.
-                  <br />
-                  This rule is not accessible.
-                </div>
-              )}
-            </div>
-          }
-          actions={ruleActions}
-        />
-      );
-    }
-    return (
-      <div>
-        <ListView>{ruleItems}</ListView>
-      </div>
-    );
-  };
-
   render() {
     return (
       <>
-        {this.renderRuleBuilder()}
-        {this.renderRules()}
+        <RuleBuilder
+          category={this.state.category}
+          operator={this.state.operator}
+          headerName={this.state.headerName}
+          matchValue={this.state.matchValue}
+          isValid={this.state.validationMsg === ''}
+          onSelectCategory={(category: string) => this.setState({ category: category })}
+          onHeaderNameChange={(event: any) => this.setState({ headerName: event.target.value, validationMsg: '' })}
+          onSelectOperator={(operator: string) => this.setState({ operator: operator })}
+          onMatchValueChange={this.onMatchValueChange}
+          onAddMatch={this.onAddMatch}
+          matches={this.state.matches}
+          onRemoveMatch={this.onRemoveMatch}
+          workloads={this.props.workloads}
+          routes={this.state.routes}
+          onSelectRoutes={(routes: string[]) => this.setState({ routes: routes })}
+          validationMsg={this.state.validationMsg}
+          onAddRule={this.onAddRule}
+        />
+        <Rules rules={this.state.rules} onRemoveRule={this.onRemoveRule} onMoveRule={this.onMoveRule} />
       </>
     );
   }

--- a/src/components/IstioWizards/MatchingRouting.tsx
+++ b/src/components/IstioWizards/MatchingRouting.tsx
@@ -27,7 +27,7 @@ class MatchingRouting extends React.Component<Props, State> {
     this.state = {
       category: HEADERS,
       operator: EXACT,
-      routes: [],
+      routes: this.props.workloads.filter((_, i) => i === 0).map(w => w.name),
       matches: [],
       headerName: '',
       matchValue: '',
@@ -146,6 +146,17 @@ class MatchingRouting extends React.Component<Props, State> {
     );
   };
 
+  onHeaderNameChange = (event: any) => {
+    let validationMsg = '';
+    if (this.state.matchValue !== '' && event.target.value === '') {
+      validationMsg = 'Header name must be non empty';
+    }
+    this.setState({
+      headerName: event.target.value,
+      validationMsg: validationMsg
+    });
+  };
+
   onMatchValueChange = (event: any) => {
     let validationMsg = '';
     if (this.state.category === HEADERS && this.state.headerName === '') {
@@ -156,6 +167,17 @@ class MatchingRouting extends React.Component<Props, State> {
     }
     this.setState({
       matchValue: event.target.value,
+      validationMsg: validationMsg
+    });
+  };
+
+  onSelectRoutes = (routes: string[]) => {
+    let validationMsg = '';
+    if (routes.length === 0) {
+      validationMsg = 'Routes must be non empty';
+    }
+    this.setState({
+      routes: routes,
       validationMsg: validationMsg
     });
   };
@@ -198,7 +220,7 @@ class MatchingRouting extends React.Component<Props, State> {
           matchValue={this.state.matchValue}
           isValid={this.state.validationMsg === ''}
           onSelectCategory={(category: string) => this.setState({ category: category })}
-          onHeaderNameChange={(event: any) => this.setState({ headerName: event.target.value, validationMsg: '' })}
+          onHeaderNameChange={this.onHeaderNameChange}
           onSelectOperator={(operator: string) => this.setState({ operator: operator })}
           onMatchValueChange={this.onMatchValueChange}
           onAddMatch={this.onAddMatch}
@@ -206,7 +228,7 @@ class MatchingRouting extends React.Component<Props, State> {
           onRemoveMatch={this.onRemoveMatch}
           workloads={this.props.workloads}
           routes={this.state.routes}
-          onSelectRoutes={(routes: string[]) => this.setState({ routes: routes })}
+          onSelectRoutes={this.onSelectRoutes}
           validationMsg={this.state.validationMsg}
           onAddRule={this.onAddRule}
         />

--- a/src/components/IstioWizards/MatchingRouting.tsx
+++ b/src/components/IstioWizards/MatchingRouting.tsx
@@ -21,13 +21,18 @@ type State = {
   validationMsg: string;
 };
 
+const MSG_SAME_MATCHING = 'A Rule with same matching criteria is already added.';
+const MSG_HEADER_NAME_NON_EMPTY = 'Header name must be non empty';
+const MSG_HEADER_VALUE_NON_EMPTY = 'Header value must be non empty';
+const MSG_ROUTES_NON_EMPTY = 'Routes must be non empty';
+
 class MatchingRouting extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {
       category: HEADERS,
       operator: EXACT,
-      routes: this.props.workloads.filter((_, i) => i === 0).map(w => w.name),
+      routes: this.props.workloads.map(w => w.name),
       matches: [],
       headerName: '',
       matchValue: '',
@@ -118,7 +123,7 @@ class MatchingRouting extends React.Component<Props, State> {
             headerName: prevState.headerName,
             matchValue: prevState.matchValue,
             rules: prevState.rules,
-            validationMsg: 'A Rule with same matching criteria is already added.'
+            validationMsg: MSG_SAME_MATCHING
           };
         }
       },
@@ -149,7 +154,10 @@ class MatchingRouting extends React.Component<Props, State> {
   onHeaderNameChange = (event: any) => {
     let validationMsg = '';
     if (this.state.matchValue !== '' && event.target.value === '') {
-      validationMsg = 'Header name must be non empty';
+      validationMsg = MSG_HEADER_NAME_NON_EMPTY;
+    }
+    if (this.state.matchValue === '' && event.target.value !== '') {
+      validationMsg = MSG_HEADER_VALUE_NON_EMPTY;
     }
     this.setState({
       headerName: event.target.value,
@@ -159,8 +167,13 @@ class MatchingRouting extends React.Component<Props, State> {
 
   onMatchValueChange = (event: any) => {
     let validationMsg = '';
-    if (this.state.category === HEADERS && this.state.headerName === '') {
-      validationMsg = 'Header name must be non empty';
+    if (this.state.category === HEADERS) {
+      if (this.state.headerName === '' && event.target.value !== '') {
+        validationMsg = MSG_HEADER_NAME_NON_EMPTY;
+      }
+      if (this.state.headerName !== '' && event.target.value === '') {
+        validationMsg = MSG_HEADER_VALUE_NON_EMPTY;
+      }
     }
     if (event.target.value === '') {
       validationMsg = '';
@@ -174,7 +187,7 @@ class MatchingRouting extends React.Component<Props, State> {
   onSelectRoutes = (routes: string[]) => {
     let validationMsg = '';
     if (routes.length === 0) {
-      validationMsg = 'Routes must be non empty';
+      validationMsg = MSG_ROUTES_NON_EMPTY;
     }
     this.setState({
       routes: routes,

--- a/src/components/IstioWizards/MatchingRouting/MatchBuilder.tsx
+++ b/src/components/IstioWizards/MatchingRouting/MatchBuilder.tsx
@@ -1,0 +1,114 @@
+import * as React from 'react';
+import { Button, DropdownButton, Form, FormControl, FormGroup, MenuItem } from 'patternfly-react';
+import { style } from 'typestyle';
+
+type Props = {
+  category: string;
+  operator: string;
+  headerName: string;
+  matchValue: string;
+  isValid: boolean;
+  onSelectCategory: (category: string) => void;
+  onHeaderNameChange: (headerName: string) => void;
+  onSelectOperator: (operator: string) => void;
+  onMatchValueChange: (matchValue: string) => void;
+  onAddMatch: () => void;
+};
+
+export const HEADERS = 'headers';
+export const URI = 'uri';
+export const SCHEME = 'scheme';
+export const METHOD = 'method';
+export const AUTHORITY = 'authority';
+
+const matchOptions: string[] = [HEADERS, URI, SCHEME, METHOD, AUTHORITY];
+
+export const EXACT = 'exact';
+export const PREFIX = 'prefix';
+export const REGEX = 'regex';
+
+const opOptions: string[] = [EXACT, PREFIX, REGEX];
+
+const placeholderText = {
+  [HEADERS]: 'Header value...',
+  [URI]: 'Uri value...',
+  [SCHEME]: 'Scheme value...',
+  [METHOD]: 'Method value...',
+  [AUTHORITY]: 'Authority value...'
+};
+
+const matchStyle = style({
+  marginLeft: 20,
+  marginRight: 20
+});
+
+class MatchBuilder extends React.Component<Props> {
+  constructor(props: Props) {
+    super(props);
+  }
+
+  matchBuilderValidation = (): string => {
+    return this.props.isValid ? 'success' : 'error';
+  };
+
+  render() {
+    const matchItems: any[] = matchOptions.map((mode, index) => (
+      <MenuItem key={mode + '-' + index} eventKey={mode} active={mode === this.props.category}>
+        {mode}
+      </MenuItem>
+    ));
+    const opItems: any[] = opOptions.map((op, index) => (
+      <MenuItem key={op + '-' + index} eventKey={op} active={op === this.props.operator}>
+        {op}
+      </MenuItem>
+    ));
+    return (
+      <Form inline={true}>
+        <FormGroup validationState={this.matchBuilderValidation()}>
+          <DropdownButton
+            bsStyle="default"
+            title={this.props.category}
+            id="match-dropdown"
+            onSelect={this.props.onSelectCategory}
+          >
+            {matchItems}
+          </DropdownButton>
+          {this.props.category === HEADERS && (
+            <FormControl
+              type="text"
+              id="header-name-text"
+              placeholder={'Header name...'}
+              value={this.props.headerName}
+              onChange={this.props.onHeaderNameChange}
+            />
+          )}
+          <DropdownButton
+            bsStyle="default"
+            title={this.props.operator}
+            id="operator-dropdown"
+            onSelect={this.props.onSelectOperator}
+          >
+            {opItems}
+          </DropdownButton>
+          <FormControl
+            type="text"
+            id="header-value-text"
+            placeholder={placeholderText[this.props.category]}
+            value={this.props.matchValue}
+            onChange={this.props.onMatchValueChange}
+          />
+          <Button
+            bsStyle="default"
+            className={matchStyle}
+            disabled={!this.props.isValid}
+            onClick={this.props.onAddMatch}
+          >
+            Add Match
+          </Button>
+        </FormGroup>
+      </Form>
+    );
+  }
+}
+
+export default MatchBuilder;

--- a/src/components/IstioWizards/MatchingRouting/MatchBuilder.tsx
+++ b/src/components/IstioWizards/MatchingRouting/MatchBuilder.tsx
@@ -38,8 +38,7 @@ const placeholderText = {
 };
 
 const matchStyle = style({
-  marginLeft: 20,
-  marginRight: 20
+  marginLeft: 20
 });
 
 class MatchBuilder extends React.Component<Props> {

--- a/src/components/IstioWizards/MatchingRouting/MatchBuilder.tsx
+++ b/src/components/IstioWizards/MatchingRouting/MatchBuilder.tsx
@@ -46,10 +46,6 @@ class MatchBuilder extends React.Component<Props> {
     super(props);
   }
 
-  matchBuilderValidation = (): string => {
-    return this.props.isValid ? 'success' : 'error';
-  };
-
   render() {
     const matchItems: any[] = matchOptions.map((mode, index) => (
       <MenuItem key={mode + '-' + index} eventKey={mode} active={mode === this.props.category}>
@@ -63,7 +59,7 @@ class MatchBuilder extends React.Component<Props> {
     ));
     return (
       <Form inline={true}>
-        <FormGroup validationState={this.matchBuilderValidation()}>
+        <FormGroup validationState={this.props.isValid ? 'success' : 'error'}>
           <DropdownButton
             bsStyle="default"
             title={this.props.category}

--- a/src/components/IstioWizards/MatchingRouting/Matches.tsx
+++ b/src/components/IstioWizards/MatchingRouting/Matches.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import { Label } from 'patternfly-react';
+import { style } from 'typestyle';
+
+type Props = {
+  matches: string[];
+  onRemoveMatch: (match: string) => void;
+};
+
+const labelContainerStyle = style({
+  marginTop: 5
+});
+
+const labelMatchStyle = style({});
+
+class Matches extends React.Component<Props> {
+  constructor(props: Props) {
+    super(props);
+  }
+
+  render() {
+    const matches: any[] = this.props.matches.map((match, index) => (
+      <span key={match + '-' + index}>
+        <Label className={labelMatchStyle} type="primary" onRemoveClick={() => this.props.onRemoveMatch(match)}>
+          {match}
+        </Label>{' '}
+      </span>
+    ));
+    return (
+      <div className={labelContainerStyle}>
+        Matching selected: {matches.length > 0 ? matches : <b>Match any request</b>}
+      </div>
+    );
+  }
+}
+
+export default Matches;

--- a/src/components/IstioWizards/MatchingRouting/RuleBuilder.tsx
+++ b/src/components/IstioWizards/MatchingRouting/RuleBuilder.tsx
@@ -1,0 +1,104 @@
+import * as React from 'react';
+import { Button, ListView, ListViewItem, TypeAheadSelect } from 'patternfly-react';
+import MatchBuilder from './MatchBuilder';
+import Matches from './Matches';
+import { style } from 'typestyle';
+import { WorkloadOverview } from '../../../types/ServiceInfo';
+import { PfColors } from '../../Pf/PfColors';
+
+type Props = {
+  // MatchBuilder props
+  category: string;
+  operator: string;
+  headerName: string;
+  matchValue: string;
+  isValid: boolean;
+  onSelectCategory: (category: string) => void;
+  onHeaderNameChange: (headerName: string) => void;
+  onSelectOperator: (operator: string) => void;
+  onMatchValueChange: (matchValue: string) => void;
+  onAddMatch: () => void;
+
+  // Matches props
+  matches: string[];
+  onRemoveMatch: (match: string) => void;
+
+  workloads: WorkloadOverview[];
+  routes: string[];
+  onSelectRoutes: (routes: string[]) => void;
+
+  // RuleBuilder
+  validationMsg: string;
+  onAddRule: () => void;
+};
+
+const routeStyle = style({
+  marginTop: 15,
+  // Yes, you are right, this is a CSS trick to adjust style on combined components
+  $nest: {
+    ['.rbt-token .rbt-token-remove-button']: {
+      right: 5
+    }
+  }
+});
+
+const validationStyle = style({
+  marginTop: 15,
+  color: PfColors.Red100
+});
+
+const createStyle = style({
+  marginTop: 90,
+  marginLeft: 20
+});
+
+class RuleBuilder extends React.Component<Props> {
+  constructor(props: Props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <ListView>
+        <ListViewItem
+          key={'match-builder'}
+          description={
+            <div>
+              <div>
+                Matches:
+                <MatchBuilder {...this.props} />
+                <Matches {...this.props} />
+              </div>
+              <div className={routeStyle}>
+                Routes:
+                <TypeAheadSelect
+                  id="workloads-selector"
+                  multiple={true}
+                  clearButton={true}
+                  placeholder="Select workloads"
+                  labelKey="workloadName"
+                  options={this.props.workloads.map(wk => wk.name)}
+                  onChange={(r: string[]) => this.props.onSelectRoutes(r)}
+                />
+              </div>
+              {!this.props.isValid && <div className={validationStyle}>{this.props.validationMsg}</div>}
+            </div>
+          }
+          // tslint:disable
+          actions={
+            <Button
+              bsStyle="primary"
+              className={createStyle}
+              disabled={!this.props.isValid}
+              onClick={this.props.onAddRule}
+            >
+              Add Rule
+            </Button>
+          }
+        />
+      </ListView>
+    );
+  }
+}
+
+export default RuleBuilder;

--- a/src/components/IstioWizards/MatchingRouting/RuleBuilder.tsx
+++ b/src/components/IstioWizards/MatchingRouting/RuleBuilder.tsx
@@ -77,6 +77,7 @@ class RuleBuilder extends React.Component<Props> {
                   clearButton={true}
                   placeholder="Select workloads"
                   labelKey="workloadName"
+                  defaultSelected={this.props.routes}
                   options={this.props.workloads.map(wk => wk.name)}
                   onChange={(r: string[]) => this.props.onSelectRoutes(r)}
                 />

--- a/src/components/IstioWizards/MatchingRouting/RuleBuilder.tsx
+++ b/src/components/IstioWizards/MatchingRouting/RuleBuilder.tsx
@@ -63,12 +63,12 @@ class RuleBuilder extends React.Component<Props> {
         <ListViewItem
           key={'match-builder'}
           description={
-            <div>
-              <div>
+            <>
+              <>
                 Matches:
                 <MatchBuilder {...this.props} />
                 <Matches {...this.props} />
-              </div>
+              </>
               <div className={routeStyle}>
                 Routes:
                 <Form>
@@ -87,7 +87,7 @@ class RuleBuilder extends React.Component<Props> {
                 </Form>
               </div>
               {!this.props.isValid && <div className={validationStyle}>{this.props.validationMsg}</div>}
-            </div>
+            </>
           }
           // tslint:disable
           actions={

--- a/src/components/IstioWizards/MatchingRouting/RuleBuilder.tsx
+++ b/src/components/IstioWizards/MatchingRouting/RuleBuilder.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, ListView, ListViewItem, TypeAheadSelect } from 'patternfly-react';
+import { Button, Form, FormGroup, ListView, ListViewItem, TypeAheadSelect } from 'patternfly-react';
 import MatchBuilder from './MatchBuilder';
 import Matches from './Matches';
 import { style } from 'typestyle';
@@ -71,16 +71,20 @@ class RuleBuilder extends React.Component<Props> {
               </div>
               <div className={routeStyle}>
                 Routes:
-                <TypeAheadSelect
-                  id="workloads-selector"
-                  multiple={true}
-                  clearButton={true}
-                  placeholder="Select workloads"
-                  labelKey="workloadName"
-                  defaultSelected={this.props.routes}
-                  options={this.props.workloads.map(wk => wk.name)}
-                  onChange={(r: string[]) => this.props.onSelectRoutes(r)}
-                />
+                <Form>
+                  <FormGroup validationState={this.props.isValid ? 'success' : 'error'}>
+                    <TypeAheadSelect
+                      id="workloads-selector"
+                      multiple={true}
+                      clearButton={true}
+                      placeholder="Select workloads"
+                      labelKey="workloadName"
+                      defaultSelected={this.props.routes}
+                      options={this.props.workloads.map(wk => wk.name)}
+                      onChange={(r: string[]) => this.props.onSelectRoutes(r)}
+                    />
+                  </FormGroup>
+                </Form>
               </div>
               {!this.props.isValid && <div className={validationStyle}>{this.props.validationMsg}</div>}
             </div>

--- a/src/components/IstioWizards/MatchingRouting/Rules.tsx
+++ b/src/components/IstioWizards/MatchingRouting/Rules.tsx
@@ -1,0 +1,144 @@
+import * as React from 'react';
+import { Button, DropdownKebab, ListView, ListViewIcon, ListViewItem, MenuItem } from 'patternfly-react';
+import { style } from 'typestyle';
+import { PfColors } from '../../Pf/PfColors';
+
+export enum MOVE_TYPE {
+  UP,
+  DOWN
+}
+
+export type Rule = {
+  matches: string[];
+  routes: string[];
+};
+
+type Props = {
+  rules: Rule[];
+  onRemoveRule: (index: number) => void;
+  onMoveRule: (index: number, move: MOVE_TYPE) => void;
+};
+
+const matchValueStyle = style({
+  fontWeight: 'normal',
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis'
+});
+
+const ruleItemStyle = style({
+  $nest: {
+    ['.list-group-item-heading']: {
+      flexBasis: 'calc(50% - 20px)',
+      width: 'calc(50% - 20px)'
+    },
+    ['.list-view-pf-actions']: {
+      zIndex: 10
+    }
+  }
+});
+
+const routeToStyle = style({
+  marginLeft: 10
+});
+
+const validationStyle = style({
+  marginTop: 15,
+  color: PfColors.Red100
+});
+
+const vsIconType = 'fa';
+const vsIconName = 'code-fork';
+
+const wkIconType = 'pf';
+const wkIconName = 'bundle';
+
+class Rules extends React.Component<Props> {
+  constructor(props: Props) {
+    super(props);
+  }
+
+  matchAllIndex = (rules: Rule[]): number => {
+    let matchAll: number = -1;
+    for (let index = 0; index < rules.length; index++) {
+      const rule = rules[index];
+      if (rule.matches.length === 0) {
+        matchAll = index;
+        break;
+      }
+    }
+    return matchAll;
+  };
+
+  render() {
+    const ruleItems: any[] = [];
+    let isValid: boolean = true;
+    const matchAll: number = this.matchAllIndex(this.props.rules);
+    for (let index = 0; index < this.props.rules.length; index++) {
+      const rule = this.props.rules[index];
+      isValid = matchAll === -1 || index <= matchAll;
+      const matches: any[] = rule.matches.map((map, i) => {
+        return (
+          <div key={'match-' + map + '-' + i} className={matchValueStyle}>
+            {map}
+          </div>
+        );
+      });
+      const ruleActions = (
+        <div>
+          <Button onClick={() => this.props.onRemoveRule(index)}>Remove</Button>
+          {this.props.rules.length > 1 && (
+            <DropdownKebab key={'move-rule-actions-' + index} id={'move-rule-actions-' + index} pullRight={true}>
+              {index > 0 && <MenuItem onClick={() => this.props.onMoveRule(index, MOVE_TYPE.UP)}>Move Up</MenuItem>}
+              {index + 1 < this.props.rules.length && (
+                <MenuItem onClick={() => this.props.onMoveRule(index, MOVE_TYPE.DOWN)}>Move Down</MenuItem>
+              )}
+            </DropdownKebab>
+          )}
+        </div>
+      );
+      ruleItems.push(
+        <ListViewItem
+          key={'match-rule-' + index}
+          className={ruleItemStyle}
+          leftContent={<ListViewIcon type={vsIconType} name={vsIconName} />}
+          heading={
+            <div>
+              Matches:
+              {rule.matches.length === 0 && <div className={matchValueStyle}>Any request</div>}
+              {rule.matches.length !== 0 && matches}
+            </div>
+          }
+          description={
+            <div>
+              <b>Route to:</b>
+              {rule.routes.map(route => (
+                <div key={'route-to-' + route}>
+                  <span>
+                    <ListViewIcon type={wkIconType} name={wkIconName} />
+                    <span className={routeToStyle}>{route}</span>
+                  </span>
+                </div>
+              ))}
+              {!isValid && (
+                <div className={validationStyle}>
+                  Match 'Any request' is defined in a previous rule.
+                  <br />
+                  This rule is not accessible.
+                </div>
+              )}
+            </div>
+          }
+          actions={ruleActions}
+        />
+      );
+    }
+    return (
+      <div>
+        <ListView>{ruleItems}</ListView>
+      </div>
+    );
+  }
+}
+
+export default Rules;

--- a/src/components/IstioWizards/MatchingRouting/Rules.tsx
+++ b/src/components/IstioWizards/MatchingRouting/Rules.tsx
@@ -85,7 +85,7 @@ class Rules extends React.Component<Props> {
         );
       });
       const ruleActions = (
-        <div>
+        <>
           <Button onClick={() => this.props.onRemoveRule(index)}>Remove</Button>
           {this.props.rules.length > 1 && (
             <DropdownKebab key={'move-rule-actions-' + index} id={'move-rule-actions-' + index} pullRight={true}>
@@ -95,7 +95,7 @@ class Rules extends React.Component<Props> {
               )}
             </DropdownKebab>
           )}
-        </div>
+        </>
       );
       ruleItems.push(
         <ListViewItem
@@ -103,14 +103,14 @@ class Rules extends React.Component<Props> {
           className={ruleItemStyle}
           leftContent={<ListViewIcon type={vsIconType} name={vsIconName} />}
           heading={
-            <div>
+            <>
               Matches:
               {rule.matches.length === 0 && <div className={matchValueStyle}>Any request</div>}
               {rule.matches.length !== 0 && matches}
-            </div>
+            </>
           }
           description={
-            <div>
+            <>
               <b>Route to:</b>
               {rule.routes.map(route => (
                 <div key={'route-to-' + route}>
@@ -127,16 +127,16 @@ class Rules extends React.Component<Props> {
                   This rule is not accessible.
                 </div>
               )}
-            </div>
+            </>
           }
           actions={ruleActions}
         />
       );
     }
     return (
-      <div>
+      <>
         <ListView>{ruleItems}</ListView>
-      </div>
+      </>
     );
   }
 }


### PR DESCRIPTION
Matching Routing Wizard only allowed to select one destination.

That limited some valid use cases like:

I.e. reviews service with v1, v2, v3 versions:
- Rule [1]: if user == lucas then go to reviews/v1
- Rule [2]: if Any request then go to reviews/v2, reviews/v3

This PRs includes multiple selection of workloads to accept these kind of VS/DR combinations

https://issues.jboss.org/browse/KIALI-2615

![image](https://user-images.githubusercontent.com/1662329/54939251-61d2c580-4f28-11e9-89d9-48e7643db445.png)

![image](https://user-images.githubusercontent.com/1662329/54939267-6dbe8780-4f28-11e9-9516-ed9bfa1bbf05.png)

![image](https://user-images.githubusercontent.com/1662329/54939281-78791c80-4f28-11e9-9d36-20213d836dcc.png)

![image](https://user-images.githubusercontent.com/1662329/54939300-83cc4800-4f28-11e9-8fc1-875987e6ff8a.png)

