### PR TITLE
KIALI-2592 Use grid instead of table for list items

### DIFF
--- a/src/pages/AppDetails/AppInfo.tsx
+++ b/src/pages/AppDetails/AppInfo.tsx
@@ -9,7 +9,7 @@ type AppInfoProps = {
   app: App;
   namespace: string;
   onRefresh: () => void;
-  onSelectTab: (tabName: string, postHandler?: (k: string) => void) => ((tabKey: string) => void);
+  onSelectTab: (tabName: string, postHandler?: (k: string) => void) => (tabKey: string) => void;
   activeTab: (tabName: string, whenEmpty: string) => string;
   health?: AppHealth;
 };

--- a/src/pages/AppList/ItemDescription.tsx
+++ b/src/pages/AppList/ItemDescription.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Col, Row } from 'patternfly-react';
 import { AppHealth } from '../../types/Health';
 import { DisplayMode, HealthIndicator } from '../../components/Health/HealthIndicator';
 import { AppListItem } from '../../types/AppList';
@@ -48,18 +49,16 @@ export default class ItemDescription extends React.PureComponent<Props, State> {
 
   render() {
     return this.state.health ? (
-      <table style={{ width: '70em', tableLayout: 'fixed' }}>
-        <tbody>
-          <tr>
-            <td>
-              <strong>Health: </strong>
-              <HealthIndicator id={this.props.item.name} health={this.state.health} mode={DisplayMode.SMALL} />
-            </td>
-            <td>{!this.props.item.istioSidecar && <MissingSidecar />}</td>
-            <td />
-          </tr>
-        </tbody>
-      </table>
+      <Row>
+        <Col xs={12} sm={12} md={4} lg={4}>
+          <strong>Health: </strong>
+          <HealthIndicator id={this.props.item.name} health={this.state.health} mode={DisplayMode.SMALL} />
+        </Col>
+        <Col xs={12} sm={12} md={4} lg={4}>
+          {!this.props.item.istioSidecar && <MissingSidecar />}
+        </Col>
+        <Col xs={12} sm={12} md={4} lg={4} />
+      </Row>
     ) : (
       <span />
     );

--- a/src/pages/ServiceList/ItemDescription.tsx
+++ b/src/pages/ServiceList/ItemDescription.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Col, Row } from 'patternfly-react';
 import { ServiceListItem } from '../../types/ServiceList';
 import { ServiceHealth } from '../../types/Health';
 import { DisplayMode, HealthIndicator } from '../../components/Health/HealthIndicator';
@@ -48,18 +49,16 @@ export default class ItemDescription extends React.PureComponent<Props, State> {
 
   render() {
     return this.state.health ? (
-      <table style={{ width: '70em', tableLayout: 'fixed' }}>
-        <tbody>
-          <tr>
-            <td>
-              <strong>Health: </strong>
-              <HealthIndicator id={this.props.item.name} health={this.state.health} mode={DisplayMode.SMALL} />
-            </td>
-            <td>{!this.props.item.istioSidecar && <MissingSidecar />}</td>
-            <td />
-          </tr>
-        </tbody>
-      </table>
+      <Row>
+        <Col xs={12} sm={12} md={4} lg={4}>
+          <strong>Health: </strong>
+          <HealthIndicator id={this.props.item.name} health={this.state.health} mode={DisplayMode.SMALL} />
+        </Col>
+        <Col xs={12} sm={12} md={4} lg={4}>
+          {!this.props.item.istioSidecar && <MissingSidecar />}
+        </Col>
+        <Col xs={12} sm={12} md={4} lg={4} />
+      </Row>
     ) : (
       <span />
     );

--- a/src/pages/ServiceList/__tests__/ItemDescription.test.tsx
+++ b/src/pages/ServiceList/__tests__/ItemDescription.test.tsx
@@ -26,11 +26,10 @@ describe('ItemDescription', () => {
   it('should render with promise resolving', () => {
     const wrapper = shallow(<ItemDescription item={item} />);
     expect(wrapper.text()).toBe('');
-
     resolver(health);
     return new Promise(r => setImmediate(r)).then(() => {
       wrapper.update();
-      expect(wrapper.text()).toBe('Health: <HealthIndicator /><MissingSidecar />');
+      expect(wrapper.find('HealthIndicator')).toHaveLength(1);
     });
   });
 });

--- a/src/pages/WorkloadDetails/WorkloadInfo.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo.tsx
@@ -14,7 +14,7 @@ type WorkloadInfoProps = {
   validations: Validations;
   namespace: string;
   onRefresh: () => void;
-  onSelectTab: (tabName: string, postHandler?: (k: string) => void) => ((tabKey: string) => void);
+  onSelectTab: (tabName: string, postHandler?: (k: string) => void) => (tabKey: string) => void;
   activeTab: (tabName: string, whenEmpty: string) => string;
   istioEnabled: boolean;
   health?: WorkloadHealth;

--- a/src/pages/WorkloadList/ItemDescription.tsx
+++ b/src/pages/WorkloadList/ItemDescription.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Badge, ListViewItem, ListViewIcon } from 'patternfly-react';
+import { Badge, Col, ListViewItem, ListViewIcon, Row } from 'patternfly-react';
 import { WorkloadIcon, WorkloadListItem, worloadLink } from '../../types/Workload';
 import { PfColors } from '../../components/Pf/PfColors';
 import { Link } from 'react-router-dom';
@@ -68,28 +68,30 @@ class ItemDescription extends React.Component<ItemDescriptionProps, ItemDescript
       </div>
     );
     const itemDescription = (
-      <table style={{ width: '70em', tableLayout: 'fixed' }}>
-        <tbody>
-          <tr>
-            {this.state.health && (
-              <td>
-                <strong>Health: </strong>
-                <HealthIndicator id={object.name} health={this.state.health} mode={DisplayMode.SMALL} />
-              </td>
-            )}
-            <td>{!object.istioSidecar && <MissingSidecar />}</td>
-            {object.appLabel || object.versionLabel ? (
-              <td>
-                <strong>Label Validation :</strong>
-                {object.appLabel && <Badge>app</Badge>}
-                {object.versionLabel && <Badge>version</Badge>}
-              </td>
-            ) : (
-              <td />
-            )}
-          </tr>
-        </tbody>
-      </table>
+      <Row>
+        <Col xs={12} sm={12} md={4} lg={4}>
+          {this.state.health && (
+            <td>
+              <strong>Health: </strong>
+              <HealthIndicator id={object.name} health={this.state.health} mode={DisplayMode.SMALL} />
+            </td>
+          )}
+        </Col>
+        <Col xs={12} sm={12} md={4} lg={4}>
+          {!object.istioSidecar && <MissingSidecar />}
+        </Col>
+        <Col xs={12} sm={12} md={4} lg={4}>
+          {object.appLabel || object.versionLabel ? (
+            <span>
+              <strong>Label Validation :</strong>
+              {object.appLabel && <Badge>app</Badge>}
+              {object.versionLabel && <Badge>version</Badge>}
+            </span>
+          ) : (
+            <span />
+          )}
+        </Col>
+      </Row>
     );
     const content = (
       <ListViewItem


### PR DESCRIPTION
List items used internally a table for layout.
That created some problems when resizing.
Moved to a grid for auto-adjust on these cases.
Changed on app/workload/service list item to maintain same aspect/ratio.

https://issues.jboss.org/browse/KIALI-2592

![image](https://user-images.githubusercontent.com/1662329/55478395-ec4bb100-561b-11e9-8caf-fbcb9117e85e.png)


