### PR TITLE
Fix compilation problem with list filter items with health data

### DIFF
--- a/src/pages/AppList/FiltersAndSorts.ts
+++ b/src/pages/AppList/FiltersAndSorts.ts
@@ -1,6 +1,6 @@
 import { ActiveFilter, FILTER_ACTION_APPEND, FilterType } from '../../types/Filters';
 import { AppListItem } from '../../types/AppList';
-import { SortField } from '../../types/SortFilters';
+import { GenericSortField, HealthSortField } from '../../types/SortFilters';
 import { getRequestErrorsStatus, WithAppHealth } from '../../types/Health';
 import {
   istioSidecarFilter,
@@ -10,13 +10,13 @@ import {
   filterByHealth
 } from '../../components/Filters/CommonFilters';
 
-export const sortFields: SortField<AppListItem>[] = [
+export const sortFields: GenericSortField<AppListItem>[] = [
   {
     id: 'namespace',
     title: 'Namespace',
     isNumeric: false,
     param: 'ns',
-    compare: (a: AppListItem, b: AppListItem) => {
+    compare: (a, b) => {
       let sortValue = a.namespace.localeCompare(b.namespace);
       if (sortValue === 0) {
         sortValue = a.name.localeCompare(b.name);
@@ -29,14 +29,14 @@ export const sortFields: SortField<AppListItem>[] = [
     title: 'App Name',
     isNumeric: false,
     param: 'wn',
-    compare: (a: AppListItem, b: AppListItem) => a.name.localeCompare(b.name)
+    compare: (a, b) => a.name.localeCompare(b.name)
   },
   {
     id: 'istiosidecar',
     title: 'IstioSidecar',
     isNumeric: false,
     param: 'is',
-    compare: (a: AppListItem, b: AppListItem) => {
+    compare: (a, b) => {
       if (a.istioSidecar && !b.istioSidecar) {
         return -1;
       } else if (!a.istioSidecar && b.istioSidecar) {
@@ -64,7 +64,7 @@ export const sortFields: SortField<AppListItem>[] = [
 
       return statusForB.priority - statusForA.priority;
     }
-  }
+  } as HealthSortField<AppListItem>
 ];
 
 const appNameFilter: FilterType = {
@@ -125,7 +125,7 @@ export const filterBy = (appsList: AppListItem[], filters: ActiveFilter[]): Prom
 
 export const sortAppsItems = (
   unsorted: AppListItem[],
-  sortField: SortField<AppListItem>,
+  sortField: GenericSortField<AppListItem>,
   isAscending: boolean
 ): Promise<AppListItem[]> => {
   if (sortField.title === 'Health') {

--- a/src/pages/ServiceList/FiltersAndSorts.ts
+++ b/src/pages/ServiceList/FiltersAndSorts.ts
@@ -1,7 +1,7 @@
 import { ActiveFilter, FilterType, FILTER_ACTION_APPEND } from '../../types/Filters';
 import { getRequestErrorsStatus, WithServiceHealth } from '../../types/Health';
 import { ServiceListItem } from '../../types/ServiceList';
-import { SortField } from '../../types/SortFilters';
+import { GenericSortField, HealthSortField } from '../../types/SortFilters';
 import {
   istioSidecarFilter,
   healthFilter,
@@ -10,13 +10,13 @@ import {
   filterByHealth
 } from '../../components/Filters/CommonFilters';
 
-export const sortFields: SortField<ServiceListItem>[] = [
+export const sortFields: GenericSortField<ServiceListItem>[] = [
   {
     id: 'namespace',
     title: 'Namespace',
     isNumeric: false,
     param: 'ns',
-    compare: (a: ServiceListItem, b: ServiceListItem) => {
+    compare: (a, b) => {
       let sortValue = a.namespace.localeCompare(b.namespace);
       if (sortValue === 0) {
         sortValue = a.name.localeCompare(b.name);
@@ -29,14 +29,14 @@ export const sortFields: SortField<ServiceListItem>[] = [
     title: 'Service Name',
     isNumeric: false,
     param: 'sn',
-    compare: (a: ServiceListItem, b: ServiceListItem) => a.name.localeCompare(b.name)
+    compare: (a, b) => a.name.localeCompare(b.name)
   },
   {
     id: 'istiosidecar',
     title: 'Istio Sidecar',
     isNumeric: false,
     param: 'is',
-    compare: (a: ServiceListItem, b: ServiceListItem) => {
+    compare: (a, b) => {
       if (a.istioSidecar && !b.istioSidecar) {
         return -1;
       } else if (!a.istioSidecar && b.istioSidecar) {
@@ -64,7 +64,7 @@ export const sortFields: SortField<ServiceListItem>[] = [
 
       return statusForB.priority - statusForA.priority;
     }
-  }
+  } as HealthSortField<ServiceListItem>
 ];
 
 const serviceNameFilter: FilterType = {
@@ -125,7 +125,7 @@ export const filterBy = (
 // Exported for test
 export const sortServices = (
   services: ServiceListItem[],
-  sortField: SortField<ServiceListItem>,
+  sortField: GenericSortField<ServiceListItem>,
   isAscending: boolean
 ): Promise<ServiceListItem[]> => {
   if (sortField.title === 'Health') {

--- a/src/pages/WorkloadList/FiltersAndSorts.ts
+++ b/src/pages/WorkloadList/FiltersAndSorts.ts
@@ -1,6 +1,6 @@
 import { ActiveFilter, FILTER_ACTION_APPEND, FILTER_ACTION_UPDATE, FilterType } from '../../types/Filters';
 import { WorkloadListItem, WorkloadType } from '../../types/Workload';
-import { SortField } from '../../types/SortFilters';
+import { GenericSortField, HealthSortField } from '../../types/SortFilters';
 import { getRequestErrorsStatus, WithWorkloadHealth } from '../../types/Health';
 import {
   presenceValues,
@@ -11,13 +11,13 @@ import {
   filterByHealth
 } from '../../components/Filters/CommonFilters';
 
-export const sortFields: SortField<WorkloadListItem>[] = [
+export const sortFields: GenericSortField<WorkloadListItem>[] = [
   {
     id: 'namespace',
     title: 'Namespace',
     isNumeric: false,
     param: 'ns',
-    compare: (a: WorkloadListItem, b: WorkloadListItem) => {
+    compare: (a, b) => {
       let sortValue = a.namespace.localeCompare(b.namespace);
       if (sortValue === 0) {
         sortValue = a.workload.name.localeCompare(b.workload.name);
@@ -30,21 +30,21 @@ export const sortFields: SortField<WorkloadListItem>[] = [
     title: 'Workload Name',
     isNumeric: false,
     param: 'wn',
-    compare: (a: WorkloadListItem, b: WorkloadListItem) => a.workload.name.localeCompare(b.workload.name)
+    compare: (a, b) => a.workload.name.localeCompare(b.workload.name)
   },
   {
     id: 'workloadtype',
     title: 'Workload Type',
     isNumeric: false,
     param: 'wt',
-    compare: (a: WorkloadListItem, b: WorkloadListItem) => a.workload.type.localeCompare(b.workload.type)
+    compare: (a, b) => a.workload.type.localeCompare(b.workload.type)
   },
   {
     id: 'istiosidecar',
     title: 'IstioSidecar',
     isNumeric: false,
     param: 'is',
-    compare: (a: WorkloadListItem, b: WorkloadListItem) => {
+    compare: (a, b) => {
       if (a.workload.istioSidecar && !b.workload.istioSidecar) {
         return -1;
       } else if (!a.workload.istioSidecar && b.workload.istioSidecar) {
@@ -59,7 +59,7 @@ export const sortFields: SortField<WorkloadListItem>[] = [
     title: 'App Label',
     isNumeric: false,
     param: 'al',
-    compare: (a: WorkloadListItem, b: WorkloadListItem) => {
+    compare: (a, b) => {
       if (a.workload.appLabel && !b.workload.appLabel) {
         return -1;
       } else if (!a.workload.appLabel && b.workload.appLabel) {
@@ -74,7 +74,7 @@ export const sortFields: SortField<WorkloadListItem>[] = [
     title: 'Version Label',
     isNumeric: false,
     param: 'vl',
-    compare: (a: WorkloadListItem, b: WorkloadListItem) => {
+    compare: (a, b) => {
       if (a.workload.versionLabel && !b.workload.versionLabel) {
         return -1;
       } else if (!a.workload.versionLabel && b.workload.versionLabel) {
@@ -102,7 +102,7 @@ export const sortFields: SortField<WorkloadListItem>[] = [
 
       return statusForB.priority - statusForA.priority;
     }
-  }
+  } as HealthSortField<WorkloadListItem>
 ];
 
 const workloadNameFilter: FilterType = {
@@ -258,7 +258,7 @@ export const filterBy = (
 
 export const sortWorkloadsItems = (
   unsorted: WorkloadListItem[],
-  sortField: SortField<WorkloadListItem>,
+  sortField: GenericSortField<WorkloadListItem>,
   isAscending: boolean
 ): Promise<WorkloadListItem[]> => {
   if (sortField.title === 'Health') {

--- a/src/types/SortFilters.ts
+++ b/src/types/SortFilters.ts
@@ -1,7 +1,12 @@
+import { Health } from '../types/Health';
+
 export interface SortField<T> {
   id: string;
   title: string;
   isNumeric: boolean;
   param: string;
-  compare: (a: T, b: T) => number;
+  compare: <A extends T>(a: A, b: A) => number;
 }
+
+export type HealthSortField<T> = SortField<T & { health: typeof Health }>;
+export type GenericSortField<T> = SortField<T> | HealthSortField<T>;


### PR DESCRIPTION
The problem happens because some of the sort fields require health data,
while others do not. This is by design, but we need a way to make the
compiler understand what is happening.

This is a follow-up for #1240 with the fixes I've found after trying to get master again to update to `react-scripts`.