### PR TITLE
KIALI-2757 Adding 'More Labels...' links when there are more than 3 labels

### DIFF
--- a/src/components/Label/Labels.tsx
+++ b/src/components/Label/Labels.tsx
@@ -5,7 +5,7 @@ import { style } from 'typestyle';
 const SHOW_MORE_TRESHOLD = 3;
 
 interface Props {
-  labels: { [key: string]: string };
+  labels?: { [key: string]: string };
 }
 
 interface State {

--- a/src/components/Label/Labels.tsx
+++ b/src/components/Label/Labels.tsx
@@ -1,11 +1,31 @@
 import * as React from 'react';
 import Label from './Label';
+import { style } from 'typestyle';
+
+const SHOW_MORE_TRESHOLD = 3;
 
 interface Props {
   labels: { [key: string]: string };
 }
 
-class Labels extends React.Component<Props> {
+interface State {
+  expanded: boolean;
+}
+
+const linkStyle = style({
+  float: 'left',
+  margin: '7px 2px 2px 3px',
+  fontSize: '0.8rem'
+});
+
+class Labels extends React.Component<Props, State> {
+  constructor(props: Props, state: State) {
+    super(props, state);
+    this.state = {
+      expanded: false
+    };
+  }
+
   labelKeys() {
     return Object.keys(this.props.labels || {});
   }
@@ -14,11 +34,37 @@ class Labels extends React.Component<Props> {
     return this.labelKeys().length > 0;
   }
 
+  hasManyLabels() {
+    return this.labelKeys().length > SHOW_MORE_TRESHOLD;
+  }
+
+  showItem(i: number) {
+    return this.state.expanded || !this.hasManyLabels() || i < SHOW_MORE_TRESHOLD;
+  }
+
+  expandLabels = () => {
+    this.setState({ expanded: true });
+  };
+
+  renderMoreLabelsLink() {
+    if (this.hasManyLabels() && !this.state.expanded) {
+      return (
+        <a className={linkStyle} onClick={this.expandLabels}>
+          {' '}
+          More labels...
+        </a>
+      );
+    }
+
+    return null;
+  }
+
   renderLabels() {
     return this.labelKeys().map((key, i) => {
+      const hideClass = this.showItem(i) ? '' : 'hide';
       return (
-        <div key={'label_' + i}>
-          <Label name={key} value={this.props.labels ? this.props.labels[key] : ''} />
+        <div key={'label_' + i} className={hideClass}>
+          <Label key={'label_' + i} name={key} value={this.props.labels ? this.props.labels[key] : ''} />
         </div>
       );
     });
@@ -30,7 +76,7 @@ class Labels extends React.Component<Props> {
 
   render() {
     if (this.hasLabels()) {
-      return this.renderLabels();
+      return [this.renderLabels(), this.renderMoreLabelsLink()];
     } else {
       return this.renderEmptyLabels();
     }

--- a/src/components/Label/__tests__/Labels.test.tsx
+++ b/src/components/Label/__tests__/Labels.test.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import Labels from '../Labels';
+
+const mockBadge = (labels: { [key: string]: string }) => {
+  const component = <Labels labels={labels} />;
+  return shallow(component);
+};
+
+describe('#Labels render correctly with data', () => {
+  it('should render badges with More labels link', () => {
+    const wrapper = mockBadge({
+      app: 'bookinfo',
+      version: 'v1',
+      env: 'prod',
+      team: 'A'
+    });
+
+    expect(wrapper).toBeDefined();
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render badges without More labels link', () => {
+    const wrapper = mockBadge({
+      app: 'bookinfo',
+      version: 'v1'
+    });
+
+    expect(wrapper).toBeDefined();
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/components/Label/__tests__/__snapshots__/Labels.test.tsx.snap
+++ b/src/components/Label/__tests__/__snapshots__/Labels.test.tsx.snap
@@ -1,0 +1,307 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`#Labels render correctly with data should render badges with More labels link 1`] = `
+ShallowWrapper {
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <Labels
+    labels={
+      Object {
+        "app": "bookinfo",
+        "env": "prod",
+        "team": "A",
+        "version": "v1",
+      }
+    }
+  />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateError": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": "label_0",
+    "nodeType": "host",
+    "props": Object {
+      "children": <Label
+        name="app"
+        value="bookinfo"
+      />,
+      "className": "",
+    },
+    "ref": null,
+    "rendered": Object {
+      "instance": null,
+      "key": "label_0",
+      "nodeType": "function",
+      "props": Object {
+        "name": "app",
+        "value": "bookinfo",
+      },
+      "ref": null,
+      "rendered": null,
+      "type": [Function],
+    },
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": "label_0",
+      "nodeType": "host",
+      "props": Object {
+        "children": <Label
+          name="app"
+          value="bookinfo"
+        />,
+        "className": "",
+      },
+      "ref": null,
+      "rendered": Object {
+        "instance": null,
+        "key": "label_0",
+        "nodeType": "function",
+        "props": Object {
+          "name": "app",
+          "value": "bookinfo",
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      "type": "div",
+    },
+    Object {
+      "instance": null,
+      "key": "label_1",
+      "nodeType": "host",
+      "props": Object {
+        "children": <Label
+          name="version"
+          value="v1"
+        />,
+        "className": "",
+      },
+      "ref": null,
+      "rendered": Object {
+        "instance": null,
+        "key": "label_1",
+        "nodeType": "function",
+        "props": Object {
+          "name": "version",
+          "value": "v1",
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      "type": "div",
+    },
+    Object {
+      "instance": null,
+      "key": "label_2",
+      "nodeType": "host",
+      "props": Object {
+        "children": <Label
+          name="env"
+          value="prod"
+        />,
+        "className": "",
+      },
+      "ref": null,
+      "rendered": Object {
+        "instance": null,
+        "key": "label_2",
+        "nodeType": "function",
+        "props": Object {
+          "name": "env",
+          "value": "prod",
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      "type": "div",
+    },
+    Object {
+      "instance": null,
+      "key": "label_3",
+      "nodeType": "host",
+      "props": Object {
+        "children": <Label
+          name="team"
+          value="A"
+        />,
+        "className": "hide",
+      },
+      "ref": null,
+      "rendered": Object {
+        "instance": null,
+        "key": "label_3",
+        "nodeType": "function",
+        "props": Object {
+          "name": "team",
+          "value": "A",
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      "type": "div",
+    },
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": " More labels...",
+        "className": "fqiflux",
+        "onClick": [Function],
+      },
+      "ref": null,
+      "rendered": " More labels...",
+      "type": "a",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+        "lifecycles": Object {
+          "componentDidUpdate": Object {
+            "onSetState": true,
+          },
+          "getDerivedStateFromProps": true,
+          "getSnapshotBeforeUpdate": true,
+          "setState": Object {
+            "skipsComponentDidUpdateOnNullish": true,
+          },
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`#Labels render correctly with data should render badges without More labels link 1`] = `
+ShallowWrapper {
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <Labels
+    labels={
+      Object {
+        "app": "bookinfo",
+        "version": "v1",
+      }
+    }
+  />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateError": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": "label_0",
+    "nodeType": "host",
+    "props": Object {
+      "children": <Label
+        name="app"
+        value="bookinfo"
+      />,
+      "className": "",
+    },
+    "ref": null,
+    "rendered": Object {
+      "instance": null,
+      "key": "label_0",
+      "nodeType": "function",
+      "props": Object {
+        "name": "app",
+        "value": "bookinfo",
+      },
+      "ref": null,
+      "rendered": null,
+      "type": [Function],
+    },
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": "label_0",
+      "nodeType": "host",
+      "props": Object {
+        "children": <Label
+          name="app"
+          value="bookinfo"
+        />,
+        "className": "",
+      },
+      "ref": null,
+      "rendered": Object {
+        "instance": null,
+        "key": "label_0",
+        "nodeType": "function",
+        "props": Object {
+          "name": "app",
+          "value": "bookinfo",
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      "type": "div",
+    },
+    Object {
+      "instance": null,
+      "key": "label_1",
+      "nodeType": "host",
+      "props": Object {
+        "children": <Label
+          name="version"
+          value="v1"
+        />,
+        "className": "",
+      },
+      "ref": null,
+      "rendered": Object {
+        "instance": null,
+        "key": "label_1",
+        "nodeType": "function",
+        "props": Object {
+          "name": "version",
+          "value": "v1",
+        },
+        "ref": null,
+        "rendered": null,
+        "type": [Function],
+      },
+      "type": "div",
+    },
+    null,
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+        "lifecycles": Object {
+          "componentDidUpdate": Object {
+            "onSetState": true,
+          },
+          "getDerivedStateFromProps": true,
+          "getSnapshotBeforeUpdate": true,
+          "setState": Object {
+            "skipsComponentDidUpdateOnNullish": true,
+          },
+        },
+      },
+    },
+  },
+}
+`;

--- a/src/components/Label/__tests__/__snapshots__/Labels.test.tsx.snap
+++ b/src/components/Label/__tests__/__snapshots__/Labels.test.tsx.snap
@@ -157,12 +157,18 @@ ShallowWrapper {
       "key": undefined,
       "nodeType": "host",
       "props": Object {
-        "children": " More labels...",
+        "children": Array [
+          " ",
+          "More labels...",
+        ],
         "className": "fqiflux",
         "onClick": [Function],
       },
       "ref": null,
-      "rendered": " More labels...",
+      "rendered": Array [
+        " ",
+        "More labels...",
+      ],
       "type": "a",
     },
   ],

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { Col, Row } from 'patternfly-react';
-import Label from '../../../components/Label/Label';
 import LocalTime from '../../../components/Time/LocalTime';
 import { DisplayMode, HealthIndicator } from '../../../components/Health/HealthIndicator';
 import { ServiceHealth } from '../../../types/Health';
@@ -10,6 +9,7 @@ import PfInfoCard from '../../../components/Pf/PfInfoCard';
 import { style } from 'typestyle';
 
 import './ServiceInfoDescription.css';
+import Labels from '../../../components/Label/Labels';
 
 interface ServiceInfoDescriptionProps {
   name: string;
@@ -48,11 +48,7 @@ class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps
                 <strong>Labels</strong>
               </div>
               <div className="label-collection">
-                {Object.keys(this.props.labels || {}).map((key, i) => (
-                  <div key={'label_' + i}>
-                    <Label name={key} value={this.props.labels ? this.props.labels[key] : ''} />
-                  </div>
-                ))}
+                <Labels labels={this.props.labels || {}} />
               </div>
               <div>
                 <strong>Type</strong> {this.props.type ? this.props.type : ''}

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoWorkload.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoWorkload.tsx
@@ -4,8 +4,6 @@ import { Link } from 'react-router-dom';
 import * as resolve from 'table-resolver';
 
 import { WorkloadOverview } from '../../../types/ServiceInfo';
-
-import Label from '../../../components/Label/Label';
 import LocalTime from '../../../components/Time/LocalTime';
 import MissingSidecar from '../../../components/MissingSidecar/MissingSidecar';
 import Labels from '../../../components/Label/Labels';

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoWorkload.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoWorkload.tsx
@@ -8,6 +8,7 @@ import { WorkloadOverview } from '../../../types/ServiceInfo';
 import Label from '../../../components/Label/Label';
 import LocalTime from '../../../components/Time/LocalTime';
 import MissingSidecar from '../../../components/MissingSidecar/MissingSidecar';
+import Labels from '../../../components/Label/Labels';
 
 interface ServiceInfoWorkloadProps {
   workloads?: WorkloadOverview[];
@@ -94,16 +95,6 @@ class ServiceInfoWorkload extends React.Component<ServiceInfoWorkloadProps> {
     );
   }
 
-  renderLabels(workload: WorkloadOverview) {
-    return (
-      <div key="labels" className="label-collection">
-        {Object.keys(workload.labels || {}).map((key, i) => (
-          <Label key={'workload_' + i} name={key} value={workload.labels ? workload.labels[key] : ''} />
-        ))}
-      </div>
-    );
-  }
-
   rows() {
     return (this.props.workloads || []).map((workload, vsIdx) => ({
       id: vsIdx,
@@ -111,7 +102,7 @@ class ServiceInfoWorkload extends React.Component<ServiceInfoWorkloadProps> {
       name: this.overviewLink(workload),
       createdAt: <LocalTime time={workload.createdAt} />,
       resourceVersion: workload.resourceVersion,
-      labels: this.renderLabels(workload)
+      labels: <Labels labels={workload.labels} />
     }));
   }
 

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
@@ -83,12 +83,13 @@ ShallowWrapper {
           <div
             className="label-collection"
           >
-            <div>
-              <Label
-                name="app"
-                value="reviews"
-              />
-            </div>
+            <Labels
+              labels={
+                Object {
+                  "app": "reviews",
+                }
+              }
+            />
           </div>
           <div>
             <strong>
@@ -258,12 +259,13 @@ ShallowWrapper {
             <div
               className="label-collection"
             >
-              <div>
-                <Label
-                  name="app"
-                  value="reviews"
-                />
-              </div>
+              <Labels
+                labels={
+                  Object {
+                    "app": "reviews",
+                  }
+                }
+              />
             </div>
             <div>
               <strong>

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoWorkloads.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoWorkloads.test.tsx.snap
@@ -255,18 +255,14 @@ ShallowWrapper {
                     time="2018-03-14T10:17:52Z\\""
                   />,
                   "id": 0,
-                  "labels": <div
-                    className="label-collection"
-                  >
-                    <Label
-                      name="app"
-                      value="reviews"
-                    />
-                    <Label
-                      name="version"
-                      value="v2"
-                    />
-                  </div>,
+                  "labels": <Labels
+                    labels={
+                      Object {
+                        "app": "reviews",
+                        "version": "v2",
+                      }
+                    }
+                  />,
                   "name": <span>
                     <Link
                       replace={false}
@@ -283,18 +279,14 @@ ShallowWrapper {
                     time="2018-03-14T10:17:52Z\\""
                   />,
                   "id": 1,
-                  "labels": <div
-                    className="label-collection"
-                  >
-                    <Label
-                      name="app"
-                      value="reviews"
-                    />
-                    <Label
-                      name="version"
-                      value="v3"
-                    />
-                  </div>,
+                  "labels": <Labels
+                    labels={
+                      Object {
+                        "app": "reviews",
+                        "version": "v3",
+                      }
+                    }
+                  />,
                   "name": <span>
                     <Link
                       replace={false}
@@ -311,18 +303,14 @@ ShallowWrapper {
                     time="2018-03-14T10:17:52Z\\""
                   />,
                   "id": 2,
-                  "labels": <div
-                    className="label-collection"
-                  >
-                    <Label
-                      name="app"
-                      value="reviews"
-                    />
-                    <Label
-                      name="version"
-                      value="v1"
-                    />
-                  </div>,
+                  "labels": <Labels
+                    labels={
+                      Object {
+                        "app": "reviews",
+                        "version": "v1",
+                      }
+                    }
+                  />,
                   "name": <span>
                     <Link
                       replace={false}
@@ -542,18 +530,14 @@ ShallowWrapper {
                     time="2018-03-14T10:17:52Z\\""
                   />,
                   "id": 0,
-                  "labels": <div
-                    className="label-collection"
-                  >
-                    <Label
-                      name="app"
-                      value="reviews"
-                    />
-                    <Label
-                      name="version"
-                      value="v2"
-                    />
-                  </div>,
+                  "labels": <Labels
+                    labels={
+                      Object {
+                        "app": "reviews",
+                        "version": "v2",
+                      }
+                    }
+                  />,
                   "name": <span>
                     <Link
                       replace={false}
@@ -570,18 +554,14 @@ ShallowWrapper {
                     time="2018-03-14T10:17:52Z\\""
                   />,
                   "id": 1,
-                  "labels": <div
-                    className="label-collection"
-                  >
-                    <Label
-                      name="app"
-                      value="reviews"
-                    />
-                    <Label
-                      name="version"
-                      value="v3"
-                    />
-                  </div>,
+                  "labels": <Labels
+                    labels={
+                      Object {
+                        "app": "reviews",
+                        "version": "v3",
+                      }
+                    }
+                  />,
                   "name": <span>
                     <Link
                       replace={false}
@@ -598,18 +578,14 @@ ShallowWrapper {
                     time="2018-03-14T10:17:52Z\\""
                   />,
                   "id": 2,
-                  "labels": <div
-                    className="label-collection"
-                  >
-                    <Label
-                      name="app"
-                      value="reviews"
-                    />
-                    <Label
-                      name="version"
-                      value="v1"
-                    />
-                  </div>,
+                  "labels": <Labels
+                    labels={
+                      Object {
+                        "app": "reviews",
+                        "version": "v1",
+                      }
+                    }
+                  />,
                   "name": <span>
                     <Link
                       replace={false}
@@ -742,18 +718,14 @@ ShallowWrapper {
                       time="2018-03-14T10:17:52Z\\""
                     />,
                     "id": 0,
-                    "labels": <div
-                      className="label-collection"
-                    >
-                      <Label
-                        name="app"
-                        value="reviews"
-                      />
-                      <Label
-                        name="version"
-                        value="v2"
-                      />
-                    </div>,
+                    "labels": <Labels
+                      labels={
+                        Object {
+                          "app": "reviews",
+                          "version": "v2",
+                        }
+                      }
+                    />,
                     "name": <span>
                       <Link
                         replace={false}
@@ -770,18 +742,14 @@ ShallowWrapper {
                       time="2018-03-14T10:17:52Z\\""
                     />,
                     "id": 1,
-                    "labels": <div
-                      className="label-collection"
-                    >
-                      <Label
-                        name="app"
-                        value="reviews"
-                      />
-                      <Label
-                        name="version"
-                        value="v3"
-                      />
-                    </div>,
+                    "labels": <Labels
+                      labels={
+                        Object {
+                          "app": "reviews",
+                          "version": "v3",
+                        }
+                      }
+                    />,
                     "name": <span>
                       <Link
                         replace={false}
@@ -798,18 +766,14 @@ ShallowWrapper {
                       time="2018-03-14T10:17:52Z\\""
                     />,
                     "id": 2,
-                    "labels": <div
-                      className="label-collection"
-                    >
-                      <Label
-                        name="app"
-                        value="reviews"
-                      />
-                      <Label
-                        name="version"
-                        value="v1"
-                      />
-                    </div>,
+                    "labels": <Labels
+                      labels={
+                        Object {
+                          "app": "reviews",
+                          "version": "v1",
+                        }
+                      }
+                    />,
                     "name": <span>
                       <Link
                         replace={false}
@@ -1025,18 +989,14 @@ ShallowWrapper {
                     time="2018-03-14T10:17:52Z\\""
                   />,
                   "id": 0,
-                  "labels": <div
-                    className="label-collection"
-                  >
-                    <Label
-                      name="app"
-                      value="reviews"
-                    />
-                    <Label
-                      name="version"
-                      value="v2"
-                    />
-                  </div>,
+                  "labels": <Labels
+                    labels={
+                      Object {
+                        "app": "reviews",
+                        "version": "v2",
+                      }
+                    }
+                  />,
                   "name": <span>
                     <Link
                       replace={false}
@@ -1053,18 +1013,14 @@ ShallowWrapper {
                     time="2018-03-14T10:17:52Z\\""
                   />,
                   "id": 1,
-                  "labels": <div
-                    className="label-collection"
-                  >
-                    <Label
-                      name="app"
-                      value="reviews"
-                    />
-                    <Label
-                      name="version"
-                      value="v3"
-                    />
-                  </div>,
+                  "labels": <Labels
+                    labels={
+                      Object {
+                        "app": "reviews",
+                        "version": "v3",
+                      }
+                    }
+                  />,
                   "name": <span>
                     <Link
                       replace={false}
@@ -1081,18 +1037,14 @@ ShallowWrapper {
                     time="2018-03-14T10:17:52Z\\""
                   />,
                   "id": 2,
-                  "labels": <div
-                    className="label-collection"
-                  >
-                    <Label
-                      name="app"
-                      value="reviews"
-                    />
-                    <Label
-                      name="version"
-                      value="v1"
-                    />
-                  </div>,
+                  "labels": <Labels
+                    labels={
+                      Object {
+                        "app": "reviews",
+                        "version": "v1",
+                      }
+                    }
+                  />,
                   "name": <span>
                     <Link
                       replace={false}
@@ -1322,18 +1274,14 @@ ShallowWrapper {
                       time="2018-03-14T10:17:52Z\\""
                     />,
                     "id": 0,
-                    "labels": <div
-                      className="label-collection"
-                    >
-                      <Label
-                        name="app"
-                        value="reviews"
-                      />
-                      <Label
-                        name="version"
-                        value="v2"
-                      />
-                    </div>,
+                    "labels": <Labels
+                      labels={
+                        Object {
+                          "app": "reviews",
+                          "version": "v2",
+                        }
+                      }
+                    />,
                     "name": <span>
                       <Link
                         replace={false}
@@ -1350,18 +1298,14 @@ ShallowWrapper {
                       time="2018-03-14T10:17:52Z\\""
                     />,
                     "id": 1,
-                    "labels": <div
-                      className="label-collection"
-                    >
-                      <Label
-                        name="app"
-                        value="reviews"
-                      />
-                      <Label
-                        name="version"
-                        value="v3"
-                      />
-                    </div>,
+                    "labels": <Labels
+                      labels={
+                        Object {
+                          "app": "reviews",
+                          "version": "v3",
+                        }
+                      }
+                    />,
                     "name": <span>
                       <Link
                         replace={false}
@@ -1378,18 +1322,14 @@ ShallowWrapper {
                       time="2018-03-14T10:17:52Z\\""
                     />,
                     "id": 2,
-                    "labels": <div
-                      className="label-collection"
-                    >
-                      <Label
-                        name="app"
-                        value="reviews"
-                      />
-                      <Label
-                        name="version"
-                        value="v1"
-                      />
-                    </div>,
+                    "labels": <Labels
+                      labels={
+                        Object {
+                          "app": "reviews",
+                          "version": "v1",
+                        }
+                      }
+                    />,
                     "name": <span>
                       <Link
                         replace={false}
@@ -1609,18 +1549,14 @@ ShallowWrapper {
                       time="2018-03-14T10:17:52Z\\""
                     />,
                     "id": 0,
-                    "labels": <div
-                      className="label-collection"
-                    >
-                      <Label
-                        name="app"
-                        value="reviews"
-                      />
-                      <Label
-                        name="version"
-                        value="v2"
-                      />
-                    </div>,
+                    "labels": <Labels
+                      labels={
+                        Object {
+                          "app": "reviews",
+                          "version": "v2",
+                        }
+                      }
+                    />,
                     "name": <span>
                       <Link
                         replace={false}
@@ -1637,18 +1573,14 @@ ShallowWrapper {
                       time="2018-03-14T10:17:52Z\\""
                     />,
                     "id": 1,
-                    "labels": <div
-                      className="label-collection"
-                    >
-                      <Label
-                        name="app"
-                        value="reviews"
-                      />
-                      <Label
-                        name="version"
-                        value="v3"
-                      />
-                    </div>,
+                    "labels": <Labels
+                      labels={
+                        Object {
+                          "app": "reviews",
+                          "version": "v3",
+                        }
+                      }
+                    />,
                     "name": <span>
                       <Link
                         replace={false}
@@ -1665,18 +1597,14 @@ ShallowWrapper {
                       time="2018-03-14T10:17:52Z\\""
                     />,
                     "id": 2,
-                    "labels": <div
-                      className="label-collection"
-                    >
-                      <Label
-                        name="app"
-                        value="reviews"
-                      />
-                      <Label
-                        name="version"
-                        value="v1"
-                      />
-                    </div>,
+                    "labels": <Labels
+                      labels={
+                        Object {
+                          "app": "reviews",
+                          "version": "v1",
+                        }
+                      }
+                    />,
                     "name": <span>
                       <Link
                         replace={false}
@@ -1809,18 +1737,14 @@ ShallowWrapper {
                         time="2018-03-14T10:17:52Z\\""
                       />,
                       "id": 0,
-                      "labels": <div
-                        className="label-collection"
-                      >
-                        <Label
-                          name="app"
-                          value="reviews"
-                        />
-                        <Label
-                          name="version"
-                          value="v2"
-                        />
-                      </div>,
+                      "labels": <Labels
+                        labels={
+                          Object {
+                            "app": "reviews",
+                            "version": "v2",
+                          }
+                        }
+                      />,
                       "name": <span>
                         <Link
                           replace={false}
@@ -1837,18 +1761,14 @@ ShallowWrapper {
                         time="2018-03-14T10:17:52Z\\""
                       />,
                       "id": 1,
-                      "labels": <div
-                        className="label-collection"
-                      >
-                        <Label
-                          name="app"
-                          value="reviews"
-                        />
-                        <Label
-                          name="version"
-                          value="v3"
-                        />
-                      </div>,
+                      "labels": <Labels
+                        labels={
+                          Object {
+                            "app": "reviews",
+                            "version": "v3",
+                          }
+                        }
+                      />,
                       "name": <span>
                         <Link
                           replace={false}
@@ -1865,18 +1785,14 @@ ShallowWrapper {
                         time="2018-03-14T10:17:52Z\\""
                       />,
                       "id": 2,
-                      "labels": <div
-                        className="label-collection"
-                      >
-                        <Label
-                          name="app"
-                          value="reviews"
-                        />
-                        <Label
-                          name="version"
-                          value="v1"
-                        />
-                      </div>,
+                      "labels": <Labels
+                        labels={
+                          Object {
+                            "app": "reviews",
+                            "version": "v1",
+                          }
+                        }
+                      />,
                       "name": <span>
                         <Link
                           replace={false}
@@ -2092,18 +2008,14 @@ ShallowWrapper {
                       time="2018-03-14T10:17:52Z\\""
                     />,
                     "id": 0,
-                    "labels": <div
-                      className="label-collection"
-                    >
-                      <Label
-                        name="app"
-                        value="reviews"
-                      />
-                      <Label
-                        name="version"
-                        value="v2"
-                      />
-                    </div>,
+                    "labels": <Labels
+                      labels={
+                        Object {
+                          "app": "reviews",
+                          "version": "v2",
+                        }
+                      }
+                    />,
                     "name": <span>
                       <Link
                         replace={false}
@@ -2120,18 +2032,14 @@ ShallowWrapper {
                       time="2018-03-14T10:17:52Z\\""
                     />,
                     "id": 1,
-                    "labels": <div
-                      className="label-collection"
-                    >
-                      <Label
-                        name="app"
-                        value="reviews"
-                      />
-                      <Label
-                        name="version"
-                        value="v3"
-                      />
-                    </div>,
+                    "labels": <Labels
+                      labels={
+                        Object {
+                          "app": "reviews",
+                          "version": "v3",
+                        }
+                      }
+                    />,
                     "name": <span>
                       <Link
                         replace={false}
@@ -2148,18 +2056,14 @@ ShallowWrapper {
                       time="2018-03-14T10:17:52Z\\""
                     />,
                     "id": 2,
-                    "labels": <div
-                      className="label-collection"
-                    >
-                      <Label
-                        name="app"
-                        value="reviews"
-                      />
-                      <Label
-                        name="version"
-                        value="v1"
-                      />
-                    </div>,
+                    "labels": <Labels
+                      labels={
+                        Object {
+                          "app": "reviews",
+                          "version": "v1",
+                        }
+                      }
+                    />,
                     "name": <span>
                       <Link
                         replace={false}

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadDescription.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadDescription.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
-import { Row, Col } from 'patternfly-react';
+import { Col, Row } from 'patternfly-react';
 import PfInfoCard from '../../../components/Pf/PfInfoCard';
 import { Workload, WorkloadIcon } from '../../../types/Workload';
-import Label from '../../../components/Label/Label';
 import LocalTime from '../../../components/Time/LocalTime';
 import { DisplayMode, HealthIndicator } from '../../../components/Health/HealthIndicator';
 import { WorkloadHealth } from '../../../types/Health';
 import { runtimesLogoProviders } from '../../../config/Logos';
+import Labels from '../../../components/Label/Labels';
 
 type WorkloadDescriptionProps = {
   workload: Workload;
@@ -49,11 +49,7 @@ class WorkloadDescription extends React.Component<WorkloadDescriptionProps, Work
                 <strong>{isTemplateLabels ? 'Template Labels' : 'Labels'}</strong>
               </div>
               <div className="label-collection">
-                {Object.keys(workload.labels || {}).map((key, i) => (
-                  <div key={'label_' + i}>
-                    <Label name={key} value={workload.labels ? workload.labels[key] : ''} />
-                  </div>
-                ))}
+                <Labels labels={workload.labels} />
               </div>
               <div>
                 <strong>Type</strong> {workload.type ? workload.type : ''}

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPods.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPods.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { ContainerInfo, Pod, Reference, ObjectValidation } from '../../../types/IstioObjects';
-import { Col, Row, OverlayTrigger, Tooltip, Table } from 'patternfly-react';
-import Label from '../../../components/Label/Label';
+import { ContainerInfo, ObjectValidation, Pod, Reference } from '../../../types/IstioObjects';
+import { Col, OverlayTrigger, Row, Table, Tooltip } from 'patternfly-react';
 import * as resolve from 'table-resolver';
 import { ConfigIndicator } from '../../../components/ConfigValidation/ConfigIndicator';
 import Labels from '../../../components/Label/Labels';

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPods.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPods.tsx
@@ -4,6 +4,7 @@ import { Col, Row, OverlayTrigger, Tooltip, Table } from 'patternfly-react';
 import Label from '../../../components/Label/Label';
 import * as resolve from 'table-resolver';
 import { ConfigIndicator } from '../../../components/ConfigValidation/ConfigIndicator';
+import Labels from '../../../components/Label/Labels';
 
 interface PodsGroup {
   commonPrefix: string;
@@ -152,15 +153,6 @@ class WorkloadPods extends React.Component<WorkloadPodsProps, WorkloadPodsState>
       <>{new Date(group.createdAtStart).toLocaleString() + ' and ' + new Date(group.createdAtEnd).toLocaleString()}</>
     );
   }
-  renderLabels(labels: { [key: string]: string }, u: Number) {
-    return (
-      <div key="labels" className="label-collection">
-        {Object.keys(labels).map((key, i) => (
-          <Label key={'pod_' + u + '_' + i} name={key} value={labels[key]} />
-        ))}
-      </div>
-    );
-  }
 
   columns() {
     return {
@@ -264,7 +256,7 @@ class WorkloadPods extends React.Component<WorkloadPodsProps, WorkloadPodsState>
           group.createdBy && group.createdBy.length > 0
             ? group.createdBy.map(ref => ref.name + ' (' + ref.kind + ')').join(', ')
             : '',
-        labels: this.renderLabels(group.commonLabels, vsIdx),
+        labels: <Labels key={'labels' + vsIdx} labels={group.commonLabels} />,
         istioInitContainers: group.istioInitContainers
           ? group.istioInitContainers.map(c => `${c.image}`).join(', ')
           : '',

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadServices.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadServices.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
-import { Service, Port } from '../../../types/IstioObjects';
-import { Row, Col, Table } from 'patternfly-react';
+import { Port, Service } from '../../../types/IstioObjects';
+import { Col, Row, Table } from 'patternfly-react';
 import { Link } from 'react-router-dom';
-import Label from '../../../components/Label/Label';
 import LocalTime from '../../../components/Time/LocalTime';
 import * as resolve from 'table-resolver';
 import Labels from '../../../components/Label/Labels';

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadServices.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadServices.tsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom';
 import Label from '../../../components/Label/Label';
 import LocalTime from '../../../components/Time/LocalTime';
 import * as resolve from 'table-resolver';
+import Labels from '../../../components/Label/Labels';
 
 type WorkloadServicesProps = {
   services: Service[];
@@ -100,17 +101,6 @@ class WorkloadServices extends React.Component<WorkloadServicesProps, WorkloadSe
     };
   }
 
-  renderLabels(labels: { [key: string]: string }, u: Number) {
-    return labels ? (
-      <div key="labels" className="label-collection">
-        {Object.keys(labels).map((key, i) => (
-          <Label key={'pod_' + u + '_' + i} name={key} value={labels ? labels[key] : ''} />
-        ))}
-      </div>
-    ) : (
-      ''
-    );
-  }
   overviewLink(service: Service) {
     return (
       <Link
@@ -141,7 +131,7 @@ class WorkloadServices extends React.Component<WorkloadServicesProps, WorkloadSe
         name: this.overviewLink(service),
         createdAt: <LocalTime time={service.createdAt} />,
         type: service.type,
-        labels: this.renderLabels(service.labels || {}, vsIdx),
+        labels: <Labels key={'pod_' + vsIdx} labels={service.labels} />,
         resourceVersion: service.resourceVersion,
         ip: service.ip,
         ports: this.renderPorts(service.ports || [])

--- a/src/pages/WorkloadDetails/WorkloadInfo/__tests__/__snapshots__/WorkloadDescription.test.tsx.snap
+++ b/src/pages/WorkloadDetails/WorkloadInfo/__tests__/__snapshots__/WorkloadDescription.test.tsx.snap
@@ -69,7 +69,11 @@ ShallowWrapper {
           </div>
           <div
             className="label-collection"
-          />
+          >
+            <Labels
+              labels={Object {}}
+            />
+          </div>
           <div>
             <strong>
               Type
@@ -175,7 +179,11 @@ ShallowWrapper {
             </div>
             <div
               className="label-collection"
-            />
+            >
+              <Labels
+                labels={Object {}}
+              />
+            </div>
             <div>
               <strong>
                 Type


### PR DESCRIPTION
** Describe the change **
Task in the roadmap of supporting Knative.

Knative services has 8 labels per service. They take a lot of space in the service page.
We should use the 'More labels...' link to hide some labels.
Openshift uses this feature when there are more than 3 labels:
![Screen recording (12)](https://user-images.githubusercontent.com/613814/56958834-cac2e400-6b4b-11e9-8f3c-3647c8237c60.gif)


- [x] Workload details page
- [x] Service details page
- [ ] Graph sidebar (don't need that bc don't list all tags)

** Issue reference **
https://issues.jboss.org/browse/KIALI-2757

** Backwards compatible? **
yes

** Screenshot **
In the Workloads details page:
![Screenshot of Kiali Console (23)](https://user-images.githubusercontent.com/613814/56680697-05e69280-66c8-11e9-9d00-6c6439313f48.png)

![Screenshot of Kiali Console (24)](https://user-images.githubusercontent.com/613814/56680687-0121de80-66c8-11e9-9138-9bd92716d9d2.png)

In Service Details page: 
![Screenshot of Kiali Console (25)](https://user-images.githubusercontent.com/613814/56680795-3b8b7b80-66c8-11e9-8e3a-6d7cbf1cdbbe.png)
![Screenshot of Kiali Console (26)](https://user-images.githubusercontent.com/613814/56680798-3d553f00-66c8-11e9-8fde-d20ca44fa422.png)

