### PR TITLE
KIALI-2872 Adjust focus animation

### DIFF
--- a/src/components/CytoscapeGraph/FocusAnimation.ts
+++ b/src/components/CytoscapeGraph/FocusAnimation.ts
@@ -98,7 +98,7 @@ export default class FocusAnimation {
 
   private render(element: any, radio: number) {
     const { x, y } = this.getCenter(element);
-    this.context.strokeStyle = PfColors.Black;
+    this.context.strokeStyle = PfColors.Blue300;
     this.context.lineWidth = LINE_WIDTH;
     this.context.beginPath();
     this.context.arc(x, y, radio, 0, 2 * Math.PI, true);

--- a/src/components/CytoscapeGraph/FocusAnimation.ts
+++ b/src/components/CytoscapeGraph/FocusAnimation.ts
@@ -1,10 +1,13 @@
 import { PfColors } from '../Pf/PfColors';
 
+// How fast refresh (frame rate)
 const FRAME_RATE = 1 / 30;
+// Radio of the biggest circle (i.e. when it starts)
 const MAX_RADIO = 60;
 const LINE_WIDTH = 1;
 
-const ANIMATION_DURATION = 800;
+// Time the animation will take in ms
+const ANIMATION_DURATION = 2000;
 
 type OnFinishedCallback = () => void;
 
@@ -63,7 +66,7 @@ export default class FocusAnimation {
         return;
       }
 
-      this.elements.forEach(element => this.render(element, (1 - step) * MAX_RADIO));
+      this.elements.forEach(element => this.render(element, this.easingFunction(step) * MAX_RADIO));
     } catch (exception) {
       // If a step failed, the next step is likely to fail.
       // Stop the rendering and throw the exception
@@ -71,6 +74,19 @@ export default class FocusAnimation {
       throw exception;
     }
   };
+
+  private easingFunction(t: number) {
+    // Do a focus animation in, out and in again.
+    // Make the first focus slower and the subsequent bit faster
+    if (t < 0.5) {
+      // %50 of the time is spent on the first in
+      return 1 - t * 2;
+    } else if (t < 0.75) {
+      // 25% is spent in the out animation
+      return (t - 0.5) * 4;
+    }
+    return 1 - (t - 0.75) * 4; // 25% is spent in the second in
+  }
 
   private getCenter(element: any) {
     if (element.isNode()) {


### PR DESCRIPTION
** Describe the change **

Adjust focus animation.

It takes 2 seconds and the first circle in takes 1s, the out half a second and the second "in" the other half second.

I could do something different, please comment what you have in mind.

** Screenshot **

Before:
![focus-animation-17](https://user-images.githubusercontent.com/3845764/57871129-42407680-77ce-11e9-817f-e85e2dc63410.gif)

After:

a)
![focus-animation-16](https://user-images.githubusercontent.com/3845764/57871038-13c29b80-77ce-11e9-853e-e2bf8d47d6b8.gif)


b)
![focus-animation-15](https://user-images.githubusercontent.com/3845764/57870882-a9116000-77cd-11e9-9eb3-5f0be3c969cd.gif)

c) same as (a) but with color PfColors.Blue300

![focus-animation-18](https://user-images.githubusercontent.com/3845764/57964072-6f874480-78f4-11e9-8d1e-70df81b2c86c.gif)