### PR TITLE
[Readme] Fix documentation on "yarn start"

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -68,6 +68,8 @@ property to `package.json` with the url of kiali.
 ...
 ----
 
+If Kiali is configured with a specific web root, make sure to append it to the URL. On many setups with Kubernetes, the web root will be `/kiali` by default.
+
 Run `yarn start` and try it!
 [source, bash]
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -83,9 +83,6 @@ Type: ClusterIP
 ...
 ----
 
-WARNING: The proxy will only serve requests without the text/html accept header,
-using the browser directly won't work.
-
 === Styling
 https://www.patternfly.org/[PatternFly] is the main UI components framework. It defines style based on SASS preprocessor.
 All Patternfly build assets are copied to `src`.


### PR DESCRIPTION
Not sure why we were telling that... any idea?
We *do* use `yarn start` with the browser.

Also, mention web root when setting up proxy.