### PR TITLE
KIALI-2793 Remove RouteRule and DestinationPolicy types - deprecated on istio long time ago

### DIFF
--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -13,7 +13,7 @@ import * as API from '../../services/Api';
 import AceEditor from 'react-ace';
 import 'brace/mode/yaml';
 import 'brace/theme/eclipse';
-import { ObjectValidation } from '../../types/IstioObjects';
+import { IstioObject, ObjectValidation } from '../../types/IstioObjects';
 import { AceValidations, jsYaml, parseKialiValidations, parseYamlValidations } from '../../types/AceValidations';
 import IstioActionDropdown from '../../components/IstioActions/IstioActionsDropdown';
 import './IstioConfigDetailsPage.css';
@@ -195,15 +195,14 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
   };
 
   fetchYaml = () => {
-    let istioObject;
+    let istioObject: IstioObject | undefined;
     if (this.state.isModified) {
       return this.state.yamlModified;
     }
+
     if (this.state.istioObjectDetails) {
       if (this.state.istioObjectDetails.gateway) {
         istioObject = this.state.istioObjectDetails.gateway;
-      } else if (this.state.istioObjectDetails.destinationPolicy) {
-        istioObject = this.state.istioObjectDetails.destinationPolicy;
       } else if (this.state.istioObjectDetails.virtualService) {
         istioObject = this.state.istioObjectDetails.virtualService;
       } else if (this.state.istioObjectDetails.destinationRule) {

--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -202,8 +202,6 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
     if (this.state.istioObjectDetails) {
       if (this.state.istioObjectDetails.gateway) {
         istioObject = this.state.istioObjectDetails.gateway;
-      } else if (this.state.istioObjectDetails.routeRule) {
-        istioObject = this.state.istioObjectDetails.routeRule;
       } else if (this.state.istioObjectDetails.destinationPolicy) {
         istioObject = this.state.istioObjectDetails.destinationPolicy;
       } else if (this.state.istioObjectDetails.virtualService) {

--- a/src/types/IstioConfigDetails.ts
+++ b/src/types/IstioConfigDetails.ts
@@ -2,7 +2,6 @@ import Namespace from './Namespace';
 import { AceOptions } from 'react-ace';
 import { ResourcePermissions } from './Permissions';
 import {
-  DestinationPolicy,
   DestinationRule,
   Gateway,
   IstioAdapter,
@@ -30,7 +29,6 @@ export interface IstioConfigId {
 export interface IstioConfigDetails {
   namespace: Namespace;
   gateway: Gateway;
-  destinationPolicy: DestinationPolicy;
   virtualService: VirtualService;
   destinationRule: DestinationRule;
   serviceEntry: ServiceEntry;

--- a/src/types/IstioConfigDetails.ts
+++ b/src/types/IstioConfigDetails.ts
@@ -11,7 +11,6 @@ import {
   Policy,
   QuotaSpec,
   QuotaSpecBinding,
-  RouteRule,
   ServiceEntry,
   VirtualService,
   ObjectValidation,
@@ -31,7 +30,6 @@ export interface IstioConfigId {
 export interface IstioConfigDetails {
   namespace: Namespace;
   gateway: Gateway;
-  routeRule: RouteRule;
   destinationPolicy: DestinationPolicy;
   virtualService: VirtualService;
   destinationRule: DestinationRule;

--- a/src/types/IstioObjects.ts
+++ b/src/types/IstioObjects.ts
@@ -111,41 +111,12 @@ export interface Host {
   cluster?: string;
 }
 
-// RouteRule type
-
-export interface RouteRule {
-  name: string;
-  createdAt: string;
-  resourceVersion: string;
-  destination?: IstioService;
-  precedence?: number;
-  match?: MatchCondition;
-  route?: DestinationWeightV1Alpha1[];
-  redirect?: HTTPRedirect;
-  rewrite?: HTTPRewrite;
-  websocketUpgrade?: string;
-  httpReqTimeout?: HTTPTimeout;
-  httpReqRetries?: HTTPRetry;
-  httpFault?: HTTPFaultInjection;
-  l4Fault?: L4FaultInjection;
-  mirror?: IstioService;
-  corsPolicy?: CorsPolicy;
-  appendHeaders?: { [key: string]: string };
-}
-
 export interface IstioService {
   name?: string;
   namespace?: string;
   domain?: string;
   service?: string;
   labels?: { [key: string]: string };
-}
-
-export interface MatchCondition {
-  source?: IstioService;
-  tcp?: L4MatchAttributes;
-  udp?: L4MatchAttributes;
-  request?: MatchRequest;
 }
 
 export interface L4MatchAttributes {
@@ -175,11 +146,6 @@ export interface StringMatch {
   regex?: string;
 }
 
-export interface DestinationWeightV1Alpha1 {
-  labels: { [key: string]: string };
-  weight?: number;
-}
-
 export interface DestinationWeight {
   destination: Destination;
   weight?: number;
@@ -193,16 +159,6 @@ export interface HTTPRedirect {
 export interface HTTPRewrite {
   uri: string;
   authority: string;
-}
-
-export interface HTTPTimeout {
-  simpleTimeout: SimpleTimeoutPolicy;
-  custom: string;
-}
-
-export interface SimpleTimeoutPolicy {
-  timeout: string;
-  overrideHeaderName: string;
 }
 
 export interface HTTPRetry {
@@ -236,11 +192,6 @@ export interface Abort {
   percent?: number;
   httpStatus?: number;
   percentage?: Percent;
-}
-
-export interface L4FaultInjection {
-  throttle: Throttle;
-  terminate: Terminate;
 }
 
 export interface Throttle {

--- a/src/types/IstioObjects.ts
+++ b/src/types/IstioObjects.ts
@@ -132,14 +132,6 @@ export interface TLSMatchAttributes {
   gateways: string[];
 }
 
-export interface MatchRequest {
-  headers?: { [key: string]: StringMatch };
-  uri?: StringMatch;
-  scheme?: StringMatch;
-  method?: StringMatch;
-  authority?: StringMatch;
-}
-
 export interface StringMatch {
   exact?: string;
   prefix?: string;
@@ -203,11 +195,6 @@ export interface Throttle {
   throttleForPeriod: string;
 }
 
-export interface Terminate {
-  percent: number;
-  terminateAfterPeriod: string;
-}
-
 export interface CorsPolicy {
   allowOrigin: string[];
   allowMethods: string[];
@@ -215,39 +202,6 @@ export interface CorsPolicy {
   exposeHeaders: string[];
   maxAge: string;
   allowCredentials: string;
-}
-
-// Destination Policy
-
-export interface LoadBalancing {
-  name: string;
-}
-
-export interface CircuitBreakerPolicy {
-  maxConnections?: number;
-  httpMaxPendingRequests?: number;
-  httpMaxRequests?: number;
-  sleepWindow?: string;
-  httpConsecutiveErrors?: string;
-  httpDetectionInterval?: string;
-  httpMaxRequestsPerConnection?: number;
-  httpMaxEjectionPercent?: number;
-  httpMaxRetries?: number;
-}
-
-export interface CircuitBreaker {
-  simpleCb: CircuitBreakerPolicy;
-  custom: string;
-}
-
-export interface DestinationPolicy {
-  name: string;
-  createdAt: string;
-  resourceVersion: string;
-  destination?: IstioService;
-  source?: IstioService;
-  loadbalancing?: LoadBalancing;
-  circuitBreaker?: CircuitBreaker;
 }
 
 // Destination Rule
@@ -318,10 +272,7 @@ export interface DestinationRuleSpec {
   subsets?: Subset[];
 }
 
-export interface DestinationRule {
-  kind?: string;
-  apiVersion?: string;
-  metadata: K8sMetadata;
+export interface DestinationRule extends IstioObject {
   spec: DestinationRuleSpec;
 }
 


### PR DESCRIPTION
** Describe the change **
Remove old references to RouteRules and DestinationPolicies. Both of them were deprecated 1 year ago (https://istio.io/blog/2018/v1alpha3-routing/).

** Issue reference **
https://issues.jboss.org/browse/KIALI-2793

** Backwards compatible? **
yes