### PR TITLE
KIALI-2840 Rename Info tab to Overview

### DIFF
--- a/src/pages/AppDetails/AppDetailsPage.tsx
+++ b/src/pages/AppDetails/AppDetailsPage.tsx
@@ -131,23 +131,15 @@ class AppDetails extends React.Component<RouteComponentProps<AppId>, AppDetailsS
         >
           <div>
             <Nav bsClass="nav nav-tabs nav-tabs-pf">
-              <NavItem eventKey="info">
-                <div>Info</div>
-              </NavItem>
-              <NavItem eventKey="traffic">
-                <div>Traffic</div>
-              </NavItem>
-              <NavItem eventKey="in_metrics">
-                <div>Inbound Metrics</div>
-              </NavItem>
-              <NavItem eventKey="out_metrics">
-                <div>Outbound Metrics</div>
-              </NavItem>
+              <NavItem eventKey="info">Overview</NavItem>
+              <NavItem eventKey="traffic">Traffic</NavItem>
+              <NavItem eventKey="in_metrics">Inbound Metrics</NavItem>
+              <NavItem eventKey="out_metrics">Outbound Metrics</NavItem>
               {this.state.app.runtimes.map(runtime => {
                 return runtime.dashboardRefs.map(dashboard => {
                   return (
                     <NavItem key={dashboard.template} eventKey={dashboard.template}>
-                      <div>{dashboard.title}</div>
+                      {dashboard.title}
                     </NavItem>
                   );
                 });

--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -262,15 +262,9 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
         >
           <div>
             <Nav bsClass="nav nav-tabs nav-tabs-pf">
-              <NavItem eventKey="info">
-                <div>Overview</div>
-              </NavItem>
-              <NavItem eventKey="traffic">
-                <div>Traffic</div>
-              </NavItem>
-              <NavItem eventKey="metrics">
-                <div>Inbound Metrics</div>
-              </NavItem>
+              <NavItem eventKey="info">Overview</NavItem>
+              <NavItem eventKey="traffic">Traffic</NavItem>
+              <NavItem eventKey="metrics">Inbound Metrics</NavItem>
               {errorTraces !== undefined &&
                 errorTraces > -1 &&
                 (this.props.jaegerIntegration ? (
@@ -293,9 +287,7 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
                 ) : (
                   this.props.jaegerUrl && (
                     <NavItem onClick={this.navigateToJaeger}>
-                      <>
-                        Traces <Icon type={'fa'} name={'external-link'} />
-                      </>
+                      Traces <Icon type={'fa'} name={'external-link'} />
                     </NavItem>
                   )
                 ))}

--- a/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -183,27 +183,17 @@ class WorkloadDetails extends React.Component<RouteComponentProps<WorkloadId>, W
           <>
             <PfTitle location={this.props.location} istio={this.state.istioEnabled} />
             <Nav bsClass="nav nav-tabs nav-tabs-pf">
-              <NavItem eventKey="info">
-                <div>Info</div>
-              </NavItem>
-              <NavItem eventKey="traffic">
-                <div>Traffic</div>
-              </NavItem>
-              <NavItem eventKey="logs">
-                <div>Logs</div>
-              </NavItem>
-              <NavItem eventKey="in_metrics">
-                <div>Inbound Metrics</div>
-              </NavItem>
-              <NavItem eventKey="out_metrics">
-                <div>Outbound Metrics</div>
-              </NavItem>
+              <NavItem eventKey="info">Overview</NavItem>
+              <NavItem eventKey="traffic">Traffic</NavItem>
+              <NavItem eventKey="logs">Logs</NavItem>
+              <NavItem eventKey="in_metrics">Inbound Metrics</NavItem>
+              <NavItem eventKey="out_metrics">Outbound Metrics</NavItem>
               {isLabeled &&
                 this.state.workload.runtimes.map(runtime => {
                   return runtime.dashboardRefs.map(dashboard => {
                     return (
                       <NavItem key={dashboard.template} eventKey={dashboard.template}>
-                        <div>{dashboard.title}</div>
+                        {dashboard.title}
                       </NavItem>
                     );
                   });
@@ -237,7 +227,7 @@ class WorkloadDetails extends React.Component<RouteComponentProps<WorkloadId>, W
                 {hasPods ? (
                   <WorkloadPodLogs namespace={this.props.match.params.namespace} pods={this.state.workload.pods} />
                 ) : (
-                  <div>There are no logs to display because the workload has no pods.</div>
+                  'There are no logs to display because the workload has no pods.'
                 )}
               </TabPane>
               <TabPane eventKey="in_metrics" mountOnEnter={true} unmountOnExit={true}>


### PR DESCRIPTION
JIRA: [KIALi-2893](https://issues.jboss.org/browse/KIALI-2893)

Continue of https://github.com/kiali/kiali-ui/pull/1171
- Rename info tab to Overview like design https://github.com/kiali/kiali-design/issues/116
- Clean code, remove empty ```<div></div>```



cc @abonas @skondkar 