### PR TITLE
KIALI-2104 Shows link to go from workload/service/app page to graph

### DIFF
--- a/src/actions/GraphFilterActions.ts
+++ b/src/actions/GraphFilterActions.ts
@@ -8,6 +8,7 @@ enum GraphFilterActionKeys {
   SET_FIND_VALUE = 'SET_FIND_VALUE',
   SET_GRAPH_TYPE = 'SET_GRAPH_TYPE',
   SET_HIDE_VALUE = 'SET_HIDE_VALUE',
+  SET_SHOW_UNUSED_NODES = 'SET_SHOW_UNUSED_NODES',
   // Toggle Actions
   TOGGLE_GRAPH_NODE_LABEL = 'TOGGLE_GRAPH_NODE_LABEL',
   TOGGLE_GRAPH_CIRCUIT_BREAKERS = 'TOGGLE_GRAPH_CIRCUIT_BREAKERS',
@@ -28,6 +29,7 @@ export const GraphFilterActions = {
   setFindValue: createStandardAction(GraphFilterActionKeys.SET_FIND_VALUE)<string>(),
   setGraphType: createStandardAction(GraphFilterActionKeys.SET_GRAPH_TYPE)<GraphType>(),
   setHideValue: createStandardAction(GraphFilterActionKeys.SET_HIDE_VALUE)<string>(),
+  setShowUnusedNodes: createStandardAction(GraphFilterActionKeys.SET_SHOW_UNUSED_NODES)<boolean>(),
   // Toggle actions
   showGraphFilters: createStandardAction(GraphFilterActionKeys.ENABLE_GRAPH_FILTERS)<boolean>(),
   toggleGraphNodeLabel: createAction(GraphFilterActionKeys.TOGGLE_GRAPH_NODE_LABEL),

--- a/src/app/History.ts
+++ b/src/app/History.ts
@@ -25,6 +25,7 @@ export enum URLParam {
   REPORTER = 'reporter',
   SHOW_AVERAGE = 'avg',
   SORT = 'sort',
+  UNUSED_NODES = 'unusedNodes',
   JAEGER_START_TIME = 'start',
   JAEGER_END_TIME = 'end',
   JAEGER_LIMIT_TRACES = 'limit',

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -477,10 +477,12 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
 
   private selectTargetAndUpdateSummary = (target: any) => {
     this.selectTarget(target);
-    this.props.updateSummary({
+    const event: CytoscapeClickEvent = {
       summaryType: target.data(CyNode.isGroup) ? 'group' : 'node',
       summaryTarget: target
-    });
+    };
+    this.props.updateSummary(event);
+    this.graphHighlighter.onClick(event);
   };
 
   private handleDoubleTap = (event: CytoscapeClickEvent) => {

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -550,7 +550,8 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
       graphType: this.props.graphType,
       node: targetNode,
       refreshInterval: this.props.refreshInterval,
-      showServiceNodes: this.props.showServiceNodes
+      showServiceNodes: this.props.showServiceNodes,
+      showUnusedNodes: this.props.showUnusedNodes
     };
 
     // To ensure updated components get the updated URL, update the URL first and then the state

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -45,6 +45,7 @@ import { NamespaceActions } from '../../actions/NamespaceAction';
 import { DurationInSeconds, PollIntervalInMs } from '../../types/Common';
 import GraphThunkActions from '../../actions/GraphThunkActions';
 import * as MessageCenterUtils from '../../utils/MessageCenter';
+import FocusAnimation from './FocusAnimation';
 
 type ReduxProps = {
   activeNamespaces: Namespace[];
@@ -104,6 +105,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
 
   private graphHighlighter: GraphHighlighter;
   private trafficRenderer: TrafficRender;
+  private focusAnimation?: FocusAnimation;
   private cytoscapeReactWrapperRef: any;
   private namespaceChanged: boolean;
   private nodeChanged: boolean;
@@ -352,6 +354,11 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
       const elements = cy.$(this.props.focusSelector);
       if (!elements.empty()) {
         centerElements = elements;
+        if (this.focusAnimation) {
+          this.focusAnimation.stop();
+        }
+        this.focusAnimation = new FocusAnimation(cy);
+        this.focusAnimation.start(centerElements);
       }
     }
 

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -76,6 +76,7 @@ type CytoscapeGraphProps = ReduxProps & {
   isMTLSEnabled: boolean;
   containerClassName?: string;
   refresh: () => void;
+  focusSelector?: string;
 };
 
 type CytoscapeGraphState = {};
@@ -346,7 +347,15 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
   }
 
   private safeFit(cy: any) {
-    CytoscapeGraphUtils.safeFit(cy);
+    let centerElements;
+    if (this.props.focusSelector) {
+      const elements = cy.$(this.props.focusSelector);
+      if (!elements.empty()) {
+        centerElements = elements;
+      }
+    }
+
+    CytoscapeGraphUtils.safeFit(cy, centerElements);
     this.initialValues.position = { ...cy.pan() };
     this.initialValues.zoom = cy.zoom();
   }

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -106,6 +106,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
   private graphHighlighter: GraphHighlighter;
   private trafficRenderer: TrafficRender;
   private focusAnimation?: FocusAnimation;
+  private focusFinished: boolean;
   private cytoscapeReactWrapperRef: any;
   private namespaceChanged: boolean;
   private nodeChanged: boolean;
@@ -115,6 +116,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
 
   constructor(props: CytoscapeGraphProps) {
     super(props);
+    this.focusFinished = false;
     this.namespaceChanged = false;
     this.nodeChanged = false;
     this.initialValues = {
@@ -345,6 +347,10 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
   }
 
   private focus(cy: any, elements?: any) {
+    // We only want to focus once, but allow the url to be shared.
+    if (this.focusFinished) {
+      return;
+    }
     let focusElements = elements;
     if (!focusElements) {
       if (this.props.focusSelector) {
@@ -373,14 +379,17 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
         this.focusAnimation.stop();
       }
       this.focusAnimation = new FocusAnimation(cy);
+      this.focusAnimation.onFinished(() => {
+        this.focusFinished = true;
+      });
       this.focusAnimation.start(focusElements);
     }
     return focusElements;
   }
 
   private safeFit(cy: any) {
-    const centerElements = this.focus(cy);
-    CytoscapeGraphUtils.safeFit(cy, centerElements);
+    this.focus(cy);
+    CytoscapeGraphUtils.safeFit(cy);
     this.initialValues.position = { ...cy.pan() };
     this.initialValues.zoom = cy.zoom();
   }

--- a/src/components/CytoscapeGraph/CytoscapeGraphSelector.ts
+++ b/src/components/CytoscapeGraph/CytoscapeGraphSelector.ts
@@ -1,3 +1,5 @@
+import { NodeType } from '../../types/Graph';
+
 export type CytoscapeGraphSelector = string;
 
 interface CytoscapeElementData {
@@ -34,7 +36,7 @@ export class CytoscapeGraphSelectorBuilder {
     return this;
   }
 
-  nodeType(nodeType: string) {
+  nodeType(nodeType: NodeType) {
     this.data.nodeType = nodeType;
     return this;
   }

--- a/src/components/CytoscapeGraph/CytoscapeGraphSelector.ts
+++ b/src/components/CytoscapeGraph/CytoscapeGraphSelector.ts
@@ -1,0 +1,60 @@
+export type CytoscapeGraphSelector = string;
+
+interface CytoscapeElementData {
+  app?: string;
+  id?: string;
+  namespace?: string;
+  nodeType?: string;
+  service?: string;
+  version?: string;
+  workload?: string;
+}
+
+export class CytoscapeGraphSelectorBuilder {
+  private data: CytoscapeElementData = {};
+
+  app(app: string) {
+    this.data.app = app;
+    return this;
+  }
+
+  id(id: string) {
+    this.data.id = id;
+    return this;
+  }
+
+  namespace(namespace: string) {
+    this.data.namespace = namespace;
+    return this;
+  }
+
+  nodeType(nodeType: string) {
+    this.data.nodeType = nodeType;
+    return this;
+  }
+
+  service(service: string) {
+    this.data.service = service;
+    return this;
+  }
+
+  version(version: string) {
+    this.data.version = version;
+    return this;
+  }
+
+  workload(workload: string) {
+    this.data.workload = workload;
+    return this;
+  }
+
+  build() {
+    return 'node' + this.buildDataSelector();
+  }
+
+  private buildDataSelector() {
+    return Object.keys(this.data).reduce((dataSelector: string, key: string) => {
+      return dataSelector + `[${key}="${this.data[key]}"]`;
+    }, '');
+  }
+}

--- a/src/components/CytoscapeGraph/CytoscapeGraphSelector.ts
+++ b/src/components/CytoscapeGraph/CytoscapeGraphSelector.ts
@@ -3,6 +3,7 @@ export type CytoscapeGraphSelector = string;
 interface CytoscapeElementData {
   app?: string;
   id?: string;
+  isGroup?: string | null;
   namespace?: string;
   nodeType?: string;
   service?: string;
@@ -20,6 +21,11 @@ export class CytoscapeGraphSelectorBuilder {
 
   id(id: string) {
     this.data.id = id;
+    return this;
+  }
+
+  isGroup(isGroup: string | null) {
+    this.data.isGroup = isGroup;
     return this;
   }
 
@@ -48,13 +54,13 @@ export class CytoscapeGraphSelectorBuilder {
     return this;
   }
 
-  build() {
+  build(): CytoscapeGraphSelector {
     return 'node' + this.buildDataSelector();
   }
 
   private buildDataSelector() {
     return Object.keys(this.data).reduce((dataSelector: string, key: string) => {
-      return dataSelector + `[${key}="${this.data[key]}"]`;
+      return dataSelector + (this.data[key] == null ? `[!${key}]` : `[${key}="${this.data[key]}"]`);
     }, '');
   }
 }

--- a/src/components/CytoscapeGraph/CytoscapeGraphUtils.ts
+++ b/src/components/CytoscapeGraph/CytoscapeGraphUtils.ts
@@ -58,11 +58,11 @@ export const ZoomOptions = {
   fitPadding: 25
 };
 
-export const safeFit = (cy: any) => {
-  cy.fit('', ZoomOptions.fitPadding);
+export const safeFit = (cy: any, centerElements?: any) => {
+  cy.fit(centerElements, ZoomOptions.fitPadding);
   if (cy.zoom() > 2.5) {
     cy.zoom(2.5);
-    cy.center();
+    cy.center(centerElements);
   }
 };
 

--- a/src/components/CytoscapeGraph/FocusAnimation.ts
+++ b/src/components/CytoscapeGraph/FocusAnimation.ts
@@ -1,0 +1,81 @@
+import { PfColors } from '../Pf/PfColors';
+
+const FRAME_RATE = 1 / 30;
+const MAX_RADIO = 60;
+const LINE_WIDTH = 1;
+
+const ANIMATION_DURATION = 800;
+
+export default class FocusAnimation {
+  private animationTimer;
+  private startTimestamp;
+  private elements;
+
+  private readonly layer;
+  private readonly context;
+
+  constructor(cy: any) {
+    this.layer = cy.cyCanvas();
+    this.context = this.layer.getCanvas().getContext('2d');
+    cy.one('destroy', () => this.stop());
+  }
+
+  start(elements: any) {
+    this.stop();
+    this.elements = elements;
+    this.animationTimer = window.setInterval(this.processStep, FRAME_RATE * 1000);
+  }
+
+  stop() {
+    if (this.animationTimer) {
+      window.clearInterval(this.animationTimer);
+      this.animationTimer = undefined;
+      this.clear();
+    }
+  }
+
+  clear() {
+    this.layer.clear(this.context);
+  }
+
+  processStep = () => {
+    try {
+      if (this.startTimestamp === undefined) {
+        this.startTimestamp = Date.now();
+      }
+      const current = Date.now();
+      const step = (current - this.startTimestamp) / ANIMATION_DURATION;
+      this.layer.clear(this.context);
+      this.layer.setTransform(this.context);
+
+      if (step >= 1) {
+        this.stop();
+        return;
+      }
+
+      this.elements.forEach(element => this.render(element, (1 - step) * MAX_RADIO));
+    } catch (exception) {
+      // If a step failed, the next step is likely to fail.
+      // Stop the rendering and throw the exception
+      this.stop();
+      throw exception;
+    }
+  };
+
+  private getCenter(element: any) {
+    if (element.isNode()) {
+      return element.position();
+    } else {
+      return element.midpoint();
+    }
+  }
+
+  private render(element: any, radio: number) {
+    const { x, y } = this.getCenter(element);
+    this.context.strokeStyle = PfColors.Black;
+    this.context.lineWidth = LINE_WIDTH;
+    this.context.beginPath();
+    this.context.arc(x, y, radio, 0, 2 * Math.PI, true);
+    this.context.stroke();
+  }
+}

--- a/src/components/CytoscapeGraph/FocusAnimation.ts
+++ b/src/components/CytoscapeGraph/FocusAnimation.ts
@@ -6,10 +6,13 @@ const LINE_WIDTH = 1;
 
 const ANIMATION_DURATION = 800;
 
+type OnFinishedCallback = () => void;
+
 export default class FocusAnimation {
   private animationTimer;
   private startTimestamp;
   private elements;
+  private onFinishedCallback: OnFinishedCallback;
 
   private readonly layer;
   private readonly context;
@@ -18,6 +21,10 @@ export default class FocusAnimation {
     this.layer = cy.cyCanvas();
     this.context = this.layer.getCanvas().getContext('2d');
     cy.one('destroy', () => this.stop());
+  }
+
+  onFinished(onFinishedCallback: OnFinishedCallback) {
+    this.onFinishedCallback = onFinishedCallback;
   }
 
   start(elements: any) {
@@ -50,6 +57,9 @@ export default class FocusAnimation {
 
       if (step >= 1) {
         this.stop();
+        if (this.onFinishedCallback) {
+          this.onFinishedCallback();
+        }
         return;
       }
 

--- a/src/components/CytoscapeGraph/__tests__/CytoscapeGraphSelector.test.ts
+++ b/src/components/CytoscapeGraph/__tests__/CytoscapeGraphSelector.test.ts
@@ -36,6 +36,16 @@ describe('CytoscapeGraphSelector test', () => {
     expect(selector).toEqual('node[workload="myworkload"]');
   });
 
+  it('Generates selector for isGroup', () => {
+    const selector = new CytoscapeGraphSelectorBuilder().isGroup('mygroup').build();
+    expect(selector).toEqual('node[isGroup="mygroup"]');
+  });
+
+  it('Generates falsy selector for isGroup', () => {
+    const selector = new CytoscapeGraphSelectorBuilder().isGroup(null).build();
+    expect(selector).toEqual('node[!isGroup]');
+  });
+
   it('Generates selector for two properties', () => {
     const selector = new CytoscapeGraphSelectorBuilder()
       .workload('myworkload')

--- a/src/components/CytoscapeGraph/__tests__/CytoscapeGraphSelector.test.ts
+++ b/src/components/CytoscapeGraph/__tests__/CytoscapeGraphSelector.test.ts
@@ -1,4 +1,5 @@
 import { CytoscapeGraphSelectorBuilder } from '../CytoscapeGraphSelector';
+import { NodeType } from '../../../types/Graph';
 
 describe('CytoscapeGraphSelector test', () => {
   it('Generates selector for app', () => {
@@ -17,8 +18,8 @@ describe('CytoscapeGraphSelector test', () => {
   });
 
   it('Generates selector for nodeType', () => {
-    const selector = new CytoscapeGraphSelectorBuilder().nodeType('mynodeType').build();
-    expect(selector).toEqual('node[nodeType="mynodeType"]');
+    const selector = new CytoscapeGraphSelectorBuilder().nodeType(NodeType.APP).build();
+    expect(selector).toEqual('node[nodeType="app"]');
   });
 
   it('Generates selector for service', () => {

--- a/src/components/CytoscapeGraph/__tests__/CytoscapeGraphSelector.test.ts
+++ b/src/components/CytoscapeGraph/__tests__/CytoscapeGraphSelector.test.ts
@@ -1,0 +1,56 @@
+import { CytoscapeGraphSelectorBuilder } from '../CytoscapeGraphSelector';
+
+describe('CytoscapeGraphSelector test', () => {
+  it('Generates selector for app', () => {
+    const selector = new CytoscapeGraphSelectorBuilder().app('myapp').build();
+    expect(selector).toEqual('node[app="myapp"]');
+  });
+
+  it('Generates selector for id', () => {
+    const selector = new CytoscapeGraphSelectorBuilder().id('myid').build();
+    expect(selector).toEqual('node[id="myid"]');
+  });
+
+  it('Generates selector for namespace', () => {
+    const selector = new CytoscapeGraphSelectorBuilder().namespace('mynamespace').build();
+    expect(selector).toEqual('node[namespace="mynamespace"]');
+  });
+
+  it('Generates selector for nodeType', () => {
+    const selector = new CytoscapeGraphSelectorBuilder().nodeType('mynodeType').build();
+    expect(selector).toEqual('node[nodeType="mynodeType"]');
+  });
+
+  it('Generates selector for service', () => {
+    const selector = new CytoscapeGraphSelectorBuilder().service('myservice').build();
+    expect(selector).toEqual('node[service="myservice"]');
+  });
+
+  it('Generates selector for version', () => {
+    const selector = new CytoscapeGraphSelectorBuilder().version('myversion').build();
+    expect(selector).toEqual('node[version="myversion"]');
+  });
+
+  it('Generates selector for workload', () => {
+    const selector = new CytoscapeGraphSelectorBuilder().workload('myworkload').build();
+    expect(selector).toEqual('node[workload="myworkload"]');
+  });
+
+  it('Generates selector for two properties', () => {
+    const selector = new CytoscapeGraphSelectorBuilder()
+      .workload('myworkload')
+      .app('myapp')
+      .build();
+    expect(selector).toEqual('node[workload="myworkload"][app="myapp"]');
+  });
+
+  it('Generates selector for multiple properties', () => {
+    const selector = new CytoscapeGraphSelectorBuilder()
+      .workload('myworkload')
+      .id('myid')
+      .version('myversion')
+      .service('myservice')
+      .build();
+    expect(selector).toEqual('node[workload="myworkload"][id="myid"][version="myversion"][service="myservice"]');
+  });
+});

--- a/src/components/GraphFilter/GraphFilter.tsx
+++ b/src/components/GraphFilter/GraphFilter.tsx
@@ -7,7 +7,12 @@ import { ThunkDispatch } from 'redux-thunk';
 import { bindActionCreators } from 'redux';
 
 import { KialiAppState } from '../../store/Store';
-import { graphTypeSelector, edgeLabelModeSelector, activeNamespacesSelector } from '../../store/Selectors';
+import {
+  graphTypeSelector,
+  edgeLabelModeSelector,
+  activeNamespacesSelector,
+  showUnusedNodesSelector
+} from '../../store/Selectors';
 import { GraphFilterActions } from '../../actions/GraphFilterActions';
 
 import { GraphType, NodeParamsType } from '../../types/Graph';
@@ -29,11 +34,13 @@ type ReduxProps = {
   edgeLabelMode: EdgeLabelMode;
   graphType: GraphType;
   node?: NodeParamsType;
+  showUnusedNodes: boolean;
 
   setActiveNamespaces: (activeNamespaces: Namespace[]) => void;
   setEdgeLabelMode: (edgeLabelMode: EdgeLabelMode) => void;
   setGraphType: (graphType: GraphType) => void;
   setNode: (node?: NodeParamsType) => void;
+  setShowUnusedNodes: (unusedNodes: boolean) => void;
 };
 
 type GraphFilterProps = ReduxProps & {
@@ -98,6 +105,15 @@ export class GraphFilter extends React.PureComponent<GraphFilterProps> {
       const activeNamespacesString = namespacesToString(props.activeNamespaces);
       HistoryManager.setParam(URLParam.NAMESPACES, activeNamespacesString);
     }
+
+    const unusedNodes = HistoryManager.getBooleanParam(URLParam.UNUSED_NODES);
+    if (unusedNodes !== undefined) {
+      if (props.showUnusedNodes !== unusedNodes) {
+        props.setShowUnusedNodes(unusedNodes);
+      }
+    } else {
+      HistoryManager.setParam(URLParam.UNUSED_NODES, String(this.props.showUnusedNodes));
+    }
   }
 
   componentDidUpdate() {
@@ -110,6 +126,7 @@ export class GraphFilter extends React.PureComponent<GraphFilterProps> {
     }
     HistoryManager.setParam(URLParam.GRAPH_EDGES, String(this.props.edgeLabelMode));
     HistoryManager.setParam(URLParam.GRAPH_TYPE, String(this.props.graphType));
+    HistoryManager.setParam(URLParam.UNUSED_NODES, String(this.props.showUnusedNodes));
   }
 
   handleRefresh = () => {
@@ -183,7 +200,8 @@ const mapStateToProps = (state: KialiAppState) => ({
   activeNamespaces: activeNamespacesSelector(state),
   edgeLabelMode: edgeLabelModeSelector(state),
   graphType: graphTypeSelector(state),
-  node: state.graph.node
+  node: state.graph.node,
+  showUnusedNodes: showUnusedNodesSelector(state)
 });
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<KialiAppState, void, KialiAppAction>) => {
@@ -191,7 +209,8 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<KialiAppState, void, KialiAp
     setActiveNamespaces: bindActionCreators(NamespaceActions.setActiveNamespaces, dispatch),
     setEdgeLabelMode: bindActionCreators(GraphFilterActions.setEdgelLabelMode, dispatch),
     setGraphType: bindActionCreators(GraphFilterActions.setGraphType, dispatch),
-    setNode: bindActionCreators(GraphActions.setNode, dispatch)
+    setNode: bindActionCreators(GraphActions.setNode, dispatch),
+    setShowUnusedNodes: bindActionCreators(GraphFilterActions.setShowUnusedNodes, dispatch)
   };
 };
 

--- a/src/components/Nav/NavUtils.tsx
+++ b/src/components/Nav/NavUtils.tsx
@@ -14,6 +14,7 @@ export type GraphUrlParams = {
   node?: NodeParamsType;
   refreshInterval: PollIntervalInMs;
   showServiceNodes: boolean;
+  showUnusedNodes: boolean;
 };
 
 const buildCommonQueryParams = (params: GraphUrlParams): string => {
@@ -23,6 +24,7 @@ const buildCommonQueryParams = (params: GraphUrlParams): string => {
   q += `&${URLParam.GRAPH_TYPE}=${params.graphType}`;
   q += `&${URLParam.DURATION}=${params.duration}`;
   q += `&${URLParam.POLL_INTERVAL}=${params.refreshInterval}`;
+  q += `&${URLParam.UNUSED_NODES}=${params.showUnusedNodes}`;
   return q;
 };
 

--- a/src/components/Pf/PfInfoCard.tsx
+++ b/src/components/Pf/PfInfoCard.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Icon } from 'patternfly-react';
 import MissingSidecar from '../../components/MissingSidecar/MissingSidecar';
+import { Link } from 'react-router-dom';
 
 interface CardProps {
   iconType?: string;
@@ -8,6 +9,7 @@ interface CardProps {
   title?: string;
   items?: any;
   istio?: boolean;
+  showOnGraphLink?: string;
 }
 
 class PfInfoCard extends React.Component<CardProps> {
@@ -22,7 +24,14 @@ class PfInfoCard extends React.Component<CardProps> {
           <h2 className="card-pf-title">
             <Icon type={this.props.iconType} name={this.props.iconName} style={{ marginRight: '10px' }} />
             {this.props.title}
-            {!this.props.istio && (
+            {this.props.istio ? (
+              this.props.showOnGraphLink && (
+                <>
+                  {' '}
+                  (<Link to={this.props.showOnGraphLink}>Show on graph</Link>)
+                </>
+              )
+            ) : (
               <span style={{ marginLeft: '10px' }}>
                 <MissingSidecar />
               </span>

--- a/src/pages/AppDetails/AppInfo/AppDescription.tsx
+++ b/src/pages/AppDetails/AppInfo/AppDescription.tsx
@@ -31,7 +31,9 @@ class AppDescription extends React.Component<AppDescriptionProps, AppDescription
   }
 
   showOnGraphLink(application: string) {
-    return `/graph/namespaces?focusSelector=${encodeURI(new CytoscapeGraphSelectorBuilder().app(application).build())}`;
+    return `/graph/namespaces?graphType=workload&injectServiceNodes=true&unusedNodes=true&focusSelector=${encodeURI(
+      new CytoscapeGraphSelectorBuilder().app(application).build()
+    )}`;
   }
 
   serviceLink(namespace: string, service: string) {
@@ -124,15 +126,16 @@ class AppDescription extends React.Component<AppDescriptionProps, AppDescription
 
   render() {
     const app = this.props.app;
+    const istioSidecar = this.istioSidecar();
     return app ? (
       <PfInfoCard
         iconType="pf"
         iconName="applications"
         title={app.name}
-        istio={this.istioSidecar()}
+        istio={istioSidecar}
         items={
           <>
-            {app.name && (
+            {app && istioSidecar && (
               <Row>
                 <Col xs={12} sm={6} md={4} lg={4}>
                   <Link to={this.showOnGraphLink(app.name)}>Show on graph</Link>

--- a/src/pages/AppDetails/AppInfo/AppDescription.tsx
+++ b/src/pages/AppDetails/AppInfo/AppDescription.tsx
@@ -9,6 +9,7 @@ import { WorkloadIcon } from '../../../types/Workload';
 import { Link } from 'react-router-dom';
 import { CytoscapeGraphSelectorBuilder } from '../../../components/CytoscapeGraph/CytoscapeGraphSelector';
 import { NodeType } from '../../../types/Graph';
+import Namespace from '../../../types/Namespace';
 
 type AppDescriptionProps = {
   app: App;
@@ -31,12 +32,13 @@ class AppDescription extends React.Component<AppDescriptionProps, AppDescription
     return istioSidecar;
   }
 
-  showOnGraphLink(application: string) {
+  showOnGraphLink(application: string, namespace: Namespace) {
     return `/graph/namespaces?graphType=app&injectServiceNodes=true&unusedNodes=true&focusSelector=${encodeURI(
       new CytoscapeGraphSelectorBuilder()
         .app(application)
         .nodeType(NodeType.APP)
         .isGroup(null)
+        .namespace(namespace.name)
         .build()
     )}`;
   }
@@ -138,7 +140,7 @@ class AppDescription extends React.Component<AppDescriptionProps, AppDescription
         iconName="applications"
         title={app.name}
         istio={istioSidecar}
-        showOnGraphLink={this.showOnGraphLink(app.name)}
+        showOnGraphLink={this.showOnGraphLink(app.name, app.namespace)}
         items={
           <>
             <Row>

--- a/src/pages/AppDetails/AppInfo/AppDescription.tsx
+++ b/src/pages/AppDetails/AppInfo/AppDescription.tsx
@@ -134,7 +134,9 @@ class AppDescription extends React.Component<AppDescriptionProps, AppDescription
           <>
             {app.name && (
               <Row>
-                <Link to={this.showOnGraphLink(app.name)}>Show on graph</Link>
+                <Col xs={12} sm={6} md={4} lg={4}>
+                  <Link to={this.showOnGraphLink(app.name)}>Show on graph</Link>
+                </Col>
               </Row>
             )}
             <Row>

--- a/src/pages/AppDetails/AppInfo/AppDescription.tsx
+++ b/src/pages/AppDetails/AppInfo/AppDescription.tsx
@@ -31,8 +31,12 @@ class AppDescription extends React.Component<AppDescriptionProps, AppDescription
   }
 
   showOnGraphLink(application: string) {
-    return `/graph/namespaces?graphType=workload&injectServiceNodes=true&unusedNodes=true&focusSelector=${encodeURI(
-      new CytoscapeGraphSelectorBuilder().app(application).build()
+    return `/graph/namespaces?graphType=app&injectServiceNodes=true&unusedNodes=true&focusSelector=${encodeURI(
+      new CytoscapeGraphSelectorBuilder()
+        .app(application)
+        .nodeType('app')
+        .isGroup(null)
+        .build()
     )}`;
   }
 
@@ -133,15 +137,9 @@ class AppDescription extends React.Component<AppDescriptionProps, AppDescription
         iconName="applications"
         title={app.name}
         istio={istioSidecar}
+        showOnGraphLink={this.showOnGraphLink(app.name)}
         items={
           <>
-            {app && istioSidecar && (
-              <Row>
-                <Col xs={12} sm={6} md={4} lg={4}>
-                  <Link to={this.showOnGraphLink(app.name)}>Show on graph</Link>
-                </Col>
-              </Row>
-            )}
             <Row>
               <Col xs={12} sm={6} md={4} lg={4}>
                 <ListView>{this.workloadList()}</ListView>

--- a/src/pages/AppDetails/AppInfo/AppDescription.tsx
+++ b/src/pages/AppDetails/AppInfo/AppDescription.tsx
@@ -132,9 +132,11 @@ class AppDescription extends React.Component<AppDescriptionProps, AppDescription
         istio={this.istioSidecar()}
         items={
           <>
-            <Row>
-              <Link to={this.showOnGraphLink(app.name)}>Show on graph</Link>
-            </Row>
+            {app.name && (
+              <Row>
+                <Link to={this.showOnGraphLink(app.name)}>Show on graph</Link>
+              </Row>
+            )}
             <Row>
               <Col xs={12} sm={6} md={4} lg={4}>
                 <ListView>{this.workloadList()}</ListView>

--- a/src/pages/AppDetails/AppInfo/AppDescription.tsx
+++ b/src/pages/AppDetails/AppInfo/AppDescription.tsx
@@ -7,7 +7,6 @@ import { AppHealth } from '../../../types/Health';
 import { App, AppWorkload } from '../../../types/App';
 import { WorkloadIcon } from '../../../types/Workload';
 import { Link } from 'react-router-dom';
-import { encode } from 'punycode';
 import { CytoscapeGraphSelectorBuilder } from '../../../components/CytoscapeGraph/CytoscapeGraphSelector';
 
 type AppDescriptionProps = {
@@ -32,7 +31,7 @@ class AppDescription extends React.Component<AppDescriptionProps, AppDescription
   }
 
   showOnGraphLink(application: string) {
-    return `/graph/namespaces?focusSelector=${encode(new CytoscapeGraphSelectorBuilder().app(application).build())}`;
+    return `/graph/namespaces?focusSelector=${encodeURI(new CytoscapeGraphSelectorBuilder().app(application).build())}`;
   }
 
   serviceLink(namespace: string, service: string) {

--- a/src/pages/AppDetails/AppInfo/AppDescription.tsx
+++ b/src/pages/AppDetails/AppInfo/AppDescription.tsx
@@ -7,6 +7,8 @@ import { AppHealth } from '../../../types/Health';
 import { App, AppWorkload } from '../../../types/App';
 import { WorkloadIcon } from '../../../types/Workload';
 import { Link } from 'react-router-dom';
+import { encode } from 'punycode';
+import { CytoscapeGraphSelectorBuilder } from '../../../components/CytoscapeGraph/CytoscapeGraphSelector';
 
 type AppDescriptionProps = {
   app: App;
@@ -27,6 +29,10 @@ class AppDescription extends React.Component<AppDescriptionProps, AppDescription
       istioSidecar = istioSidecar && wkd.istioSidecar;
     });
     return istioSidecar;
+  }
+
+  showOnGraphLink(application: string) {
+    return `/graph/namespaces?focusSelector=${encode(new CytoscapeGraphSelectorBuilder().app(application).build())}`;
   }
 
   serviceLink(namespace: string, service: string) {
@@ -126,26 +132,31 @@ class AppDescription extends React.Component<AppDescriptionProps, AppDescription
         title={app.name}
         istio={this.istioSidecar()}
         items={
-          <Row>
-            <Col xs={12} sm={6} md={4} lg={4}>
-              <ListView>{this.workloadList()}</ListView>
-            </Col>
-            <Col xs={12} sm={6} md={4} lg={4}>
-              <ListView>{this.serviceList()}</ListView>
-            </Col>
-            <Col xs={0} sm={0} md={1} lg={1} />
-            <Col xs={12} sm={6} md={3} lg={3}>
-              <div className="progress-description">
-                <strong>Health</strong>
-              </div>
-              <HealthIndicator
-                id={app.name}
-                health={this.props.health}
-                mode={DisplayMode.LARGE}
-                tooltipPlacement="left"
-              />
-            </Col>
-          </Row>
+          <>
+            <Row>
+              <Link to={this.showOnGraphLink(app.name)}>Show on graph</Link>
+            </Row>
+            <Row>
+              <Col xs={12} sm={6} md={4} lg={4}>
+                <ListView>{this.workloadList()}</ListView>
+              </Col>
+              <Col xs={12} sm={6} md={4} lg={4}>
+                <ListView>{this.serviceList()}</ListView>
+              </Col>
+              <Col xs={0} sm={0} md={1} lg={1} />
+              <Col xs={12} sm={6} md={3} lg={3}>
+                <div className="progress-description">
+                  <strong>Health</strong>
+                </div>
+                <HealthIndicator
+                  id={app.name}
+                  health={this.props.health}
+                  mode={DisplayMode.LARGE}
+                  tooltipPlacement="left"
+                />
+              </Col>
+            </Row>
+          </>
         }
       />
     ) : (

--- a/src/pages/AppDetails/AppInfo/AppDescription.tsx
+++ b/src/pages/AppDetails/AppInfo/AppDescription.tsx
@@ -8,6 +8,7 @@ import { App, AppWorkload } from '../../../types/App';
 import { WorkloadIcon } from '../../../types/Workload';
 import { Link } from 'react-router-dom';
 import { CytoscapeGraphSelectorBuilder } from '../../../components/CytoscapeGraph/CytoscapeGraphSelector';
+import { NodeType } from '../../../types/Graph';
 
 type AppDescriptionProps = {
   app: App;
@@ -34,7 +35,7 @@ class AppDescription extends React.Component<AppDescriptionProps, AppDescription
     return `/graph/namespaces?graphType=app&injectServiceNodes=true&unusedNodes=true&focusSelector=${encodeURI(
       new CytoscapeGraphSelectorBuilder()
         .app(application)
-        .nodeType('app')
+        .nodeType(NodeType.APP)
         .isGroup(null)
         .build()
     )}`;

--- a/src/pages/Graph/GraphPage.tsx
+++ b/src/pages/Graph/GraphPage.tsx
@@ -21,7 +21,7 @@ import EmptyGraphLayoutContainer from '../../containers/EmptyGraphLayoutContaine
 import SummaryPanel from './SummaryPanel';
 import graphHelp from './GraphHelpTour';
 import { arrayEquals } from '../../utils/Common';
-import { isKioskMode } from '../../utils/SearchParamUtils';
+import { getFocusSelector, isKioskMode } from '../../utils/SearchParamUtils';
 
 // GraphURLPathProps holds path variable values.  Currenly all path variables are relevant only to a node graph
 type GraphURLPathProps = {
@@ -280,6 +280,7 @@ export default class GraphPage extends React.Component<GraphPageProps, GraphPage
     if (isKioskMode()) {
       conStyle = kioskContainerStyle;
     }
+    const focusSelector = getFocusSelector();
     return (
       <>
         <StatefulTour steps={graphHelp} isOpen={this.state.showHelp} onClose={this.toggleHelp} />
@@ -322,6 +323,7 @@ export default class GraphPage extends React.Component<GraphPageProps, GraphPage
                 containerClassName={cytoscapeGraphContainerStyle}
                 ref={refInstance => this.setCytoscapeGraph(refInstance)}
                 isMTLSEnabled={this.props.mtlsEnabled}
+                focusSelector={focusSelector}
               />
               {this.props.graphData.nodes && Object.keys(this.props.graphData.nodes).length > 0 && !this.props.isError && (
                 <div className={cytoscapeToolbarWrapperDivStyle}>

--- a/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -144,6 +144,7 @@ class ServiceInfo extends React.Component<ServiceDetails, ServiceInfoState> {
             <Col xs={12} sm={12} md={12} lg={12}>
               <ServiceInfoDescription
                 name={this.props.serviceDetails.service.name}
+                namespace={this.props.namespace}
                 createdAt={this.props.serviceDetails.service.createdAt}
                 resourceVersion={this.props.serviceDetails.service.resourceVersion}
                 istioEnabled={this.props.serviceDetails.istioSidecar}

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
@@ -79,9 +79,11 @@ class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps
               <div>
                 <strong>Resource Version</strong> {this.props.resourceVersion}
               </div>
-              <div>
-                <Link to={this.showOnGraphLink(this.props.name)}>Show on graph</Link>
-              </div>
+              {this.props.name && (
+                <div>
+                  <Link to={this.showOnGraphLink(this.props.name)}>Show on graph</Link>
+                </div>
+              )}
             </Col>
             <Col xs={12} sm={4} md={2} lg={2}>
               <div className="progress-description">

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
@@ -14,6 +14,7 @@ import { CytoscapeGraphSelectorBuilder } from '../../../components/CytoscapeGrap
 
 interface ServiceInfoDescriptionProps {
   name: string;
+  namespace: string;
   createdAt: string;
   resourceVersion: string;
   istioEnabled?: boolean;
@@ -38,9 +39,12 @@ class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps
     super(props);
   }
 
-  showOnGraphLink(serviceName: string) {
+  showOnGraphLink(serviceName: string, namespace: string) {
     return `/graph/namespaces?graphType=service&injectServiceNodes=true&unusedNodes=true&focusSelector=${encodeURI(
-      new CytoscapeGraphSelectorBuilder().service(serviceName).build()
+      new CytoscapeGraphSelectorBuilder()
+        .service(serviceName)
+        .namespace(namespace)
+        .build()
     )}`;
   }
 
@@ -51,7 +55,7 @@ class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps
         iconName="service"
         title={this.props.name}
         istio={this.props.istioEnabled}
-        showOnGraphLink={this.showOnGraphLink(this.props.name)}
+        showOnGraphLink={this.showOnGraphLink(this.props.name, this.props.namespace)}
         items={
           <Row>
             <Col xs={12} sm={6} md={5} lg={5}>

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
@@ -11,7 +11,6 @@ import { style } from 'typestyle';
 import './ServiceInfoDescription.css';
 import Labels from '../../../components/Label/Labels';
 import { Link } from 'react-router-dom';
-import { encode } from 'punycode';
 import { CytoscapeGraphSelectorBuilder } from '../../../components/CytoscapeGraph/CytoscapeGraphSelector';
 
 interface ServiceInfoDescriptionProps {
@@ -41,7 +40,7 @@ class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps
   }
 
   showOnGraphLink(serviceName: string) {
-    return `/graph/namespaces?focusSelector=${encode(
+    return `/graph/namespaces?focusSelector=${encodeURI(
       new CytoscapeGraphSelectorBuilder().service(serviceName).build()
     )}`;
   }

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
@@ -40,7 +40,7 @@ class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps
   }
 
   showOnGraphLink(serviceName: string) {
-    return `/graph/namespaces?focusSelector=${encodeURI(
+    return `/graph/namespaces?graphType=workload&injectServiceNodes=true&unusedNodes=true&focusSelector=${encodeURI(
       new CytoscapeGraphSelectorBuilder().service(serviceName).build()
     )}`;
   }
@@ -79,7 +79,7 @@ class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps
               <div>
                 <strong>Resource Version</strong> {this.props.resourceVersion}
               </div>
-              {this.props.name && (
+              {this.props.name && this.props.istioEnabled && (
                 <div>
                   <Link to={this.showOnGraphLink(this.props.name)}>Show on graph</Link>
                 </div>

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
@@ -10,7 +10,6 @@ import { style } from 'typestyle';
 
 import './ServiceInfoDescription.css';
 import Labels from '../../../components/Label/Labels';
-import { Link } from 'react-router-dom';
 import { CytoscapeGraphSelectorBuilder } from '../../../components/CytoscapeGraph/CytoscapeGraphSelector';
 
 interface ServiceInfoDescriptionProps {
@@ -40,7 +39,7 @@ class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps
   }
 
   showOnGraphLink(serviceName: string) {
-    return `/graph/namespaces?graphType=workload&injectServiceNodes=true&unusedNodes=true&focusSelector=${encodeURI(
+    return `/graph/namespaces?graphType=service&injectServiceNodes=true&unusedNodes=true&focusSelector=${encodeURI(
       new CytoscapeGraphSelectorBuilder().service(serviceName).build()
     )}`;
   }
@@ -52,6 +51,7 @@ class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps
         iconName="service"
         title={this.props.name}
         istio={this.props.istioEnabled}
+        showOnGraphLink={this.showOnGraphLink(this.props.name)}
         items={
           <Row>
             <Col xs={12} sm={6} md={5} lg={5}>
@@ -79,11 +79,6 @@ class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps
               <div>
                 <strong>Resource Version</strong> {this.props.resourceVersion}
               </div>
-              {this.props.name && this.props.istioEnabled && (
-                <div>
-                  <Link to={this.showOnGraphLink(this.props.name)}>Show on graph</Link>
-                </div>
-              )}
             </Col>
             <Col xs={12} sm={4} md={2} lg={2}>
               <div className="progress-description">

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
@@ -10,6 +10,9 @@ import { style } from 'typestyle';
 
 import './ServiceInfoDescription.css';
 import Labels from '../../../components/Label/Labels';
+import { Link } from 'react-router-dom';
+import { encode } from 'punycode';
+import { CytoscapeGraphSelectorBuilder } from '../../../components/CytoscapeGraph/CytoscapeGraphSelector';
 
 interface ServiceInfoDescriptionProps {
   name: string;
@@ -35,6 +38,12 @@ const ExternalNameType = 'ExternalName';
 class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps> {
   constructor(props: ServiceInfoDescriptionProps) {
     super(props);
+  }
+
+  showOnGraphLink(serviceName: string) {
+    return `/graph/namespaces?focusSelector=${encode(
+      new CytoscapeGraphSelectorBuilder().service(serviceName).build()
+    )}`;
   }
 
   render() {
@@ -70,6 +79,9 @@ class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps
               </div>
               <div>
                 <strong>Resource Version</strong> {this.props.resourceVersion}
+              </div>
+              <div>
+                <Link to={this.showOnGraphLink(this.props.name)}>Show on graph</Link>
               </div>
             </Col>
             <Col xs={12} sm={4} md={2} lg={2}>

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/ServiceInfoDescription.test.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/ServiceInfoDescription.test.tsx
@@ -38,6 +38,7 @@ describe('#ServiceInfoDescription render correctly with data', () => {
     const wrapper = shallow(
       <ServiceInfoDescription
         name="reviews"
+        namespace="my-namespace"
         labels={labels}
         type="ClusterIP"
         ip="172.30.78.33"

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
@@ -121,14 +121,6 @@ ShallowWrapper {
              
             1234
           </div>
-          <div>
-            <Link
-              replace={false}
-              to="/graph/namespaces?focusSelector=node%5Bservice=%22reviews%22%5D"
-            >
-              Show on graph
-            </Link>
-          </div>
         </Col>
         <Col
           bsClass="col"
@@ -304,14 +296,6 @@ ShallowWrapper {
               </strong>
                
               1234
-            </div>
-            <div>
-              <Link
-                replace={false}
-                to="/graph/namespaces?focusSelector=node%5Bservice=%22reviews%22%5D"
-              >
-                Show on graph
-              </Link>
             </div>
           </Col>
           <Col

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
@@ -222,6 +222,7 @@ ShallowWrapper {
           />
         </Col>
       </Row>,
+      "showOnGraphLink": "/graph/namespaces?graphType=service&injectServiceNodes=true&unusedNodes=true&focusSelector=node%5Bservice=%22reviews%22%5D",
       "title": "reviews",
     },
     "ref": null,
@@ -398,6 +399,7 @@ ShallowWrapper {
             />
           </Col>
         </Row>,
+        "showOnGraphLink": "/graph/namespaces?graphType=service&injectServiceNodes=true&unusedNodes=true&focusSelector=node%5Bservice=%22reviews%22%5D",
         "title": "reviews",
       },
       "ref": null,

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
@@ -42,6 +42,7 @@ ShallowWrapper {
       }
     }
     name="reviews"
+    namespace="my-namespace"
     resourceVersion="1234"
     type="ClusterIP"
   />,
@@ -222,7 +223,7 @@ ShallowWrapper {
           />
         </Col>
       </Row>,
-      "showOnGraphLink": "/graph/namespaces?graphType=service&injectServiceNodes=true&unusedNodes=true&focusSelector=node%5Bservice=%22reviews%22%5D",
+      "showOnGraphLink": "/graph/namespaces?graphType=service&injectServiceNodes=true&unusedNodes=true&focusSelector=node%5Bservice=%22reviews%22%5D%5Bnamespace=%22my-namespace%22%5D",
       "title": "reviews",
     },
     "ref": null,
@@ -399,7 +400,7 @@ ShallowWrapper {
             />
           </Col>
         </Row>,
-        "showOnGraphLink": "/graph/namespaces?graphType=service&injectServiceNodes=true&unusedNodes=true&focusSelector=node%5Bservice=%22reviews%22%5D",
+        "showOnGraphLink": "/graph/namespaces?graphType=service&injectServiceNodes=true&unusedNodes=true&focusSelector=node%5Bservice=%22reviews%22%5D%5Bnamespace=%22my-namespace%22%5D",
         "title": "reviews",
       },
       "ref": null,

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
@@ -124,7 +124,7 @@ ShallowWrapper {
           <div>
             <Link
               replace={false}
-              to="/graph/namespaces?focusSelector=node[service=\\"reviews\\"]-"
+              to="/graph/namespaces?focusSelector=node%5Bservice=%22reviews%22%5D"
             >
               Show on graph
             </Link>
@@ -308,7 +308,7 @@ ShallowWrapper {
             <div>
               <Link
                 replace={false}
-                to="/graph/namespaces?focusSelector=node[service=\\"reviews\\"]-"
+                to="/graph/namespaces?focusSelector=node%5Bservice=%22reviews%22%5D"
               >
                 Show on graph
               </Link>

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
@@ -121,6 +121,14 @@ ShallowWrapper {
              
             1234
           </div>
+          <div>
+            <Link
+              replace={false}
+              to="/graph/namespaces?focusSelector=node[service=\\"reviews\\"]-"
+            >
+              Show on graph
+            </Link>
+          </div>
         </Col>
         <Col
           bsClass="col"
@@ -296,6 +304,14 @@ ShallowWrapper {
               </strong>
                
               1234
+            </div>
+            <div>
+              <Link
+                replace={false}
+                to="/graph/namespaces?focusSelector=node[service=\\"reviews\\"]-"
+              >
+                Show on graph
+              </Link>
             </div>
           </Col>
           <Col

--- a/src/pages/ServiceDetails/__tests__/__snapshots__/ServiceInfo.test.tsx.snap
+++ b/src/pages/ServiceDetails/__tests__/__snapshots__/ServiceInfo.test.tsx.snap
@@ -396,6 +396,7 @@ ShallowWrapper {
                   }
                 }
                 name="reviews"
+                namespace="istio-system"
                 ports={
                   Array [
                     Object {
@@ -780,6 +781,7 @@ ShallowWrapper {
                     }
                   }
                   name="reviews"
+                  namespace="istio-system"
                   ports={
                     Array [
                       Object {
@@ -1528,6 +1530,7 @@ ShallowWrapper {
                     }
                   }
                   name="reviews"
+                  namespace="istio-system"
                   ports={
                     Array [
                       Object {
@@ -1593,6 +1596,7 @@ ShallowWrapper {
                     }
                   }
                   name="reviews"
+                  namespace="istio-system"
                   ports={
                     Array [
                       Object {
@@ -1654,6 +1658,7 @@ ShallowWrapper {
                     "app": "reviews",
                   },
                   "name": "reviews",
+                  "namespace": "istio-system",
                   "ports": Array [
                     Object {
                       "name": "http",
@@ -3081,6 +3086,7 @@ ShallowWrapper {
                     }
                   }
                   name="reviews"
+                  namespace="istio-system"
                   ports={
                     Array [
                       Object {
@@ -3465,6 +3471,7 @@ ShallowWrapper {
                       }
                     }
                     name="reviews"
+                    namespace="istio-system"
                     ports={
                       Array [
                         Object {
@@ -4213,6 +4220,7 @@ ShallowWrapper {
                       }
                     }
                     name="reviews"
+                    namespace="istio-system"
                     ports={
                       Array [
                         Object {
@@ -4278,6 +4286,7 @@ ShallowWrapper {
                       }
                     }
                     name="reviews"
+                    namespace="istio-system"
                     ports={
                       Array [
                         Object {
@@ -4339,6 +4348,7 @@ ShallowWrapper {
                       "app": "reviews",
                     },
                     "name": "reviews",
+                    "namespace": "istio-system",
                     "ports": Array [
                       Object {
                         "name": "http",

--- a/src/pages/WorkloadDetails/WorkloadInfo.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo.tsx
@@ -92,6 +92,7 @@ class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInfoState>
             <Col xs={12} sm={12} md={12} lg={12}>
               <WorkloadDescription
                 workload={workload}
+                namespace={this.props.namespace}
                 istioEnabled={this.props.istioEnabled}
                 health={this.props.health}
               />

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadDescription.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadDescription.tsx
@@ -33,7 +33,7 @@ class WorkloadDescription extends React.Component<WorkloadDescriptionProps, Work
   }
 
   showOnGraphLink(workloadName: string) {
-    return `/graph/namespaces?focusSelector=${encodeURI(
+    return `/graph/namespaces?graphType=workload&injectServiceNodes=true&unusedNodes=true&focusSelector=${encodeURI(
       new CytoscapeGraphSelectorBuilder().workload(workloadName).build()
     )}`;
   }
@@ -80,7 +80,7 @@ class WorkloadDescription extends React.Component<WorkloadDescriptionProps, Work
                     )}
                 </div>
               )}
-              {workload && (
+              {workload && this.props.istioEnabled && (
                 <div>
                   <Link to={this.showOnGraphLink(this.props.workload.name)}>Show on graph</Link>
                 </div>

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadDescription.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadDescription.tsx
@@ -9,7 +9,6 @@ import { runtimesLogoProviders } from '../../../config/Logos';
 import Labels from '../../../components/Label/Labels';
 import { Link } from 'react-router-dom';
 import { CytoscapeGraphSelectorBuilder } from '../../../components/CytoscapeGraph/CytoscapeGraphSelector';
-import { encode } from 'punycode';
 
 type WorkloadDescriptionProps = {
   workload: Workload;
@@ -34,7 +33,7 @@ class WorkloadDescription extends React.Component<WorkloadDescriptionProps, Work
   }
 
   showOnGraphLink(workloadName: string) {
-    return `/graph/namespaces?focusSelector=${encode(
+    return `/graph/namespaces?focusSelector=${encodeURI(
       new CytoscapeGraphSelectorBuilder().workload(workloadName).build()
     )}`;
   }

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadDescription.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadDescription.tsx
@@ -11,6 +11,7 @@ import { CytoscapeGraphSelectorBuilder } from '../../../components/CytoscapeGrap
 
 type WorkloadDescriptionProps = {
   workload: Workload;
+  namespace: string;
   istioEnabled: boolean;
   health?: WorkloadHealth;
 };
@@ -31,9 +32,12 @@ class WorkloadDescription extends React.Component<WorkloadDescriptionProps, Work
     return <span key={'runtime-' + idx}>{name}</span>;
   }
 
-  showOnGraphLink(workloadName: string) {
+  showOnGraphLink(workloadName: string, namespace: string) {
     return `/graph/namespaces?graphType=workload&injectServiceNodes=true&unusedNodes=true&focusSelector=${encodeURI(
-      new CytoscapeGraphSelectorBuilder().workload(workloadName).build()
+      new CytoscapeGraphSelectorBuilder()
+        .workload(workloadName)
+        .namespace(namespace)
+        .build()
     )}`;
   }
 
@@ -49,7 +53,7 @@ class WorkloadDescription extends React.Component<WorkloadDescriptionProps, Work
         iconName={WorkloadIcon}
         title={workload.name}
         istio={this.props.istioEnabled}
-        showOnGraphLink={this.showOnGraphLink(this.props.workload.name)}
+        showOnGraphLink={this.showOnGraphLink(this.props.workload.name, this.props.namespace)}
         items={
           <Row>
             <Col xs={12} sm={8} md={6} lg={6}>

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadDescription.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadDescription.tsx
@@ -7,7 +7,6 @@ import { DisplayMode, HealthIndicator } from '../../../components/Health/HealthI
 import { WorkloadHealth } from '../../../types/Health';
 import { runtimesLogoProviders } from '../../../config/Logos';
 import Labels from '../../../components/Label/Labels';
-import { Link } from 'react-router-dom';
 import { CytoscapeGraphSelectorBuilder } from '../../../components/CytoscapeGraph/CytoscapeGraphSelector';
 
 type WorkloadDescriptionProps = {
@@ -50,6 +49,7 @@ class WorkloadDescription extends React.Component<WorkloadDescriptionProps, Work
         iconName={WorkloadIcon}
         title={workload.name}
         istio={this.props.istioEnabled}
+        showOnGraphLink={this.showOnGraphLink(this.props.workload.name)}
         items={
           <Row>
             <Col xs={12} sm={8} md={6} lg={6}>
@@ -78,11 +78,6 @@ class WorkloadDescription extends React.Component<WorkloadDescriptionProps, Work
                       (list: JSX.Element[], elem) => (list ? [...list, <span key="sep"> | </span>, elem] : [elem]),
                       undefined
                     )}
-                </div>
-              )}
-              {workload && this.props.istioEnabled && (
-                <div>
-                  <Link to={this.showOnGraphLink(this.props.workload.name)}>Show on graph</Link>
                 </div>
               )}
             </Col>

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadDescription.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadDescription.tsx
@@ -7,6 +7,9 @@ import { DisplayMode, HealthIndicator } from '../../../components/Health/HealthI
 import { WorkloadHealth } from '../../../types/Health';
 import { runtimesLogoProviders } from '../../../config/Logos';
 import Labels from '../../../components/Label/Labels';
+import { Link } from 'react-router-dom';
+import { CytoscapeGraphSelectorBuilder } from '../../../components/CytoscapeGraph/CytoscapeGraphSelector';
+import { encode } from 'punycode';
 
 type WorkloadDescriptionProps = {
   workload: Workload;
@@ -28,6 +31,12 @@ class WorkloadDescription extends React.Component<WorkloadDescriptionProps, Work
       return <img key={'logo-' + idx} src={logoProvider()} alt={name} title={name} />;
     }
     return <span key={'runtime-' + idx}>{name}</span>;
+  }
+
+  showOnGraphLink(workloadName: string) {
+    return `/graph/namespaces?focusSelector=${encode(
+      new CytoscapeGraphSelectorBuilder().workload(workloadName).build()
+    )}`;
   }
 
   render() {
@@ -72,6 +81,9 @@ class WorkloadDescription extends React.Component<WorkloadDescriptionProps, Work
                     )}
                 </div>
               )}
+              <div>
+                <Link to={this.showOnGraphLink(this.props.workload.name)}>Show on graph</Link>
+              </div>
             </Col>
             <Col xs={12} sm={4} md={3} lg={3} />
             <Col xs={12} sm={4} md={3} lg={3}>

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadDescription.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadDescription.tsx
@@ -80,9 +80,11 @@ class WorkloadDescription extends React.Component<WorkloadDescriptionProps, Work
                     )}
                 </div>
               )}
-              <div>
-                <Link to={this.showOnGraphLink(this.props.workload.name)}>Show on graph</Link>
-              </div>
+              {workload && (
+                <div>
+                  <Link to={this.showOnGraphLink(this.props.workload.name)}>Show on graph</Link>
+                </div>
+              )}
             </Col>
             <Col xs={12} sm={4} md={3} lg={3} />
             <Col xs={12} sm={4} md={3} lg={3}>

--- a/src/pages/WorkloadDetails/WorkloadInfo/__tests__/WorkloadDescription.test.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/__tests__/WorkloadDescription.test.tsx
@@ -30,7 +30,9 @@ const workload: Workload = {
 
 describe('WorkloadDescription', () => {
   it('should render with runtimes', () => {
-    const wrapper = shallow(<WorkloadDescription workload={workload} istioEnabled={false} />);
+    const wrapper = shallow(
+      <WorkloadDescription workload={workload} namespace={'my-namespace'} istioEnabled={false} />
+    );
     expect(wrapper).toMatchSnapshot();
   });
 });

--- a/src/pages/WorkloadDetails/WorkloadInfo/__tests__/__snapshots__/WorkloadDescription.test.tsx.snap
+++ b/src/pages/WorkloadDetails/WorkloadInfo/__tests__/__snapshots__/WorkloadDescription.test.tsx.snap
@@ -111,14 +111,6 @@ ShallowWrapper {
               42
             </span>
           </div>
-          <div>
-            <Link
-              replace={false}
-              to="/graph/namespaces?focusSelector=node%5Bworkload=%22myworkload%22%5D"
-            >
-              Show on graph
-            </Link>
-          </div>
         </Col>
         <Col
           bsClass="col"
@@ -228,14 +220,6 @@ ShallowWrapper {
               <span>
                 42
               </span>
-            </div>
-            <div>
-              <Link
-                replace={false}
-                to="/graph/namespaces?focusSelector=node%5Bworkload=%22myworkload%22%5D"
-              >
-                Show on graph
-              </Link>
             </div>
           </Col>
           <Col

--- a/src/pages/WorkloadDetails/WorkloadInfo/__tests__/__snapshots__/WorkloadDescription.test.tsx.snap
+++ b/src/pages/WorkloadDetails/WorkloadInfo/__tests__/__snapshots__/WorkloadDescription.test.tsx.snap
@@ -111,6 +111,14 @@ ShallowWrapper {
               42
             </span>
           </div>
+          <div>
+            <Link
+              replace={false}
+              to="/graph/namespaces?focusSelector=node[workload=\\"myworkload\\"]-"
+            >
+              Show on graph
+            </Link>
+          </div>
         </Col>
         <Col
           bsClass="col"
@@ -220,6 +228,14 @@ ShallowWrapper {
               <span>
                 42
               </span>
+            </div>
+            <div>
+              <Link
+                replace={false}
+                to="/graph/namespaces?focusSelector=node[workload=\\"myworkload\\"]-"
+              >
+                Show on graph
+              </Link>
             </div>
           </Col>
           <Col

--- a/src/pages/WorkloadDetails/WorkloadInfo/__tests__/__snapshots__/WorkloadDescription.test.tsx.snap
+++ b/src/pages/WorkloadDetails/WorkloadInfo/__tests__/__snapshots__/WorkloadDescription.test.tsx.snap
@@ -5,6 +5,7 @@ ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <WorkloadDescription
     istioEnabled={false}
+    namespace="my-namespace"
     workload={
       Object {
         "appLabel": false,
@@ -143,7 +144,7 @@ ShallowWrapper {
           />
         </Col>
       </Row>,
-      "showOnGraphLink": "/graph/namespaces?graphType=workload&injectServiceNodes=true&unusedNodes=true&focusSelector=node%5Bworkload=%22myworkload%22%5D",
+      "showOnGraphLink": "/graph/namespaces?graphType=workload&injectServiceNodes=true&unusedNodes=true&focusSelector=node%5Bworkload=%22myworkload%22%5D%5Bnamespace=%22my-namespace%22%5D",
       "title": "myworkload",
     },
     "ref": null,
@@ -254,7 +255,7 @@ ShallowWrapper {
             />
           </Col>
         </Row>,
-        "showOnGraphLink": "/graph/namespaces?graphType=workload&injectServiceNodes=true&unusedNodes=true&focusSelector=node%5Bworkload=%22myworkload%22%5D",
+        "showOnGraphLink": "/graph/namespaces?graphType=workload&injectServiceNodes=true&unusedNodes=true&focusSelector=node%5Bworkload=%22myworkload%22%5D%5Bnamespace=%22my-namespace%22%5D",
         "title": "myworkload",
       },
       "ref": null,

--- a/src/pages/WorkloadDetails/WorkloadInfo/__tests__/__snapshots__/WorkloadDescription.test.tsx.snap
+++ b/src/pages/WorkloadDetails/WorkloadInfo/__tests__/__snapshots__/WorkloadDescription.test.tsx.snap
@@ -143,6 +143,7 @@ ShallowWrapper {
           />
         </Col>
       </Row>,
+      "showOnGraphLink": "/graph/namespaces?graphType=workload&injectServiceNodes=true&unusedNodes=true&focusSelector=node%5Bworkload=%22myworkload%22%5D",
       "title": "myworkload",
     },
     "ref": null,
@@ -253,6 +254,7 @@ ShallowWrapper {
             />
           </Col>
         </Row>,
+        "showOnGraphLink": "/graph/namespaces?graphType=workload&injectServiceNodes=true&unusedNodes=true&focusSelector=node%5Bworkload=%22myworkload%22%5D",
         "title": "myworkload",
       },
       "ref": null,

--- a/src/pages/WorkloadDetails/WorkloadInfo/__tests__/__snapshots__/WorkloadDescription.test.tsx.snap
+++ b/src/pages/WorkloadDetails/WorkloadInfo/__tests__/__snapshots__/WorkloadDescription.test.tsx.snap
@@ -114,7 +114,7 @@ ShallowWrapper {
           <div>
             <Link
               replace={false}
-              to="/graph/namespaces?focusSelector=node[workload=\\"myworkload\\"]-"
+              to="/graph/namespaces?focusSelector=node%5Bworkload=%22myworkload%22%5D"
             >
               Show on graph
             </Link>
@@ -232,7 +232,7 @@ ShallowWrapper {
             <div>
               <Link
                 replace={false}
-                to="/graph/namespaces?focusSelector=node[workload=\\"myworkload\\"]-"
+                to="/graph/namespaces?focusSelector=node%5Bworkload=%22myworkload%22%5D"
               >
                 Show on graph
               </Link>

--- a/src/reducers/GraphDataState.ts
+++ b/src/reducers/GraphDataState.ts
@@ -108,6 +108,9 @@ const graphDataState = (state: GraphState = INITIAL_GRAPH_STATE, action: KialiAp
     case getType(GraphFilterActions.setHideValue):
       newState.filterState.hideValue = action.payload;
       break;
+    case getType(GraphFilterActions.setShowUnusedNodes):
+      newState.filterState.showUnusedNodes = action.payload;
+      break;
     case getType(GraphFilterActions.toggleFindHelp):
       newState.filterState.showFindHelp = !state.filterState.showFindHelp;
       break;

--- a/src/store/Selectors.ts
+++ b/src/store/Selectors.ts
@@ -61,6 +61,10 @@ const showServiceNodes = (state: KialiAppState) => state.graph.filterState.showS
 
 export const showServiceNodesSelector = createIdentitySelector(showServiceNodes);
 
+const showUnusedNodes = (state: KialiAppState) => state.graph.filterState.showUnusedNodes;
+
+export const showUnusedNodesSelector = createIdentitySelector(showUnusedNodes);
+
 export const graphDataSelector = GraphData.graphDataSelector;
 
 const meshwideMTLSStatus = (state: KialiAppState) => state.statusState.status['Istio mTLS'];

--- a/src/utils/SearchParamUtils.ts
+++ b/src/utils/SearchParamUtils.ts
@@ -2,3 +2,7 @@ export const isKioskMode = () => {
   const urlParams = new URLSearchParams(window.location.search);
   return urlParams.get('kiosk') === 'true';
 };
+
+export const getFocusSelector = () => {
+  return new URLSearchParams(window.location.search).get('focusSelector') || undefined;
+};


### PR DESCRIPTION
 - This focus on the desired element, centering it on the resulting graph

** Describe the change **

It adds a link on the detail page of app/workload/service to "show on graph" the element.
It does that by going to the graph page and focusing (currently only centers the view on the element(s))

Probably a visual cue is needed aside of just centering the graph on the nodes.

** Screenshot **

![show-in-graph-2](https://user-images.githubusercontent.com/3845764/56840795-2f7df600-684f-11e9-8929-51215bbc9ae4.gif)

//cc: @pilhuhn 
