### PR TITLE
KIALI-3093 [v1.0] Fix reset pagination when NS changes

### DIFF
--- a/src/pages/AppList/AppListComponent.tsx
+++ b/src/pages/AppList/AppListComponent.tsx
@@ -15,7 +15,7 @@ import { ListComponent } from '../../components/ListPage/ListComponent';
 import { AlignRightStyle, ThinStyle } from '../../components/Filters/FilterStyles';
 import { KialiAppState } from '../../store/Store';
 import { activeNamespacesSelector, durationSelector } from '../../store/Selectors';
-import { arrayEquals } from '../../utils/Common';
+import { namespaceEquals } from '../../utils/Common';
 import { DurationInSeconds } from '../../types/Common';
 import { DurationDropdownContainer } from '../../components/DurationDropdown/DurationDropdown';
 import RefreshButtonContainer from '../../components/Refresh/RefreshButton';
@@ -47,7 +47,12 @@ class AppListComponent extends ListComponent.Component<AppListComponentProps, Ap
   }
 
   componentDidUpdate(prevProps: AppListComponentProps, prevState: AppListComponentState, snapshot: any) {
-    if (!this.paramsAreSynced(prevProps)) {
+    const [paramsSynced, nsSynced] = this.paramsAreSynced(prevProps);
+    if (!paramsSynced) {
+      if (!nsSynced) {
+        // If there is a change in the namespace selection, page is set to 1
+        this.pageSet(1);
+      }
       this.setState({
         pagination: this.props.pagination,
         currentSortField: this.props.currentSortField,
@@ -61,21 +66,17 @@ class AppListComponent extends ListComponent.Component<AppListComponentProps, Ap
     this.promises.cancelAll();
   }
 
-  paramsAreSynced(prevProps: AppListComponentProps) {
-    const activeNamespacesCompare = arrayEquals(
-      prevProps.activeNamespaces,
-      this.props.activeNamespaces,
-      (n1, n2) => n1.name === n2.name
-    );
-    return (
+  paramsAreSynced = (prevProps: AppListComponentProps): [boolean, boolean] => {
+    const activeNamespacesCompare = namespaceEquals(prevProps.activeNamespaces, this.props.activeNamespaces);
+    const paramsSynced =
       prevProps.pagination.page === this.props.pagination.page &&
       prevProps.pagination.perPage === this.props.pagination.perPage &&
       prevProps.duration === this.props.duration &&
       activeNamespacesCompare &&
       prevProps.isSortAscending === this.props.isSortAscending &&
-      prevProps.currentSortField.title === this.props.currentSortField.title
-    );
-  }
+      prevProps.currentSortField.title === this.props.currentSortField.title;
+    return [paramsSynced, activeNamespacesCompare];
+  };
 
   sortItemList(apps: AppListItem[], sortField: SortField<AppListItem>, isAscending: boolean): Promise<AppListItem[]> {
     // Chain promises, as there may be an ongoing fetch/refresh and sort can be called after UI interaction

--- a/src/pages/IstioConfigList/IstioConfigListComponent.tsx
+++ b/src/pages/IstioConfigList/IstioConfigListComponent.tsx
@@ -22,7 +22,7 @@ import { ListComponent } from '../../components/ListPage/ListComponent';
 import { SortField } from '../../types/SortFilters';
 import { getFilterSelectedValues } from '../../components/Filters/CommonFilters';
 import { AlignRightStyle, ThinStyle } from '../../components/Filters/FilterStyles';
-import { arrayEquals } from '../../utils/Common';
+import { namespaceEquals } from '../../utils/Common';
 import { KialiAppState } from '../../store/Store';
 import { activeNamespacesSelector } from '../../store/Selectors';
 import RefreshButtonContainer from '../../components/Refresh/RefreshButton';
@@ -58,7 +58,12 @@ class IstioConfigListComponent extends ListComponent.Component<
     prevState: IstioConfigListComponentState,
     snapshot: any
   ) {
-    if (!this.paramsAreSynced(prevProps)) {
+    const [paramsSynced, nsSynced] = this.paramsAreSynced(prevProps);
+    if (!paramsSynced) {
+      if (!nsSynced) {
+        // If there is a change in the namespace selection, page is set to 1
+        this.pageSet(1);
+      }
       this.setState({
         pagination: this.props.pagination,
         currentSortField: this.props.currentSortField,
@@ -73,20 +78,16 @@ class IstioConfigListComponent extends ListComponent.Component<
     this.promises.cancelAll();
   }
 
-  paramsAreSynced(prevProps: IstioConfigListComponentProps) {
-    const activeNamespacesCompare = arrayEquals(
-      prevProps.activeNamespaces,
-      this.props.activeNamespaces,
-      (n1, n2) => n1.name === n2.name
-    );
-    return (
+  paramsAreSynced = (prevProps: IstioConfigListComponentProps): [boolean, boolean] => {
+    const activeNamespacesCompare = namespaceEquals(prevProps.activeNamespaces, this.props.activeNamespaces);
+    const paramsSynced =
       prevProps.pagination.page === this.props.pagination.page &&
       prevProps.pagination.perPage === this.props.pagination.perPage &&
       activeNamespacesCompare &&
       prevProps.isSortAscending === this.props.isSortAscending &&
-      prevProps.currentSortField.title === this.props.currentSortField.title
-    );
-  }
+      prevProps.currentSortField.title === this.props.currentSortField.title;
+    return [paramsSynced, activeNamespacesCompare];
+  };
 
   sortItemList(apps: IstioConfigItem[], sortField: SortField<IstioConfigItem>, isAscending: boolean) {
     return IstioConfigListFilters.sortIstioItems(apps, sortField, isAscending);

--- a/src/pages/ServiceList/ServiceListComponent.tsx
+++ b/src/pages/ServiceList/ServiceListComponent.tsx
@@ -16,7 +16,7 @@ import './ServiceListComponent.css';
 import { SortField } from '../../types/SortFilters';
 import { ListComponent } from '../../components/ListPage/ListComponent';
 import { AlignRightStyle, ThinStyle } from '../../components/Filters/FilterStyles';
-import { arrayEquals } from '../../utils/Common';
+import { namespaceEquals } from '../../utils/Common';
 import { KialiAppState } from '../../store/Store';
 import { activeNamespacesSelector, durationSelector } from '../../store/Selectors';
 import { DurationInSeconds } from '../../types/Common';
@@ -56,7 +56,12 @@ class ServiceListComponent extends ListComponent.Component<
   }
 
   componentDidUpdate(prevProps: ServiceListComponentProps, prevState: ServiceListComponentState, snapshot: any) {
-    if (!this.paramsAreSynced(prevProps)) {
+    const [paramsSynced, nsSynced] = this.paramsAreSynced(prevProps);
+    if (!paramsSynced) {
+      if (!nsSynced) {
+        // If there is a change in the namespace selection, page is set to 1
+        this.pageSet(1);
+      }
       this.setState({
         pagination: this.props.pagination,
         currentSortField: this.props.currentSortField,
@@ -71,21 +76,17 @@ class ServiceListComponent extends ListComponent.Component<
     this.promises.cancelAll();
   }
 
-  paramsAreSynced(prevProps: ServiceListComponentProps) {
-    const activeNamespacesCompare = arrayEquals(
-      prevProps.activeNamespaces,
-      this.props.activeNamespaces,
-      (n1, n2) => n1.name === n2.name
-    );
-    return (
+  paramsAreSynced = (prevProps: ServiceListComponentProps): [boolean, boolean] => {
+    const activeNamespacesCompare = namespaceEquals(prevProps.activeNamespaces, this.props.activeNamespaces);
+    const paramsSynced =
       prevProps.pagination.page === this.props.pagination.page &&
       prevProps.pagination.perPage === this.props.pagination.perPage &&
       prevProps.duration === this.props.duration &&
       activeNamespacesCompare &&
       prevProps.isSortAscending === this.props.isSortAscending &&
-      prevProps.currentSortField.title === this.props.currentSortField.title
-    );
-  }
+      prevProps.currentSortField.title === this.props.currentSortField.title;
+    return [paramsSynced, activeNamespacesCompare];
+  };
 
   sortItemList(services: ServiceListItem[], sortField: SortField<ServiceListItem>, isAscending: boolean) {
     // Chain promises, as there may be an ongoing fetch/refresh and sort can be called after UI interaction

--- a/src/pages/WorkloadList/WorkloadListComponent.tsx
+++ b/src/pages/WorkloadList/WorkloadListComponent.tsx
@@ -13,7 +13,7 @@ import { ListPagesHelper } from '../../components/ListPage/ListPagesHelper';
 import { SortField } from '../../types/SortFilters';
 import { ListComponent } from '../../components/ListPage/ListComponent';
 import { AlignRightStyle, ThinStyle } from '../../components/Filters/FilterStyles';
-import { arrayEquals } from '../../utils/Common';
+import { namespaceEquals } from '../../utils/Common';
 import { KialiAppState } from '../../store/Store';
 import { activeNamespacesSelector, durationSelector } from '../../store/Selectors';
 import { DurationInSeconds } from '../../types/Common';
@@ -51,7 +51,12 @@ class WorkloadListComponent extends ListComponent.Component<
   }
 
   componentDidUpdate(prevProps: WorkloadListComponentProps, prevState: WorkloadListComponentState, snapshot: any) {
-    if (!this.paramsAreSynced(prevProps)) {
+    const [paramsSynced, nsSynced] = this.paramsAreSynced(prevProps);
+    if (!paramsSynced) {
+      if (!nsSynced) {
+        // If there is a change in the namespace selection, page is set to 1
+        this.pageSet(1);
+      }
       this.setState({
         pagination: this.props.pagination,
         currentSortField: this.props.currentSortField,
@@ -66,21 +71,17 @@ class WorkloadListComponent extends ListComponent.Component<
     this.promises.cancelAll();
   }
 
-  paramsAreSynced(prevProps: WorkloadListComponentProps) {
-    const activeNamespacesCompare = arrayEquals(
-      prevProps.activeNamespaces,
-      this.props.activeNamespaces,
-      (n1, n2) => n1.name === n2.name
-    );
-    return (
+  paramsAreSynced = (prevProps: WorkloadListComponentProps): [boolean, boolean] => {
+    const activeNamespacesCompare = namespaceEquals(prevProps.activeNamespaces, this.props.activeNamespaces);
+    const paramsSynced =
       prevProps.pagination.page === this.props.pagination.page &&
       prevProps.pagination.perPage === this.props.pagination.perPage &&
       prevProps.duration === this.props.duration &&
       activeNamespacesCompare &&
       prevProps.isSortAscending === this.props.isSortAscending &&
-      prevProps.currentSortField.title === this.props.currentSortField.title
-    );
-  }
+      prevProps.currentSortField.title === this.props.currentSortField.title;
+    return [paramsSynced, activeNamespacesCompare];
+  };
 
   sortItemList(workloads: WorkloadListItem[], sortField: SortField<WorkloadListItem>, isAscending: boolean) {
     // Chain promises, as there may be an ongoing fetch/refresh and sort can be called after UI interaction

--- a/src/utils/Common.ts
+++ b/src/utils/Common.ts
@@ -1,3 +1,5 @@
+import Namespace from '../types/Namespace';
+
 export const removeDuplicatesArray = a => [...Array.from(new Set(a))] as string[];
 
 export const arrayEquals = <T>(a1: T[], a2: T[], comparator: (v1: T, v2: T) => boolean) => {
@@ -11,3 +13,6 @@ export const arrayEquals = <T>(a1: T[], a2: T[], comparator: (v1: T, v2: T) => b
   }
   return true;
 };
+
+export const namespaceEquals = (ns1: Namespace[], ns2: Namespace[]): boolean =>
+  arrayEquals(ns1, ns2, (n1, n2) => n1.name === n2.name);


### PR DESCRIPTION
Backport of KIALI-3093 for v1.0.

master and v1.0 branches diverge a lot, so, now "git cherry-pick" is more difficult to use and it needs some manual backport of the issue.