### PR TITLE
KIALI-2876 Fix broken Wizard Menu

### DIFF
--- a/src/components/IstioWizards/IstioWizardDropdown.tsx
+++ b/src/components/IstioWizards/IstioWizardDropdown.tsx
@@ -193,6 +193,7 @@ class IstioWizardDropdown extends React.Component<Props, State> {
             overlay={<Tooltip id={'mtls-status-masthead'}>Traffic routing already exists for this service</Tooltip>}
             trigger={['hover', 'focus']}
             rootClose={false}
+            key={eventKey}
           >
             {menuItem}
           </OverlayTrigger>
@@ -211,6 +212,7 @@ class IstioWizardDropdown extends React.Component<Props, State> {
             overlay={<Tooltip id={'mtls-status-masthead'}>Traffic routing doesn't exist for this service</Tooltip>}
             trigger={['hover', 'focus']}
             rootClose={false}
+            key={eventKey}
           >
             {deleteMenuItem}
           </OverlayTrigger>
@@ -232,6 +234,7 @@ class IstioWizardDropdown extends React.Component<Props, State> {
             overlay={<Tooltip id={'mtls-status-masthead'}>{toolTipMsgExists}</Tooltip>}
             trigger={['hover', 'focus']}
             rootClose={false}
+            key={eventKey}
           >
             {threeScaleMenuItem}
           </OverlayTrigger>
@@ -255,6 +258,7 @@ class IstioWizardDropdown extends React.Component<Props, State> {
             overlay={<Tooltip id={'mtls-status-masthead'}>{toolTipMsgDelete}</Tooltip>}
             trigger={['hover', 'focus']}
             rootClose={false}
+            key={eventKey}
           >
             {deleteThreeScaleMenuItem}
           </OverlayTrigger>
@@ -300,9 +304,7 @@ class IstioWizardDropdown extends React.Component<Props, State> {
       <>
         <DropdownButton id="service_actions" title="Actions" onSelect={this.onAction} pullRight={true}>
           {(this.canCreate() || this.canUpdate()) &&
-            WIZARD_ACTIONS.map(action => (
-              <React.Fragment key={action}>{this.renderMenuItem(action, updateLabel)}</React.Fragment>
-            ))}
+            WIZARD_ACTIONS.map(action => this.renderMenuItem(action, updateLabel))}
           <MenuItem divider={true} />
           {this.canDelete() && this.renderMenuItem(DELETE_TRAFFIC_ROUTING, '')}
           {this.props.threeScaleInfo.enabled && <MenuItem divider={true} />}


### PR DESCRIPTION
propagate the key inside the elements instead to surround the higher component with a React.Fragment

cc @josejulio as he introduced the regression :-).

The helper render...() function has some missing keys, I fixed that.
The fragment used here broke the events of the menu.