### PR TITLE
KIALI-2497 Show message to user at first load if secret is missing

### DIFF
--- a/src/app/StartupInitializer.tsx
+++ b/src/app/StartupInitializer.tsx
@@ -30,6 +30,7 @@ class InitializerComponent extends React.Component<InitializerComponentProps, { 
     try {
       const authConfig = await API.getAuthInfo();
       authenticationConfig.authorizationEndpoint = authConfig.data.authorizationEndpoint;
+      authenticationConfig.secretMissing = authConfig.data.secretMissing;
       authenticationConfig.strategy = authConfig.data.strategy;
 
       if (authConfig.data.sessionInfo.expiresOn && authConfig.data.sessionInfo.username) {

--- a/src/config/AuthenticationConfig.ts
+++ b/src/config/AuthenticationConfig.ts
@@ -1,7 +1,8 @@
 import { AuthConfig, AuthStrategy } from '../types/Auth';
 
 const authenticationConfig: AuthConfig = {
-  strategy: AuthStrategy.login
+  strategy: AuthStrategy.login,
+  secretMissing: false
 };
 
 export default authenticationConfig;

--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -79,7 +79,15 @@ export default class LoginPage extends React.Component<LoginProps, LoginState> {
                 <Col sm={10} smOffset={1} md={8} mdOffset={2} lg={8} lgOffset={2}>
                   <div className={'card-pf'}>
                     <header className={'login-pf-header'} />
-                    {this.props.status === LoginStatus.error && <Alert>{this.props.message}</Alert>}
+                    {authenticationConfig.secretMissing && (
+                      <Alert>
+                        The Kiali secret is missing. Users are prohibited from accessing Kiali until an administrator
+                        creates a valid secret. Please refer to the Kiali documentation for more details.
+                      </Alert>
+                    )}
+                    {!authenticationConfig.secretMissing && this.props.status === LoginStatus.error && (
+                      <Alert>{this.props.message}</Alert>
+                    )}
                     {this.props.status === LoginStatus.expired && (
                       <Alert type="warning">Your session has expired or was terminated in another window.</Alert>
                     )}

--- a/src/pages/Login/__tests__/__snapshots__/LoginPage.test.tsx.snap
+++ b/src/pages/Login/__tests__/__snapshots__/LoginPage.test.tsx.snap
@@ -640,6 +640,7 @@ ShallowWrapper {
                       />,
                       false,
                       false,
+                      false,
                       <Form
                         bsClass="form"
                         componentClass="form"
@@ -708,6 +709,7 @@ ShallowWrapper {
                       "rendered": null,
                       "type": "header",
                     },
+                    false,
                     false,
                     false,
                     Object {
@@ -1520,6 +1522,7 @@ ShallowWrapper {
                         />,
                         false,
                         false,
+                        false,
                         <Form
                           bsClass="form"
                           componentClass="form"
@@ -1588,6 +1591,7 @@ ShallowWrapper {
                         "rendered": null,
                         "type": "header",
                       },
+                      false,
                       false,
                       false,
                       Object {

--- a/src/types/Auth.ts
+++ b/src/types/Auth.ts
@@ -1,5 +1,6 @@
 export interface AuthConfig {
   authorizationEndpoint?: string;
+  secretMissing?: boolean;
   strategy: AuthStrategy;
 }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/KIALI-2497

These changes will show the _secret missing_ message to the user without the need to try to login. Taking advantage that a request is made to the /api/auth/info endpoint as initialization to check if secret configuration is pending.

Related backend PR: https://github.com/kiali/kiali/pull/979