### PR TITLE
Remove all unused constructors

### DIFF
--- a/src/components/Details/DetailObject.tsx
+++ b/src/components/Details/DetailObject.tsx
@@ -18,10 +18,6 @@ interface Validation {
 }
 
 class DetailObject extends React.Component<DetailObjectProps> {
-  constructor(props: DetailObjectProps) {
-    super(props);
-  }
-
   // Pseudo unique ID generator used for keys
   // The recursive nature of buildList() requires uniques list keys.
   // Modified from https://gist.github.com/gordonbrander/2230317

--- a/src/components/Health/HealthDetails.tsx
+++ b/src/components/Health/HealthDetails.tsx
@@ -7,10 +7,6 @@ interface Props {
 }
 
 export class HealthDetails extends React.PureComponent<Props, {}> {
-  constructor(props: Props) {
-    super(props);
-  }
-
   renderStatus(status: H.Status) {
     if (status.icon) {
       return <Icon type="pf" name={status.icon} />;

--- a/src/components/IstioWizards/MatchingRouting/MatchBuilder.tsx
+++ b/src/components/IstioWizards/MatchingRouting/MatchBuilder.tsx
@@ -42,10 +42,6 @@ const matchStyle = style({
 });
 
 class MatchBuilder extends React.Component<Props> {
-  constructor(props: Props) {
-    super(props);
-  }
-
   render() {
     const matchItems: any[] = matchOptions.map((mode, index) => (
       <MenuItem key={mode + '-' + index} eventKey={mode} active={mode === this.props.category}>

--- a/src/components/IstioWizards/MatchingRouting/Matches.tsx
+++ b/src/components/IstioWizards/MatchingRouting/Matches.tsx
@@ -14,10 +14,6 @@ const labelContainerStyle = style({
 const labelMatchStyle = style({});
 
 class Matches extends React.Component<Props> {
-  constructor(props: Props) {
-    super(props);
-  }
-
   render() {
     const matches: any[] = this.props.matches.map((match, index) => (
       <span key={match + '-' + index}>

--- a/src/components/IstioWizards/MatchingRouting/RuleBuilder.tsx
+++ b/src/components/IstioWizards/MatchingRouting/RuleBuilder.tsx
@@ -53,10 +53,6 @@ const createStyle = style({
 });
 
 class RuleBuilder extends React.Component<Props> {
-  constructor(props: Props) {
-    super(props);
-  }
-
   render() {
     return (
       <ListView className={'match-routing-wizard'}>

--- a/src/components/IstioWizards/VirtualServiceHosts.tsx
+++ b/src/components/IstioWizards/VirtualServiceHosts.tsx
@@ -6,10 +6,6 @@ type Props = {
 };
 
 class VirtualServiceHosts extends React.Component<Props> {
-  constructor(props: Props) {
-    super(props);
-  }
-
   render() {
     const vsHosts = this.props.vsHosts.length > 0 ? this.props.vsHosts.join(',') : '';
     return (

--- a/src/components/JaegerIntegration/LookBack.tsx
+++ b/src/components/JaegerIntegration/LookBack.tsx
@@ -15,10 +15,6 @@ export class LookBack extends React.PureComponent<LookBackProps> {
   lookBackOptions = { ...serverConfig.durations, ...{ 0: 'Custom Time Range' } };
   lookbackDefault = config.toolbar.defaultDuration;
 
-  constructor(props: LookBackProps) {
-    super(props);
-  }
-
   componentDidMount() {
     this.props.setLookback(String(this.props.lookback), null);
   }

--- a/src/components/JaegerIntegration/TagsControl.tsx
+++ b/src/components/JaegerIntegration/TagsControl.tsx
@@ -12,10 +12,6 @@ interface TagsControlProps {
 const tagsInput = style({ marginLeft: '-100px' });
 
 export class TagsControl extends React.PureComponent<TagsControlProps, {}> {
-  constructor(props: TagsControlProps) {
-    super(props);
-  }
-
   tagsHelp = () => {
     return (
       <>

--- a/src/components/MetricsOptions/MetricsSettings.tsx
+++ b/src/components/MetricsOptions/MetricsSettings.tsx
@@ -60,10 +60,6 @@ export class MetricsSettingsDropdown extends React.Component<Props> {
     return settings;
   };
 
-  constructor(props: Props) {
-    super(props);
-  }
-
   componentDidUpdate() {
     if (this.shouldReportOptions) {
       this.shouldReportOptions = false;

--- a/src/components/NamespaceDropdown.tsx
+++ b/src/components/NamespaceDropdown.tsx
@@ -65,10 +65,6 @@ interface NamespaceDropdownProps extends ReduxProps {
 }
 
 export class NamespaceDropdown extends React.PureComponent<NamespaceDropdownProps> {
-  constructor(props: NamespaceDropdownProps) {
-    super(props);
-  }
-
   componentDidMount() {
     this.props.refresh();
     this.syncNamespacesURLParam();

--- a/src/components/Nav/RenderPage.tsx
+++ b/src/components/Nav/RenderPage.tsx
@@ -8,10 +8,6 @@ import { style } from 'typestyle';
 const containerStyle = style({ marginLeft: 0, marginRight: 0 });
 
 class RenderPage extends React.Component<{ needScroll: boolean }> {
-  constructor(props: { needScroll: boolean }) {
-    super(props);
-  }
-
   renderPaths(paths: Path[]) {
     return paths.map((item, index) => {
       return <Route key={index} path={item.path} component={item.component} />;

--- a/src/components/SessionTimeout/SessionTimeout.tsx
+++ b/src/components/SessionTimeout/SessionTimeout.tsx
@@ -14,10 +14,6 @@ type SessionTimeoutProps = {
 };
 
 export class SessionTimeout extends React.Component<SessionTimeoutProps, {}> {
-  constructor(props: SessionTimeoutProps) {
-    super(props);
-  }
-
   render() {
     return (
       <Modal

--- a/src/components/SummaryPanel/InOutRateChart.tsx
+++ b/src/components/SummaryPanel/InOutRateChart.tsx
@@ -26,10 +26,6 @@ export class InOutRateChartGrpc extends React.Component<InOutRateChartGrpcPropTy
     width: SUMMARY_PANEL_CHART_WIDTH
   };
 
-  constructor(props: InOutRateChartGrpcPropType) {
-    super(props);
-  }
-
   render() {
     return (
       <StackedBarChart
@@ -114,10 +110,6 @@ export class InOutRateChartHttp extends React.Component<InOutRateChartHttpPropTy
     showLegend: true,
     width: SUMMARY_PANEL_CHART_WIDTH
   };
-
-  constructor(props: InOutRateChartHttpPropType) {
-    super(props);
-  }
 
   render() {
     return (

--- a/src/components/SummaryPanel/RateChart.tsx
+++ b/src/components/SummaryPanel/RateChart.tsx
@@ -22,10 +22,6 @@ export class RateChartGrpc extends React.Component<RateChartGrpcPropType> {
     width: SUMMARY_PANEL_CHART_WIDTH
   };
 
-  constructor(props: RateChartGrpcPropType) {
-    super(props);
-  }
-
   render() {
     return (
       <StackedBarChart
@@ -99,10 +95,6 @@ export class RateChartHttp extends React.Component<RateChartHttpPropType> {
     showLegend: true,
     width: SUMMARY_PANEL_CHART_WIDTH
   };
-
-  constructor(props: RateChartHttpPropType) {
-    super(props);
-  }
 
   render() {
     return (

--- a/src/components/SummaryPanel/ResponseTable.tsx
+++ b/src/components/SummaryPanel/ResponseTable.tsx
@@ -37,10 +37,6 @@ const Flags: object = {
 };
 
 export class ResponseTable extends React.PureComponent<ResponseTableProps> {
-  constructor(props: ResponseTableProps) {
-    super(props);
-  }
-
   render() {
     return (
       <>

--- a/src/components/SummaryPanel/ResponseTimeChart.tsx
+++ b/src/components/SummaryPanel/ResponseTimeChart.tsx
@@ -13,10 +13,6 @@ type ResponseTimeChartTypeProp = {
 };
 
 export default class ResponseTimeChart extends React.Component<ResponseTimeChartTypeProp, {}> {
-  constructor(props: ResponseTimeChartTypeProp) {
-    super(props);
-  }
-
   thereIsTrafficData = () => {
     return this.props.rtAvg && this.props.rtAvg.length > 1 && this.props.rtAvg[0].length > 1;
   };

--- a/src/components/SummaryPanel/RpsChart.tsx
+++ b/src/components/SummaryPanel/RpsChart.tsx
@@ -91,10 +91,6 @@ const renderSparkline = (series: [string | number][], colors: PfColors[], yTickF
 };
 
 export class RpsChart extends React.Component<RpsChartTypeProp, {}> {
-  constructor(props: RpsChartTypeProp) {
-    super(props);
-  }
-
   render() {
     return (
       <>

--- a/src/pages/Graph/GraphHelpFind.tsx
+++ b/src/pages/Graph/GraphHelpFind.tsx
@@ -28,10 +28,6 @@ export default class GraphHelpFind extends React.Component<GraphHelpFindProps> {
     return <Table.Cell className={className}>{value}</Table.Cell>;
   };
 
-  constructor(props: GraphHelpFindProps) {
-    super(props);
-  }
-
   edgeColumns = () => {
     return {
       columns: [

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/DestinationRuleDetail.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/DestinationRuleDetail.tsx
@@ -15,10 +15,6 @@ interface DestinationRuleProps {
 }
 
 class DestinationRuleDetail extends React.Component<DestinationRuleProps> {
-  constructor(props: DestinationRuleProps) {
-    super(props);
-  }
-
   validation(_destinationRule: DestinationRule): ObjectValidation | undefined {
     return this.props.validation;
   }

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceDetail.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceDetail.tsx
@@ -21,10 +21,6 @@ interface VirtualServiceProps {
 }
 
 class VirtualServiceDetail extends React.Component<VirtualServiceProps> {
-  constructor(props: VirtualServiceProps) {
-    super(props);
-  }
-
   validation(_virtualService: VirtualService): ObjectValidation | undefined {
     return this.props.validation;
   }

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceRoute.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceRoute.tsx
@@ -44,10 +44,6 @@ class VirtualServiceRoute extends React.Component<VirtualServiceRouteProps> {
     );
   };
 
-  constructor(props: VirtualServiceRouteProps) {
-    super(props);
-  }
-
   columns() {
     return {
       columns: [

--- a/src/pages/Overview/OverviewCardContent.tsx
+++ b/src/pages/Overview/OverviewCardContent.tsx
@@ -15,10 +15,6 @@ type Props = {
 };
 
 class OverviewCardContent extends React.Component<Props> {
-  constructor(props: Props) {
-    super(props);
-  }
-
   render() {
     const targetPage = switchType(this.props.type, Paths.APPLICATIONS, Paths.SERVICES, Paths.WORKLOADS);
     const name = this.props.name;

--- a/src/pages/Overview/OverviewCardContentExpanded.tsx
+++ b/src/pages/Overview/OverviewCardContentExpanded.tsx
@@ -26,10 +26,6 @@ type Props = {
 };
 
 class OverviewCardContentExpanded extends React.Component<Props> {
-  constructor(props: Props) {
-    super(props);
-  }
-
   render() {
     return (
       <>

--- a/src/pages/Overview/OverviewCardLinks.tsx
+++ b/src/pages/Overview/OverviewCardLinks.tsx
@@ -14,10 +14,6 @@ const iconStyle = style({
 });
 
 class OverviewCardLinks extends React.Component<Props> {
-  constructor(props: Props) {
-    super(props);
-  }
-
   render() {
     return (
       <div style={{ marginTop: '10px' }}>

--- a/src/pages/Overview/OverviewStatus.tsx
+++ b/src/pages/Overview/OverviewStatus.tsx
@@ -16,10 +16,6 @@ type Props = {
 };
 
 class OverviewStatus extends React.Component<Props, {}> {
-  constructor(props: Props) {
-    super(props);
-  }
-
   setFilters = () => {
     const filters: (ActiveFilter & { id: string })[] = [
       {

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
@@ -51,10 +51,6 @@ const labelListStyle = style({
 const ExternalNameType = 'ExternalName';
 
 class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps> {
-  constructor(props: ServiceInfoDescriptionProps) {
-    super(props);
-  }
-
   getValidations(): ObjectValidation {
     return this.props.validations ? this.props.validations : ({} as ObjectValidation);
   }

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDestinationRules.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDestinationRules.tsx
@@ -15,10 +15,6 @@ interface ServiceInfoDestinationRulesProps {
 }
 
 class ServiceInfoDestinationRules extends React.Component<ServiceInfoDestinationRulesProps> {
-  constructor(props: ServiceInfoDestinationRulesProps) {
-    super(props);
-  }
-
   headerFormat = (label, { column }) => <Table.Heading className={column.property}>{label}</Table.Heading>;
   cellFormat = (value, { column }) => {
     const props = column.cell.props;

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoVirtualServices.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoVirtualServices.tsx
@@ -21,10 +21,6 @@ class ServiceInfoVirtualServices extends React.Component<ServiceInfoVirtualServi
     return <Table.Cell className={className}>{value}</Table.Cell>;
   };
 
-  constructor(props: ServiceInfoVirtualServicesProps) {
-    super(props);
-  }
-
   columns() {
     return {
       columns: [

--- a/src/pages/ServiceDetails/ServiceTraces.tsx
+++ b/src/pages/ServiceDetails/ServiceTraces.tsx
@@ -8,10 +8,6 @@ interface ServiceTracesProps {
 }
 
 class ServiceTraces extends React.Component<ServiceTracesProps> {
-  constructor(props: ServiceTracesProps) {
-    super(props);
-  }
-
   render() {
     const serviceSelected = `${this.props.service}.${this.props.namespace}`;
     const tags = this.props.errorTags ? 'error=true' : '';

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPods.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPods.tsx
@@ -12,10 +12,6 @@ type WorkloadPodsProps = {
 };
 
 class WorkloadPods extends React.Component<WorkloadPodsProps> {
-  constructor(props: WorkloadPodsProps) {
-    super(props);
-  }
-
   headerFormat = (label, { column }) => <Table.Heading className={column.property}>{label}</Table.Heading>;
   cellFormat = value => {
     return <Table.Cell>{value}</Table.Cell>;


### PR DESCRIPTION
Part of #1154.

Those are warnings after the upgrade to `react-scripts`, so we're
cleaning those up.

Only removing unused code, no breakage is expected.