### PR TITLE
KIALI-2737 Fix links in the About box

### DIFF
--- a/src/components/About/AboutUIModal.tsx
+++ b/src/components/About/AboutUIModal.tsx
@@ -92,7 +92,8 @@ class AboutUIModal extends React.Component<AboutUIModalProps, AboutUIModalState>
     if (config.about && config.about.website) {
       const Icon = icons[config.about.website.icon];
       return (
-        <Button href={config.about.website.url} variant="link" target="_blank">
+        // @ts-ignore
+        <Button component="a" href={config.about.website.url} variant="link" target="_blank">
           <Icon style={{ marginRight: '10px' }} />
           {config.about.website.linkText}
         </Button>
@@ -106,7 +107,8 @@ class AboutUIModal extends React.Component<AboutUIModalProps, AboutUIModalState>
     if (config.about && config.about.project) {
       const Icon = icons[config.about.project.icon];
       return (
-        <Button href={config.about.project.url} variant="link" target="_blank">
+        // @ts-ignore
+        <Button component="a" href={config.about.project.url} variant="link" target="_blank">
           <Icon style={{ marginRight: '10px' }} />
           {config.about.project.linkText}
         </Button>

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -35,12 +35,12 @@ const conf = {
   about: {
     project: {
       url: 'https://github.com/kiali',
-      icon: 'HomeIcon',
+      icon: 'RepositoryIcon',
       linkText: 'Find us on GitHub'
     },
     website: {
       url: 'http://kiali.io',
-      icon: 'RepositoryIcon',
+      icon: 'HomeIcon',
       linkText: 'Visit our web page'
     }
   },


### PR DESCRIPTION
The `component="a"` attribute was missing.
I had to add @ts-ignore comments, because typescript complains, but the app works correctly.

Also, swapping icons of Homepage and Repository links, since they look inverted.