### PR TITLE
 KIALI-3109 Fix service graph error

### DIFF
--- a/src/pages/Graph/SummaryPanelNode.tsx
+++ b/src/pages/Graph/SummaryPanelNode.tsx
@@ -436,7 +436,7 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
     const isServiceNode = node.data(CyNode.nodeType) === NodeType.SERVICE;
     let serviceWithUnknownSource: boolean = false;
     if (isServiceNode) {
-      for (const n of node.incomers) {
+      for (const n of node.incomers()) {
         if (NodeType.UNKNOWN === n.data(CyNode.nodeType)) {
           serviceWithUnknownSource = true;
           break;

--- a/src/pages/Graph/SummaryPanelNode.tsx
+++ b/src/pages/Graph/SummaryPanelNode.tsx
@@ -436,12 +436,13 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
     const isServiceNode = node.data(CyNode.nodeType) === NodeType.SERVICE;
     let serviceWithUnknownSource: boolean = false;
     if (isServiceNode) {
-      for (const n of node.incomers()) {
+      node.incomers().forEach(n => {
         if (NodeType.UNKNOWN === n.data(CyNode.nodeType)) {
           serviceWithUnknownSource = true;
-          break;
+          return false; // Equivalent of break for cytoscapejs forEach API
         }
-      }
+        return undefined; // Every code paths needs to return something to avoid the wrath of the linter.
+      });
     }
 
     let grpcCharts, httpCharts, tcpCharts;


### PR DESCRIPTION
** Describe the change **

Fix error that appeared when using the service graph (e.g. by going to a service and clicking "Show on graph")

This was caused because the result of incomers() do not implement the [Symbol.iterator](https://www.typescriptlang.org/docs/handbook/iterators-and-generators.html#iterables) needed for the `for-of` syntax.

Changed to use the [forEach](http://js.cytoscape.org/#eles.forEach) of cytoscapejs.

[KIALI-3109 ](https://issues.jboss.org/browse/KIALI-3109)

Before:
![image-2019-07-08-14-29-57-652](https://user-images.githubusercontent.com/3845764/60844983-86ce0a00-a1a0-11e9-83b9-3294af14a402.png)

After:
![Screenshot_2019-07-08_16-51-20](https://user-images.githubusercontent.com/3845764/60845020-a49b6f00-a1a0-11e9-81fc-3214e2b7a7d8.png)

