### PR TITLE
KIALI-2799 Adapt logs pane to the height of the browser window

### DIFF
--- a/src/components/Nav/Navigation.tsx
+++ b/src/components/Nav/Navigation.tsx
@@ -53,12 +53,7 @@ class Navigation extends React.Component<PropsType, NavigationState> {
   }
 
   isContentScrollable = () => {
-    const urlParams = new URLSearchParams(this.props.location.search);
-    let isMetricTab = false;
-    if (urlParams.has('tab')) {
-      isMetricTab = urlParams.get('tab') === 'metrics';
-    }
-    return !this.props.location.pathname.startsWith('/graph') && !isMetricTab;
+    return !this.props.location.pathname.startsWith('/graph');
   };
 
   onNavToggleDesktop = () => {
@@ -85,7 +80,7 @@ class Navigation extends React.Component<PropsType, NavigationState> {
 
     const Header = (
       <PageHeader
-        logo={<Brand src={kialiLogo} alt="Patternfly Logo" />}
+        logo={<Brand src={kialiLogo} alt="Kiali Logo" />}
         toolbar={<Masthead />}
         showNavToggle={true}
         onNavToggle={isMobileView ? this.onNavToggleMobile : this.onNavToggleDesktop}

--- a/src/components/Nav/RenderPage.tsx
+++ b/src/components/Nav/RenderPage.tsx
@@ -36,7 +36,7 @@ class RenderPage extends React.Component<{ needScroll: boolean }> {
     );
     return (
       <>
-        <div>{this.renderSecondaryMastheadRoutes()}</div>
+        {this.renderSecondaryMastheadRoutes()}
         {this.props.needScroll ? <div id="content-scrollable">{component}</div> : component}
       </>
     );

--- a/src/components/Nav/SecondaryMasthead.tsx
+++ b/src/components/Nav/SecondaryMasthead.tsx
@@ -11,6 +11,10 @@ const secondaryMastheadStyle = style({
 
 export default class SecondaryMasthead extends React.PureComponent {
   render() {
-    return <div className={`container-fluid ${secondaryMastheadStyle}`}>{this.props.children}</div>;
+    return (
+      <div id="global-namespace-selector" className={`container-fluid ${secondaryMastheadStyle}`}>
+        {this.props.children}
+      </div>
+    );
   }
 }

--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.scss
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.scss
@@ -1,4 +1,10 @@
 .istio-ace-editor {
+  /*
+   * 50px is the height of the bottom toolbar (save, reload and cancel buttons)
+   * 20px is the top margin of the yaml editor.
+   * So, substracting 70px from the tab content height.
+   */
+  --kiali-yaml-editor-height: calc(var(--kiali-details-pages-tab-content-height) - 70px);
   position: relative;
   min-height: 200px;
   border: 1px solid #8b8d8f;

--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -266,7 +266,7 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
                 theme="eclipse"
                 onChange={this.onEditorChange}
                 width={'100%'}
-                height={'50vh'}
+                height={'var(--kiali-yaml-editor-height)'}
                 className={'istio-ace-editor'}
                 readOnly={!this.canUpdate()}
                 setOptions={aceOptions}

--- a/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -231,16 +231,7 @@ class WorkloadDetails extends React.Component<RouteComponentProps<WorkloadId>, W
                   onRefresh={this.doRefresh}
                 />
               </TabPane>
-              {
-                // I don't know why but the TabContainer's parent height does not extend to the available space. Nothing
-                // I tried extended it to 100%, so below I set to 50vh to provide space to the logs textbox.
-              }
-              <TabPane
-                eventKey="logs"
-                mountOnEnter={true}
-                unmountOnExit={true}
-                style={{ height: 'calc(100vh - 80px - var(--pf-c-page__header--MinHeight))' }}
-              >
+              <TabPane eventKey="logs" mountOnEnter={true} unmountOnExit={true}>
                 {hasPods ? (
                   <WorkloadPodLogs namespace={this.props.match.params.namespace} pods={this.state.workload.pods} />
                 ) : (

--- a/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -235,7 +235,12 @@ class WorkloadDetails extends React.Component<RouteComponentProps<WorkloadId>, W
                 // I don't know why but the TabContainer's parent height does not extend to the available space. Nothing
                 // I tried extended it to 100%, so below I set to 50vh to provide space to the logs textbox.
               }
-              <TabPane eventKey="logs" mountOnEnter={true} unmountOnExit={true} style={{ height: '50vh' }}>
+              <TabPane
+                eventKey="logs"
+                mountOnEnter={true}
+                unmountOnExit={true}
+                style={{ height: 'calc(100vh - 80px - var(--pf-c-page__header--MinHeight))' }}
+              >
                 {hasPods ? (
                   <WorkloadPodLogs namespace={this.props.match.params.namespace} pods={this.state.workload.pods} />
                 ) : (

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
@@ -43,7 +43,8 @@ const TailLinesOptions = {
 
 const logsTextarea = style({
   width: '100%',
-  height: 'calc(100% - 75px)',
+  // 75px is the height of the toolbar inside "Logs" tab
+  height: 'calc(var(--kiali-details-pages-tab-content-height) - 75px)',
   overflow: 'auto',
   resize: 'vertical',
   color: '#fff',

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
@@ -43,7 +43,7 @@ const TailLinesOptions = {
 
 const logsTextarea = style({
   width: '100%',
-  height: '100%',
+  height: 'calc(100% - 75px)',
   overflow: 'auto',
   resize: 'vertical',
   color: '#fff',

--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -16,9 +16,13 @@ body,
 #content-scrollable {
   overflow-x: auto;
   overflow-y: auto;
-  height: 85vh;
+  height: calc(100vh - var(--pf-c-page__header--MinHeight));
   position: relative;
   -webkit-overflow-scrolling: touch;
+}
+
+#global-namespace-selector + #content-scrollable {
+  height: calc(100vh - 42px - var(--pf-c-page__header--MinHeight));
 }
 
 .pf-c-page__main {

--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -4,6 +4,12 @@ body,
 #content,
 #content-scrollable,
 .pf-c-page__main-section {
+  /*
+   * --pf-c-page__header--MinHeight is the height of the masthead
+   * 82px is the vertical space being used by the breadcrumb and tab headers
+   */
+  --kiali-details-pages-tab-content-height: calc(100vh - 82px - var(--pf-c-page__header--MinHeight));
+
   height: 100%; // so .co-p-has-sidebar, .yaml-editor are full height
 }
 
@@ -22,6 +28,7 @@ body,
 }
 
 #global-namespace-selector + #content-scrollable {
+  // 45px is the height of the global namespace selector
   height: calc(100vh - 42px - var(--pf-c-page__header--MinHeight));
 }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/KIALI-2799

Not a great approach, but I don't see other option rather than making
calculations using the size of the controls at the top of the pane.

As a plus, this also fixes:
* Sizing issues with the main content `div`. The issue can be seen
  in any of the app/workloads/services list pages. The scroll bar
  will run beyond the screen.
* Scroll bar issue in the metrics tab of the service details page.
* Applies the same fix of the logs tab to the YAML editor to fill the available page space.