### PR TITLE
KIALI-3117 Revert "Separate browserlist from all in one to production…

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,17 +158,10 @@
       "pre-commit": "yarn run pretty-quick --staged --pattern \"{src/**/*.{js,jsx,ts,tsx,json,yml,css,scss},travis.yml,*.json}\" && npm run lint:precommit"
     }
   },
-  "browserslist": {
-    "production": [
-      ">10%",
-      "last 2 versions",
-      "not ie <= 11"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
-  },
+  "browserslist": [
+    ">10%",
+    "last 2 versions",
+    "not ie <= 11"
+  ],
   "snyk": true
 }


### PR DESCRIPTION

** Describe the change **

This fixes the **blocker** that was crashing the graph. Revert previous commit that separates browserlist from all in one to production and development settings for use with 'yarn build' and 'yarn start' respectively."

This reverts commit 1637f28f0bf52bed3204b41601c2c95d89dd04b8.



** Issue reference **

https://issues.jboss.org/browse/KIALI-3117

** Backwards compatible? **
Yes
[ ] Is your pull-request introducing changes in behaviour?
No
