### PR TITLE
Fix metrics settings when filters are first checked

### DIFF
--- a/src/components/Metrics/Helper.ts
+++ b/src/components/Metrics/Helper.ts
@@ -61,7 +61,7 @@ namespace MetricsHelper {
         Object.keys(values).forEach(k => {
           if (previous.hasOwnProperty(k)) {
             values[k] = previous[k];
-          } else {
+          } else if (Object.getOwnPropertyNames(previous).length > 0) {
             values[k] = false;
           }
         });


### PR DESCRIPTION
When working on links from Traffic tab, needed a way to preselect filters. I succeeded to preselect filters, but also broke the normal behavior and sub-filters are not being checked by default when user selects a filter. This seems to fix the issue.