### PR TITLE
KIALI-2747 KIALi-2736 KIALI-2730 Redo namespaceSelector but with PF4 …

### DIFF
--- a/src/styles/_overrides.scss
+++ b/src/styles/_overrides.scss
@@ -310,30 +310,3 @@ Fix icon in buttons of pagination pages
 .pagination > li > a > .i {
   margin-top: 5px;
 }
-
-/*
-
-Namespace Selector style
-
-*/
-
-.namespace-selector {
-  width: 20%;
-}
-
-.namespace-selector .filter-selector-namespace {
-  width: 90%;
-  margin-left: 7%;
-}
-
-.namespace-selector .pf-c-select {
-  --pf-c-select__toggle--BorderWidth: 0px !important;
-}
-
-.namespace-selector .pf-c-input-group {
-  margin-left: -6px;
-}
-
-.namespace-selector input {
-  margin: 0 0 0;
-}


### PR DESCRIPTION
[KIALI-2736](https://issues.jboss.org/browse/KIALI-2736)
[KIALI-2747](https://issues.jboss.org/browse/KIALI-2747)
[KIALI-2730](https://issues.jboss.org/browse/KIALI-2730)

I get back the code of the namespace selector while PF4 team fix the issue, I applied the styles of PF4 , with this we should be aligned, have the same behaviour and fix the problems.

cc @lucasponce @hhovsepy @mwringe 

I'll open another JIRA to track the migration of this component in the future to PF4