### PR TITLE
KIALI-2829 Don't hide graph-find clear buttons prematurely

### DIFF
--- a/src/components/GraphFilter/GraphFind.tsx
+++ b/src/components/GraphFilter/GraphFind.tsx
@@ -113,13 +113,13 @@ export class GraphFind extends React.PureComponent<GraphFindProps, GraphFindStat
                 onKeyPress={this.checkSubmitFind}
                 placeholder="Find..."
               />
-              {this.state.findInputValue && (
+              {this.props.findValue && (
                 <OverlayTrigger
-                  key="ot-clear_find"
+                  key="ot_clear_find"
                   placement="top"
                   trigger={['hover', 'focus']}
                   delayShow={1000}
-                  overlay={<Tooltip id="tt-clear_find">Clear Find...</Tooltip>}
+                  overlay={<Tooltip id="tt_clear_find">Clear Find...</Tooltip>}
                 >
                   <InputGroup.Button>
                     <Button onClick={this.clearFind}>
@@ -142,13 +142,13 @@ export class GraphFind extends React.PureComponent<GraphFindProps, GraphFindStat
                 onKeyPress={this.checkSubmitHide}
                 placeholder="Hide..."
               />
-              {this.state.hideInputValue && (
+              {this.props.hideValue && (
                 <OverlayTrigger
-                  key="ot-clear_hide"
+                  key="ot_clear_hide"
                   placement="top"
                   trigger={['hover', 'focus']}
                   delayShow={1000}
-                  overlay={<Tooltip id="tt-clear_hide">Clear Hide...</Tooltip>}
+                  overlay={<Tooltip id="tt_clear_hide">Clear Hide...</Tooltip>}
                 >
                   <InputGroup.Button>
                     <Button onClick={this.clearHide}>
@@ -159,9 +159,9 @@ export class GraphFind extends React.PureComponent<GraphFindProps, GraphFindStat
               )}
             </InputGroup>
             <OverlayTrigger
-              key={'graph-find-help-ot'}
+              key={'ot_graph_find_help'}
               placement="top"
-              overlay={<Tooltip id={'graph-find-help-tt'}>Find/Hide Help...</Tooltip>}
+              overlay={<Tooltip id={'tt_graph_find_help'}>Find/Hide Help...</Tooltip>}
             >
               <Button bsStyle="link" style={{ paddingLeft: '6px' }} onClick={this.toggleFindHelp}>
                 <Icon name="help" type="pf" />

--- a/src/components/GraphFilter/GraphFind.tsx
+++ b/src/components/GraphFilter/GraphFind.tsx
@@ -184,11 +184,19 @@ export class GraphFind extends React.PureComponent<GraphFindProps, GraphFindStat
   };
 
   private updateFind = event => {
-    this.setState({ findInputValue: event.target.value, errorMessage: '' });
+    if ('' === event.target.value) {
+      this.clearFind();
+    } else {
+      this.setState({ findInputValue: event.target.value, errorMessage: '' });
+    }
   };
 
   private updateHide = event => {
-    this.setState({ hideInputValue: event.target.value, errorMessage: '' });
+    if ('' === event.target.value) {
+      this.clearHide();
+    } else {
+      this.setState({ hideInputValue: event.target.value, errorMessage: '' });
+    }
   };
 
   private checkSubmitFind = event => {


### PR DESCRIPTION
The buttons can be hidden only when the input is clear *and* submitted. Otherwise
editing is in progress.

also: fix some static keys and ids to be consistently formed.

@xeviknal This video shows the clear button staying in place until the edit is submitted.  Is this sufficient or do you believe we should auto-submit if the user edits to an empty value?  I feel like that is a non-standard thing to do but let me know.

![kiali-2829](https://user-images.githubusercontent.com/2104052/57545763-5a754900-7329-11e9-8f83-8d734044d3f2.gif)
