### PR TITLE
KIALI-3057 mTLS status messages reduced to informative when user hasn't namespaces

### DIFF
--- a/src/app/AuthenticationController.tsx
+++ b/src/app/AuthenticationController.tsx
@@ -121,18 +121,12 @@ class AuthenticationController extends React.Component<AuthenticationControllerP
             MessageType.INFO
           );
         });
-      const getMeshTlsPromise = API.getMeshTls()
-        .then(response => this.props.setMeshTlsStatus(response.data))
-        .catch(error => {
-          MessageCenter.add(API.getErrorMsg('Error fetching TLS Info.', error), 'default', MessageType.WARNING);
-        });
 
       const configs = await Promise.all([
         API.getServerConfig(),
         getStatusPromise,
         getGrafanaInfoPromise,
-        getJaegerInfoPromise,
-        getMeshTlsPromise
+        getJaegerInfoPromise
       ]);
       setServerConfig(configs[0].data);
 

--- a/src/app/AuthenticationController.tsx
+++ b/src/app/AuthenticationController.tsx
@@ -107,7 +107,7 @@ class AuthenticationController extends React.Component<AuthenticationControllerP
         .then(response => this.props.setGrafanaInfo(response.data))
         .catch(error => {
           MessageCenter.add(
-            API.getErrorMsg('Could not fetch Grafana info. Turning off links to Grafana.', error),
+            API.getInfoMsg('Could not fetch Grafana info. Turning off links to Grafana.', error),
             'default',
             MessageType.INFO
           );
@@ -116,7 +116,7 @@ class AuthenticationController extends React.Component<AuthenticationControllerP
         .then(response => this.setJaegerInfo(response.data))
         .catch(error => {
           MessageCenter.add(
-            API.getErrorMsg('Could not fetch Jaeger info. Turning off Jaeger integration.', error),
+            API.getInfoMsg('Could not fetch Jaeger info. Turning off Jaeger integration.', error),
             'default',
             MessageType.INFO
           );

--- a/src/components/MTls/MeshMTLSStatus.tsx
+++ b/src/components/MTls/MeshMTLSStatus.tsx
@@ -63,9 +63,20 @@ class MeshMTLSStatus extends React.Component<Props> {
       })
       .catch(error => {
         // User without namespaces can't have access to mTLS information. Reduce severity to info.
-        const severity: MessageType =
-          this.props.namespaces && this.props.namespaces.length ? MessageType.WARNING : MessageType.INFO;
-        MessageCenter.add(API.getErrorMsg('Error fetching status.', error), 'default', severity);
+        const informative = this.props.namespaces && this.props.namespaces.length < 1;
+        if (informative) {
+          MessageCenter.add(
+            API.getInfoMsg('Mesh-wide mTLS status feature disabled.', error),
+            'default',
+            MessageType.INFO
+          );
+        } else {
+          MessageCenter.add(
+            API.getErrorMsg('Error fetching Mesh-wide mTLS status.', error),
+            'default',
+            MessageType.ERROR
+          );
+        }
       });
   };
 

--- a/src/components/MTls/MeshMTLSStatus.tsx
+++ b/src/components/MTls/MeshMTLSStatus.tsx
@@ -4,7 +4,7 @@ import { KialiAppState } from '../../store/Store';
 import { MTLSIconTypes } from './MTLSIcon';
 import { default as MTLSStatus, emptyDescriptor, StatusDescriptor } from './MTLSStatus';
 import { style } from 'typestyle';
-import { lastRefreshAtSelector, meshWideMTLSStatusSelector } from '../../store/Selectors';
+import { lastRefreshAtSelector, meshWideMTLSStatusSelector, namespaceItemsSelector } from '../../store/Selectors';
 import { connect } from 'react-redux';
 import { MTLSStatuses, TLSStatus } from '../../types/TLSStatus';
 import * as MessageCenter from '../../utils/MessageCenter';
@@ -14,10 +14,12 @@ import { KialiDispatch } from '../../types/Redux';
 import { bindActionCreators } from 'redux';
 import { MeshTlsActions } from '../../actions/MeshTlsActions';
 import { PollIntervalInMs } from '../../types/Common';
+import Namespace from '../../types/Namespace';
 
 type ReduxProps = {
   lastRefreshAt: PollIntervalInMs;
   setMeshTlsStatus: (meshStatus: TLSStatus) => void;
+  namespaces: Namespace[] | undefined;
   status: string;
 };
 
@@ -60,7 +62,10 @@ class MeshMTLSStatus extends React.Component<Props> {
         return this.props.setMeshTlsStatus(response.data);
       })
       .catch(error => {
-        MessageCenter.add(API.getErrorMsg('Error fetching status.', error), 'default', MessageType.WARNING);
+        // User without namespaces can't have access to mTLS information. Reduce severity to info.
+        const severity: MessageType =
+          this.props.namespaces && this.props.namespaces.length ? MessageType.WARNING : MessageType.INFO;
+        MessageCenter.add(API.getErrorMsg('Error fetching status.', error), 'default', severity);
       });
   };
 
@@ -83,7 +88,8 @@ class MeshMTLSStatus extends React.Component<Props> {
 
 const mapStateToProps = (state: KialiAppState) => ({
   status: meshWideMTLSStatusSelector(state),
-  lastRefreshAt: lastRefreshAtSelector(state)
+  lastRefreshAt: lastRefreshAtSelector(state),
+  namespaces: namespaceItemsSelector(state)
 });
 
 const mapDispatchToProps = (dispatch: KialiDispatch) => ({

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -441,19 +441,27 @@ export const getPodLogs = (
   return newRequest<PodLogs>(HTTP_VERBS.GET, urls.podLogs(namespace, name), params, {});
 };
 
-export const getErrorMsg = (msg: string, error: AxiosError) => {
+export const getMessage = (type: string, msg: string, error: AxiosError) => {
   let errorMessage = msg;
   if (error && error.response) {
     if (error.response.data && error.response.data.error) {
-      errorMessage = `${msg}, Error: [ ${error.response.data.error} ]`;
+      errorMessage = `${msg}, ${type}: [ ${error.response.data.error} ]`;
     } else if (error.response.statusText) {
-      errorMessage = `${msg}, Error: [ ${error.response.statusText} ]`;
+      errorMessage = `${msg}, ${type}: [ ${error.response.statusText} ]`;
       if (error.response.status === 401) {
         errorMessage += ' Has your session expired? Try logging in again.';
       }
     }
   }
   return errorMessage;
+};
+
+export const getInfoMsg = (msg: string, error: AxiosError) => {
+  return getMessage('Info', msg, error);
+};
+
+export const getErrorMsg = (msg: string, error: AxiosError) => {
+  return getMessage('Error', msg, error);
 };
 
 export const getThreeScaleInfo = () => {


### PR DESCRIPTION
** Describe the change **

Decreasing Severity from MTLS Status message: from warning to informative. This prevents UI to show messages outside the MessageCenter. Less intrusive solution.

Needs: https://github.com/kiali/kiali/pull/1187

** Issue reference **
https://issues.jboss.org/browse/KIALI-3057

** Backwards compatible? **
yes

** Screenshot **

![Screenshot of Kiali Console (51)](https://user-images.githubusercontent.com/613814/60180327-13331100-9820-11e9-931a-575b8e10eb86.png)

![Screen recording (16)](https://user-images.githubusercontent.com/613814/60180484-6d33d680-9820-11e9-8d1b-a5fbd36ec248.gif)

