### PR TITLE
KIALI-3002 Fix Handlebars subpackages CVE with version < 4.0.14.

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
   },
   "resolutions": {
     "@types/react": "16.7.13",
+    "handlebars": "4.0.14",
     "js-yaml": "3.13.1"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4931,10 +4931,10 @@ handle-thing@^1.2.5:
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-1.2.5.tgz#fd7aad726bf1a5fd16dfc29b2f7a6601d27139c4"
   integrity sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ=
 
-handlebars@^4.0.3:
-  version "4.0.12"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.12.tgz#2c15c8a96d46da5e266700518ba8cb8d919d5bc5"
-  integrity sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==
+handlebars@4.0.14, handlebars@^4.0.3:
+  version "4.0.14"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.14.tgz#88de711eb693a5b783ae06065f9b91b0dd373a71"
+  integrity sha512-E7tDoyAA8ilZIV3xDJgl18sX3M8xB9/fMw8+mfW4msLW8jlX97bAnWgT3pmaNXuvzIEgSBMnAHfuXsB2hdzfow==
   dependencies:
     async "^2.5.0"
     optimist "^0.6.1"


### PR DESCRIPTION
** Describe the change **
Fix a CVE with handlebars version < 4.0.14

WS-2019-0064 More information
high severity
Vulnerable versions: < 4.0.14
Patched version: 4.0.14
Versions of handlebars prior to 4.0.14 are vulnerable to Prototype Pollution. Templates may alter an Objects' prototype, thus allowing an attacker to execute arbitrary code on the server.

![Security_Alerts_·_kiali_kiali-ui](https://user-images.githubusercontent.com/1312165/59290403-52ad0b00-8c2d-11e9-8f5f-59d60f40e251.jpg)


** Issue reference **
https://issues.jboss.org/browse/KIALI-3002


** Backwards compatible? **
Yes
[ ] Is your pull-request introducing changes in behaviour?
No

** Documentation **

See https://github.com/wycats/handlebars.js/compare/v4.1.1...v4.1.2

