### PR TITLE
KIALI-2768 UX updates to compound node labels

### DIFF
--- a/src/components/CytoscapeGraph/Layout/GroupCompoundLayout.ts
+++ b/src/components/CytoscapeGraph/Layout/GroupCompoundLayout.ts
@@ -222,6 +222,13 @@ export default class GroupCompoundLayout {
         // Discard the saved values
         parent.removeScratch(CHILDREN_KEY);
         parent.removeScratch(STYLES_KEY);
+
+        // This will fix the label width issue when the layout changes, but it
+        // doesn't work well when the node is selected or hovered. It also prevents
+        // the label from being properly aligned when the graph is first loaded
+        /* parent.style('text-margin-x', (ele: any) => {
+                return '-' + (+ele.width() + +ele.style('padding').slice(0,-2) * 2 )+ "px";
+        }); */
       });
       // (4.a) Add the real edges, we already added the children nodes.
       this.cy.add(

--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -219,7 +219,7 @@ export class GraphStyles {
         } else {
           const contentArray: string[] = [];
           if ((isMultiNamespace || isOutside) && !(isServiceEntry || nodeType === NodeType.UNKNOWN)) {
-            contentArray.push(namespace);
+            contentArray.push('(' + namespace + ')');
           }
           switch (nodeType) {
             case NodeType.APP:
@@ -350,9 +350,10 @@ export class GraphStyles {
         css: {
           'text-valign': 'top',
           'text-halign': 'right',
-          'text-margin-x': '2px',
-          'text-margin-y': '8px',
-          'text-rotation': '90deg',
+          'text-margin-x': (ele: any) => {
+            return '-' + (+ele.width() + +ele.style('padding').slice(0, -2) * 2) + 'px';
+          },
+          'text-margin-y': '-2px',
           'background-color': NodeColorFillBox
         }
       },


### PR DESCRIPTION
**Describe the change**

Change to the compound node labels based on UX feedback. https://github.com/kiali/kiali-design/issues/121

**Issue reference**

https://issues.jboss.org/browse/KIALI-2768

~~**DO NOT MERGE**~~

~~There is a bug here which has my a bit stumped. When you first load the graph everything works fine, if you switch the layout then the labels are not aligned properly.~~

~~I suspect its in how we are doing things in the GroupCompoundLayout with removing elements and adding things back in, I think it might be taking the size with the temporary elements and not the final size.~~

~~If we explicitly set the label margin in GroupCompoundLayout, then it works when you change the layout, but is broken when you first load the page (and it also doesn't work when you hover over things).~~

~~I have submitted the PR to see if we can get feedback from someone who might know more about this than me.~~

~~@josejulio Any ideas here?~~

Thanks to @josejulio this is now working and is ready for review