### PR TITLE
KIALI-3008 Adds Router to cytoscape context menu

### DIFF
--- a/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
+++ b/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { NodeContextMenuProps } from '../CytoscapeContextMenu';
 import { JaegerSearchOptions, JaegerURLSearch } from '../../JaegerIntegration/RouteHelper';
-import history from '../../../app/History';
 import { Paths } from '../../../config';
 import { style } from 'typestyle';
 import { KialiAppState } from '../../../store/Store';
 import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
 
 type ReduxProps = {
   jaegerIntegration: boolean;
@@ -94,12 +94,17 @@ export class NodeContextMenu extends React.PureComponent<Props> {
     return tracesUrl;
   }
 
-  createMenuItem(href: string, title: string, target: string = '_self') {
+  createMenuItem(href: string, title: string, target: string = '_self', external: boolean = false) {
+    const commonLinkProps = {
+      className: graphContextMenuItemLinkStyle,
+      children: title,
+      onClick: this.onClick,
+      target
+    };
+
     return (
       <div className={graphContextMenuItemStyle}>
-        <a onClick={this.redirectContextLink} className={graphContextMenuItemLinkStyle} target={target} href={href}>
-          {title}
-        </a>
+        {external ? <a href={href} {...commonLinkProps} /> : <Link to={href} {...commonLinkProps} />}
       </div>
     );
   }
@@ -132,23 +137,15 @@ export class NodeContextMenu extends React.PureComponent<Props> {
           this.createMenuItem(
             this.getJaegerURL(name),
             'Show Traces',
-            this.props.jaegerIntegration ? '_self' : '_blank'
+            this.props.jaegerIntegration ? '_self' : '_blank',
+            !this.props.jaegerIntegration
           )}
       </div>
     );
   }
 
-  private redirectContextLink = (e: React.MouseEvent<HTMLAnchorElement>) => {
-    if (e.target) {
-      const anchor = e.target as HTMLAnchorElement;
-      const href = anchor.getAttribute('href');
-      const newTab = anchor.getAttribute('target') === '_blank';
-      if (href && !newTab) {
-        e.preventDefault();
-        this.props.contextMenu.hide(0);
-        history.push(href);
-      }
-    }
+  private onClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    this.props.contextMenu.hide(0);
   };
 }
 

--- a/src/components/CytoscapeGraph/CytoscapeContextMenu.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeContextMenu.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
+import { Router } from 'react-router';
 import tippy, { Instance } from 'tippy.js';
 import { DecoratedGraphEdgeData, DecoratedGraphNodeData } from '../../types/Graph';
 import { Provider } from 'react-redux';
 import { store } from '../../store/ConfigStore';
+import history from '../../app/History';
 
 type Props = {
   groupContextMenuContent?: NodeContextMenuType;
@@ -151,7 +153,9 @@ export class CytoscapeContextMenuWrapper extends React.PureComponent<Props> {
 
     ReactDOM.render(
       <Provider store={store}>
-        <ContextMenuComponentClass element={target} contextMenu={tippyInstance} {...target.data()} />
+        <Router history={history}>
+          <ContextMenuComponentClass element={target} contextMenu={tippyInstance} {...target.data()} />
+        </Router>
       </Provider>,
       content,
       () => {


### PR DESCRIPTION
** Describe the change **

This allows to use `Link` in the context menu.

KIALI-3008 Links from graph's context menu yield 404 when open in new window/tab

** Screenshot **

No UI changes
