### PR TITLE
KIALI-2961 Add icon for unknown health + move to PF4 icons

### DIFF
--- a/src/components/Health/HealthDetails.tsx
+++ b/src/components/Health/HealthDetails.tsx
@@ -1,27 +1,19 @@
 import * as React from 'react';
-import { Icon } from 'patternfly-react';
 import * as H from '../../types/Health';
+import { createIcon } from './Helper';
 
 interface Props {
   health: H.Health;
 }
 
 export class HealthDetails extends React.PureComponent<Props, {}> {
-  renderStatus(status: H.Status) {
-    if (status.icon) {
-      return <Icon type="pf" name={status.icon} />;
-    } else {
-      return <span style={{ color: status.color }}>{status.text}</span>;
-    }
-  }
-
   render() {
     const health = this.props.health;
     return health.items.map((item, idx) => {
       return (
         <div key={idx}>
           <strong>
-            {this.renderStatus(item.status)}
+            {createIcon(item.status)}
             {' ' + item.title + ': '}
           </strong>
           {item.text}
@@ -30,7 +22,7 @@ export class HealthDetails extends React.PureComponent<Props, {}> {
               {item.children.map((sub, subIdx) => {
                 return (
                   <li key={subIdx}>
-                    {this.renderStatus(sub.status)} {sub.text}
+                    {createIcon(sub.status)} {sub.text}
                   </li>
                 );
               })}

--- a/src/components/Health/HealthIndicator.tsx
+++ b/src/components/Health/HealthIndicator.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { Icon, OverlayTrigger, Popover } from 'patternfly-react';
+import { OverlayTrigger, Popover } from 'patternfly-react';
 import { HealthDetails } from './HealthDetails';
 import * as H from '../../types/Health';
+import { createIcon } from './Helper';
 
 export enum DisplayMode {
   LARGE,
@@ -43,8 +44,7 @@ export class HealthIndicator extends React.PureComponent<Props, HealthState> {
   }
 
   renderSmall(health: H.Health) {
-    const icon = this.renderIcon('18px', '12px');
-    return this.renderPopover(health, icon);
+    return this.renderPopover(health, createIcon(this.state.globalStatus, 'sm'));
   }
 
   renderLarge(health: H.Health) {
@@ -57,31 +57,13 @@ export class HealthIndicator extends React.PureComponent<Props, HealthState> {
     };
     return (
       <>
-        {this.renderIcon('35px', '24px')}
+        {createIcon(this.state.globalStatus, 'lg')}
         <span style={spanStyle}>{this.state.globalStatus.name}</span>
         <br />
         <br />
         <HealthDetails health={health} />
       </>
     );
-  }
-
-  renderIcon(iconSize: string, textSize: string) {
-    if (this.state.globalStatus.icon) {
-      return (
-        <Icon
-          type="pf"
-          name={this.state.globalStatus.icon}
-          style={{ fontSize: iconSize }}
-          className="health-icon"
-          tabIndex="0"
-        />
-      );
-    } else {
-      return (
-        <span style={{ color: this.state.globalStatus.color, fontSize: textSize }}>{this.state.globalStatus.text}</span>
-      );
-    }
   }
 
   renderPopover(health: H.Health, icon: JSX.Element) {

--- a/src/components/Health/Helper.ts
+++ b/src/components/Health/Helper.ts
@@ -1,0 +1,8 @@
+import * as React from 'react';
+import { Status } from 'types/Health';
+
+type Size = 'sm' | 'md' | 'lg' | 'xl';
+
+export const createIcon = (status: Status, size?: Size) => {
+  return React.createElement(status.icon, { color: status.color, size: size });
+};

--- a/src/components/Health/__tests__/HealthIndicator.test.tsx
+++ b/src/components/Health/__tests__/HealthIndicator.test.tsx
@@ -30,12 +30,12 @@ describe('HealthIndicator', () => {
     let wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.SMALL} />);
     expect(shallowToJson(wrapper)).toMatchSnapshot();
     let html = wrapper.html();
-    expect(html).toContain('pficon-ok');
+    expect(html).toContain('#3f9c35');
 
     // LARGE
     wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} />);
     html = wrapper.html();
-    expect(html).toContain('pficon-ok');
+    expect(html).toContain('#3f9c35');
   });
 
   it('renders workloads degraded', () => {
@@ -51,12 +51,12 @@ describe('HealthIndicator', () => {
     // SMALL
     let wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.SMALL} />);
     let html = wrapper.html();
-    expect(html).toContain('pficon-warning');
+    expect(html).toContain('#ec7a08');
 
     // LARGE
     wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} />);
     html = wrapper.html();
-    expect(html).toContain('pficon-warning');
+    expect(html).toContain('#ec7a08');
     expect(html).toContain('1 / 10');
   });
 
@@ -73,12 +73,12 @@ describe('HealthIndicator', () => {
     // SMALL
     let wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.SMALL} />);
     let html = wrapper.html();
-    expect(html).toContain('pficon-ok');
+    expect(html).toContain('#3f9c35');
 
     // LARGE
     wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} />);
     html = wrapper.html();
-    expect(html).toContain('pficon-ok');
+    expect(html).toContain('#3f9c35');
     expect(html).toContain('0 / 0');
   });
 
@@ -95,12 +95,12 @@ describe('HealthIndicator', () => {
     // SMALL
     let wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.SMALL} />);
     let html = wrapper.html();
-    expect(html).toContain('pficon-error');
+    expect(html).toContain('#cc0000');
 
     // LARGE
     wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} />);
     html = wrapper.html();
-    expect(html).toContain('pficon-error');
+    expect(html).toContain('#cc0000');
   });
 
   it('renders error rate failure', () => {
@@ -113,12 +113,12 @@ describe('HealthIndicator', () => {
     // SMALL
     let wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.SMALL} />);
     let html = wrapper.html();
-    expect(html).toContain('pficon-error');
+    expect(html).toContain('#cc0000');
 
     // LARGE
     wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} />);
     html = wrapper.html();
-    expect(html).toContain('pficon-error');
+    expect(html).toContain('#cc0000');
     expect(html).toContain('Outbound: 20.00%');
     expect(html).toContain('Inbound: 10.00%');
   });

--- a/src/components/Health/__tests__/__snapshots__/HealthDetails.test.tsx.snap
+++ b/src/components/Health/__tests__/__snapshots__/HealthDetails.test.tsx.snap
@@ -5,15 +5,11 @@ exports[`HealthDetails renders deployments failure 1`] = `
   key="0"
 >
   <strong>
-    <span
-      style={
-        Object {
-          "color": "#72767b",
-        }
-      }
-    >
-      N/A
-    </span>
+    <UnknownIcon
+      color="#72767b"
+      size="sm"
+      title={null}
+    />
      Error Rate over last 1m: 
   </strong>
   No requests
@@ -25,15 +21,11 @@ exports[`HealthDetails renders healthy 1`] = `
   key="0"
 >
   <strong>
-    <span
-      style={
-        Object {
-          "color": "#72767b",
-        }
-      }
-    >
-      N/A
-    </span>
+    <UnknownIcon
+      color="#72767b"
+      size="sm"
+      title={null}
+    />
      Error Rate over last 1m: 
   </strong>
   No requests

--- a/src/components/Health/__tests__/__snapshots__/HealthIndicator.test.tsx.snap
+++ b/src/components/Health/__tests__/__snapshots__/HealthIndicator.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`HealthIndicator renders healthy 1`] = `
                   Object {
                     "status": Object {
                       "color": "#3f9c35",
-                      "icon": "ok",
+                      "icon": [Function],
                       "name": "Healthy",
                       "priority": 1,
                     },
@@ -28,7 +28,7 @@ exports[`HealthIndicator renders healthy 1`] = `
                   Object {
                     "status": Object {
                       "color": "#3f9c35",
-                      "icon": "ok",
+                      "icon": [Function],
                       "name": "Healthy",
                       "priority": 1,
                     },
@@ -37,7 +37,7 @@ exports[`HealthIndicator renders healthy 1`] = `
                 ],
                 "status": Object {
                   "color": "#3f9c35",
-                  "icon": "ok",
+                  "icon": [Function],
                   "name": "Healthy",
                   "priority": 1,
                 },
@@ -48,27 +48,27 @@ exports[`HealthIndicator renders healthy 1`] = `
                   Object {
                     "status": Object {
                       "color": "#72767b",
+                      "icon": [Function],
                       "name": "No health information",
                       "priority": 0,
-                      "text": "N/A",
                     },
                     "text": "Inbound: No requests",
                   },
                   Object {
                     "status": Object {
                       "color": "#72767b",
+                      "icon": [Function],
                       "name": "No health information",
                       "priority": 0,
-                      "text": "N/A",
                     },
                     "text": "Outbound: No requests",
                   },
                 ],
                 "status": Object {
                   "color": "#72767b",
+                  "icon": [Function],
                   "name": "No health information",
                   "priority": 0,
-                  "text": "N/A",
                 },
                 "title": "Error Rate over last 10m",
               },
@@ -92,16 +92,10 @@ exports[`HealthIndicator renders healthy 1`] = `
     ]
   }
 >
-  <Icon
-    className="health-icon"
-    name="ok"
-    style={
-      Object {
-        "fontSize": "18px",
-      }
-    }
-    tabIndex="0"
-    type="pf"
+  <OkIcon
+    color="#3f9c35"
+    size="sm"
+    title={null}
   />
 </OverlayTrigger>
 `;

--- a/src/pages/Overview/OverviewStatus.tsx
+++ b/src/pages/Overview/OverviewStatus.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
-import { AggregateStatusNotification, Icon, OverlayTrigger, Popover } from 'patternfly-react';
+import { AggregateStatusNotification, OverlayTrigger, Popover } from 'patternfly-react';
 import { Link } from 'react-router-dom';
 import { Status } from '../../types/Health';
 import { Paths } from '../../config';
 import { ActiveFilter } from '../../types/Filters';
 import { healthFilter } from '../../components/Filters/CommonFilters';
 import { FilterSelected } from '../../components/Filters/StatefulFilters';
+import { createIcon } from '../../components/Health/Helper';
 
 type Props = {
   id: string;
@@ -49,7 +50,7 @@ class OverviewStatus extends React.Component<Props, {}> {
       >
         <AggregateStatusNotification>
           <Link to={`/${this.props.targetPage}?namespaces=${this.props.namespace}`} onClick={() => this.setFilters()}>
-            <Icon type="pf" name={this.props.status.icon} />
+            {createIcon(this.props.status)}
             {length}
           </Link>
         </AggregateStatusNotification>

--- a/src/types/Health.ts
+++ b/src/types/Health.ts
@@ -1,3 +1,5 @@
+import { ErrorCircleOIcon, WarningTriangleIcon, OkIcon, UnknownIcon } from '@patternfly/react-icons';
+import { IconType } from '@patternfly/react-icons/dist/js/createIcon';
 import { PfColors } from '../components/Pf/PfColors';
 import { getName } from '../utils/RateIntervals';
 
@@ -30,33 +32,32 @@ export interface Status {
   name: string;
   color: string;
   priority: number;
-  icon?: string;
-  text?: string;
+  icon: IconType;
 }
 
 export const FAILURE: Status = {
   name: 'Failure',
   color: PfColors.Red100,
   priority: 3,
-  icon: 'error-circle-o'
+  icon: ErrorCircleOIcon
 };
 export const DEGRADED: Status = {
   name: 'Degraded',
   color: PfColors.Orange400,
   priority: 2,
-  icon: 'warning-triangle-o'
+  icon: WarningTriangleIcon
 };
 export const HEALTHY: Status = {
   name: 'Healthy',
   color: PfColors.Green400,
   priority: 1,
-  icon: 'ok'
+  icon: OkIcon
 };
 export const NA: Status = {
   name: 'No health information',
   color: PfColors.Gray,
   priority: 0,
-  text: 'N/A'
+  icon: UnknownIcon
 };
 
 interface Thresholds {


### PR DESCRIPTION
The move to PF4 icons impacts all health icons, including on overview page

Some screenshots:

**List view**
![1](https://i.imgur.com/PXfGc4W.png)

**Details**
![2](https://i.imgur.com/8Fdm346.png)

**Details, N/A**
![3](https://i.imgur.com/QXqSqFc.png)

**Overview cards**
![4](https://i.imgur.com/dFZy9ch.png)

Maybe you will notice that the icons are not exactly the same size as before.
Previously we were setting the exact size manually, now with PF4 there are pre-defined sizes (large/medium/small) that we can (must?) use.

This is more visible on the overview cards, where the icon is bigger than before.

Please tell me what you think
cc @aljesusg @lucasponce @abonas @kiali/ux-reviewers 