### PR TITLE
KIALI-3046 Present a link to login into OpenShift

### DIFF
--- a/src/services/Login.ts
+++ b/src/services/Login.ts
@@ -76,8 +76,6 @@ class OpenshiftLogin implements LoginStrategy<any> {
     if (window.location.hash.startsWith('#access_token')) {
       return AuthResult.CONTINUE;
     } else {
-      window.location.href = info.authorizationEndpoint!;
-
       return AuthResult.HOLD;
     }
   }


### PR DESCRIPTION
** Describe the change **

Instead of taking the user directly to the OpenShift login page, we take them to the Kiali Login page that has a button to go to the OpenShift login page.

** Issue reference **

https://issues.jboss.org/browse/KIALI-3046

** Screenshot **

What the login page looks like (note: this login page already exists, but its bypassed currently)

![Screenshot from 2019-06-27 15-43-29](https://user-images.githubusercontent.com/691166/60296034-2b279500-98f3-11e9-9697-f921de23ed5f.png)

Note: awaiting feedback from UX
