### PR TITLE
KIALI-2663 Prevent duplicate calls to this.updateListItems()

### DIFF
--- a/src/pages/AppList/AppListComponent.tsx
+++ b/src/pages/AppList/AppListComponent.tsx
@@ -37,7 +37,7 @@ class AppListComponent extends ListComponent.Component<AppListComponentProps, Ap
   }
 
   componentDidMount() {
-    this.updateListItems();
+    this.setState({});
   }
 
   componentDidUpdate(prevProps: AppListComponentProps, prevState: AppListComponentState, snapshot: any) {

--- a/src/pages/AppList/AppListComponent.tsx
+++ b/src/pages/AppList/AppListComponent.tsx
@@ -12,6 +12,7 @@ import { ListPagesHelper } from '../../components/ListPage/ListPagesHelper';
 import { SortField } from '../../types/SortFilters';
 import { ListComponent } from '../../components/ListPage/ListComponent';
 import { AlignRightStyle, ThinStyle } from '../../components/Filters/FilterStyles';
+import { arrayEquals } from '../../utils/Common';
 
 interface AppListComponentState extends ListComponent.State<AppListItem> {
   rateInterval: number;
@@ -37,7 +38,7 @@ class AppListComponent extends ListComponent.Component<AppListComponentProps, Ap
   }
 
   componentDidMount() {
-    this.setState({});
+    this.updateListItems();
   }
 
   componentDidUpdate(prevProps: AppListComponentProps, prevState: AppListComponentState, snapshot: any) {
@@ -57,11 +58,16 @@ class AppListComponent extends ListComponent.Component<AppListComponentProps, Ap
   }
 
   paramsAreSynced(prevProps: AppListComponentProps) {
+    const activeNamespacesCompare = arrayEquals(
+      prevProps.activeNamespaces,
+      this.props.activeNamespaces,
+      (n1, n2) => n1.name === n2.name
+    );
     return (
       prevProps.pagination.page === this.props.pagination.page &&
       prevProps.pagination.perPage === this.props.pagination.perPage &&
       prevProps.rateInterval === this.props.rateInterval &&
-      prevProps.activeNamespaces === this.props.activeNamespaces &&
+      activeNamespacesCompare &&
       prevProps.isSortAscending === this.props.isSortAscending &&
       prevProps.currentSortField.title === this.props.currentSortField.title
     );

--- a/src/pages/IstioConfigList/IstioConfigListComponent.tsx
+++ b/src/pages/IstioConfigList/IstioConfigListComponent.tsx
@@ -54,7 +54,7 @@ class IstioConfigListComponent extends ListComponent.Component<
   }
 
   componentDidMount() {
-    this.updateListItems();
+    this.setState({});
   }
 
   componentDidUpdate(

--- a/src/pages/IstioConfigList/IstioConfigListComponent.tsx
+++ b/src/pages/IstioConfigList/IstioConfigListComponent.tsx
@@ -30,6 +30,7 @@ import { ListComponent } from '../../components/ListPage/ListComponent';
 import { SortField } from '../../types/SortFilters';
 import { getFilterSelectedValues } from '../../components/Filters/CommonFilters';
 import { AlignRightStyle, ThinStyle } from '../../components/Filters/FilterStyles';
+import { arrayEquals } from '../../utils/Common';
 
 interface IstioConfigListComponentState extends ListComponent.State<IstioConfigItem> {}
 interface IstioConfigListComponentProps extends ListComponent.Props<IstioConfigItem> {
@@ -54,7 +55,7 @@ class IstioConfigListComponent extends ListComponent.Component<
   }
 
   componentDidMount() {
-    this.setState({});
+    this.updateListItems();
   }
 
   componentDidUpdate(
@@ -78,10 +79,15 @@ class IstioConfigListComponent extends ListComponent.Component<
   }
 
   paramsAreSynced(prevProps: IstioConfigListComponentProps) {
+    const activeNamespacesCompare = arrayEquals(
+      prevProps.activeNamespaces,
+      this.props.activeNamespaces,
+      (n1, n2) => n1.name === n2.name
+    );
     return (
       prevProps.pagination.page === this.props.pagination.page &&
       prevProps.pagination.perPage === this.props.pagination.perPage &&
-      prevProps.activeNamespaces === this.props.activeNamespaces &&
+      activeNamespacesCompare &&
       prevProps.isSortAscending === this.props.isSortAscending &&
       prevProps.currentSortField.title === this.props.currentSortField.title
     );

--- a/src/pages/ServiceList/ServiceListComponent.tsx
+++ b/src/pages/ServiceList/ServiceListComponent.tsx
@@ -24,6 +24,7 @@ import './ServiceListComponent.css';
 import { SortField } from '../../types/SortFilters';
 import { ListComponent } from '../../components/ListPage/ListComponent';
 import { AlignRightStyle, ThinStyle } from '../../components/Filters/FilterStyles';
+import { arrayEquals } from '../../utils/Common';
 
 interface ServiceListComponentState extends ListComponent.State<ServiceListItem> {
   rateInterval: number;
@@ -54,7 +55,7 @@ class ServiceListComponent extends ListComponent.Component<
   }
 
   componentDidMount() {
-    this.setState({});
+    this.updateListItems();
   }
 
   componentDidUpdate(prevProps: ServiceListComponentProps, prevState: ServiceListComponentState, snapshot: any) {
@@ -75,11 +76,16 @@ class ServiceListComponent extends ListComponent.Component<
   }
 
   paramsAreSynced(prevProps: ServiceListComponentProps) {
+    const activeNamespacesCompare = arrayEquals(
+      prevProps.activeNamespaces,
+      this.props.activeNamespaces,
+      (n1, n2) => n1.name === n2.name
+    );
     return (
       prevProps.pagination.page === this.props.pagination.page &&
       prevProps.pagination.perPage === this.props.pagination.perPage &&
       prevProps.rateInterval === this.props.rateInterval &&
-      prevProps.activeNamespaces === this.props.activeNamespaces &&
+      activeNamespacesCompare &&
       prevProps.isSortAscending === this.props.isSortAscending &&
       prevProps.currentSortField.title === this.props.currentSortField.title
     );

--- a/src/pages/ServiceList/ServiceListComponent.tsx
+++ b/src/pages/ServiceList/ServiceListComponent.tsx
@@ -54,7 +54,7 @@ class ServiceListComponent extends ListComponent.Component<
   }
 
   componentDidMount() {
-    this.updateListItems();
+    this.setState({});
   }
 
   componentDidUpdate(prevProps: ServiceListComponentProps, prevState: ServiceListComponentState, snapshot: any) {

--- a/src/pages/WorkloadList/WorkloadListComponent.tsx
+++ b/src/pages/WorkloadList/WorkloadListComponent.tsx
@@ -41,7 +41,7 @@ class WorkloadListComponent extends ListComponent.Component<
   }
 
   componentDidMount() {
-    this.updateListItems();
+    this.setState({});
   }
 
   componentDidUpdate(prevProps: WorkloadListComponentProps, prevState: WorkloadListComponentState, snapshot: any) {

--- a/src/pages/WorkloadList/WorkloadListComponent.tsx
+++ b/src/pages/WorkloadList/WorkloadListComponent.tsx
@@ -12,6 +12,7 @@ import { ListPagesHelper } from '../../components/ListPage/ListPagesHelper';
 import { SortField } from '../../types/SortFilters';
 import { ListComponent } from '../../components/ListPage/ListComponent';
 import { AlignRightStyle, ThinStyle } from '../../components/Filters/FilterStyles';
+import { arrayEquals } from '../../utils/Common';
 
 interface WorkloadListComponentState extends ListComponent.State<WorkloadListItem> {
   rateInterval: number;
@@ -41,7 +42,7 @@ class WorkloadListComponent extends ListComponent.Component<
   }
 
   componentDidMount() {
-    this.setState({});
+    this.updateListItems();
   }
 
   componentDidUpdate(prevProps: WorkloadListComponentProps, prevState: WorkloadListComponentState, snapshot: any) {
@@ -62,11 +63,16 @@ class WorkloadListComponent extends ListComponent.Component<
   }
 
   paramsAreSynced(prevProps: WorkloadListComponentProps) {
+    const activeNamespacesCompare = arrayEquals(
+      prevProps.activeNamespaces,
+      this.props.activeNamespaces,
+      (n1, n2) => n1.name === n2.name
+    );
     return (
       prevProps.pagination.page === this.props.pagination.page &&
       prevProps.pagination.perPage === this.props.pagination.perPage &&
       prevProps.rateInterval === this.props.rateInterval &&
-      prevProps.activeNamespaces === this.props.activeNamespaces &&
+      activeNamespacesCompare &&
       prevProps.isSortAscending === this.props.isSortAscending &&
       prevProps.currentSortField.title === this.props.currentSortField.title
     );


### PR DESCRIPTION
** Describe the change **

componentDidMount() was calling this.updateListItems() which caused the React to call componentDidUpdate() which called again this.updateListItems() and that caused the backend calls to be duplicated.

Replaced with this.setState({}); in this componentDidMount() which causes only the call to componentDidUpdate() and as such there's only a single call to the backend.

** Issue reference **

KIALI-2663
