### PR TITLE
[v1.0] KIALI-2985 normalize timeseries on X axis

### DIFF
--- a/src/utils/Graphing.ts
+++ b/src/utils/Graphing.ts
@@ -1,5 +1,57 @@
 import { TimeSeries, Histogram } from '../types/Metrics';
 
+type Series = {
+  name: string;
+  values: number[];
+};
+
+type Normalized = {
+  x: number[];
+  ys: Series[];
+};
+
+const compare = (a: number, b: number) => {
+  if (Math.abs(a - b) < 1000) {
+    // Consider equal
+    return 0;
+  }
+  return a - b;
+};
+
+// Exported for test
+export const mergeTimestampsAndNormalize = (normalized: Normalized, newX: number[], newY: Series): Normalized => {
+  if (normalized.x.length === 0) {
+    return {
+      x: newX,
+      ys: [newY]
+    };
+  }
+  if (newX.length === 0) {
+    return normalized;
+  }
+  const cmp = compare(normalized.x[0], newX[0]);
+
+  if (cmp < 0) {
+    // "current" starts before "new" => don't change current timestamps, but fill newY with undefined values
+    for (let i = 0; i < normalized.x.length && compare(normalized.x[i], newX[0]) < 0; i++) {
+      newY.values.unshift(NaN);
+    }
+  } else if (cmp > 0) {
+    // "new" starts before "current" => prepend "new" in "current", fill all previously normalized Y with undefined values
+    const toPrepend: number[] = [];
+    for (let i = 0; i < newX.length && compare(normalized.x[0], newX[i]) > 0; i++) {
+      toPrepend.push(newX[i]);
+      normalized.ys.forEach(y => y.values.unshift(NaN));
+    }
+    normalized.x.unshift(...toPrepend);
+  } else {
+    // Same timestamps => nothing to normalize
+  }
+
+  normalized.ys.push(newY);
+  return normalized;
+};
+
 export default {
   histogramToC3Columns(histogram: Histogram) {
     const stats = Object.keys(histogram);
@@ -7,33 +59,45 @@ export default {
       return [['x'], ['']];
     }
 
-    let series = [(['x'] as any[]).concat(histogram[stats[0]].matrix[0].values.map(dp => dp[0] * 1000))];
+    let normalized: Normalized = { x: [], ys: [] };
     stats.forEach(stat => {
-      const statSeries = histogram[stat].matrix.map(mat => {
-        return [mat.name as any].concat(mat.values.map(dp => dp[1]));
+      const matrix = histogram[stat].matrix;
+      matrix.forEach(mat => {
+        const timestamps = mat.values.map(dp => dp[0] * 1000);
+        const y: Series = {
+          name: mat.name,
+          values: mat.values.map(dp => dp[1])
+        };
+        normalized = mergeTimestampsAndNormalize(normalized, timestamps, y);
       });
-      series = series.concat(statSeries);
     });
-    return series;
+
+    const x = ['x' as any].concat(normalized.x);
+    const ys = normalized.ys.map(y => [y.name as any].concat(y.values));
+
+    // timestamps + data is the format required by C3 (all concatenated: an array with arrays)
+    return [x, ...ys];
   },
 
-  toC3Columns(matrix?: TimeSeries[], title?: string) {
+  toC3Columns(matrix?: TimeSeries[], title?: string): any[] {
     if (!matrix || matrix.length === 0) {
       return [['x'], [title || '']];
     }
 
-    // xseries are timestamps. Timestamps are taken from the first series and assumed
-    // that all series have the same timestamps.
-    let xseries: any = ['x'];
-    xseries = xseries.concat(matrix[0].values.map(dp => dp[0] * 1000));
-
-    // yseries are the values of each serie.
-    const yseries: any[] = matrix.map(mat => {
-      const serie: any = [title || mat.name];
-      return serie.concat(mat.values.map(dp => dp[1]));
+    let normalized: Normalized = { x: [], ys: [] };
+    matrix.forEach(mat => {
+      const timestamps = mat.values.map(dp => dp[0] * 1000);
+      const y: Series = {
+        name: title || mat.name,
+        values: mat.values.map(dp => dp[1])
+      };
+      normalized = mergeTimestampsAndNormalize(normalized, timestamps, y);
     });
 
+    const x = ['x' as any].concat(normalized.x);
+    const ys = normalized.ys.map(y => [y.name as any].concat(y.values));
+
     // timestamps + data is the format required by C3 (all concatenated: an array with arrays)
-    return [xseries, ...yseries];
+    return [x, ...ys];
   }
 };

--- a/src/utils/__tests__/Graphing.test.ts
+++ b/src/utils/__tests__/Graphing.test.ts
@@ -1,0 +1,91 @@
+import { mergeTimestampsAndNormalize } from '../Graphing';
+import graphUtils from '../Graphing';
+import { TimeSeries } from 'types/Metrics';
+
+describe('C3 series normalization', () => {
+  it('should normalize with ealier metric', () => {
+    const current = {
+      x: [15000, 20000, 25000, 30000],
+      ys: [
+        {
+          name: 'a',
+          values: [5, 6, 6, 5]
+        },
+        {
+          name: 'b',
+          values: [9, 7, 7, 9]
+        }
+      ]
+    };
+    const newTimestamps = [10001, 15001, 20001, 25001, 30001];
+    const newValues = {
+      name: 'c',
+      values: [3, 2, 3, 2, 3]
+    };
+    const normalized = mergeTimestampsAndNormalize(current, newTimestamps, newValues);
+
+    expect(normalized.x).toEqual([10001, 15000, 20000, 25000, 30000]);
+    expect(normalized.ys).toHaveLength(3);
+    expect(normalized.ys[0].name).toEqual('a');
+    expect(normalized.ys[1].name).toEqual('b');
+    expect(normalized.ys[2].name).toEqual('c');
+    expect(normalized.ys[0].values).toEqual([NaN, 5, 6, 6, 5]);
+    expect(normalized.ys[1].values).toEqual([NaN, 9, 7, 7, 9]);
+    expect(normalized.ys[2].values).toEqual([3, 2, 3, 2, 3]);
+  });
+
+  it('should normalize with later metric', () => {
+    const current = {
+      x: [15000, 20000, 25000, 30000],
+      ys: [
+        {
+          name: 'a',
+          values: [5, 6, 6, 5]
+        },
+        {
+          name: 'b',
+          values: [9, 7, 7, 9]
+        }
+      ]
+    };
+    const newTimestamps = [20001, 25001, 30001];
+    const newValues = {
+      name: 'c',
+      values: [3, 2, 3]
+    };
+    const normalized = mergeTimestampsAndNormalize(current, newTimestamps, newValues);
+
+    expect(normalized.x).toEqual([15000, 20000, 25000, 30000]);
+    expect(normalized.ys).toHaveLength(3);
+    expect(normalized.ys[0].name).toEqual('a');
+    expect(normalized.ys[1].name).toEqual('b');
+    expect(normalized.ys[2].name).toEqual('c');
+    expect(normalized.ys[0].values).toEqual([5, 6, 6, 5]);
+    expect(normalized.ys[1].values).toEqual([9, 7, 7, 9]);
+    expect(normalized.ys[2].values).toEqual([NaN, 3, 2, 3]);
+  });
+});
+
+describe('C3 conversion', () => {
+  it('should convert with normalized metrics', () => {
+    const input: TimeSeries[] = [
+      {
+        name: 'a',
+        metric: {},
+        values: [[15, 5], [20, 6], [25, 5]]
+      },
+      {
+        name: 'b',
+        metric: {},
+        values: [[25.5, 10]]
+      }
+    ];
+
+    const c3Columns = graphUtils.toC3Columns(input);
+
+    expect(c3Columns).toHaveLength(3);
+    expect(c3Columns[0]).toEqual(['x', 15000, 20000, 25000]);
+    expect(c3Columns[1]).toEqual(['a', 5, 6, 5]);
+    expect(c3Columns[2]).toEqual(['b', NaN, NaN, 10]);
+  });
+});


### PR DESCRIPTION
+ Add tests

This is targeting v1.0 branch directly.
Note that a slightly different fix will be needed for master, as it's involving k-charted there (no cherry-pick). I'll open a separate PR.

Series are now correctly left-aligned when they start later (here, v3 started after v1):

![shift](https://i.imgur.com/ZfmMLbP.png)