### PR TITLE
KIALI-3053 Adds a scrollbar when needed when listing too many namespaces

### DIFF
--- a/src/components/BoundingClientAwareComponent/BoundingClientAwareComponent.tsx
+++ b/src/components/BoundingClientAwareComponent/BoundingClientAwareComponent.tsx
@@ -1,0 +1,90 @@
+import * as React from 'react';
+
+type Rect = ClientRect | DOMRect;
+
+export enum PropertyType {
+  VIEWPORT_HEIGHT_MINUS_TOP
+}
+
+export type Property = {
+  type: PropertyType;
+  margin?: number;
+};
+
+type ComputeOffsetProps = {
+  className: string;
+  maxHeight?: Property;
+  handleBoundingClientRect?(rect: Rect): void;
+};
+
+type ComputeOffsetState = {
+  maxHeight?: string;
+};
+
+export const vhMinusTop = (rect: Rect, offset: number) => `calc(100vh - ${rect.top + offset}px)`;
+
+// Computes the BoundingClientRect of the container, this helps to calculate the remaining height without
+// going further off the screen and without having to fix the value in the code.
+// Note: This does re-compute when there is a change in this component, but external changes are not yet
+// managed, that might require to observe the offsets, for our current use case this seems OK, as the top
+// headers doesn't change in height.
+export class BoundingClientAwareComponent extends React.Component<ComputeOffsetProps, ComputeOffsetState> {
+  private readonly containerRef: React.RefObject<HTMLDivElement>;
+
+  constructor(props: ComputeOffsetProps) {
+    super(props);
+    this.containerRef = React.createRef<HTMLDivElement>();
+    this.state = {};
+  }
+
+  componentDidMount() {
+    this.handleComponentUpdated();
+  }
+
+  componentDidUpdate() {
+    this.handleComponentUpdated();
+  }
+
+  handleComponentUpdated() {
+    const rect = this.containerRef.current!.getBoundingClientRect();
+
+    const stateUpdate: ComputeOffsetState = {};
+
+    if (this.props.maxHeight) {
+      const updatedValue = this.processProperty(this.props.maxHeight, rect);
+      if (updatedValue !== this.state.maxHeight) {
+        stateUpdate.maxHeight = updatedValue;
+      }
+    }
+
+    if (Object.values(stateUpdate).length > 0) {
+      this.setState(stateUpdate);
+    }
+
+    if (this.props.handleBoundingClientRect) {
+      this.props.handleBoundingClientRect(rect);
+    }
+  }
+
+  render() {
+    const style = {
+      maxHeight: this.state.maxHeight
+    };
+
+    return (
+      <div className={this.props.className} style={style} ref={this.containerRef}>
+        {this.props.children}
+      </div>
+    );
+  }
+
+  private processProperty(property: Property, rect: Rect) {
+    const margin = property.margin ? property.margin : 0;
+    switch (property.type) {
+      case PropertyType.VIEWPORT_HEIGHT_MINUS_TOP:
+        return vhMinusTop(rect, margin);
+      default:
+        throw Error('Undefined property type:' + property.type);
+    }
+  }
+}

--- a/src/components/NamespaceDropdown.tsx
+++ b/src/components/NamespaceDropdown.tsx
@@ -3,15 +3,19 @@ import { connect } from 'react-redux';
 import { ThunkDispatch } from 'redux-thunk';
 import _ from 'lodash';
 import { style } from 'typestyle';
-import { Button, Icon, OverlayTrigger, Popover, FormControl, InputGroup } from 'patternfly-react';
+import { Button, FormControl, Icon, InputGroup, OverlayTrigger, Popover } from 'patternfly-react';
 import { KialiAppState } from '../store/Store';
-import { activeNamespacesSelector, namespaceItemsSelector, namespaceFilterSelector } from '../store/Selectors';
+import { activeNamespacesSelector, namespaceFilterSelector, namespaceItemsSelector } from '../store/Selectors';
 import { KialiAppAction } from '../actions/KialiAppAction';
 import { NamespaceActions } from '../actions/NamespaceAction';
 import NamespaceThunkActions from '../actions/NamespaceThunkActions';
 import Namespace from '../types/Namespace';
 import { PfColors } from './Pf/PfColors';
 import { HistoryManager, URLParam } from '../app/History';
+import {
+  BoundingClientAwareComponent,
+  PropertyType
+} from './BoundingClientAwareComponent/BoundingClientAwareComponent';
 
 const namespaceButtonColors = {
   backgroundColor: PfColors.White,
@@ -39,20 +43,29 @@ const namespaceValueStyle = style({
   fontWeight: 400
 });
 
-interface NamespaceListType {
-  disabled: boolean;
-  filter: string;
+const popoverMarginBottom = 20;
+
+const namespaceContainerStyle = style({
+  overflow: 'overlay'
+});
+
+interface ReduxProps {
   activeNamespaces: Namespace[];
+  filter: string;
   items: Namespace[];
-  toggleNamespace: (namespace: Namespace) => void;
-  setNamespaces: (namespaces: Namespace[]) => void;
-  setFilter: (filter: string) => void;
   refresh: () => void;
+  toggleNamespace: (namespace: Namespace) => void;
+  setFilter: (filter: string) => void;
+  setNamespaces: (namespaces: Namespace[]) => void;
+}
+
+interface NamespaceDropdownProps extends ReduxProps {
+  disabled: boolean;
   clearAll: () => void;
 }
 
-export class NamespaceDropdown extends React.PureComponent<NamespaceListType, {}> {
-  constructor(props: NamespaceListType) {
+export class NamespaceDropdown extends React.PureComponent<NamespaceDropdownProps> {
+  constructor(props: NamespaceDropdownProps) {
     super(props);
   }
 
@@ -61,7 +74,7 @@ export class NamespaceDropdown extends React.PureComponent<NamespaceListType, {}
     this.syncNamespacesURLParam();
   }
 
-  componentDidUpdate(prevProps: NamespaceListType) {
+  componentDidUpdate(prevProps: NamespaceDropdownProps) {
     if (prevProps.activeNamespaces !== this.props.activeNamespaces) {
       if (this.props.activeNamespaces.length === 0) {
         HistoryManager.deleteParam(URLParam.NAMESPACES);
@@ -164,7 +177,12 @@ export class NamespaceDropdown extends React.PureComponent<NamespaceListType, {}
               Clear all
             </Button>
           </div>
-          <div>{namespaces}</div>
+          <BoundingClientAwareComponent
+            className={namespaceContainerStyle}
+            maxHeight={{ type: PropertyType.VIEWPORT_HEIGHT_MINUS_TOP, margin: popoverMarginBottom }}
+          >
+            {namespaces}
+          </BoundingClientAwareComponent>
         </>
       );
     }


### PR DESCRIPTION
** Describe the change **

It provides scrollbars to the namespace selector when needed.

This also add a class that computes the offset from the element to the screen, it allows us to avoid manual computations on that value, adjusting better if we ever make a change there.

If someone could find a better name for this component, please let me know.

** Issue reference **

Fixes https://github.com/kiali/kiali/issues/1166

** Screenshot **

![namespaces](https://user-images.githubusercontent.com/3845764/59937278-a54daa80-9417-11e9-8dbf-37ef7aa3161f.gif)
