### PR TITLE
KIALI-2728 Introduce Desired/Current/Available Pod Status details

### DIFF
--- a/src/components/Health/__tests__/HealthIndicator.test.tsx
+++ b/src/components/Health/__tests__/HealthIndicator.test.tsx
@@ -17,7 +17,10 @@ describe('HealthIndicator', () => {
 
   it('renders healthy', () => {
     const health = new AppHealth(
-      [{ name: 'A', available: 1, replicas: 1 }, { name: 'B', available: 2, replicas: 2 }],
+      [
+        { name: 'A', availableReplicas: 1, currentReplicas: 1, desiredReplicas: 1 },
+        { name: 'B', availableReplicas: 2, currentReplicas: 2, desiredReplicas: 2 }
+      ],
       { errorRatio: -1, inboundErrorRatio: -1, outboundErrorRatio: -1 },
       { rateInterval: 600, hasSidecar: true }
     );
@@ -36,7 +39,10 @@ describe('HealthIndicator', () => {
 
   it('renders workloads degraded', () => {
     const health = new AppHealth(
-      [{ name: 'A', available: 1, replicas: 10 }, { name: 'B', available: 2, replicas: 2 }],
+      [
+        { name: 'A', availableReplicas: 1, currentReplicas: 1, desiredReplicas: 10 },
+        { name: 'B', availableReplicas: 2, currentReplicas: 2, desiredReplicas: 2 }
+      ],
       { errorRatio: -1, inboundErrorRatio: -1, outboundErrorRatio: -1 },
       { rateInterval: 600, hasSidecar: true }
     );
@@ -55,7 +61,10 @@ describe('HealthIndicator', () => {
 
   it('renders some scaled down workload', () => {
     const health = new AppHealth(
-      [{ name: 'A', available: 0, replicas: 0 }, { name: 'B', available: 2, replicas: 2 }],
+      [
+        { name: 'A', availableReplicas: 0, currentReplicas: 0, desiredReplicas: 0 },
+        { name: 'B', availableReplicas: 2, currentReplicas: 2, desiredReplicas: 2 }
+      ],
       { errorRatio: -1, inboundErrorRatio: -1, outboundErrorRatio: -1 },
       { rateInterval: 600, hasSidecar: true }
     );
@@ -74,7 +83,10 @@ describe('HealthIndicator', () => {
 
   it('renders all workloads down', () => {
     const health = new AppHealth(
-      [{ name: 'A', available: 0, replicas: 0 }, { name: 'B', available: 0, replicas: 0 }],
+      [
+        { name: 'A', availableReplicas: 0, currentReplicas: 0, desiredReplicas: 0 },
+        { name: 'B', availableReplicas: 0, currentReplicas: 0, desiredReplicas: 0 }
+      ],
       { errorRatio: -1, inboundErrorRatio: -1, outboundErrorRatio: -1 },
       { rateInterval: 600, hasSidecar: true }
     );
@@ -92,7 +104,7 @@ describe('HealthIndicator', () => {
 
   it('renders error rate failure', () => {
     const health = new AppHealth(
-      [{ name: 'A', available: 1, replicas: 1 }],
+      [{ name: 'A', availableReplicas: 1, currentReplicas: 1, desiredReplicas: 1 }],
       { errorRatio: 0.3, inboundErrorRatio: 0.1, outboundErrorRatio: 0.2 },
       { rateInterval: 600, hasSidecar: true }
     );

--- a/src/components/Health/__tests__/__snapshots__/HealthIndicator.test.tsx.snap
+++ b/src/components/Health/__tests__/__snapshots__/HealthIndicator.test.tsx.snap
@@ -77,14 +77,16 @@ ShallowWrapper {
         },
         "workloadStatuses": Array [
           Object {
-            "available": 1,
+            "availableReplicas": 1,
+            "currentReplicas": 1,
+            "desiredReplicas": 1,
             "name": "A",
-            "replicas": 1,
           },
           Object {
-            "available": 2,
+            "availableReplicas": 2,
+            "currentReplicas": 2,
+            "desiredReplicas": 2,
             "name": "B",
-            "replicas": 2,
           },
         ],
       }
@@ -197,14 +199,16 @@ ShallowWrapper {
               },
               "workloadStatuses": Array [
                 Object {
-                  "available": 1,
+                  "availableReplicas": 1,
+                  "currentReplicas": 1,
+                  "desiredReplicas": 1,
                   "name": "A",
-                  "replicas": 1,
                 },
                 Object {
-                  "available": 2,
+                  "availableReplicas": 2,
+                  "currentReplicas": 2,
+                  "desiredReplicas": 2,
                   "name": "B",
-                  "replicas": 2,
                 },
               ],
             }
@@ -336,14 +340,16 @@ ShallowWrapper {
                 },
                 "workloadStatuses": Array [
                   Object {
-                    "available": 1,
+                    "availableReplicas": 1,
+                    "currentReplicas": 1,
+                    "desiredReplicas": 1,
                     "name": "A",
-                    "replicas": 1,
                   },
                   Object {
-                    "available": 2,
+                    "availableReplicas": 2,
+                    "currentReplicas": 2,
+                    "desiredReplicas": 2,
                     "name": "B",
-                    "replicas": 2,
                   },
                 ],
               }

--- a/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -63,6 +63,9 @@ class WorkloadDetails extends React.Component<RouteComponentProps<WorkloadId>, W
     const noIstiosidecar: ObjectCheck = { message: 'Pod has no Istio sidecar', severity: 'warning', path: '' };
     const noAppLabel: ObjectCheck = { message: 'Pod has no app label', severity: 'warning', path: '' };
     const noVersionLabel: ObjectCheck = { message: 'Pod has no version label', severity: 'warning', path: '' };
+    const pendingPod: ObjectCheck = { message: 'Pod is in Pending Phase', severity: 'warning', path: '' };
+    const unknownPod: ObjectCheck = { message: 'Pod is in Unknown Phase', severity: 'warning', path: '' };
+    const failedPod: ObjectCheck = { message: 'Pod is in Failed Phase', severity: 'error', path: '' };
 
     const validations: Validations = {};
     if (workload.pods.length > 0) {
@@ -87,6 +90,19 @@ class WorkloadDetails extends React.Component<RouteComponentProps<WorkloadId>, W
           if (!pod.versionLabel) {
             validations.pod[pod.name].checks.push(noVersionLabel);
           }
+        }
+        switch (pod.status) {
+          case 'Pending':
+            validations.pod[pod.name].checks.push(pendingPod);
+            break;
+          case 'Unknown':
+            validations.pod[pod.name].checks.push(unknownPod);
+            break;
+          case 'Failed':
+            validations.pod[pod.name].checks.push(failedPod);
+            break;
+          default:
+          // Pod healthy
         }
         validations.pod[pod.name].valid = validations.pod[pod.name].checks.length === 0;
       });

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPods.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPods.tsx
@@ -1,23 +1,9 @@
 import * as React from 'react';
-import { ContainerInfo, ObjectValidation, Pod, Reference } from '../../../types/IstioObjects';
-import { Col, OverlayTrigger, Row, Table, Tooltip } from 'patternfly-react';
+import { ObjectValidation, Pod } from '../../../types/IstioObjects';
+import { Col, Row, Table } from 'patternfly-react';
 import * as resolve from 'table-resolver';
 import { ConfigIndicator } from '../../../components/ConfigValidation/ConfigIndicator';
 import Labels from '../../../components/Label/Labels';
-
-interface PodsGroup {
-  commonPrefix: string;
-  names: string[];
-  validations: ObjectValidation[];
-  commonLabels: { [key: string]: string };
-  createdAtStart: number;
-  createdAtEnd: number;
-  createdBy: Reference[];
-  istioContainers?: ContainerInfo[];
-  istioInitContainers?: ContainerInfo[];
-  numberOfPods: number;
-  status: string;
-}
 
 type WorkloadPodsProps = {
   namespace: string;
@@ -25,133 +11,15 @@ type WorkloadPodsProps = {
   validations: { [key: string]: ObjectValidation };
 };
 
-type WorkloadPodsState = {
-  groups: PodsGroup[];
-};
-
-class WorkloadPods extends React.Component<WorkloadPodsProps, WorkloadPodsState> {
-  static getDerivedStateFromProps(props: WorkloadPodsProps, currentState: WorkloadPodsState) {
-    return { groups: WorkloadPods.updateGroups(props) };
-  }
-  static groupKey = (pod: Pod): string => {
-    return JSON.stringify({
-      cb: pod.createdBy ? pod.createdBy.map(ref => ref.name).join(',') : '',
-      ic: pod.istioContainers ? pod.istioContainers.map(ctnr => ctnr.name + ctnr.image).join(',') : '',
-      iic: pod.istioInitContainers ? pod.istioInitContainers.map(ctnr => ctnr.name + ctnr.image).join(',') : ''
-    });
-  };
-
-  static updateGroups(props: WorkloadPodsProps) {
-    if (props.pods) {
-      return WorkloadPods.groupPods(props.pods, props.validations);
-    } else {
-      return [];
-    }
-  }
-
-  static mergeInGroup = (group: PodsGroup, pod: Pod, validation: ObjectValidation) => {
-    group.names.push(pod.name);
-    // Update common prefix
-    group.commonPrefix = WorkloadPods.commonPrefix(group.commonPrefix, pod.name);
-    // Update validations
-    group.validations.push(validation);
-    // Remove any group.commonLabels that is not found in pod
-    Object.keys(group.commonLabels).map(key => {
-      const val = group.commonLabels[key];
-      if (!pod.labels || val !== pod.labels[key]) {
-        delete group.commonLabels[key];
-      }
-    });
-    // Update start/end timestamps
-    const podTimestamp = new Date(pod.createdAt).getTime();
-    if (podTimestamp < group.createdAtStart) {
-      group.createdAtStart = podTimestamp;
-    } else if (podTimestamp > group.createdAtEnd) {
-      group.createdAtEnd = podTimestamp;
-    }
-    group.numberOfPods++;
-  };
-
-  static groupPods = (pods: Pod[], validations: { [key: string]: ObjectValidation }): PodsGroup[] => {
-    const allGroups = new Map<string, PodsGroup>();
-    pods.forEach(pod => {
-      const key = WorkloadPods.groupKey(pod);
-      if (allGroups.has(key)) {
-        const group = allGroups.get(key)!;
-        WorkloadPods.mergeInGroup(group, pod, validations[pod.name]);
-      } else {
-        // Make a copy of the labels. This object might be modified later, so do not use the original reference.
-        const labels: { [key: string]: string } = {};
-        if (pod.labels) {
-          Object.keys(pod.labels).map(k => {
-            labels[k] = pod.labels![k];
-          });
-        }
-        const timestamp = new Date(pod.createdAt).getTime();
-        allGroups.set(key, {
-          commonPrefix: pod.name,
-          names: [pod.name],
-          validations: [validations[pod.name]],
-          commonLabels: labels,
-          createdAtStart: timestamp,
-          createdAtEnd: timestamp,
-          createdBy: pod.createdBy,
-          istioContainers: pod.istioContainers,
-          istioInitContainers: pod.istioInitContainers,
-          numberOfPods: 1,
-          status: pod.status
-        });
-      }
-    });
-    return Array.from(allGroups.values()).sort((a, b) => a.commonPrefix.localeCompare(b.commonPrefix));
-  };
-
-  static commonPrefix = (s1: string, s2: string): string => {
-    let i = 0;
-    while (i < s1.length && i < s2.length && s1.charAt(i) === s2.charAt(i)) {
-      i++;
-    }
-    return s1.substring(0, i);
-  };
-
+class WorkloadPods extends React.Component<WorkloadPodsProps> {
   constructor(props: WorkloadPodsProps) {
     super(props);
-    this.state = {
-      groups: WorkloadPods.updateGroups(props)
-    };
-  }
-
-  validation(pod: PodsGroup): ObjectValidation[] {
-    return pod.validations;
   }
 
   headerFormat = (label, { column }) => <Table.Heading className={column.property}>{label}</Table.Heading>;
   cellFormat = value => {
     return <Table.Cell>{value}</Table.Cell>;
   };
-
-  renderName(group: PodsGroup, u: Number) {
-    return group.numberOfPods > 1 ? (
-      <OverlayTrigger
-        // Prettier makes irrelevant line-breaking clashing with tslint
-        // prettier-ignore
-        overlay={<Tooltip id={'pod_names_' + u} title="Pod Names">{group.names.join(', ')}</Tooltip>}
-        placement="top"
-        trigger={['hover', 'focus']}
-      >
-        <span>{group.commonPrefix + '... (' + group.numberOfPods + ' replicas)'}</span>
-      </OverlayTrigger>
-    ) : (
-      group.commonPrefix + ' (1 replica)'
-    );
-  }
-  renderCreated(group: PodsGroup) {
-    return group.createdAtStart === group.createdAtEnd ? (
-      <>{new Date(group.createdAtStart).toLocaleString()}</>
-    ) : (
-      <>{new Date(group.createdAtStart).toLocaleString() + ' and ' + new Date(group.createdAtEnd).toLocaleString()}</>
-    );
-  }
 
   columns() {
     return {
@@ -242,28 +110,27 @@ class WorkloadPods extends React.Component<WorkloadPodsProps, WorkloadPodsState>
       ]
     };
   }
-  rows() {
-    return (this.state.groups || []).map((group, vsIdx) => {
-      const generateRows = {
-        id: vsIdx,
-        status: (
-          <ConfigIndicator id={vsIdx + '-config-validation'} validations={this.validation(group)} definition={true} />
-        ),
-        name: this.renderName(group, vsIdx),
-        createdAt: this.renderCreated(group),
-        createdBy:
-          group.createdBy && group.createdBy.length > 0
-            ? group.createdBy.map(ref => ref.name + ' (' + ref.kind + ')').join(', ')
-            : '',
-        labels: <Labels key={'labels' + vsIdx} labels={group.commonLabels} />,
-        istioInitContainers: group.istioInitContainers
-          ? group.istioInitContainers.map(c => `${c.image}`).join(', ')
-          : '',
-        istioContainers: group.istioContainers ? group.istioContainers.map(c => `${c.image}`).join(', ') : '',
-        podStatus: group.status
-      };
 
-      return generateRows;
+  rows() {
+    return (this.props.pods || []).map((pod, podIdx) => {
+      const validations: ObjectValidation[] = [];
+      if (this.props.validations[pod.name]) {
+        validations.push(this.props.validations[pod.name]);
+      }
+      return {
+        id: podIdx,
+        status: <ConfigIndicator id={podIdx + '-config-validation'} validations={validations} definition={true} />,
+        name: pod.name,
+        createdAt: new Date(pod.createdAt).toLocaleString(),
+        createdBy:
+          pod.createdBy && pod.createdBy.length > 0
+            ? pod.createdBy.map(ref => ref.name + ' (' + ref.kind + ')').join(', ')
+            : '',
+        labels: <Labels key={'labels' + podIdx} labels={pod.labels} />,
+        istioInitContainers: pod.istioInitContainers ? pod.istioInitContainers.map(c => `${c.image}`).join(', ') : '',
+        istioContainers: pod.istioContainers ? pod.istioContainers.map(c => `${c.image}`).join(', ') : '',
+        podStatus: pod.status
+      };
     });
   }
 

--- a/src/types/__tests__/Health.test.ts
+++ b/src/types/__tests__/Health.test.ts
@@ -2,16 +2,20 @@ import * as H from '../Health';
 
 describe('Health', () => {
   it('should check ratio with 0 valid', () => {
-    expect(H.ratioCheck(0, 3)).toEqual(H.FAILURE);
+    expect(H.ratioCheck(0, 3, 3)).toEqual(H.FAILURE);
   });
   it('should check ratio with some valid', () => {
-    expect(H.ratioCheck(1, 3)).toEqual(H.DEGRADED);
+    expect(H.ratioCheck(1, 3, 3)).toEqual(H.DEGRADED);
   });
   it('should check ratio with all valid', () => {
-    expect(H.ratioCheck(3, 3)).toEqual(H.HEALTHY);
+    expect(H.ratioCheck(3, 3, 3)).toEqual(H.HEALTHY);
   });
   it('should check ratio with no item', () => {
-    expect(H.ratioCheck(0, 0)).toEqual(H.NA);
+    expect(H.ratioCheck(0, 0, 0)).toEqual(H.NA);
+  });
+  it('should check ratio pending Pods', () => {
+    // 3 Pods with problems
+    expect(H.ratioCheck(3, 6, 3)).toEqual(H.FAILURE);
   });
   it('should merge status with correct priority', () => {
     let status = H.mergeStatus(H.NA, H.HEALTHY);
@@ -58,7 +62,7 @@ describe('Health', () => {
   });
   it('should aggregate without reporter', () => {
     const health = new H.AppHealth(
-      [{ available: 0, replicas: 1, name: 'a' }],
+      [{ availableReplicas: 0, currentReplicas: 1, desiredReplicas: 1, name: 'a' }],
       { errorRatio: 1, inboundErrorRatio: 1, outboundErrorRatio: 1 },
       { rateInterval: 60, hasSidecar: true }
     );
@@ -66,7 +70,10 @@ describe('Health', () => {
   });
   it('should aggregate healthy', () => {
     const health = new H.AppHealth(
-      [{ available: 1, replicas: 1, name: 'a' }, { available: 2, replicas: 2, name: 'b' }],
+      [
+        { availableReplicas: 1, currentReplicas: 1, desiredReplicas: 1, name: 'a' },
+        { availableReplicas: 2, currentReplicas: 2, desiredReplicas: 2, name: 'b' }
+      ],
       { errorRatio: 0, inboundErrorRatio: 0, outboundErrorRatio: 0 },
       { rateInterval: 60, hasSidecar: true }
     );
@@ -74,7 +81,10 @@ describe('Health', () => {
   });
   it('should aggregate degraded workload', () => {
     const health = new H.AppHealth(
-      [{ available: 1, replicas: 1, name: 'a' }, { available: 1, replicas: 2, name: 'b' }],
+      [
+        { availableReplicas: 1, currentReplicas: 1, desiredReplicas: 1, name: 'a' },
+        { availableReplicas: 1, currentReplicas: 1, desiredReplicas: 2, name: 'b' }
+      ],
       { errorRatio: 0, inboundErrorRatio: 0, outboundErrorRatio: 0 },
       { rateInterval: 60, hasSidecar: true }
     );
@@ -82,7 +92,10 @@ describe('Health', () => {
   });
   it('should aggregate failing requests', () => {
     const health = new H.AppHealth(
-      [{ available: 1, replicas: 1, name: 'a' }, { available: 2, replicas: 2, name: 'b' }],
+      [
+        { availableReplicas: 1, currentReplicas: 1, desiredReplicas: 1, name: 'a' },
+        { availableReplicas: 2, currentReplicas: 2, desiredReplicas: 2, name: 'b' }
+      ],
       { errorRatio: 0.2, inboundErrorRatio: 0.3, outboundErrorRatio: 0.1 },
       { rateInterval: 60, hasSidecar: true }
     );
@@ -90,7 +103,10 @@ describe('Health', () => {
   });
   it('should aggregate multiple issues', () => {
     const health = new H.AppHealth(
-      [{ available: 0, replicas: 0, name: 'a' }, { available: 0, replicas: 0, name: 'b' }],
+      [
+        { availableReplicas: 0, currentReplicas: 0, desiredReplicas: 0, name: 'a' },
+        { availableReplicas: 0, currentReplicas: 0, desiredReplicas: 0, name: 'b' }
+      ],
       { errorRatio: 0.2, inboundErrorRatio: 0.3, outboundErrorRatio: 0.1 },
       { rateInterval: 60, hasSidecar: true }
     );
@@ -98,7 +114,7 @@ describe('Health', () => {
   });
   it('should not ignore error rates when has sidecar', () => {
     const health = new H.AppHealth(
-      [{ available: 1, replicas: 1, name: 'a' }],
+      [{ availableReplicas: 1, currentReplicas: 1, desiredReplicas: 1, name: 'a' }],
       { errorRatio: 0, inboundErrorRatio: 0, outboundErrorRatio: 0 },
       { rateInterval: 60, hasSidecar: true }
     );
@@ -106,7 +122,7 @@ describe('Health', () => {
   });
   it('should ignore error rates when no sidecar', () => {
     const health = new H.AppHealth(
-      [{ available: 1, replicas: 1, name: 'a' }],
+      [{ availableReplicas: 1, currentReplicas: 1, desiredReplicas: 1, name: 'a' }],
       { errorRatio: 0, inboundErrorRatio: 0, outboundErrorRatio: 0 },
       { rateInterval: 60, hasSidecar: false }
     );


### PR DESCRIPTION
List Pods individually
This UI needs backend PR https://github.com/kiali/kiali/pull/1081.

Pod Status details desired/current/available info.

This will help to give user more information on Pod problems.

![image](https://user-images.githubusercontent.com/1662329/58037047-ca0ae580-7b2c-11e9-8e76-86688df0bf82.png)

![image](https://user-images.githubusercontent.com/1662329/58037105-eeff5880-7b2c-11e9-976a-6341c65a5223.png)

Also, another problem we had in our previous design, is that the Group Pods can't be really merged, as in situation like these, you want to see what are the failed Pods. So, now Pod table shows all individual Pods (as it happens with OpenShift Console).

![image](https://user-images.githubusercontent.com/1662329/58037186-25d56e80-7b2d-11e9-9881-cc7f75d950ce.png)

Note that for an investigation fields like Phase or CreatedAt can be completely different, so we can't merge it.

