### PR TITLE
KIALI-2895 Use PF tooltips for Overview card icons

### DIFF
--- a/src/pages/Overview/OverviewCardLinks.tsx
+++ b/src/pages/Overview/OverviewCardLinks.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { Icon } from 'patternfly-react';
+import { Icon, OverlayTrigger, Tooltip } from 'patternfly-react';
 import { Paths } from '../../config';
 
 type Props = {
@@ -15,21 +15,43 @@ class OverviewCardLinks extends React.Component<Props> {
   render() {
     return (
       <div style={{ marginTop: '10px' }}>
-        <Link to={`/graph/namespaces?namespaces=` + this.props.name} title="Graph">
-          <Icon type="pf" name="topology" style={{ paddingLeft: 10, paddingRight: 10 }} />
-        </Link>
-        <Link to={`/${Paths.APPLICATIONS}?namespaces=` + this.props.name} title="Applications list">
-          <Icon type="pf" name="applications" style={{ paddingLeft: 10, paddingRight: 10 }} />
-        </Link>
-        <Link to={`/${Paths.WORKLOADS}?namespaces=` + this.props.name} title="Workloads list">
-          <Icon type="pf" name="bundle" style={{ paddingLeft: 10, paddingRight: 10 }} />
-        </Link>
-        <Link to={`/${Paths.SERVICES}?namespaces=` + this.props.name} title="Services list">
-          <Icon type="pf" name="service" style={{ paddingLeft: 10, paddingRight: 10 }} />
-        </Link>
-        <Link to={`/${Paths.ISTIO}?namespaces=` + this.props.name} title="Istio Config list">
-          <Icon type="pf" name="template" style={{ paddingLeft: 10, paddingRight: 10 }} />
-        </Link>
+        <OverlayTrigger key="ot_graph" placement="top" overlay={<Tooltip id="tt_graph">Go to graph...</Tooltip>}>
+          <Link to={`/graph/namespaces?namespaces=` + this.props.name}>
+            <Icon type="pf" name="topology" style={{ paddingLeft: 10, paddingRight: 10 }} />
+          </Link>
+        </OverlayTrigger>
+        <OverlayTrigger key="ot_apps" placement="top" overlay={<Tooltip id="tt_apps">Go to applications...</Tooltip>}>
+          <Link to={`/${Paths.APPLICATIONS}?namespaces=` + this.props.name}>
+            <Icon type="pf" name="applications" style={{ paddingLeft: 10, paddingRight: 10 }} />
+          </Link>
+        </OverlayTrigger>
+        <OverlayTrigger
+          key="ot_workloads"
+          placement="top"
+          overlay={<Tooltip id="tt_workloads">Go to workloads...</Tooltip>}
+        >
+          <Link to={`/${Paths.WORKLOADS}?namespaces=` + this.props.name}>
+            <Icon type="pf" name="bundle" style={{ paddingLeft: 10, paddingRight: 10 }} />
+          </Link>
+        </OverlayTrigger>
+        <OverlayTrigger
+          key="ot_services"
+          placement="top"
+          overlay={<Tooltip id="tt_services">Go to services...</Tooltip>}
+        >
+          <Link to={`/${Paths.SERVICES}?namespaces=` + this.props.name}>
+            <Icon type="pf" name="service" style={{ paddingLeft: 10, paddingRight: 10 }} />
+          </Link>
+        </OverlayTrigger>
+        <OverlayTrigger
+          key="ot_istio"
+          placement="top"
+          overlay={<Tooltip id="tt_istio">Go to Istio configs...</Tooltip>}
+        >
+          <Link to={`/${Paths.ISTIO}?namespaces=` + this.props.name}>
+            <Icon type="pf" name="template" style={{ paddingLeft: 10, paddingRight: 10 }} />
+          </Link>
+        </OverlayTrigger>
       </div>
     );
   }

--- a/src/pages/Overview/OverviewCardLinks.tsx
+++ b/src/pages/Overview/OverviewCardLinks.tsx
@@ -1,11 +1,17 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { Icon, OverlayTrigger, Tooltip } from 'patternfly-react';
+import { style } from 'typestyle';
 import { Paths } from '../../config';
 
 type Props = {
   name: string;
 };
+
+const iconStyle = style({
+  paddingLeft: 10,
+  paddingRight: 10
+});
 
 class OverviewCardLinks extends React.Component<Props> {
   constructor(props: Props) {
@@ -15,41 +21,33 @@ class OverviewCardLinks extends React.Component<Props> {
   render() {
     return (
       <div style={{ marginTop: '10px' }}>
-        <OverlayTrigger key="ot_graph" placement="top" overlay={<Tooltip id="tt_graph">Go to graph...</Tooltip>}>
+        <OverlayTrigger key="ot_graph" placement="top" overlay={<Tooltip id="tt_graph">Go to graph</Tooltip>}>
           <Link to={`/graph/namespaces?namespaces=` + this.props.name}>
-            <Icon type="pf" name="topology" style={{ paddingLeft: 10, paddingRight: 10 }} />
+            <Icon type="pf" name="topology" className={iconStyle} />
           </Link>
         </OverlayTrigger>
-        <OverlayTrigger key="ot_apps" placement="top" overlay={<Tooltip id="tt_apps">Go to applications...</Tooltip>}>
+        <OverlayTrigger key="ot_apps" placement="top" overlay={<Tooltip id="tt_apps">Go to applications</Tooltip>}>
           <Link to={`/${Paths.APPLICATIONS}?namespaces=` + this.props.name}>
-            <Icon type="pf" name="applications" style={{ paddingLeft: 10, paddingRight: 10 }} />
+            <Icon type="pf" name="applications" className={iconStyle} />
           </Link>
         </OverlayTrigger>
         <OverlayTrigger
           key="ot_workloads"
           placement="top"
-          overlay={<Tooltip id="tt_workloads">Go to workloads...</Tooltip>}
+          overlay={<Tooltip id="tt_workloads">Go to workloads</Tooltip>}
         >
           <Link to={`/${Paths.WORKLOADS}?namespaces=` + this.props.name}>
-            <Icon type="pf" name="bundle" style={{ paddingLeft: 10, paddingRight: 10 }} />
+            <Icon type="pf" name="bundle" className={iconStyle} />
           </Link>
         </OverlayTrigger>
-        <OverlayTrigger
-          key="ot_services"
-          placement="top"
-          overlay={<Tooltip id="tt_services">Go to services...</Tooltip>}
-        >
+        <OverlayTrigger key="ot_services" placement="top" overlay={<Tooltip id="tt_services">Go to services</Tooltip>}>
           <Link to={`/${Paths.SERVICES}?namespaces=` + this.props.name}>
-            <Icon type="pf" name="service" style={{ paddingLeft: 10, paddingRight: 10 }} />
+            <Icon type="pf" name="service" className={iconStyle} />
           </Link>
         </OverlayTrigger>
-        <OverlayTrigger
-          key="ot_istio"
-          placement="top"
-          overlay={<Tooltip id="tt_istio">Go to Istio configs...</Tooltip>}
-        >
+        <OverlayTrigger key="ot_istio" placement="top" overlay={<Tooltip id="tt_istio">Go to Istio config</Tooltip>}>
           <Link to={`/${Paths.ISTIO}?namespaces=` + this.props.name}>
-            <Icon type="pf" name="template" style={{ paddingLeft: 10, paddingRight: 10 }} />
+            <Icon type="pf" name="template" className={iconStyle} />
           </Link>
         </OverlayTrigger>
       </div>


### PR DESCRIPTION
- Make tooltip text better indicate that these are links

![kiali-2895](https://user-images.githubusercontent.com/2104052/58128423-9770f380-7be5-11e9-89ba-49597904d786.gif)
