### PR TITLE
KIALI-2624 Prevent UI crash even if validation is missing

### DIFF
--- a/src/components/ConfigValidation/ConfigIndicator.tsx
+++ b/src/components/ConfigValidation/ConfigIndicator.tsx
@@ -57,7 +57,9 @@ export class ConfigIndicator extends React.PureComponent<Props, {}> {
   numberOfChecks = (type: string) => {
     let numCheck = 0;
     this.props.validations.forEach(validation => {
-      numCheck += validation.checks.filter(i => i.severity === type).length;
+      if (validation.checks) {
+        numCheck += validation.checks.filter(i => i.severity === type).length;
+      }
     });
     return numCheck;
   };
@@ -72,6 +74,9 @@ export class ConfigIndicator extends React.PureComponent<Props, {}> {
   };
 
   getValid() {
+    if (this.props.validations.length === 0) {
+      return WARNING;
+    }
     const warnIssues = this.numberOfChecks('warning');
     const errIssues = this.numberOfChecks('error');
     return warnIssues === 0 && errIssues === 0 ? VALID : errIssues > 0 ? NOT_VALID : WARNING;
@@ -84,23 +89,27 @@ export class ConfigIndicator extends React.PureComponent<Props, {}> {
   tooltipContent() {
     let numChecks = 0;
     this.props.validations.forEach(validation => {
-      if (validation !== undefined) {
+      if (validation.checks) {
         numChecks += validation.checks.length;
       }
     });
 
     const issuesMessages: string[] = [];
-    if (numChecks === 0) {
-      issuesMessages.push('No issues found');
+    if (this.props.validations.length > 0) {
+      if (numChecks === 0) {
+        issuesMessages.push('No issues found');
+      } else {
+        const errMessage = this.getTypeMessage('error');
+        if (errMessage) {
+          issuesMessages.push(errMessage);
+        }
+        const warnMessage = this.getTypeMessage('warning');
+        if (warnMessage) {
+          issuesMessages.push(warnMessage);
+        }
+      }
     } else {
-      const errMessage = this.getTypeMessage('error');
-      if (errMessage) {
-        issuesMessages.push(errMessage);
-      }
-      const warnMessage = this.getTypeMessage('warning');
-      if (warnMessage) {
-        issuesMessages.push(warnMessage);
-      }
+      issuesMessages.push('Expected validation results are missing');
     }
 
     const validationsInfo: JSX.Element[] = [];

--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -317,7 +317,7 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
   };
 
   renderOverview = (): any => {
-    if (this.state.istioObjectDetails && this.state.istioValidations) {
+    if (this.state.istioObjectDetails) {
       if (this.state.istioObjectDetails.virtualService) {
         return (
           <VirtualServiceDetail

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/DestinationRuleDetail.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/DestinationRuleDetail.tsx
@@ -11,7 +11,7 @@ import { Link } from 'react-router-dom';
 interface DestinationRuleProps {
   namespace: string;
   destinationRule: DestinationRule;
-  validation: ObjectValidation;
+  validation?: ObjectValidation;
 }
 
 class DestinationRuleDetail extends React.Component<DestinationRuleProps> {
@@ -20,10 +20,7 @@ class DestinationRuleDetail extends React.Component<DestinationRuleProps> {
   }
 
   validation(destinationRule: DestinationRule): ObjectValidation | undefined {
-    if (this.props.validation) {
-      return this.props.validation;
-    }
-    return undefined;
+    return this.props.validation;
   }
 
   globalStatus(rule: DestinationRule) {

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceDetail.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceDetail.tsx
@@ -17,7 +17,7 @@ import { Link } from 'react-router-dom';
 interface VirtualServiceProps {
   namespace: string;
   virtualService: VirtualService;
-  validation: ObjectValidation;
+  validation?: ObjectValidation;
 }
 
 class VirtualServiceDetail extends React.Component<VirtualServiceProps> {
@@ -25,12 +25,16 @@ class VirtualServiceDetail extends React.Component<VirtualServiceProps> {
     super(props);
   }
 
-  validation(virtualService: VirtualService): ObjectValidation {
+  validation(virtualService: VirtualService): ObjectValidation | undefined {
     return this.props.validation;
   }
 
   globalStatus(rule: VirtualService) {
     const validation = this.validation(rule);
+    if (!validation) {
+      return '';
+    }
+
     const checks = globalChecks(validation);
     const severity = validationToSeverity(validation);
     const iconName = severityToIconName(severity);

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceRoute.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceRoute.tsx
@@ -19,7 +19,7 @@ interface VirtualServiceRouteProps {
   namespace: string;
   kind: string;
   routes: any[];
-  validation: ObjectValidation;
+  validation?: ObjectValidation;
 }
 
 const PFBlueColors = [
@@ -161,7 +161,7 @@ class VirtualServiceRoute extends React.Component<VirtualServiceRouteProps> {
   }
 
   validation(): ObjectValidation {
-    return this.props.validation;
+    return this.props.validation ? this.props.validation : ({} as ObjectValidation);
   }
 
   statusFrom(validation: ObjectValidation, routeItem: DestinationWeight, routeIndex: number, destinationIndex: number) {

--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -193,16 +193,18 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
       const dr = new DestinationRuleValidator(destinationRule);
       const formatValidation = dr.formatValidation();
 
-      const objectValidations = validations['destinationrule'][destinationRule.metadata.name];
-      if (
-        formatValidation !== null &&
-        !objectValidations.checks.some(check => check.message === formatValidation.message)
-      ) {
-        objectValidations.checks.push(formatValidation);
-        objectValidations.valid = false;
+      if (validations['destinationrule']) {
+        const objectValidations = validations['destinationrule'][destinationRule.metadata.name];
+        if (
+          formatValidation !== null &&
+          !objectValidations.checks.some(check => check.message === formatValidation.message)
+        ) {
+          objectValidations.checks.push(formatValidation);
+          objectValidations.valid = false;
+        }
       }
     });
-    return validations;
+    return validations ? validations : ({} as Validations);
   }
 
   navigateToJaeger = () => {

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDestinationRules.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDestinationRules.tsx
@@ -133,6 +133,13 @@ class ServiceInfoDestinationRules extends React.Component<ServiceInfoDestination
     );
   }
 
+  hasValidations(destinationRule: DestinationRule): boolean {
+    if (this.props.validations && this.props.validations[destinationRule.metadata.name]) {
+      return true;
+    }
+    return false;
+  }
+
   validation(destinationRule: DestinationRule): ObjectValidation {
     return this.props.validations[destinationRule.metadata.name];
   }
@@ -158,7 +165,12 @@ class ServiceInfoDestinationRules extends React.Component<ServiceInfoDestination
       return {
         id: vsIdx,
         name: this.overviewLink(destinationRule),
-        status: <ConfigIndicator id={vsIdx + '-config-validation'} validations={[this.validation(destinationRule)]} />,
+        status: (
+          <ConfigIndicator
+            id={vsIdx + '-config-validation'}
+            validations={this.hasValidations(destinationRule) ? [this.validation(destinationRule)] : []}
+          />
+        ),
         trafficPolicy: destinationRule.spec.trafficPolicy ? (
           <DetailObject name="" detail={destinationRule.spec.trafficPolicy} />
         ) : (

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDestinationRules.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDestinationRules.tsx
@@ -134,10 +134,7 @@ class ServiceInfoDestinationRules extends React.Component<ServiceInfoDestination
   }
 
   hasValidations(destinationRule: DestinationRule): boolean {
-    if (this.props.validations && this.props.validations[destinationRule.metadata.name]) {
-      return true;
-    }
-    return false;
+    return !!this.props.validations && !!this.props.validations[destinationRule.metadata.name];
   }
 
   validation(destinationRule: DestinationRule): ObjectValidation {

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoVirtualServices.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoVirtualServices.tsx
@@ -85,6 +85,14 @@ class ServiceInfoVirtualServices extends React.Component<ServiceInfoVirtualServi
     };
   }
 
+  hasValidations(virtualService: VirtualService): boolean {
+    // This is insane, but doing return to the clause inside the if will cause compiler failure
+    if (this.props.validations && this.props.validations[virtualService.metadata.name]) {
+      return true;
+    }
+    return false;
+  }
+
   validation(virtualService: VirtualService): ObjectValidation {
     return this.props.validations[virtualService.metadata.name];
   }
@@ -124,7 +132,12 @@ class ServiceInfoVirtualServices extends React.Component<ServiceInfoVirtualServi
   rows() {
     return (this.props.virtualServices || []).map((virtualService, vsIdx) => ({
       id: vsIdx,
-      status: <ConfigIndicator id={vsIdx + '-config-validation'} validations={[this.validation(virtualService)]} />,
+      status: (
+        <ConfigIndicator
+          id={vsIdx + '-config-validation'}
+          validations={this.hasValidations(virtualService) ? [this.validation(virtualService)] : []}
+        />
+      ),
       name: this.overviewLink(virtualService),
       createdAt: <LocalTime time={virtualService.metadata.creationTimestamp || ''} />,
       resourceVersion: virtualService.metadata.resourceVersion,

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoVirtualServices.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoVirtualServices.tsx
@@ -87,10 +87,7 @@ class ServiceInfoVirtualServices extends React.Component<ServiceInfoVirtualServi
 
   hasValidations(virtualService: VirtualService): boolean {
     // This is insane, but doing return to the clause inside the if will cause compiler failure
-    if (this.props.validations && this.props.validations[virtualService.metadata.name]) {
-      return true;
-    }
-    return false;
+    return !!this.props.validations && !!this.props.validations[virtualService.metadata.name];
   }
 
   validation(virtualService: VirtualService): ObjectValidation {

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoRouteVirtualServices.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoRouteVirtualServices.test.tsx.snap
@@ -293,11 +293,7 @@ ShallowWrapper {
                   "resourceVersion": "1234",
                   "status": <ConfigIndicator
                     id="0-config-validation"
-                    validations={
-                      Array [
-                        undefined,
-                      ]
-                    }
+                    validations={Array []}
                   />,
                 },
               ]
@@ -523,11 +519,7 @@ ShallowWrapper {
                   "resourceVersion": "1234",
                   "status": <ConfigIndicator
                     id="0-config-validation"
-                    validations={
-                      Array [
-                        undefined,
-                      ]
-                    }
+                    validations={Array []}
                   />,
                 },
               ]
@@ -666,11 +658,7 @@ ShallowWrapper {
                     "resourceVersion": "1234",
                     "status": <ConfigIndicator
                       id="0-config-validation"
-                      validations={
-                        Array [
-                          undefined,
-                        ]
-                      }
+                      validations={Array []}
                     />,
                   },
                 ]
@@ -892,11 +880,7 @@ ShallowWrapper {
                   "resourceVersion": "1234",
                   "status": <ConfigIndicator
                     id="0-config-validation"
-                    validations={
-                      Array [
-                        undefined,
-                      ]
-                    }
+                    validations={Array []}
                   />,
                 },
               ],
@@ -1132,11 +1116,7 @@ ShallowWrapper {
                     "resourceVersion": "1234",
                     "status": <ConfigIndicator
                       id="0-config-validation"
-                      validations={
-                        Array [
-                          undefined,
-                        ]
-                      }
+                      validations={Array []}
                     />,
                   },
                 ]
@@ -1362,11 +1342,7 @@ ShallowWrapper {
                     "resourceVersion": "1234",
                     "status": <ConfigIndicator
                       id="0-config-validation"
-                      validations={
-                        Array [
-                          undefined,
-                        ]
-                      }
+                      validations={Array []}
                     />,
                   },
                 ]
@@ -1505,11 +1481,7 @@ ShallowWrapper {
                       "resourceVersion": "1234",
                       "status": <ConfigIndicator
                         id="0-config-validation"
-                        validations={
-                          Array [
-                            undefined,
-                          ]
-                        }
+                        validations={Array []}
                       />,
                     },
                   ]
@@ -1731,11 +1703,7 @@ ShallowWrapper {
                     "resourceVersion": "1234",
                     "status": <ConfigIndicator
                       id="0-config-validation"
-                      validations={
-                        Array [
-                          undefined,
-                        ]
-                      }
+                      validations={Array []}
                     />,
                   },
                 ],

--- a/src/types/ServiceInfo.ts
+++ b/src/types/ServiceInfo.ts
@@ -136,7 +136,7 @@ export const validationToSeverity = (object: ObjectValidation): string => {
     : 'correct';
 };
 
-export const checkForPath = (object: ObjectValidation, path: string): ObjectCheck[] => {
+export const checkForPath = (object: ObjectValidation | undefined, path: string): ObjectCheck[] => {
   if (!object || !object.checks) {
     return [];
   }


### PR DESCRIPTION
** Describe the change **

These modifications check if validations is empty from the backend result and then goes to avoid displaying those items that require validation. All the pages should work, but the validation result is missing or text is displayed indicating that the validations that were expected could not be found.

Related to issue 936 in kiali repository. I could not repeat the issue at all and as such, one will need a modified kiali backend to test this. I have posted a docker image to ``docker.io/burmanm/kiali:kiali-2624`` that returns empty validations.

** Issue reference **

KIALI-2624 (I hope, JIRA is not working)
