### PR TITLE
KIALI-2529 Fix values that can be undefined or null

### DIFF
--- a/src/actions/GraphActions.ts
+++ b/src/actions/GraphActions.ts
@@ -6,7 +6,7 @@ import { ActionKeys } from './ActionKeys';
 export const GraphActions = {
   changed: createAction(ActionKeys.GRAPH_CHANGED),
   setLayout: createStandardAction(ActionKeys.GRAPH_SET_LAYOUT)<Layout>(),
-  setNode: createStandardAction(ActionKeys.GRAPH_SET_NODE)<NodeParamsType>(),
+  setNode: createStandardAction(ActionKeys.GRAPH_SET_NODE)<NodeParamsType | undefined>(),
   updateGraph: createStandardAction(ActionKeys.UPDATE_GRAPH)<CyData>(),
   updateSummary: createStandardAction(ActionKeys.UPDATE_SUMMARY)<CytoscapeClickEvent>()
 };

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -107,15 +107,15 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
   static tapTarget: any;
   static tapTimeout: any;
 
-  private graphHighlighter: GraphHighlighter;
-  private trafficRenderer: TrafficRender;
+  private graphHighlighter?: GraphHighlighter;
+  private trafficRenderer?: TrafficRender;
   private focusAnimation?: FocusAnimation;
   private focusFinished: boolean;
   private cytoscapeReactWrapperRef: any;
   private contextMenuRef: React.RefObject<CytoscapeContextMenuWrapper>;
   private namespaceChanged: boolean;
   private nodeChanged: boolean;
-  private resetSelection: boolean;
+  private resetSelection: boolean = false;
   private initialValues: InitialValues;
   private cy: any;
 
@@ -354,7 +354,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
     });
 
     cy.on('destroy', (evt: any) => {
-      this.trafficRenderer.stop();
+      this.trafficRenderer!.stop();
       this.cy = undefined;
       this.props.updateSummary({ summaryType: 'graph', summaryTarget: undefined });
     });
@@ -413,7 +413,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
       return;
     }
 
-    this.trafficRenderer.stop();
+    this.trafficRenderer!.stop();
 
     const isTheGraphSelected = cy.$(':selected').length === 0;
     if (this.resetSelection) {
@@ -478,9 +478,9 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
     }
 
     // Update TrafficRenderer
-    this.trafficRenderer.setEdges(cy.edges());
+    this.trafficRenderer!.setEdges(cy.edges());
     if (this.props.showTrafficAnimation) {
-      this.trafficRenderer.start();
+      this.trafficRenderer!.start();
     }
   }
 
@@ -508,7 +508,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
       summaryTarget: target
     };
     this.props.updateSummary(event);
-    this.graphHighlighter.onClick(event);
+    this.graphHighlighter!.onClick(event);
   };
 
   private handleDoubleTap = (event: CytoscapeClickEvent) => {
@@ -600,15 +600,15 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
 
   private handleTap = (event: CytoscapeClickEvent) => {
     this.props.updateSummary(event);
-    this.graphHighlighter.onClick(event);
+    this.graphHighlighter!.onClick(event);
   };
 
   private handleMouseIn = (event: CytoscapeMouseInEvent) => {
-    this.graphHighlighter.onMouseIn(event);
+    this.graphHighlighter!.onMouseIn(event);
   };
 
   private handleMouseOut = (event: CytoscapeMouseOutEvent) => {
-    this.graphHighlighter.onMouseOut(event);
+    this.graphHighlighter!.onMouseOut(event);
   };
 
   private namespaceNeedsRelayout(prevElements: any, nextElements: any) {

--- a/src/components/CytoscapeGraph/FocusAnimation.ts
+++ b/src/components/CytoscapeGraph/FocusAnimation.ts
@@ -23,6 +23,10 @@ export default class FocusAnimation {
   constructor(cy: any) {
     this.layer = cy.cyCanvas();
     this.context = this.layer.getCanvas().getContext('2d');
+    this.onFinishedCallback = () => {
+      return;
+    };
+
     cy.one('destroy', () => this.stop());
   }
 
@@ -48,7 +52,7 @@ export default class FocusAnimation {
     this.layer.clear(this.context);
   }
 
-  processStep = () => {
+  processStep() {
     try {
       if (this.startTimestamp === undefined) {
         this.startTimestamp = Date.now();
@@ -73,7 +77,7 @@ export default class FocusAnimation {
       this.stop();
       throw exception;
     }
-  };
+  }
 
   private easingFunction(t: number) {
     // Do a focus animation in, out and in again.

--- a/src/components/CytoscapeGraph/FocusAnimation.ts
+++ b/src/components/CytoscapeGraph/FocusAnimation.ts
@@ -15,7 +15,7 @@ export default class FocusAnimation {
   private animationTimer;
   private startTimestamp;
   private elements;
-  private onFinishedCallback: OnFinishedCallback;
+  private onFinishedCallback?: OnFinishedCallback;
 
   private readonly layer;
   private readonly context;
@@ -23,9 +23,6 @@ export default class FocusAnimation {
   constructor(cy: any) {
     this.layer = cy.cyCanvas();
     this.context = this.layer.getCanvas().getContext('2d');
-    this.onFinishedCallback = () => {
-      return;
-    };
 
     cy.one('destroy', () => this.stop());
   }

--- a/src/components/CytoscapeGraph/TrafficAnimation/TrafficRenderer.ts
+++ b/src/components/CytoscapeGraph/TrafficAnimation/TrafficRenderer.ts
@@ -115,9 +115,9 @@ type TrafficPoint = {
 class TrafficPointGenerator {
   private timer?: number;
   private timerForNextPoint?: number;
-  private speed: number;
-  private errorRate: number;
-  private type: TrafficEdgeType;
+  private speed: number = 0;
+  private errorRate: number = 0;
+  private type: TrafficEdgeType = TrafficEdgeType.NONE;
 
   /**
    * Process a render step for the generator, decrements the timerForNextPoint and
@@ -192,7 +192,7 @@ class TrafficEdge {
   private points: Array<TrafficPoint> = [];
   private generator: TrafficPointGenerator;
   private edge: any;
-  private type: TrafficEdgeType;
+  private type: TrafficEdgeType = TrafficEdgeType.NONE;
 
   constructor() {
     this.generator = new TrafficPointGenerator();

--- a/src/components/GraphFilter/GraphFind.tsx
+++ b/src/components/GraphFilter/GraphFind.tsx
@@ -15,7 +15,7 @@ import { CyNode, CyEdge } from '../CytoscapeGraph/CytoscapeGraphUtils';
 import { CyData } from '../../types/Graph';
 
 type ReduxProps = {
-  cyData: CyData;
+  cyData: CyData | null;
   findValue: string;
   hideValue: string;
   showFindHelp: boolean;

--- a/src/components/Metrics/IstioMetrics.tsx
+++ b/src/components/Metrics/IstioMetrics.tsx
@@ -231,7 +231,7 @@ class IstioMetrics extends React.Component<IstioMetricsProps, MetricsState> {
 
 const mapStateToProps = (state: KialiAppState) => ({
   isPageVisible: state.globalState.isPageVisible,
-  grafanaInfo: state.grafanaInfo
+  grafanaInfo: state.grafanaInfo || undefined
 });
 
 const IstioMetricsContainer = withRouter<RouteComponentProps<{}> & IstioMetricsProps>(

--- a/src/components/MetricsOptions/MetricsSettings.tsx
+++ b/src/components/MetricsOptions/MetricsSettings.tsx
@@ -27,7 +27,7 @@ const secondLevelStyle = style({ marginLeft: 14 });
 const spacerStyle = style({ height: '1em' });
 
 export class MetricsSettingsDropdown extends React.Component<Props> {
-  private shouldReportOptions: boolean = false;
+  private shouldReportOptions = false;
   private settings: MetricsSettings = MetricsSettingsDropdown.initialMetricsSettings();
 
   static initialMetricsSettings = (): MetricsSettings => {

--- a/src/components/MetricsOptions/MetricsSettings.tsx
+++ b/src/components/MetricsOptions/MetricsSettings.tsx
@@ -27,8 +27,8 @@ const secondLevelStyle = style({ marginLeft: 14 });
 const spacerStyle = style({ height: '1em' });
 
 export class MetricsSettingsDropdown extends React.Component<Props> {
-  private shouldReportOptions: boolean;
-  private settings: MetricsSettings;
+  private shouldReportOptions: boolean = false;
+  private settings: MetricsSettings = MetricsSettingsDropdown.initialMetricsSettings();
 
   static initialMetricsSettings = (): MetricsSettings => {
     const urlParams = new URLSearchParams(history.location.search);

--- a/src/components/NamespaceDropdown.tsx
+++ b/src/components/NamespaceDropdown.tsx
@@ -41,7 +41,7 @@ const namespaceValueStyle = style({
 
 interface NamespaceListType {
   disabled: boolean;
-  filter?: string;
+  filter: string;
   activeNamespaces: Namespace[];
   items: Namespace[];
   toggleNamespace: (namespace: Namespace) => void;
@@ -124,7 +124,7 @@ export class NamespaceDropdown extends React.PureComponent<NamespaceListType, {}
       }, {});
       const checkboxStyle = style({ marginLeft: 5 });
       const namespaces = this.props.items
-        .filter((namespace: Namespace) => namespace.name.includes(this.props.filter!))
+        .filter((namespace: Namespace) => namespace.name.includes(this.props.filter))
         .map((namespace: Namespace) => (
           <div id={`namespace-list-item[${namespace.name}]`} key={`namespace-list-item[${namespace.name}]`}>
             <label>

--- a/src/components/NamespaceDropdown.tsx
+++ b/src/components/NamespaceDropdown.tsx
@@ -41,7 +41,7 @@ const namespaceValueStyle = style({
 
 interface NamespaceListType {
   disabled: boolean;
-  filter: string;
+  filter?: string;
   activeNamespaces: Namespace[];
   items: Namespace[];
   toggleNamespace: (namespace: Namespace) => void;
@@ -124,7 +124,7 @@ export class NamespaceDropdown extends React.PureComponent<NamespaceListType, {}
       }, {});
       const checkboxStyle = style({ marginLeft: 5 });
       const namespaces = this.props.items
-        .filter((namespace: Namespace) => namespace.name.includes(this.props.filter))
+        .filter((namespace: Namespace) => namespace.name.includes(this.props.filter!))
         .map((namespace: Namespace) => (
           <div id={`namespace-list-item[${namespace.name}]`} key={`namespace-list-item[${namespace.name}]`}>
             <label>

--- a/src/components/Nav/Masthead/UserDropdown.tsx
+++ b/src/components/Nav/Masthead/UserDropdown.tsx
@@ -123,13 +123,13 @@ class UserDropdownConnected extends React.Component<UserProps, UserState> {
           show={this.state.showSessionTimeOut && !this.state.isSessionTimeoutDismissed}
           timeOutCountDown={this.state.timeCountDownSeconds}
         />
-        {this.props.session! && (
+        {this.props.session && (
           <Dropdown
             isPlain={true}
             position="right"
             onSelect={this.onDropdownSelect}
             isOpen={isDropdownOpen}
-            toggle={<DropdownToggle onToggle={this.onDropdownToggle}>{this.props.session!.username}</DropdownToggle>}
+            toggle={<DropdownToggle onToggle={this.onDropdownToggle}>{this.props.session.username}</DropdownToggle>}
             dropdownItems={[userDropdownItems]}
           />
         )}

--- a/src/components/Nav/Masthead/UserDropdown.tsx
+++ b/src/components/Nav/Masthead/UserDropdown.tsx
@@ -15,7 +15,7 @@ import { connect } from 'react-redux';
 import * as API from '../../../services/Api';
 
 type UserProps = {
-  session: LoginSession;
+  session?: LoginSession;
   logout: () => void;
   extendSession: (session: LoginSession) => void;
 };
@@ -63,7 +63,7 @@ class UserDropdownConnected extends React.Component<UserProps, UserState> {
   }
 
   timeLeft = (): number => {
-    const expiresOn = moment(this.props.session.expiresOn);
+    const expiresOn = moment(this.props.session!.expiresOn);
 
     if (expiresOn <= moment()) {
       this.props.logout();
@@ -123,13 +123,13 @@ class UserDropdownConnected extends React.Component<UserProps, UserState> {
           show={this.state.showSessionTimeOut && !this.state.isSessionTimeoutDismissed}
           timeOutCountDown={this.state.timeCountDownSeconds}
         />
-        {this.props.session && (
+        {this.props.session! && (
           <Dropdown
             isPlain={true}
             position="right"
             onSelect={this.onDropdownSelect}
             isOpen={isDropdownOpen}
-            toggle={<DropdownToggle onToggle={this.onDropdownToggle}>{this.props.session.username}</DropdownToggle>}
+            toggle={<DropdownToggle onToggle={this.onDropdownToggle}>{this.props.session!.username}</DropdownToggle>}
             dropdownItems={[userDropdownItems]}
           />
         )}

--- a/src/pages/Graph/GraphPage.tsx
+++ b/src/pages/Graph/GraphPage.tsx
@@ -62,7 +62,6 @@ type ReduxProps = {
   isError: boolean;
   isLoading: boolean;
   isPageVisible: boolean;
-  isReady: boolean;
   layout: Layout;
   node?: NodeParamsType;
   pollInterval: PollIntervalInMs;
@@ -84,16 +83,12 @@ type ReduxProps = {
     node?: NodeParamsType
   ) => any;
   graphChanged: () => void;
-  setlayout: (layout: Layout) => void;
   setNode: (node?: NodeParamsType) => void;
   toggleLegend: () => void;
   setLastRefreshAt: (lastRefreshAt: TimeInMilliseconds) => void;
 };
 
-export type GraphPageProps = RouteComponentProps<GraphURLPathProps> &
-  ReduxProps & {
-    isReady: boolean;
-  };
+export type GraphPageProps = RouteComponentProps<Partial<GraphURLPathProps>> & ReduxProps;
 
 type GraphPageState = {
   showHelp: boolean;
@@ -153,7 +148,7 @@ export class GraphPage extends React.Component<GraphPageProps, GraphPageState> {
   private readonly errorBoundaryRef: any;
   private cytoscapeGraphRef: any;
 
-  static getNodeParamsFromProps(props: RouteComponentProps<GraphURLPathProps>): NodeParamsType | undefined {
+  static getNodeParamsFromProps(props: RouteComponentProps<Partial<GraphURLPathProps>>): NodeParamsType | undefined {
     const app = props.match.params.app;
     const appOk = app && app !== 'unknown' && app !== 'undefined';
     const namespace = props.match.params.namespace;
@@ -176,12 +171,12 @@ export class GraphPage extends React.Component<GraphPageProps, GraphPageState> {
       version = '';
     }
     const node: NodeParamsType = {
-      app: app,
-      namespace: { name: namespace },
+      app: app!,
+      namespace: { name: namespace! },
       nodeType: nodeType,
-      service: service,
+      service: service!,
       version: version,
-      workload: workload
+      workload: workload!
     };
     return node;
   }

--- a/src/pages/ServiceDetails/ServiceInfo/types/DestinationRuleValidator.ts
+++ b/src/pages/ServiceDetails/ServiceInfo/types/DestinationRuleValidator.ts
@@ -7,6 +7,7 @@ export default class DestinationRuleValidator {
 
   constructor(destinationRule: DestinationRule) {
     this.destinationRule = destinationRule;
+    this.unformattedField = 'none';
   }
 
   isValid() {

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadDescription.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadDescription.tsx
@@ -65,8 +65,9 @@ class WorkloadDescription extends React.Component<WorkloadDescriptionProps, Work
                     .filter(r => r.name !== '')
                     .map((rt, idx) => this.renderLogo(rt.name, idx))
                     .reduce(
-                      (list: JSX.Element[], elem) => (list ? [...list, <span key="sep"> | </span>, elem] : [elem]),
-                      undefined
+                      (list: JSX.Element[], elem) =>
+                        list.length > 0 ? [...list, <span key="sep"> | </span>, elem] : [elem],
+                      []
                     )}
                 </div>
               )}

--- a/src/reducers/__tests__/NamespacesReducer.test.ts
+++ b/src/reducers/__tests__/NamespacesReducer.test.ts
@@ -112,13 +112,15 @@ describe('Namespaces reducer', () => {
     const currentState = {
       activeNamespaces: [{ name: 'my-namespace' }],
       isFetching: true,
-      items: []
+      items: [],
+      filter: ''
     };
     const requestStartedAction = NamespaceActions.requestFailed();
     const expectedState = {
       activeNamespaces: [{ name: 'my-namespace' }],
       isFetching: false,
-      items: []
+      items: [],
+      filter: ''
     };
     expect(namespaceState(currentState, requestStartedAction)).toEqual(expectedState);
   });

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -25,7 +25,7 @@ export interface NamespaceState {
   readonly items?: Namespace[];
   readonly isFetching: boolean;
   readonly lastUpdated?: Date;
-  readonly filter?: string;
+  readonly filter: string;
 }
 
 // Various pages are described here with their various sections


### PR DESCRIPTION
Parameters that come from the URL and from redux can be null or
undefined without causing compilation errors. This does not compile
anymore with `react-scripts`, so it needs to be fixed before the
upgrade.