### PR TITLE
KIALI-2901 Fix missing nulls in MergeJsonPatch

### DIFF
--- a/src/utils/IstioConfigUtils.ts
+++ b/src/utils/IstioConfigUtils.ts
@@ -1,0 +1,58 @@
+import { IstioConfigDetails } from '../types/IstioConfigDetails';
+import { IstioObject } from '../types/IstioObjects';
+import _ from 'lodash';
+
+export const mergeJsonPatch = (objectModified: object, object?: object): object => {
+  if (!object) {
+    return objectModified;
+  }
+  const customizer = (objValue, srcValue) => {
+    if (!objValue) {
+      return null;
+    }
+    if (_.isObject(objValue) && _.isObject(srcValue)) {
+      _.mergeWith(objValue, srcValue, customizer);
+    }
+    return objValue;
+  };
+  _.mergeWith(objectModified, object, customizer);
+  return objectModified;
+};
+
+export const getIstioObject = (istioObjectDetails?: IstioConfigDetails) => {
+  let istioObject: IstioObject | undefined;
+  if (istioObjectDetails) {
+    if (istioObjectDetails.gateway) {
+      istioObject = istioObjectDetails.gateway;
+    } else if (istioObjectDetails.virtualService) {
+      istioObject = istioObjectDetails.virtualService;
+    } else if (istioObjectDetails.destinationRule) {
+      istioObject = istioObjectDetails.destinationRule;
+    } else if (istioObjectDetails.serviceEntry) {
+      istioObject = istioObjectDetails.serviceEntry;
+    } else if (istioObjectDetails.rule) {
+      istioObject = istioObjectDetails.rule;
+    } else if (istioObjectDetails.adapter) {
+      istioObject = istioObjectDetails.adapter;
+    } else if (istioObjectDetails.template) {
+      istioObject = istioObjectDetails.template;
+    } else if (istioObjectDetails.quotaSpec) {
+      istioObject = istioObjectDetails.quotaSpec;
+    } else if (istioObjectDetails.quotaSpecBinding) {
+      istioObject = istioObjectDetails.quotaSpecBinding;
+    } else if (istioObjectDetails.policy) {
+      istioObject = istioObjectDetails.policy;
+    } else if (istioObjectDetails.meshPolicy) {
+      istioObject = istioObjectDetails.meshPolicy;
+    } else if (istioObjectDetails.clusterRbacConfig) {
+      istioObject = istioObjectDetails.clusterRbacConfig;
+    } else if (istioObjectDetails.rbacConfig) {
+      istioObject = istioObjectDetails.rbacConfig;
+    } else if (istioObjectDetails.serviceRole) {
+      istioObject = istioObjectDetails.serviceRole;
+    } else if (istioObjectDetails.serviceRoleBinding) {
+      istioObject = istioObjectDetails.serviceRoleBinding;
+    }
+  }
+  return istioObject;
+};

--- a/src/utils/__tests__/IstioConfigUtils.test.ts
+++ b/src/utils/__tests__/IstioConfigUtils.test.ts
@@ -1,0 +1,55 @@
+import { mergeJsonPatch } from '../IstioConfigUtils';
+
+describe('Validate JSON Patchs', () => {
+  const gateway: object = {
+    kind: 'Gateway',
+    namespace: {
+      name: 'bookinfo'
+    },
+    spec: {
+      selector: {
+        istio: 'ingressgateway'
+      },
+      servers: [
+        {
+          port: {
+            number: 80,
+            name: 'http',
+            protocol: 'HTTP'
+          },
+          hosts: ['*']
+        }
+      ]
+    }
+  };
+
+  const gatewayModified: object = {
+    apiVersion: 'networking.istio.io/v1alpha3',
+    kind: 'Gateway',
+    spec: {
+      selector: {
+        app: 'myapp'
+      },
+      servers: [
+        {
+          port: {
+            number: 80,
+            name: 'http',
+            protocol: 'HTTP'
+          },
+          hosts: ['*']
+        }
+      ]
+    }
+  };
+
+  it('Dummy test', () => {
+    mergeJsonPatch(gatewayModified, gateway);
+
+    // tslint:disable-next-line
+    expect(gatewayModified['namespace']).toBeNull();
+
+    // tslint:disable-next-line
+    expect(gatewayModified['spec']['selector']['istio']).toBeNull();
+  });
+});


### PR DESCRIPTION
This fix adds key: null into the mergeJsonPatch used by Kiali to update an Istio config resource.
Those null in the patch values are necessary when an attribute is removed from the yaml view and transformed into an non key. The Merge Patch needs a key with a null value to perform the delete.

