### PR TITLE
Remove snyk from the dependency install script

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,8 +56,7 @@
     "snyk": "snyk test",
     "analyze": "source-map-explorer build/static/js/main.*",
     "prettier": "prettier --write \"{src/**/*.{js,jsx,ts,tsx,json,yml,css,scss},travis.yml,*.json}\"",
-    "snyk-protect": "snyk protect",
-    "prepublish": "npm run snyk-protect"
+    "snyk-protect": "snyk protect"
   },
   "dependencies": {
     "@patternfly/patternfly": "2.4.1",


### PR DESCRIPTION
Snyk does not work properly [on my machine][1] because of an issue that has [been known][2] by the developers for months, and that [fails our CI process][3] with cryptic messages that do not help, while also increasing a lot the time for the build to run (timed it at up to 1 minute per build, but could not find a way to time this correctly because it runs as a part of the install script).

It still is installed and can be run, just won't run anymore when you run `yarn install`.

[1]: https://gist.github.com/cfcosta/edb0c69b5bcd01e7dfa433c29bde8312
[2]: https://github.com/snyk/snyk/issues/445
[3]: https://travis-ci.org/kiali/kiali-ui/builds/547395925?utm_source=github_status&utm_medium=notification