### PR TITLE
Use tsc unused variable checking instead of tslint

### DIFF
--- a/src/components/IstioWizards/WeightedRouting.tsx
+++ b/src/components/IstioWizards/WeightedRouting.tsx
@@ -158,14 +158,12 @@ class WeightedRouting extends React.Component<Props, State> {
   onLock = (workloadName: string, locked: boolean) => {
     this.setState(prevState => {
       let maxWeights = 100;
-      let numLocks = 0;
       for (let i = 0; i < prevState.workloads.length; i++) {
         if (prevState.workloads[i].name === workloadName) {
           prevState.workloads[i].locked = locked;
         }
         // Calculate maxWeights from locked nodes
         if (prevState.workloads[i].locked) {
-          numLocks++;
           maxWeights -= prevState.workloads[i].weight;
         }
       }

--- a/src/components/JaegerIntegration/__tests__/LookBack.test.tsx
+++ b/src/components/JaegerIntegration/__tests__/LookBack.test.tsx
@@ -3,10 +3,9 @@ import { shallow } from 'enzyme';
 import { LookBack } from '../LookBack';
 
 describe('LookBack', () => {
-  let wrapper, onChangeCustom, setLookback;
+  let wrapper, setLookback;
 
   beforeEach(() => {
-    onChangeCustom = jest.fn();
     setLookback = jest.fn();
     wrapper = shallow(<LookBack setLookback={setLookback} disabled={false} lookback={3600} />);
   });

--- a/src/components/JaegerIntegration/__tests__/RightToolbar.test.tsx
+++ b/src/components/JaegerIntegration/__tests__/RightToolbar.test.tsx
@@ -3,11 +3,8 @@ import { shallow } from 'enzyme';
 import RightToolbar from '../RightToolbar';
 
 describe('RightToolbar', () => {
-  let wrapper, onGraphClick, onSummaryClick, onMinimapClick, onSubmit;
+  let wrapper, onSubmit;
   beforeEach(() => {
-    onGraphClick = jest.fn();
-    onMinimapClick = jest.fn();
-    onSummaryClick = jest.fn();
     onSubmit = jest.fn();
     const props = {
       disabled: false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "noImplicitThis": true,
     "noImplicitAny": false,
     "strictNullChecks": true,
+    "noUnusedLocals": true,
     "suppressImplicitAnyIndexErrors": true,
     "allowSyntheticDefaultImports": true,
     "tsBuildInfoFile": ".tsbuildinfo"

--- a/tslint.json
+++ b/tslint.json
@@ -32,6 +32,7 @@
     "no-switch-case-fall-through": true,
     "no-trailing-whitespace": false,
     "no-unused-expression": true,
+    "no-unused-variable": false,
     "no-use-before-declare": true,
     "no-var-keyword": true,
     "one-line": [true, "check-catch", "check-else", "check-open-brace", "check-whitespace"],


### PR DESCRIPTION
Related to #1154.

This was supposed to fix the warning that appears when you try to build:

```
no-unused-variable is deprecated. Since TypeScript 2.9. Please use the built-in compiler checks instead.
```

Even disabling the rule did not make the warning disappear, but enabling the checking on tsconfig showed some warnings that this PR fixes.
Those are also errors after the upgrade to `react-scripts`, but we can get the benefits now.

Those are the offending files:

```
ERROR: /home/cfcosta/Projects/go/src/github.com/kiali/kiali-ui/src/components/IstioWizards/WeightedRouting.tsx:161:11 - 'numLocks' is declared but its value is never read.
ERROR: /home/cfcosta/Projects/go/src/github.com/kiali/kiali-ui/src/components/JaegerIntegration/__tests__/LookBack.test.tsx:6:16 - 'onChangeCustom' is declared but its value is never read.
ERROR: /home/cfcosta/Projects/go/src/github.com/kiali/kiali-ui/src/components/JaegerIntegration/__tests__/RightToolbar.test.tsx:6:16 - 'onGraphClick' is declared but its value is never read.
ERROR: /home/cfcosta/Projects/go/src/github.com/kiali/kiali-ui/src/components/JaegerIntegration/__tests__/RightToolbar.test.tsx:6:30 - 'onSummaryClick' is declared but its value is never read.
ERROR: /home/cfcosta/Projects/go/src/github.com/kiali/kiali-ui/src/components/JaegerIntegration/__tests__/RightToolbar.test.tsx:6:46 - 'onMinimapClick' is declared but its value is never read.
```