### PR TITLE
KIALI-2969 Disallow to drilldown to group nodes where every node has …

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -97,7 +97,6 @@ type InitialValues = {
   zoom?: number;
 };
 
-// @todo: Move this class to 'containers' folder -- but it effects many other things
 // exporting this class for testing
 export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, CytoscapeGraphState> {
   static contextTypes = {
@@ -518,10 +517,14 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
     if (targetType !== 'node' && targetType !== 'group') {
       return;
     }
+
+    const targetOrGroupChildren = targetType === 'group' ? target.descendants() : target;
+
     if (target.data(CyNode.isInaccessible)) {
       return;
     }
-    if (target.data(CyNode.hasMissingSC)) {
+
+    if (targetOrGroupChildren.every(t => t.data(CyNode.hasMissingSC))) {
       MessageCenterUtils.add(
         `A node with a missing sidecar provides no node-specific telemetry and can not provide a node detail graph.`,
         undefined,
@@ -529,7 +532,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
       );
       return;
     }
-    if (target.data(CyNode.isUnused)) {
+    if (targetOrGroupChildren.every(t => t.data(CyNode.isUnused))) {
       MessageCenterUtils.add(
         `An unused node has no node-specific traffic and can not provide a node detail graph.`,
         undefined,


### PR DESCRIPTION
…no telemetry/sidecar

** Describe the change **

Previous to this PR you were allowed to drill down to a group where every node had no telemetry / sidecar.
Now you get the same message as if you were trying to drill down to a node without telemetry / sidecar

** Screenshot **

Every node in the group has no telemetry, disallow to drill down to any node

![without-telemetry](https://user-images.githubusercontent.com/3845764/58895849-7bc41d80-86ba-11e9-8a47-d5399188c1b9.gif)

One node in the group has telemetry, but the others don't, this allows to drill down in the group node or the node that has telemetry, but not the others.

![group-access](https://user-images.githubusercontent.com/3845764/58895850-7bc41d80-86ba-11e9-9146-72ff44896cc2.gif)
