### PR TITLE
KIALI-2529 Remove const enums

### DIFF
--- a/src/actions/MessageCenterActions.ts
+++ b/src/actions/MessageCenterActions.ts
@@ -4,7 +4,7 @@ import { MessageType } from '../types/MessageCenter';
 const DEFAULT_GROUP_ID = 'default';
 const DEFAULT_MESSAGE_TYPE = MessageType.ERROR;
 
-const enum MessageCenterActionKeys {
+enum MessageCenterActionKeys {
   ADD_MESSAGE = 'ADD_MESSAGE',
   REMOVE_MESSAGE = 'REMOVE_MESSAGE',
   MARK_MESSAGE_AS_READ = 'MARK_MESSAGE_AS_READ',


### PR DESCRIPTION
Const enums are deprecated[1] and breaks the build after the update from
`react-scripts-ts` to `react-scripts`.

This PR has no breaking changes.

[1]: https://github.com/Microsoft/TypeScript/issues/21391

Refers to #1154.