### PR TITLE
Trivial: Separate browserlist from all in one to PROD and DEV sections

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,10 +158,17 @@
       "pre-commit": "yarn run pretty-quick --staged --pattern \"{src/**/*.{js,jsx,ts,tsx,json,yml,css,scss},travis.yml,*.json}\" && npm run lint:precommit"
     }
   },
-  "browserslist": [
-    ">10%",
-    "last 2 versions",
-    "not ie <= 11"
-  ],
+  "browserslist": {
+    "production": [
+      ">10%",
+      "last 2 versions",
+      "not ie <= 11"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  },
   "snyk": true
 }


### PR DESCRIPTION
** Describe the change **

Separate browserlist from all in one to production and development settings for use with 'yarn build' and 'yarn start' respectively. This means we will be testing the more current browsers in development while supporting more versions in production (and more kinds)

** Backwards compatible? **
Yes
[ ] Is your pull-request introducing changes in behaviour?
No

https://github.com/browserslist/browserslist