### PR TITLE
KIALI-2556 Fix links to unknown destination service

### DIFF
--- a/src/components/Details/DetailedTrafficList.tsx
+++ b/src/components/Details/DetailedTrafficList.tsx
@@ -145,7 +145,7 @@ class DetailedTrafficList extends React.Component<DetailedTrafficProps> {
       }
     } else if (NodeType.SERVICE === node.type) {
       icon = <Icon type="pf" name="service" style={style} />;
-      if (!node.isServiceEntry || !node.isInaccessible) {
+      if (!node.isServiceEntry && !node.isInaccessible) {
         name = (
           <Link to={`/namespaces/${encodeURIComponent(node.namespace)}/services/${encodeURIComponent(node.name)}`}>
             {node.name}

--- a/src/pages/Graph/SummaryPanelEdge.tsx
+++ b/src/pages/Graph/SummaryPanelEdge.tsx
@@ -251,8 +251,14 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
       this.metricsPromise = undefined;
     }
 
-    // Just return if the metric types are unset, there is no data, or charts are unsupported
-    if (!destMetricType || !sourceMetricType || !this.hasSupportedCharts(edge) || (!isGrpc && !isHttp && !isTcp)) {
+    // Just return if the metric types are unset, there is no data, destination node is "unknown" or charts are unsupported
+    if (
+      !destMetricType ||
+      !sourceMetricType ||
+      !this.hasSupportedCharts(edge) ||
+      (!isGrpc && !isHttp && !isTcp) ||
+      destData.isInaccessible
+    ) {
       this.setState({
         loading: false
       });
@@ -407,6 +413,15 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
         <>
           <Icon type="pf" name="info" /> Service graphs do not support service-to-service aggregate sparklines. Use the
           workload graph type to observe individual workload-to-service edge sparklines.
+        </>
+      );
+    }
+
+    const data = nodeData(edge.target());
+    if (data.isInaccessible) {
+      return (
+        <>
+          <Icon type="pf" name="info" /> Sparkline charts cannot be shown because the destination is inaccessible.
         </>
       );
     }

--- a/src/pages/Graph/SummaryPanelNode.tsx
+++ b/src/pages/Graph/SummaryPanelNode.tsx
@@ -126,6 +126,12 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
       return;
     }
 
+    // If destination node is inaccessible, we cannot query the data.
+    if (data.isInaccessible) {
+      this.setState({ loading: false });
+      return;
+    }
+
     let promiseOut: Promise<Response<Metrics>> = Promise.resolve({ data: { metrics: {}, histograms: {} } });
     let promiseIn: Promise<Response<Metrics>> = Promise.resolve({ data: { metrics: {}, histograms: {} } });
 
@@ -373,11 +379,22 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
   };
 
   private renderCharts = node => {
-    if (NodeType.UNKNOWN === node.data(CyNode.nodeType)) {
+    const data = nodeData(node);
+
+    if (NodeType.UNKNOWN === data.nodeType) {
       return (
         <>
           <div>
             <Icon type="pf" name="info" /> Sparkline charts not supported for unknown node. Use edge for details.
+            <hr />
+          </div>
+        </>
+      );
+    } else if (data.isInaccessible) {
+      return (
+        <>
+          <div>
+            <Icon type="pf" name="info" /> Sparkline charts cannot be shown because the selected node is inaccessible.
             <hr />
           </div>
         </>


### PR DESCRIPTION
https://issues.jboss.org/browse/KIALI-2556

This prevents creating links for the "unknown" node when it is a destination of traffic.

This fix is for the side panels of the graph and, also for the traffic tabs of the details pages.