### PR TITLE
KIALI-2950 Improve login - avoid unnecessary screen switching

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -115,7 +115,9 @@ class App extends React.Component<{}, AppState> {
         <PersistGate loading={<InitializingScreen />} persistor={persistor}>
           {this.state.isInitialized ? (
             <AuthenticationControllerContainer
-              publicAreaComponent={<LoginPageContainer />}
+              publicAreaComponent={(isPostLoginPerforming: boolean, errorMsg?: string) => (
+                <LoginPageContainer isPostLoginPerforming={isPostLoginPerforming} postLoginErrorMsg={errorMsg} />
+              )}
               protectedAreaComponent={this.protectedArea}
             />
           ) : (

--- a/src/app/AuthenticationController.tsx
+++ b/src/app/AuthenticationController.tsx
@@ -26,11 +26,11 @@ interface AuthenticationControllerReduxProps {
 
 type AuthenticationControllerProps = AuthenticationControllerReduxProps & {
   protectedAreaComponent: React.ReactNode;
-  publicAreaComponent: React.ReactNode;
+  publicAreaComponent: (isPostLoginPerforming: boolean, errorMsg?: string) => React.ReactNode;
 };
 
 interface AuthenticationControllerState {
-  stage: 'login' | 'post-login' | 'logged-in';
+  stage: 'login' | 'post-login' | 'logged-in' | 'logged-in-at-load';
   isPostLoginError: boolean;
 }
 
@@ -42,13 +42,13 @@ class AuthenticationController extends React.Component<AuthenticationControllerP
   constructor(props: AuthenticationControllerProps) {
     super(props);
     this.state = {
-      stage: this.props.authenticated ? 'post-login' : 'login',
+      stage: this.props.authenticated ? 'logged-in-at-load' : 'login',
       isPostLoginError: false
     };
   }
 
   componentDidMount(): void {
-    if (this.state.stage === 'post-login') {
+    if (this.state.stage === 'logged-in-at-load') {
       this.doPostLoginActions();
     }
 
@@ -72,14 +72,18 @@ class AuthenticationController extends React.Component<AuthenticationControllerP
   render() {
     if (this.state.stage === 'logged-in') {
       return this.props.protectedAreaComponent;
-    } else if (this.state.stage === 'post-login') {
+    } else if (this.state.stage === 'logged-in-at-load') {
       return !this.state.isPostLoginError ? (
         <InitializingScreen />
       ) : (
         <InitializingScreen errorMsg={AuthenticationController.PostLoginErrorMsg} />
       );
+    } else if (this.state.stage === 'post-login') {
+      return !this.state.isPostLoginError
+        ? this.props.publicAreaComponent(true)
+        : this.props.publicAreaComponent(false, AuthenticationController.PostLoginErrorMsg);
     } else {
-      return this.props.publicAreaComponent;
+      return this.props.publicAreaComponent(false);
     }
   }
 

--- a/src/app/AuthenticationController.tsx
+++ b/src/app/AuthenticationController.tsx
@@ -29,8 +29,15 @@ type AuthenticationControllerProps = AuthenticationControllerReduxProps & {
   publicAreaComponent: (isPostLoginPerforming: boolean, errorMsg?: string) => React.ReactNode;
 };
 
+enum LoginStage {
+  LOGIN,
+  POST_LOGIN,
+  LOGGED_IN,
+  LOGGED_IN_AT_LOAD
+}
+
 interface AuthenticationControllerState {
-  stage: 'login' | 'post-login' | 'logged-in' | 'logged-in-at-load';
+  stage: LoginStage;
   isPostLoginError: boolean;
 }
 
@@ -42,13 +49,13 @@ class AuthenticationController extends React.Component<AuthenticationControllerP
   constructor(props: AuthenticationControllerProps) {
     super(props);
     this.state = {
-      stage: this.props.authenticated ? 'logged-in-at-load' : 'login',
+      stage: this.props.authenticated ? LoginStage.LOGGED_IN_AT_LOAD : LoginStage.LOGIN,
       isPostLoginError: false
     };
   }
 
   componentDidMount(): void {
-    if (this.state.stage === 'logged-in-at-load') {
+    if (this.state.stage === LoginStage.LOGGED_IN_AT_LOAD) {
       this.doPostLoginActions();
     }
 
@@ -60,25 +67,25 @@ class AuthenticationController extends React.Component<AuthenticationControllerP
     prevState: Readonly<AuthenticationControllerState>
   ): void {
     if (!prevProps.authenticated && this.props.authenticated) {
-      this.setState({ stage: 'post-login' });
+      this.setState({ stage: LoginStage.POST_LOGIN });
       this.doPostLoginActions();
     } else if (prevProps.authenticated && !this.props.authenticated) {
-      this.setState({ stage: 'login' });
+      this.setState({ stage: LoginStage.LOGIN });
     }
 
     this.setDocLayout();
   }
 
   render() {
-    if (this.state.stage === 'logged-in') {
+    if (this.state.stage === LoginStage.LOGGED_IN) {
       return this.props.protectedAreaComponent;
-    } else if (this.state.stage === 'logged-in-at-load') {
+    } else if (this.state.stage === LoginStage.LOGGED_IN_AT_LOAD) {
       return !this.state.isPostLoginError ? (
         <InitializingScreen />
       ) : (
         <InitializingScreen errorMsg={AuthenticationController.PostLoginErrorMsg} />
       );
-    } else if (this.state.stage === 'post-login') {
+    } else if (this.state.stage === LoginStage.POST_LOGIN) {
       return !this.state.isPostLoginError
         ? this.props.publicAreaComponent(true)
         : this.props.publicAreaComponent(false, AuthenticationController.PostLoginErrorMsg);
@@ -113,7 +120,7 @@ class AuthenticationController extends React.Component<AuthenticationControllerP
       ]);
       setServerConfig(configs[0].data);
 
-      this.setState({ stage: 'logged-in' });
+      this.setState({ stage: LoginStage.LOGGED_IN });
     } catch (err) {
       console.error('Error on post-login actions.', err);
       this.setState({ isPostLoginError: true });

--- a/src/app/InitializingScreen.tsx
+++ b/src/app/InitializingScreen.tsx
@@ -27,6 +27,9 @@ const defaultErrorStyle = style({
     },
     '& textarea, & hr': {
       display: 'none'
+    },
+    '& p:first-of-type': {
+      textAlign: 'left'
     }
   }
 });

--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { ThunkDispatch } from 'redux-thunk';
 import {
+  BackgroundImageSrc,
   Button,
-  LoginPage as LoginNext,
-  LoginForm,
   ListItem,
   LoginFooterItem,
-  BackgroundImageSrc
+  LoginForm,
+  LoginPage as LoginNext
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { KialiAppState, LoginSession, LoginStatus } from '../../store/Store';
@@ -37,6 +37,8 @@ type LoginProps = {
   error?: any;
   authenticate: (username: string, password: string) => void;
   checkCredentials: () => void;
+  isPostLoginPerforming: boolean;
+  postLoginErrorMsg?: string;
 };
 
 type LoginState = {
@@ -160,6 +162,9 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
     if (!authenticationConfig.secretMissing && this.props.status === LoginStatus.error) {
       messages.push(this.props.message);
     }
+    if (this.props.postLoginErrorMsg) {
+      messages.push(this.renderMessage(this.props.postLoginErrorMsg));
+    }
     return messages;
   };
 
@@ -182,9 +187,14 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
     };
 
     const messages = this.getHelperMessage();
+    const isLoggingIn = this.props.isPostLoginPerforming || this.props.status === LoginStatus.logging;
 
+    // Unfortunately, typescripg typings are wrong in the PatternFly
+    // library. So, this casts LoginForm as "any" so that it is
+    // possible to use the "isLoginButtonDisabled" property.
+    const Form = LoginForm as any;
     const loginForm = (
-      <LoginForm
+      <Form
         usernameLabel="Username"
         showHelperText={this.state.showHelperText || this.props.message !== '' || messages.length > 0}
         helperText={<>{messages}</>}
@@ -198,6 +208,8 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
         rememberMeAriaLabel="Remember me Checkbox"
         onLoginButtonClick={(e: any) => this.handleSubmit(e)}
         style={{ marginTop: '10px' }}
+        loginButtonLabel={isLoggingIn ? 'Logging in...' : undefined}
+        isLoginButtonDisabled={isLoggingIn || this.props.postLoginErrorMsg}
       />
     );
 

--- a/src/pages/Login/__tests__/LoginPage.test.tsx
+++ b/src/pages/Login/__tests__/LoginPage.test.tsx
@@ -6,7 +6,8 @@ import { LoginStatus } from '../../../store/Store';
 const LoginProps = {
   status: LoginStatus.loggedOut,
   authenticate: jest.fn(),
-  checkCredentials: jest.fn()
+  checkCredentials: jest.fn(),
+  isPostLoginPerforming: false
 };
 
 const wrapper = shallow(<LoginPage {...LoginProps} />);

--- a/src/pages/Login/__tests__/__snapshots__/LoginPage.test.tsx.snap
+++ b/src/pages/Login/__tests__/__snapshots__/LoginPage.test.tsx.snap
@@ -12,6 +12,7 @@ ShallowWrapper {
         ],
       }
     }
+    isPostLoginPerforming={false}
     status={2}
   />,
   Symbol(enzyme.__renderer__): Object {


### PR DESCRIPTION
https://issues.jboss.org/browse/KIALI-2950

After logging in, the "initializing" screen is no longer shown. Instead, the "Log in" button text is disabled and the text is changed to "Logging in...".

Openshift authentication is not affected.

Also, if user is already logged in, Kiali's first load is also unaffected.

**A succeeded login**

![loginSucceed](https://user-images.githubusercontent.com/23639005/58730932-136ff600-83b3-11e9-9cb1-71ecc554c26a.gif)

**A failed login**

![loginFail](https://user-images.githubusercontent.com/23639005/58730816-c8ee7980-83b2-11e9-9ee4-31cf937d8194.gif)
