### PR TITLE
KIALI-2641 Add Wizard for 3scale adapter config

### DIFF
--- a/src/components/IstioWizards/IstioWizardActions.ts
+++ b/src/components/IstioWizards/IstioWizardActions.ts
@@ -14,23 +14,27 @@ import {
   VirtualServices
 } from '../../types/IstioObjects';
 import { serverConfig } from '../../config';
+import { ThreeScaleServiceRule } from '../../types/ThreeScale';
 
 export const WIZARD_WEIGHTED_ROUTING = 'weighted_routing';
 export const WIZARD_MATCHING_ROUTING = 'matching_routing';
 export const WIZARD_SUSPEND_TRAFFIC = 'suspend_traffic';
+export const WIZARD_THREESCALE_INTEGRATION = 'threescale';
 
 export const WIZARD_ACTIONS = [WIZARD_WEIGHTED_ROUTING, WIZARD_MATCHING_ROUTING, WIZARD_SUSPEND_TRAFFIC];
 
 export const WIZARD_TITLES = {
   [WIZARD_WEIGHTED_ROUTING]: 'Create Weighted Routing',
   [WIZARD_MATCHING_ROUTING]: 'Create Matching Routing',
-  [WIZARD_SUSPEND_TRAFFIC]: 'Suspend Traffic'
+  [WIZARD_SUSPEND_TRAFFIC]: 'Suspend Traffic',
+  [WIZARD_THREESCALE_INTEGRATION]: 'Add 3Scale API Management Rule'
 };
 
 export const WIZARD_UPDATE_TITLES = {
   [WIZARD_WEIGHTED_ROUTING]: 'Update Weighted Routing',
   [WIZARD_MATCHING_ROUTING]: 'Update Matching Routing',
-  [WIZARD_SUSPEND_TRAFFIC]: 'Update Suspended Traffic'
+  [WIZARD_SUSPEND_TRAFFIC]: 'Update Suspended Traffic',
+  [WIZARD_THREESCALE_INTEGRATION]: 'Update 3Scale API Management Rule'
 };
 
 export type WizardProps = {
@@ -43,6 +47,7 @@ export type WizardProps = {
   workloads: WorkloadOverview[];
   virtualServices: VirtualServices;
   destinationRules: DestinationRules;
+  threeScaleServiceRule?: ThreeScaleServiceRule;
   onClose: (changed: boolean) => void;
 };
 
@@ -56,6 +61,7 @@ export type WizardState = {
   tlsModified: boolean;
   loadBalancer: string;
   lbModified: boolean;
+  threeScaleServiceRule?: ThreeScaleServiceRule;
 };
 
 const SERVICE_UNAVAILABLE = 503;

--- a/src/components/IstioWizards/IstioWizardActions.ts
+++ b/src/components/IstioWizards/IstioWizardActions.ts
@@ -27,14 +27,14 @@ export const WIZARD_TITLES = {
   [WIZARD_WEIGHTED_ROUTING]: 'Create Weighted Routing',
   [WIZARD_MATCHING_ROUTING]: 'Create Matching Routing',
   [WIZARD_SUSPEND_TRAFFIC]: 'Suspend Traffic',
-  [WIZARD_THREESCALE_INTEGRATION]: 'Add 3Scale API Management Rule'
+  [WIZARD_THREESCALE_INTEGRATION]: 'Add 3scale API Management Rule'
 };
 
 export const WIZARD_UPDATE_TITLES = {
   [WIZARD_WEIGHTED_ROUTING]: 'Update Weighted Routing',
   [WIZARD_MATCHING_ROUTING]: 'Update Matching Routing',
   [WIZARD_SUSPEND_TRAFFIC]: 'Update Suspended Traffic',
-  [WIZARD_THREESCALE_INTEGRATION]: 'Update 3Scale API Management Rule'
+  [WIZARD_THREESCALE_INTEGRATION]: 'Update 3scale API Management Rule'
 };
 
 export type WizardProps = {

--- a/src/components/IstioWizards/IstioWizardDropdown.tsx
+++ b/src/components/IstioWizards/IstioWizardDropdown.tsx
@@ -11,11 +11,13 @@ import {
   WIZARD_ACTIONS,
   WIZARD_MATCHING_ROUTING,
   WIZARD_SUSPEND_TRAFFIC,
+  WIZARD_THREESCALE_INTEGRATION,
   WIZARD_TITLES,
   WIZARD_UPDATE_TITLES,
   WIZARD_WEIGHTED_ROUTING
 } from './IstioWizardActions';
 import IstioWizard from './IstioWizard';
+import { ThreeScaleInfo, ThreeScaleServiceRule } from '../../types/ThreeScale';
 
 type Props = {
   namespace: string;
@@ -25,6 +27,8 @@ type Props = {
   virtualServices: VirtualServices;
   destinationRules: DestinationRules;
   tlsStatus?: TLSStatus;
+  threeScaleInfo: ThreeScaleInfo;
+  threeScaleServiceRule?: ThreeScaleServiceRule;
   onChange: () => void;
 };
 
@@ -33,10 +37,12 @@ type State = {
   updateWizard: boolean;
   wizardType: string;
   showConfirmDelete: boolean;
+  deleteAction: string;
   isDeleting: boolean;
 };
 
 const DELETE_TRAFFIC_ROUTING = 'delete_traffic_routing';
+const DELETE_THREESCALE_INTEGRATION = 'delete_threescale_integration';
 
 class IstioWizardDropdown extends React.Component<Props, State> {
   constructor(props: Props) {
@@ -45,6 +51,7 @@ class IstioWizardDropdown extends React.Component<Props, State> {
       showWizard: props.show,
       wizardType: '',
       showConfirmDelete: false,
+      deleteAction: '',
       isDeleting: false,
       updateWizard: false
     };
@@ -84,8 +91,20 @@ class IstioWizardDropdown extends React.Component<Props, State> {
         this.setState({ showWizard: true, wizardType: key, updateWizard: key === updateLabel });
         break;
       }
+      case WIZARD_THREESCALE_INTEGRATION: {
+        this.setState({
+          showWizard: true,
+          wizardType: key,
+          updateWizard: this.props.threeScaleServiceRule !== undefined
+        });
+        break;
+      }
       case DELETE_TRAFFIC_ROUTING: {
-        this.setState({ showConfirmDelete: true });
+        this.setState({ showConfirmDelete: true, deleteAction: key });
+        break;
+      }
+      case DELETE_THREESCALE_INTEGRATION: {
+        this.setState({ showConfirmDelete: true, deleteAction: key });
         break;
       }
       default:
@@ -98,16 +117,24 @@ class IstioWizardDropdown extends React.Component<Props, State> {
       isDeleting: true
     });
     const deletePromises: Promise<any>[] = [];
-    this.props.virtualServices.items.forEach(vs => {
-      deletePromises.push(
-        API.deleteIstioConfigDetail(vs.metadata.namespace || '', 'virtualservices', vs.metadata.name)
-      );
-    });
-    this.props.destinationRules.items.forEach(dr => {
-      deletePromises.push(
-        API.deleteIstioConfigDetail(dr.metadata.namespace || '', 'destinationrules', dr.metadata.name)
-      );
-    });
+    switch (this.state.deleteAction) {
+      case DELETE_TRAFFIC_ROUTING:
+        this.props.virtualServices.items.forEach(vs => {
+          deletePromises.push(
+            API.deleteIstioConfigDetail(vs.metadata.namespace || '', 'virtualservices', vs.metadata.name)
+          );
+        });
+        this.props.destinationRules.items.forEach(dr => {
+          deletePromises.push(
+            API.deleteIstioConfigDetail(dr.metadata.namespace || '', 'destinationrules', dr.metadata.name)
+          );
+        });
+        break;
+      case DELETE_THREESCALE_INTEGRATION:
+        deletePromises.push(API.deleteThreeScaleServiceRule(this.props.namespace, this.props.serviceName));
+        break;
+      default:
+    }
     // For slow scenarios, dialog is hidden and Delete All action blocked until promises have finished
     this.hideConfirmDelete();
     Promise.all(deletePromises)
@@ -181,6 +208,50 @@ class IstioWizardDropdown extends React.Component<Props, State> {
         ) : (
           deleteMenuItem
         );
+      case WIZARD_THREESCALE_INTEGRATION:
+        const threeScaleEnabledItem =
+          !this.props.threeScaleServiceRule || (this.props.threeScaleServiceRule && updateLabel === eventKey);
+        const threeScaleMenuItem = (
+          <MenuItem disabled={!threeScaleEnabledItem} key={eventKey} eventKey={eventKey}>
+            {updateLabel === eventKey ? WIZARD_UPDATE_TITLES[eventKey] : WIZARD_TITLES[eventKey]}
+          </MenuItem>
+        );
+        const toolTipMsgExists = '3Scale API Integration Rule already exists for this service';
+        return !threeScaleEnabledItem ? (
+          <OverlayTrigger
+            placement={'left'}
+            overlay={<Tooltip id={'mtls-status-masthead'}>{toolTipMsgExists}</Tooltip>}
+            trigger={['hover', 'focus']}
+            rootClose={false}
+          >
+            {threeScaleMenuItem}
+          </OverlayTrigger>
+        ) : (
+          threeScaleMenuItem
+        );
+      case DELETE_THREESCALE_INTEGRATION:
+        const deleteThreeScaleMenuItem = (
+          <MenuItem
+            disabled={!this.props.threeScaleServiceRule || this.state.isDeleting}
+            key={eventKey}
+            eventKey={eventKey}
+          >
+            Delete 3Scale API Management Rule
+          </MenuItem>
+        );
+        const toolTipMsgDelete = 'There is not a 3Scale API Integration Rule for this service';
+        return !this.props.threeScaleServiceRule ? (
+          <OverlayTrigger
+            placement={'left'}
+            overlay={<Tooltip id={'mtls-status-masthead'}>{toolTipMsgDelete}</Tooltip>}
+            trigger={['hover', 'focus']}
+            rootClose={false}
+          >
+            {deleteThreeScaleMenuItem}
+          </OverlayTrigger>
+        ) : (
+          deleteThreeScaleMenuItem
+        );
       default:
         return <>Unsupported</>;
     }
@@ -188,20 +259,28 @@ class IstioWizardDropdown extends React.Component<Props, State> {
 
   getDeleteMessage = () => {
     let deleteMessage = 'Are you sure you want to delete ';
-    deleteMessage +=
-      this.props.virtualServices.items.length > 0
-        ? `VirtualService${
-            this.props.virtualServices.items.length > 1 ? 's' : ''
-          }: '${this.props.virtualServices.items.map(vs => vs.metadata.name)}'`
-        : '';
-    deleteMessage +=
-      this.props.virtualServices.items.length > 0 && this.props.destinationRules.items.length > 0 ? ' and ' : '';
-    deleteMessage +=
-      this.props.destinationRules.items.length > 0
-        ? `DestinationRule${
-            this.props.destinationRules.items.length > 1 ? 's' : ''
-          }: '${this.props.destinationRules.items.map(dr => dr.metadata.name)}'`
-        : '';
+    switch (this.state.deleteAction) {
+      case DELETE_TRAFFIC_ROUTING:
+        deleteMessage +=
+          this.props.virtualServices.items.length > 0
+            ? `VirtualService${
+                this.props.virtualServices.items.length > 1 ? 's' : ''
+              }: '${this.props.virtualServices.items.map(vs => vs.metadata.name)}'`
+            : '';
+        deleteMessage +=
+          this.props.virtualServices.items.length > 0 && this.props.destinationRules.items.length > 0 ? ' and ' : '';
+        deleteMessage +=
+          this.props.destinationRules.items.length > 0
+            ? `DestinationRule${
+                this.props.destinationRules.items.length > 1 ? 's' : ''
+              }: '${this.props.destinationRules.items.map(dr => dr.metadata.name)}'`
+            : '';
+        break;
+      case DELETE_THREESCALE_INTEGRATION:
+        deleteMessage += ' 3Scale API Management Integration Rule ';
+        break;
+      default:
+    }
     deleteMessage += ' ?.  ';
     return deleteMessage;
   };
@@ -215,6 +294,13 @@ class IstioWizardDropdown extends React.Component<Props, State> {
             WIZARD_ACTIONS.map(action => this.renderMenuItem(action, updateLabel))}
           <MenuItem divider={true} />
           {this.canDelete() && this.renderMenuItem(DELETE_TRAFFIC_ROUTING, '')}
+          {this.props.threeScaleInfo.enabled && <MenuItem divider={true} />}
+          {this.props.threeScaleInfo.enabled &&
+            this.renderMenuItem(
+              WIZARD_THREESCALE_INTEGRATION,
+              this.props.threeScaleServiceRule ? WIZARD_THREESCALE_INTEGRATION : ''
+            )}
+          {this.props.threeScaleInfo.enabled && this.renderMenuItem(DELETE_THREESCALE_INTEGRATION, '')}
         </DropdownButton>
         <IstioWizard
           show={this.state.showWizard}
@@ -229,6 +315,7 @@ class IstioWizardDropdown extends React.Component<Props, State> {
           })}
           virtualServices={this.props.virtualServices}
           destinationRules={this.props.destinationRules}
+          threeScaleServiceRule={this.props.threeScaleServiceRule}
           tlsStatus={this.props.tlsStatus}
           onClose={this.onClose}
         />

--- a/src/components/IstioWizards/IstioWizardDropdown.tsx
+++ b/src/components/IstioWizards/IstioWizardDropdown.tsx
@@ -216,7 +216,7 @@ class IstioWizardDropdown extends React.Component<Props, State> {
             {updateLabel === eventKey ? WIZARD_UPDATE_TITLES[eventKey] : WIZARD_TITLES[eventKey]}
           </MenuItem>
         );
-        const toolTipMsgExists = '3Scale API Integration Rule already exists for this service';
+        const toolTipMsgExists = '3scale API Integration Rule already exists for this service';
         return !threeScaleEnabledItem ? (
           <OverlayTrigger
             placement={'left'}
@@ -239,7 +239,7 @@ class IstioWizardDropdown extends React.Component<Props, State> {
             Delete 3Scale API Management Rule
           </MenuItem>
         );
-        const toolTipMsgDelete = 'There is not a 3Scale API Integration Rule for this service';
+        const toolTipMsgDelete = 'There is not a 3scale API Integration Rule for this service';
         return !this.props.threeScaleServiceRule ? (
           <OverlayTrigger
             placement={'left'}
@@ -277,7 +277,7 @@ class IstioWizardDropdown extends React.Component<Props, State> {
             : '';
         break;
       case DELETE_THREESCALE_INTEGRATION:
-        deleteMessage += ' 3Scale API Management Integration Rule ';
+        deleteMessage += ' 3scale API Management Integration Rule ';
         break;
       default:
     }

--- a/src/components/IstioWizards/ThreeScaleIntegration.tsx
+++ b/src/components/IstioWizards/ThreeScaleIntegration.tsx
@@ -322,11 +322,14 @@ class ThreeScaleIntegration extends React.Component<Props, State> {
               description={
                 <>
                   {isLinked && (
-                    <div>
+                    <>
                       Service <b>{this.props.serviceName}</b> will be linked with 3scale API
-                    </div>
+                    </>
                   )}
-                  <i>{handler.systemUrl}</i>
+                  <br />
+                  Service Id: <i>{handler.serviceId}</i>
+                  <br />
+                  System Url: <i>{handler.systemUrl}</i>
                 </>
               }
               actions={handlerActions}

--- a/src/components/IstioWizards/ThreeScaleIntegration.tsx
+++ b/src/components/IstioWizards/ThreeScaleIntegration.tsx
@@ -1,0 +1,470 @@
+import * as React from 'react';
+import { ThreeScaleHandler, ThreeScaleServiceRule } from '../../types/ThreeScale';
+import {
+  Button,
+  Col,
+  ControlLabel,
+  DropdownKebab,
+  ExpandCollapse,
+  Form,
+  FormControl,
+  FormGroup,
+  ListView,
+  ListViewIcon,
+  ListViewItem,
+  MenuItem,
+  Row
+} from 'patternfly-react';
+import { style } from 'typestyle';
+import * as API from '../../services/Api';
+import * as MessageCenter from '../../utils/MessageCenter';
+
+type Props = {
+  serviceName: string;
+  serviceNamespace: string;
+  threeScaleServiceRule: ThreeScaleServiceRule;
+  onChange: (valid: boolean, threeScaleServiceRule: ThreeScaleServiceRule) => void;
+};
+
+type ModifiedHandler = ThreeScaleHandler & {
+  modified: boolean;
+};
+
+type State = {
+  threeScaleHandlers: ModifiedHandler[];
+  threeScaleServiceRule: ThreeScaleServiceRule;
+  newThreeScaleHandler: ThreeScaleHandler;
+};
+
+const expandStyle = style({
+  marginTop: 20,
+  $nest: {
+    ['.btn']: {
+      fontSize: '14px'
+    }
+  }
+});
+
+const createHandlerStyle = style({
+  marginTop: 20
+});
+
+const headingStyle = style({
+  fontWeight: 'normal',
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis'
+});
+
+class ThreeScaleIntegration extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      threeScaleHandlers: [],
+      threeScaleServiceRule: props.threeScaleServiceRule,
+      newThreeScaleHandler: {
+        name: '',
+        serviceId: '',
+        accessToken: '',
+        systemUrl: ''
+      }
+    };
+  }
+
+  componentDidMount() {
+    this.fetchHandlers();
+  }
+
+  fetchHandlers = () => {
+    API.getThreeScaleHandlers()
+      .then(results => {
+        this.setState(
+          prevState => {
+            let handlerName = prevState.threeScaleServiceRule.threeScaleHandlerName;
+            if (handlerName === '' && results.data.length > 0) {
+              handlerName = results.data[0].name;
+            }
+            return {
+              threeScaleHandlers: results.data.map(h => {
+                return {
+                  name: h.name,
+                  serviceId: h.serviceId,
+                  accessToken: h.accessToken,
+                  systemUrl: h.systemUrl,
+                  modified: false
+                };
+              }),
+              threeScaleServiceRule: {
+                serviceName: prevState.threeScaleServiceRule.serviceName,
+                serviceNamespace: prevState.threeScaleServiceRule.serviceNamespace,
+                threeScaleHandlerName: handlerName
+              }
+            };
+          },
+          () => this.props.onChange(this.state.threeScaleHandlers.length > 0, this.state.threeScaleServiceRule)
+        );
+      })
+      .catch(error => {
+        MessageCenter.add(API.getErrorMsg('Could not fetch ThreeScaleHandlers', error));
+      });
+  };
+
+  onUpdateHandler = (id: number) => {
+    const handler = this.state.threeScaleHandlers[id];
+    const patch = {
+      name: handler.name,
+      serviceId: handler.serviceId,
+      accessToken: handler.accessToken,
+      systemUrl: handler.systemUrl
+    };
+    API.updateThreeScaleHandler(this.state.threeScaleHandlers[id].name, JSON.stringify(patch))
+      .then(results => {
+        this.setState(
+          prevState => {
+            return {
+              threeScaleHandlers: results.data.map(h => {
+                return {
+                  name: h.name,
+                  serviceId: h.serviceId,
+                  accessToken: h.accessToken,
+                  systemUrl: h.systemUrl,
+                  modified: false
+                };
+              }),
+              threeScaleServiceRule: prevState.threeScaleServiceRule
+            };
+          },
+          () => this.props.onChange(true, this.state.threeScaleServiceRule)
+        );
+      })
+      .catch(error => {
+        MessageCenter.add(API.getErrorMsg('Could not update ThreeScaleHandlers', error));
+      });
+  };
+
+  onDeleteHandler = (handlerName: string) => {
+    API.deleteThreeScaleHandler(handlerName)
+      .then(results => {
+        this.setState(
+          prevState => {
+            return {
+              threeScaleHandlers: results.data.map(h => {
+                return {
+                  name: h.name,
+                  serviceId: h.serviceId,
+                  accessToken: h.accessToken,
+                  systemUrl: h.systemUrl,
+                  modified: false
+                };
+              }),
+              threeScaleServiceRule: {
+                serviceName: prevState.threeScaleServiceRule.serviceName,
+                serviceNamespace: prevState.threeScaleServiceRule.serviceNamespace,
+                threeScaleHandlerName:
+                  prevState.threeScaleServiceRule.threeScaleHandlerName === handlerName
+                    ? ''
+                    : prevState.threeScaleServiceRule.threeScaleHandlerName
+              }
+            };
+          },
+          () => this.props.onChange(this.state.threeScaleHandlers.length > 0, this.state.threeScaleServiceRule)
+        );
+      })
+      .catch(error => {
+        MessageCenter.add(API.getErrorMsg('Could not delete ThreeScaleHandlers', error));
+      });
+  };
+
+  isValid = () => {
+    let isModified = true;
+    this.state.threeScaleHandlers.forEach(handlers => {
+      isModified = isModified && handlers.modified;
+    });
+    const isNewModified =
+      this.state.newThreeScaleHandler.name !== '' ||
+      this.state.newThreeScaleHandler.serviceId !== '' ||
+      this.state.newThreeScaleHandler.systemUrl !== '' ||
+      this.state.newThreeScaleHandler.accessToken !== '';
+    return !(isModified || isNewModified);
+  };
+
+  onChangeHandler = (selectedId: number, field: string, value: string) => {
+    this.setState(
+      prevState => {
+        const newThreeScaleHandler = prevState.newThreeScaleHandler;
+        if (selectedId === -1) {
+          switch (field) {
+            case 'name':
+              newThreeScaleHandler.name = value.trim();
+              break;
+            case 'serviceId':
+              newThreeScaleHandler.serviceId = value.trim();
+              break;
+            case 'accessToken':
+              newThreeScaleHandler.accessToken = value.trim();
+              break;
+            case 'systemUrl':
+              newThreeScaleHandler.systemUrl = value.trim();
+              break;
+            default:
+          }
+        }
+        return {
+          threeScaleServiceRule: prevState.threeScaleServiceRule,
+          threeScaleHandlers: prevState.threeScaleHandlers.map((handler, id) => {
+            if (selectedId === id) {
+              handler.modified = true;
+              switch (field) {
+                case 'serviceId':
+                  handler.serviceId = value.trim();
+                  break;
+                case 'accessToken':
+                  handler.accessToken = value.trim();
+                  break;
+                case 'systemUrl':
+                  handler.systemUrl = value.trim();
+                  break;
+                default:
+              }
+            }
+            return handler;
+          }),
+          newThreeScaleHandler: newThreeScaleHandler
+        };
+      },
+      () => this.props.onChange(this.isValid(), this.state.threeScaleServiceRule)
+    );
+  };
+
+  onCreateHandler = () => {
+    API.createThreeScaleHandler(JSON.stringify(this.state.newThreeScaleHandler))
+      .then(results => {
+        this.setState(
+          prevState => {
+            return {
+              threeScaleHandlers: results.data.map(h => {
+                return {
+                  name: h.name,
+                  serviceId: h.serviceId,
+                  accessToken: h.accessToken,
+                  systemUrl: h.systemUrl,
+                  modified: false
+                };
+              }),
+              threeScaleServiceRule: {
+                serviceName: prevState.threeScaleServiceRule.serviceName,
+                serviceNamespace: prevState.threeScaleServiceRule.serviceNamespace,
+                threeScaleHandlerName: this.state.newThreeScaleHandler.name
+              },
+              newThreeScaleHandler: {
+                name: '',
+                serviceId: '',
+                systemUrl: '',
+                accessToken: ''
+              }
+            };
+          },
+          () => this.props.onChange(true, this.state.threeScaleServiceRule)
+        );
+      })
+      .catch(error => {
+        MessageCenter.add(API.getErrorMsg('Could not create ThreeScaleHandlers', error));
+      });
+  };
+
+  onSelectHandler = (handlerName: string) => {
+    this.setState(
+      prevState => {
+        return {
+          threeScaleHandlers: prevState.threeScaleHandlers,
+          threeScaleServiceRule: {
+            serviceName: prevState.threeScaleServiceRule.serviceName,
+            serviceNamespace: prevState.threeScaleServiceRule.serviceNamespace,
+            threeScaleHandlerName: handlerName
+          }
+        };
+      },
+      () => this.props.onChange(true, this.state.threeScaleServiceRule)
+    );
+  };
+
+  renderHandlers = () => {
+    return (
+      <ListView>
+        {this.state.threeScaleHandlers.map((handler, id) => {
+          const isLinked =
+            handler.name === this.state.threeScaleServiceRule.threeScaleHandlerName ||
+            (this.state.threeScaleServiceRule.threeScaleHandlerName === '' && id === 0);
+          const handlerActions = (
+            <>
+              {!isLinked && <Button onClick={() => this.onSelectHandler(handler.name)}>Select</Button>}
+              <DropdownKebab key={'delete-handler-actions-' + id} id={'delete-handler-actions-' + id} pullRight={true}>
+                <MenuItem onClick={() => this.onDeleteHandler(handler.name)}>Delete Handler</MenuItem>
+              </DropdownKebab>
+            </>
+          );
+          const leftContent = isLinked ? <ListViewIcon type="pf" name="connected" /> : undefined;
+
+          return (
+            <ListViewItem
+              key={id}
+              leftContent={leftContent}
+              heading={
+                <>
+                  <div>
+                    {handler.name} {handler.modified && '*'}
+                  </div>
+                  <div className={headingStyle}>3Scale Handler</div>
+                </>
+              }
+              description={
+                <>
+                  {isLinked && (
+                    <div>
+                      Service <b>{this.props.serviceName}</b> will be linked with 3Scale API
+                    </div>
+                  )}
+                  <i>{handler.systemUrl}</i>
+                </>
+              }
+              actions={handlerActions}
+            >
+              <Form horizontal={true}>
+                <FormGroup controlId="serviceId" disabled={false}>
+                  <Col componentClass={ControlLabel} sm={2}>
+                    Service Id:
+                  </Col>
+                  <Col sm={8}>
+                    <FormControl
+                      type="text"
+                      disabled={false}
+                      value={handler.serviceId}
+                      onChange={e => this.onChangeHandler(id, 'serviceId', e.target.value)}
+                    />
+                  </Col>
+                </FormGroup>
+                <FormGroup controlId="systemUrl" disabled={false}>
+                  <Col componentClass={ControlLabel} sm={2}>
+                    System Url:
+                  </Col>
+                  <Col sm={8}>
+                    <FormControl
+                      type="text"
+                      disabled={false}
+                      value={handler.systemUrl}
+                      onChange={e => this.onChangeHandler(id, 'systemUrl', e.target.value)}
+                    />
+                  </Col>
+                </FormGroup>
+                <FormGroup controlId="accessToken" disabled={false}>
+                  <Col componentClass={ControlLabel} sm={2}>
+                    Access Token:
+                  </Col>
+                  <Col sm={8}>
+                    <FormControl
+                      type="text"
+                      disabled={false}
+                      value={handler.accessToken}
+                      onChange={e => this.onChangeHandler(id, 'accessToken', e.target.value)}
+                    />
+                  </Col>
+                </FormGroup>
+                <Row style={{ paddingTop: '10px', paddingBottom: '10px' }}>
+                  <Col smOffset={10} sm={2}>
+                    <Button bsStyle="primary" style={{ marginLeft: '-10px' }} onClick={() => this.onUpdateHandler(id)}>
+                      Update Handler
+                    </Button>
+                  </Col>
+                </Row>
+              </Form>
+            </ListViewItem>
+          );
+        })}
+      </ListView>
+    );
+  };
+
+  renderCreateHandler = () => {
+    return (
+      <Form className={createHandlerStyle} horizontal={true}>
+        <FormGroup
+          controlId="handlerName"
+          disabled={false}
+          value={this.state.newThreeScaleHandler.name}
+          onChange={e => this.onChangeHandler(-1, 'name', e.target.value)}
+        >
+          <Col componentClass={ControlLabel} sm={2}>
+            Handler Name:
+          </Col>
+          <Col sm={8}>
+            <FormControl type="text" disabled={false} />
+          </Col>
+        </FormGroup>
+        <FormGroup
+          controlId="serviceId"
+          disabled={false}
+          value={this.state.newThreeScaleHandler.serviceId}
+          onChange={e => this.onChangeHandler(-1, 'serviceId', e.target.value)}
+        >
+          <Col componentClass={ControlLabel} sm={2}>
+            Service Id:
+          </Col>
+          <Col sm={8}>
+            <FormControl type="text" disabled={false} />
+          </Col>
+        </FormGroup>
+        <FormGroup
+          controlId="systemUrl"
+          disabled={false}
+          value={this.state.newThreeScaleHandler.accessToken}
+          onChange={e => this.onChangeHandler(-1, 'systemUrl', e.target.value)}
+        >
+          <Col componentClass={ControlLabel} sm={2}>
+            System Url:
+          </Col>
+          <Col sm={8}>
+            <FormControl type="text" disabled={false} />
+          </Col>
+        </FormGroup>
+        <FormGroup
+          controlId="accessToken"
+          disabled={false}
+          value={this.state.newThreeScaleHandler.accessToken}
+          onChange={e => this.onChangeHandler(-1, 'accessToken', e.target.value)}
+        >
+          <Col componentClass={ControlLabel} sm={2}>
+            Access Token:
+          </Col>
+          <Col sm={8}>
+            <FormControl type="text" disabled={false} />
+          </Col>
+        </FormGroup>
+        <Row style={{ paddingTop: '10px', paddingBottom: '10px' }}>
+          <Col smOffset={10} sm={2}>
+            <Button bsStyle="primary" onClick={this.onCreateHandler}>
+              Create Handler
+            </Button>
+          </Col>
+        </Row>
+      </Form>
+    );
+  };
+
+  render() {
+    return (
+      <>
+        {this.renderHandlers()}
+        <ExpandCollapse
+          className={expandStyle}
+          textCollapsed="Show Advanced Options"
+          textExpanded="Hide Advanced Options"
+          expanded={this.state.threeScaleHandlers.length === 0 || this.state.newThreeScaleHandler.name !== ''}
+        >
+          {this.renderCreateHandler()}
+        </ExpandCollapse>
+      </>
+    );
+  }
+}
+
+export default ThreeScaleIntegration;

--- a/src/components/IstioWizards/ThreeScaleIntegration.tsx
+++ b/src/components/IstioWizards/ThreeScaleIntegration.tsx
@@ -314,14 +314,14 @@ class ThreeScaleIntegration extends React.Component<Props, State> {
                   <div>
                     {handler.name} {handler.modified && '*'}
                   </div>
-                  <div className={headingStyle}>3Scale Handler</div>
+                  <div className={headingStyle}>3scale Handler</div>
                 </>
               }
               description={
                 <>
                   {isLinked && (
                     <div>
-                      Service <b>{this.props.serviceName}</b> will be linked with 3Scale API
+                      Service <b>{this.props.serviceName}</b> will be linked with 3scale API
                     </div>
                   )}
                   <i>{handler.systemUrl}</i>

--- a/src/components/IstioWizards/ThreeScaleIntegration.tsx
+++ b/src/components/IstioWizards/ThreeScaleIntegration.tsx
@@ -9,6 +9,7 @@ import {
   Form,
   FormControl,
   FormGroup,
+  HelpBlock,
   ListView,
   ListViewIcon,
   ListViewItem,
@@ -57,6 +58,8 @@ const headingStyle = style({
   overflow: 'hidden',
   textOverflow: 'ellipsis'
 });
+
+const k8sRegExpName = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[-a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
 
 class ThreeScaleIntegration extends React.Component<Props, State> {
   constructor(props: Props) {
@@ -191,51 +194,48 @@ class ThreeScaleIntegration extends React.Component<Props, State> {
   };
 
   onChangeHandler = (selectedId: number, field: string, value: string) => {
-    this.setState(
-      prevState => {
-        const newThreeScaleHandler = prevState.newThreeScaleHandler;
-        if (selectedId === -1) {
-          switch (field) {
-            case 'name':
-              newThreeScaleHandler.name = value.trim();
-              break;
-            case 'serviceId':
-              newThreeScaleHandler.serviceId = value.trim();
-              break;
-            case 'accessToken':
-              newThreeScaleHandler.accessToken = value.trim();
-              break;
-            case 'systemUrl':
-              newThreeScaleHandler.systemUrl = value.trim();
-              break;
-            default:
-          }
+    this.setState(prevState => {
+      const newThreeScaleHandler = prevState.newThreeScaleHandler;
+      if (selectedId === -1) {
+        switch (field) {
+          case 'name':
+            newThreeScaleHandler.name = value.trim();
+            break;
+          case 'serviceId':
+            newThreeScaleHandler.serviceId = value.trim();
+            break;
+          case 'accessToken':
+            newThreeScaleHandler.accessToken = value.trim();
+            break;
+          case 'systemUrl':
+            newThreeScaleHandler.systemUrl = value.trim();
+            break;
+          default:
         }
-        return {
-          threeScaleServiceRule: prevState.threeScaleServiceRule,
-          threeScaleHandlers: prevState.threeScaleHandlers.map((handler, id) => {
-            if (selectedId === id) {
-              handler.modified = true;
-              switch (field) {
-                case 'serviceId':
-                  handler.serviceId = value.trim();
-                  break;
-                case 'accessToken':
-                  handler.accessToken = value.trim();
-                  break;
-                case 'systemUrl':
-                  handler.systemUrl = value.trim();
-                  break;
-                default:
-              }
+      }
+      return {
+        threeScaleServiceRule: prevState.threeScaleServiceRule,
+        threeScaleHandlers: prevState.threeScaleHandlers.map((handler, id) => {
+          if (selectedId === id) {
+            handler.modified = true;
+            switch (field) {
+              case 'serviceId':
+                handler.serviceId = value.trim();
+                break;
+              case 'accessToken':
+                handler.accessToken = value.trim();
+                break;
+              case 'systemUrl':
+                handler.systemUrl = value.trim();
+                break;
+              default:
             }
-            return handler;
-          }),
-          newThreeScaleHandler: newThreeScaleHandler
-        };
-      },
-      () => this.props.onChange(this.isValid(), this.state.threeScaleServiceRule)
-    );
+          }
+          return handler;
+        }),
+        newThreeScaleHandler: newThreeScaleHandler
+      };
+    });
   };
 
   onCreateHandler = () => {
@@ -429,14 +429,19 @@ class ThreeScaleIntegration extends React.Component<Props, State> {
 
   isValidCreateHandler = () => {
     return (
-      this.state.newThreeScaleHandler.name !== '' &&
+      this.isValidK8SName(this.state.newThreeScaleHandler.name) &&
       this.state.newThreeScaleHandler.serviceId !== '' &&
       this.state.newThreeScaleHandler.systemUrl !== '' &&
       this.state.newThreeScaleHandler.accessToken !== ''
     );
   };
 
+  isValidK8SName = (name: string) => {
+    return name === '' ? false : name.search(k8sRegExpName) === 0;
+  };
+
   renderCreateHandler = () => {
+    const isValidName = this.isValidK8SName(this.state.newThreeScaleHandler.name);
     return (
       <Form className={createHandlerStyle} horizontal={true}>
         <FormGroup
@@ -444,13 +449,19 @@ class ThreeScaleIntegration extends React.Component<Props, State> {
           disabled={false}
           value={this.state.newThreeScaleHandler.name}
           onChange={e => this.onChangeHandler(-1, 'name', e.target.value)}
-          validationState={this.state.newThreeScaleHandler.name !== '' ? 'success' : 'error'}
+          validationState={isValidName ? 'success' : 'error'}
         >
           <Col componentClass={ControlLabel} sm={2}>
             Handler Name:
           </Col>
           <Col sm={8}>
             <FormControl type="text" disabled={false} />
+            {!isValidName && (
+              <HelpBlock>
+                Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an
+                alphanumeric character.
+              </HelpBlock>
+            )}
           </Col>
         </FormGroup>
         <FormGroup

--- a/src/components/IstioWizards/ThreeScaleIntegration.tsx
+++ b/src/components/IstioWizards/ThreeScaleIntegration.tsx
@@ -13,6 +13,8 @@ import {
   ListViewIcon,
   ListViewItem,
   MenuItem,
+  OverlayTrigger,
+  Tooltip,
   Row
 } from 'patternfly-react';
 import { style } from 'typestyle';
@@ -330,48 +332,86 @@ class ThreeScaleIntegration extends React.Component<Props, State> {
               actions={handlerActions}
             >
               <Form horizontal={true}>
-                <FormGroup controlId="serviceId" disabled={false}>
+                <FormGroup
+                  controlId="serviceId"
+                  disabled={false}
+                  validationState={handler.serviceId !== '' ? 'success' : 'error'}
+                >
                   <Col componentClass={ControlLabel} sm={2}>
                     Service Id:
                   </Col>
                   <Col sm={8}>
-                    <FormControl
-                      type="text"
-                      disabled={false}
-                      value={handler.serviceId}
-                      onChange={e => this.onChangeHandler(id, 'serviceId', e.target.value)}
-                    />
+                    <OverlayTrigger
+                      placement={'right'}
+                      overlay={<Tooltip id={'mtls-status-masthead'}>3scale ID for API calls</Tooltip>}
+                      trigger={['hover', 'focus']}
+                      rootClose={false}
+                    >
+                      <FormControl
+                        type="text"
+                        disabled={false}
+                        value={handler.serviceId}
+                        onChange={e => this.onChangeHandler(id, 'serviceId', e.target.value)}
+                      />
+                    </OverlayTrigger>
                   </Col>
                 </FormGroup>
-                <FormGroup controlId="systemUrl" disabled={false}>
+                <FormGroup
+                  controlId="systemUrl"
+                  disabled={false}
+                  validationState={handler.systemUrl !== '' ? 'success' : 'error'}
+                >
                   <Col componentClass={ControlLabel} sm={2}>
                     System Url:
                   </Col>
                   <Col sm={8}>
-                    <FormControl
-                      type="text"
-                      disabled={false}
-                      value={handler.systemUrl}
-                      onChange={e => this.onChangeHandler(id, 'systemUrl', e.target.value)}
-                    />
+                    <OverlayTrigger
+                      placement={'right'}
+                      overlay={<Tooltip id={'mtls-status-masthead'}>3scale System Url for API</Tooltip>}
+                      trigger={['hover', 'focus']}
+                      rootClose={false}
+                    >
+                      <FormControl
+                        type="text"
+                        disabled={false}
+                        value={handler.systemUrl}
+                        onChange={e => this.onChangeHandler(id, 'systemUrl', e.target.value)}
+                      />
+                    </OverlayTrigger>
                   </Col>
                 </FormGroup>
-                <FormGroup controlId="accessToken" disabled={false}>
+                <FormGroup
+                  controlId="accessToken"
+                  disabled={false}
+                  validationState={handler.accessToken !== '' ? 'success' : 'error'}
+                >
                   <Col componentClass={ControlLabel} sm={2}>
                     Access Token:
                   </Col>
                   <Col sm={8}>
-                    <FormControl
-                      type="text"
-                      disabled={false}
-                      value={handler.accessToken}
-                      onChange={e => this.onChangeHandler(id, 'accessToken', e.target.value)}
-                    />
+                    <OverlayTrigger
+                      placement={'right'}
+                      overlay={<Tooltip id={'mtls-status-masthead'}>3scale access token</Tooltip>}
+                      trigger={['hover', 'focus']}
+                      rootClose={false}
+                    >
+                      <FormControl
+                        type="text"
+                        disabled={false}
+                        value={handler.accessToken}
+                        onChange={e => this.onChangeHandler(id, 'accessToken', e.target.value)}
+                      />
+                    </OverlayTrigger>
                   </Col>
                 </FormGroup>
                 <Row style={{ paddingTop: '10px', paddingBottom: '10px' }}>
                   <Col smOffset={10} sm={2}>
-                    <Button bsStyle="primary" style={{ marginLeft: '-10px' }} onClick={() => this.onUpdateHandler(id)}>
+                    <Button
+                      bsStyle="primary"
+                      style={{ marginLeft: '-10px' }}
+                      onClick={() => this.onUpdateHandler(id)}
+                      disabled={handler.serviceId === '' || handler.systemUrl === '' || handler.accessToken === ''}
+                    >
                       Update Handler
                     </Button>
                   </Col>
@@ -384,6 +424,15 @@ class ThreeScaleIntegration extends React.Component<Props, State> {
     );
   };
 
+  isValidCreateHandler = () => {
+    return (
+      this.state.newThreeScaleHandler.name !== '' &&
+      this.state.newThreeScaleHandler.serviceId !== '' &&
+      this.state.newThreeScaleHandler.systemUrl !== '' &&
+      this.state.newThreeScaleHandler.accessToken !== ''
+    );
+  };
+
   renderCreateHandler = () => {
     return (
       <Form className={createHandlerStyle} horizontal={true}>
@@ -392,6 +441,7 @@ class ThreeScaleIntegration extends React.Component<Props, State> {
           disabled={false}
           value={this.state.newThreeScaleHandler.name}
           onChange={e => this.onChangeHandler(-1, 'name', e.target.value)}
+          validationState={this.state.newThreeScaleHandler.name !== '' ? 'success' : 'error'}
         >
           <Col componentClass={ControlLabel} sm={2}>
             Handler Name:
@@ -405,25 +455,41 @@ class ThreeScaleIntegration extends React.Component<Props, State> {
           disabled={false}
           value={this.state.newThreeScaleHandler.serviceId}
           onChange={e => this.onChangeHandler(-1, 'serviceId', e.target.value)}
+          validationState={this.state.newThreeScaleHandler.serviceId !== '' ? 'success' : 'error'}
         >
           <Col componentClass={ControlLabel} sm={2}>
             Service Id:
           </Col>
           <Col sm={8}>
-            <FormControl type="text" disabled={false} />
+            <OverlayTrigger
+              placement={'right'}
+              overlay={<Tooltip id={'mtls-status-masthead'}>3scale ID for API calls</Tooltip>}
+              trigger={['hover', 'focus']}
+              rootClose={false}
+            >
+              <FormControl type="text" disabled={false} />
+            </OverlayTrigger>
           </Col>
         </FormGroup>
         <FormGroup
           controlId="systemUrl"
           disabled={false}
-          value={this.state.newThreeScaleHandler.accessToken}
+          value={this.state.newThreeScaleHandler.systemUrl}
           onChange={e => this.onChangeHandler(-1, 'systemUrl', e.target.value)}
+          validationState={this.state.newThreeScaleHandler.systemUrl !== '' ? 'success' : 'error'}
         >
           <Col componentClass={ControlLabel} sm={2}>
             System Url:
           </Col>
           <Col sm={8}>
-            <FormControl type="text" disabled={false} />
+            <OverlayTrigger
+              placement={'right'}
+              overlay={<Tooltip id={'mtls-status-masthead'}>3scale System Url for API</Tooltip>}
+              trigger={['hover', 'focus']}
+              rootClose={false}
+            >
+              <FormControl type="text" disabled={false} />
+            </OverlayTrigger>
           </Col>
         </FormGroup>
         <FormGroup
@@ -431,17 +497,25 @@ class ThreeScaleIntegration extends React.Component<Props, State> {
           disabled={false}
           value={this.state.newThreeScaleHandler.accessToken}
           onChange={e => this.onChangeHandler(-1, 'accessToken', e.target.value)}
+          validationState={this.state.newThreeScaleHandler.accessToken !== '' ? 'success' : 'error'}
         >
           <Col componentClass={ControlLabel} sm={2}>
             Access Token:
           </Col>
           <Col sm={8}>
-            <FormControl type="text" disabled={false} />
+            <OverlayTrigger
+              placement={'right'}
+              overlay={<Tooltip id={'mtls-status-masthead'}>3scale access token</Tooltip>}
+              trigger={['hover', 'focus']}
+              rootClose={false}
+            >
+              <FormControl type="text" disabled={false} />
+            </OverlayTrigger>
           </Col>
         </FormGroup>
         <Row style={{ paddingTop: '10px', paddingBottom: '10px' }}>
           <Col smOffset={10} sm={2}>
-            <Button bsStyle="primary" onClick={this.onCreateHandler}>
+            <Button bsStyle="primary" onClick={this.onCreateHandler} disabled={!this.isValidCreateHandler()}>
               Create Handler
             </Button>
           </Col>

--- a/src/components/IstioWizards/__tests__/ThreeScaleIntegration.test.ts
+++ b/src/components/IstioWizards/__tests__/ThreeScaleIntegration.test.ts
@@ -1,0 +1,22 @@
+describe('Should check a complex regexp name', () => {
+  const regexp = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[-a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
+
+  it('should check valid name', () => {
+    const result = 'valid-name.namespace'.search(regexp);
+    expect(result).toBe(0);
+  });
+
+  it('should check an invalid name', () => {
+    let result = 'Invalid-name.namespace'.search(regexp);
+    expect(result).toBe(-1);
+
+    result = '-invalid-name.namespace'.search(regexp);
+    expect(result).toBe(-1);
+
+    result = 'invalid-name.namespace-'.search(regexp);
+    expect(result).toBe(-1);
+
+    result = 'invalid-name.namespace.'.search(regexp);
+    expect(result).toBe(-1);
+  });
+});

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -96,6 +96,12 @@ const conf = {
       serviceDashboard: (namespace: string, service: string) =>
         `api/namespaces/${namespace}/services/${service}/dashboard`,
       status: 'api/status',
+      threeScale: 'api/threescale',
+      threeScaleHandler: (handlerName: string) => `api/threescale/handlers/${handlerName}`,
+      threeScaleHandlers: 'api/threescale/handlers',
+      threeScaleServiceRule: (namespace: string, service: string) =>
+        `api/threescale/namespaces/${namespace}/services/${service}`,
+      threeScaleServiceRules: (namespace: string) => `api/threescale/namespaces/${namespace}/services`,
       workloads: (namespace: string) => `api/namespaces/${namespace}/workloads`,
       workload: (namespace: string, workload: string) => `api/namespaces/${namespace}/workloads/${workload}`,
       workloadGraphElements: (namespace: string, workload: string) =>

--- a/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -22,6 +22,7 @@ import ServiceInfoWorkload from './ServiceInfo/ServiceInfoWorkload';
 import { Validations } from '../../types/IstioObjects';
 import { TabPaneWithErrorBoundary } from '../../components/ErrorBoundary/WithErrorBoundary';
 import IstioWizardDropdown from '../../components/IstioWizards/IstioWizardDropdown';
+import { ThreeScaleInfo, ThreeScaleServiceRule } from '../../types/ThreeScale';
 
 interface ServiceDetails extends ServiceId {
   serviceDetails: ServiceDetailsInfo;
@@ -29,6 +30,8 @@ interface ServiceDetails extends ServiceId {
   onRefresh: () => void;
   onSelectTab: (tabName: string, postHandler?: (tabName: string) => void) => void;
   activeTab: (tabName: string, whenEmpty: string) => string;
+  threeScaleInfo: ThreeScaleInfo;
+  threeScaleServiceRule?: ThreeScaleServiceRule;
 }
 
 type ServiceInfoState = {
@@ -136,6 +139,8 @@ class ServiceInfo extends React.Component<ServiceDetails, ServiceInfoState> {
                   destinationRules={destinationRules}
                   tlsStatus={this.props.serviceDetails.namespaceMTLS}
                   onChange={this.props.onRefresh}
+                  threeScaleInfo={this.props.threeScaleInfo}
+                  threeScaleServiceRule={this.props.threeScaleServiceRule}
                 />
               </span>
             </Col>
@@ -155,6 +160,7 @@ class ServiceInfo extends React.Component<ServiceDetails, ServiceInfoState> {
                 endpoints={this.props.serviceDetails.endpoints}
                 health={this.props.serviceDetails.health}
                 externalName={this.props.serviceDetails.service.externalName}
+                threeScaleServiceRule={this.props.threeScaleServiceRule}
               />
             </Col>
           </Row>

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
@@ -11,6 +11,7 @@ import { style } from 'typestyle';
 import './ServiceInfoDescription.css';
 import Labels from '../../../components/Label/Labels';
 import { CytoscapeGraphSelectorBuilder } from '../../../components/CytoscapeGraph/CytoscapeGraphSelector';
+import { ThreeScaleServiceRule } from '../../../types/ThreeScale';
 
 interface ServiceInfoDescriptionProps {
   name: string;
@@ -25,6 +26,7 @@ interface ServiceInfoDescriptionProps {
   ports?: Port[];
   endpoints?: Endpoints[];
   health?: ServiceHealth;
+  threeScaleServiceRule?: ThreeScaleServiceRule;
 }
 
 const listStyle = style({
@@ -83,6 +85,9 @@ class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps
               <div>
                 <strong>Resource Version</strong> {this.props.resourceVersion}
               </div>
+              {this.props.threeScaleServiceRule && this.props.threeScaleServiceRule.threeScaleHandlerName !== '' && (
+                <div>Service linked with 3Scale API</div>
+              )}
             </Col>
             <Col xs={12} sm={4} md={2} lg={2}>
               <div className="progress-description">

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
@@ -86,7 +86,7 @@ class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps
                 <strong>Resource Version</strong> {this.props.resourceVersion}
               </div>
               {this.props.threeScaleServiceRule && this.props.threeScaleServiceRule.threeScaleHandlerName !== '' && (
-                <div>Service linked with 3Scale API</div>
+                <div>Service linked with 3scale API</div>
               )}
             </Col>
             <Col xs={12} sm={4} md={2} lg={2}>

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
@@ -85,9 +85,9 @@ class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps
               <div>
                 <strong>Resource Version</strong> {this.props.resourceVersion}
               </div>
-              {this.props.threeScaleServiceRule && this.props.threeScaleServiceRule.threeScaleHandlerName !== '' && (
-                <div>Service linked with 3scale API</div>
-              )}
+              {this.props.threeScaleServiceRule &&
+                this.props.threeScaleServiceRule.threeScaleHandlerName !== '' &&
+                'Service linked with 3scale API'}
             </Col>
             <Col xs={12} sm={4} md={2} lg={2}>
               <div className="progress-description">

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
@@ -85,9 +85,11 @@ class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps
               <div>
                 <strong>Resource Version</strong> {this.props.resourceVersion}
               </div>
-              {this.props.threeScaleServiceRule &&
-                this.props.threeScaleServiceRule.threeScaleHandlerName !== '' &&
-                'Service linked with 3scale API'}
+              {this.props.threeScaleServiceRule && this.props.threeScaleServiceRule.threeScaleHandlerName !== '' && (
+                <span>
+                  Service linked with 3scale API Handler <i>{this.props.threeScaleServiceRule.threeScaleHandlerName}</i>
+                </span>
+              )}
             </Col>
             <Col xs={12} sm={4} md={2} lg={2}>
               <div className="progress-description">

--- a/src/pages/ServiceDetails/__tests__/ServiceInfo.test.tsx
+++ b/src/pages/ServiceDetails/__tests__/ServiceInfo.test.tsx
@@ -20,6 +20,14 @@ describe('#ServiceInfo render correctly with data', () => {
           onRefresh={jest.fn()}
           onSelectTab={jest.fn()}
           activeTab={jest.fn()}
+          threeScaleInfo={{
+            enabled: false,
+            permissions: {
+              create: false,
+              update: false,
+              delete: false
+            }
+          }}
         />
       );
       expect(wrapper).toBeDefined();

--- a/src/pages/ServiceDetails/__tests__/__snapshots__/ServiceInfo.test.tsx.snap
+++ b/src/pages/ServiceDetails/__tests__/__snapshots__/ServiceInfo.test.tsx.snap
@@ -175,6 +175,16 @@ ShallowWrapper {
         "workloads": Array [],
       }
     }
+    threeScaleInfo={
+      Object {
+        "enabled": false,
+        "permissions": Object {
+          "create": false,
+          "delete": false,
+          "update": false,
+        },
+      }
+    }
     validations={
       Object {
         "destinationrule": Object {
@@ -298,6 +308,17 @@ ShallowWrapper {
                   onChange={[MockFunction]}
                   serviceName="reviews"
                   show={false}
+                  threeScaleInfo={
+                    Object {
+                      "enabled": false,
+                      "permissions": Object {
+                        "create": false,
+                        "delete": false,
+                        "update": false,
+                      },
+                    }
+                  }
+                  threeScaleServiceRule={undefined}
                   tlsStatus={undefined}
                   virtualServices={
                     Object {
@@ -407,6 +428,7 @@ ShallowWrapper {
                   ]
                 }
                 resourceVersion="2652"
+                threeScaleServiceRule={undefined}
                 type="ClusterIP"
               />
             </Col>
@@ -683,6 +705,17 @@ ShallowWrapper {
                     onChange={[MockFunction]}
                     serviceName="reviews"
                     show={false}
+                    threeScaleInfo={
+                      Object {
+                        "enabled": false,
+                        "permissions": Object {
+                          "create": false,
+                          "delete": false,
+                          "update": false,
+                        },
+                      }
+                    }
+                    threeScaleServiceRule={undefined}
                     tlsStatus={undefined}
                     virtualServices={
                       Object {
@@ -792,6 +825,7 @@ ShallowWrapper {
                     ]
                   }
                   resourceVersion="2652"
+                  threeScaleServiceRule={undefined}
                   type="ClusterIP"
                 />
               </Col>
@@ -1062,6 +1096,17 @@ ShallowWrapper {
                     onChange={[MockFunction]}
                     serviceName="reviews"
                     show={false}
+                    threeScaleInfo={
+                      Object {
+                        "enabled": false,
+                        "permissions": Object {
+                          "create": false,
+                          "delete": false,
+                          "update": false,
+                        },
+                      }
+                    }
+                    threeScaleServiceRule={undefined}
                     tlsStatus={undefined}
                     virtualServices={
                       Object {
@@ -1182,6 +1227,17 @@ ShallowWrapper {
                     onChange={[MockFunction]}
                     serviceName="reviews"
                     show={false}
+                    threeScaleInfo={
+                      Object {
+                        "enabled": false,
+                        "permissions": Object {
+                          "create": false,
+                          "delete": false,
+                          "update": false,
+                        },
+                      }
+                    }
+                    threeScaleServiceRule={undefined}
                     tlsStatus={undefined}
                     virtualServices={
                       Object {
@@ -1297,6 +1353,17 @@ ShallowWrapper {
                       onChange={[MockFunction]}
                       serviceName="reviews"
                       show={false}
+                      threeScaleInfo={
+                        Object {
+                          "enabled": false,
+                          "permissions": Object {
+                            "create": false,
+                            "delete": false,
+                            "update": false,
+                          },
+                        }
+                      }
+                      threeScaleServiceRule={undefined}
                       tlsStatus={undefined}
                       virtualServices={
                         Object {
@@ -1425,6 +1492,15 @@ ShallowWrapper {
                       "onChange": [MockFunction],
                       "serviceName": "reviews",
                       "show": false,
+                      "threeScaleInfo": Object {
+                        "enabled": false,
+                        "permissions": Object {
+                          "create": false,
+                          "delete": false,
+                          "update": false,
+                        },
+                      },
+                      "threeScaleServiceRule": undefined,
                       "tlsStatus": undefined,
                       "virtualServices": Object {
                         "items": Array [
@@ -1541,6 +1617,7 @@ ShallowWrapper {
                     ]
                   }
                   resourceVersion="2652"
+                  threeScaleServiceRule={undefined}
                   type="ClusterIP"
                 />
               </Col>,
@@ -1607,6 +1684,7 @@ ShallowWrapper {
                     ]
                   }
                   resourceVersion="2652"
+                  threeScaleServiceRule={undefined}
                   type="ClusterIP"
                 />,
                 "componentClass": "div",
@@ -1667,6 +1745,7 @@ ShallowWrapper {
                     },
                   ],
                   "resourceVersion": "2652",
+                  "threeScaleServiceRule": undefined,
                   "type": "ClusterIP",
                 },
                 "ref": null,
@@ -2988,6 +3067,17 @@ ShallowWrapper {
                     onChange={[MockFunction]}
                     serviceName="reviews"
                     show={false}
+                    threeScaleInfo={
+                      Object {
+                        "enabled": false,
+                        "permissions": Object {
+                          "create": false,
+                          "delete": false,
+                          "update": false,
+                        },
+                      }
+                    }
+                    threeScaleServiceRule={undefined}
                     tlsStatus={undefined}
                     virtualServices={
                       Object {
@@ -3097,6 +3187,7 @@ ShallowWrapper {
                     ]
                   }
                   resourceVersion="2652"
+                  threeScaleServiceRule={undefined}
                   type="ClusterIP"
                 />
               </Col>
@@ -3373,6 +3464,17 @@ ShallowWrapper {
                       onChange={[MockFunction]}
                       serviceName="reviews"
                       show={false}
+                      threeScaleInfo={
+                        Object {
+                          "enabled": false,
+                          "permissions": Object {
+                            "create": false,
+                            "delete": false,
+                            "update": false,
+                          },
+                        }
+                      }
+                      threeScaleServiceRule={undefined}
                       tlsStatus={undefined}
                       virtualServices={
                         Object {
@@ -3482,6 +3584,7 @@ ShallowWrapper {
                       ]
                     }
                     resourceVersion="2652"
+                    threeScaleServiceRule={undefined}
                     type="ClusterIP"
                   />
                 </Col>
@@ -3752,6 +3855,17 @@ ShallowWrapper {
                       onChange={[MockFunction]}
                       serviceName="reviews"
                       show={false}
+                      threeScaleInfo={
+                        Object {
+                          "enabled": false,
+                          "permissions": Object {
+                            "create": false,
+                            "delete": false,
+                            "update": false,
+                          },
+                        }
+                      }
+                      threeScaleServiceRule={undefined}
                       tlsStatus={undefined}
                       virtualServices={
                         Object {
@@ -3872,6 +3986,17 @@ ShallowWrapper {
                       onChange={[MockFunction]}
                       serviceName="reviews"
                       show={false}
+                      threeScaleInfo={
+                        Object {
+                          "enabled": false,
+                          "permissions": Object {
+                            "create": false,
+                            "delete": false,
+                            "update": false,
+                          },
+                        }
+                      }
+                      threeScaleServiceRule={undefined}
                       tlsStatus={undefined}
                       virtualServices={
                         Object {
@@ -3987,6 +4112,17 @@ ShallowWrapper {
                         onChange={[MockFunction]}
                         serviceName="reviews"
                         show={false}
+                        threeScaleInfo={
+                          Object {
+                            "enabled": false,
+                            "permissions": Object {
+                              "create": false,
+                              "delete": false,
+                              "update": false,
+                            },
+                          }
+                        }
+                        threeScaleServiceRule={undefined}
                         tlsStatus={undefined}
                         virtualServices={
                           Object {
@@ -4115,6 +4251,15 @@ ShallowWrapper {
                         "onChange": [MockFunction],
                         "serviceName": "reviews",
                         "show": false,
+                        "threeScaleInfo": Object {
+                          "enabled": false,
+                          "permissions": Object {
+                            "create": false,
+                            "delete": false,
+                            "update": false,
+                          },
+                        },
+                        "threeScaleServiceRule": undefined,
                         "tlsStatus": undefined,
                         "virtualServices": Object {
                           "items": Array [
@@ -4231,6 +4376,7 @@ ShallowWrapper {
                       ]
                     }
                     resourceVersion="2652"
+                    threeScaleServiceRule={undefined}
                     type="ClusterIP"
                   />
                 </Col>,
@@ -4297,6 +4443,7 @@ ShallowWrapper {
                       ]
                     }
                     resourceVersion="2652"
+                    threeScaleServiceRule={undefined}
                     type="ClusterIP"
                   />,
                   "componentClass": "div",
@@ -4357,6 +4504,7 @@ ShallowWrapper {
                       },
                     ],
                     "resourceVersion": "2652",
+                    "threeScaleServiceRule": undefined,
                     "type": "ClusterIP",
                   },
                   "ref": null,

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -27,6 +27,7 @@ import { config } from '../config';
 import { ServerConfig } from '../types/ServerConfig';
 import { TLSStatus } from '../types/TLSStatus';
 import { Pod, PodLogs } from '../types/IstioObjects';
+import { ThreeScaleHandler, ThreeScaleInfo, ThreeScaleServiceRule } from '../types/ThreeScale';
 
 export const ANONYMOUS_USER = 'anonymous';
 
@@ -436,4 +437,40 @@ export const getErrorMsg = (msg: string, error: AxiosError) => {
     }
   }
   return errorMessage;
+};
+
+export const getThreeScaleInfo = () => {
+  return newRequest<ThreeScaleInfo>(HTTP_VERBS.GET, urls.threeScale, {}, {});
+};
+
+export const getThreeScaleHandlers = () => {
+  return newRequest<ThreeScaleHandler[]>(HTTP_VERBS.GET, urls.threeScaleHandlers, {}, {});
+};
+
+export const createThreeScaleHandler = (json: string) => {
+  return newRequest<ThreeScaleHandler[]>(HTTP_VERBS.POST, urls.threeScaleHandlers, {}, json);
+};
+
+export const updateThreeScaleHandler = (handlerName: string, json: string) => {
+  return newRequest<ThreeScaleHandler[]>(HTTP_VERBS.PATCH, urls.threeScaleHandler(handlerName), {}, json);
+};
+
+export const deleteThreeScaleHandler = (handlerName: string) => {
+  return newRequest<ThreeScaleHandler[]>(HTTP_VERBS.DELETE, urls.threeScaleHandler(handlerName), {}, {});
+};
+
+export const getThreeScaleServiceRule = (namespace: string, service: string) => {
+  return newRequest<ThreeScaleServiceRule>(HTTP_VERBS.GET, urls.threeScaleServiceRule(namespace, service), {}, {});
+};
+
+export const createThreeScaleServiceRule = (namespace: string, json: string) => {
+  return newRequest<string>(HTTP_VERBS.POST, urls.threeScaleServiceRules(namespace), {}, json);
+};
+
+export const updateThreeScaleServiceRule = (namespace: string, service: string, json: string) => {
+  return newRequest<string>(HTTP_VERBS.PATCH, urls.threeScaleServiceRule(namespace, service), {}, json);
+};
+
+export const deleteThreeScaleServiceRule = (namespace: string, service: string) => {
+  return newRequest<string>(HTTP_VERBS.DELETE, urls.threeScaleServiceRule(namespace, service), {}, {});
 };

--- a/src/types/ThreeScale.ts
+++ b/src/types/ThreeScale.ts
@@ -1,0 +1,19 @@
+import { ResourcePermissions } from './Permissions';
+
+export interface ThreeScaleInfo {
+  enabled: boolean;
+  permissions: ResourcePermissions;
+}
+
+export interface ThreeScaleHandler {
+  name: string;
+  serviceId: string;
+  systemUrl: string;
+  accessToken: string;
+}
+
+export interface ThreeScaleServiceRule {
+  serviceName: string;
+  serviceNamespace: string;
+  threeScaleHandlerName: string;
+}


### PR DESCRIPTION
This PRs refers to JIRA
https://issues.jboss.org/browse/KIALI-2641
and it needs backend PR https://github.com/kiali/kiali/pull/1050 with the API services.

Summary
----
Maistra will include a new Istio 3Scale adapter [1] that will allow to autenticate Services deployed in Istio with a 3Scale API. 

The configuration of this integration is somehow complex as a user needs to create Istio objects like rules, handlers and template instances.

The goal of this PR is to provide a high level integration from the UI to make this setup easier.

For this first step, we have defined a new Wizard at Service Details level. 
This Wizard only will be visible when the 3scale adapter is present in the cluster, otherwise, this PR will be transparent to the rest of the users.

![image](https://user-images.githubusercontent.com/1662329/57390377-7dceb580-71bc-11e9-8133-361e58423165.png)

When the 3scale adapter is available user will be able to "Add a 3Scale" rule for a service or to "Delete" an existing one. Note that this operation is 1to1, so, Kiali will only permit one 3Scale Rule per Service.

This will means that a specific service will query 3Scale for authentication, following the described policies defined in [1].

If cluster has not defined any 3Scale Handler, first action a user will do is to create one. To perform this operation, user needs to supply some parameters provided by the 3Scale Admin site.

![image](https://user-images.githubusercontent.com/1662329/57390661-2f6de680-71bd-11e9-9a39-3785add94290.png)

Once this handler is created; the handler is selected for the service that will be linked.

![image](https://user-images.githubusercontent.com/1662329/57390781-6643fc80-71bd-11e9-8678-4a8e2a640990.png)

Note, that user can create multiple handlers, but it will be typically only one per cluster, that will be used for multiple services. But multiple handlers can be created using the "Show Advanced Options".

![image](https://user-images.githubusercontent.com/1662329/57391006-d9e60980-71bd-11e9-88ac-db06708c4317.png)

Basic delete/update operations on handler(s) are supported from the Wizard:

![image](https://user-images.githubusercontent.com/1662329/57391068-fc782280-71bd-11e9-9ec8-e820204c1f0a.png)

Once the 3Scale Rule is created, a particular service is "linked" with 3Scale API using and indicated into the Service Description details:

![image](https://user-images.githubusercontent.com/1662329/57391123-27627680-71be-11e9-97d9-7654a7ab6afc.png)

Note that in the future, there can be more complex operations, like to perform a Rule on mulitple Services in a single operation. 

That is out of the scope of this PR.

How to test
---

There are several preliminary steps before you can test this feature.

First is to use install Maistra enabling the 3Scale adapter. To do that, you need to use a special custom installation yaml like this one:

```
apiVersion: "istio.openshift.com/v1alpha1"
kind: "Installation"
metadata:
  name: "istio-installation"
  namespace: istio-operator
spec:
  threeScale:
    enabled: true
```
That will deploy the 3scale adapter under the istio-system namespace:
![image](https://user-images.githubusercontent.com/1662329/57391450-e028b580-71be-11e9-9277-e5420de43d5c.png)

Also, 3Scale adapter needs to enable policies in Istio, if not, Rules won't take any effect without showing any warning/error on logs (yeap, I hope this would save you some time):

```
echo "Check policies...."
oc -n istio-system get cm istio -o jsonpath="{@.data.mesh}" | grep disablePolicyChecks
cd $ISTIO_HOME
echo "Updating policies..."
helm template install/kubernetes/helm/istio --namespace=istio-system -x templates/configmap.yaml --set global.disablePolicyChecks=false | oc -n istio-system replace -f -
```

For these tests I've created a special API in 3Scale called Kiali, under the API I prepared some configuration to be used with a special demo app called travel-agency:

https://github.com/lucasponce/travel-comparison-demo

So, first you need to deploy the travel-agency app using

```
https://github.com/lucasponce/travel-comparison-demo/blob/master/deploy-travel-agency.sh

Note: no need to install the full example, just the travel-agency is enough for this 3scale testing
```

Next, you would need to expose the travels service with a gateway

```
https://github.com/lucasponce/travel-comparison-demo/blob/master/travel_agency_gateway.yaml
```

And you can invoke the travel service through the gateway using something like this script

```
#!/bin/bash

export INGRESS_HOST=$(oc get po -l istio=ingressgateway -n istio-system -o 'jsonpath={.items[0].status.hostIP}')
export INGRESS_PORT=$(oc -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="http2")].nodePort}')

TRAVEL_AGENCY_HOST="Host:www.travel-agency.com"
TRAVELS_SERVICE="http://${INGRESS_HOST}:${INGRESS_PORT}"

while true
do
    for city in paris rome london
    do
        for user in vip normal
        do
            RESULT=$(curl -H "${TRAVEL_AGENCY_HOST}" -H "user:${user}" -o /dev/null -s -w %{http_code} ${TRAVELS_SERVICE}/travels/${city}?user_key=4406b917c719df23055919c134651ee4)
            echo "Travel quota for ${city} from ${user} => $RESULT"
            sleep 1
        done
        RESULT=$(curl -H "${TRAVEL_AGENCY_HOST}" -H "user:${user}" -o /dev/null -s -w %{http_code} ${TRAVELS_SERVICE}/travels/${city})
        echo "Travel quota for ${city} from anonymous => $RESULT"
        sleep 1
    done
done
```

Note that this script will add a special 3scale query parameters "user_key" to propagate the user key of the demo user connected with 3Scale (you need to use this value, as it's a valid code).

Then, you can use the following 3scale parameters to create handlers/rule in the Wizard:

```
{
  "name": "my-test-handler",
  "serviceId": "2555417792901",
  "systemUrl": "https://kiali-admin.3scale.net",
  "accessToken": "15586d0814cf49c5fd8fef46940e774063476c3845a368d218ac6edc6befb054"
}

Note: "name" can be anything, but serviceId, systemUrl and accessToken are valid
```

How to validate things are working as expected
---

Once that you have created a 3Scale Rule under the "travels" service, only the calls with the valid user_key are responding a 200 Ok, the others should have a 403 Error.
When no rule is created, all calls should return a 200 Ok.

```
[...]
Travel quota for london from vip => 200
Travel quota for london from normal => 200
Travel quota for london from anonymous => 403
[...]
```

Also, in Istio Config, we can check that the Wizard generates a pair of Hanlder/Instances resources per "3Scale Handler" and a specific "Istio Rule" per link between "Service and 3Scale".

[1] https://github.com/3scale/3scale-istio-adapter