### PR TITLE
KIALI-2666 Show open lock whenever traffic is under 100%

### DIFF
--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -147,7 +147,7 @@ export class GraphStyles {
       if (cyGlobal.showSecurity && mtlsPercentage >= 0) {
         if (mtlsPercentage > 0 && !cyGlobal.mtlsEnabled) {
           content = EdgeIconMTLS + ' ' + content;
-        } else if (mtlsPercentage === 0 && cyGlobal.mtlsEnabled) {
+        } else if (mtlsPercentage < 100 && cyGlobal.mtlsEnabled) {
           content = EdgeIconDisabledMTLS + ' ' + content;
         }
       }


### PR DESCRIPTION
** Describe the change **
In the scenario of having mTLS enabled mesh-wide, the open locks on edges should be visible whenever there is traffic not using mTLS (from 0% to 99% of traffic that uses mTLS).

** Issue reference **
https://issues.jboss.org/browse/KIALI-2666

** Backwards compatible? **
yes

** Screenshot **
mTLS not enabled globally. Graph shows locks whenever there is traffic with using mtls (from 1% to 100% of the traffic using mTLS).
![Screen recording (18)](https://user-images.githubusercontent.com/613814/55489830-fa58fc00-5632-11e9-9541-cf90c79862d5.gif)

mTLS enabled for service mesh. Graph should show open locks whenever there is traffic **not** using mTLS (from 0% to 99% of traffic using mTLS)
![Screen recording (17)](https://user-images.githubusercontent.com/613814/55489756-dbf30080-5632-11e9-9fcc-0497b86b3d6b.gif)
