### PR TITLE
Graph toolbar truncated on chrome

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeToolbar.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeToolbar.tsx
@@ -31,6 +31,7 @@ type CytoscapeToolbarProps = ReduxProps & {
 };
 
 const cytoscapeToolbarStyle = style({
+  marginBottom: '15px',
   padding: '7px 10px',
   borderWidth: '1px',
   borderStyle: 'solid',


### PR DESCRIPTION
** Describe the change **
Fixes some weird truncation issues with the graph toolbar that happen on Chrome on smaller screens.

** Issue reference **

https://issues.jboss.org/browse/KIALI-2743


** Backwards compatible? **
Yes
[ ] Is your pull-request introducing changes in behaviour?
No

** Screenshot **

Before:

![bad-toolbar](https://user-images.githubusercontent.com/1312165/59470965-53d96600-8dee-11e9-9b4a-0e9668694423.jpg)

After:

![toolbar-good](https://user-images.githubusercontent.com/1312165/59470413-723e6200-8dec-11e9-8818-d7957f8735c3.jpg)

