### PR TITLE
KIALI-2940 Restore Kiali colors

### DIFF
--- a/src/app/InitializingScreen.tsx
+++ b/src/app/InitializingScreen.tsx
@@ -19,6 +19,7 @@ type initializingScreenProps = {
 };
 
 const kialiTitle = require('../assets/img/logo-login.svg');
+const kialiBlueBg = require('../img/kiali-blue-bg.png');
 
 const defaultErrorStyle = style({
   $nest: {
@@ -58,7 +59,7 @@ const InitializingScreen: React.FC<initializingScreenProps> = (props: initializi
   }
 
   return (
-    <LoginPageContainer style={{ backgroundImage: 'none' }}>
+    <LoginPageContainer backgroundUrl={kialiBlueBg}>
       <BasicLoginPageLayout>
         <LoginPageHeader logoSrc={kialiTitle} />
         <BasicLoginCardLayout>

--- a/src/components/Nav/Menu.tsx
+++ b/src/components/Nav/Menu.tsx
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import * as React from 'react';
 import { matchPath } from 'react-router';
 import { Link } from 'react-router-dom';
+import { style } from 'typestyle';
 import { Nav, NavList, NavItem, PageSidebar } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
@@ -15,6 +16,12 @@ const ExternalLink = ({ href, name }) => (
     </a>
   </NavItem>
 );
+
+const sidebarStyle = style({
+  borderTopStyle: 'solid',
+  borderTopWidth: '1px',
+  borderTopColor: '#19506d'
+});
 
 type MenuProps = {
   isNavOpen: boolean;
@@ -74,7 +81,7 @@ class Menu extends React.Component<MenuProps, MenuState> {
       </Nav>
     );
 
-    return <PageSidebar isNavOpen={isNavOpen} nav={PageNav} />;
+    return <PageSidebar className={sidebarStyle} isNavOpen={isNavOpen} nav={PageNav} />;
   }
 }
 

--- a/src/components/Nav/Navigation.tsx
+++ b/src/components/Nav/Navigation.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { ThunkDispatch } from 'redux-thunk';
+import { style } from 'typestyle';
 import RenderPage from './RenderPage';
 import { RouteComponentProps } from 'react-router';
 import Masthead from './Masthead/Masthead';
@@ -13,8 +14,7 @@ import { KialiAppState } from '../../store/Store';
 import { KialiAppAction } from '../../actions/KialiAppAction';
 import UserSettingsThunkActions from '../../actions/UserSettingsThunkActions';
 
-export const istioConfigTitle = 'Istio Config';
-export const servicesTitle = 'Services';
+const kialiBlueBg = require('../../img/kiali-blue-bg.png');
 
 type PropsType = RouteComponentProps & {
   navCollapsed: boolean;
@@ -28,6 +28,11 @@ type NavigationState = {
   isNavOpenDesktop: boolean;
   isNavOpenMobile: boolean;
 };
+
+const headerStyle = style({
+  backgroundImage: `url(${kialiBlueBg})`,
+  backgroundColor: '#003145'
+});
 
 class Navigation extends React.Component<PropsType, NavigationState> {
   static contextTypes = {
@@ -89,6 +94,7 @@ class Navigation extends React.Component<PropsType, NavigationState> {
 
     const Header = (
       <PageHeader
+        className={headerStyle}
         logo={<Brand src={kialiLogo} alt="Kiali Logo" />}
         toolbar={<Masthead />}
         showNavToggle={true}

--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -1,14 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { ThunkDispatch } from 'redux-thunk';
-import {
-  Button,
-  LoginPage as LoginNext,
-  LoginForm,
-  ListItem,
-  LoginFooterItem,
-  BackgroundImageSrc
-} from '@patternfly/react-core';
+import { Button, LoginPage as LoginNext, LoginForm, ListItem, LoginFooterItem } from '@patternfly/react-core';
 import { ExclamationCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { KialiAppState, LoginSession, LoginStatus } from '../../store/Store';
 import { AuthStrategy } from '../../types/Auth';
@@ -20,15 +13,8 @@ import LoginThunkActions from '../../actions/LoginThunkActions';
  *
  * Background Images
  *
- * Fix for Firefox browser
  */
-
-const bgFilter = require('../../img/background-filter.svg');
-const pfBg576 = require('../../img/pfbg_576.jpg');
-const pfBg576R2x = require('../../img/pfbg_576@2x.jpg');
-const pfBg768 = require('../../img/pfbg_768.jpg');
-const pfBg768R2x = require('../../img/pfbg_768@2x.jpg');
-const pfBg1200 = require('../../img/pfbg_1200.jpg');
+const kialiBlueBg = require('../../img/kiali-blue-bg.png');
 
 type LoginProps = {
   status: LoginStatus;
@@ -163,18 +149,6 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
     if (authenticationConfig.strategy === AuthStrategy.openshift) {
       loginLabel = 'Log In With OpenShift';
     }
-    /**
-     * Note: When using background-filter.svg, you must also include #image_overlay as the fragment identifier
-     */
-
-    const backgroundLoginImg = {
-      [BackgroundImageSrc.lg]: pfBg1200,
-      [BackgroundImageSrc.sm]: pfBg768,
-      [BackgroundImageSrc.sm2x]: pfBg768R2x,
-      [BackgroundImageSrc.xs]: pfBg576,
-      [BackgroundImageSrc.xs2x]: pfBg576R2x,
-      [BackgroundImageSrc.filter]: `${bgFilter}#image_overlay`
-    };
 
     const messages = this.getHelperMessage();
 
@@ -210,9 +184,9 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
       <LoginNext
         footerListVariants="inline"
         brandImgSrc={kialiLogo}
-        brandImgAlt="pf-logo"
-        backgroundImgSrc={backgroundLoginImg}
-        backgroundImgAlt="Images"
+        brandImgAlt="Kiali logo"
+        backgroundImgSrc={kialiBlueBg}
+        backgroundImgAlt="Kiali background"
         footerListItems={listItem}
         textContent="Service Mesh Observability."
         loginTitle="Log in Kiali"

--- a/src/pages/Login/__tests__/__snapshots__/LoginPage.test.tsx.snap
+++ b/src/pages/Login/__tests__/__snapshots__/LoginPage.test.tsx.snap
@@ -27,16 +27,9 @@ ShallowWrapper {
     "key": undefined,
     "nodeType": "function",
     "props": Object {
-      "backgroundImgAlt": "Images",
-      "backgroundImgSrc": Object {
-        "filter": "background-filter.svg#image_overlay",
-        "lg": "pfbg_1200.jpg",
-        "sm": "pfbg_768.jpg",
-        "sm2x": "pfbg_768@2x.jpg",
-        "xs": "pfbg_576.jpg",
-        "xs2x": "pfbg_576@2x.jpg",
-      },
-      "brandImgAlt": "pf-logo",
+      "backgroundImgAlt": "Kiali background",
+      "backgroundImgSrc": "kiali-blue-bg.png",
+      "brandImgAlt": "Kiali logo",
       "brandImgSrc": "logo-alt.svg",
       "children": <LoginForm
         className=""
@@ -131,16 +124,9 @@ ShallowWrapper {
       "key": undefined,
       "nodeType": "function",
       "props": Object {
-        "backgroundImgAlt": "Images",
-        "backgroundImgSrc": Object {
-          "filter": "background-filter.svg#image_overlay",
-          "lg": "pfbg_1200.jpg",
-          "sm": "pfbg_768.jpg",
-          "sm2x": "pfbg_768@2x.jpg",
-          "xs": "pfbg_576.jpg",
-          "xs2x": "pfbg_576@2x.jpg",
-        },
-        "brandImgAlt": "pf-logo",
+        "backgroundImgAlt": "Kiali background",
+        "backgroundImgSrc": "kiali-blue-bg.png",
+        "brandImgAlt": "Kiali logo",
         "brandImgSrc": "logo-alt.svg",
         "children": <LoginForm
           className=""

--- a/src/styles/_overrides.scss
+++ b/src/styles/_overrides.scss
@@ -62,9 +62,9 @@ $grid-float-breakpoint: $screen-sm-min !default;
 }
 
 .pf-c-page__sidebar {
-  --pf-c-page__sidebar--BackgroundColor: #{$color-pf-black-900};
-  --pf-c-page__sidebar--PaddingBottom: 0;
-  --pf-c-page__sidebar--PaddingTop: 0;
+  --pf-c-page__sidebar--BackgroundColor: #003145;
+  --pf-c-page__sidebar-body--PaddingBottom: 0;
+  --pf-c-page__sidebar-body--PaddingTop: 0;
   --pf-c-page__sidebar--md--Width: 210px; // TODO: Remove. Test enlarged message center when removing.
   min-height: 100vh;
   position: relative; // fix z-index bug in Edge
@@ -94,7 +94,7 @@ $grid-float-breakpoint: $screen-sm-min !default;
     --pf-c-nav__list-link--focus--BackgroundColor: var(--pf-c-nav__list-link--hover--BackgroundColor);
     --pf-c-nav__list-link--focus--Color: var(--pf-c-nav__list-link--hover--Color);
     --pf-c-nav__list-link--hover--after--BackgroundColor: transparent;
-    --pf-c-nav__list-link--hover--BackgroundColor: #{$color-pf-black-700};
+    --pf-c-nav__list-link--hover--BackgroundColor: #003f5f;
     --pf-c-nav__list-link--hover--Color: #{$color-pf-white};
     --pf-c-nav__list-link--m-current--after--BackgroundColor: #{$color-pf-blue-300};
     --pf-c-nav__list-link--m-current--Color: var(--pf-c-nav__list-link--hover--Color);
@@ -136,7 +136,7 @@ $grid-float-breakpoint: $screen-sm-min !default;
   .pf-c-nav__list {
     list-style: none; // turn off list-styles to fix bug in Edge
     > .pf-c-nav__item {
-      border-bottom: 1px solid #{$color-pf-black};
+      border-bottom: 1px solid #19506d;
       margin-top: 0;
 
       &:not(.pf-m-current) > .pf-c-nav__link {
@@ -211,6 +211,14 @@ $grid-float-breakpoint: $screen-sm-min !default;
     color: var(--pf-c-nav__list-link--Color);
     display: none;
   }
+}
+
+.pf-c-background-image::before {
+  filter: unset;
+}
+
+.pf-c-login {
+  background-image: none;
 }
 
 /**


### PR DESCRIPTION
https://issues.jboss.org/browse/KIALI-2940

Restoring colors that were present in Kiali before the PF4 migration.

Login page:

![image](https://user-images.githubusercontent.com/23639005/58514801-89cce800-8168-11e9-987e-2c0db11e997b.png)

Initializing screen:

![image](https://user-images.githubusercontent.com/23639005/58514849-a5d08980-8168-11e9-9d99-77984da38163.png)

Main console:

![image](https://user-images.githubusercontent.com/23639005/58514857-acf79780-8168-11e9-9ae4-1b1cd18deb41.png)

