### PR TITLE
KIALI-2529 Remove absolute imports

### DIFF
--- a/src/components/Nav/Masthead/UserDropdown.tsx
+++ b/src/components/Nav/Masthead/UserDropdown.tsx
@@ -4,7 +4,7 @@ import { SessionTimeout } from '../../SessionTimeout/SessionTimeout';
 import { config } from '../../../config';
 import { MILLISECONDS } from '../../../types/Common';
 import Timer = NodeJS.Timer;
-import { KialiAppState, LoginSession } from 'src/store/Store';
+import { KialiAppState, LoginSession } from '../../../store/Store';
 import authenticationConfig from '../../../config/AuthenticationConfig';
 import { AuthStrategy } from '../../../types/Auth';
 import moment from 'moment';

--- a/src/pages/ServiceList/ServiceListComponent.tsx
+++ b/src/pages/ServiceList/ServiceListComponent.tsx
@@ -25,7 +25,7 @@ import './ServiceListComponent.css';
 import { SortField } from '../../types/SortFilters';
 import { ListComponent } from '../../components/ListPage/ListComponent';
 import { AlignRightStyle, ThinStyle } from '../../components/Filters/FilterStyles';
-import { Validations, ObjectValidation } from 'src/types/IstioObjects';
+import { Validations, ObjectValidation } from '../../types/IstioObjects';
 import { arrayEquals } from '../../utils/Common';
 import { KialiAppState } from '../../store/Store';
 import { activeNamespacesSelector, durationSelector } from '../../store/Selectors';

--- a/src/pages/ServiceList/__tests__/ItemDescription.test.tsx
+++ b/src/pages/ServiceList/__tests__/ItemDescription.test.tsx
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 import ItemDescription from '../ItemDescription';
 import { ServiceHealth } from '../../../types/Health';
 import { ServiceListItem } from '../../../types/ServiceList';
-import { ObjectValidation } from 'src/types/IstioObjects';
+import { ObjectValidation } from '../../../types/IstioObjects';
 
 const health = new ServiceHealth(
   { errorRatio: 0.1, inboundErrorRatio: 0.17, outboundErrorRatio: -1 },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "baseUrl": "./",
+    "baseUrl": "src",
     "outDir": "build/dist",
     "module": "esnext",
     "target": "es5",


### PR DESCRIPTION
Moving to `react-scripts` from `react-scripts-ts` moves our
transpilation layer to use babel instead of tsc, which forbids absolute
imports.