### PR TITLE
KIALI-3028 Allow DestinationRules without subset.labels

### DIFF
--- a/src/pages/IstioConfigDetails/IstioObjectDetails/DestinationRuleDetail.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/DestinationRuleDetail.tsx
@@ -101,9 +101,9 @@ class DestinationRuleDetail extends React.Component<DestinationRuleProps> {
     return subsets.map((subset, vsIdx) => ({
       id: vsIdx,
       name: subset.name,
-      labelSubset: Object.keys(subset.labels).map((key, _) => (
-        <Label key={key} name={key} value={subset.labels[key]} />
-      )),
+      labelSubset: subset.labels
+        ? Object.keys(subset.labels).map((key, _) => <Label key={key} name={key} value={subset.labels[key]} />)
+        : [],
       trafficPolicy: <DetailObject name={subset.trafficPolicy ? 'trafficPolicy' : ''} detail={subset.trafficPolicy} />
     }));
   }


### PR DESCRIPTION
When a DestinationRule has a subset but no labels, the DestinationRuleDetail page fails, testing to check if subset.labels is defined fixes the problem.

** Issue reference **
https://issues.jboss.org/browse/KIALI-3028