### PR TITLE
KIALI-3039 Minor fix to Empty Graph text

### DIFF
--- a/src/components/EmptyGraphLayout.tsx
+++ b/src/components/EmptyGraphLayout.tsx
@@ -117,7 +117,7 @@ export class EmptyGraphLayout extends React.Component<EmptyGraphLayoutProps, Emp
         <EmptyState className={emptyStateStyle}>
           <EmptyStateTitle>No namespace is selected</EmptyStateTitle>
           <EmptyStateInfo>
-            There is currently no namespace selected, please select one using the Namespace selection button.
+            There is currently no namespace selected, please select one using the Namespace selector.
           </EmptyStateInfo>
         </EmptyState>
       );


### PR DESCRIPTION
Use widget-independent wording:

![image](https://user-images.githubusercontent.com/2104052/60360388-9e8bde00-99a9-11e9-8873-024a795036d2.png)
