### PR TITLE
KIALI-2948 Chart expand link overlaps chart

### DIFF
--- a/src/components/Metrics/MetricsChartBase.tsx
+++ b/src/components/Metrics/MetricsChartBase.tsx
@@ -15,7 +15,7 @@ type MetricsChartBaseProps = {
 };
 
 const expandBlockStyle = style({
-  marginBottom: '-1.5em',
+  marginBottom: '-1.0em',
   zIndex: 1,
   position: 'relative',
   textAlign: 'right'


### PR DESCRIPTION
** Describe the change **
The expand link text overlaps the chart and looks off.

** Issue reference **
https://issues.jboss.org/browse/KIALI-2948

** Backwards compatible? **
Yes

[ ] Is your pull-request introducing changes in behaviour?
No
_Describe the changes if appropriate. E.g. a new link, a change on what a click does, etc_

** Screenshot **

Add a screenshot of the UI after your changes.

**Before**

![overlap-bug](https://user-images.githubusercontent.com/1312165/58735336-f3d6ce80-83ae-11e9-87c2-60de49acc2c3.jpg)

**After**

![after-expand-fix](https://user-images.githubusercontent.com/1312165/58735241-ac504280-83ae-11e9-8cb5-53dd2d0881ab.jpg)
**:
