### PR TITLE
KIALI-2918 Enable group nodes to have a context menu

### DIFF
--- a/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
+++ b/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
@@ -105,8 +105,8 @@ export class NodeContextMenu extends React.PureComponent<Props> {
   }
 
   render() {
-    // Disable context menu if we are dealing with a unknown node
-    if (this.props.nodeType === 'unknown') {
+    // Disable context menu if we are dealing with a unknown or an inaccessible node
+    if (this.props.nodeType === 'unknown' || this.props.isInaccessible) {
       this.props.contextMenu.disable();
       return null;
     }

--- a/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
+++ b/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
@@ -4,10 +4,12 @@ import { JaegerSearchOptions, JaegerURLSearch } from '../../JaegerIntegration/Ro
 import history from '../../../app/History';
 import { Paths } from '../../../config';
 import { style } from 'typestyle';
+import { KialiAppState } from '../../../store/Store';
+import { connect } from 'react-redux';
 
-type NodeContextMenuState = {
-  nodeType: string;
-  app: string | undefined;
+type ReduxProps = {
+  jaegerIntegration: boolean;
+  jaegerURL: string;
 };
 
 const graphContextMenuContainerStyle = style({
@@ -36,39 +38,48 @@ const graphContextMenuItemLinkStyle = style({
   color: '#363636'
 });
 
-export class NodeContextMenu extends React.PureComponent<NodeContextMenuProps, NodeContextMenuState> {
-  constructor(props: NodeContextMenuProps) {
-    super(props);
-    let app: string | undefined = '';
-    let nodeType = '';
-    switch (this.props.nodeType) {
+type Props = NodeContextMenuProps & ReduxProps;
+
+export class NodeContextMenu extends React.PureComponent<Props> {
+  private static derivedValuesFromProps(props: Props) {
+    let name: string | undefined = '';
+    let type = '';
+    switch (props.nodeType) {
       case 'app':
-        nodeType = Paths.APPLICATIONS;
-        app = this.props.app;
+        // Prefer workload type for nodes backed by a workload
+        if (props.workload && props.parent) {
+          name = props.workload;
+          type = Paths.WORKLOADS;
+        } else {
+          type = Paths.APPLICATIONS;
+          name = props.app;
+        }
         break;
       case 'service':
-        nodeType = Paths.SERVICES;
-        app = this.props.service;
+        type = Paths.SERVICES;
+        name = props.service;
         break;
       case 'workload':
-        app = this.props.workload;
-        nodeType = Paths.WORKLOADS;
+        name = props.workload;
+        type = Paths.WORKLOADS;
         break;
       default:
     }
-    this.state = { nodeType, app };
-  }
-  // @todo: We need take care of this at global app level
-  makeDetailsPageUrl() {
-    return `/namespaces/${this.props.namespace}/${this.state.nodeType}/${this.state.app}`;
+
+    return { type, name };
   }
 
-  getJaegerURL() {
-    let tracesUrl = `/jaeger?namespaces=${this.props.namespace}&service=${this.state.app}.${this.props.namespace}`;
+  // @todo: We need take care of this at global app level
+  makeDetailsPageUrl(type: string, name?: string) {
+    return `/namespaces/${this.props.namespace}/${type}/${name}`;
+  }
+
+  getJaegerURL(name?: string) {
+    let tracesUrl = `/jaeger?namespaces=${this.props.namespace}&service=${name}.${this.props.namespace}`;
     if (!this.props.jaegerIntegration) {
       const url = new JaegerURLSearch(this.props.jaegerURL, false);
       const options: JaegerSearchOptions = {
-        serviceSelected: `${this.state.app}.${this.props.namespace}`,
+        serviceSelected: `${name}.${this.props.namespace}`,
         limit: 20,
         start: '',
         end: '',
@@ -94,27 +105,35 @@ export class NodeContextMenu extends React.PureComponent<NodeContextMenuProps, N
   }
 
   render() {
-    const version = this.props.version !== '' ? `:${this.props.version}` : '';
-    const detailsPageUrl = this.makeDetailsPageUrl();
-    const { nodeType, app } = this.state;
+    // Disable context menu if we are dealing with a unknown node
+    if (this.props.nodeType === 'unknown') {
+      this.props.contextMenu.disable();
+      return null;
+    }
+
+    const { type, name } = NodeContextMenu.derivedValuesFromProps(this.props);
+    const detailsPageUrl = this.makeDetailsPageUrl(type, name);
+
     return (
       <div className={graphContextMenuContainerStyle}>
         <div className={graphContextMenuTitleStyle}>
-          <strong>{app}</strong>
-          {version}
+          <strong>{name}</strong>
         </div>
         {this.createMenuItem(detailsPageUrl, 'Show Details')}
         {this.createMenuItem(`${detailsPageUrl}?tab=traffic`, 'Show Traffic')}
-        {nodeType === Paths.WORKLOADS && this.createMenuItem(`${detailsPageUrl}?tab=logs`, 'Show Logs')}
+        {type === Paths.WORKLOADS && this.createMenuItem(`${detailsPageUrl}?tab=logs`, 'Show Logs')}
         {this.createMenuItem(
-          `${detailsPageUrl}?tab=${nodeType === Paths.SERVICES ? 'metrics' : 'in_metrics'}`,
+          `${detailsPageUrl}?tab=${type === Paths.SERVICES ? 'metrics' : 'in_metrics'}`,
           'Show Inbound Metrics'
         )}
-        {nodeType !== Paths.SERVICES &&
-          this.createMenuItem(`${detailsPageUrl}?tab=out_metrics`, 'Show Outbound Metrics')}
-        {nodeType === Paths.SERVICES &&
+        {type !== Paths.SERVICES && this.createMenuItem(`${detailsPageUrl}?tab=out_metrics`, 'Show Outbound Metrics')}
+        {type === Paths.SERVICES &&
           this.props.jaegerURL !== '' &&
-          this.createMenuItem(this.getJaegerURL(), 'Show Traces', this.props.jaegerIntegration ? '_self' : '_blank')}
+          this.createMenuItem(
+            this.getJaegerURL(name),
+            'Show Traces',
+            this.props.jaegerIntegration ? '_self' : '_blank'
+          )}
       </div>
     );
   }
@@ -132,3 +151,10 @@ export class NodeContextMenu extends React.PureComponent<NodeContextMenuProps, N
     }
   };
 }
+
+const mapStateToProps = (state: KialiAppState) => ({
+  jaegerIntegration: state.jaegerState.enableIntegration,
+  jaegerURL: state.jaegerState.jaegerURL
+});
+
+export const NodeContextMenuContainer = connect(mapStateToProps)(NodeContextMenu);

--- a/src/components/CytoscapeGraph/CytoscapeContextMenu.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeContextMenu.tsx
@@ -2,13 +2,13 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import tippy, { Instance } from 'tippy.js';
 import { DecoratedGraphEdgeData, DecoratedGraphNodeData } from '../../types/Graph';
+import { Provider } from 'react-redux';
+import { store } from '../../store/ConfigStore';
 
 type Props = {
   groupContextMenuContent?: NodeContextMenuType;
   nodeContextMenuContent?: NodeContextMenuType;
   edgeContextMenuContent?: EdgeContextMenuType;
-  jaegerIntegration: boolean;
-  jaegerURL: string;
 };
 
 type TippyInstance = Instance;
@@ -20,8 +20,6 @@ type ContextMenuContainer = HTMLDivElement & {
 type ContextMenuProps = {
   element: any;
   contextMenu: TippyInstance;
-  jaegerIntegration: boolean;
-  jaegerURL: string;
 };
 
 export type NodeContextMenuProps = DecoratedGraphNodeData & ContextMenuProps;
@@ -152,13 +150,9 @@ export class CytoscapeContextMenuWrapper extends React.PureComponent<Props> {
     }).instances[0];
 
     ReactDOM.render(
-      <ContextMenuComponentClass
-        element={target}
-        contextMenu={tippyInstance}
-        {...target.data()}
-        jaegerIntegration={this.props.jaegerIntegration}
-        jaegerURL={this.props.jaegerURL}
-      />,
+      <Provider store={store}>
+        <ContextMenuComponentClass element={target} contextMenu={tippyInstance} {...target.data()} />
+      </Provider>,
       content,
       () => {
         this.setCurrentContextMenu(tippyInstance);

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -66,8 +66,6 @@ type ReduxProps = {
   showTrafficAnimation: boolean;
   showUnusedNodes: boolean;
   showVirtualServices: boolean;
-  jaegerIntegration: boolean;
-  jaegerURL: string;
   onReady: (cytoscapeRef: any) => void;
   setActiveNamespaces: (namespace: Namespace[]) => void;
   setNode: (node?: NodeParamsType) => void;
@@ -226,8 +224,6 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
             edgeContextMenuContent={this.props.contextMenuEdgeComponent}
             nodeContextMenuContent={this.props.contextMenuNodeComponent}
             groupContextMenuContent={this.props.contextMenuGroupComponent}
-            jaegerIntegration={this.props.jaegerIntegration}
-            jaegerURL={this.props.jaegerURL}
           />
           <CytoscapeReactWrapper ref={e => this.setCytoscapeReactWrapperRef(e)} />
         </EmptyGraphLayoutContainer>
@@ -775,9 +771,7 @@ const mapStateToProps = (state: KialiAppState) => ({
   showServiceNodes: state.graph.filterState.showServiceNodes,
   showTrafficAnimation: state.graph.filterState.showTrafficAnimation,
   showUnusedNodes: state.graph.filterState.showUnusedNodes,
-  showVirtualServices: state.graph.filterState.showVirtualServices,
-  jaegerIntegration: state.jaegerState.enableIntegration,
-  jaegerURL: state.jaegerState.jaegerURL
+  showVirtualServices: state.graph.filterState.showVirtualServices
 });
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<KialiAppState, void, KialiAppAction>) => ({

--- a/src/components/CytoscapeGraph/__tests__/CytoscapeGraph.test.tsx
+++ b/src/components/CytoscapeGraph/__tests__/CytoscapeGraph.test.tsx
@@ -54,8 +54,6 @@ describe('CytoscapeGraph component test', () => {
         showVirtualServices={true}
         isLoading={false}
         isError={false}
-        jaegerIntegration={true}
-        jaegerURL={''}
         graphType={GraphType.VERSIONED_APP}
       />
     );

--- a/src/pages/Graph/GraphPage.tsx
+++ b/src/pages/Graph/GraphPage.tsx
@@ -39,7 +39,7 @@ import { KialiAppAction } from '../../actions/KialiAppAction';
 import GraphDataThunkActions from '../../actions/GraphDataThunkActions';
 import { GraphActions } from '../../actions/GraphActions';
 import { GraphFilterActions } from '../../actions/GraphFilterActions';
-import { NodeContextMenu } from '../../components/CytoscapeGraph/ContextMenu/NodeContextMenu';
+import { NodeContextMenuContainer } from '../../components/CytoscapeGraph/ContextMenu/NodeContextMenu';
 
 // GraphURLPathProps holds path variable values.  Currenly all path variables are relevant only to a node graph
 type GraphURLPathProps = {
@@ -345,7 +345,8 @@ export class GraphPage extends React.Component<GraphPageProps, GraphPageState> {
                 ref={refInstance => this.setCytoscapeGraph(refInstance)}
                 isMTLSEnabled={this.props.mtlsEnabled}
                 focusSelector={focusSelector}
-                contextMenuNodeComponent={NodeContextMenu}
+                contextMenuNodeComponent={NodeContextMenuContainer}
+                contextMenuGroupComponent={NodeContextMenuContainer}
               />
               {this.props.graphData.nodes && Object.keys(this.props.graphData.nodes).length > 0 && !this.props.isError && (
                 <div className={cytoscapeToolbarWrapperDivStyle}>


### PR DESCRIPTION
** Describe the change **

- Moved some redux properties to redux-connect syntax
- In versioned graph, the versioned node (v1, v2) will be considered as workloads
- Droped the version from the title because it won't be valid to show a workload name with a version
- NodeType=unknown and isInaccessible won't show any menu

** Screenshot **
![Peek 2019-05-31 11-42](https://user-images.githubusercontent.com/3845764/58721051-7bb1de00-8399-11e9-94f4-58f87cee210c.gif)


