### PR TITLE
KIALI-2764 Update typescript to 2.4.5 to get --incremental compile feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "snyk": "^1.143.0",
     "source-map-explorer": "1.8.0",
     "tslint-no-circular-imports": "0.6.2",
-    "typescript": "3.3.4000"
+    "typescript": "3.4.5"
   },
   "resolutions": {
     "@types/react": "16.7.13",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "outDir": "build/dist",
     "module": "esnext",
     "target": "es5",
+    "incremental": true,
     "lib": ["es2016", "dom"],
     "sourceMap": true,
     "allowJs": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11116,10 +11116,10 @@ typesafe-actions@3.2.1:
   resolved "https://registry.yarnpkg.com/typesafe-actions/-/typesafe-actions-3.2.1.tgz#833623a4079eda5dbcb775113f6dcf02b71c03f8"
   integrity sha512-hvhuNqsai6LzXQ+Hl6vajC9bGd/kHHL1hJvI4GQ0Rs6Fax1cjbNEsuFGy/RbfLPhBAL10n6DECEHUa+Q9E+MxQ==
 
-typescript@3.3.4000:
-  version "3.3.4000"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.4000.tgz#76b0f89cfdbf97827e1112d64f283f1151d6adf0"
-  integrity sha512-jjOcCZvpkl2+z7JFn0yBOoLQyLoIkNZAs/fYJkUG6VKy6zLPHJGfQJYFHzibB6GJaF/8QrcECtlQ5cpvRHSMEA==
+typescript@3.4.5:
+  version "3.4.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
+  integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
 
 typestyle@2.0.1:
   version "2.0.1"


### PR DESCRIPTION
KIALI-2764 Update typescript to 2.4.5 from 3.3.4000 to get --incremental dev compilation performance increases and other things.

http://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html

> For a project the size of Visual Studio Code, TypeScript’s new --incremental flag was able to reduce subsequent build times down to approximately a fifth of the original.

** Issue reference **

https://issues.jboss.org/browse/KIALI-2764

** Backwards compatible? **
yes
[ ] Is your pull-request introducing changes in behaviour?
No
