### PR TITLE
KIALI-3035 Code-splitting for main navigation components

### DIFF
--- a/src/components/Nav/RenderPage.tsx
+++ b/src/components/Nav/RenderPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import { Redirect, Route } from 'react-router-dom';
 import SwitchErrorBoundary from '../SwitchErrorBoundary/SwitchErrorBoundary';
 import { pathRoutes, defaultRoute, secondaryMastheadRoutes } from '../../routes';
@@ -25,12 +25,16 @@ class RenderPage extends React.Component<{ needScroll: boolean }> {
   render() {
     const component = (
       <div className={`container-fluid ${containerStyle}`}>
-        <SwitchErrorBoundary
-          fallBackComponent={() => <h2>Sorry, there was a problem. Try a refresh or navigate to a different page.</h2>}
-        >
-          {this.renderPathRoutes()}
-          <Redirect from="/" to={defaultRoute} />
-        </SwitchErrorBoundary>
+        <Suspense fallback={<div>Loading...</div>}>
+          <SwitchErrorBoundary
+            fallBackComponent={() => (
+              <h2>Sorry, there was a problem. Try a refresh or navigate to a different page.</h2>
+            )}
+          >
+            {this.renderPathRoutes()}
+            <Redirect from="/" to={defaultRoute} />
+          </SwitchErrorBoundary>
+        </Suspense>
       </div>
     );
     return (

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,16 +1,6 @@
-import WorkloadListPage from './pages/WorkloadList/WorkloadListPage';
-import ServiceListPage from './pages/ServiceList/ServiceListPage';
-import IstioConfigPage from './pages/IstioConfigList/IstioConfigListPage';
-import ServiceJaegerPage from './pages/ServiceJaeger/ServiceJaegerPage';
-import IstioConfigDetailsPage from './pages/IstioConfigDetails/IstioConfigDetailsPage';
-import WorkloadDetailsPage from './pages/WorkloadDetails/WorkloadDetailsPage';
-import AppListPage from './pages/AppList/AppListPage';
-import AppDetailsPage from './pages/AppDetails/AppDetailsPage';
-import OverviewPageContainer from './pages/Overview/OverviewPage';
+import { lazy } from 'react';
 import { MenuItem, Path } from './types/Routes';
-import GraphPageContainer from './pages/Graph/GraphPage';
 import { icons, Paths } from './config';
-import ServiceDetailsPageContainer from './pages/ServiceDetails/ServiceDetailsPage';
 import DefaultSecondaryMasthead from './components/DefaultSecondaryMasthead/DefaultSecondaryMasthead';
 
 /**
@@ -63,71 +53,74 @@ const navItems: MenuItem[] = [
 
 const defaultRoute = '/overview';
 
+const graphPage = lazy(() => import('./pages/Graph/GraphPage'));
+const istioConfigDetailsPage = lazy(() => import('./pages/IstioConfigDetails/IstioConfigDetailsPage'));
+
 const pathRoutes: Path[] = [
   {
     path: '/overview',
-    component: OverviewPageContainer
+    component: lazy(() => import('./pages/Overview/OverviewPage'))
   },
   {
     path: '/graph/node/namespaces/:namespace/' + Paths.APPLICATIONS + '/:app/versions/:version',
-    component: GraphPageContainer
+    component: graphPage
   },
   {
     path: '/graph/node/namespaces/:namespace/' + Paths.APPLICATIONS + '/:app',
-    component: GraphPageContainer
+    component: graphPage
   },
   {
     path: '/graph/node/namespaces/:namespace/' + Paths.SERVICES + '/:service',
-    component: GraphPageContainer
+    component: graphPage
   },
   {
     path: '/graph/node/namespaces/:namespace/' + Paths.WORKLOADS + '/:workload',
-    component: GraphPageContainer
+    component: graphPage
   },
   {
     path: '/graph/namespaces',
-    component: GraphPageContainer
+    component: graphPage
   },
   {
     path: '/namespaces/:namespace/' + Paths.SERVICES + '/:service',
-    component: ServiceDetailsPageContainer
+    component: lazy(() => import('./pages/ServiceDetails/ServiceDetailsPage'))
   },
   // NOTE that order on routes is important
   {
     path: '/namespaces/:namespace/' + Paths.ISTIO + '/:objectType/:objectSubtype/:object',
-    component: IstioConfigDetailsPage
+    component: istioConfigDetailsPage
   },
   {
     path: '/namespaces/:namespace/' + Paths.ISTIO + '/:objectType/:object',
-    component: IstioConfigDetailsPage
+    component: istioConfigDetailsPage
   },
   {
     path: '/' + Paths.SERVICES,
-    component: ServiceListPage
+    component: lazy(() => import('./pages/ServiceList/ServiceListPage'))
   },
   {
     path: '/' + Paths.APPLICATIONS,
-    component: AppListPage
+    component: lazy(() => import('./pages/AppList/AppListPage'))
   },
   {
     path: '/namespaces/:namespace/' + Paths.APPLICATIONS + '/:app',
-    component: AppDetailsPage
+    component: lazy(() => import('./pages/AppDetails/AppDetailsPage'))
   },
   {
     path: '/' + Paths.WORKLOADS,
-    component: WorkloadListPage
+    component: lazy(() => import('./pages/WorkloadList/WorkloadListPage'))
   },
   {
     path: '/namespaces/:namespace/' + Paths.WORKLOADS + '/:workload',
-    component: WorkloadDetailsPage
+    component: lazy(() => import('./pages/WorkloadDetails/WorkloadDetailsPage'))
   },
   {
     path: '/' + Paths.ISTIO,
-    component: IstioConfigPage
+    component: lazy(() => import('./pages/IstioConfigList/IstioConfigListPage'))
   },
   {
     path: '/' + Paths.JAEGER,
-    component: ServiceJaegerPage
+    component: lazy(() => import('./pages/ServiceJaeger/ServiceJaegerPage'))
   }
 ];
 


### PR DESCRIPTION
Before code-splitting, build reports these sizes:

```
File sizes after gzip:

  1.35 MB (+555.98 KB)  build/static/js/main.86522805.js
  165.32 KB (+460 B)    build/static/css/main.1734869f.css
```

After code-splitting, build reports these sizes:

```
File sizes after gzip:

  828.63 KB (-7 B)  build/static/js/main.158c81c6.js
  239.87 KB         build/static/js/3.08cdbb49.chunk.js
  177.84 KB         build/static/js/4.5d409cea.chunk.js
  164.87 KB         build/static/css/main.7eaa2ccd.css
  135.46 KB         build/static/js/0.fe2dc93f.chunk.js
  115.75 KB         build/static/js/1.5419a62c.chunk.js
  109.91 KB         build/static/js/2.40757215.chunk.js
  8.83 KB           build/static/js/5.b70775d6.chunk.js
  7.91 KB           build/static/js/6.2642d802.chunk.js
  7.48 KB           build/static/js/7.2ff671c9.chunk.js
  7.07 KB           build/static/js/10.b29f83f1.chunk.js
  6.96 KB           build/static/js/8.d1a01ffb.chunk.js
  5.62 KB           build/static/js/9.e62e27ca.chunk.js
```