### PR TITLE
update the base url for relative url

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <meta name="theme-color" content="#000000" />
-    <base href="/" />
+    <base href="./" />
     <script type="text/javascript" src="./env.js"></script>
     <!--
       manifest.json provides metadata used when your web app is added to the


### PR DESCRIPTION
** Describe the change **
 Update the base url to take the relative url not the absolute path
  while running the kiali under reverse proxy for the url like
 `abc.com/xyz/def/api/v1/namespaces/istio-system/services/kiali:20001/proxy/`
   it takes the wrong base url URL `abc.com/api/v1/namespaces/istio-system/services/kiali:20001/proxy/`

 To solve this I have taken the relative URL and it starts taking the relative url 

** Issue reference **
* If this is a fix for a GH-issue, please link it here
   https://github.com/kiali/kiali/issues/1059



