### PR TITLE
KIALI-2849 Tracing options still appear when removed in the backend

### DIFF
--- a/src/app/AuthenticationController.tsx
+++ b/src/app/AuthenticationController.tsx
@@ -114,13 +114,15 @@ const processServerStatus = (dispatch: KialiDispatch, serverStatus: ServerStatus
   dispatch(
     HelpDropdownActions.statusRefresh(serverStatus.status, serverStatus.externalServices, serverStatus.warningMessages)
   );
-
   // Get the jaeger URL
   const hasJaeger = serverStatus.externalServices.filter(item => item.name === 'Jaeger');
   if (hasJaeger.length === 1 && hasJaeger[0].url) {
     dispatch(JaegerActions.setUrl(hasJaeger[0].url));
     // If same protocol enable integration
     dispatch(JaegerActions.setEnableIntegration(hasJaeger[0].url.startsWith(window.location.protocol)));
+  } else {
+    dispatch(JaegerActions.setUrl(''));
+    dispatch(JaegerActions.setEnableIntegration(false));
   }
 
   serverStatus.warningMessages.forEach(wMsg => {

--- a/src/components/Nav/Menu.tsx
+++ b/src/components/Nav/Menu.tsx
@@ -3,13 +3,14 @@ import { navItems } from '../../routes';
 import { matchPath } from 'react-router';
 import { Link } from 'react-router-dom';
 import { Nav, NavList, NavItem, PageSidebar } from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+
 import _ from 'lodash';
 
 const ExternalLink = ({ href, name }) => (
   <NavItem isActive={false} key={name}>
     <a className="pf-c-nav__link" href={href} target="_blank">
-      {name}
-      <span className="co-external-link" />
+      {name} <ExternalLinkAltIcon style={{ margin: '-4px 0 0 5px' }} />
     </a>
   </NavItem>
 );

--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -287,11 +287,13 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
                     )}
                   </NavItem>
                 ) : (
-                  <NavItem onClick={this.navigateToJaeger}>
-                    <>
-                      Traces <Icon type={'fa'} name={'external-link'} />
-                    </>
-                  </NavItem>
+                  this.props.jaegerUrl && (
+                    <NavItem onClick={this.navigateToJaeger}>
+                      <>
+                        Traces <Icon type={'fa'} name={'external-link'} />
+                      </>
+                    </NavItem>
+                  )
                 ))}
             </Nav>
             <TabContent>


### PR DESCRIPTION
JIRA: [KIALI-2849](https://issues.jboss.org/browse/KIALI-2849)

- Now in authentication process if jaeger is disabled we set the values to false, the problem was in the persist configuration
- Fixed externalIcon , it wasn't working with PF4
- This is fixed in https://github.com/kiali/kiali-ui/pull/1188 where we check if the errTraces is not -1, anyway I added an extra control with the URL.