### PR TITLE
KIALI-2529 Add type hints to composite types

### DIFF
--- a/src/components/Health/__tests__/__snapshots__/HealthDetails.test.tsx.snap
+++ b/src/components/Health/__tests__/__snapshots__/HealthDetails.test.tsx.snap
@@ -6,10 +6,6 @@ ShallowWrapper {
   Symbol(enzyme.__unrendered__): <HealthDetails
     health={
       ServiceHealth {
-        "ctx": Object {
-          "hasSidecar": true,
-          "rateInterval": 60,
-        },
         "items": Array [
           Object {
             "status": Object {
@@ -200,10 +196,6 @@ ShallowWrapper {
   Symbol(enzyme.__unrendered__): <HealthDetails
     health={
       ServiceHealth {
-        "ctx": Object {
-          "hasSidecar": true,
-          "rateInterval": 60,
-        },
         "items": Array [
           Object {
             "status": Object {

--- a/src/components/Health/__tests__/__snapshots__/HealthIndicator.test.tsx.snap
+++ b/src/components/Health/__tests__/__snapshots__/HealthIndicator.test.tsx.snap
@@ -6,10 +6,6 @@ ShallowWrapper {
   Symbol(enzyme.__unrendered__): <HealthIndicator
     health={
       AppHealth {
-        "ctx": Object {
-          "hasSidecar": true,
-          "rateInterval": 600,
-        },
         "items": Array [
           Object {
             "children": Array [
@@ -75,20 +71,6 @@ ShallowWrapper {
           "inboundErrorRatio": -1,
           "outboundErrorRatio": -1,
         },
-        "workloadStatuses": Array [
-          Object {
-            "availableReplicas": 1,
-            "currentReplicas": 1,
-            "desiredReplicas": 1,
-            "name": "A",
-          },
-          Object {
-            "availableReplicas": 2,
-            "currentReplicas": 2,
-            "desiredReplicas": 2,
-            "name": "B",
-          },
-        ],
       }
     }
     id="svc"
@@ -128,10 +110,6 @@ ShallowWrapper {
         <HealthDetails
           health={
             AppHealth {
-              "ctx": Object {
-                "hasSidecar": true,
-                "rateInterval": 600,
-              },
               "items": Array [
                 Object {
                   "children": Array [
@@ -197,20 +175,6 @@ ShallowWrapper {
                 "inboundErrorRatio": -1,
                 "outboundErrorRatio": -1,
               },
-              "workloadStatuses": Array [
-                Object {
-                  "availableReplicas": 1,
-                  "currentReplicas": 1,
-                  "desiredReplicas": 1,
-                  "name": "A",
-                },
-                Object {
-                  "availableReplicas": 2,
-                  "currentReplicas": 2,
-                  "desiredReplicas": 2,
-                  "name": "B",
-                },
-              ],
             }
           }
         />
@@ -269,10 +233,6 @@ ShallowWrapper {
           <HealthDetails
             health={
               AppHealth {
-                "ctx": Object {
-                  "hasSidecar": true,
-                  "rateInterval": 600,
-                },
                 "items": Array [
                   Object {
                     "children": Array [
@@ -338,20 +298,6 @@ ShallowWrapper {
                   "inboundErrorRatio": -1,
                   "outboundErrorRatio": -1,
                 },
-                "workloadStatuses": Array [
-                  Object {
-                    "availableReplicas": 1,
-                    "currentReplicas": 1,
-                    "desiredReplicas": 1,
-                    "name": "A",
-                  },
-                  Object {
-                    "availableReplicas": 2,
-                    "currentReplicas": 2,
-                    "desiredReplicas": 2,
-                    "name": "B",
-                  },
-                ],
               }
             }
           />

--- a/src/pages/AppList/FiltersAndSorts.ts
+++ b/src/pages/AppList/FiltersAndSorts.ts
@@ -136,7 +136,7 @@ export namespace AppListFilters {
       // In the case of health sorting, we may not have all health promises ready yet
       // So we need to get them all before actually sorting
       const allHealthPromises: Promise<WithAppHealth<AppListItem>>[] = unsorted.map(item => {
-        return item.healthPromise.then((health): WithAppHealth<AppListItem> => ({ ...item, ...{ health } }));
+        return item.healthPromise.then((health): WithAppHealth<AppListItem> => ({ ...item, health }));
       });
       return Promise.all(allHealthPromises).then(arr => {
         return arr.sort(isAscending ? sortField.compare : (a, b) => sortField.compare(b, a));

--- a/src/pages/ServiceList/FiltersAndSorts.ts
+++ b/src/pages/ServiceList/FiltersAndSorts.ts
@@ -1,5 +1,5 @@
 import { ActiveFilter, FilterType, FILTER_ACTION_APPEND } from '../../types/Filters';
-import { getRequestErrorsStatus, WithHealth, hasHealth } from '../../types/Health';
+import { getRequestErrorsStatus, WithServiceHealth } from '../../types/Health';
 import { ServiceListItem } from '../../types/ServiceList';
 import { SortField } from '../../types/SortFilters';
 import {
@@ -52,22 +52,18 @@ export namespace ServiceListFilters {
       title: 'Health',
       isNumeric: false,
       param: 'he',
-      compare: (a: ServiceListItem, b: ServiceListItem) => {
-        if (hasHealth(a) && hasHealth(b)) {
-          const statusForA = a.health.getGlobalStatus();
-          const statusForB = b.health.getGlobalStatus();
+      compare: (a: WithServiceHealth<ServiceListItem>, b: WithServiceHealth<ServiceListItem>) => {
+        const statusForA = a.health.getGlobalStatus();
+        const statusForB = b.health.getGlobalStatus();
 
-          if (statusForA.priority === statusForB.priority) {
-            // If both services have same health status, use error rate to determine order.
-            const ratioA = getRequestErrorsStatus(a.health.requests.errorRatio).value;
-            const ratioB = getRequestErrorsStatus(b.health.requests.errorRatio).value;
-            return ratioA === ratioB ? a.name.localeCompare(b.name) : ratioB - ratioA;
-          }
-
-          return statusForB.priority - statusForA.priority;
+        if (statusForA.priority === statusForB.priority) {
+          // If both services have same health status, use error rate to determine order.
+          const ratioA = getRequestErrorsStatus(a.health.requests.errorRatio).value;
+          const ratioB = getRequestErrorsStatus(b.health.requests.errorRatio).value;
+          return ratioA === ratioB ? a.name.localeCompare(b.name) : ratioB - ratioA;
         }
 
-        return 0;
+        return statusForB.priority - statusForA.priority;
       }
     }
   ];
@@ -136,8 +132,8 @@ export namespace ServiceListFilters {
     if (sortField.title === 'Health') {
       // In the case of health sorting, we may not have all health promises ready yet
       // So we need to get them all before actually sorting
-      const allHealthPromises: Promise<WithHealth<ServiceListItem>>[] = services.map(item => {
-        return item.healthPromise.then((health): WithHealth<ServiceListItem> => ({ ...item, ...{ health } }));
+      const allHealthPromises: Promise<WithServiceHealth<ServiceListItem>>[] = services.map(item => {
+        return item.healthPromise.then((health): WithServiceHealth<ServiceListItem> => ({ ...item, ...{ health } }));
       });
       return Promise.all(allHealthPromises).then(arr => {
         return arr.sort(isAscending ? sortField.compare : (a, b) => sortField.compare(b, a));

--- a/src/pages/ServiceList/FiltersAndSorts.ts
+++ b/src/pages/ServiceList/FiltersAndSorts.ts
@@ -133,7 +133,7 @@ export namespace ServiceListFilters {
       // In the case of health sorting, we may not have all health promises ready yet
       // So we need to get them all before actually sorting
       const allHealthPromises: Promise<WithServiceHealth<ServiceListItem>>[] = services.map(item => {
-        return item.healthPromise.then((health): WithServiceHealth<ServiceListItem> => ({ ...item, ...{ health } }));
+        return item.healthPromise.then((health): WithServiceHealth<ServiceListItem> => ({ ...item, health }));
       });
       return Promise.all(allHealthPromises).then(arr => {
         return arr.sort(isAscending ? sortField.compare : (a, b) => sortField.compare(b, a));

--- a/src/pages/ServiceList/__tests__/ServiceListComponent.test.ts
+++ b/src/pages/ServiceList/__tests__/ServiceListComponent.test.ts
@@ -1,8 +1,8 @@
-import { ServiceHealth, RequestHealth, WithHealth } from '../../../types/Health';
+import { ServiceHealth, RequestHealth, WithServiceHealth } from '../../../types/Health';
 import { ServiceListItem } from '../../../types/ServiceList';
 import { ServiceListFilters } from '../FiltersAndSorts';
 
-const makeService = (name: string, errRatio: number): WithHealth<ServiceListItem> => {
+const makeService = (name: string, errRatio: number): WithServiceHealth<ServiceListItem> => {
   const reqErrs: RequestHealth = { errorRatio: errRatio, inboundErrorRatio: errRatio, outboundErrorRatio: -1 };
   const health = new ServiceHealth(reqErrs, { rateInterval: 60, hasSidecar: true });
 

--- a/src/pages/ServiceList/__tests__/ServiceListComponent.test.ts
+++ b/src/pages/ServiceList/__tests__/ServiceListComponent.test.ts
@@ -1,15 +1,15 @@
+import { ServiceHealth, RequestHealth, WithHealth } from '../../../types/Health';
 import { ServiceListItem } from '../../../types/ServiceList';
-import { ServiceHealth, RequestHealth } from '../../../types/Health';
 import { ServiceListFilters } from '../FiltersAndSorts';
 
-const makeService = (name: string, errRatio: number): ServiceListItem & { health: ServiceHealth } => {
+const makeService = (name: string, errRatio: number): WithHealth<ServiceListItem> => {
   const reqErrs: RequestHealth = { errorRatio: errRatio, inboundErrorRatio: errRatio, outboundErrorRatio: -1 };
+  const health = new ServiceHealth(reqErrs, { rateInterval: 60, hasSidecar: true });
+
   return {
     name: name,
-    health: new ServiceHealth(reqErrs, { rateInterval: 60, hasSidecar: true })
-  } as ServiceListItem & {
-    health: ServiceHealth;
-  };
+    health: health
+  } as any;
 };
 
 describe('SortField#compare', () => {

--- a/src/pages/WorkloadList/FiltersAndSorts.ts
+++ b/src/pages/WorkloadList/FiltersAndSorts.ts
@@ -266,7 +266,7 @@ export namespace WorkloadListFilters {
       // In the case of health sorting, we may not have all health promises ready yet
       // So we need to get them all before actually sorting
       const allHealthPromises: Promise<WithWorkloadHealth<WorkloadListItem>>[] = unsorted.map(item => {
-        return item.healthPromise.then((health): WithWorkloadHealth<WorkloadListItem> => ({ ...item, ...{ health } }));
+        return item.healthPromise.then((health): WithWorkloadHealth<WorkloadListItem> => ({ ...item, health }));
       });
       return Promise.all(allHealthPromises).then(arr => {
         return arr.sort(isAscending ? sortField.compare : (a, b) => sortField.compare(b, a));

--- a/src/types/Health.ts
+++ b/src/types/Health.ts
@@ -151,9 +151,7 @@ export const getRequestErrorsViolations = (reqIn: ThresholdStatus, reqOut: Thres
 };
 
 export abstract class Health {
-  items: HealthItem[];
-
-  constructor(items: HealthItem[]) {
+  constructor(public items: HealthItem[], public requests: RequestHealth, public ctx: HealthContext) {
     this.items = items;
   }
 
@@ -195,9 +193,12 @@ export class ServiceHealth extends Health {
   }
 
   constructor(public requests: RequestHealth, public ctx: HealthContext) {
-    super(ServiceHealth.computeItems(requests, ctx));
+    super(ServiceHealth.computeItems(requests, ctx), requests, ctx);
   }
 }
+
+export type WithHealth<T> = T & { health: Health };
+export const hasHealth = <T extends unknown>(val: T): val is WithHealth<T> => Object.hasOwnProperty('health');
 
 export class AppHealth extends Health {
   public static fromJson = (json: any, ctx: HealthContext) => new AppHealth(json.workloadStatuses, json.requests, ctx);
@@ -251,7 +252,7 @@ export class AppHealth extends Health {
   }
 
   constructor(public workloadStatuses: WorkloadStatus[], public requests: RequestHealth, public ctx: HealthContext) {
-    super(AppHealth.computeItems(workloadStatuses, requests, ctx));
+    super(AppHealth.computeItems(workloadStatuses, requests, ctx), requests, ctx);
   }
 }
 
@@ -319,7 +320,7 @@ export class WorkloadHealth extends Health {
   }
 
   constructor(public workloadStatus: WorkloadStatus, public requests: RequestHealth, public ctx: HealthContext) {
-    super(WorkloadHealth.computeItems(workloadStatus, requests, ctx));
+    super(WorkloadHealth.computeItems(workloadStatus, requests, ctx), requests, ctx);
   }
 }
 

--- a/src/types/Health.ts
+++ b/src/types/Health.ts
@@ -151,9 +151,7 @@ export const getRequestErrorsViolations = (reqIn: ThresholdStatus, reqOut: Thres
 };
 
 export abstract class Health {
-  constructor(public items: HealthItem[], public requests: RequestHealth, public ctx: HealthContext) {
-    this.items = items;
-  }
+  constructor(public items: HealthItem[]) {}
 
   getGlobalStatus(): Status {
     return this.items.map(i => i.status).reduce((prev, cur) => mergeStatus(prev, cur), NA);
@@ -192,13 +190,10 @@ export class ServiceHealth extends Health {
     return items;
   }
 
-  constructor(public requests: RequestHealth, public ctx: HealthContext) {
-    super(ServiceHealth.computeItems(requests, ctx), requests, ctx);
+  constructor(public requests: RequestHealth, ctx: HealthContext) {
+    super(ServiceHealth.computeItems(requests, ctx));
   }
 }
-
-export type WithHealth<T> = T & { health: Health };
-export const hasHealth = <T extends unknown>(val: T): val is WithHealth<T> => Object.hasOwnProperty('health');
 
 export class AppHealth extends Health {
   public static fromJson = (json: any, ctx: HealthContext) => new AppHealth(json.workloadStatuses, json.requests, ctx);
@@ -251,8 +246,8 @@ export class AppHealth extends Health {
     return items;
   }
 
-  constructor(public workloadStatuses: WorkloadStatus[], public requests: RequestHealth, public ctx: HealthContext) {
-    super(AppHealth.computeItems(workloadStatuses, requests, ctx), requests, ctx);
+  constructor(workloadStatuses: WorkloadStatus[], public requests: RequestHealth, ctx: HealthContext) {
+    super(AppHealth.computeItems(workloadStatuses, requests, ctx));
   }
 }
 
@@ -319,8 +314,8 @@ export class WorkloadHealth extends Health {
     return items;
   }
 
-  constructor(public workloadStatus: WorkloadStatus, public requests: RequestHealth, public ctx: HealthContext) {
-    super(WorkloadHealth.computeItems(workloadStatus, requests, ctx), requests, ctx);
+  constructor(workloadStatus: WorkloadStatus, public requests: RequestHealth, ctx: HealthContext) {
+    super(WorkloadHealth.computeItems(workloadStatus, requests, ctx));
   }
 }
 
@@ -335,3 +330,7 @@ export const healthNotAvailable = (): AppHealth => {
 export type NamespaceAppHealth = { [app: string]: AppHealth };
 export type NamespaceServiceHealth = { [service: string]: ServiceHealth };
 export type NamespaceWorkloadHealth = { [workload: string]: WorkloadHealth };
+
+export type WithAppHealth<T> = T & { health: AppHealth };
+export type WithServiceHealth<T> = T & { health: ServiceHealth };
+export type WithWorkloadHealth<T> = T & { health: WorkloadHealth };


### PR DESCRIPTION
Typescript has no way to know if the item has the health attribute or
not. Before, it just defaulted to any, but when we start using babel, it
becomes a compilation error.

This is one of those cases where the current implementation is incorrect
and only worked because it downcasted it to `any`.