### PR TITLE
KIALI-2832 Clean errors if there is no namespace selected

### DIFF
--- a/src/actions/GraphDataActions.ts
+++ b/src/actions/GraphDataActions.ts
@@ -6,7 +6,8 @@ enum GraphDataActionKeys {
   GET_GRAPH_DATA_START = 'GET_GRAPH_DATA_START',
   GET_GRAPH_DATA_SUCCESS = 'GET_GRAPH_DATA_SUCCESS',
   GET_GRAPH_DATA_FAILURE = 'GET_GRAPH_DATA_FAILURE',
-  HANDLE_LEGEND = 'HANDLE_LEGEND'
+  HANDLE_LEGEND = 'HANDLE_LEGEND',
+  GET_GRAPH_DATA_WITHOUT_NAMESPACES = 'GET_GRAPH_DATA_WITHOUT_NAMESPACES'
 }
 
 // synchronous action creators
@@ -24,6 +25,7 @@ export const GraphDataActions = {
   getGraphDataFailure: createAction(GraphDataActionKeys.GET_GRAPH_DATA_FAILURE, resolve => (error: any) =>
     resolve({ error: error })
   ),
+  getGraphDataWithoutNamespaces: createAction(GraphDataActionKeys.GET_GRAPH_DATA_WITHOUT_NAMESPACES),
   handleLegend: createAction(GraphDataActionKeys.HANDLE_LEGEND)
 };
 

--- a/src/actions/GraphDataThunkActions.ts
+++ b/src/actions/GraphDataThunkActions.ts
@@ -34,6 +34,7 @@ const GraphDataThunkActions = {
   ) => {
     return (dispatch: ThunkDispatch<KialiAppState, undefined, KialiAppAction>, getState: () => KialiAppState) => {
       if (namespaces.length === 0) {
+        dispatch(GraphDataActions.getGraphDataWithoutNamespaces());
         return Promise.resolve();
       }
       dispatch(GraphDataActions.getGraphDataStart());

--- a/src/reducers/GraphDataState.ts
+++ b/src/reducers/GraphDataState.ts
@@ -60,6 +60,15 @@ const graphDataState = (state: GraphState = INITIAL_GRAPH_STATE, action: KialiAp
       newState.isError = true;
       newState.error = action.payload.error;
       break;
+    case getType(GraphDataActions.getGraphDataWithoutNamespaces):
+      newState.isLoading = false;
+      newState.isError = false;
+      newState.error = INITIAL_GRAPH_STATE.error;
+      newState.graphData = INITIAL_GRAPH_STATE.graphData;
+      newState.graphDataDuration = INITIAL_GRAPH_STATE.graphDataDuration;
+      newState.graphDataTimestamp = INITIAL_GRAPH_STATE.graphDataTimestamp;
+      newState.summaryData = INITIAL_GRAPH_STATE.summaryData;
+      break;
     case getType(GraphActions.changed):
       newState.graphData = INITIAL_GRAPH_STATE.graphData;
       newState.graphDataDuration = INITIAL_GRAPH_STATE.graphDataDuration;


### PR DESCRIPTION
** Describe the change **

Clean errors when requesting graph data without namespaces
The issue happens because the graph data without namespaces just returns and doesn't clean previous errors (if any)

The error will stop appearing when Kiali notices that we don't have that namespace anymore (e.g. when opening the namespace selector) 

** Screenshot **

![no-namespace-shows-error](https://user-images.githubusercontent.com/3845764/57492990-c653a500-7288-11e9-98f1-b3a190b79828.gif)
