### PR TITLE
KIALI-2529 Fix compilation error

### DIFF
--- a/src/pages/Overview/OverviewCardContentExpanded.tsx
+++ b/src/pages/Overview/OverviewCardContentExpanded.tsx
@@ -136,7 +136,7 @@ class OverviewCardContentExpanded extends React.Component<Props> {
         <>
           {'Traffic, ' + getName(this.props.duration).toLowerCase()}
           <SparklineChart
-            id={'card-sparkline-' + name}
+            id={'card-sparkline-' + this.props.name}
             data={{ x: 'x', columns: graphUtils.toC3Columns(this.props.metrics, 'RPS'), type: 'area' }}
             tooltip={{}}
             axis={{


### PR DESCRIPTION
This should not compile before, and it does not after the update to `react-scripts`, and to be honest I have no idea if that has even worked at all. Either way, this PR fixes it.