### PR TITLE
KIALI-2676 Show ExternalName field for ExternalName Services

### DIFF
--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -40,7 +40,8 @@ const emptyService = {
     name: '',
     createdAt: '',
     resourceVersion: '',
-    ip: ''
+    ip: '',
+    externalName: ''
   },
   virtualServices: {
     items: [],

--- a/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -153,6 +153,7 @@ class ServiceInfo extends React.Component<ServiceDetails, ServiceInfoState> {
                 ip={this.props.serviceDetails.service.ip}
                 endpoints={this.props.serviceDetails.endpoints}
                 health={this.props.serviceDetails.health}
+                externalName={this.props.serviceDetails.service.externalName}
               />
             </Col>
           </Row>

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
@@ -19,6 +19,7 @@ interface ServiceInfoDescriptionProps {
   labels?: { [key: string]: string };
   type?: string;
   ip?: any;
+  externalName?: string;
   ports?: Port[];
   endpoints?: Endpoints[];
   health?: ServiceHealth;
@@ -28,6 +29,8 @@ const listStyle = style({
   listStyleType: 'none',
   padding: 0
 });
+
+const ExternalNameType = 'ExternalName';
 
 class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps> {
   constructor(props: ServiceInfoDescriptionProps) {
@@ -57,9 +60,15 @@ class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps
               <div>
                 <strong>Type</strong> {this.props.type ? this.props.type : ''}
               </div>
-              <div>
-                <strong>IP</strong> {this.props.ip ? this.props.ip : ''}
-              </div>
+              {this.props.type !== ExternalNameType ? (
+                <div>
+                  <strong>IP</strong> {this.props.ip ? this.props.ip : ''}
+                </div>
+              ) : (
+                <div>
+                  <strong>ExternalName</strong> {this.props.externalName ? this.props.externalName : ''}
+                </div>
+              )}
               <div>
                 <strong>Created at</strong> <LocalTime time={this.props.createdAt} />
               </div>

--- a/src/pages/ServiceDetails/__tests__/__snapshots__/ServiceInfo.test.tsx.snap
+++ b/src/pages/ServiceDetails/__tests__/__snapshots__/ServiceInfo.test.tsx.snap
@@ -100,6 +100,7 @@ ShallowWrapper {
         "istioSidecar": true,
         "service": Object {
           "createdAt": "2018-06-29T16:43:18+02:00",
+          "externalName": "my.database.example.com",
           "ip": "172.30.196.248",
           "labels": Object {
             "app": "reviews",
@@ -385,6 +386,7 @@ ShallowWrapper {
                     },
                   ]
                 }
+                externalName="my.database.example.com"
                 health={undefined}
                 ip="172.30.196.248"
                 istioEnabled={true}
@@ -768,6 +770,7 @@ ShallowWrapper {
                       },
                     ]
                   }
+                  externalName="my.database.example.com"
                   health={undefined}
                   ip="172.30.196.248"
                   istioEnabled={true}
@@ -1515,6 +1518,7 @@ ShallowWrapper {
                       },
                     ]
                   }
+                  externalName="my.database.example.com"
                   health={undefined}
                   ip="172.30.196.248"
                   istioEnabled={true}
@@ -1579,6 +1583,7 @@ ShallowWrapper {
                       },
                     ]
                   }
+                  externalName="my.database.example.com"
                   health={undefined}
                   ip="172.30.196.248"
                   istioEnabled={true}
@@ -1641,6 +1646,7 @@ ShallowWrapper {
                       ],
                     },
                   ],
+                  "externalName": "my.database.example.com",
                   "health": undefined,
                   "ip": "172.30.196.248",
                   "istioEnabled": true,
@@ -3065,6 +3071,7 @@ ShallowWrapper {
                       },
                     ]
                   }
+                  externalName="my.database.example.com"
                   health={undefined}
                   ip="172.30.196.248"
                   istioEnabled={true}
@@ -3448,6 +3455,7 @@ ShallowWrapper {
                         },
                       ]
                     }
+                    externalName="my.database.example.com"
                     health={undefined}
                     ip="172.30.196.248"
                     istioEnabled={true}
@@ -4195,6 +4203,7 @@ ShallowWrapper {
                         },
                       ]
                     }
+                    externalName="my.database.example.com"
                     health={undefined}
                     ip="172.30.196.248"
                     istioEnabled={true}
@@ -4259,6 +4268,7 @@ ShallowWrapper {
                         },
                       ]
                     }
+                    externalName="my.database.example.com"
                     health={undefined}
                     ip="172.30.196.248"
                     istioEnabled={true}
@@ -4321,6 +4331,7 @@ ShallowWrapper {
                         ],
                       },
                     ],
+                    "externalName": "my.database.example.com",
                     "health": undefined,
                     "ip": "172.30.196.248",
                     "istioEnabled": true,

--- a/src/services/__mockData__/getServiceDetail.ts
+++ b/src/services/__mockData__/getServiceDetail.ts
@@ -5,6 +5,7 @@ export const SERVICE_DETAILS: ServiceDetailsInfo = {
     name: 'reviews',
     createdAt: '2018-06-29T16:43:18+02:00',
     type: 'ClusterIP',
+    externalName: 'my.database.example.com',
     labels: {
       app: 'reviews'
     },

--- a/src/types/ServiceInfo.ts
+++ b/src/types/ServiceInfo.ts
@@ -48,6 +48,7 @@ export interface Service {
   resourceVersion: string;
   ip: string;
   ports?: Port[];
+  externalName: string;
 }
 
 export interface ServiceDetailsInfo {


### PR DESCRIPTION
** Describe the change **
Knative introduced a new kind of services, the ExternalName services.
I think it would be a good idea to show which is that ExternalName.

Depending on: https://github.com/kiali/kiali/pull/1030

** Issue reference **

https://issues.jboss.org/browse/KIALI-2676

** Backwards compatible? **
yes

** Screenshot **
ExternalName Service doesn't show any IP but shows the actual ExternalName.
![Screenshot of Kiali Console (10)](https://user-images.githubusercontent.com/613814/56599551-14b14480-65f7-11e9-8631-2323cbe57817.png)

ClusterIP doesn't show the externalName since it doesn't make sense for this type of services:
![Screenshot of Kiali Console (11)](https://user-images.githubusercontent.com/613814/56599661-4cb88780-65f7-11e9-9a61-90d1ba37bb56.png)

