### PR TITLE
KIALI-2335 Improvements in YAML editor

### DIFF
--- a/src/components/IstioActions/IstioActionsButtons.tsx
+++ b/src/components/IstioActions/IstioActionsButtons.tsx
@@ -2,9 +2,11 @@ import * as React from 'react';
 import { Button } from 'patternfly-react';
 type Props = {
   objectName: string;
+  readOnly: boolean;
   canUpdate: boolean;
   onCancel: () => void;
   onUpdate: () => void;
+  onRefresh: () => void;
 };
 type State = {
   showConfirmModal: boolean;
@@ -21,13 +23,18 @@ class IstioActionButtons extends React.Component<Props, State> {
     return (
       <>
         <span style={{ float: 'left', paddingTop: '10px', paddingBottom: '10px' }}>
+          {!this.props.readOnly && (
+            <span style={{ paddingRight: '5px' }}>
+              <Button bsStyle="primary" disabled={!this.props.canUpdate} onClick={this.props.onUpdate}>
+                Save
+              </Button>
+            </span>
+          )}
           <span style={{ paddingRight: '5px' }}>
-            <Button bsStyle="primary" disabled={!this.props.canUpdate} onClick={this.props.onUpdate}>
-              Save
-            </Button>
+            <Button onClick={this.props.onRefresh}>Reload</Button>
           </span>
           <span style={{ paddingRight: '5px' }}>
-            <Button onClick={this.props.onCancel}>Cancel</Button>
+            <Button onClick={this.props.onCancel}>{this.props.readOnly ? 'Close' : 'Cancel'}</Button>
           </span>
         </span>
       </>

--- a/src/reducers/MessageCenter.ts
+++ b/src/reducers/MessageCenter.ts
@@ -43,7 +43,7 @@ const createMessage = (
     content,
     type,
     count,
-    show_notification: type === MessageType.ERROR || type === MessageType.WARNING,
+    show_notification: type === MessageType.ERROR || type === MessageType.WARNING || type === MessageType.SUCCESS,
     seen: false,
     created: created,
     firstTriggered


### PR DESCRIPTION
- Save / Reload / Cancel buttons when user can write
- Reload / Close buttons on readonly scenarios
- Success msg and toast on Save operations

https://issues.jboss.org/browse/KIALI-2335

![image](https://user-images.githubusercontent.com/1662329/55232034-8b3f6a00-5224-11e9-8f06-9a6a61e1ba4b.png)

![image](https://user-images.githubusercontent.com/1662329/55232051-9a261c80-5224-11e9-9dbb-4a8e99ee25dc.png)
