### PR TITLE
KIALI-2722 Fix unit mismatch in timeLeft() method

### DIFF
--- a/src/components/Nav/Masthead/UserDropdown.tsx
+++ b/src/components/Nav/Masthead/UserDropdown.tsx
@@ -68,7 +68,7 @@ class UserDropdownConnected extends React.Component<UserProps, UserState> {
       this.props.logout();
     }
 
-    return expiresOn.diff(moment(), 'seconds');
+    return expiresOn.diff(moment());
   };
 
   checkSession = () => {


### PR DESCRIPTION
https://issues.jboss.org/browse/KIALI-2722

This was fixed previously and is a partial regression of https://issues.jboss.org/browse/KIALI-2518.