### PR TITLE
KIALI-3093 Fix reset pagination when NS changes

### DIFF
--- a/src/utils/Common.ts
+++ b/src/utils/Common.ts
@@ -1,3 +1,5 @@
+import Namespace from '../types/Namespace';
+
 export const removeDuplicatesArray = a => [...Array.from(new Set(a))] as string[];
 
 export const arrayEquals = <T>(a1: T[], a2: T[], comparator: (v1: T, v2: T) => boolean) => {
@@ -11,3 +13,6 @@ export const arrayEquals = <T>(a1: T[], a2: T[], comparator: (v1: T, v2: T) => b
   }
   return true;
 };
+
+export const namespaceEquals = (ns1: Namespace[], ns2: Namespace[]): boolean =>
+  arrayEquals(ns1, ns2, (n1, n2) => n1.name === n2.name);


### PR DESCRIPTION
** Describe the change **

Reset pagination when user changes the namespace to fetch.
There are some scenarios where user can move to a page that doesn't exist.

** Issue reference **

https://issues.jboss.org/browse/KIALI-3093

