### PR TITLE
KIALI-2689 Support OAuth logout in OpenShift 4

### DIFF
--- a/src/app/StartupInitializer.tsx
+++ b/src/app/StartupInitializer.tsx
@@ -30,6 +30,8 @@ class InitializerComponent extends React.Component<InitializerComponentProps, { 
     try {
       const authConfig = await API.getAuthInfo();
       authenticationConfig.authorizationEndpoint = authConfig.data.authorizationEndpoint;
+      authenticationConfig.logoutEndpoint = authConfig.data.logoutEndpoint;
+      authenticationConfig.logoutRedirect = authConfig.data.logoutRedirect;
       authenticationConfig.secretMissing = authConfig.data.secretMissing;
       authenticationConfig.strategy = authConfig.data.strategy;
 

--- a/src/components/Nav/Masthead/UserDropdown.tsx
+++ b/src/components/Nav/Masthead/UserDropdown.tsx
@@ -5,7 +5,8 @@ import { config } from '../../../config';
 import { MILLISECONDS } from '../../../types/Common';
 import Timer = NodeJS.Timer;
 import { KialiAppState, LoginSession } from 'src/store/Store';
-
+import authenticationConfig from '../../../config/AuthenticationConfig';
+import { AuthStrategy } from '../../../types/Auth';
 import moment from 'moment';
 import { ThunkDispatch } from 'redux-thunk';
 import { KialiAppAction } from '../../../actions/KialiAppAction';
@@ -78,7 +79,11 @@ class UserDropdownConnected extends React.Component<UserProps, UserState> {
 
   handleLogout = e => {
     e.preventDefault();
-    this.props.logout();
+    if (authenticationConfig.logoutEndpoint) {
+      (document.getElementById('openshiftlogout') as HTMLFormElement).submit();
+    } else {
+      this.props.logout();
+    }
   };
 
   extendSession = (session: LoginSession) => {
@@ -122,6 +127,11 @@ class UserDropdownConnected extends React.Component<UserProps, UserState> {
           toggle={<DropdownToggle onToggle={this.onDropdownToggle}>{this.props.session.username}</DropdownToggle>}
           dropdownItems={[userDropdownItems]}
         />
+        {authenticationConfig.strategy === AuthStrategy.openshift && authenticationConfig.logoutEndpoint && (
+          <form id="openshiftlogout" action={authenticationConfig.logoutEndpoint} method="post">
+            <input type="hidden" name="then" value={authenticationConfig.logoutRedirect} />
+          </form>
+        )}
       </>
     );
   }

--- a/src/types/Auth.ts
+++ b/src/types/Auth.ts
@@ -1,5 +1,7 @@
 export interface AuthConfig {
   authorizationEndpoint?: string;
+  logoutEndpoint?: string;
+  logoutRedirect?: string;
   secretMissing?: boolean;
   strategy: AuthStrategy;
 }


### PR DESCRIPTION
** Describe the change **

If running on OpenShift 4 we will now redirect to the OpenShift logout page so that the user is properly logged out.

** Issue reference **

https://issues.jboss.org/browse/KIALI-2689

** Backwards compatible? **

This is backwards compatible with OpenShift 3.
