### PR TITLE
kiali-2827 Improve handling of missing sidecar icon on detail pages

### DIFF
--- a/src/components/Pf/PfInfoCard.tsx
+++ b/src/components/Pf/PfInfoCard.tsx
@@ -24,17 +24,15 @@ class PfInfoCard extends React.Component<CardProps> {
           <h2 className="card-pf-title">
             <Icon type={this.props.iconType} name={this.props.iconName} style={{ marginRight: '10px' }} />
             {this.props.title}
-            {this.props.istio ? (
-              this.props.showOnGraphLink && (
-                <>
-                  {' '}
-                  (<Link to={this.props.showOnGraphLink}>Show on graph</Link>)
-                </>
-              )
-            ) : (
+            {this.props.title && this.props.istio !== undefined && !this.props.istio && (
               <span style={{ marginLeft: '10px' }}>
                 <MissingSidecar />
               </span>
+            )}
+            {this.props.title && this.props.showOnGraphLink && (
+              <>
+                {'  '}(<Link to={this.props.showOnGraphLink}>Show on graph</Link>)
+              </>
             )}
           </h2>
         </div>

--- a/src/pages/AppDetails/AppInfo/AppDescription.tsx
+++ b/src/pages/AppDetails/AppInfo/AppDescription.tsx
@@ -25,7 +25,7 @@ class AppDescription extends React.Component<AppDescriptionProps, AppDescription
   }
 
   istioSidecar() {
-    let istioSidecar = this.props.app.workloads && this.props.app.workloads.length > 0 ? true : false;
+    let istioSidecar = true; // true until proven otherwise (workload with missing sidecar exists)
     this.props.app.workloads.forEach(wkd => {
       istioSidecar = istioSidecar && wkd.istioSidecar;
     });

--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -39,7 +39,7 @@ interface ParsedSearch {
 }
 
 const emptyService = {
-  istioSidecar: false,
+  istioSidecar: true, // true until proven otherwise (workload with missing sidecar exists)
   service: {
     type: '',
     name: '',

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoCard.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoCard.test.tsx.snap
@@ -61,22 +61,6 @@ ShallowWrapper {
               type="fa"
             />
             Pods
-            <span
-              style={
-                Object {
-                  "marginLeft": "10px",
-                }
-              }
-            >
-              <MissingSidecar
-                color="red"
-                name="blueprint"
-                text="Missing Sidecar"
-                textTooltip="Missing Sidecar"
-                tooltip={false}
-                type="pf"
-              />
-            </span>
           </h2>
         </div>,
         <div
@@ -127,22 +111,6 @@ ShallowWrapper {
               type="fa"
             />
             Pods
-            <span
-              style={
-                Object {
-                  "marginLeft": "10px",
-                }
-              }
-            >
-              <MissingSidecar
-                color="red"
-                name="blueprint"
-                text="Missing Sidecar"
-                textTooltip="Missing Sidecar"
-                tooltip={false}
-                type="pf"
-              />
-            </span>
           </h2>,
           "className": "card-pf-heading",
         },
@@ -163,22 +131,8 @@ ShallowWrapper {
                 type="fa"
               />,
               "Pods",
-              <span
-                style={
-                  Object {
-                    "marginLeft": "10px",
-                  }
-                }
-              >
-                <MissingSidecar
-                  color="red"
-                  name="blueprint"
-                  text="Missing Sidecar"
-                  textTooltip="Missing Sidecar"
-                  tooltip={false}
-                  type="pf"
-                />
-              </span>,
+              false,
+              undefined,
             ],
             "className": "card-pf-title",
           },
@@ -200,42 +154,8 @@ ShallowWrapper {
               "type": [Function],
             },
             "Pods",
-            Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "host",
-              "props": Object {
-                "children": <MissingSidecar
-                  color="red"
-                  name="blueprint"
-                  text="Missing Sidecar"
-                  textTooltip="Missing Sidecar"
-                  tooltip={false}
-                  type="pf"
-                />,
-                "style": Object {
-                  "marginLeft": "10px",
-                },
-              },
-              "ref": null,
-              "rendered": Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "function",
-                "props": Object {
-                  "color": "red",
-                  "name": "blueprint",
-                  "text": "Missing Sidecar",
-                  "textTooltip": "Missing Sidecar",
-                  "tooltip": false,
-                  "type": "pf",
-                },
-                "ref": null,
-                "rendered": null,
-                "type": [Function],
-              },
-              "type": "span",
-            },
+            false,
+            undefined,
           ],
           "type": "h2",
         },
@@ -396,22 +316,6 @@ ShallowWrapper {
                 type="fa"
               />
               Pods
-              <span
-                style={
-                  Object {
-                    "marginLeft": "10px",
-                  }
-                }
-              >
-                <MissingSidecar
-                  color="red"
-                  name="blueprint"
-                  text="Missing Sidecar"
-                  textTooltip="Missing Sidecar"
-                  tooltip={false}
-                  type="pf"
-                />
-              </span>
             </h2>
           </div>,
           <div
@@ -462,22 +366,6 @@ ShallowWrapper {
                 type="fa"
               />
               Pods
-              <span
-                style={
-                  Object {
-                    "marginLeft": "10px",
-                  }
-                }
-              >
-                <MissingSidecar
-                  color="red"
-                  name="blueprint"
-                  text="Missing Sidecar"
-                  textTooltip="Missing Sidecar"
-                  tooltip={false}
-                  type="pf"
-                />
-              </span>
             </h2>,
             "className": "card-pf-heading",
           },
@@ -498,22 +386,8 @@ ShallowWrapper {
                   type="fa"
                 />,
                 "Pods",
-                <span
-                  style={
-                    Object {
-                      "marginLeft": "10px",
-                    }
-                  }
-                >
-                  <MissingSidecar
-                    color="red"
-                    name="blueprint"
-                    text="Missing Sidecar"
-                    textTooltip="Missing Sidecar"
-                    tooltip={false}
-                    type="pf"
-                  />
-                </span>,
+                false,
+                undefined,
               ],
               "className": "card-pf-title",
             },
@@ -535,42 +409,8 @@ ShallowWrapper {
                 "type": [Function],
               },
               "Pods",
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "children": <MissingSidecar
-                    color="red"
-                    name="blueprint"
-                    text="Missing Sidecar"
-                    textTooltip="Missing Sidecar"
-                    tooltip={false}
-                    type="pf"
-                  />,
-                  "style": Object {
-                    "marginLeft": "10px",
-                  },
-                },
-                "ref": null,
-                "rendered": Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "function",
-                  "props": Object {
-                    "color": "red",
-                    "name": "blueprint",
-                    "text": "Missing Sidecar",
-                    "textTooltip": "Missing Sidecar",
-                    "tooltip": false,
-                    "type": "pf",
-                  },
-                  "ref": null,
-                  "rendered": null,
-                  "type": [Function],
-                },
-                "type": "span",
-              },
+              false,
+              undefined,
             ],
             "type": "h2",
           },

--- a/src/types/Workload.ts
+++ b/src/types/Workload.ts
@@ -28,7 +28,7 @@ export const emptyWorkload: Workload = {
   type: '',
   createdAt: '',
   resourceVersion: '',
-  istioSidecar: false,
+  istioSidecar: true, // true until proven otherwise
   labels: {},
   appLabel: false,
   versionLabel: false,


### PR DESCRIPTION
Because Info tab is the default it renders multiple times, first without all
of the item detail, and then again after the detail is available/fetched. By
assuming a missing sidecar the icon is rendered initially.
- Don't assume missing sidecar by default
  - Only show icon when explicitly set false for optional prop
- Don't render "Show on Graph" link or MS icon until title is available
- Consistently position "Show on Graph" link on the right (i.e. after MS icon)

![kiali-2827](https://user-images.githubusercontent.com/2104052/57864282-9c8b0880-77c9-11e9-92a5-01bb41fd7f16.gif)
