### PR TITLE
KIALI-3005 Hide nodes with only hidden edges

### DIFF
--- a/src/components/GraphFilter/GraphFind.tsx
+++ b/src/components/GraphFilter/GraphFind.tsx
@@ -261,7 +261,13 @@ export class GraphFind extends React.PureComponent<GraphFindProps, GraphFindStat
     if (selector) {
       // select the new hide-hits
       this.hiddenElements = cy.$(selector);
+      // add the edges connected to hidden nodes
       this.hiddenElements = this.hiddenElements.add(this.hiddenElements.connectedEdges());
+      // add nodes with only hidden edges (keep unused nodes as that is an explicit option)
+      const visibleElements = this.hiddenElements.absoluteComplement();
+      const nodesWithVisibleEdges = visibleElements.edges().connectedNodes();
+      const nodesWithOnlyHiddenEdges = visibleElements.nodes(`[^${CyNode.isUnused}]`).subtract(nodesWithVisibleEdges);
+      this.hiddenElements = this.hiddenElements.add(nodesWithOnlyHiddenEdges);
       // remove any appbox hits, we only hide empty appboxes
       this.hiddenElements = this.hiddenElements.subtract(this.hiddenElements.filter('$node[isGroup]'));
       // set the remaining hide-hits hidden

--- a/src/pages/Graph/GraphHelpFind.tsx
+++ b/src/pages/Graph/GraphHelpFind.tsx
@@ -209,17 +209,16 @@ export default class GraphHelpFind extends React.Component<GraphHelpFindProps> {
     });
     const prefaceStyle = style({
       width: '100%',
-      height: '105px',
+      height: '75px',
       padding: '10px',
-      resize: 'vertical',
+      resize: 'none',
       color: '#fff',
       backgroundColor: '#003145'
     });
     const preface =
       'You can use the Find and Hide fields to highlight or hide edges and nodes from the graph. Each field ' +
       'accepts text expressions using the language described below. Hide takes precedence when using Find and ' +
-      'Hide together. To get started click the "Examples" tab. Click "Usage Notes" for restrictions and tips. ' +
-      'The other tabs provide details about the full set of node and edge operands, as well as operators.';
+      'Hide together. Hide maintains the layout, it does not reposition the remaining graph elements.';
 
     return (
       <Draggable handle="#helpheader" bounds="#root">
@@ -294,6 +293,14 @@ export default class GraphHelpFind extends React.Component<GraphHelpFindProps> {
                             id: 't90',
                             t:
                               'Abbrevations: circuitbreaker|cb, responsetime|rt, serviceentry->se, sidecar|sc, virtualservice|vs'
+                          },
+                          {
+                            id: 't100',
+                            t: 'Hiding nodes will automatically hide connected edges.'
+                          },
+                          {
+                            id: 't110',
+                            t: 'Hiding edges will automatically hide nodes left with no visible edges.'
                           }
                         ]}
                       />


### PR DESCRIPTION
Here is an example of the change. I have bookinfo and istio-system and I hide the GRPC traffic edges:

Before:
![image](https://user-images.githubusercontent.com/2104052/59284808-e6390880-8c3a-11e9-9989-1139dd329d74.png)
After:
![image](https://user-images.githubusercontent.com/2104052/59287050-e2a78080-8c3e-11e9-870c-923c00b6174c.png)

