### PR TITLE
KIALI-2529 Fix type erasure on selectors

### DIFF
--- a/src/store/Selectors.ts
+++ b/src/store/Selectors.ts
@@ -4,10 +4,12 @@ import { KialiAppState } from './Store';
 import { isMTLSEnabled } from '../types/TLSStatus';
 // These memoized selectors are from Redux Reselect package
 
-const createIdentitySelector = selector =>
+type Selector<T> = (state: KialiAppState) => T;
+
+const createIdentitySelector = <T extends unknown>(selector: Selector<T>): Selector<T> =>
   createSelector(
     selector,
-    x => x
+    (x: T): T => x
   );
 
 // select the proper field from Redux State


### PR DESCRIPTION
This is extracted from #1154, using the `unknown` type added on
Typescript 3.0 (we're using 3.4.5). It fixes a compilation problem that happens
after the change from `react-scripts-ts` to `react-scripts` and breaks
the build there.

There should not be any breakage, as the generated code is the same. The
only thing this is doing is helping the compiler to understand what
types are being returned.