### PR TITLE
KIALI-2812 Remove TLS MUTUAL option from Wizard

### DIFF
--- a/src/components/IstioWizards/TrafficPolicy.tsx
+++ b/src/components/IstioWizards/TrafficPolicy.tsx
@@ -12,7 +12,7 @@ export const ROUND_ROBIN = 'ROUND_ROBIN';
 
 export const loadBalancerSimple: string[] = [ROUND_ROBIN, 'LEAST_CONN', 'RANDOM', 'PASSTHROUGH'];
 
-export const mTLSMode: string[] = [DISABLE, ISTIO_MUTUAL, 'MUTUAL', 'SIMPLE'];
+export const mTLSMode: string[] = [DISABLE, ISTIO_MUTUAL, 'SIMPLE'];
 
 type ReduxProps = {
   meshWideStatus: string;


### PR DESCRIPTION
MUTUAL option is an advanced option that requires more fields and objects correctly configured.
So it does make sense to remove it from the high level Wizard use case.

Also, an "advanced" Wizard is planned to be investigated 

https://issues.jboss.org/browse/KIALI-2855

Which can cover this and other complex options.