### PR TITLE
Enable `noUnusedParams` on tsconfig

### DIFF
--- a/src/actions/GraphDataThunkActions.ts
+++ b/src/actions/GraphDataThunkActions.ts
@@ -32,7 +32,7 @@ const GraphDataThunkActions = {
     showUnusedNodes: boolean,
     node?: NodeParamsType
   ) => {
-    return (dispatch: ThunkDispatch<KialiAppState, undefined, KialiAppAction>, getState: () => KialiAppState) => {
+    return (dispatch: ThunkDispatch<KialiAppState, undefined, KialiAppAction>, _getState: () => KialiAppState) => {
       if (namespaces.length === 0) {
         dispatch(GraphDataActions.getGraphDataWithoutNamespaces());
         return Promise.resolve();

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -30,7 +30,7 @@ const loadRcueCssIfNeeded = async (): Promise<void> => {
   }
 };
 
-Visibility.change((e, state) => {
+Visibility.change((_e, state) => {
   // There are 3 states, visible, hidden and prerender, consider prerender as hidden.
   // https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilityState
   if (state === 'visible') {

--- a/src/app/AuthenticationController.tsx
+++ b/src/app/AuthenticationController.tsx
@@ -64,7 +64,7 @@ class AuthenticationController extends React.Component<AuthenticationControllerP
 
   componentDidUpdate(
     prevProps: Readonly<AuthenticationControllerProps>,
-    prevState: Readonly<AuthenticationControllerState>
+    _prevState: Readonly<AuthenticationControllerState>
   ): void {
     if (!prevProps.authenticated && this.props.authenticated) {
       this.setState({ stage: LoginStage.POST_LOGIN });

--- a/src/components/BreadcrumbView/BreadcrumbView.tsx
+++ b/src/components/BreadcrumbView/BreadcrumbView.tsx
@@ -62,8 +62,8 @@ export class BreadcrumbView extends React.Component<BreadCumbViewProps, BreadCum
 
   componentDidUpdate(
     prevProps: Readonly<BreadCumbViewProps>,
-    prevState: Readonly<BreadCumbViewState>,
-    snapshot?: any
+    _prevState: Readonly<BreadCumbViewState>,
+    _snapshot?: any
   ): void {
     if (prevProps.location !== this.props.location) {
       this.setState(this.updateItem());

--- a/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
+++ b/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
@@ -144,7 +144,7 @@ export class NodeContextMenu extends React.PureComponent<Props> {
     );
   }
 
-  private onClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+  private onClick = (_e: React.MouseEvent<HTMLAnchorElement>) => {
     this.props.contextMenu.hide(0);
   };
 }

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -132,7 +132,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
     this.contextMenuRef = React.createRef<CytoscapeContextMenuWrapper>();
   }
 
-  shouldComponentUpdate(nextProps: CytoscapeGraphProps, nextState: CytoscapeGraphState) {
+  shouldComponentUpdate(nextProps: CytoscapeGraphProps, _nextState: CytoscapeGraphState) {
     this.nodeChanged = this.nodeChanged || this.props.node !== nextProps.node;
     let result =
       this.props.edgeLabelMode !== nextProps.edgeLabelMode ||
@@ -160,7 +160,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
     this.cyInitialization(this.getCy());
   }
 
-  componentDidUpdate(prevProps: CytoscapeGraphProps, prevState: CytoscapeGraphState) {
+  componentDidUpdate(prevProps: CytoscapeGraphProps, _prevState: CytoscapeGraphState) {
     const cy = this.getCy();
     if (!cy) {
       return;
@@ -343,7 +343,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
       }
     });
 
-    cy.on('layoutstop', (evt: any) => {
+    cy.on('layoutstop', (_evt: any) => {
       // Don't allow a large zoom if the graph has a few nodes (nodes would look too big).
       this.safeFit(cy);
     });
@@ -353,7 +353,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
       this.processGraphUpdate(cy, true);
     });
 
-    cy.on('destroy', (evt: any) => {
+    cy.on('destroy', (_evt: any) => {
       this.trafficRenderer!.stop();
       this.cy = undefined;
       this.props.updateSummary({ summaryType: 'graph', summaryTarget: undefined });

--- a/src/components/CytoscapeGraph/CytoscapeReactWrapper.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeReactWrapper.tsx
@@ -57,7 +57,7 @@ export class CytoscapeReactWrapper extends React.Component<CytoscapeReactWrapper
 
   // This is VERY important - this must always return false to ensure the div is never destroyed.
   // If the div is destroyed, the cached cy becomes useless.
-  shouldComponentUpdate(nextProps: any, nextState: any) {
+  shouldComponentUpdate(_nextProps: any, _nextState: any) {
     return false;
   }
 

--- a/src/components/CytoscapeGraph/Layout/GroupCompoundLayout.ts
+++ b/src/components/CytoscapeGraph/Layout/GroupCompoundLayout.ts
@@ -126,7 +126,7 @@ export default class GroupCompoundLayout {
 
       // We expect a discrete layout here
       const compoundLayout = targetElements.layout(compoundLayoutOptions);
-      compoundLayout.on('layoutstart layoutready layoutstop', evt => {
+      compoundLayout.on('layoutstart layoutready layoutstop', _evt => {
         // Avoid to propagate any local layout events up to cy, this would yield a global operation when not all nodes are ready.
         return false;
       });
@@ -205,7 +205,7 @@ export default class GroupCompoundLayout {
     });
 
     // (2) Add a one-time callback to be fired when the layout stops
-    layout.one('layoutstop', event => {
+    layout.one('layoutstop', _event => {
       // This part of the code needs to be executed inside a batch to work, else the relative position is not correctly
       // updated
       this.cy.startBatch();

--- a/src/components/CytoscapeGraph/TrafficAnimation/TrafficRenderer.ts
+++ b/src/components/CytoscapeGraph/TrafficAnimation/TrafficRenderer.ts
@@ -62,7 +62,7 @@ enum TrafficEdgeType {
  * @param edge
  * @returns {TrafficPointRenderer}
  */
-const getTrafficPointRendererForRpsError: (edge: any) => TrafficPointRenderer = (edge: any) => {
+const getTrafficPointRendererForRpsError: (edge: any) => TrafficPointRenderer = (_edge: any) => {
   return new TrafficPointConcentricDiamondRenderer(
     new Diamond(2.5, PfColors.White, PfColors.Red100, 1.0),
     new Diamond(1, PfColors.Red100, PfColors.Red100, 1.0)
@@ -83,7 +83,7 @@ const getTrafficPointRendererForRpsSuccess: (edge: any) => TrafficPointRenderer 
  * @param edge
  * @returns {TrafficPointCircleRenderer}
  */
-const getTrafficPointRendererForTcp: (edge: any) => TrafficPointRenderer = (edge: any) => {
+const getTrafficPointRendererForTcp: (edge: any) => TrafficPointRenderer = (_edge: any) => {
   return new TrafficPointCircleRenderer(0.8, PfColors.Black100, PfColors.Black500, 1);
 };
 

--- a/src/components/DebugInformation/DebugInformation.tsx
+++ b/src/components/DebugInformation/DebugInformation.tsx
@@ -64,7 +64,7 @@ export class DebugInformation extends React.PureComponent<DebugInformationProps,
     this.setState({ show: false });
   };
 
-  copyCallback = (text: string, result: boolean) => {
+  copyCallback = (_text: string, result: boolean) => {
     this.textareaRef.current.select();
     this.setState({ copyStatus: result ? CopyStatus.COPIED : CopyStatus.NOT_COPIED });
   };
@@ -73,7 +73,7 @@ export class DebugInformation extends React.PureComponent<DebugInformationProps,
     this.setState({ copyStatus: CopyStatus.NOT_COPIED });
   };
 
-  componentDidUpdate(prevProps: DebugInformationProps, prevState: DebugInformationState) {
+  componentDidUpdate(prevProps: DebugInformationProps, _prevState: DebugInformationState) {
     if (this.props.appState !== prevProps.appState && this.state.copyStatus === CopyStatus.COPIED) {
       this.setState({ copyStatus: CopyStatus.OLD_COPY });
     }

--- a/src/components/Filters/StatefulFilters.tsx
+++ b/src/components/Filters/StatefulFilters.tsx
@@ -88,7 +88,7 @@ export class StatefulFilters extends React.Component<StatefulFiltersProps, State
     this.promises.registerAll('filterType', filterTypePromises).then(types => this.setState({ filterTypes: types }));
   }
 
-  componentDidUpdate(prevProps: StatefulFiltersProps, prevState: StatefulFiltersState, snapshot: any) {
+  componentDidUpdate(_prevProps: StatefulFiltersProps, _prevState: StatefulFiltersState, _snapshot: any) {
     if (!ListPagesHelper.filtersMatchURL(this.state.filterTypes, this.state.activeFilters)) {
       ListPagesHelper.setFiltersToURL(this.state.filterTypes, this.state.activeFilters);
     }

--- a/src/components/GraphFilter/GraphFind.tsx
+++ b/src/components/GraphFilter/GraphFind.tsx
@@ -530,7 +530,7 @@ export class GraphFind extends React.PureComponent<GraphFindProps, GraphFindStat
     }
   };
 
-  private getNumericSelector(field: string, op: string, val: any, expression: string): string | undefined {
+  private getNumericSelector(field: string, op: string, val: any, _expression: string): string | undefined {
     switch (op) {
       case '>':
       case '<':

--- a/src/components/GraphFilter/GraphSettings.tsx
+++ b/src/components/GraphFilter/GraphSettings.tsx
@@ -53,7 +53,7 @@ class GraphSettings extends React.PureComponent<GraphSettingsProps> {
     }
   }
 
-  componentDidUpdate(prevProps: GraphSettingsProps) {
+  componentDidUpdate(_prevProps: GraphSettingsProps) {
     // ensure redux state and URL are aligned
     HistoryManager.setParam(URLParam.GRAPH_SERVICE_NODES, String(this.props.showServiceNodes));
   }

--- a/src/components/GraphFilter/__tests__/GraphFind.test.tsx
+++ b/src/components/GraphFilter/__tests__/GraphFind.test.tsx
@@ -7,7 +7,7 @@ const testHandler = () => {
   console.log('handled');
 };
 
-const testSetter = val => {
+const testSetter = _val => {
   console.log('set');
 };
 

--- a/src/components/IstioWizards/IstioWizardDropdown.tsx
+++ b/src/components/IstioWizards/IstioWizardDropdown.tsx
@@ -148,7 +148,7 @@ class IstioWizardDropdown extends React.Component<Props, State> {
     // For slow scenarios, dialog is hidden and Delete All action blocked until promises have finished
     this.hideConfirmDelete();
     Promise.all(deletePromises)
-      .then(results => {
+      .then(_results => {
         this.setState({
           isDeleting: false
         });

--- a/src/components/JaegerIntegration/JaegerToolbar.tsx
+++ b/src/components/JaegerIntegration/JaegerToolbar.tsx
@@ -127,7 +127,7 @@ export class JaegerToolbar extends React.Component<JaegerToolbarProps, JaegerToo
               <FormGroup label={'Lookback'} isRequired={true} fieldId={'lookback_jaeger_form'}>
                 <LookBack
                   lookback={this.state.lookback !== 'custom' ? Number(this.state.lookback) : 0}
-                  setLookback={(value, event) => {
+                  setLookback={(value, _event) => {
                     this.setState({ lookback: value });
                   }}
                 />

--- a/src/components/MessageCenter/MessageCenter.tsx
+++ b/src/components/MessageCenter/MessageCenter.tsx
@@ -81,7 +81,7 @@ const mapDispatchToPropsMessageCenter = (dispatch: ThunkDispatch<KialiAppState, 
     onMarkGroupAsRead: group => dispatch(MessageCenterThunkActions.markGroupAsRead(group.id)),
     onClearGroup: group => dispatch(MessageCenterThunkActions.clearGroup(group.id)),
     onNotificationClick: message => dispatch(MessageCenterActions.markAsRead(message.id)),
-    onDismissNotification: (message, group, userDismissed) => {
+    onDismissNotification: (message, _group, userDismissed) => {
       if (userDismissed) {
         dispatch(MessageCenterActions.markAsRead(message.id));
       } else {

--- a/src/components/Nav/Masthead/UserDropdown.tsx
+++ b/src/components/Nav/Masthead/UserDropdown.tsx
@@ -99,7 +99,7 @@ class UserDropdownConnected extends React.Component<UserProps, UserState> {
     });
   };
 
-  onDropdownSelect = event => {
+  onDropdownSelect = _event => {
     this.setState({
       isDropdownOpen: !this.state.isDropdownOpen
     });

--- a/src/pages/AppDetails/AppInfo/AppDescription.tsx
+++ b/src/pages/AppDetails/AppInfo/AppDescription.tsx
@@ -74,7 +74,7 @@ class AppDescription extends React.Component<AppDescriptionProps, AppDescription
     return content;
   }
 
-  renderServiceItem(namespace: string, appName: string, serviceName: string) {
+  renderServiceItem(namespace: string, _appName: string, serviceName: string) {
     const iconName = 'service';
     const iconType = 'pf';
     const heading = (

--- a/src/pages/AppList/AppListComponent.tsx
+++ b/src/pages/AppList/AppListComponent.tsx
@@ -46,7 +46,7 @@ class AppListComponent extends ListComponent.Component<AppListComponentProps, Ap
     this.updateListItems();
   }
 
-  componentDidUpdate(prevProps: AppListComponentProps, prevState: AppListComponentState, snapshot: any) {
+  componentDidUpdate(prevProps: AppListComponentProps, _prevState: AppListComponentState, _snapshot: any) {
     if (!this.paramsAreSynced(prevProps)) {
       this.setState({
         pagination: this.props.pagination,

--- a/src/pages/Graph/SummaryPanelCommon.tsx
+++ b/src/pages/Graph/SummaryPanelCommon.tsx
@@ -54,7 +54,7 @@ export const updateHealth = (summaryTarget: any, stateSetter: (hs: HealthState) 
     stateSetter({ health: undefined, healthLoading: true });
     healthPromise
       .then(h => stateSetter({ health: h, healthLoading: false }))
-      .catch(err => stateSetter({ health: healthNotAvailable(), healthLoading: false }));
+      .catch(_err => stateSetter({ health: healthNotAvailable(), healthLoading: false }));
   } else {
     stateSetter({ health: undefined, healthLoading: false });
   }

--- a/src/pages/Graph/SummaryPanelGroup.tsx
+++ b/src/pages/Graph/SummaryPanelGroup.tsx
@@ -226,7 +226,7 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
     return this.props.data.summaryTarget
       .children(`node[${CyNode.version}]`)
       .toArray()
-      .map((c, i) => (
+      .map((c, _i) => (
         <Label
           key={c.data(CyNode.version)}
           name={serverConfig.istioLabels.versionLabelName}

--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -147,7 +147,7 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
           this.props.match.params.object
         );
     deletePromise
-      .then(r => this.backToList())
+      .then(_r => this.backToList())
       .catch(error => {
         MessageCenter.add(API.getErrorMsg('Could not delete IstioConfig details.', error));
       });
@@ -171,7 +171,7 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
             jsonPatch
           );
       updatePromise
-        .then(r => {
+        .then(_r => {
           const targetMessage =
             this.props.match.params.namespace +
             ' / ' +

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/DestinationRuleDetail.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/DestinationRuleDetail.tsx
@@ -19,7 +19,7 @@ class DestinationRuleDetail extends React.Component<DestinationRuleProps> {
     super(props);
   }
 
-  validation(destinationRule: DestinationRule): ObjectValidation | undefined {
+  validation(_destinationRule: DestinationRule): ObjectValidation | undefined {
     return this.props.validation;
   }
 

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceDetail.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceDetail.tsx
@@ -25,7 +25,7 @@ class VirtualServiceDetail extends React.Component<VirtualServiceProps> {
     super(props);
   }
 
-  validation(virtualService: VirtualService): ObjectValidation | undefined {
+  validation(_virtualService: VirtualService): ObjectValidation | undefined {
     return this.props.validation;
   }
 

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceRoute.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceRoute.tsx
@@ -218,7 +218,7 @@ class VirtualServiceRoute extends React.Component<VirtualServiceRouteProps> {
     }
   }
 
-  destinationFrom(destinationWeight: DestinationWeight, i: number, isValid: boolean) {
+  destinationFrom(destinationWeight: DestinationWeight, _i: number, isValid: boolean) {
     const destination = destinationWeight.destination;
     if (destination) {
       return {
@@ -314,7 +314,7 @@ class VirtualServiceRoute extends React.Component<VirtualServiceRouteProps> {
     );
   }
 
-  routeStatusMessage(route: HTTPRoute | TCPRoute, routeIndex: number) {
+  routeStatusMessage(_route: HTTPRoute | TCPRoute, routeIndex: number) {
     const checks = checkForPath(
       this.validation(),
       'spec/' + this.props.kind.toLowerCase() + '[' + routeIndex + ']/route'

--- a/src/pages/IstioConfigList/FiltersAndSorts.ts
+++ b/src/pages/IstioConfigList/FiltersAndSorts.ts
@@ -189,7 +189,7 @@ export const sortIstioItems = (
   sortField: SortField<IstioConfigItem>,
   isAscending: boolean
 ) => {
-  const sortPromise: Promise<IstioConfigItem[]> = new Promise((resolve, reject) => {
+  const sortPromise: Promise<IstioConfigItem[]> = new Promise(resolve => {
     resolve(unsorted.sort(isAscending ? sortField.compare : (a, b) => sortField.compare(b, a)));
   });
 

--- a/src/pages/IstioConfigList/IstioConfigListComponent.tsx
+++ b/src/pages/IstioConfigList/IstioConfigListComponent.tsx
@@ -55,8 +55,8 @@ class IstioConfigListComponent extends ListComponent.Component<
 
   componentDidUpdate(
     prevProps: IstioConfigListComponentProps,
-    prevState: IstioConfigListComponentState,
-    snapshot: any
+    _prevState: IstioConfigListComponentState,
+    _snapshot: any
   ) {
     if (!this.paramsAreSynced(prevProps)) {
       this.setState({

--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -145,7 +145,7 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
     this.doRefresh();
   }
 
-  componentDidUpdate(prevProps: ServiceDetailsProps, prevState: ServiceDetailsState) {
+  componentDidUpdate(prevProps: ServiceDetailsProps, _prevState: ServiceDetailsState) {
     if (
       prevProps.match.params.namespace !== this.props.match.params.namespace ||
       prevProps.match.params.service !== this.props.match.params.service ||
@@ -279,7 +279,7 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
   };
 
   addFormatValidation(details: ServiceDetailsInfo, validations: Validations): Validations {
-    details.destinationRules.items.forEach((destinationRule, index, ary) => {
+    details.destinationRules.items.forEach((destinationRule, _index, _ary) => {
       const dr = new DestinationRuleValidator(destinationRule);
       const formatValidation = dr.formatValidation();
 

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoPods.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoPods.tsx
@@ -12,7 +12,7 @@ interface ServiceInfoPodsState {
   groups: PodsGroup[];
 }
 class ServiceInfoPods extends React.Component<Props, ServiceInfoPodsState> {
-  static getDerivedStateFromProps(props: Props, currentState: ServiceInfoPodsState) {
+  static getDerivedStateFromProps(props: Props, _currentState: ServiceInfoPodsState) {
     return { groups: ServiceInfoPods.updateGroups(props) };
   }
 

--- a/src/pages/ServiceDetails/ServiceInfo/types/DestinationRuleValidator.ts
+++ b/src/pages/ServiceDetails/ServiceInfo/types/DestinationRuleValidator.ts
@@ -33,7 +33,8 @@ export default class DestinationRuleValidator {
     }
 
     let valid = this.destinationRule.spec.subsets instanceof Array;
-    valid = valid && this.destinationRule.spec.subsets.every((subset, i, ary) => new SubsetValidator(subset).isValid());
+    valid =
+      valid && this.destinationRule.spec.subsets.every((subset, _i, _ary) => new SubsetValidator(subset).isValid());
 
     if (!valid) {
       this.unformattedField = 'Subsets';

--- a/src/pages/ServiceDetails/ServiceInfo/types/SubsetValidator.ts
+++ b/src/pages/ServiceDetails/ServiceInfo/types/SubsetValidator.ts
@@ -16,7 +16,7 @@ export default class SubsetValidator {
   }
 
   hasValidLabels() {
-    const valid = Object.keys(this.subset.labels).every((k, i) => this.hasValidLabel(k, this.subset.labels[k]));
+    const valid = Object.keys(this.subset.labels).every((k, _i) => this.hasValidLabel(k, this.subset.labels[k]));
     return this.subset.labels instanceof Object && valid;
   }
 

--- a/src/pages/ServiceList/ServiceListComponent.tsx
+++ b/src/pages/ServiceList/ServiceListComponent.tsx
@@ -55,7 +55,7 @@ class ServiceListComponent extends ListComponent.Component<
     this.updateListItems();
   }
 
-  componentDidUpdate(prevProps: ServiceListComponentProps, prevState: ServiceListComponentState, snapshot: any) {
+  componentDidUpdate(prevProps: ServiceListComponentProps, _prevState: ServiceListComponentState, _snapshot: any) {
     if (!this.paramsAreSynced(prevProps)) {
       this.setState({
         pagination: this.props.pagination,

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
@@ -103,7 +103,7 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
     }
   }
 
-  componentDidUpdate(prevProps: WorkloadPodLogsProps, prevState: WorkloadPodLogsState) {
+  componentDidUpdate(_prevProps: WorkloadPodLogsProps, prevState: WorkloadPodLogsState) {
     const prevContainer = prevState.containerInfo ? prevState.containerInfo.container : undefined;
     const newContainer = this.state.containerInfo ? this.state.containerInfo.container : undefined;
     const updateContainerInfo = this.state.containerInfo && this.state.containerInfo !== prevState.containerInfo;

--- a/src/pages/WorkloadList/WorkloadListComponent.tsx
+++ b/src/pages/WorkloadList/WorkloadListComponent.tsx
@@ -50,7 +50,7 @@ class WorkloadListComponent extends ListComponent.Component<
     this.updateListItems();
   }
 
-  componentDidUpdate(prevProps: WorkloadListComponentProps, prevState: WorkloadListComponentState, snapshot: any) {
+  componentDidUpdate(prevProps: WorkloadListComponentProps, _prevState: WorkloadListComponentState, _snapshot: any) {
     if (!this.paramsAreSynced(prevProps)) {
       this.setState({
         pagination: this.props.pagination,

--- a/src/services/Login.ts
+++ b/src/services/Login.ts
@@ -30,7 +30,7 @@ interface DispatchRequest<T> {
 type NullDispatch = DispatchRequest<any>;
 
 class AnonymousLogin implements LoginStrategy {
-  public async prepare(info: AuthConfig) {
+  public async prepare(_info: AuthConfig) {
     return AuthResult.CONTINUE;
   }
 
@@ -53,7 +53,7 @@ interface WebLoginData {
 }
 
 class WebLogin implements LoginStrategy<WebLoginData> {
-  public async prepare(info: AuthConfig) {
+  public async prepare(_info: AuthConfig) {
     return AuthResult.CONTINUE;
   }
 

--- a/src/services/__mocks__/Api.ts
+++ b/src/services/__mocks__/Api.ts
@@ -10,6 +10,6 @@ export const getGraphElements = (params: any) => {
   }
 };
 
-export const getServiceDetail = (namespace: string, service: string): Promise<ServiceDetailsInfo> => {
+export const getServiceDetail = (_namespace: string, _service: string): Promise<ServiceDetailsInfo> => {
   return Promise.resolve(ServiceData.SERVICE_DETAILS);
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "noImplicitAny": false,
     "strictNullChecks": true,
     "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "suppressImplicitAnyIndexErrors": true,
     "allowSyntheticDefaultImports": true,
     "tsBuildInfoFile": ".tsbuildinfo"


### PR DESCRIPTION
Part of #1154.

Enabling this added the following errors:

```
ERROR: kiali-ui/src/actions/GraphDataThunkActions.ts:35:80 - 'getState' is declared but its value is never read.
ERROR: kiali-ui/src/app/App.tsx:33:20 - 'e' is declared but its value is never read.
ERROR: kiali-ui/src/app/AuthenticationController.tsx:67:5 - 'prevState' is declared but its value is never read.
ERROR: kiali-ui/src/components/BreadcrumbView/BreadcrumbView.tsx:65:5 - 'prevState' is declared but its value is never read.
ERROR: kiali-ui/src/components/BreadcrumbView/BreadcrumbView.tsx:66:5 - 'snapshot' is declared but its value is never read.
ERROR: kiali-ui/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx:147:22 - 'e' is declared but its value is never read.
ERROR: kiali-ui/src/components/CytoscapeGraph/CytoscapeGraph.tsx:135:57 - 'nextState' is declared but its value is never read.
ERROR: kiali-ui/src/components/CytoscapeGraph/CytoscapeGraph.tsx:163:54 - 'prevState' is declared but its value is never read.
ERROR: kiali-ui/src/components/CytoscapeGraph/CytoscapeGraph.tsx:346:26 - 'evt' is declared but its value is never read.
ERROR: kiali-ui/src/components/CytoscapeGraph/CytoscapeGraph.tsx:356:23 - 'evt' is declared but its value is never read.
ERROR: kiali-ui/src/components/CytoscapeGraph/CytoscapeReactWrapper.tsx:60:25 - 'nextProps' is declared but its value is never read.
ERROR: kiali-ui/src/components/CytoscapeGraph/CytoscapeReactWrapper.tsx:60:41 - 'nextState' is declared but its value is never read.
ERROR: kiali-ui/src/components/CytoscapeGraph/Layout/GroupCompoundLayout.ts:129:63 - 'evt' is declared but its value is never read.
ERROR: kiali-ui/src/components/CytoscapeGraph/Layout/GroupCompoundLayout.ts:208:30 - 'event' is declared but its value is never read.
ERROR: kiali-ui/src/components/CytoscapeGraph/TrafficAnimation/TrafficRenderer.ts:65:82 - 'edge' is declared but its value is never read.
ERROR: kiali-ui/src/components/CytoscapeGraph/TrafficAnimation/TrafficRenderer.ts:86:77 - 'edge' is declared but its value is never read.
ERROR: kiali-ui/src/components/DebugInformation/DebugInformation.tsx:67:19 - 'text' is declared but its value is never read.
ERROR: kiali-ui/src/components/DebugInformation/DebugInformation.tsx:76:56 - 'prevState' is declared but its value is never read.
ERROR: kiali-ui/src/components/Filters/StatefulFilters.tsx:91:22 - 'prevProps' is declared but its value is never read.
ERROR: kiali-ui/src/components/Filters/StatefulFilters.tsx:91:55 - 'prevState' is declared but its value is never read.
ERROR: kiali-ui/src/components/Filters/StatefulFilters.tsx:91:88 - 'snapshot' is declared but its value is never read.
ERROR: kiali-ui/src/components/GraphFilter/GraphFind.tsx:533:67 - 'expression' is declared but its value is never read.
ERROR: kiali-ui/src/components/GraphFilter/GraphSettings.tsx:56:22 - 'prevProps' is declared but its value is never read.
ERROR: kiali-ui/src/components/GraphFilter/__tests__/GraphFind.test.tsx:10:20 - 'val' is declared but its value is never read.
ERROR: kiali-ui/src/components/IstioWizards/IstioWizardDropdown.tsx:151:13 - 'results' is declared but its value is never read.
ERROR: kiali-ui/src/components/JaegerIntegration/JaegerToolbar.tsx:130:40 - 'event' is declared but its value is never read.
ERROR: kiali-ui/src/components/MessageCenter/MessageCenter.tsx:84:38 - 'group' is declared but its value is never read.
ERROR: kiali-ui/src/components/Nav/Masthead/UserDropdown.tsx:102:22 - 'event' is declared but its value is never read.
ERROR: kiali-ui/src/pages/AppDetails/AppInfo/AppDescription.tsx:77:40 - 'appName' is declared but its value is never read.
ERROR: kiali-ui/src/pages/AppList/AppListComponent.tsx:49:56 - 'prevState' is declared but its value is never read.
ERROR: kiali-ui/src/pages/AppList/AppListComponent.tsx:49:90 - 'snapshot' is declared but its value is never read.
ERROR: kiali-ui/src/pages/Graph/SummaryPanelCommon.tsx:57:14 - 'err' is declared but its value is never read.
ERROR: kiali-ui/src/pages/Graph/SummaryPanelGroup.tsx:229:16 - 'i' is declared but its value is never read.
ERROR: kiali-ui/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx:150:13 - 'r' is declared but its value is never read.
ERROR: kiali-ui/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx:174:15 - 'r' is declared but its value is never read.
ERROR: kiali-ui/src/pages/IstioConfigDetails/IstioObjectDetails/DestinationRuleDetail.tsx:22:14 - 'destinationRule' is declared but its value is never read.
ERROR: kiali-ui/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceDetail.tsx:28:14 - 'virtualService' is declared but its value is never read.
ERROR: kiali-ui/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceRoute.tsx:221:57 - 'i' is declared but its value is never read.
ERROR: kiali-ui/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceRoute.tsx:317:22 - 'route' is declared but its value is never read.
ERROR: kiali-ui/src/pages/IstioConfigList/FiltersAndSorts.ts:192:73 - 'reject' is declared but its value is never read.
ERROR: kiali-ui/src/pages/IstioConfigList/IstioConfigListComponent.tsx:58:5 - 'prevState' is declared but its value is never read.
ERROR: kiali-ui/src/pages/IstioConfigList/IstioConfigListComponent.tsx:59:5 - 'snapshot' is declared but its value is never read.
ERROR: kiali-ui/src/pages/ServiceDetails/ServiceDetailsPage.tsx:148:54 - 'prevState' is declared but its value is never read.
ERROR: kiali-ui/src/pages/ServiceDetails/ServiceDetailsPage.tsx:282:62 - 'index' is declared but its value is never read.
ERROR: kiali-ui/src/pages/ServiceDetails/ServiceDetailsPage.tsx:282:69 - 'ary' is declared but its value is never read.
ERROR: kiali-ui/src/pages/ServiceDetails/ServiceInfo/ServiceInfoPods.tsx:15:49 - 'currentState' is declared but its value is never read.
ERROR: kiali-ui/src/pages/ServiceDetails/ServiceInfo/types/DestinationRuleValidator.ts:36:71 - 'i' is declared but its value is never read.
ERROR: kiali-ui/src/pages/ServiceDetails/ServiceInfo/types/DestinationRuleValidator.ts:36:74 - 'ary' is declared but its value is never read.
ERROR: kiali-ui/src/pages/ServiceDetails/ServiceInfo/types/SubsetValidator.ts:19:61 - 'i' is declared but its value is never read.
ERROR: kiali-ui/src/pages/ServiceList/ServiceListComponent.tsx:58:60 - 'prevState' is declared but its value is never read.
ERROR: kiali-ui/src/pages/ServiceList/ServiceListComponent.tsx:58:98 - 'snapshot' is declared but its value is never read.
ERROR: kiali-ui/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx:106:22 - 'prevProps' is declared but its value is never read.
ERROR: kiali-ui/src/pages/WorkloadList/WorkloadListComponent.tsx:53:61 - 'prevState' is declared but its value is never read.
ERROR: kiali-ui/src/pages/WorkloadList/WorkloadListComponent.tsx:53:100 - 'snapshot' is declared but its value is never read.
ERROR: kiali-ui/src/services/Login.ts:33:24 - 'info' is declared but its value is never read.
ERROR: kiali-ui/src/services/Login.ts:56:24 - 'info' is declared but its value is never read.
ERROR: kiali-ui/src/services/__mocks__/Api.ts:13:34 - 'namespace' is declared but its value is never read.
ERROR: kiali-ui/src/services/__mocks__/Api.ts:13:53 - 'service' is declared but its value is never read.
```

I did not change the signature of most the methods as that might have different outputs or break stuff that is not supposed to break.