### PR TITLE
KIALI-2919 Allows context menu to use react components.

### DIFF
--- a/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
+++ b/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
-import { ContextMenuNodeProps } from '../CytoscapeContextMenu';
+import { NodeContextMenuProps } from '../CytoscapeContextMenu';
 import history from '../../../app/History';
 
-export class ContextMenuNodeComponent extends React.PureComponent<ContextMenuNodeProps> {
+export class NodeContextMenu extends React.PureComponent<NodeContextMenuProps> {
   // @todo: We need take care of this at global app level
-  private static makeDetailsPageUrl(props: ContextMenuNodeProps) {
+  private static makeDetailsPageUrl(props: NodeContextMenuProps) {
     const namespace = props.namespace;
     const nodeType = props.nodeType;
     const workload = props.workload;
@@ -23,7 +23,7 @@ export class ContextMenuNodeComponent extends React.PureComponent<ContextMenuNod
 
   render() {
     const version = this.props.version ? `${this.props.version}` : '';
-    const detailsPageUrl = ContextMenuNodeComponent.makeDetailsPageUrl(this.props);
+    const detailsPageUrl = NodeContextMenu.makeDetailsPageUrl(this.props);
     return (
       <div className="kiali-graph-context-menu-container">
         <div className="kiali-graph-context-menu-title">

--- a/src/components/CytoscapeGraph/ContextMenuComponent/ContextMenuNodeComponent.tsx
+++ b/src/components/CytoscapeGraph/ContextMenuComponent/ContextMenuNodeComponent.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import { ContextMenuNodeProps } from '../CytoscapeContextMenu';
+import history from '../../../app/History';
+
+export class ContextMenuNodeComponent extends React.PureComponent<ContextMenuNodeProps> {
+  // @todo: We need take care of this at global app level
+  private static makeDetailsPageUrl(props: ContextMenuNodeProps) {
+    const namespace = props.namespace;
+    const nodeType = props.nodeType;
+    const workload = props.workload;
+    let app = props.app;
+    let urlNodeType = app;
+    if (nodeType === 'app') {
+      urlNodeType = 'applications';
+    } else if (nodeType === 'service') {
+      urlNodeType = 'services';
+    } else if (workload) {
+      urlNodeType = 'workloads';
+      app = workload;
+    }
+    return `/namespaces/${namespace}/${urlNodeType}/${app}`;
+  }
+
+  render() {
+    const version = this.props.version ? `${this.props.version}` : '';
+    const detailsPageUrl = ContextMenuNodeComponent.makeDetailsPageUrl(this.props);
+    return (
+      <div className="kiali-graph-context-menu-container">
+        <div className="kiali-graph-context-menu-title">
+          <strong>{this.props.app}</strong>:{version}
+        </div>
+        <div className="kiali-graph-context-menu-item">
+          <a onClick={this.redirectContextLink} className="kiali-graph-context-menu-item-link" href={detailsPageUrl}>
+            Show Details
+          </a>
+        </div>
+      </div>
+    );
+  }
+
+  private redirectContextLink = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
+    if (e.target) {
+      const anchor = e.target as HTMLAnchorElement;
+      const href = anchor.getAttribute('href');
+      if (href) {
+        this.props.contextMenu.hide(0);
+        history.push(href);
+      }
+    }
+  };
+}

--- a/src/components/CytoscapeGraph/CytoscapeContextMenu.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeContextMenu.tsx
@@ -1,0 +1,129 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import tippy, { Instance } from 'tippy.js';
+import { DecoratedGraphEdgeData, DecoratedGraphNodeData } from '../../types/Graph';
+
+type Props = {
+  groupContextMenuContent?: ContextMenuNodeComponent;
+  nodeContextMenuContent?: ContextMenuNodeComponent;
+  edgeContextMenuContent?: ContextMenuEdgeComponent;
+};
+
+type ContextMenuContainer = HTMLDivElement & {
+  _contextMenu: any;
+};
+
+type TippyInstance = Instance;
+
+type ContextMenuProps = {
+  element: any;
+  contextMenu: TippyInstance;
+};
+
+export type ContextMenuNodeProps = DecoratedGraphNodeData & ContextMenuProps;
+export type ContextMenuEdgeProps = DecoratedGraphEdgeData & ContextMenuProps;
+
+export type ContextMenuNodeComponent = React.ComponentType<ContextMenuNodeProps>;
+export type ContextMenuEdgeComponent = React.ComponentType<ContextMenuEdgeProps>;
+
+// Keep the browser right-click menu from popping up since have our own context menu
+window.oncontextmenu = (event: MouseEvent) => {
+  const isChildrenOfTippy = (target: HTMLElement | null) => {
+    if (target === null || target === document.body) {
+      return false;
+    } else if (target.className.startsWith('tippy')) {
+      return true;
+    }
+    return isChildrenOfTippy(target.parentElement);
+  };
+  // Ironically, the tippy-arrow and sometimes the tippy-tooltip itself (or their contents) are the one that triggers the context menu.
+  return !isChildrenOfTippy(event.target as HTMLElement);
+};
+
+export class CytoscapeContextMenu extends React.PureComponent<Props> {
+  private readonly contextMenuRef: React.RefObject<ContextMenuContainer>;
+
+  constructor(props: Props) {
+    super(props);
+    this.contextMenuRef = React.createRef<ContextMenuContainer>();
+  }
+
+  // Connects cy to this component
+  connectCy(cy: any) {
+    cy.on('cxttapstart taphold', (event: any) => {
+      event.preventDefault();
+      if (event.target) {
+        const currentContextMenu = this.getCurrentContextMenu();
+        if (currentContextMenu) {
+          currentContextMenu.hide(0); // hide it in 0ms
+        }
+
+        let contextMenuContent: ContextMenuEdgeComponent | ContextMenuNodeComponent | undefined;
+
+        if (event.target === cy) {
+          contextMenuContent = undefined;
+        } else if (event.target.isNode() && event.target.isParent()) {
+          contextMenuContent = this.props.groupContextMenuContent;
+        } else if (event.target.isNode()) {
+          contextMenuContent = this.props.nodeContextMenuContent;
+        } else if (event.target.isEdge()) {
+          contextMenuContent = this.props.edgeContextMenuContent;
+        }
+
+        if (contextMenuContent) {
+          this.makeContextMenu(contextMenuContent, event.target);
+        }
+      }
+      return false;
+    });
+  }
+
+  render() {
+    return (
+      <div className="hidden">
+        <div ref={this.contextMenuRef} />
+      </div>
+    );
+  }
+
+  private getCurrentContextMenu() {
+    return this.contextMenuRef!.current!._contextMenu;
+  }
+
+  private setCurrentContextMenu(current: any) {
+    this.contextMenuRef!.current!._contextMenu = current;
+  }
+
+  private tippyDistance(target: any) {
+    if (target.isNode === undefined || target.isNode()) {
+      return 10;
+    }
+    return -30;
+  }
+
+  private makeContextMenu(ContextMenuComponentClass: ContextMenuEdgeComponent | ContextMenuNodeComponent, target: any) {
+    const content = this.contextMenuRef.current;
+    const tippyInstance = tippy(target.popperRef(), {
+      content: content as HTMLDivElement,
+      trigger: 'manual',
+      arrow: true,
+      placement: 'bottom',
+      hideOnClick: true,
+      multiple: false,
+      sticky: true,
+      interactive: true,
+      theme: 'light-border',
+      size: 'large',
+      distance: this.tippyDistance(target)
+    }).instances[0];
+
+    ReactDOM.render(
+      <ContextMenuComponentClass element={target} contextMenu={tippyInstance} {...target.data()} />,
+      content,
+      () => {
+        this.setCurrentContextMenu(tippyInstance);
+        tippyInstance.show();
+      }
+    );
+  }
+}

--- a/src/components/CytoscapeGraph/CytoscapeContextMenu.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeContextMenu.tsx
@@ -4,9 +4,9 @@ import tippy, { Instance } from 'tippy.js';
 import { DecoratedGraphEdgeData, DecoratedGraphNodeData } from '../../types/Graph';
 
 type Props = {
-  groupContextMenuContent?: ContextMenuNodeComponent;
-  nodeContextMenuContent?: ContextMenuNodeComponent;
-  edgeContextMenuContent?: ContextMenuEdgeComponent;
+  groupContextMenuContent?: NodeContextMenuType;
+  nodeContextMenuContent?: NodeContextMenuType;
+  edgeContextMenuContent?: EdgeContextMenuType;
 };
 
 type ContextMenuContainer = HTMLDivElement & {
@@ -20,11 +20,11 @@ type ContextMenuProps = {
   contextMenu: TippyInstance;
 };
 
-export type ContextMenuNodeProps = DecoratedGraphNodeData & ContextMenuProps;
-export type ContextMenuEdgeProps = DecoratedGraphEdgeData & ContextMenuProps;
+export type NodeContextMenuProps = DecoratedGraphNodeData & ContextMenuProps;
+export type EdgeContextMenuProps = DecoratedGraphEdgeData & ContextMenuProps;
 
-export type ContextMenuNodeComponent = React.ComponentType<ContextMenuNodeProps>;
-export type ContextMenuEdgeComponent = React.ComponentType<ContextMenuEdgeProps>;
+export type NodeContextMenuType = React.ComponentType<NodeContextMenuProps>;
+export type EdgeContextMenuType = React.ComponentType<EdgeContextMenuProps>;
 
 // Keep the browser right-click menu from popping up since have our own context menu
 window.oncontextmenu = (event: MouseEvent) => {
@@ -40,7 +40,7 @@ window.oncontextmenu = (event: MouseEvent) => {
   return !isChildrenOfTippy(event.target as HTMLElement);
 };
 
-export class CytoscapeContextMenu extends React.PureComponent<Props> {
+export class CytoscapeContextMenuWrapper extends React.PureComponent<Props> {
   private readonly contextMenuRef: React.RefObject<ContextMenuContainer>;
 
   constructor(props: Props) {
@@ -58,20 +58,20 @@ export class CytoscapeContextMenu extends React.PureComponent<Props> {
           currentContextMenu.hide(0); // hide it in 0ms
         }
 
-        let contextMenuContent: ContextMenuEdgeComponent | ContextMenuNodeComponent | undefined;
+        let contextMenuComponentType: EdgeContextMenuType | NodeContextMenuType | undefined;
 
         if (event.target === cy) {
-          contextMenuContent = undefined;
+          contextMenuComponentType = undefined;
         } else if (event.target.isNode() && event.target.isParent()) {
-          contextMenuContent = this.props.groupContextMenuContent;
+          contextMenuComponentType = this.props.groupContextMenuContent;
         } else if (event.target.isNode()) {
-          contextMenuContent = this.props.nodeContextMenuContent;
+          contextMenuComponentType = this.props.nodeContextMenuContent;
         } else if (event.target.isEdge()) {
-          contextMenuContent = this.props.edgeContextMenuContent;
+          contextMenuComponentType = this.props.edgeContextMenuContent;
         }
 
-        if (contextMenuContent) {
-          this.makeContextMenu(contextMenuContent, event.target);
+        if (contextMenuComponentType) {
+          this.makeContextMenu(contextMenuComponentType, event.target);
         }
       }
       return false;
@@ -101,7 +101,7 @@ export class CytoscapeContextMenu extends React.PureComponent<Props> {
     return -30;
   }
 
-  private makeContextMenu(ContextMenuComponentClass: ContextMenuEdgeComponent | ContextMenuNodeComponent, target: any) {
+  private makeContextMenu(ContextMenuComponentClass: EdgeContextMenuType | NodeContextMenuType, target: any) {
     const content = this.contextMenuRef.current;
     const tippyInstance = tippy(target.popperRef(), {
       content: content as HTMLDivElement,

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -47,6 +47,7 @@ import { DurationInSeconds, PollIntervalInMs } from '../../types/Common';
 import GraphThunkActions from '../../actions/GraphThunkActions';
 import * as MessageCenterUtils from '../../utils/MessageCenter';
 import FocusAnimation from './FocusAnimation';
+import { CytoscapeContextMenu, ContextMenuNodeComponent, ContextMenuEdgeComponent } from './CytoscapeContextMenu';
 
 type ReduxProps = {
   activeNamespaces: Namespace[];
@@ -79,6 +80,9 @@ type CytoscapeGraphProps = ReduxProps & {
   containerClassName?: string;
   refresh: () => void;
   focusSelector?: string;
+  contextMenuNodeComponent?: ContextMenuNodeComponent;
+  contextMenuGroupComponent?: ContextMenuNodeComponent;
+  contextMenuEdgeComponent?: ContextMenuEdgeComponent;
 };
 
 type CytoscapeGraphState = {};
@@ -109,6 +113,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
   private focusAnimation?: FocusAnimation;
   private focusFinished: boolean;
   private cytoscapeReactWrapperRef: any;
+  private contextMenuRef: React.RefObject<CytoscapeContextMenu>;
   private namespaceChanged: boolean;
   private nodeChanged: boolean;
   private resetSelection: boolean;
@@ -125,6 +130,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
       zoom: undefined
     };
     this.cytoscapeReactWrapperRef = React.createRef();
+    this.contextMenuRef = React.createRef<CytoscapeContextMenu>();
   }
 
   shouldComponentUpdate(nextProps: CytoscapeGraphProps, nextState: CytoscapeGraphState) {
@@ -213,6 +219,12 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
           isLoading={this.props.isLoading}
           isError={this.props.isError}
         >
+          <CytoscapeContextMenu
+            ref={this.contextMenuRef}
+            edgeContextMenuContent={this.props.contextMenuEdgeComponent}
+            nodeContextMenuContent={this.props.contextMenuNodeComponent}
+            groupContextMenuContent={this.props.contextMenuGroupComponent}
+          />
           <CytoscapeReactWrapper ref={e => this.setCytoscapeReactWrapperRef(e)} />
         </EmptyGraphLayoutContainer>
       </div>
@@ -263,6 +275,8 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
       return;
     }
     this.cy = cy;
+
+    this.contextMenuRef!.current!.connectCy(this.cy);
 
     this.graphHighlighter = new GraphHighlighter(cy);
     this.trafficRenderer = new TrafficRender(cy, cy.edges());

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -47,7 +47,7 @@ import { DurationInSeconds, PollIntervalInMs } from '../../types/Common';
 import GraphThunkActions from '../../actions/GraphThunkActions';
 import * as MessageCenterUtils from '../../utils/MessageCenter';
 import FocusAnimation from './FocusAnimation';
-import { CytoscapeContextMenu, ContextMenuNodeComponent, ContextMenuEdgeComponent } from './CytoscapeContextMenu';
+import { CytoscapeContextMenuWrapper, NodeContextMenuType, EdgeContextMenuType } from './CytoscapeContextMenu';
 
 type ReduxProps = {
   activeNamespaces: Namespace[];
@@ -80,9 +80,9 @@ type CytoscapeGraphProps = ReduxProps & {
   containerClassName?: string;
   refresh: () => void;
   focusSelector?: string;
-  contextMenuNodeComponent?: ContextMenuNodeComponent;
-  contextMenuGroupComponent?: ContextMenuNodeComponent;
-  contextMenuEdgeComponent?: ContextMenuEdgeComponent;
+  contextMenuNodeComponent?: NodeContextMenuType;
+  contextMenuGroupComponent?: NodeContextMenuType;
+  contextMenuEdgeComponent?: EdgeContextMenuType;
 };
 
 type CytoscapeGraphState = {};
@@ -113,7 +113,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
   private focusAnimation?: FocusAnimation;
   private focusFinished: boolean;
   private cytoscapeReactWrapperRef: any;
-  private contextMenuRef: React.RefObject<CytoscapeContextMenu>;
+  private contextMenuRef: React.RefObject<CytoscapeContextMenuWrapper>;
   private namespaceChanged: boolean;
   private nodeChanged: boolean;
   private resetSelection: boolean;
@@ -130,7 +130,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
       zoom: undefined
     };
     this.cytoscapeReactWrapperRef = React.createRef();
-    this.contextMenuRef = React.createRef<CytoscapeContextMenu>();
+    this.contextMenuRef = React.createRef<CytoscapeContextMenuWrapper>();
   }
 
   shouldComponentUpdate(nextProps: CytoscapeGraphProps, nextState: CytoscapeGraphState) {
@@ -219,7 +219,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
           isLoading={this.props.isLoading}
           isError={this.props.isError}
         >
-          <CytoscapeContextMenu
+          <CytoscapeContextMenuWrapper
             ref={this.contextMenuRef}
             edgeContextMenuContent={this.props.contextMenuEdgeComponent}
             nodeContextMenuContent={this.props.contextMenuNodeComponent}

--- a/src/pages/Graph/GraphPage.tsx
+++ b/src/pages/Graph/GraphPage.tsx
@@ -39,7 +39,7 @@ import { KialiAppAction } from '../../actions/KialiAppAction';
 import GraphDataThunkActions from '../../actions/GraphDataThunkActions';
 import { GraphActions } from '../../actions/GraphActions';
 import { GraphFilterActions } from '../../actions/GraphFilterActions';
-import { ContextMenuNodeComponent } from '../../components/CytoscapeGraph/ContextMenuComponent/ContextMenuNodeComponent';
+import { NodeContextMenu } from '../../components/CytoscapeGraph/ContextMenu/NodeContextMenu';
 
 // GraphURLPathProps holds path variable values.  Currenly all path variables are relevant only to a node graph
 type GraphURLPathProps = {
@@ -345,7 +345,7 @@ export class GraphPage extends React.Component<GraphPageProps, GraphPageState> {
                 ref={refInstance => this.setCytoscapeGraph(refInstance)}
                 isMTLSEnabled={this.props.mtlsEnabled}
                 focusSelector={focusSelector}
-                contextMenuNodeComponent={ContextMenuNodeComponent}
+                contextMenuNodeComponent={NodeContextMenu}
               />
               {this.props.graphData.nodes && Object.keys(this.props.graphData.nodes).length > 0 && !this.props.isError && (
                 <div className={cytoscapeToolbarWrapperDivStyle}>

--- a/src/pages/Graph/GraphPage.tsx
+++ b/src/pages/Graph/GraphPage.tsx
@@ -39,6 +39,7 @@ import { KialiAppAction } from '../../actions/KialiAppAction';
 import GraphDataThunkActions from '../../actions/GraphDataThunkActions';
 import { GraphActions } from '../../actions/GraphActions';
 import { GraphFilterActions } from '../../actions/GraphFilterActions';
+import { ContextMenuNodeComponent } from '../../components/CytoscapeGraph/ContextMenuComponent/ContextMenuNodeComponent';
 
 // GraphURLPathProps holds path variable values.  Currenly all path variables are relevant only to a node graph
 type GraphURLPathProps = {
@@ -344,6 +345,7 @@ export class GraphPage extends React.Component<GraphPageProps, GraphPageState> {
                 ref={refInstance => this.setCytoscapeGraph(refInstance)}
                 isMTLSEnabled={this.props.mtlsEnabled}
                 focusSelector={focusSelector}
+                contextMenuNodeComponent={ContextMenuNodeComponent}
               />
               {this.props.graphData.nodes && Object.keys(this.props.graphData.nodes).length > 0 && !this.props.isError && (
                 <div className={cytoscapeToolbarWrapperDivStyle}>


### PR DESCRIPTION
  The react components take the node/edge data as their props,
  the tippyInstance (contextMenu) and the node/edge element from cy

** Screenshot **

Warning: UI didn't change, the gif is only a basic example of what can be done given the following components:

```typescript
   class CEdge extends React.Component<ContextMenuEdgeProps> {
      render() {
        return (
          <div>
            Hello Edge from: {this.props.source} to: {this.props.target}{' '}
          </div>
        );
      }
    }

   const CNode = () => {
      return <div> Hello Node</div>;
    };

    class CGroup extends React.PureComponent<ContextMenuNodeProps> {
      render() {
        return <div>Hello Group with id {this.props.id}</div>;
      }
    }
```

![context-menu-component](https://user-images.githubusercontent.com/3845764/58499676-45305500-8146-11e9-903c-8305ea556f68.gif)


