### PR TITLE
KIALI-2772 Support new gateway annotation format for VS gateway parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@kiali/kiali-ui",
   "version": "0.19.0",
+  "proxy": "https://kiali-istio-system.127.0.0.1.nip.io",
   "description": "React UI for [Kiali](https://github.com/kiali/kiali).",
   "keywords": [
     "istio service mesh",

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceDetail.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceDetail.tsx
@@ -72,6 +72,14 @@ class VirtualServiceDetail extends React.Component<VirtualServiceProps> {
   }
 
   parseHost(host: string): Host {
+    if (host.includes('/')) {
+      const gatewayParts = host.split('/');
+      return {
+        service: gatewayParts[1],
+        namespace: gatewayParts[0]
+      };
+    }
+
     const hostParts = host.split('.');
     const h = {
       service: hostParts[0],


### PR DESCRIPTION
** Describe the change **

Istio 1.1 added new way to write the gateway string in the VirtualService definition. This one allows correct parsing to happen in the UI if the resource is in another namespace (current parsing only works for the same namespace).

** Issue reference **

KIALI-2772

** Backwards compatible? **

Yes