### PR TITLE
Update to Typescript 3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "@types/node": "11.11.4",
     "@types/react": "16.7.13",
     "@types/react-dom": "16.0.11",
-    "@types/react-redux": "6.0.11",
+    "@types/react-redux": "7.0.9",
     "@types/react-router-dom": "4.3.1",
     "axios-mock-adapter": "1.16.0",
     "babel-core": "6.26.3",
@@ -128,12 +128,13 @@
     "snyk": "^1.161.1",
     "source-map-explorer": "1.8.0",
     "tslint-no-circular-imports": "0.6.2",
-    "typescript": "3.4.5"
+    "typescript": "3.5"
   },
   "resolutions": {
     "@types/react": "16.7.13",
     "handlebars": "4.0.14",
-    "js-yaml": "3.13.1"
+    "js-yaml": "3.13.1",
+    "hoist-non-react-statics": "3.3.0"
   },
   "engines": {
     "node": ">=10.0.0 ",

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -288,7 +288,7 @@ export const getNamespaceAppHealth = (namespace: string, durationSec: number): P
   if (durationSec) {
     params.rateInterval = String(durationSec) + 's';
   }
-  return newRequest(HTTP_VERBS.GET, urls.namespaceHealth(namespace), params, {}).then(response => {
+  return newRequest<NamespaceAppHealth>(HTTP_VERBS.GET, urls.namespaceHealth(namespace), params, {}).then(response => {
     const ret: NamespaceAppHealth = {};
     Object.keys(response.data).forEach(k => {
       ret[k] = AppHealth.fromJson(response.data[k], { rateInterval: durationSec, hasSidecar: true });
@@ -304,13 +304,15 @@ export const getNamespaceServiceHealth = (namespace: string, durationSec: number
   if (durationSec) {
     params.rateInterval = String(durationSec) + 's';
   }
-  return newRequest(HTTP_VERBS.GET, urls.namespaceHealth(namespace), params, {}).then(response => {
-    const ret: NamespaceServiceHealth = {};
-    Object.keys(response.data).forEach(k => {
-      ret[k] = ServiceHealth.fromJson(response.data[k], { rateInterval: durationSec, hasSidecar: true });
-    });
-    return ret;
-  });
+  return newRequest<NamespaceServiceHealth>(HTTP_VERBS.GET, urls.namespaceHealth(namespace), params, {}).then(
+    response => {
+      const ret: NamespaceServiceHealth = {};
+      Object.keys(response.data).forEach(k => {
+        ret[k] = ServiceHealth.fromJson(response.data[k], { rateInterval: durationSec, hasSidecar: true });
+      });
+      return ret;
+    }
+  );
 };
 
 export const getNamespaceWorkloadHealth = (
@@ -323,13 +325,15 @@ export const getNamespaceWorkloadHealth = (
   if (durationSec) {
     params.rateInterval = String(durationSec) + 's';
   }
-  return newRequest(HTTP_VERBS.GET, urls.namespaceHealth(namespace), params, {}).then(response => {
-    const ret: NamespaceWorkloadHealth = {};
-    Object.keys(response.data).forEach(k => {
-      ret[k] = WorkloadHealth.fromJson(response.data[k], { rateInterval: durationSec, hasSidecar: true });
-    });
-    return ret;
-  });
+  return newRequest<NamespaceWorkloadHealth>(HTTP_VERBS.GET, urls.namespaceHealth(namespace), params, {}).then(
+    response => {
+      const ret: NamespaceWorkloadHealth = {};
+      Object.keys(response.data).forEach(k => {
+        ret[k] = WorkloadHealth.fromJson(response.data[k], { rateInterval: durationSec, hasSidecar: true });
+      });
+      return ret;
+    }
+  );
 };
 
 export const getGrafanaInfo = () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,8 @@
     "noImplicitAny": false,
     "strictNullChecks": true,
     "suppressImplicitAnyIndexErrors": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "tsBuildInfoFile": ".tsbuildinfo"
   },
   "exclude": [
     "node_modules",

--- a/yarn.lock
+++ b/yarn.lock
@@ -407,6 +407,14 @@
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.2.tgz#0e670ea254d559241b6eeb3894f8754991e73220"
   integrity sha512-ui3WwXmjTaY73fOQ3/m3nnajU/Orhi6cEu5rzX+BrAAJxa3eITXZ5ch9suPqtM03OWhAHhPSyBGCN4UKoxO20Q==
 
+"@types/hoist-non-react-statics@^3.3.0":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/jest@23.3.10":
   version "23.3.10"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.10.tgz#4897974cc317bf99d4fe6af1efa15957fa9c94de"
@@ -444,12 +452,14 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-redux@6.0.11":
-  version "6.0.11"
-  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-6.0.11.tgz#d872254bbcba42465195a5475f40b22502b0407d"
-  integrity sha512-I3POoeGGwNqZjbK7TfnPJS2C51TFvT0atQPz4M+xpVTrLMjsX37AAfcTF3XUOTnmxHsryEjwJN9r/ScGwSXdtg==
+"@types/react-redux@7.0.9":
+  version "7.0.9"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.0.9.tgz#4825ee2872c44768916304b6bb8df5b46d443b88"
+  integrity sha512-fMVX9SneWWw68d/JoeNUh6hj42kx2G30YhPdCYJTOv3xqbJ1xzIz6tEM/xzi7nBvpNbwZkSa9TMsV06kWOFIIg==
   dependencies:
+    "@types/hoist-non-react-statics" "^3.3.0"
     "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
     redux "^4.0.0"
 
 "@types/react-router-dom@4.3.1":
@@ -5072,17 +5082,12 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^2.1.1, hoist-non-react-statics@^2.3.1:
-  version "2.5.5"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
-  integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
-
-hoist-non-react-statics@^3.1.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.2.1.tgz#c09c0555c84b38a7ede6912b61efddafd6e75e1e"
-  integrity sha512-TFsu3TV3YLY+zFTZDrN8L2DTFanObwmBLpWvJs1qfUuEQ5bTAdFcwfx2T/bsCXfM9QHSLvjfP+nihEl0yvozxw==
+hoist-non-react-statics@3.3.0, hoist-non-react-statics@^2.1.1, hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz#b09178f0122184fb95acf525daaecb4d8f45958b"
+  integrity sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==
   dependencies:
-    react-is "^16.3.2"
+    react-is "^16.7.0"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -11283,10 +11288,10 @@ typesafe-actions@3.2.1:
   resolved "https://registry.yarnpkg.com/typesafe-actions/-/typesafe-actions-3.2.1.tgz#833623a4079eda5dbcb775113f6dcf02b71c03f8"
   integrity sha512-hvhuNqsai6LzXQ+Hl6vajC9bGd/kHHL1hJvI4GQ0Rs6Fax1cjbNEsuFGy/RbfLPhBAL10n6DECEHUa+Q9E+MxQ==
 
-typescript@3.4.5:
-  version "3.4.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
-  integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
+typescript@3.5:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.1.tgz#ba72a6a600b2158139c5dd8850f700e231464202"
+  integrity sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==
 
 typestyle@2.0.1:
   version "2.0.1"


### PR DESCRIPTION
Updates to latest version of typescript:
- https://devblogs.microsoft.com/typescript/announcing-typescript-3-5/

This update makes the compiler a little more strict, so some of the
things that we had before will not work. This update has the same
motivation as #1154, and having a more up to date typescript helps us
with it (some errors happen because of the lacking `unknown` type, which
is defined as `null | undefined | T extends {}`).

Some other changes:

* `@types/react-redux` has been updated because it generates a
  compilation error. This is build-only, so no impact. Also, we're already
  running the latest redux, so we're just keeping them in sync.
* `hoist-non-react-statics` had improper typescript typings and had to
  be forcefully updated. I did some investigations on the changes for
  the versions, nothing seems non-breaking.
* Health-related API namespaces were erasing types, so typescript just
  defaulted to `any` and ignored the typing. This has been fixed.
* Typescript 3.5 broke webpack ts-loader implementation when using
  `incremental`: microsoft/TypeScript#31447
  This is fixed by also setting the `tsbuildinfo` file on tsconfig.

Some tests are failing, and I found the same problems on #1154, so I'm
backporting those changes to the tests.