### PR TITLE
KIALI-2529 Fix export problems

### DIFF
--- a/src/components/Metrics/IstioMetrics.tsx
+++ b/src/components/Metrics/IstioMetrics.tsx
@@ -29,7 +29,7 @@ type ObjectId = {
   object: string;
 };
 
-type IstioMetricsProps = ObjectId &
+export type IstioMetricsProps = ObjectId &
   RouteComponentProps<{}> & {
     isPageVisible?: boolean;
     grafanaInfo?: GrafanaInfo;
@@ -236,8 +236,6 @@ class IstioMetrics extends React.Component<IstioMetricsProps, MetricsState> {
     );
   }
 }
-
-export { IstioMetricsProps };
 
 const mapStateToProps = (state: KialiAppState) => ({
   isPageVisible: state.globalState.isPageVisible,

--- a/src/reducers/JaegerState.ts
+++ b/src/reducers/JaegerState.ts
@@ -9,7 +9,7 @@ export const INITIAL_JAEGER_STATE: JaegerState = {
   enableIntegration: false
 };
 
-const JaegerState = (state: JaegerState = INITIAL_JAEGER_STATE, action: KialiAppAction): JaegerState => {
+const JaegerStateGenerator = (state: JaegerState = INITIAL_JAEGER_STATE, action: KialiAppAction): JaegerState => {
   switch (action.type) {
     case getType(JaegerActions.setEnableIntegration):
       return updateState(state, {
@@ -24,4 +24,4 @@ const JaegerState = (state: JaegerState = INITIAL_JAEGER_STATE, action: KialiApp
   }
 };
 
-export default JaegerState;
+export default JaegerStateGenerator;

--- a/src/types/Namespace.ts
+++ b/src/types/Namespace.ts
@@ -1,8 +1,6 @@
-interface Namespace {
+export default interface Namespace {
   name: string;
 }
-
-export default Namespace;
 
 export const namespaceFromString = (namespace: string) => ({ name: namespace });
 


### PR DESCRIPTION
The exports on this PR are failing compilation after the change to
`react-scripts`:

* `export { x }` does not work anymore.
* You can not overwrite an imported type and then export it anymore.