### PR TITLE
KIALI-3058 Add version label in app-based custom metrics page

### DIFF
--- a/src/components/Metrics/CustomMetrics.tsx
+++ b/src/components/Metrics/CustomMetrics.tsx
@@ -48,13 +48,15 @@ class CustomMetrics extends React.Component<CustomMetricsProps, MetricsState> {
   }
 
   initOptions(): DashboardQuery {
-    let filters = `${serverConfig.istioLabels.appLabelName}:${this.props.app}`;
-    if (this.props.version) {
-      filters += `,${serverConfig.istioLabels.versionLabelName}:${this.props.version}`;
-    }
-    const options: DashboardQuery = {
-      labelsFilters: filters
-    };
+    const filters = `${serverConfig.istioLabels.appLabelName}:${this.props.app}`;
+    const options: DashboardQuery = this.props.version
+      ? {
+          labelsFilters: `${filters},${serverConfig.istioLabels.versionLabelName}:${this.props.version}`
+        }
+      : {
+          labelsFilters: filters,
+          additionalLabels: 'version:Version'
+        };
     MetricsHelper.initMetricsSettings(options);
     MetricsHelper.initDuration(options);
     return options;


### PR DESCRIPTION
The "additionalLabels" param was missing in case version is not provided (app view)

Now back to normal:

![view](https://i.imgur.com/hlYz4IB.png)

JIRA: https://issues.jboss.org/browse/KIALI-3058