### PR TITLE
KIALI-2894 Scroll to top of side panel when graph selection changes

### DIFF
--- a/src/pages/Graph/SummaryPanelEdge.tsx
+++ b/src/pages/Graph/SummaryPanelEdge.tsx
@@ -60,11 +60,13 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
   };
 
   private metricsPromise?: CancelablePromise<Response<Metrics>>;
+  private readonly mainDivRef: React.RefObject<HTMLDivElement>;
 
   constructor(props: SummaryPanelPropType) {
     super(props);
 
     this.state = { ...defaultSummaryPanelState };
+    this.mainDivRef = React.createRef<HTMLDivElement>();
   }
 
   componentDidMount() {
@@ -77,6 +79,9 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
         loading: true,
         reqRates: null
       });
+      if (this.mainDivRef.current) {
+        this.mainDivRef.current.scrollTop = 0;
+      }
     }
     if (shouldRefreshData(prevProps, this.props)) {
       this.updateCharts(this.props);
@@ -116,7 +121,7 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
     };
 
     return (
-      <div className="panel panel-default" style={SummaryPanelEdge.panelStyle}>
+      <div ref={this.mainDivRef} className="panel panel-default" style={SummaryPanelEdge.panelStyle}>
         <HeadingBlock prefix="From" node={source} />
         <HeadingBlock prefix="To" node={dest} />
         {isMtls && <MTLSBlock />}

--- a/src/pages/Graph/SummaryPanelGroup.tsx
+++ b/src/pages/Graph/SummaryPanelGroup.tsx
@@ -51,6 +51,7 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
   };
 
   private metricsPromise?: CancelablePromise<Response<Metrics>[]>;
+  private readonly mainDivRef: React.RefObject<HTMLDivElement>;
 
   constructor(props: SummaryPanelPropType) {
     super(props);
@@ -67,6 +68,8 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
       healthLoading: false,
       metricsLoadError: null
     };
+
+    this.mainDivRef = React.createRef<HTMLDivElement>();
   }
 
   componentDidMount() {
@@ -80,6 +83,9 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
         requestCountIn: null,
         loading: true
       });
+      if (this.mainDivRef.current) {
+        this.mainDivRef.current.scrollTop = 0;
+      }
     }
     if (shouldRefreshData(prevProps, this.props)) {
       this.updateRpsCharts(this.props);
@@ -101,7 +107,7 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
     const workloadList = this.renderWorkloadList(group);
 
     return (
-      <div className="panel panel-default" style={SummaryPanelGroup.panelStyle}>
+      <div ref={this.mainDivRef} className="panel panel-default" style={SummaryPanelGroup.panelStyle}>
         <div className="panel-heading">
           {this.state.healthLoading ? (
             // Remove glitch while health is being reloaded

--- a/src/pages/Graph/SummaryPanelNode.tsx
+++ b/src/pages/Graph/SummaryPanelNode.tsx
@@ -63,6 +63,7 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
   };
 
   private metricsPromise?: CancelablePromise<Response<Metrics>[]>;
+  private readonly mainDivRef: React.RefObject<HTMLDivElement>;
 
   constructor(props: SummaryPanelPropType) {
     super(props);
@@ -85,6 +86,8 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
       healthLoading: false,
       metricsLoadError: null
     };
+
+    this.mainDivRef = React.createRef<HTMLDivElement>();
   }
 
   componentDidMount() {
@@ -98,6 +101,9 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
         grpcRequestCountIn: null,
         loading: true
       });
+      if (this.mainDivRef.current) {
+        this.mainDivRef.current.scrollTop = 0;
+      }
     }
     if (shouldRefreshData(prevProps, this.props)) {
       this.updateCharts(this.props);
@@ -280,7 +286,7 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
     const shouldRenderWorkload = nodeType !== NodeType.WORKLOAD && nodeType !== NodeType.UNKNOWN && workload;
 
     return (
-      <div className="panel panel-default" style={SummaryPanelNode.panelStyle}>
+      <div ref={this.mainDivRef} className="panel panel-default" style={SummaryPanelNode.panelStyle}>
         <div className="panel-heading">
           {this.state.healthLoading ? (
             // Remove glitch while health is being reloaded


### PR DESCRIPTION
https://issues.jboss.org/browse/KIALI-2894

This ensures that the side panel scroll is at the top position when changing a selection in the graph.

The issue only happens when changing selection of same cytoscape "type" (i.e select and edge while another edge is currently selected). It does not happen if screen resolution leads to no scrollbars in side panel when changing context.