### PR TITLE
KIALI-3055 Fix namespace scrollbar for non-webkit browsers

### DIFF
--- a/src/components/NamespaceDropdown.tsx
+++ b/src/components/NamespaceDropdown.tsx
@@ -46,7 +46,7 @@ const namespaceValueStyle = style({
 const popoverMarginBottom = 20;
 
 const namespaceContainerStyle = style({
-  overflow: 'overlay'
+  overflow: 'auto'
 });
 
 interface ReduxProps {


### PR DESCRIPTION
 - I was using "overflow: overlay" which is only supported
   on webkit, changed it to auto and is working properly on
   both chrome and firefox.
