### PR TITLE
KIALI-2949 Focus login's username field on load

### DIFF
--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -70,6 +70,11 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
   componentDidMount() {
     // handle initial path from the browser
     this.props.checkCredentials();
+
+    const loginInput = document.getElementById('pf-login-username-id');
+    if (loginInput) {
+      loginInput.focus();
+    }
   }
 
   handleUsernameChange = value => {


### PR DESCRIPTION
https://issues.jboss.org/browse/KIALI-2949

This will avoid the need to use the mouse to select the username field and/or use extra keypresses to somehow focus on the username field.