### PR TITLE
KIALI-2930 Show details of error in initialization screen

### DIFF
--- a/src/app/InitializingScreen.tsx
+++ b/src/app/InitializingScreen.tsx
@@ -10,11 +10,49 @@ import {
   LoginPageHeader,
   Spinner
 } from 'patternfly-react';
+import { style } from 'typestyle';
 import { isKioskMode } from '../utils/SearchParamUtils';
+
+type initializingScreenProps = {
+  errorMsg?: string;
+  errorDetails?: string;
+};
 
 const kialiTitle = require('../assets/img/logo-login.svg');
 
-const InitializingScreen: React.FC<{ errorMsg?: string }> = (props: { errorMsg?: string }) => {
+const defaultErrorStyle = style({
+  $nest: {
+    '& p:last-of-type': {
+      textAlign: 'right'
+    },
+    '& textarea, & hr': {
+      display: 'none'
+    }
+  }
+});
+
+const expandedErrorStyle = style({
+  $nest: {
+    '& p:last-of-type': {
+      display: 'none'
+    },
+    '& textarea': {
+      width: '100%',
+      whiteSpace: 'pre'
+    }
+  }
+});
+
+const InitializingScreen: React.FC<initializingScreenProps> = (props: initializingScreenProps) => {
+  const errorDiv = React.createRef<HTMLDivElement>();
+
+  const onClickHandler = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
+    if (errorDiv.current) {
+      errorDiv.current.setAttribute('class', expandedErrorStyle);
+    }
+  };
+
   if (document.documentElement) {
     document.documentElement.className = isKioskMode() ? 'kiosk' : '';
   }
@@ -27,8 +65,23 @@ const InitializingScreen: React.FC<{ errorMsg?: string }> = (props: { errorMsg?:
           <LoginCard>
             <LoginCardHeader>
               {props.errorMsg ? (
-                <div>
-                  <Icon type="pf" name="error-circle-o" /> {props.errorMsg}
+                <div ref={errorDiv} className={defaultErrorStyle}>
+                  <p>
+                    <Icon type="pf" name="error-circle-o" /> {props.errorMsg}
+                  </p>
+                  {props.errorDetails ? (
+                    <>
+                      <p>
+                        <a href="#" onClick={onClickHandler}>
+                          Show details
+                        </a>
+                      </p>
+                      <hr />
+                      <textarea readOnly={true} rows={10}>
+                        {props.errorDetails}
+                      </textarea>
+                    </>
+                  ) : null}
                 </div>
               ) : (
                 <>

--- a/src/app/StartupInitializer.tsx
+++ b/src/app/StartupInitializer.tsx
@@ -12,7 +12,12 @@ interface InitializerComponentProps {
   onInitializationFinished: () => void;
 }
 
-class InitializerComponent extends React.Component<InitializerComponentProps, { errorMsg?: string }> {
+interface InitializerComponentState {
+  errorMsg?: string;
+  errorDetails?: string;
+}
+
+class InitializerComponent extends React.Component<InitializerComponentProps, InitializerComponentState> {
   constructor(props: InitializerComponentProps) {
     super(props);
     this.state = {};
@@ -23,7 +28,7 @@ class InitializerComponent extends React.Component<InitializerComponentProps, { 
   }
 
   render() {
-    return <InitializingScreen errorMsg={this.state.errorMsg} />;
+    return <InitializingScreen errorMsg={this.state.errorMsg} errorDetails={this.state.errorDetails} />;
   }
 
   private fetchAuthenticationConfig = async () => {
@@ -44,7 +49,18 @@ class InitializerComponent extends React.Component<InitializerComponentProps, { 
 
       this.props.onInitializationFinished();
     } catch (err) {
-      this.setState({ errorMsg: API.getErrorMsg('Initialization failed', err) });
+      let errDetails: string | undefined;
+      if (err.request) {
+        const response = (err.request as XMLHttpRequest).responseText;
+        if (response.trim().length > 0) {
+          errDetails = response;
+        }
+      }
+
+      this.setState({
+        errorMsg: API.getErrorMsg('Initialization failed', err),
+        errorDetails: errDetails
+      });
     }
   };
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/KIALI-2930

At first load of Kiali, a request is done to retrieve some settings. If this request fails, an error message is shown. Sometimes, this error message is not enough to troubleshoot the issue and the developer console is needed to see what the back-end is returning.

To improve this experience, adding a "Show details" pane to display the raw response sent by the back-end if first-load initialization fails.

![showDetails](https://user-images.githubusercontent.com/23639005/58439693-0db89e80-809b-11e9-8baa-2e63ede6c1c1.gif)
