### PR TITLE
Fix browserversion warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,8 @@
     "@types/react": "16.7.13",
     "handlebars": "4.0.14",
     "js-yaml": "3.13.1",
-    "hoist-non-react-statics": "3.3.0"
+    "hoist-non-react-statics": "3.3.0",
+    "caniuse-lite": "1.0.30000974"
   },
   "engines": {
     "node": ">=10.0.0 && <11",
@@ -156,7 +157,7 @@
     }
   },
   "browserslist": [
-    ">3%",
+    ">10%",
     "last 2 versions",
     "not ie <= 11"
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2267,10 +2267,10 @@ caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
   resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000927.tgz#9906eecf59ae7ee5d1bb2c16cf06fc31b642bfda"
   integrity sha512-CX/QvLA8oh7kQ9cHCCzFm0UZW4KwSyQSRJ5A1XtH42HaMJQ0yh+9fEVWagMqv9I1vSCtaqA5Mb8k0uKfv7jhDw==
 
-caniuse-lite@^1.0.30000748, caniuse-lite@^1.0.30000792:
-  version "1.0.30000927"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000927.tgz#114a9de4ff1e01f5790fe578ecd93421c7524665"
-  integrity sha512-ogq4NbUWf1uG/j66k0AmiO3GjqJAlQyF8n4w8a954cbCyFKmYGvRtgz6qkq2fWuduTXHibX7GyYL5Pg58Aks2g==
+caniuse-lite@1.0.30000974, caniuse-lite@^1.0.30000748, caniuse-lite@^1.0.30000792:
+  version "1.0.30000974"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000974.tgz#b7afe14ee004e97ce6dc73e3f878290a12928ad8"
+  integrity sha512-xc3rkNS/Zc3CmpMKuczWEdY2sZgx09BkAxfvkxlAEBTqcMHeL8QnPqhKse+5sRTi3nrw2pJwToD2WvKn1Uhvww==
 
 capture-exit@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Part of #1154.

Fix the warnings that happen after the `react-scripts` update that look
like this:

```
BrowserslistError: Unknown browser query `android all`
BrowserslistError: Unknown browser query `android all`
BrowserslistError: Unknown browser query `android all`
BrowserslistError: Unknown browser query `android all`
BrowserslistError: Unknown browser query `android all`
BrowserslistError: Unknown browser query `android all`
BrowserslistError: Unknown browser query `android all`
BrowserslistError: Unknown browser query `android all`
BrowserslistError: Unknown browser query `android all`
BrowserslistError: Unknown browser query `android all`
BrowserslistError: Unknown browser query `android all`
BrowserslistError: Unknown browser query `android all`
BrowserslistError: Unknown browser query `android all`
BrowserslistError: Unknown browser query `android all`
BrowserslistError: Unknown browser query `android all`
BrowserslistError: Unknown browser query `android all`
BrowserslistError: Unknown browser query `android all`
BrowserslistError: Unknown browser query `android all`
BrowserslistError: Unknown browser query `android all`
BrowserslistError: Unknown browser query `android all`
BrowserslistError: Unknown browser query `android all`
```

Reference: https://github.com/browserslist/browserslist/issues/382