### PR TITLE
KIALI-2970 Removes fixed height of 95vh for page

### DIFF
--- a/src/components/Nav/Navigation.tsx
+++ b/src/components/Nav/Navigation.tsx
@@ -6,6 +6,7 @@ import { RouteComponentProps } from 'react-router';
 import Masthead from './Masthead/Masthead';
 import Menu from './Menu';
 import { Page, PageHeader, PageSection, Brand } from '@patternfly/react-core';
+import { style } from 'typestyle';
 
 import MessageCenterContainer from '../../components/MessageCenter/MessageCenter';
 import { kialiLogo, serverConfig } from '../../config';
@@ -28,6 +29,11 @@ type NavigationState = {
   isNavOpenDesktop: boolean;
   isNavOpenMobile: boolean;
 };
+
+const flexBoxColumnStyle = style({
+  display: 'flex',
+  flexDirection: 'column'
+});
 
 class Navigation extends React.Component<PropsType, NavigationState> {
   static contextTypes = {
@@ -107,9 +113,9 @@ class Navigation extends React.Component<PropsType, NavigationState> {
     );
 
     return (
-      <Page header={Header} sidebar={Sidebar} onPageResize={this.onPageResize}>
+      <Page style={{ backgroundColor: 'purple' }} header={Header} sidebar={Sidebar} onPageResize={this.onPageResize}>
         <MessageCenterContainer drawerTitle="Message Center" />
-        <PageSection variant={'light'}>
+        <PageSection className={flexBoxColumnStyle} variant={'light'}>
           <RenderPage needScroll={this.isContentScrollable()} />
         </PageSection>
       </Page>

--- a/src/components/Nav/Navigation.tsx
+++ b/src/components/Nav/Navigation.tsx
@@ -113,7 +113,7 @@ class Navigation extends React.Component<PropsType, NavigationState> {
     );
 
     return (
-      <Page style={{ backgroundColor: 'purple' }} header={Header} sidebar={Sidebar} onPageResize={this.onPageResize}>
+      <Page header={Header} sidebar={Sidebar} onPageResize={this.onPageResize}>
         <MessageCenterContainer drawerTitle="Message Center" />
         <PageSection className={flexBoxColumnStyle} variant={'light'}>
           <RenderPage needScroll={this.isContentScrollable()} />

--- a/src/components/Nav/RenderPage.tsx
+++ b/src/components/Nav/RenderPage.tsx
@@ -3,6 +3,9 @@ import { Redirect, Route } from 'react-router-dom';
 import SwitchErrorBoundary from '../SwitchErrorBoundary/SwitchErrorBoundary';
 import { pathRoutes, defaultRoute, secondaryMastheadRoutes } from '../../routes';
 import { Path } from '../../types/Routes';
+import { style } from 'typestyle';
+
+const containerStyle = style({ marginLeft: 0, marginRight: 0 });
 
 class RenderPage extends React.Component<{ needScroll: boolean }> {
   constructor(props: { needScroll: boolean }) {
@@ -25,7 +28,7 @@ class RenderPage extends React.Component<{ needScroll: boolean }> {
 
   render() {
     const component = (
-      <div className="container-fluid">
+      <div className={`container-fluid ${containerStyle}`}>
         <SwitchErrorBoundary
           fallBackComponent={() => <h2>Sorry, there was a problem. Try a refresh or navigate to a different page.</h2>}
         >

--- a/src/components/Nav/SecondaryMasthead.tsx
+++ b/src/components/Nav/SecondaryMasthead.tsx
@@ -6,7 +6,9 @@ const secondaryMastheadStyle = style({
   borderBottom: '1px solid #ccc;',
   height: '42px',
   position: 'sticky',
-  zIndex: 10
+  zIndex: 10,
+  marginLeft: 0,
+  marginRight: 0
 });
 
 export default class SecondaryMasthead extends React.PureComponent {

--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -31,7 +31,3 @@ body,
   // 45px is the height of the global namespace selector
   height: calc(100vh - 42px - var(--pf-c-page__header--MinHeight));
 }
-
-.pf-c-page__main {
-  height: 95vh;
-}


### PR DESCRIPTION
** Describe the change **

Patternfly sets the height of the "Page" to 95vh, so we can our calc wrong in the GraphPage.
Additionally, sets the header height to the remaining 5vh, if not, when the screen is big (height about 1800px) a black bar appears on bottom.
