### PR TITLE
KIALI-2570 Add Selector labels to Service Details page

### DIFF
--- a/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -163,6 +163,7 @@ class ServiceInfo extends React.Component<ServiceDetails, ServiceInfoState> {
                 resourceVersion={this.props.serviceDetails.service.resourceVersion}
                 istioEnabled={this.props.serviceDetails.istioSidecar}
                 labels={this.props.serviceDetails.service.labels}
+                selectors={this.props.serviceDetails.service.selectors}
                 ports={this.props.serviceDetails.service.ports}
                 type={this.props.serviceDetails.service.type}
                 ip={this.props.serviceDetails.service.ip}

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
@@ -88,17 +88,21 @@ class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps
         <div className="card-pf-body">
           <Row>
             <Col xs={12} sm={6} md={5} lg={5}>
-              <div className={'progress-description ' + labelTitleStyle}>
-                <strong>Labels</strong>
+              <div id="labels">
+                <div className={'progress-description ' + labelTitleStyle}>
+                  <strong>Labels</strong>
+                </div>
+                <div className={'label-collection ' + labelListStyle}>
+                  <Labels labels={this.props.labels || {}} />
+                </div>
               </div>
-              <div className={'label-collection ' + labelListStyle}>
-                <Labels labels={this.props.labels || {}} />
-              </div>
-              <div className={'progress-description ' + labelTitleStyle}>
-                <strong>Selectors</strong>
-              </div>
-              <div className={'label-collection ' + labelListStyle}>
-                <Labels labels={this.props.selectors || {}} />
+              <div id="selectors">
+                <div className={'progress-description ' + labelTitleStyle}>
+                  <strong>Selectors</strong>
+                </div>
+                <div className={'label-collection ' + labelListStyle}>
+                  <Labels labels={this.props.selectors || {}} />
+                </div>
               </div>
               <div>
                 <strong>Type</strong> {this.props.type ? this.props.type : ''}

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
@@ -24,6 +24,7 @@ interface ServiceInfoDescriptionProps {
   resourceVersion: string;
   istioEnabled?: boolean;
   labels?: { [key: string]: string };
+  selectors?: { [key: string]: string };
   type?: string;
   ip?: any;
   externalName?: string;
@@ -37,6 +38,14 @@ interface ServiceInfoDescriptionProps {
 const listStyle = style({
   listStyleType: 'none',
   padding: 0
+});
+
+const labelTitleStyle = style({
+  marginBottom: '2px'
+});
+
+const labelListStyle = style({
+  marginBottom: '4px'
 });
 
 const ExternalNameType = 'ExternalName';
@@ -79,11 +88,17 @@ class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps
         <div className="card-pf-body">
           <Row>
             <Col xs={12} sm={6} md={5} lg={5}>
-              <div className="progress-description">
+              <div className={'progress-description ' + labelTitleStyle}>
                 <strong>Labels</strong>
               </div>
-              <div className="label-collection">
+              <div className={'label-collection ' + labelListStyle}>
                 <Labels labels={this.props.labels || {}} />
+              </div>
+              <div className={'progress-description ' + labelTitleStyle}>
+                <strong>Selectors</strong>
+              </div>
+              <div className={'label-collection ' + labelListStyle}>
+                <Labels labels={this.props.selectors || {}} />
               </div>
               <div>
                 <strong>Type</strong> {this.props.type ? this.props.type : ''}

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
@@ -75,36 +75,44 @@ ShallowWrapper {
             xs={12}
           >
             <div
-              className="progress-description f2zkptl"
+              id="labels"
             >
-              <strong>
-                Labels
-              </strong>
-            </div>
-            <div
-              className="label-collection f3lrwsf"
-            >
-              <Labels
-                labels={
-                  Object {
-                    "app": "reviews",
+              <div
+                className="progress-description f2zkptl"
+              >
+                <strong>
+                  Labels
+                </strong>
+              </div>
+              <div
+                className="label-collection f3lrwsf"
+              >
+                <Labels
+                  labels={
+                    Object {
+                      "app": "reviews",
+                    }
                   }
-                }
-              />
+                />
+              </div>
             </div>
             <div
-              className="progress-description f2zkptl"
+              id="selectors"
             >
-              <strong>
-                Selectors
-              </strong>
-            </div>
-            <div
-              className="label-collection f3lrwsf"
-            >
-              <Labels
-                labels={Object {}}
-              />
+              <div
+                className="progress-description f2zkptl"
+              >
+                <strong>
+                  Selectors
+                </strong>
+              </div>
+              <div
+                className="label-collection f3lrwsf"
+              >
+                <Labels
+                  labels={Object {}}
+                />
+              </div>
             </div>
             <div>
               <strong>
@@ -268,36 +276,44 @@ ShallowWrapper {
             xs={12}
           >
             <div
-              className="progress-description f2zkptl"
+              id="labels"
             >
-              <strong>
-                Labels
-              </strong>
-            </div>
-            <div
-              className="label-collection f3lrwsf"
-            >
-              <Labels
-                labels={
-                  Object {
-                    "app": "reviews",
+              <div
+                className="progress-description f2zkptl"
+              >
+                <strong>
+                  Labels
+                </strong>
+              </div>
+              <div
+                className="label-collection f3lrwsf"
+              >
+                <Labels
+                  labels={
+                    Object {
+                      "app": "reviews",
+                    }
                   }
-                }
-              />
+                />
+              </div>
             </div>
             <div
-              className="progress-description f2zkptl"
+              id="selectors"
             >
-              <strong>
-                Selectors
-              </strong>
-            </div>
-            <div
-              className="label-collection f3lrwsf"
-            >
-              <Labels
-                labels={Object {}}
-              />
+              <div
+                className="progress-description f2zkptl"
+              >
+                <strong>
+                  Selectors
+                </strong>
+              </div>
+              <div
+                className="label-collection f3lrwsf"
+              >
+                <Labels
+                  labels={Object {}}
+                />
+              </div>
             </div>
             <div>
               <strong>
@@ -458,36 +474,44 @@ ShallowWrapper {
               xs={12}
             >
               <div
-                className="progress-description f2zkptl"
+                id="labels"
               >
-                <strong>
-                  Labels
-                </strong>
-              </div>
-              <div
-                className="label-collection f3lrwsf"
-              >
-                <Labels
-                  labels={
-                    Object {
-                      "app": "reviews",
+                <div
+                  className="progress-description f2zkptl"
+                >
+                  <strong>
+                    Labels
+                  </strong>
+                </div>
+                <div
+                  className="label-collection f3lrwsf"
+                >
+                  <Labels
+                    labels={
+                      Object {
+                        "app": "reviews",
+                      }
                     }
-                  }
-                />
+                  />
+                </div>
               </div>
               <div
-                className="progress-description f2zkptl"
+                id="selectors"
               >
-                <strong>
-                  Selectors
-                </strong>
-              </div>
-              <div
-                className="label-collection f3lrwsf"
-              >
-                <Labels
-                  labels={Object {}}
-                />
+                <div
+                  className="progress-description f2zkptl"
+                >
+                  <strong>
+                    Selectors
+                  </strong>
+                </div>
+                <div
+                  className="label-collection f3lrwsf"
+                >
+                  <Labels
+                    labels={Object {}}
+                  />
+                </div>
               </div>
               <div>
                 <strong>
@@ -641,36 +665,44 @@ ShallowWrapper {
               "bsClass": "col",
               "children": Array [
                 <div
-                  className="progress-description f2zkptl"
+                  id="labels"
                 >
-                  <strong>
-                    Labels
-                  </strong>
-                </div>,
-                <div
-                  className="label-collection f3lrwsf"
-                >
-                  <Labels
-                    labels={
-                      Object {
-                        "app": "reviews",
+                  <div
+                    className="progress-description f2zkptl"
+                  >
+                    <strong>
+                      Labels
+                    </strong>
+                  </div>
+                  <div
+                    className="label-collection f3lrwsf"
+                  >
+                    <Labels
+                      labels={
+                        Object {
+                          "app": "reviews",
+                        }
                       }
-                    }
-                  />
+                    />
+                  </div>
                 </div>,
                 <div
-                  className="progress-description f2zkptl"
+                  id="selectors"
                 >
-                  <strong>
-                    Selectors
-                  </strong>
-                </div>,
-                <div
-                  className="label-collection f3lrwsf"
-                >
-                  <Labels
-                    labels={Object {}}
-                  />
+                  <div
+                    className="progress-description f2zkptl"
+                  >
+                    <strong>
+                      Selectors
+                    </strong>
+                  </div>
+                  <div
+                    className="label-collection f3lrwsf"
+                  >
+                    <Labels
+                      labels={Object {}}
+                    />
+                  </div>
                 </div>,
                 <div>
                   <strong>
@@ -717,53 +749,85 @@ ShallowWrapper {
                 "key": undefined,
                 "nodeType": "host",
                 "props": Object {
-                  "children": <strong>
-                    Labels
-                  </strong>,
-                  "className": "progress-description f2zkptl",
+                  "children": Array [
+                    <div
+                      className="progress-description f2zkptl"
+                    >
+                      <strong>
+                        Labels
+                      </strong>
+                    </div>,
+                    <div
+                      className="label-collection f3lrwsf"
+                    >
+                      <Labels
+                        labels={
+                          Object {
+                            "app": "reviews",
+                          }
+                        }
+                      />
+                    </div>,
+                  ],
+                  "id": "labels",
                 },
                 "ref": null,
-                "rendered": Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": "Labels",
-                  },
-                  "ref": null,
-                  "rendered": "Labels",
-                  "type": "strong",
-                },
-                "type": "div",
-              },
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "children": <Labels
-                    labels={
-                      Object {
-                        "app": "reviews",
-                      }
-                    }
-                  />,
-                  "className": "label-collection f3lrwsf",
-                },
-                "ref": null,
-                "rendered": Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "class",
-                  "props": Object {
-                    "labels": Object {
-                      "app": "reviews",
+                "rendered": Array [
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": <strong>
+                        Labels
+                      </strong>,
+                      "className": "progress-description f2zkptl",
                     },
+                    "ref": null,
+                    "rendered": Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": "Labels",
+                      },
+                      "ref": null,
+                      "rendered": "Labels",
+                      "type": "strong",
+                    },
+                    "type": "div",
                   },
-                  "ref": null,
-                  "rendered": null,
-                  "type": [Function],
-                },
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": <Labels
+                        labels={
+                          Object {
+                            "app": "reviews",
+                          }
+                        }
+                      />,
+                      "className": "label-collection f3lrwsf",
+                    },
+                    "ref": null,
+                    "rendered": Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "class",
+                      "props": Object {
+                        "labels": Object {
+                          "app": "reviews",
+                        },
+                      },
+                      "ref": null,
+                      "rendered": null,
+                      "type": [Function],
+                    },
+                    "type": "div",
+                  },
+                ],
                 "type": "div",
               },
               Object {
@@ -771,47 +835,75 @@ ShallowWrapper {
                 "key": undefined,
                 "nodeType": "host",
                 "props": Object {
-                  "children": <strong>
-                    Selectors
-                  </strong>,
-                  "className": "progress-description f2zkptl",
+                  "children": Array [
+                    <div
+                      className="progress-description f2zkptl"
+                    >
+                      <strong>
+                        Selectors
+                      </strong>
+                    </div>,
+                    <div
+                      className="label-collection f3lrwsf"
+                    >
+                      <Labels
+                        labels={Object {}}
+                      />
+                    </div>,
+                  ],
+                  "id": "selectors",
                 },
                 "ref": null,
-                "rendered": Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": "Selectors",
+                "rendered": Array [
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": <strong>
+                        Selectors
+                      </strong>,
+                      "className": "progress-description f2zkptl",
+                    },
+                    "ref": null,
+                    "rendered": Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": "Selectors",
+                      },
+                      "ref": null,
+                      "rendered": "Selectors",
+                      "type": "strong",
+                    },
+                    "type": "div",
                   },
-                  "ref": null,
-                  "rendered": "Selectors",
-                  "type": "strong",
-                },
-                "type": "div",
-              },
-              Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "children": <Labels
-                    labels={Object {}}
-                  />,
-                  "className": "label-collection f3lrwsf",
-                },
-                "ref": null,
-                "rendered": Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "class",
-                  "props": Object {
-                    "labels": Object {},
+                  Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": <Labels
+                        labels={Object {}}
+                      />,
+                      "className": "label-collection f3lrwsf",
+                    },
+                    "ref": null,
+                    "rendered": Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "class",
+                      "props": Object {
+                        "labels": Object {},
+                      },
+                      "ref": null,
+                      "rendered": null,
+                      "type": [Function],
+                    },
+                    "type": "div",
                   },
-                  "ref": null,
-                  "rendered": null,
-                  "type": [Function],
-                },
+                ],
                 "type": "div",
               },
               Object {
@@ -1492,36 +1584,44 @@ ShallowWrapper {
               xs={12}
             >
               <div
-                className="progress-description f2zkptl"
+                id="labels"
               >
-                <strong>
-                  Labels
-                </strong>
-              </div>
-              <div
-                className="label-collection f3lrwsf"
-              >
-                <Labels
-                  labels={
-                    Object {
-                      "app": "reviews",
+                <div
+                  className="progress-description f2zkptl"
+                >
+                  <strong>
+                    Labels
+                  </strong>
+                </div>
+                <div
+                  className="label-collection f3lrwsf"
+                >
+                  <Labels
+                    labels={
+                      Object {
+                        "app": "reviews",
+                      }
                     }
-                  }
-                />
+                  />
+                </div>
               </div>
               <div
-                className="progress-description f2zkptl"
+                id="selectors"
               >
-                <strong>
-                  Selectors
-                </strong>
-              </div>
-              <div
-                className="label-collection f3lrwsf"
-              >
-                <Labels
-                  labels={Object {}}
-                />
+                <div
+                  className="progress-description f2zkptl"
+                >
+                  <strong>
+                    Selectors
+                  </strong>
+                </div>
+                <div
+                  className="label-collection f3lrwsf"
+                >
+                  <Labels
+                    labels={Object {}}
+                  />
+                </div>
               </div>
               <div>
                 <strong>
@@ -1685,36 +1785,44 @@ ShallowWrapper {
               xs={12}
             >
               <div
-                className="progress-description f2zkptl"
+                id="labels"
               >
-                <strong>
-                  Labels
-                </strong>
-              </div>
-              <div
-                className="label-collection f3lrwsf"
-              >
-                <Labels
-                  labels={
-                    Object {
-                      "app": "reviews",
+                <div
+                  className="progress-description f2zkptl"
+                >
+                  <strong>
+                    Labels
+                  </strong>
+                </div>
+                <div
+                  className="label-collection f3lrwsf"
+                >
+                  <Labels
+                    labels={
+                      Object {
+                        "app": "reviews",
+                      }
                     }
-                  }
-                />
+                  />
+                </div>
               </div>
               <div
-                className="progress-description f2zkptl"
+                id="selectors"
               >
-                <strong>
-                  Selectors
-                </strong>
-              </div>
-              <div
-                className="label-collection f3lrwsf"
-              >
-                <Labels
-                  labels={Object {}}
-                />
+                <div
+                  className="progress-description f2zkptl"
+                >
+                  <strong>
+                    Selectors
+                  </strong>
+                </div>
+                <div
+                  className="label-collection f3lrwsf"
+                >
+                  <Labels
+                    labels={Object {}}
+                  />
+                </div>
               </div>
               <div>
                 <strong>
@@ -1875,36 +1983,44 @@ ShallowWrapper {
                 xs={12}
               >
                 <div
-                  className="progress-description f2zkptl"
+                  id="labels"
                 >
-                  <strong>
-                    Labels
-                  </strong>
-                </div>
-                <div
-                  className="label-collection f3lrwsf"
-                >
-                  <Labels
-                    labels={
-                      Object {
-                        "app": "reviews",
+                  <div
+                    className="progress-description f2zkptl"
+                  >
+                    <strong>
+                      Labels
+                    </strong>
+                  </div>
+                  <div
+                    className="label-collection f3lrwsf"
+                  >
+                    <Labels
+                      labels={
+                        Object {
+                          "app": "reviews",
+                        }
                       }
-                    }
-                  />
+                    />
+                  </div>
                 </div>
                 <div
-                  className="progress-description f2zkptl"
+                  id="selectors"
                 >
-                  <strong>
-                    Selectors
-                  </strong>
-                </div>
-                <div
-                  className="label-collection f3lrwsf"
-                >
-                  <Labels
-                    labels={Object {}}
-                  />
+                  <div
+                    className="progress-description f2zkptl"
+                  >
+                    <strong>
+                      Selectors
+                    </strong>
+                  </div>
+                  <div
+                    className="label-collection f3lrwsf"
+                  >
+                    <Labels
+                      labels={Object {}}
+                    />
+                  </div>
                 </div>
                 <div>
                   <strong>
@@ -2058,36 +2174,44 @@ ShallowWrapper {
                 "bsClass": "col",
                 "children": Array [
                   <div
-                    className="progress-description f2zkptl"
+                    id="labels"
                   >
-                    <strong>
-                      Labels
-                    </strong>
-                  </div>,
-                  <div
-                    className="label-collection f3lrwsf"
-                  >
-                    <Labels
-                      labels={
-                        Object {
-                          "app": "reviews",
+                    <div
+                      className="progress-description f2zkptl"
+                    >
+                      <strong>
+                        Labels
+                      </strong>
+                    </div>
+                    <div
+                      className="label-collection f3lrwsf"
+                    >
+                      <Labels
+                        labels={
+                          Object {
+                            "app": "reviews",
+                          }
                         }
-                      }
-                    />
+                      />
+                    </div>
                   </div>,
                   <div
-                    className="progress-description f2zkptl"
+                    id="selectors"
                   >
-                    <strong>
-                      Selectors
-                    </strong>
-                  </div>,
-                  <div
-                    className="label-collection f3lrwsf"
-                  >
-                    <Labels
-                      labels={Object {}}
-                    />
+                    <div
+                      className="progress-description f2zkptl"
+                    >
+                      <strong>
+                        Selectors
+                      </strong>
+                    </div>
+                    <div
+                      className="label-collection f3lrwsf"
+                    >
+                      <Labels
+                        labels={Object {}}
+                      />
+                    </div>
                   </div>,
                   <div>
                     <strong>
@@ -2134,53 +2258,85 @@ ShallowWrapper {
                   "key": undefined,
                   "nodeType": "host",
                   "props": Object {
-                    "children": <strong>
-                      Labels
-                    </strong>,
-                    "className": "progress-description f2zkptl",
+                    "children": Array [
+                      <div
+                        className="progress-description f2zkptl"
+                      >
+                        <strong>
+                          Labels
+                        </strong>
+                      </div>,
+                      <div
+                        className="label-collection f3lrwsf"
+                      >
+                        <Labels
+                          labels={
+                            Object {
+                              "app": "reviews",
+                            }
+                          }
+                        />
+                      </div>,
+                    ],
+                    "id": "labels",
                   },
                   "ref": null,
-                  "rendered": Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "host",
-                    "props": Object {
-                      "children": "Labels",
-                    },
-                    "ref": null,
-                    "rendered": "Labels",
-                    "type": "strong",
-                  },
-                  "type": "div",
-                },
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": <Labels
-                      labels={
-                        Object {
-                          "app": "reviews",
-                        }
-                      }
-                    />,
-                    "className": "label-collection f3lrwsf",
-                  },
-                  "ref": null,
-                  "rendered": Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "class",
-                    "props": Object {
-                      "labels": Object {
-                        "app": "reviews",
+                  "rendered": Array [
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": <strong>
+                          Labels
+                        </strong>,
+                        "className": "progress-description f2zkptl",
                       },
+                      "ref": null,
+                      "rendered": Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": "Labels",
+                        },
+                        "ref": null,
+                        "rendered": "Labels",
+                        "type": "strong",
+                      },
+                      "type": "div",
                     },
-                    "ref": null,
-                    "rendered": null,
-                    "type": [Function],
-                  },
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": <Labels
+                          labels={
+                            Object {
+                              "app": "reviews",
+                            }
+                          }
+                        />,
+                        "className": "label-collection f3lrwsf",
+                      },
+                      "ref": null,
+                      "rendered": Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "class",
+                        "props": Object {
+                          "labels": Object {
+                            "app": "reviews",
+                          },
+                        },
+                        "ref": null,
+                        "rendered": null,
+                        "type": [Function],
+                      },
+                      "type": "div",
+                    },
+                  ],
                   "type": "div",
                 },
                 Object {
@@ -2188,47 +2344,75 @@ ShallowWrapper {
                   "key": undefined,
                   "nodeType": "host",
                   "props": Object {
-                    "children": <strong>
-                      Selectors
-                    </strong>,
-                    "className": "progress-description f2zkptl",
+                    "children": Array [
+                      <div
+                        className="progress-description f2zkptl"
+                      >
+                        <strong>
+                          Selectors
+                        </strong>
+                      </div>,
+                      <div
+                        className="label-collection f3lrwsf"
+                      >
+                        <Labels
+                          labels={Object {}}
+                        />
+                      </div>,
+                    ],
+                    "id": "selectors",
                   },
                   "ref": null,
-                  "rendered": Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "host",
-                    "props": Object {
-                      "children": "Selectors",
+                  "rendered": Array [
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": <strong>
+                          Selectors
+                        </strong>,
+                        "className": "progress-description f2zkptl",
+                      },
+                      "ref": null,
+                      "rendered": Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "host",
+                        "props": Object {
+                          "children": "Selectors",
+                        },
+                        "ref": null,
+                        "rendered": "Selectors",
+                        "type": "strong",
+                      },
+                      "type": "div",
                     },
-                    "ref": null,
-                    "rendered": "Selectors",
-                    "type": "strong",
-                  },
-                  "type": "div",
-                },
-                Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": <Labels
-                      labels={Object {}}
-                    />,
-                    "className": "label-collection f3lrwsf",
-                  },
-                  "ref": null,
-                  "rendered": Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "class",
-                    "props": Object {
-                      "labels": Object {},
+                    Object {
+                      "instance": null,
+                      "key": undefined,
+                      "nodeType": "host",
+                      "props": Object {
+                        "children": <Labels
+                          labels={Object {}}
+                        />,
+                        "className": "label-collection f3lrwsf",
+                      },
+                      "ref": null,
+                      "rendered": Object {
+                        "instance": null,
+                        "key": undefined,
+                        "nodeType": "class",
+                        "props": Object {
+                          "labels": Object {},
+                        },
+                        "ref": null,
+                        "rendered": null,
+                        "type": [Function],
+                      },
+                      "type": "div",
                     },
-                    "ref": null,
-                    "rendered": null,
-                    "type": [Function],
-                  },
+                  ],
                   "type": "div",
                 },
                 Object {

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
@@ -75,14 +75,14 @@ ShallowWrapper {
             xs={12}
           >
             <div
-              className="progress-description"
+              className="progress-description f2zkptl"
             >
               <strong>
                 Labels
               </strong>
             </div>
             <div
-              className="label-collection"
+              className="label-collection f3lrwsf"
             >
               <Labels
                 labels={
@@ -90,6 +90,20 @@ ShallowWrapper {
                     "app": "reviews",
                   }
                 }
+              />
+            </div>
+            <div
+              className="progress-description f2zkptl"
+            >
+              <strong>
+                Selectors
+              </strong>
+            </div>
+            <div
+              className="label-collection f3lrwsf"
+            >
+              <Labels
+                labels={Object {}}
               />
             </div>
             <div>
@@ -254,14 +268,14 @@ ShallowWrapper {
             xs={12}
           >
             <div
-              className="progress-description"
+              className="progress-description f2zkptl"
             >
               <strong>
                 Labels
               </strong>
             </div>
             <div
-              className="label-collection"
+              className="label-collection f3lrwsf"
             >
               <Labels
                 labels={
@@ -269,6 +283,20 @@ ShallowWrapper {
                     "app": "reviews",
                   }
                 }
+              />
+            </div>
+            <div
+              className="progress-description f2zkptl"
+            >
+              <strong>
+                Selectors
+              </strong>
+            </div>
+            <div
+              className="label-collection f3lrwsf"
+            >
+              <Labels
+                labels={Object {}}
               />
             </div>
             <div>
@@ -430,14 +458,14 @@ ShallowWrapper {
               xs={12}
             >
               <div
-                className="progress-description"
+                className="progress-description f2zkptl"
               >
                 <strong>
                   Labels
                 </strong>
               </div>
               <div
-                className="label-collection"
+                className="label-collection f3lrwsf"
               >
                 <Labels
                   labels={
@@ -445,6 +473,20 @@ ShallowWrapper {
                       "app": "reviews",
                     }
                   }
+                />
+              </div>
+              <div
+                className="progress-description f2zkptl"
+              >
+                <strong>
+                  Selectors
+                </strong>
+              </div>
+              <div
+                className="label-collection f3lrwsf"
+              >
+                <Labels
+                  labels={Object {}}
                 />
               </div>
               <div>
@@ -599,14 +641,14 @@ ShallowWrapper {
               "bsClass": "col",
               "children": Array [
                 <div
-                  className="progress-description"
+                  className="progress-description f2zkptl"
                 >
                   <strong>
                     Labels
                   </strong>
                 </div>,
                 <div
-                  className="label-collection"
+                  className="label-collection f3lrwsf"
                 >
                   <Labels
                     labels={
@@ -614,6 +656,20 @@ ShallowWrapper {
                         "app": "reviews",
                       }
                     }
+                  />
+                </div>,
+                <div
+                  className="progress-description f2zkptl"
+                >
+                  <strong>
+                    Selectors
+                  </strong>
+                </div>,
+                <div
+                  className="label-collection f3lrwsf"
+                >
+                  <Labels
+                    labels={Object {}}
                   />
                 </div>,
                 <div>
@@ -664,7 +720,7 @@ ShallowWrapper {
                   "children": <strong>
                     Labels
                   </strong>,
-                  "className": "progress-description",
+                  "className": "progress-description f2zkptl",
                 },
                 "ref": null,
                 "rendered": Object {
@@ -692,7 +748,7 @@ ShallowWrapper {
                       }
                     }
                   />,
-                  "className": "label-collection",
+                  "className": "label-collection f3lrwsf",
                 },
                 "ref": null,
                 "rendered": Object {
@@ -703,6 +759,54 @@ ShallowWrapper {
                     "labels": Object {
                       "app": "reviews",
                     },
+                  },
+                  "ref": null,
+                  "rendered": null,
+                  "type": [Function],
+                },
+                "type": "div",
+              },
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": <strong>
+                    Selectors
+                  </strong>,
+                  "className": "progress-description f2zkptl",
+                },
+                "ref": null,
+                "rendered": Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": "Selectors",
+                  },
+                  "ref": null,
+                  "rendered": "Selectors",
+                  "type": "strong",
+                },
+                "type": "div",
+              },
+              Object {
+                "instance": null,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": <Labels
+                    labels={Object {}}
+                  />,
+                  "className": "label-collection f3lrwsf",
+                },
+                "ref": null,
+                "rendered": Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "class",
+                  "props": Object {
+                    "labels": Object {},
                   },
                   "ref": null,
                   "rendered": null,
@@ -1388,14 +1492,14 @@ ShallowWrapper {
               xs={12}
             >
               <div
-                className="progress-description"
+                className="progress-description f2zkptl"
               >
                 <strong>
                   Labels
                 </strong>
               </div>
               <div
-                className="label-collection"
+                className="label-collection f3lrwsf"
               >
                 <Labels
                   labels={
@@ -1403,6 +1507,20 @@ ShallowWrapper {
                       "app": "reviews",
                     }
                   }
+                />
+              </div>
+              <div
+                className="progress-description f2zkptl"
+              >
+                <strong>
+                  Selectors
+                </strong>
+              </div>
+              <div
+                className="label-collection f3lrwsf"
+              >
+                <Labels
+                  labels={Object {}}
                 />
               </div>
               <div>
@@ -1567,14 +1685,14 @@ ShallowWrapper {
               xs={12}
             >
               <div
-                className="progress-description"
+                className="progress-description f2zkptl"
               >
                 <strong>
                   Labels
                 </strong>
               </div>
               <div
-                className="label-collection"
+                className="label-collection f3lrwsf"
               >
                 <Labels
                   labels={
@@ -1582,6 +1700,20 @@ ShallowWrapper {
                       "app": "reviews",
                     }
                   }
+                />
+              </div>
+              <div
+                className="progress-description f2zkptl"
+              >
+                <strong>
+                  Selectors
+                </strong>
+              </div>
+              <div
+                className="label-collection f3lrwsf"
+              >
+                <Labels
+                  labels={Object {}}
                 />
               </div>
               <div>
@@ -1743,14 +1875,14 @@ ShallowWrapper {
                 xs={12}
               >
                 <div
-                  className="progress-description"
+                  className="progress-description f2zkptl"
                 >
                   <strong>
                     Labels
                   </strong>
                 </div>
                 <div
-                  className="label-collection"
+                  className="label-collection f3lrwsf"
                 >
                   <Labels
                     labels={
@@ -1758,6 +1890,20 @@ ShallowWrapper {
                         "app": "reviews",
                       }
                     }
+                  />
+                </div>
+                <div
+                  className="progress-description f2zkptl"
+                >
+                  <strong>
+                    Selectors
+                  </strong>
+                </div>
+                <div
+                  className="label-collection f3lrwsf"
+                >
+                  <Labels
+                    labels={Object {}}
                   />
                 </div>
                 <div>
@@ -1912,14 +2058,14 @@ ShallowWrapper {
                 "bsClass": "col",
                 "children": Array [
                   <div
-                    className="progress-description"
+                    className="progress-description f2zkptl"
                   >
                     <strong>
                       Labels
                     </strong>
                   </div>,
                   <div
-                    className="label-collection"
+                    className="label-collection f3lrwsf"
                   >
                     <Labels
                       labels={
@@ -1927,6 +2073,20 @@ ShallowWrapper {
                           "app": "reviews",
                         }
                       }
+                    />
+                  </div>,
+                  <div
+                    className="progress-description f2zkptl"
+                  >
+                    <strong>
+                      Selectors
+                    </strong>
+                  </div>,
+                  <div
+                    className="label-collection f3lrwsf"
+                  >
+                    <Labels
+                      labels={Object {}}
                     />
                   </div>,
                   <div>
@@ -1977,7 +2137,7 @@ ShallowWrapper {
                     "children": <strong>
                       Labels
                     </strong>,
-                    "className": "progress-description",
+                    "className": "progress-description f2zkptl",
                   },
                   "ref": null,
                   "rendered": Object {
@@ -2005,7 +2165,7 @@ ShallowWrapper {
                         }
                       }
                     />,
-                    "className": "label-collection",
+                    "className": "label-collection f3lrwsf",
                   },
                   "ref": null,
                   "rendered": Object {
@@ -2016,6 +2176,54 @@ ShallowWrapper {
                       "labels": Object {
                         "app": "reviews",
                       },
+                    },
+                    "ref": null,
+                    "rendered": null,
+                    "type": [Function],
+                  },
+                  "type": "div",
+                },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": <strong>
+                      Selectors
+                    </strong>,
+                    "className": "progress-description f2zkptl",
+                  },
+                  "ref": null,
+                  "rendered": Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "host",
+                    "props": Object {
+                      "children": "Selectors",
+                    },
+                    "ref": null,
+                    "rendered": "Selectors",
+                    "type": "strong",
+                  },
+                  "type": "div",
+                },
+                Object {
+                  "instance": null,
+                  "key": undefined,
+                  "nodeType": "host",
+                  "props": Object {
+                    "children": <Labels
+                      labels={Object {}}
+                    />,
+                    "className": "label-collection f3lrwsf",
+                  },
+                  "ref": null,
+                  "rendered": Object {
+                    "instance": null,
+                    "key": undefined,
+                    "nodeType": "class",
+                    "props": Object {
+                      "labels": Object {},
                     },
                     "ref": null,
                     "rendered": null,

--- a/src/pages/ServiceDetails/__tests__/__snapshots__/ServiceInfo.test.tsx.snap
+++ b/src/pages/ServiceDetails/__tests__/__snapshots__/ServiceInfo.test.tsx.snap
@@ -432,6 +432,7 @@ ShallowWrapper {
                   ]
                 }
                 resourceVersion="2652"
+                selectors={undefined}
                 threeScaleServiceRule={undefined}
                 type="ClusterIP"
                 validations={Object {}}
@@ -834,6 +835,7 @@ ShallowWrapper {
                     ]
                   }
                   resourceVersion="2652"
+                  selectors={undefined}
                   threeScaleServiceRule={undefined}
                   type="ClusterIP"
                   validations={Object {}}
@@ -1651,6 +1653,7 @@ ShallowWrapper {
                     ]
                   }
                   resourceVersion="2652"
+                  selectors={undefined}
                   threeScaleServiceRule={undefined}
                   type="ClusterIP"
                   validations={Object {}}
@@ -1719,6 +1722,7 @@ ShallowWrapper {
                     ]
                   }
                   resourceVersion="2652"
+                  selectors={undefined}
                   threeScaleServiceRule={undefined}
                   type="ClusterIP"
                   validations={Object {}}
@@ -1781,6 +1785,7 @@ ShallowWrapper {
                     },
                   ],
                   "resourceVersion": "2652",
+                  "selectors": undefined,
                   "threeScaleServiceRule": undefined,
                   "type": "ClusterIP",
                   "validations": Object {},
@@ -3228,6 +3233,7 @@ ShallowWrapper {
                     ]
                   }
                   resourceVersion="2652"
+                  selectors={undefined}
                   threeScaleServiceRule={undefined}
                   type="ClusterIP"
                   validations={Object {}}
@@ -3630,6 +3636,7 @@ ShallowWrapper {
                       ]
                     }
                     resourceVersion="2652"
+                    selectors={undefined}
                     threeScaleServiceRule={undefined}
                     type="ClusterIP"
                     validations={Object {}}
@@ -4447,6 +4454,7 @@ ShallowWrapper {
                       ]
                     }
                     resourceVersion="2652"
+                    selectors={undefined}
                     threeScaleServiceRule={undefined}
                     type="ClusterIP"
                     validations={Object {}}
@@ -4515,6 +4523,7 @@ ShallowWrapper {
                       ]
                     }
                     resourceVersion="2652"
+                    selectors={undefined}
                     threeScaleServiceRule={undefined}
                     type="ClusterIP"
                     validations={Object {}}
@@ -4577,6 +4586,7 @@ ShallowWrapper {
                       },
                     ],
                     "resourceVersion": "2652",
+                    "selectors": undefined,
                     "threeScaleServiceRule": undefined,
                     "type": "ClusterIP",
                     "validations": Object {},

--- a/src/types/ServiceInfo.ts
+++ b/src/types/ServiceInfo.ts
@@ -41,7 +41,6 @@ export const hasIstioSidecar = (pods?: Pod[]) => {
 };
 
 export interface Service {
-  labels?: { [key: string]: string };
   type: string;
   name: string;
   createdAt: string;
@@ -49,6 +48,8 @@ export interface Service {
   ip: string;
   ports?: Port[];
   externalName: string;
+  labels?: { [key: string]: string };
+  selectors?: { [key: string]: string };
 }
 
 export interface ServiceDetailsInfo {


### PR DESCRIPTION
** Describe the change **

Adding the selector labels of a service into the Service Details page.
Needs: https://github.com/kiali/kiali/pull/1100

** Issue reference **
https://issues.jboss.org/browse/KIALI-2570

** Backwards compatible? **
yes

** Screenshot **
![Screenshot of Kiali Console (44)](https://user-images.githubusercontent.com/613814/58466052-368f7100-8139-11e9-9126-e6c208f56f6c.png)

![Screenshot of Kiali Console (43)](https://user-images.githubusercontent.com/613814/58466057-398a6180-8139-11e9-8aa8-040734f6b4d5.png)

