### PR TITLE
KIALI-3034 Improve side-panel for serviceEntry nodes (#1271)

### DIFF
--- a/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
+++ b/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
@@ -56,7 +56,7 @@ export class NodeContextMenu extends React.PureComponent<Props> {
         }
         break;
       case 'service':
-        type = Paths.SERVICES;
+        type = props.isServiceEntry ? Paths.SERVICEENTRIES : Paths.SERVICES;
         name = props.service;
         break;
       case 'workload':
@@ -120,20 +120,25 @@ export class NodeContextMenu extends React.PureComponent<Props> {
           <strong>{name}</strong>
         </div>
         {this.createMenuItem(detailsPageUrl, 'Show Details')}
-        {this.createMenuItem(`${detailsPageUrl}?tab=traffic`, 'Show Traffic')}
-        {type === Paths.WORKLOADS && this.createMenuItem(`${detailsPageUrl}?tab=logs`, 'Show Logs')}
-        {this.createMenuItem(
-          `${detailsPageUrl}?tab=${type === Paths.SERVICES ? 'metrics' : 'in_metrics'}`,
-          'Show Inbound Metrics'
+        {type !== Paths.SERVICEENTRIES && (
+          <>
+            {this.createMenuItem(`${detailsPageUrl}?tab=traffic`, 'Show Traffic')}
+            {type === Paths.WORKLOADS && this.createMenuItem(`${detailsPageUrl}?tab=logs`, 'Show Logs')}
+            {this.createMenuItem(
+              `${detailsPageUrl}?tab=${type === Paths.SERVICES ? 'metrics' : 'in_metrics'}`,
+              'Show Inbound Metrics'
+            )}
+            {type !== Paths.SERVICES &&
+              this.createMenuItem(`${detailsPageUrl}?tab=out_metrics`, 'Show Outbound Metrics')}
+            {type === Paths.SERVICES &&
+              this.props.jaegerURL !== '' &&
+              this.createMenuItem(
+                this.getJaegerURL(name),
+                'Show Traces',
+                this.props.jaegerIntegration ? '_self' : '_blank'
+              )}
+          </>
         )}
-        {type !== Paths.SERVICES && this.createMenuItem(`${detailsPageUrl}?tab=out_metrics`, 'Show Outbound Metrics')}
-        {type === Paths.SERVICES &&
-          this.props.jaegerURL !== '' &&
-          this.createMenuItem(
-            this.getJaegerURL(name),
-            'Show Traces',
-            this.props.jaegerIntegration ? '_self' : '_blank'
-          )}
       </div>
     );
   }

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -520,7 +520,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
 
     const targetOrGroupChildren = targetType === 'group' ? target.descendants() : target;
 
-    if (target.data(CyNode.isInaccessible)) {
+    if (target.data(CyNode.isInaccessible) || target.data(CyNode.isServiceEntry)) {
       return;
     }
 

--- a/src/config/Paths.ts
+++ b/src/config/Paths.ts
@@ -4,8 +4,9 @@
 
 export enum Paths {
   APPLICATIONS = 'applications',
-  SERVICES = 'services',
-  WORKLOADS = 'workloads',
   ISTIO = 'istio',
-  JAEGER = 'jaeger'
+  JAEGER = 'jaeger',
+  SERVICES = 'services',
+  SERVICEENTRIES = 'istio/serviceentries',
+  WORKLOADS = 'workloads'
 }

--- a/src/pages/Graph/SummaryLink.tsx
+++ b/src/pages/Graph/SummaryLink.tsx
@@ -16,7 +16,7 @@ const getTitle = (data: NodeData) => {
 };
 
 const isInaccessible = (data: NodeData): boolean => {
-  return data.isInaccessible || data.isServiceEntry !== undefined;
+  return data.isInaccessible;
 };
 
 const getLink = (data: NodeData, nodeType?: NodeType) => {
@@ -36,10 +36,12 @@ const getLink = (data: NodeData, nodeType?: NodeType) => {
       displayName = app;
       break;
     case NodeType.SERVICE:
-      if (!data.isServiceEntry) {
+      if (data.isServiceEntry) {
+        link = `/namespaces/${encodeURIComponent(namespace)}/istio/serviceentries/${encodeURIComponent(service)}`;
+      } else {
         link = `/namespaces/${encodeURIComponent(namespace)}/services/${encodeURIComponent(service)}`;
-        key = `${namespace}.svc.${service}`;
       }
+      key = `${namespace}.svc.${service}`;
       displayName = service;
       break;
     case NodeType.WORKLOAD:

--- a/src/pages/Graph/SummaryPanelEdge.tsx
+++ b/src/pages/Graph/SummaryPanelEdge.tsx
@@ -417,11 +417,20 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
       );
     }
 
-    const data = nodeData(edge.target());
-    if (data.isInaccessible) {
+    const source = nodeData(edge.source());
+    const target = nodeData(edge.target());
+    if (target.isInaccessible) {
       return (
         <>
           <Icon type="pf" name="info" /> Sparkline charts cannot be shown because the destination is inaccessible.
+        </>
+      );
+    }
+    if (source.isServiceEntry || target.isServiceEntry) {
+      return (
+        <>
+          <Icon type="pf" name="info" /> Sparkline charts cannot be shown because the source or destination is a
+          serviceEntry.
         </>
       );
     }


### PR DESCRIPTION
- provide a real link to the ServiceEntry detail
- show the individually requested destinations
- prevent drill down because serviceEntries are aggregates
- limit contextmenu options because serviceEntries are aggregates
- prevent sparklines in side panel because serviceEntries are aggregates

Conflicts:
  src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx

!! REQUIRES server pr https://github.com/kiali/kiali/pull/1193