### PR TITLE
KIALI-2423 Add links from traffic tab to metrics

### DIFF
--- a/src/components/Metrics/Helper.ts
+++ b/src/components/Metrics/Helper.ts
@@ -61,6 +61,8 @@ namespace MetricsHelper {
         Object.keys(values).forEach(k => {
           if (previous.hasOwnProperty(k)) {
             values[k] = previous[k];
+          } else {
+            values[k] = false;
           }
         });
       }

--- a/src/components/Metrics/__tests__/TrafficDetails.test.tsx
+++ b/src/components/Metrics/__tests__/TrafficDetails.test.tsx
@@ -102,6 +102,7 @@ describe('TrafficDetails', () => {
           '->' +
           item
             .find('Link')
+            .first()
             .children()
             .text()
         );
@@ -113,6 +114,7 @@ describe('TrafficDetails', () => {
 
       return item
         .find('Link')
+        .first()
         .children()
         .text();
     };

--- a/src/components/MetricsOptions/MetricsSettings.tsx
+++ b/src/components/MetricsOptions/MetricsSettings.tsx
@@ -51,6 +51,9 @@ export class MetricsSettingsDropdown extends React.Component<Props> {
     }
     const byLabels = urlParams.getAll(URLParam.BY_LABELS);
     if (byLabels.length !== 0) {
+      byLabels.map((val, idx) => {
+        byLabels[idx] = val.split('=', 1)[0];
+      });
       settings.activeLabels = byLabels as LabelDisplayName[];
     }
     return settings;

--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -110,9 +110,15 @@ export default class LoginPage extends React.Component<LoginProps, LoginState> {
       }
     }
   };
-  renderMessage = (message: string|undefined, type?: string) => {
-    if (!message) { return ''; }
-    const variant = type ? type : this.props.status === LoginStatus.error || this.state.filledInputs ? 'danger' : 'warning';
+  renderMessage = (message: string | undefined, type?: string) => {
+    if (!message) {
+      return '';
+    }
+    const variant = type
+      ? type
+      : this.props.status === LoginStatus.error || this.state.filledInputs
+      ? 'danger'
+      : 'warning';
     const icon = variant === 'danger' ? <ExclamationCircleIcon /> : <ExclamationTriangleIcon />;
     return (
       <span style={{ color: variant === 'danger' ? '#c00' : '#f0ab00', fontWeight: 'bold', fontSize: 16 }}>
@@ -128,8 +134,11 @@ export default class LoginPage extends React.Component<LoginProps, LoginState> {
       messages.push(this.renderMessage(this.state.errorInput));
     }
     if (authenticationConfig.secretMissing) {
-      messages.push('The Kiali secret is missing. Users are prohibited from accessing Kiali until an administrator \
-      creates a valid secret. Please refer to the Kiali documentation for more details.', 'danger');
+      messages.push(
+        'The Kiali secret is missing. Users are prohibited from accessing Kiali until an administrator \
+      creates a valid secret. Please refer to the Kiali documentation for more details.',
+        'danger'
+      );
     }
     if (this.props.status === LoginStatus.expired) {
       messages.push('Your session has expired or was terminated in another window.', 'warning');
@@ -137,7 +146,7 @@ export default class LoginPage extends React.Component<LoginProps, LoginState> {
     if (!authenticationConfig.secretMissing && this.props.status === LoginStatus.error) {
       messages.push(this.props.message);
     }
-    return (<>{messages}</>);
+    return <>{messages}</>;
   };
 
   render() {


### PR DESCRIPTION
https://issues.jboss.org/browse/KIALI-2423

This will let the user navigate to the detailed metrics. Filters are preset depending on the clicked row.

![image](https://user-images.githubusercontent.com/23639005/56165870-b56d8780-5f99-11e9-85a4-bef2794f5072.png)

