### PR TITLE
KIALI-2138 Show type in confirmation when deleting Istio Objects

### DIFF
--- a/src/components/IstioActions/IstioActionsDropdown.tsx
+++ b/src/components/IstioActions/IstioActionsDropdown.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { DropdownButton, MenuItem, MessageDialog } from 'patternfly-react';
 
 type Props = {
+  objectKind?: string;
   objectName: string;
   canDelete: boolean;
   onDelete: () => void;
@@ -33,6 +34,8 @@ class IstioActionDropdown extends React.Component<Props, State> {
   };
 
   render() {
+    const objectName = this.props.objectKind ? this.props.objectKind : 'Istio object';
+
     return (
       <>
         <DropdownButton id="actions" title="Actions" onSelect={this.onAction} pullRight={true}>
@@ -49,7 +52,7 @@ class IstioActionDropdown extends React.Component<Props, State> {
           secondaryActionButtonContent="Cancel"
           primaryActionButtonBsStyle="danger"
           title="Confirm Delete"
-          primaryContent={`Are you sure you want to delete the Istio object '${this.props.objectName}'? `}
+          primaryContent={`Are you sure you want to delete the ${objectName} '${this.props.objectName}'? `}
           secondaryContent="It cannot be undone. Make sure this is something you really want to do!"
           accessibleName="deleteConfirmationDialog"
           accessibleDescription="deleteConfirmationDialogContent"

--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -194,12 +194,8 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
     }
   };
 
-  fetchYaml = () => {
+  getIstioObject = () => {
     let istioObject: IstioObject | undefined;
-    if (this.state.isModified) {
-      return this.state.yamlModified;
-    }
-
     if (this.state.istioObjectDetails) {
       if (this.state.istioObjectDetails.gateway) {
         istioObject = this.state.istioObjectDetails.gateway;
@@ -233,6 +229,14 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
         istioObject = this.state.istioObjectDetails.serviceRoleBinding;
       }
     }
+    return istioObject;
+  };
+
+  fetchYaml = () => {
+    if (this.state.isModified) {
+      return this.state.yamlModified;
+    }
+    const istioObject = this.getIstioObject();
     return istioObject ? jsYaml.safeDump(istioObject, safeDumpOptions) : '';
   };
 
@@ -295,9 +299,12 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
 
   renderRightToolbar = () => {
     const canDelete = this.state.istioObjectDetails !== undefined && this.state.istioObjectDetails.permissions.delete;
+    const istioObject = this.getIstioObject();
+
     return (
       <span style={{ float: 'right' }}>
         <IstioActionDropdown
+          objectKind={istioObject ? istioObject.kind : undefined}
           objectName={this.props.match.params.object}
           canDelete={canDelete}
           onDelete={this.onDelete}


### PR DESCRIPTION
https://issues.jboss.org/browse/KIALI-2138

All types that show up in the "Istio Config" list page seems to have the
"kind" property. Using this property to show the type in the confirm
dialog. Falling back to "Isito object" just in case.

![image](https://user-images.githubusercontent.com/23639005/56933903-63efed00-6aaf-11e9-9887-4a07e7c3df84.png)
