### PR TITLE
Increase Namespace dropdown label space between dropdown and label

### DIFF
--- a/src/components/NamespaceDropdown.tsx
+++ b/src/components/NamespaceDropdown.tsx
@@ -21,6 +21,10 @@ const buttonClearStyle = style({
   float: 'right'
 });
 
+const namespaceLabelStyle = style({
+  margin: '0 0 0 10px'
+});
+
 interface NamespaceListType {
   disabled: boolean;
   filter: string;
@@ -113,7 +117,7 @@ export class NamespaceDropdown extends React.PureComponent<NamespaceListType, Na
                     checked={!!activeMap[namespace.name]}
                     onChange={this.onNamespaceToggled}
                   />
-                  <span>{namespace.name}</span>
+                  <span className={namespaceLabelStyle}>{namespace.name}</span>
                 </label>
               </div>
             ))}


### PR DESCRIPTION
The current namespace dropdown label and checkbox are backed up to one another. This PR gives them a 10px space so as not to look so compacted.

** Issue reference **
https://issues.jboss.org/browse/KIALI-2744

** Backwards compatible? **
yes

** Screenshot **
Before:
![ns-spacing](https://user-images.githubusercontent.com/1312165/56554136-8d57c880-6545-11e9-8d38-0459677f5a4e.jpg)


After:
![ns-increased-space](https://user-images.githubusercontent.com/1312165/56553995-17536180-6545-11e9-86c1-03ab5d01cbc4.jpg)

** Documentation **
