### PR TITLE
KIALI-2712 Share duration with other tabs

### DIFF
--- a/src/components/MetricsOptions/MetricsDuration.tsx
+++ b/src/components/MetricsOptions/MetricsDuration.tsx
@@ -6,6 +6,8 @@ import { ToolbarDropdown } from '../ToolbarDropdown/ToolbarDropdown';
 import { serverConfig } from '../../config/ServerConfig';
 
 type Props = {
+  disabled?: boolean;
+  tooltip?: string;
   onChanged: (duration: DurationInSeconds) => void;
 };
 
@@ -41,12 +43,12 @@ export default class MetricsDuration extends React.Component<Props> {
     return (
       <ToolbarDropdown
         id={'metrics_filter_interval_duration'}
-        disabled={false}
+        disabled={this.props.disabled}
         handleSelect={this.onDurationChanged}
         initialValue={this.duration}
         initialLabel={serverConfig.durations[this.duration]}
         options={serverConfig.durations}
-        tooltip={'Time range for metrics data'}
+        tooltip={this.props.tooltip || 'Time range for metrics data'}
       />
     );
   }

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
@@ -146,11 +146,7 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
                   tooltip={'Show up to last N log lines'}
                 />
                 {'   '}
-                <MetricsDurationContainer
-                  disabled={this.state.tailLines > 0}
-                  tooltip="Time range for log messages"
-                  onChanged={this.setDuration}
-                />
+                <MetricsDurationContainer tooltip="Time range for log messages" onChanged={this.setDuration} />
                 {'  '}
                 <Button id={'wpl_refresh'} disabled={!this.state.podLogs} onClick={() => this.handleRefresh()}>
                   <Icon name="refresh" />

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
@@ -6,6 +6,8 @@ import { getPodLogs, Response } from '../../../services/Api';
 import { CancelablePromise, makeCancelablePromise } from '../../../utils/CancelablePromises';
 import { ToolbarDropdown } from '../../../components/ToolbarDropdown/ToolbarDropdown';
 import { DurationInSeconds } from '../../../types/Common';
+import MetricsDurationContainer from '../../../components/MetricsOptions/MetricsDuration';
+import MetricsDuration from '../../../components/MetricsOptions/MetricsDuration';
 
 export interface WorkloadPodLogsProps {
   namespace: string;
@@ -19,25 +21,24 @@ interface ContainerInfo {
 
 interface WorkloadPodLogsState {
   containerInfo?: ContainerInfo;
-  duration: string; // DurationInSeconds
+  duration: DurationInSeconds;
   loadingPodLogs: boolean;
   loadingPodLogsError?: string;
   podValue?: number;
   podLogs?: PodLogs;
+  tailLines: number;
 }
 
-const DurationDefault = '300';
-const DurationOptions = {
-  '60': 'Last 1m',
-  '300': 'Last 5m',
-  '600': 'Last 10m',
-  '1800': 'Last 30m',
-  '3600': 'Last 1h',
-  '10800': 'Last 3h',
-  '21600': 'Last 6h',
-  '43200': 'Last 12h',
-  '86400': 'Last 1d',
-  '604800': 'Last 7d'
+const TailLinesDefault = 500;
+const TailLinesOptions = {
+  '-1': 'All lines',
+  '10': '10 lines',
+  '50': '50 lines',
+  '100': '100 lines',
+  '300': '300 lines',
+  '500': '500 lines',
+  '1000': '1000 lines',
+  '5000': '5000 lines'
 };
 
 const logsTextarea = style({
@@ -49,10 +50,6 @@ const logsTextarea = style({
   backgroundColor: '#003145'
 });
 
-const leftPaddedSpan = style({
-  paddingLeft: '0.5em'
-});
-
 export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, WorkloadPodLogsState> {
   private loadPodLogsPromise?: CancelablePromise<Response<PodLogs>[]>;
   private podOptions: object = {};
@@ -62,9 +59,10 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
 
     if (this.props.pods.length < 1) {
       this.state = {
-        duration: DurationDefault,
+        duration: MetricsDuration.initialDuration(),
         loadingPodLogs: false,
-        loadingPodLogsError: 'There are no logs to display because no pods are available.'
+        loadingPodLogsError: 'There are no logs to display because no pods are available.',
+        tailLines: TailLinesDefault
       };
       return;
     }
@@ -81,16 +79,23 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
 
     this.state = {
       containerInfo: containerInfo,
-      duration: DurationDefault,
+      duration: MetricsDuration.initialDuration(),
       loadingPodLogs: false,
-      podValue: podValue
+      podValue: podValue,
+      tailLines: TailLinesDefault
     };
   }
 
   componentDidMount() {
     if (this.state.containerInfo) {
       const pod = this.props.pods[this.state.podValue!];
-      this.fetchLogs(this.props.namespace, pod.name, this.state.containerInfo.container, Number(this.state.duration));
+      this.fetchLogs(
+        this.props.namespace,
+        pod.name,
+        this.state.containerInfo.container,
+        this.state.tailLines,
+        this.state.duration
+      );
     }
   }
 
@@ -99,9 +104,10 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
     const newContainer = this.state.containerInfo ? this.state.containerInfo.container : undefined;
     const updateContainer = newContainer && newContainer !== prevContainer;
     const updateDuration = this.state.duration && prevState.duration !== this.state.duration;
-    if (updateContainer || updateDuration) {
+    const updateTailLines = this.state.tailLines && prevState.tailLines !== this.state.tailLines;
+    if (updateContainer || updateDuration || updateTailLines) {
       const pod = this.props.pods[this.state.podValue!];
-      this.fetchLogs(this.props.namespace, pod.name, newContainer!, Number(this.state.duration));
+      this.fetchLogs(this.props.namespace, pod.name, newContainer!, this.state.tailLines, this.state.duration);
     }
   }
 
@@ -131,18 +137,24 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
               />
               <Toolbar.RightContent>
                 <ToolbarDropdown
-                  id={'wpl_duration'}
-                  handleSelect={key => this.setDuration(key)}
-                  value={this.state.duration}
-                  label={DurationOptions[this.state.duration]}
-                  options={DurationOptions}
-                  tooltip={'Time range for graph data'}
+                  id={'wpl_tailLines'}
+                  nameDropdown="Tail"
+                  handleSelect={key => this.setTailLines(Number(key))}
+                  value={this.state.tailLines}
+                  label={TailLinesOptions[this.state.tailLines]}
+                  options={TailLinesOptions}
+                  tooltip={'Show up to last N log lines'}
                 />
-                <span className={leftPaddedSpan}>
-                  <Button id={'wpl_refresh'} disabled={!this.state.podLogs} onClick={() => this.handleRefresh()}>
-                    <Icon name="refresh" />
-                  </Button>
-                </span>
+                {'   '}
+                <MetricsDurationContainer
+                  disabled={this.state.tailLines > 0}
+                  tooltip="Time range for log messages"
+                  onChanged={this.setDuration}
+                />
+                {'  '}
+                <Button id={'wpl_refresh'} disabled={!this.state.podLogs} onClick={() => this.handleRefresh()}>
+                  <Icon name="refresh" />
+                </Button>
               </Toolbar.RightContent>
             </Toolbar>
             <textarea
@@ -169,13 +181,23 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
     });
   };
 
-  private setDuration = (duration: string) => {
+  private setDuration = (duration: DurationInSeconds) => {
     this.setState({ duration: duration });
+  };
+
+  private setTailLines = (tailLines: number) => {
+    this.setState({ tailLines: tailLines });
   };
 
   private handleRefresh = () => {
     const pod = this.props.pods[this.state.podValue!];
-    this.fetchLogs(this.props.namespace, pod.name, this.state.containerInfo!.container, Number(this.state.duration));
+    this.fetchLogs(
+      this.props.namespace,
+      pod.name,
+      this.state.containerInfo!.container,
+      this.state.tailLines,
+      this.state.duration
+    );
   };
 
   private getContainerInfo = (pod: Pod): ContainerInfo => {
@@ -189,9 +211,15 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
     return { container: containerNames[0], containerOptions: options };
   };
 
-  private fetchLogs = (namespace: string, podName: string, container: string, duration: DurationInSeconds) => {
+  private fetchLogs = (
+    namespace: string,
+    podName: string,
+    container: string,
+    tailLines: number,
+    duration: DurationInSeconds
+  ) => {
     const sinceTime = Math.floor(Date.now() / 1000) - duration;
-    const promise: Promise<Response<PodLogs>> = getPodLogs(namespace, podName, container, sinceTime);
+    const promise: Promise<Response<PodLogs>> = getPodLogs(namespace, podName, container, tailLines, sinceTime);
     this.loadPodLogsPromise = makeCancelablePromise(Promise.all([promise]));
     this.loadPodLogsPromise.promise
       .then(response => {

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -403,13 +403,22 @@ export const getPod = (namespace: string, name: string) => {
   return newRequest<Pod>(HTTP_VERBS.GET, urls.pod(namespace, name), {}, {});
 };
 
-export const getPodLogs = (namespace: string, name: string, container?: string, sinceTime?: number) => {
+export const getPodLogs = (
+  namespace: string,
+  name: string,
+  container?: string,
+  tailLines?: number,
+  sinceTime?: number
+) => {
   const params: any = {};
   if (container) {
     params.container = container;
   }
   if (sinceTime) {
     params.sinceTime = sinceTime;
+  }
+  if (tailLines && tailLines > 0) {
+    params.tailLines = tailLines;
   }
   return newRequest<PodLogs>(HTTP_VERBS.GET, urls.podLogs(namespace, name), params, {});
 };


### PR DESCRIPTION
- introduce tail lines limit
- add disabled and tooltip options to MetricsDuration

By default Tail 500 lines to ensure that we don't ask for an overwhelming number of lines based on duration.  In the screenshot below show 10 lines.  Note that the duration is disabled when using a line limit:
![image](https://user-images.githubusercontent.com/2104052/56151223-c9f05680-5f7e-11e9-90e1-051dcb42b62c.png)
When asking for all lines the time limit is enabled:
![image](https://user-images.githubusercontent.com/2104052/56151299-f2785080-5f7e-11e9-9bd5-348d44ebe4f8.png)

** Question: Perhaps it would be better to keep the duration dropdown enabled even though it's value is trumped when there is a line limit.  Otherwise the user can not alter the duration for the first fetch after selecting "All Lines".  Thoughts?

*** SERVER PR REQUIRED: https://github.com/kiali/kiali/pull/1009