### PR TITLE
KIALI-2830 Fix the params compare to avoid duplicate loads from backend

### DIFF
--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -88,9 +88,18 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
       this.aceEditorRef.current!['editor'].onChangeAnnotation();
     }
 
-    if (this.props.match.params !== prevProps.match.params) {
+    if (!this.propsMatch(prevProps)) {
       this.fetchIstioObjectDetailsFromProps(this.props.match.params);
     }
+  }
+
+  propsMatch(prevProps: RouteComponentProps<IstioConfigId>) {
+    return (
+      this.props.match.params.namespace === prevProps.match.params.namespace &&
+      this.props.match.params.object === prevProps.match.params.object &&
+      this.props.match.params.objectType === prevProps.match.params.objectType &&
+      this.props.match.params.objectSubtype === prevProps.match.params.objectSubtype
+    );
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
** Describe the change **

When opening the overview of a single Istio Config item, the params does an object !== object compare which will not work. Thus the backend is called twice to load the same information even if the information inside the object is equivalent.

Fix the compare to avoid dual loading.

** Issue reference **

KIALI-2830
