### PR TITLE
KIALI-2899 Upgrade react-router-dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "react-iframe": "1.5.0",
     "react-redux": "5.1.1",
     "react-resize-detector": "3.4.0",
-    "react-router-dom": "4.3.1",
+    "react-router-dom": "5.0.0",
     "react-scripts-ts": "2.17.0",
     "redux": "4.0.1",
     "redux-persist": "5.10.0",

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { ThunkDispatch } from 'redux-thunk';
 import ReactResizeDetector from 'react-resize-detector';
 
+import history from '../../app/History';
 import Namespace from '../../types/Namespace';
 import { GraphHighlighter } from './graphs/GraphHighlighter';
 import TrafficRender from './TrafficAnimation/TrafficRenderer';
@@ -564,7 +565,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
     };
 
     // To ensure updated components get the updated URL, update the URL first and then the state
-    this.context.router.history.push(makeNodeGraphUrlFromParams(urlParams));
+    history.push(makeNodeGraphUrlFromParams(urlParams));
     this.props.setNode(targetNode);
   };
 

--- a/src/components/GraphFilter/GraphFilter.tsx
+++ b/src/components/GraphFilter/GraphFilter.tsx
@@ -135,7 +135,7 @@ export class GraphFilter extends React.PureComponent<GraphFilterProps> {
 
   handleNamespaceReturn = () => {
     this.props.setNode(undefined);
-    this.context.router.history.push('/graph/namespaces');
+    history.push('/graph/namespaces');
   };
 
   // TODO [jshaughn] Is there a better typescript way than the style attribute with the spread syntax (here and other places)

--- a/src/components/Nav/Menu.tsx
+++ b/src/components/Nav/Menu.tsx
@@ -1,11 +1,12 @@
+import _ from 'lodash';
 import * as React from 'react';
-import { navItems } from '../../routes';
 import { matchPath } from 'react-router';
 import { Link } from 'react-router-dom';
 import { Nav, NavList, NavItem, PageSidebar } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
-import _ from 'lodash';
+import history from '../../app/History';
+import { navItems } from '../../routes';
 
 const ExternalLink = ({ href, name }) => (
   <NavItem isActive={false} key={name}>
@@ -56,7 +57,7 @@ class Menu extends React.Component<MenuProps, MenuState> {
         ''
       ) : (
         <NavItem isActive={activeItem === item} key={item.to}>
-          <Link id={item.title} to={item.to} onClick={() => this.context.router.history.push(item.to)}>
+          <Link id={item.title} to={item.to} onClick={() => history.push(item.to)}>
             {item.title}
           </Link>
         </NavItem>

--- a/src/components/Nav/NavUtils.tsx
+++ b/src/components/Nav/NavUtils.tsx
@@ -40,7 +40,7 @@ export const makeNamespacesGraphUrlFromParams = (params: GraphUrlParams): string
   return `/graph/namespaces?` + queryParams;
 };
 
-export const makeNodeGraphUrlFromParams = (params: GraphUrlParams): string | undefined => {
+export const makeNodeGraphUrlFromParams = (params: GraphUrlParams): string => {
   const node = params.node;
   if (node) {
     switch (node.nodeType) {
@@ -68,6 +68,6 @@ export const makeNodeGraphUrlFromParams = (params: GraphUrlParams): string | und
     }
   } else {
     // this should never happen but typescript needs this
-    return undefined;
+    return '';
   }
 };

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoRouteVirtualServices.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoRouteVirtualServices.test.tsx.snap
@@ -275,7 +275,6 @@ ShallowWrapper {
               Array [
                 Object {
                   "actions": <Link
-                    replace={false}
                     to="/namespaces/undefined/istio/virtualservices/reviews-default?list=yaml"
                   >
                     View YAML
@@ -285,7 +284,6 @@ ShallowWrapper {
                   />,
                   "id": 0,
                   "name": <Link
-                    replace={false}
                     to="/namespaces/undefined/istio/virtualservices/reviews-default?list=overview"
                   >
                     reviews-default
@@ -501,7 +499,6 @@ ShallowWrapper {
               Array [
                 Object {
                   "actions": <Link
-                    replace={false}
                     to="/namespaces/undefined/istio/virtualservices/reviews-default?list=yaml"
                   >
                     View YAML
@@ -511,7 +508,6 @@ ShallowWrapper {
                   />,
                   "id": 0,
                   "name": <Link
-                    replace={false}
                     to="/namespaces/undefined/istio/virtualservices/reviews-default?list=overview"
                   >
                     reviews-default
@@ -640,7 +636,6 @@ ShallowWrapper {
                 Array [
                   Object {
                     "actions": <Link
-                      replace={false}
                       to="/namespaces/undefined/istio/virtualservices/reviews-default?list=yaml"
                     >
                       View YAML
@@ -650,7 +645,6 @@ ShallowWrapper {
                     />,
                     "id": 0,
                     "name": <Link
-                      replace={false}
                       to="/namespaces/undefined/istio/virtualservices/reviews-default?list=overview"
                     >
                       reviews-default
@@ -862,7 +856,6 @@ ShallowWrapper {
               "rows": Array [
                 Object {
                   "actions": <Link
-                    replace={false}
                     to="/namespaces/undefined/istio/virtualservices/reviews-default?list=yaml"
                   >
                     View YAML
@@ -872,7 +865,6 @@ ShallowWrapper {
                   />,
                   "id": 0,
                   "name": <Link
-                    replace={false}
                     to="/namespaces/undefined/istio/virtualservices/reviews-default?list=overview"
                   >
                     reviews-default
@@ -1098,7 +1090,6 @@ ShallowWrapper {
                 Array [
                   Object {
                     "actions": <Link
-                      replace={false}
                       to="/namespaces/undefined/istio/virtualservices/reviews-default?list=yaml"
                     >
                       View YAML
@@ -1108,7 +1099,6 @@ ShallowWrapper {
                     />,
                     "id": 0,
                     "name": <Link
-                      replace={false}
                       to="/namespaces/undefined/istio/virtualservices/reviews-default?list=overview"
                     >
                       reviews-default
@@ -1324,7 +1314,6 @@ ShallowWrapper {
                 Array [
                   Object {
                     "actions": <Link
-                      replace={false}
                       to="/namespaces/undefined/istio/virtualservices/reviews-default?list=yaml"
                     >
                       View YAML
@@ -1334,7 +1323,6 @@ ShallowWrapper {
                     />,
                     "id": 0,
                     "name": <Link
-                      replace={false}
                       to="/namespaces/undefined/istio/virtualservices/reviews-default?list=overview"
                     >
                       reviews-default
@@ -1463,7 +1451,6 @@ ShallowWrapper {
                   Array [
                     Object {
                       "actions": <Link
-                        replace={false}
                         to="/namespaces/undefined/istio/virtualservices/reviews-default?list=yaml"
                       >
                         View YAML
@@ -1473,7 +1460,6 @@ ShallowWrapper {
                       />,
                       "id": 0,
                       "name": <Link
-                        replace={false}
                         to="/namespaces/undefined/istio/virtualservices/reviews-default?list=overview"
                       >
                         reviews-default
@@ -1685,7 +1671,6 @@ ShallowWrapper {
                 "rows": Array [
                   Object {
                     "actions": <Link
-                      replace={false}
                       to="/namespaces/undefined/istio/virtualservices/reviews-default?list=yaml"
                     >
                       View YAML
@@ -1695,7 +1680,6 @@ ShallowWrapper {
                     />,
                     "id": 0,
                     "name": <Link
-                      replace={false}
                       to="/namespaces/undefined/istio/virtualservices/reviews-default?list=overview"
                     >
                       reviews-default

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoWorkloads.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoWorkloads.test.tsx.snap
@@ -265,7 +265,6 @@ ShallowWrapper {
                   />,
                   "name": <span>
                     <Link
-                      replace={false}
                       to="/namespaces/ns/workloads/reviews-v2"
                     >
                       reviews-v2
@@ -289,7 +288,6 @@ ShallowWrapper {
                   />,
                   "name": <span>
                     <Link
-                      replace={false}
                       to="/namespaces/ns/workloads/reviews-v3"
                     >
                       reviews-v3
@@ -313,7 +311,6 @@ ShallowWrapper {
                   />,
                   "name": <span>
                     <Link
-                      replace={false}
                       to="/namespaces/ns/workloads/reviews-v1"
                     >
                       reviews-v1
@@ -540,7 +537,6 @@ ShallowWrapper {
                   />,
                   "name": <span>
                     <Link
-                      replace={false}
                       to="/namespaces/ns/workloads/reviews-v2"
                     >
                       reviews-v2
@@ -564,7 +560,6 @@ ShallowWrapper {
                   />,
                   "name": <span>
                     <Link
-                      replace={false}
                       to="/namespaces/ns/workloads/reviews-v3"
                     >
                       reviews-v3
@@ -588,7 +583,6 @@ ShallowWrapper {
                   />,
                   "name": <span>
                     <Link
-                      replace={false}
                       to="/namespaces/ns/workloads/reviews-v1"
                     >
                       reviews-v1
@@ -728,7 +722,6 @@ ShallowWrapper {
                     />,
                     "name": <span>
                       <Link
-                        replace={false}
                         to="/namespaces/ns/workloads/reviews-v2"
                       >
                         reviews-v2
@@ -752,7 +745,6 @@ ShallowWrapper {
                     />,
                     "name": <span>
                       <Link
-                        replace={false}
                         to="/namespaces/ns/workloads/reviews-v3"
                       >
                         reviews-v3
@@ -776,7 +768,6 @@ ShallowWrapper {
                     />,
                     "name": <span>
                       <Link
-                        replace={false}
                         to="/namespaces/ns/workloads/reviews-v1"
                       >
                         reviews-v1
@@ -999,7 +990,6 @@ ShallowWrapper {
                   />,
                   "name": <span>
                     <Link
-                      replace={false}
                       to="/namespaces/ns/workloads/reviews-v2"
                     >
                       reviews-v2
@@ -1023,7 +1013,6 @@ ShallowWrapper {
                   />,
                   "name": <span>
                     <Link
-                      replace={false}
                       to="/namespaces/ns/workloads/reviews-v3"
                     >
                       reviews-v3
@@ -1047,7 +1036,6 @@ ShallowWrapper {
                   />,
                   "name": <span>
                     <Link
-                      replace={false}
                       to="/namespaces/ns/workloads/reviews-v1"
                     >
                       reviews-v1
@@ -1284,7 +1272,6 @@ ShallowWrapper {
                     />,
                     "name": <span>
                       <Link
-                        replace={false}
                         to="/namespaces/ns/workloads/reviews-v2"
                       >
                         reviews-v2
@@ -1308,7 +1295,6 @@ ShallowWrapper {
                     />,
                     "name": <span>
                       <Link
-                        replace={false}
                         to="/namespaces/ns/workloads/reviews-v3"
                       >
                         reviews-v3
@@ -1332,7 +1318,6 @@ ShallowWrapper {
                     />,
                     "name": <span>
                       <Link
-                        replace={false}
                         to="/namespaces/ns/workloads/reviews-v1"
                       >
                         reviews-v1
@@ -1559,7 +1544,6 @@ ShallowWrapper {
                     />,
                     "name": <span>
                       <Link
-                        replace={false}
                         to="/namespaces/ns/workloads/reviews-v2"
                       >
                         reviews-v2
@@ -1583,7 +1567,6 @@ ShallowWrapper {
                     />,
                     "name": <span>
                       <Link
-                        replace={false}
                         to="/namespaces/ns/workloads/reviews-v3"
                       >
                         reviews-v3
@@ -1607,7 +1590,6 @@ ShallowWrapper {
                     />,
                     "name": <span>
                       <Link
-                        replace={false}
                         to="/namespaces/ns/workloads/reviews-v1"
                       >
                         reviews-v1
@@ -1747,7 +1729,6 @@ ShallowWrapper {
                       />,
                       "name": <span>
                         <Link
-                          replace={false}
                           to="/namespaces/ns/workloads/reviews-v2"
                         >
                           reviews-v2
@@ -1771,7 +1752,6 @@ ShallowWrapper {
                       />,
                       "name": <span>
                         <Link
-                          replace={false}
                           to="/namespaces/ns/workloads/reviews-v3"
                         >
                           reviews-v3
@@ -1795,7 +1775,6 @@ ShallowWrapper {
                       />,
                       "name": <span>
                         <Link
-                          replace={false}
                           to="/namespaces/ns/workloads/reviews-v1"
                         >
                           reviews-v1
@@ -2018,7 +1997,6 @@ ShallowWrapper {
                     />,
                     "name": <span>
                       <Link
-                        replace={false}
                         to="/namespaces/ns/workloads/reviews-v2"
                       >
                         reviews-v2
@@ -2042,7 +2020,6 @@ ShallowWrapper {
                     />,
                     "name": <span>
                       <Link
-                        replace={false}
                         to="/namespaces/ns/workloads/reviews-v3"
                       >
                         reviews-v3
@@ -2066,7 +2043,6 @@ ShallowWrapper {
                     />,
                     "name": <span>
                       <Link
-                        replace={false}
                         to="/namespaces/ns/workloads/reviews-v1"
                       >
                         reviews-v1

--- a/yarn.lock
+++ b/yarn.lock
@@ -2830,7 +2830,7 @@ create-react-context@<=0.2.2:
     fbjs "^0.8.0"
     gud "^1.0.0"
 
-create-react-context@^0.2.3:
+create-react-context@^0.2.2, create-react-context@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.3.tgz#9ec140a6914a22ef04b8b09b7771de89567cb6f3"
   integrity sha512-CQBmD0+QGgTaxDL3OX1IDXYqjkp2It4RIbcb99jS6AEg27Ga+a9G3JtK6SIu0HBwPLZlmwt9F7UwWA4Bn92Rag==
@@ -5037,7 +5037,7 @@ heap@^0.2.6:
   resolved "https://registry.yarnpkg.com/heap/-/heap-0.2.6.tgz#087e1f10b046932fc8594dd9e6d378afc9d1e5ac"
   integrity sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw=
 
-history@^4.7.2:
+history@^4.9.0:
   version "4.9.0"
   resolved "https://registry.yarnpkg.com/history/-/history-4.9.0.tgz#84587c2068039ead8af769e9d6a6860a14fa1bca"
   integrity sha512-H2DkjCjXf0Op9OAr6nJ56fcRkTSNrUiv41vNJ6IswJjif6wlpZK0BTfFbi7qK9dXLSYZxkq5lBsj3vUjlYBYZA==
@@ -5058,7 +5058,7 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^2.1.1, hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0:
+hoist-non-react-statics@^2.1.1, hoist-non-react-statics@^2.3.1:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
   integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
@@ -9097,30 +9097,34 @@ react-resize-detector@3.4.0:
     prop-types "^15.6.2"
     resize-observer-polyfill "^1.5.1"
 
-react-router-dom@4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-4.3.1.tgz#4c2619fc24c4fa87c9fd18f4fb4a43fe63fbd5c6"
-  integrity sha512-c/MlywfxDdCp7EnB7YfPMOfMD3tOtIjrQlj/CKfNMBxdmpJP8xcz5P/UAFn3JbnQCNUxsHyVVqllF9LhgVyFCA==
+react-router-dom@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.0.0.tgz#542a9b86af269a37f0b87218c4c25ea8dcf0c073"
+  integrity sha512-wSpja5g9kh5dIteZT3tUoggjnsa+TPFHSMrpHXMpFsaHhQkm/JNVGh2jiF9Dkh4+duj4MKCkwO6H08u6inZYgQ==
   dependencies:
-    history "^4.7.2"
-    invariant "^2.2.4"
+    "@babel/runtime" "^7.1.2"
+    history "^4.9.0"
     loose-envify "^1.3.1"
-    prop-types "^15.6.1"
-    react-router "^4.3.1"
-    warning "^4.0.1"
+    prop-types "^15.6.2"
+    react-router "5.0.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
 
-react-router@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-4.3.1.tgz#aada4aef14c809cb2e686b05cee4742234506c4e"
-  integrity sha512-yrvL8AogDh2X42Dt9iknk4wF4V8bWREPirFfS9gLU1huk6qK41sg7Z/1S81jjTrGHxa3B8R3J6xIkDAA6CVarg==
+react-router@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.0.0.tgz#349863f769ffc2fa10ee7331a4296e86bc12879d"
+  integrity sha512-6EQDakGdLG/it2x9EaCt9ZpEEPxnd0OCLBHQ1AcITAAx7nCnyvnzf76jKWG1s2/oJ7SSviUgfWHofdYljFexsA==
   dependencies:
-    history "^4.7.2"
-    hoist-non-react-statics "^2.5.0"
-    invariant "^2.2.4"
+    "@babel/runtime" "^7.1.2"
+    create-react-context "^0.2.2"
+    history "^4.9.0"
+    hoist-non-react-statics "^3.1.0"
     loose-envify "^1.3.1"
     path-to-regexp "^1.7.0"
-    prop-types "^15.6.1"
-    warning "^4.0.1"
+    prop-types "^15.6.2"
+    react-is "^16.6.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
 
 react-scripts-ts@2.17.0:
   version "2.17.0"


### PR DESCRIPTION
Upgrading from 4.3.1 to 5.0.0.
According to https://reacttraining.com/blog/react-router-v5/, version 5.0.0 was meant to be published as 4.4, so versioni 5.0 is fully backwards compatible with 4.x.

Upgrading to major version 5.0 is safe, since API is compatible.