### PR TITLE
KIALI-2751 Include Gateways in Wizards

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "Instead update 'web_root' in Kaili config map in OpenShift console."
   ],
   "homepage": "./",
+  "proxy": "http://localhost:8000",
   "bugs": {
     "url": "https://issues.jboss.org/projects/KIALI/issues/"
   },

--- a/src/components/IstioWizards/GatewaySelector.tsx
+++ b/src/components/IstioWizards/GatewaySelector.tsx
@@ -1,0 +1,257 @@
+import * as React from 'react';
+import {
+  Col,
+  ControlLabel,
+  DropdownButton,
+  Form,
+  FormControl,
+  FormGroup,
+  HelpBlock,
+  MenuItem,
+  Radio,
+  Switch
+} from 'patternfly-react';
+import { style } from 'typestyle';
+
+type Props = {
+  serviceName: string;
+  hasGateway: boolean;
+  vsHosts: string[];
+  gateway: string;
+  gateways: string[];
+  onGatewayChange: (valid: boolean, gateway: GatewaySelectorState) => void;
+};
+
+export type GatewaySelectorState = {
+  addGateway: boolean;
+  vsHosts: string;
+  gwHosts: string;
+  gwHostsValid: boolean;
+  newGateway: boolean;
+  selectedGateway: string;
+  port: number;
+};
+
+enum GatewayForm {
+  SWITCH,
+  VS_HOSTS,
+  GW_HOSTS,
+  SELECT,
+  GATEWAY_SELECTED,
+  PORT
+}
+
+const labelStyle = style({
+  marginTop: 20
+});
+
+const rightText = style({
+  textAlign: 'right'
+});
+
+class GatewaySelector extends React.Component<Props, GatewaySelectorState> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      addGateway: props.hasGateway,
+      vsHosts: props.vsHosts.length > 0 ? props.vsHosts.join(',') : props.serviceName,
+      gwHosts: '*',
+      gwHostsValid: true,
+      newGateway: props.gateways.length === 0,
+      selectedGateway: props.gateways.length > 0 ? (props.gateway !== '' ? props.gateway : props.gateways[0]) : '',
+      port: 80
+    };
+  }
+
+  checkGwHosts = (gwHosts: string): boolean => {
+    const hosts = gwHosts.split(',');
+    for (let i = 0; i < hosts.length; i++) {
+      if (hosts[i] === '*') {
+        continue;
+      }
+      if (!hosts[i].includes('.')) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  onFormChange = (component: GatewayForm, value: string) => {
+    switch (component) {
+      case GatewayForm.SWITCH:
+        this.setState(
+          prevState => {
+            return {
+              addGateway: !prevState.addGateway
+            };
+          },
+          () => this.props.onGatewayChange(true, this.state)
+        );
+        break;
+      case GatewayForm.VS_HOSTS:
+        this.setState(
+          {
+            vsHosts: value
+          },
+          () => this.props.onGatewayChange(true, this.state)
+        );
+        break;
+      case GatewayForm.GW_HOSTS:
+        this.setState(
+          {
+            gwHosts: value,
+            gwHostsValid: this.checkGwHosts(value)
+          },
+          () => this.props.onGatewayChange(this.state.gwHostsValid, this.state)
+        );
+        break;
+      case GatewayForm.SELECT:
+        this.setState(
+          {
+            newGateway: value === 'true'
+          },
+          () => this.props.onGatewayChange(true, this.state)
+        );
+        break;
+      case GatewayForm.GATEWAY_SELECTED:
+        this.setState(
+          {
+            selectedGateway: value
+          },
+          () => this.props.onGatewayChange(true, this.state)
+        );
+        break;
+      case GatewayForm.PORT:
+        this.setState(
+          {
+            port: +value
+          },
+          () => this.props.onGatewayChange(true, this.state)
+        );
+        break;
+      default:
+      // No default action
+    }
+  };
+
+  render() {
+    const gatewayItems: any[] = this.props.gateways.map(gw => (
+      <MenuItem key={gw} eventKey={gw} active={gw === this.state.selectedGateway}>
+        {gw}
+      </MenuItem>
+    ));
+    return (
+      <Form horizontal={true}>
+        <FormGroup controlId="vsHosts">
+          <Col componentClass={ControlLabel} sm={3}>
+            VirtualService Hosts
+          </Col>
+          <Col sm={9}>
+            <FormControl
+              type="text"
+              value={this.state.vsHosts}
+              onChange={e => this.onFormChange(GatewayForm.VS_HOSTS, e.target.value)}
+            />
+            <HelpBlock>
+              The destination hosts to which traffic is being sent. Enter one or multiple hosts separated by comma.
+            </HelpBlock>
+          </Col>
+        </FormGroup>
+        <FormGroup controlId="gatewaySwitch" disabled={false}>
+          <Col componentClass={ControlLabel} sm={3}>
+            Add Gateway
+          </Col>
+          <Col sm={9}>
+            <Switch
+              bsSize="normal"
+              title="normal"
+              id="gateway-form"
+              onChange={() => this.onFormChange(GatewayForm.SWITCH, '')}
+              defaultValue={this.props.hasGateway}
+            />
+          </Col>
+        </FormGroup>
+        <FormGroup>
+          <Col sm={3} className={rightText}>
+            <Radio
+              name="selectGateway"
+              className={labelStyle}
+              disabled={!this.state.addGateway}
+              checked={!this.state.newGateway}
+              onChange={() => this.onFormChange(GatewayForm.SELECT, 'false')}
+            >
+              Select Gateway
+            </Radio>
+          </Col>
+          <Col sm={9} />
+        </FormGroup>
+        <FormGroup>
+          <Col componentClass={ControlLabel} sm={3}>
+            Gateway
+          </Col>
+          <Col sm={9}>
+            <DropdownButton
+              id="trafficPolicy-tls"
+              bsStyle="default"
+              title={this.state.selectedGateway}
+              disabled={!this.state.addGateway || this.state.newGateway}
+              onSelect={(gw: string) => this.onFormChange(GatewayForm.GATEWAY_SELECTED, gw)}
+            >
+              {gatewayItems}
+            </DropdownButton>
+          </Col>
+        </FormGroup>
+        <FormGroup>
+          <Col sm={3} className={rightText}>
+            <Radio
+              name="selectGateway"
+              className={labelStyle}
+              disabled={!this.state.addGateway}
+              checked={this.state.newGateway}
+              onChange={() => this.onFormChange(GatewayForm.SELECT, 'true')}
+            >
+              Create Gateway
+            </Radio>
+          </Col>
+          <Col sm={9} />
+        </FormGroup>
+        <FormGroup>
+          <Col componentClass={ControlLabel} sm={3}>
+            Port
+          </Col>
+          <Col sm={9}>
+            <FormControl
+              type="number"
+              disabled={!this.state.addGateway || !this.state.newGateway}
+              value={this.state.port}
+              onChange={e => this.onFormChange(GatewayForm.PORT, e.target.value)}
+            />
+          </Col>
+        </FormGroup>
+        <FormGroup
+          controlId="gwHosts"
+          disabled={!this.state.addGateway}
+          validationState={this.state.gwHostsValid ? '' : 'error'}
+        >
+          <Col componentClass={ControlLabel} sm={3}>
+            Gateway Hosts
+          </Col>
+          <Col sm={9}>
+            <FormControl
+              type="text"
+              disabled={!this.state.addGateway || !this.state.newGateway}
+              value={this.state.gwHosts}
+              onChange={e => this.onFormChange(GatewayForm.GW_HOSTS, e.target.value)}
+            />
+            <HelpBlock>
+              One or more hosts exposed by this gateway. Enter one or multiple hosts separated by comma.
+              {!this.state.gwHostsValid && <p>Gateway hosts should be specified using FQDN format or '*' wildcard.</p>}
+            </HelpBlock>
+          </Col>
+        </FormGroup>
+      </Form>
+    );
+  }
+}
+
+export default GatewaySelector;

--- a/src/components/IstioWizards/IstioWizard.tsx
+++ b/src/components/IstioWizards/IstioWizard.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, Wizard } from 'patternfly-react';
+import { Button, ExpandCollapse, Wizard } from 'patternfly-react';
 import { WorkloadOverview } from '../../types/ServiceInfo';
 import * as API from '../../services/Api';
 import * as MessageCenter from '../../utils/MessageCenter';
@@ -11,11 +11,14 @@ import SuspendTraffic, { SuspendedRoute } from './SuspendTraffic';
 import { Rule } from './MatchingRouting/Rules';
 import {
   buildIstioConfig,
+  getInitGateway,
+  getInitHosts,
   getInitLoadBalancer,
   getInitRules,
   getInitSuspendedRoutes,
   getInitTlsMode,
   getInitWeights,
+  hasGateway,
   WIZARD_MATCHING_ROUTING,
   WIZARD_SUSPEND_TRAFFIC,
   WIZARD_THREESCALE_INTEGRATION,
@@ -29,6 +32,16 @@ import { Response } from '../../services/Api';
 import { MessageType } from '../../types/MessageCenter';
 import ThreeScaleIntegration from './ThreeScaleIntegration';
 import { ThreeScaleServiceRule } from '../../types/ThreeScale';
+import { style } from 'typestyle';
+import GatewaySelector, { GatewaySelectorState } from './GatewaySelector';
+
+const expandStyle = style({
+  $nest: {
+    ['.btn']: {
+      fontSize: '14px'
+    }
+  }
+});
 
 class IstioWizard extends React.Component<WizardProps, WizardState> {
   constructor(props: WizardProps) {
@@ -101,7 +114,11 @@ class IstioWizard extends React.Component<WizardProps, WizardState> {
       case WIZARD_WEIGHTED_ROUTING:
       case WIZARD_MATCHING_ROUTING:
       case WIZARD_SUSPEND_TRAFFIC:
-        const [dr, vs] = buildIstioConfig(this.props, this.state);
+        const [dr, vs, gw] = buildIstioConfig(this.props, this.state);
+        // Gateway is only created when user has explicit selected this option
+        if (gw) {
+          promises.push(API.createIstioConfigDetail(this.props.namespace, 'gateways', JSON.stringify(gw)));
+        }
         if (this.props.update) {
           promises.push(
             API.updateIstioConfigDetail(this.props.namespace, 'destinationrules', dr.metadata.name, JSON.stringify(dr))
@@ -109,6 +126,7 @@ class IstioWizard extends React.Component<WizardProps, WizardState> {
           promises.push(
             API.updateIstioConfigDetail(this.props.namespace, 'virtualservices', vs.metadata.name, JSON.stringify(vs))
           );
+          // Note that Gateways are not updated from the Wizard, only the VS hosts/gateways sections are updated
         } else {
           promises.push(API.createIstioConfigDetail(this.props.namespace, 'destinationrules', JSON.stringify(dr)));
           promises.push(API.createIstioConfigDetail(this.props.namespace, 'virtualservices', JSON.stringify(vs)));
@@ -171,6 +189,13 @@ class IstioWizard extends React.Component<WizardProps, WizardState> {
     this.setState({
       loadBalancer: simple,
       lbModified: true
+    });
+  };
+
+  onGateway = (valid: boolean, gateway: GatewaySelectorState) => {
+    this.setState({
+      valid: valid,
+      gateway: gateway
     });
   };
 
@@ -254,14 +279,28 @@ class IstioWizard extends React.Component<WizardProps, WizardState> {
                 {(this.props.type === WIZARD_WEIGHTED_ROUTING ||
                   this.props.type === WIZARD_MATCHING_ROUTING ||
                   this.props.type === WIZARD_SUSPEND_TRAFFIC) && (
-                  <TrafficPolicyContainer
-                    mtlsMode={this.state.mtlsMode}
-                    loadBalancer={this.state.loadBalancer}
-                    onTlsChange={this.onTLS}
-                    onLoadbalancerChange={this.onLoadBalancer}
+                  <ExpandCollapse
+                    className={expandStyle}
+                    textCollapsed="Show Advanced Options"
+                    textExpanded="Hide Advanced Options"
                     expanded={false}
-                    nsWideStatus={this.props.tlsStatus}
-                  />
+                  >
+                    <TrafficPolicyContainer
+                      mtlsMode={this.state.mtlsMode}
+                      loadBalancer={this.state.loadBalancer}
+                      onTlsChange={this.onTLS}
+                      onLoadbalancerChange={this.onLoadBalancer}
+                      nsWideStatus={this.props.tlsStatus}
+                    />
+                    <GatewaySelector
+                      serviceName={this.props.serviceName}
+                      hasGateway={hasGateway(this.props.virtualServices)}
+                      vsHosts={getInitHosts(this.props.virtualServices)}
+                      gateway={getInitGateway(this.props.virtualServices)}
+                      gateways={this.props.gateways.map(gw => gw.metadata.name)}
+                      onGatewayChange={this.onGateway}
+                    />
+                  </ExpandCollapse>
                 )}
               </Wizard.Contents>
             </Wizard.Main>

--- a/src/components/IstioWizards/IstioWizardActions.ts
+++ b/src/components/IstioWizards/IstioWizardActions.ts
@@ -7,6 +7,7 @@ import {
   DestinationRule,
   DestinationRules,
   DestinationWeight,
+  Gateway,
   HTTPMatchRequest,
   HTTPRoute,
   StringMatch,
@@ -15,6 +16,7 @@ import {
 } from '../../types/IstioObjects';
 import { serverConfig } from '../../config';
 import { ThreeScaleServiceRule } from '../../types/ThreeScale';
+import { GatewaySelectorState } from './GatewaySelector';
 
 export const WIZARD_WEIGHTED_ROUTING = 'weighted_routing';
 export const WIZARD_MATCHING_ROUTING = 'matching_routing';
@@ -47,6 +49,7 @@ export type WizardProps = {
   workloads: WorkloadOverview[];
   virtualServices: VirtualServices;
   destinationRules: DestinationRules;
+  gateways: Gateway[];
   threeScaleServiceRule?: ThreeScaleServiceRule;
   onClose: (changed: boolean) => void;
 };
@@ -61,6 +64,7 @@ export type WizardState = {
   tlsModified: boolean;
   loadBalancer: string;
   lbModified: boolean;
+  gateway?: GatewaySelectorState;
   threeScaleServiceRule?: ThreeScaleServiceRule;
 };
 
@@ -144,7 +148,33 @@ const parseHttpMatchRequest = (httpMatchRequest: HTTPMatchRequest): string[] => 
   return matches;
 };
 
-export const buildIstioConfig = (wProps: WizardProps, wState: WizardState): [DestinationRule, VirtualService] => {
+export const getGatewayName = (serviceName: string, gatewayNames: string[]): string => {
+  let gatewayName = serviceName + '-gateway';
+  if (gatewayNames.length === 0) {
+    return gatewayName;
+  }
+  let goodName = false;
+  while (!goodName) {
+    if (!gatewayNames.includes(gatewayName)) {
+      goodName = true;
+    } else {
+      // Iterate until we find a good gatewayName
+      if (gatewayName.charAt(gatewayName.length - 2) === '-') {
+        let version = +gatewayName.charAt(gatewayName.length - 1);
+        version = version + 1;
+        gatewayName = gatewayName.substr(0, gatewayName.length - 1) + version;
+      } else {
+        gatewayName = gatewayName + '-1';
+      }
+    }
+  }
+  return gatewayName;
+};
+
+export const buildIstioConfig = (
+  wProps: WizardProps,
+  wState: WizardState
+): [DestinationRule, VirtualService, Gateway?] => {
   const wkdNameVersion: { [key: string]: string } = {};
 
   // DestinationRule from the labels
@@ -185,11 +215,42 @@ export const buildIstioConfig = (wProps: WizardProps, wState: WizardState): [Des
     spec: {}
   };
 
+  // Wizard is optional, only when user has explicitly selected "Create a Gateway"
+  const newGatewayName = getGatewayName(wProps.serviceName, wProps.gateways.map(gw => gw.metadata.name));
+  const wizardGW: Gateway | undefined =
+    wState.gateway && wState.gateway.addGateway && wState.gateway.newGateway
+      ? {
+          metadata: {
+            namespace: wProps.namespace,
+            name: newGatewayName,
+            labels: {
+              [KIALI_WIZARD_LABEL]: wProps.type
+            }
+          },
+          spec: {
+            selector: {
+              istio: 'ingressgateway'
+            },
+            servers: [
+              {
+                port: {
+                  number: wState.gateway.port,
+                  name: 'http',
+                  protocol: 'HTTP'
+                },
+                hosts: wState.gateway.gwHosts.split(',')
+              }
+            ]
+          }
+        }
+      : undefined;
+
+  const vsHosts = wState.gateway ? wState.gateway.vsHosts.split(',') : [wProps.serviceName];
   switch (wProps.type) {
     case WIZARD_WEIGHTED_ROUTING: {
       // VirtualService from the weights
       wizardVS.spec = {
-        hosts: [wProps.serviceName],
+        hosts: vsHosts,
         http: [
           {
             route: wState.workloads.map(workload => {
@@ -209,7 +270,7 @@ export const buildIstioConfig = (wProps: WizardProps, wState: WizardState): [Des
     case WIZARD_MATCHING_ROUTING: {
       // VirtualService from the routes
       wizardVS.spec = {
-        hosts: [wProps.serviceName],
+        hosts: vsHosts,
         http: wState.rules.map(rule => {
           const httpRoute: HTTPRoute = {};
           httpRoute.route = [];
@@ -287,7 +348,7 @@ export const buildIstioConfig = (wProps: WizardProps, wState: WizardState): [Des
         };
       }
       wizardVS.spec = {
-        hosts: [wProps.serviceName],
+        hosts: vsHosts,
         http: [httpRoute]
       };
       break;
@@ -309,7 +370,18 @@ export const buildIstioConfig = (wProps: WizardProps, wState: WizardState): [Des
       };
     }
   }
-  return [wizardDR, wizardVS];
+
+  if (wState.gateway && wState.gateway.vsHosts) {
+    wizardVS.spec.hosts = wState.gateway.vsHosts.split(',');
+  }
+
+  if (wState.gateway && wState.gateway.addGateway) {
+    wizardVS.spec.gateways = [wState.gateway.newGateway ? newGatewayName : wState.gateway.selectedGateway];
+  } else {
+    wizardVS.spec.gateways = null;
+  }
+
+  return [wizardDR, wizardVS, wizardGW];
 };
 
 const getWorkloadsByVersion = (workloads: WorkloadOverview[]): { [key: string]: string } => {
@@ -403,6 +475,38 @@ export const getInitLoadBalancer = (destinationRules: DestinationRules): string 
     destinationRules.items[0].spec.trafficPolicy.loadBalancer
   ) {
     return destinationRules.items[0].spec.trafficPolicy.loadBalancer.simple || '';
+  }
+  return '';
+};
+
+export const hasGateway = (virtualServices: VirtualServices): boolean => {
+  // We need to if sentence, otherwise a potential undefined is not well handled
+  if (
+    virtualServices.items.length === 1 &&
+    virtualServices.items[0] &&
+    virtualServices.items[0].spec.gateways &&
+    virtualServices.items[0].spec.gateways.length > 0
+  ) {
+    return true;
+  }
+  return false;
+};
+
+export const getInitHosts = (virtualServices: VirtualServices): string[] => {
+  if (virtualServices.items.length === 1 && virtualServices.items[0] && virtualServices.items[0].spec.hosts) {
+    return virtualServices.items[0].spec.hosts;
+  }
+  return [];
+};
+
+export const getInitGateway = (virtualServices: VirtualServices): string => {
+  if (
+    virtualServices.items.length === 1 &&
+    virtualServices.items[0] &&
+    virtualServices.items[0].spec.gateways &&
+    virtualServices.items[0].spec.gateways.length === 1
+  ) {
+    return virtualServices.items[0].spec.gateways[0];
   }
   return '';
 };

--- a/src/components/IstioWizards/IstioWizardDropdown.tsx
+++ b/src/components/IstioWizards/IstioWizardDropdown.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { DropdownButton, MenuItem, MessageDialog, OverlayTrigger, Tooltip } from 'patternfly-react';
 import { WorkloadOverview } from '../../types/ServiceInfo';
-import { DestinationRules, VirtualServices } from '../../types/IstioObjects';
+import { DestinationRules, Gateway, VirtualServices } from '../../types/IstioObjects';
 import * as MessageCenter from '../../utils/MessageCenter';
 import * as API from '../../services/Api';
 import { serverConfig } from '../../config/ServerConfig';
@@ -27,6 +27,7 @@ type Props = {
   workloads: WorkloadOverview[];
   virtualServices: VirtualServices;
   destinationRules: DestinationRules;
+  gateways: Gateway[];
   tlsStatus?: TLSStatus;
   threeScaleInfo: ThreeScaleInfo;
   threeScaleServiceRule?: ThreeScaleServiceRule;
@@ -328,6 +329,7 @@ class IstioWizardDropdown extends React.Component<Props, State> {
           })}
           virtualServices={this.props.virtualServices}
           destinationRules={this.props.destinationRules}
+          gateways={this.props.gateways}
           threeScaleServiceRule={this.props.threeScaleServiceRule}
           tlsStatus={this.props.tlsStatus}
           onClose={this.onClose}

--- a/src/components/IstioWizards/TrafficPolicy.tsx
+++ b/src/components/IstioWizards/TrafficPolicy.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { Col, ControlLabel, DropdownButton, ExpandCollapse, Icon, MenuItem, Row } from 'patternfly-react';
-import { style } from 'typestyle';
+import { Col, ControlLabel, DropdownButton, Form, FormGroup, Icon, MenuItem } from 'patternfly-react';
 import { MTLSStatuses, nsWideMTLSStatus, TLSStatus } from '../../types/TLSStatus';
 import { KialiAppState } from '../../store/Store';
 import { meshWideMTLSStatusSelector } from '../../store/Selectors';
@@ -23,31 +22,11 @@ type Props = ReduxProps & {
   loadBalancer: string;
   onTlsChange: (mtlsMode: string) => void;
   onLoadbalancerChange: (loadbalancer: string) => void;
-  expanded: boolean;
   nsWideStatus?: TLSStatus;
 };
 
-const tlsStyle = style({
-  marginTop: 20,
-  marginLeft: 20,
-  marginRight: 20
-});
-
-const lbStyle = style({
-  marginLeft: 40,
-  marginRight: 20
-});
-
 const tlsIconType = 'pf';
 const tlsIconName = 'locked';
-
-const expandStyle = style({
-  $nest: {
-    ['.btn']: {
-      fontSize: '14px'
-    }
-  }
-});
 
 class TrafficPolicy extends React.Component<Props> {
   constructor(props: Props) {
@@ -75,17 +54,12 @@ class TrafficPolicy extends React.Component<Props> {
       </MenuItem>
     ));
     return (
-      <ExpandCollapse
-        className={expandStyle}
-        textCollapsed="Show Advanced Options"
-        textExpanded="Hide Advanced Options"
-        expanded={this.props.expanded}
-      >
-        <Row>
-          <Col sm={12}>
-            <ControlLabel className={tlsStyle}>
-              <Icon type={tlsIconType} name={tlsIconName} /> TLS
-            </ControlLabel>
+      <Form horizontal={true}>
+        <FormGroup controlId="tls" disabled={false}>
+          <Col componentClass={ControlLabel} sm={3}>
+            <Icon type={tlsIconType} name={tlsIconName} /> TLS
+          </Col>
+          <Col sm={9}>
             <DropdownButton
               bsStyle="default"
               title={this.props.mtlsMode}
@@ -94,7 +68,13 @@ class TrafficPolicy extends React.Component<Props> {
             >
               {tlsMenuItems}
             </DropdownButton>
-            <ControlLabel className={lbStyle}>LoadBalancer</ControlLabel>
+          </Col>
+        </FormGroup>
+        <FormGroup controlId="loadBalancer" disabled={false}>
+          <Col componentClass={ControlLabel} sm={3}>
+            LoadBalancer
+          </Col>
+          <Col sm={9}>
             <DropdownButton
               bsStyle="default"
               title={this.props.loadBalancer}
@@ -104,8 +84,8 @@ class TrafficPolicy extends React.Component<Props> {
               {lbMenuItems}
             </DropdownButton>
           </Col>
-        </Row>
-      </ExpandCollapse>
+        </FormGroup>
+      </Form>
     );
   }
 }

--- a/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -19,7 +19,7 @@ import { ServiceDetailsInfo, severityToIconName, validationToSeverity } from '..
 import ServiceInfoVirtualServices from './ServiceInfo/ServiceInfoVirtualServices';
 import ServiceInfoDestinationRules from './ServiceInfo/ServiceInfoDestinationRules';
 import ServiceInfoWorkload from './ServiceInfo/ServiceInfoWorkload';
-import { Validations, ObjectValidation } from '../../types/IstioObjects';
+import { Validations, ObjectValidation, Gateway } from '../../types/IstioObjects';
 import { TabPaneWithErrorBoundary } from '../../components/ErrorBoundary/WithErrorBoundary';
 import IstioWizardDropdown from '../../components/IstioWizards/IstioWizardDropdown';
 import { ThreeScaleInfo, ThreeScaleServiceRule } from '../../types/ThreeScale';
@@ -27,6 +27,7 @@ import { DurationDropdownContainer } from '../../components/DurationDropdown/Dur
 
 interface ServiceDetails extends ServiceId {
   serviceDetails: ServiceDetailsInfo;
+  gateways: Gateway[];
   validations: Validations;
   onRefresh: () => void;
   onSelectTab: (tabName: string, postHandler?: (tabName: string) => void) => void;
@@ -146,6 +147,7 @@ class ServiceInfo extends React.Component<ServiceDetails, ServiceInfoState> {
                   workloads={workloads}
                   virtualServices={virtualServices}
                   destinationRules={destinationRules}
+                  gateways={this.props.gateways}
                   tlsStatus={this.props.serviceDetails.namespaceMTLS}
                   onChange={this.props.onRefresh}
                   threeScaleInfo={this.props.threeScaleInfo}

--- a/src/pages/ServiceDetails/__tests__/ServiceInfo.test.tsx
+++ b/src/pages/ServiceDetails/__tests__/ServiceInfo.test.tsx
@@ -16,6 +16,7 @@ describe('#ServiceInfo render correctly with data', () => {
           namespace="istio-system"
           service="reviews"
           serviceDetails={data}
+          gateways={[]}
           validations={data.validations}
           onRefresh={jest.fn()}
           onSelectTab={jest.fn()}

--- a/src/types/IstioObjects.ts
+++ b/src/types/IstioObjects.ts
@@ -331,7 +331,7 @@ export interface TLSRoute {
 
 export interface VirtualServiceSpec {
   hosts?: string[];
-  gateways?: string[];
+  gateways?: string[] | null;
   http?: HTTPRoute[];
   tcp?: TCPRoute[];
   tls?: TLSRoute[];
@@ -366,7 +366,7 @@ export interface Gateway extends IstioObject {
 export interface Server {
   port: ServerPort;
   hosts: string[];
-  tls: TLSOptions;
+  tls?: TLSOptions;
 }
 
 export interface ServerPort {


### PR DESCRIPTION
This PRs allows to add support for Gateways in Kiali Wizards.
Before this work, any gateway addition should be added manually using the YAML editor.

With this change, now user can select a wizard or create a default new one from the "Advance Options".

So, now Advanced Options section is organized in the following layout:

![image](https://user-images.githubusercontent.com/1662329/58423839-5c176e80-8096-11e9-96c1-73af707e998e.png)

User can modify/define the VirtualService Hosts section (by default, Wizard uses the short name of the service, the goal of this PR is not going to add more features here, but now user can also personalize this, as when selecting a gateway, it can be different).

Also, there is a switch to add a gateway, and also user can choose between selecting an existing gateway, or creating a default one (selecting the port and Gateway Hosts, which may can be different from VirtualService hosts).

Please @hhovsepy and @burmanm, we have commented about this, if you can test it and tell me if there is no missing use case, it would be great.

Thanks.
