### PR TITLE
KIALI-2394 Don't update the graph if it is still empty

### DIFF
--- a/src/components/EmptyGraphLayout.tsx
+++ b/src/components/EmptyGraphLayout.tsx
@@ -64,6 +64,12 @@ export class EmptyGraphLayout extends React.Component<EmptyGraphLayoutProps, Emp
     if (currentIsEmpty !== nextIsEmpty) {
       return true;
     }
+
+    // Don't update if we still don't have any elements
+    if (currentIsEmpty && nextIsEmpty) {
+      return false;
+    }
+
     // Do not update if we have elements and the namespace didn't change, as this means we are refreshing
     return !(!nextIsEmpty && this.props.namespaces === nextProps.namespaces);
   }


### PR DESCRIPTION
** Describe the change **

Previously if the graph was empty it would still switch to the 'loading' graph page when fetching new 
data. The loading graph page should only show up on the initial load and not in between data fetches (like how it works when the graph has some data).

** Issue reference **

https://issues.jboss.org/browse/KIALI-2394
