### PR TITLE
KIALI-2831 Add unary 'traffic' operator for edges

### DIFF
--- a/src/components/GraphFilter/GraphFind.tsx
+++ b/src/components/GraphFilter/GraphFind.tsx
@@ -544,33 +544,36 @@ export class GraphFind extends React.PureComponent<GraphFindProps, GraphFindStat
       //
       case 'cb':
       case 'circuitbreaker':
-        return { target: 'node', selector: isNegation ? `[^${CyNode.hasCB}]` : `[${CyNode.hasCB}]` };
+        return { target: 'node', selector: isNegation ? `[^${CyNode.hasCB}]` : `[?${CyNode.hasCB}]` };
       case 'dead':
-        return { target: 'node', selector: isNegation ? `[^${CyNode.isDead}]` : `[${CyNode.isDead}]` };
+        return { target: 'node', selector: isNegation ? `[^${CyNode.isDead}]` : `[?${CyNode.isDead}]` };
       case 'inaccessible':
-        return { target: 'node', selector: isNegation ? `[^${CyNode.isInaccessible}]` : `[${CyNode.isInaccessible}]` };
+        return { target: 'node', selector: isNegation ? `[^${CyNode.isInaccessible}]` : `[?${CyNode.isInaccessible}]` };
       case 'outside':
       case 'outsider':
-        return { target: 'node', selector: isNegation ? `[^${CyNode.isOutside}]` : `[${CyNode.isOutside}]` };
+        return { target: 'node', selector: isNegation ? `[^${CyNode.isOutside}]` : `[?${CyNode.isOutside}]` };
       case 'se':
       case 'serviceentry':
-        return { target: 'node', selector: isNegation ? `[^${CyNode.isServiceEntry}]` : `[${CyNode.isServiceEntry}]` };
+        return { target: 'node', selector: isNegation ? `[^${CyNode.isServiceEntry}]` : `[?${CyNode.isServiceEntry}]` };
       case 'sc':
       case 'sidecar':
-        return { target: 'node', selector: isNegation ? `[${CyNode.hasMissingSC}]` : `[^${CyNode.hasMissingSC}]` };
+        return { target: 'node', selector: isNegation ? `[?${CyNode.hasMissingSC}]` : `[^${CyNode.hasMissingSC}]` };
       case 'trafficsource':
       case 'root':
-        return { target: 'node', selector: isNegation ? `[^${CyNode.isRoot}]` : `[${CyNode.isRoot}]` };
+        return { target: 'node', selector: isNegation ? `[^${CyNode.isRoot}]` : `[?${CyNode.isRoot}]` };
       case 'unused':
-        return { target: 'node', selector: isNegation ? `[^${CyNode.isUnused}]` : `[${CyNode.isUnused}]` };
+        return { target: 'node', selector: isNegation ? `[^${CyNode.isUnused}]` : `[?${CyNode.isUnused}]` };
       case 'vs':
       case 'virtualservice':
-        return { target: 'node', selector: isNegation ? `[^${CyNode.hasVS}]` : `[${CyNode.hasVS}]` };
+        return { target: 'node', selector: isNegation ? `[^${CyNode.hasVS}]` : `[?${CyNode.hasVS}]` };
       //
       // edges...
       //
       case 'mtls':
         return { target: 'edge', selector: isNegation ? `[${CyEdge.isMTLS} <= 0]` : `[${CyEdge.isMTLS} > 0]` };
+      case 'traffic': {
+        return { target: 'edge', selector: isNegation ? `[^${CyEdge.protocol}]` : `[?${CyEdge.protocol}]` };
+      }
       default:
         return undefined;
     }

--- a/src/components/GraphFilter/__tests__/GraphFind.test.tsx
+++ b/src/components/GraphFilter/__tests__/GraphFind.test.tsx
@@ -65,25 +65,25 @@ describe('Parse find value test', () => {
     expect(instance.parseValue('wl = foo')).toEqual('node[workload = "foo"]');
 
     // @ts-ignore
-    expect(instance.parseValue('circuitBreaker')).toEqual('node[hasCB]');
+    expect(instance.parseValue('circuitBreaker')).toEqual('node[?hasCB]');
     // @ts-ignore
-    expect(instance.parseValue('cb')).toEqual('node[hasCB]');
+    expect(instance.parseValue('cb')).toEqual('node[?hasCB]');
     // @ts-ignore
     expect(instance.parseValue('sidecar')).toEqual('node[^hasMissingSC]');
     // @ts-ignore
     expect(instance.parseValue('sc')).toEqual('node[^hasMissingSC]');
     // @ts-ignore
-    expect(instance.parseValue('outside')).toEqual('node[isOutside]');
+    expect(instance.parseValue('outside')).toEqual('node[?isOutside]');
     // @ts-ignore
-    expect(instance.parseValue('outsider')).toEqual('node[isOutside]');
+    expect(instance.parseValue('outsider')).toEqual('node[?isOutside]');
     // @ts-ignore
-    expect(instance.parseValue('root')).toEqual('node[isRoot]');
+    expect(instance.parseValue('root')).toEqual('node[?isRoot]');
     // @ts-ignore
-    expect(instance.parseValue('trafficsource')).toEqual('node[isRoot]');
+    expect(instance.parseValue('trafficsource')).toEqual('node[?isRoot]');
     // @ts-ignore
-    expect(instance.parseValue('virtualService')).toEqual('node[hasVS]');
+    expect(instance.parseValue('virtualService')).toEqual('node[?hasVS]');
     // @ts-ignore
-    expect(instance.parseValue('vs')).toEqual('node[hasVS]');
+    expect(instance.parseValue('vs')).toEqual('node[?hasVS]');
 
     // check coverage of edge operands
     // @ts-ignore
@@ -111,6 +111,10 @@ describe('Parse find value test', () => {
 
     // @ts-ignore
     expect(instance.parseValue('mtls')).toEqual('edge[isMTLS > 0]');
+    // @ts-ignore
+    expect(instance.parseValue('traffic')).toEqual('edge[?protocol]');
+    // @ts-ignore
+    expect(instance.parseValue('!traffic')).toEqual('edge[^protocol]');
 
     // check all numeric operators
     // @ts-ignore

--- a/src/pages/Graph/GraphHelpFind.tsx
+++ b/src/pages/Graph/GraphHelpFind.tsx
@@ -392,7 +392,8 @@ export default class GraphHelpFind extends React.Component<GraphHelpFindProps> {
                             n: `unit: millis, 'Response Time' edge labels required`
                           },
                           { id: 'ec50', c: 'tcp <op> <number>', n: 'unit: requests per second' },
-                          { id: 'ec60', c: 'mtls' }
+                          { id: 'ec60', c: 'mtls' },
+                          { id: 'ec70', c: 'traffic', n: 'any traffic for any protocol' }
                         ]}
                       />
                     </TablePfProvider>
@@ -432,6 +433,7 @@ export default class GraphHelpFind extends React.Component<GraphHelpFindProps> {
                           { id: 'e40', e: '!sc', d: `nodes without a sidecar` },
                           { id: 'e50', e: 'httpin > 0.5', d: `nodes with incoming http rate > 0.5 rps` },
                           { id: 'e60', e: 'tcpout >= 1000', d: `nodes with outgoing tcp rates >= 1000 bps` },
+                          { id: 'e65', e: '!traffic', d: 'edges with no traffic' },
                           { id: 'e70', e: 'http > 0.5', d: `edges with http rate > 0.5 rps` },
                           {
                             id: 'e80',


### PR DESCRIPTION
Can now easily find edges with any traffic for any protocol, or negated can
find edges with no traffic for all protocols.

Also, slightly improve unary patterns to now match in a truthy way.

![kiali-2831](https://user-images.githubusercontent.com/2104052/57544451-5e06d100-7325-11e9-8a7e-1d12c0bb1a9b.gif)
