### PR TITLE
KIALI-1717 Overview default sort from namespace name to health (aka status)

### DIFF
--- a/src/pages/Overview/Sorts.ts
+++ b/src/pages/Overview/Sorts.ts
@@ -5,7 +5,7 @@ export namespace Sorts {
   export const sortFields: SortField<NamespaceInfo>[] = [
     {
       id: 'health',
-      title: 'Status',
+      title: 'Health',
       isNumeric: false,
       param: 'h',
       compare: (a: NamespaceInfo, b: NamespaceInfo) => {
@@ -15,6 +15,10 @@ export namespace Sorts {
             return diff;
           }
           diff = b.status.inWarning.length - a.status.inWarning.length;
+          if (diff !== 0) {
+            return diff;
+          }
+          diff = b.status.inSuccess.length - a.status.inSuccess.length;
           if (diff !== 0) {
             return diff;
           }

--- a/src/pages/Overview/Sorts.ts
+++ b/src/pages/Overview/Sorts.ts
@@ -4,13 +4,6 @@ import NamespaceInfo from './NamespaceInfo';
 export namespace Sorts {
   export const sortFields: SortField<NamespaceInfo>[] = [
     {
-      id: 'namespace',
-      title: 'Name',
-      isNumeric: false,
-      param: 'ns',
-      compare: (a: NamespaceInfo, b: NamespaceInfo) => a.name.localeCompare(b.name)
-    },
-    {
       id: 'health',
       title: 'Status',
       isNumeric: false,
@@ -33,6 +26,13 @@ export namespace Sorts {
         // default comparison fallback
         return a.name.localeCompare(b.name);
       }
+    },
+    {
+      id: 'namespace',
+      title: 'Name',
+      isNumeric: false,
+      param: 'ns',
+      compare: (a: NamespaceInfo, b: NamespaceInfo) => a.name.localeCompare(b.name)
     },
     {
       id: 'mtls',


### PR DESCRIPTION
Now, by default, the most unhealthy namespace cards should appear first.  Note that the URL will trump the default, so when testing ensure the URL 'sort' or 'direction' params are not overriding the default.

@jotak Any reason this sort field is called 'status' and not 'health' ?