### PR TITLE
KIALI-3071 Split details and 3scale promises

### DIFF
--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -292,6 +292,7 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
         const objectValidations = validations.destinationrule[destinationRule.metadata.name];
         if (
           formatValidation !== null &&
+          objectValidations.checks &&
           !objectValidations.checks.some(check => check.message === formatValidation.message)
         ) {
           objectValidations.checks.push(formatValidation);

--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -25,6 +25,7 @@ import { DurationInSeconds } from '../../types/Common';
 import { durationSelector } from '../../store/Selectors';
 import { PromisesRegistry } from '../../utils/CancelablePromises';
 import Namespace from '../../types/Namespace';
+import { MessageType } from '../../types/MessageCenter';
 
 type ServiceDetailsState = {
   serviceDetailsInfo: ServiceDetailsInfo;
@@ -203,22 +204,13 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
         MessageCenter.add(API.getErrorMsg('Could not fetch Namespaces list', error));
       });
 
-    const promiseDetails = API.getServiceDetail(
-      this.props.match.params.namespace,
-      this.props.match.params.service,
-      true,
-      this.props.duration
-    );
-    const promiseThreeScale = API.getThreeScaleInfo();
-    Promise.all([promiseDetails, promiseThreeScale])
+    API.getServiceDetail(this.props.match.params.namespace, this.props.match.params.service, true, this.props.duration)
       .then(results => {
         this.setState({
-          serviceDetailsInfo: results[0],
-          validations: this.addFormatValidation(results[0], results[0].validations),
-          threeScaleInfo: results[1].data
+          serviceDetailsInfo: results,
+          validations: this.addFormatValidation(results, results.validations)
         });
-
-        if (results[0].errorTraces === -1 && this.props.jaegerUrl !== '') {
+        if (results.errorTraces === -1 && this.props.jaegerUrl !== '') {
           MessageCenter.add(
             'Could not fetch Traces in the service ' +
               this.props.match.params.service +
@@ -229,8 +221,17 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
               ' is available.'
           );
         }
+      })
+      .catch(error => {
+        MessageCenter.add(API.getErrorMsg('Could not fetch Service Details', error));
+      });
 
-        if (results[1].data.enabled) {
+    API.getThreeScaleInfo()
+      .then(results => {
+        this.setState({
+          threeScaleInfo: results.data
+        });
+        if (results.data.enabled) {
           API.getThreeScaleServiceRule(this.props.match.params.namespace, this.props.match.params.service)
             .then(result => {
               this.setState({
@@ -249,7 +250,11 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
         }
       })
       .catch(error => {
-        MessageCenter.add(API.getErrorMsg('Could not fetch Service Details', error));
+        MessageCenter.add(
+          API.getInfoMsg('Could not fetch 3scale info. Turning off 3scale integration.', error),
+          'default',
+          MessageType.INFO
+        );
       });
   };
 

--- a/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -70,6 +70,7 @@ class ServiceInfo extends React.Component<ServiceDetails, ServiceInfoState> {
       virtualService =>
         validations.virtualservice &&
         validations.virtualservice[virtualService.metadata.name] &&
+        validations.virtualservice[virtualService.metadata.name].checks &&
         validations.virtualservice[virtualService.metadata.name].checks.length > 0
     );
 
@@ -78,6 +79,7 @@ class ServiceInfo extends React.Component<ServiceDetails, ServiceInfoState> {
         validations.destinationrule &&
         destinationRule.metadata &&
         validations.destinationrule[destinationRule.metadata.name] &&
+        validations.destinationrule[destinationRule.metadata.name].checks &&
         validations.destinationrule[destinationRule.metadata.name].checks.length > 0
     );
 

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
@@ -65,7 +65,7 @@ class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps
 
   getPortIssue(portId: number): string {
     let message = '';
-    if (this.props.validations) {
+    if (this.props.validations && this.props.validations.checks) {
       message = this.props.validations.checks
         .filter(c => c.path === 'spec/ports[' + portId + ']')
         .map(c => c.message)


### PR DESCRIPTION
- Move 3scale error message to INFO

As similar strategy with Jaeger/Grafana, if user has not rights to query istio-system ns to check if 3scale adapter is deployed, it shouldn't fail the service details page, but show an informative message instead.


