### PR TITLE
KIALI-2598 protect against negative countdown

### DIFF
--- a/src/components/SessionTimeout/SessionTimeout.tsx
+++ b/src/components/SessionTimeout/SessionTimeout.tsx
@@ -34,9 +34,7 @@ export class SessionTimeout extends React.Component<SessionTimeoutProps, {}> {
               <Icon name="warning-triangle-o" type="pf" style={{ fontSize: '48px' }} />
             </Col>
             <Col xs={12} sm={10} md={10} lg={10}>
-              {authenticationConfig.strategy === AuthStrategy.login
-                ? this.textForLoginStrategy()
-                : this.textForOpenshiftStrategy()}
+              {this.textForAuthStrategy(authenticationConfig.strategy)}
             </Col>
           </Row>
         </Modal.Body>
@@ -69,30 +67,22 @@ export class SessionTimeout extends React.Component<SessionTimeoutProps, {}> {
     }
   };
 
-  private textForLoginStrategy = () => {
-    const message =
+  private textForAuthStrategy = (strategy: AuthStrategy) => {
+    const line1 =
       this.props.timeOutCountDown <= 0
         ? 'Your session has expired.'
         : `Your session will expire in ${this.props.timeOutCountDown.toFixed()} seconds.`;
-    return (
-      <p className={'lead'}>
-        {message}
-        <br />
-        Would you like to extend your session?
-      </p>
-    );
-  };
 
-  private textForOpenshiftStrategy = () => {
-    const message =
-      this.props.timeOutCountDown <= 0
-        ? 'Your session has expired.'
-        : `Your session will expire in ${this.props.timeOutCountDown.toFixed()} seconds.`;
+    const line2 =
+      strategy === AuthStrategy.openshift
+        ? 'You will need to re-login with your cluster credentials. Please save your changes, if any.'
+        : 'Would you like to extend your session?';
+
     return (
       <p className={'lead'}>
-        {message}
+        {line1}
         <br />
-        You will need to re-login with your cluster credentials. Please, save your changes, if any.
+        {line2}
       </p>
     );
   };

--- a/src/components/SessionTimeout/SessionTimeout.tsx
+++ b/src/components/SessionTimeout/SessionTimeout.tsx
@@ -70,9 +70,13 @@ export class SessionTimeout extends React.Component<SessionTimeoutProps, {}> {
   };
 
   private textForLoginStrategy = () => {
+    const message =
+      this.props.timeOutCountDown <= 0
+        ? 'Your session has expired.'
+        : `Your session will expire in ${this.props.timeOutCountDown.toFixed()} seconds.`;
     return (
       <p className={'lead'}>
-        Your session will timeout in {this.props.timeOutCountDown.toFixed()} seconds.
+        {message}
         <br />
         Would you like to extend your session?
       </p>
@@ -80,9 +84,13 @@ export class SessionTimeout extends React.Component<SessionTimeoutProps, {}> {
   };
 
   private textForOpenshiftStrategy = () => {
+    const message =
+      this.props.timeOutCountDown <= 0
+        ? 'Your session has expired.'
+        : `Your session will expire in ${this.props.timeOutCountDown.toFixed()} seconds.`;
     return (
       <p className={'lead'}>
-        Your session will timeout in {this.props.timeOutCountDown.toFixed()} seconds.
+        {message}
         <br />
         You will need to re-login with your cluster credentials. Please, save your changes, if any.
       </p>


### PR DESCRIPTION
This doesn't really do much but maybe it's enough to solve this minor issue.  I'm not 100% sure this countdown mechanism really works as expected.  We may want to consider changing to a more simple approach that just pops up a dialog when the session expires and then gives the user a minute or so to extend before logging out.