### PR TITLE
KIALI-2795 Automaticaly refresh the mesh-wide TLS lock in the masthead

### DIFF
--- a/src/actions/KialiAppAction.ts
+++ b/src/actions/KialiAppAction.ts
@@ -9,6 +9,7 @@ import { MessageCenterAction } from './MessageCenterActions';
 import { NamespaceAction } from './NamespaceAction';
 import { UserSettingsAction } from './UserSettingsActions';
 import { JaegerAction } from './JaegerActions';
+import { MeshTlsAction } from './MeshTlsActions';
 
 export type KialiAppAction =
   | GlobalAction
@@ -21,4 +22,5 @@ export type KialiAppAction =
   | MessageCenterAction
   | NamespaceAction
   | UserSettingsAction
-  | JaegerAction;
+  | JaegerAction
+  | MeshTlsAction;

--- a/src/actions/MeshTlsActions.ts
+++ b/src/actions/MeshTlsActions.ts
@@ -1,0 +1,12 @@
+import { ActionType, createStandardAction } from 'typesafe-actions';
+import { TLSStatus } from '../types/TLSStatus';
+
+enum MeshTlsActionKeys {
+  SET_INFO = 'SET_INFO'
+}
+
+export const MeshTlsActions = {
+  setinfo: createStandardAction(MeshTlsActionKeys.SET_INFO)<TLSStatus>()
+};
+
+export type MeshTlsAction = ActionType<typeof MeshTlsActions>;

--- a/src/components/MTls/MeshMTLSStatus.tsx
+++ b/src/components/MTls/MeshMTLSStatus.tsx
@@ -4,12 +4,26 @@ import { KialiAppState } from '../../store/Store';
 import { MTLSIconTypes } from './MTLSIcon';
 import { default as MTLSStatus, emptyDescriptor, StatusDescriptor } from './MTLSStatus';
 import { style } from 'typestyle';
-import { meshWideMTLSStatusSelector } from '../../store/Selectors';
+import { meshWideMTLSStatusSelector, refreshIntervalSelector } from '../../store/Selectors';
 import { connect } from 'react-redux';
-import { MTLSStatuses } from '../../types/TLSStatus';
+import { MTLSStatuses, TLSStatus } from '../../types/TLSStatus';
+import * as MessageCenter from '../../utils/MessageCenter';
+import { MessageType } from '../../types/MessageCenter';
+import * as API from '../../services/Api';
+import { KialiDispatch } from '../../types/Redux';
+import { bindActionCreators } from 'redux';
+import { MeshTlsActions } from '../../actions/MeshTlsActions';
+import { PollIntervalInMs } from '../../types/Common';
 
 type Props = {
   status: string;
+  refreshInterval: PollIntervalInMs;
+  setMeshTlsStatus: (meshStatus: TLSStatus) => void;
+};
+
+type State = {
+  intervalId: NodeJS.Timeout;
+  refreshInterval: PollIntervalInMs;
 };
 
 const statusDescriptors = new Map<string, StatusDescriptor>([
@@ -32,7 +46,41 @@ const statusDescriptors = new Map<string, StatusDescriptor>([
   [MTLSStatuses.NOT_ENABLED, emptyDescriptor]
 ]);
 
-class MeshMTLSStatus extends React.Component<Props> {
+class MeshMTLSStatus extends React.Component<Props, State> {
+  componentDidMount() {
+    const intervalId = setInterval(this.fetchStatus, this.props.refreshInterval);
+    this.setState({
+      intervalId: intervalId,
+      refreshInterval: this.props.refreshInterval
+    });
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.state.intervalId);
+  }
+
+  componentDidUpdate() {
+    if (this.props.refreshInterval !== this.state.refreshInterval) {
+      clearInterval(this.state.intervalId);
+
+      const intervalId = setInterval(this.fetchStatus, this.props.refreshInterval);
+      this.setState({
+        intervalId: intervalId,
+        refreshInterval: this.props.refreshInterval
+      });
+    }
+  }
+
+  fetchStatus = () => {
+    API.getMeshTls()
+      .then(response => {
+        return this.props.setMeshTlsStatus(response.data);
+      })
+      .catch(error => {
+        MessageCenter.add(API.getErrorMsg('Error fetching status.', error), 'default', MessageType.WARNING);
+      });
+  };
+
   iconStyle() {
     return style({
       marginTop: -3,
@@ -51,8 +99,16 @@ class MeshMTLSStatus extends React.Component<Props> {
 }
 
 const mapStateToProps = (state: KialiAppState) => ({
-  status: meshWideMTLSStatusSelector(state)
+  status: meshWideMTLSStatusSelector(state),
+  refreshInterval: refreshIntervalSelector(state)
 });
 
-const MeshMTLSSatutsConnected = connect(mapStateToProps)(MeshMTLSStatus);
+const mapDispatchToProps = (dispatch: KialiDispatch) => ({
+  setMeshTlsStatus: bindActionCreators(MeshTlsActions.setinfo, dispatch)
+});
+
+const MeshMTLSSatutsConnected = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(MeshMTLSStatus);
 export default MeshMTLSSatutsConnected;

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -84,6 +84,7 @@ const conf = {
       namespaceHealth: (namespace: string) => `api/namespaces/${namespace}/health`,
       namespaceMetrics: (namespace: string) => `api/namespaces/${namespace}/metrics`,
       namespaceTls: (namespace: string) => `api/namespaces/${namespace}/tls`,
+      meshTls: () => 'api/mesh/tls',
       pod: (namespace: string, pod: string) => `api/namespaces/${namespace}/pods/${pod}`,
       podLogs: (namespace: string, pod: string) => `api/namespaces/${namespace}/pods/${pod}/logs`,
       serverConfig: `api/config`,

--- a/src/reducers/MeshTlsState.ts
+++ b/src/reducers/MeshTlsState.ts
@@ -1,0 +1,23 @@
+import { getType } from 'typesafe-actions';
+import { KialiAppAction } from '../actions/KialiAppAction';
+import { TLSStatus } from '../types/TLSStatus';
+import { MeshTlsActions } from '../actions/MeshTlsActions';
+
+export const INITIAL_MESH_TLS_STATE: TLSStatus = {
+  status: ''
+};
+
+// This Reducer allows changes to the 'graphDataState' portion of Redux Store
+const MeshTlsState = (state: TLSStatus = INITIAL_MESH_TLS_STATE, action: KialiAppAction): TLSStatus => {
+  switch (action.type) {
+    case getType(MeshTlsActions.setinfo):
+      return {
+        ...INITIAL_MESH_TLS_STATE,
+        status: action.payload.status
+      };
+    default:
+      return state;
+  }
+};
+
+export default MeshTlsState;

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -11,6 +11,7 @@ import UserSettingsState from './UserSettingsState';
 import GrafanaState from './GrafanaState';
 import JaegerState from './JaegerState';
 import { KialiAppAction } from '../actions/KialiAppAction';
+import MeshTlsState from './MeshTlsState';
 
 const rootReducer = combineReducers<KialiAppState, KialiAppAction>({
   authentication: loginState,
@@ -21,7 +22,8 @@ const rootReducer = combineReducers<KialiAppState, KialiAppAction>({
   namespaces: namespaceState,
   statusState: HelpDropdownState,
   userSettings: UserSettingsState,
-  jaegerState: JaegerState
+  jaegerState: JaegerState,
+  meshTLSStatus: MeshTlsState
 });
 
 export default rootReducer;

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -107,6 +107,10 @@ export const getNamespaceMetrics = (namespace: string, params: MetricsOptions) =
   return newRequest<Readonly<Metrics>>(HTTP_VERBS.GET, urls.namespaceMetrics(namespace), params, {});
 };
 
+export const getMeshTls = () => {
+  return newRequest<TLSStatus>(HTTP_VERBS.GET, urls.meshTls(), {}, {});
+};
+
 export const getNamespaceTls = (namespace: string) => {
   return newRequest<TLSStatus>(HTTP_VERBS.GET, urls.namespaceTls(namespace), {}, {});
 };

--- a/src/store/ConfigStore.ts
+++ b/src/store/ConfigStore.ts
@@ -18,6 +18,7 @@ import { INITIAL_STATUS_STATE } from '../reducers/HelpDropdownState';
 import { INITIAL_NAMESPACE_STATE } from '../reducers/NamespaceState';
 import { INITIAL_GRAFANA_STATE } from '../reducers/GrafanaState';
 import { INITIAL_JAEGER_STATE } from '../reducers/JaegerState';
+import { INITIAL_MESH_TLS_STATE } from '../reducers/MeshTlsState';
 
 declare const window;
 
@@ -71,7 +72,8 @@ const initialStore: KialiAppState = {
   graph: INITIAL_GRAPH_STATE,
   userSettings: INITIAL_USER_SETTINGS_STATE,
   grafanaInfo: INITIAL_GRAFANA_STATE,
-  jaegerState: INITIAL_JAEGER_STATE
+  jaegerState: INITIAL_JAEGER_STATE,
+  meshTLSStatus: INITIAL_MESH_TLS_STATE
 };
 
 // pass an optional param to rehydrate state on app start

--- a/src/store/Selectors.ts
+++ b/src/store/Selectors.ts
@@ -67,10 +67,10 @@ export const showUnusedNodesSelector = createIdentitySelector(showUnusedNodes);
 
 export const graphDataSelector = GraphData.graphDataSelector;
 
-const meshwideMTLSStatus = (state: KialiAppState) => state.statusState.status['Istio mTLS'];
+const meshwideMTLSStatus = (state: KialiAppState) => state.meshTLSStatus.status;
 
 export const meshWideMTLSStatusSelector = createIdentitySelector(meshwideMTLSStatus);
 
-const meshwideMTLSEnabled = (state: KialiAppState) => isMTLSEnabled(state.statusState.status['Istio mTLS']);
+const meshwideMTLSEnabled = (state: KialiAppState) => isMTLSEnabled(state.meshTLSStatus.status);
 
 export const meshWideMTLSEnabledSelector = createIdentitySelector(meshwideMTLSEnabled);

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -3,6 +3,7 @@ import Namespace from '../types/Namespace';
 import { DurationInSeconds, PollIntervalInMs, TimeInSeconds, UserName, RawDate } from '../types/Common';
 import { EdgeLabelMode, Layout } from '../types/GraphFilter';
 import { GraphType, NodeParamsType, SummaryData, CyData, GraphElements } from '../types/Graph';
+import { TLSStatus } from '../types/TLSStatus';
 
 // Store is the Redux Data store
 
@@ -125,6 +126,7 @@ export interface KialiAppState {
   globalState: GlobalState;
   grafanaInfo: GrafanaInfo | null;
   statusState: StatusState;
+  meshTLSStatus: TLSStatus;
   /** Page Settings */
   authentication: LoginState;
   messageCenter: MessageCenterState;


### PR DESCRIPTION
** Describe the change **
Automatically refresh the mesh-wide TLS status.

- The lock appears and disappears in the masthead. 
- In the graph, it switches the logic between using open locks and full locks. 
- In the Overview page, locks next to namespaces, changes accordingly.

Needs: https://github.com/kiali/kiali/pull/1102

** Issue reference **
https://issues.jboss.org/browse/KIALI-2795

** Backwards compatible? **
yes

** Screenshot **
![Kiali Console (1)](https://user-images.githubusercontent.com/613814/58553580-893e5b00-8215-11e9-96b1-563a323ea8b5.gif)

![Kiali Console (2)](https://user-images.githubusercontent.com/613814/58554185-9f005000-8216-11e9-8a7a-ee4ab04f6a36.gif)