### PR TITLE
KIALI-2746 Reduce size of graph sidepanel and main nav menu

### DIFF
--- a/src/pages/Graph/SummaryPanel.tsx
+++ b/src/pages/Graph/SummaryPanel.tsx
@@ -16,11 +16,13 @@ type MainSummaryPanelPropType = SummaryPanelPropType & {
 };
 
 const expandedStyle = style({
+  fontSize: '74%', // TODO: Remove
   paddingTop: '1em',
   position: 'relative'
 });
 
 const collapsedStyle = style({
+  fontSize: '74%', // TODO: Remove
   paddingTop: '1em',
   position: 'relative',
   $nest: {

--- a/src/styles/_overrides.scss
+++ b/src/styles/_overrides.scss
@@ -65,6 +65,7 @@ $grid-float-breakpoint: $screen-sm-min !default;
   --pf-c-page__sidebar--BackgroundColor: #{$color-pf-black-900};
   --pf-c-page__sidebar--PaddingBottom: 0;
   --pf-c-page__sidebar--PaddingTop: 0;
+  --pf-c-page__sidebar--md--Width: 210px; // TODO: Remove. Test enlarged message center when removing.
   min-height: 100vh;
   position: relative; // fix z-index bug in Edge
   width: 0 !important; // only set size when expanded (.pf-m-expanded is added)

--- a/src/types/Graph.ts
+++ b/src/types/Graph.ts
@@ -7,7 +7,7 @@ export interface CyData {
   cyRef: any;
 }
 
-export const SUMMARY_PANEL_CHART_WIDTH = 350;
+export const SUMMARY_PANEL_CHART_WIDTH = 250;
 export type LegendPosition = 'bottom' | 'right' | 'inset';
 export type SummaryType = 'graph' | 'node' | 'edge' | 'group';
 export interface SummaryData {


### PR DESCRIPTION
https://issues.jboss.org/browse/KIALI-2746
Also: https://issues.jboss.org/browse/KIALI-2765

Reducing sizes as a workaround until we have a new design available.

* Font size of side panel is reduced. This produces a more adequate
size to not distract the user from the graph.
* Width of main navigation menu is reduced to make better use of
available screen space.

Before:
![image](https://user-images.githubusercontent.com/23639005/56995856-8c87ed80-6b68-11e9-9989-0fef6da4abbf.png)

After:
![image](https://user-images.githubusercontent.com/23639005/56995893-a6c1cb80-6b68-11e9-9b7e-ca2abe928335.png)
