### PR TITLE
KIALI-3102 Show TCP edges without traffic as "triangle-cross"

### DIFF
--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -15,6 +15,7 @@ const EdgeColor = PfColors.Green400;
 const EdgeColorDead = PfColors.Black500;
 const EdgeColorDegraded = PfColors.Orange;
 const EdgeColorFailure = PfColors.Red;
+const EdgeColorTCPWithTraffic = PfColors.Blue600;
 const EdgeIconMTLS = icons.istio.mtls.ascii; // lock
 const EdgeIconDisabledMTLS = icons.istio.disabledMtls.ascii; // broken lock
 const EdgeTextOutlineColor = PfColors.White;
@@ -70,10 +71,15 @@ export class GraphStyles {
       } else if (ele.data(CyEdge.grpc) > 0) {
         rate = Number(ele.data(CyEdge.grpc));
         pErr = ele.data(CyEdge.grpcPercentErr) > 0 ? Number(ele.data(CyEdge.grpcPercentErr)) : 0;
+      } else if (ele.data(CyEdge.tcp) > 0) {
+        rate = Number(ele.data(CyEdge.tcp));
       }
 
       if (rate === 0) {
         return EdgeColorDead;
+      }
+      if (ele.data(CyEdge.protocol) === 'tcp') {
+        return EdgeColorTCPWithTraffic;
       }
       if (pErr > REQUESTS_THRESHOLDS.failure) {
         return EdgeColorFailure;
@@ -426,11 +432,9 @@ export class GraphStyles {
         }
       },
       {
-        selector: 'edge[tcp > 0]',
+        selector: 'edge[protocol="tcp"]',
         css: {
-          'target-arrow-shape': 'triangle-cross',
-          'line-color': PfColors.Blue600,
-          'target-arrow-color': PfColors.Blue600
+          'target-arrow-shape': 'triangle-cross'
         }
       },
       {

--- a/src/types/Graph.ts
+++ b/src/types/Graph.ts
@@ -95,8 +95,10 @@ export interface CytoscapeMouseOutEvent extends CytoscapeBaseEvent {}
 //   }}
 export type Responses = object;
 
+type ValidProtocols = 'http' | 'grpc' | 'tcp';
+
 export type ProtocolTrafficNoData = {
-  protocol: '';
+  protocol: ValidProtocols;
 };
 
 export type ProtocolTrafficHttp = {
@@ -125,7 +127,17 @@ export type ProtocolTrafficTcp = {
   responses: Responses;
 };
 
-export type ProtocolTraffic = ProtocolTrafficHttp | ProtocolTrafficTcp | ProtocolTrafficGrpc | ProtocolTrafficNoData;
+export type ProtocolTrafficWithData = ProtocolTrafficHttp | ProtocolTrafficTcp | ProtocolTrafficGrpc;
+export type ProtocolTraffic = ProtocolTrafficWithData | ProtocolTrafficNoData;
+
+export const protocolTrafficHasData = (
+  protocolTraffic: ProtocolTraffic
+): protocolTraffic is ProtocolTrafficWithData => {
+  return (
+    (protocolTraffic as ProtocolTrafficWithData).rates !== undefined &&
+    (protocolTraffic as ProtocolTrafficWithData).responses !== undefined
+  );
+};
 
 export interface GraphNodeData {
   id: string;
@@ -181,29 +193,33 @@ export interface GraphDefinition {
 }
 
 export interface DecoratedGraphNodeData extends GraphNodeData {
-  grpcIn: string;
-  grpcInErr: string;
-  grpcOut: string;
-  httpIn: string;
-  httpIn3xx: string;
-  httpIn4xx: string;
-  httpIn5xx: string;
-  httpOut: string;
-  tcpIn: string;
-  tcpOut: string;
+  grpcIn: number;
+  grpcInErr: number;
+  grpcOut: number;
+  httpIn: number;
+  httpIn3xx: number;
+  httpIn4xx: number;
+  httpIn5xx: number;
+  httpOut: number;
+  tcpIn: number;
+  tcpOut: number;
+
+  traffic: never;
 }
 
 export interface DecoratedGraphEdgeData extends GraphEdgeData {
-  grpc: string;
-  grpcErr: string;
-  http: string;
-  http3xx: string;
-  http4xx: string;
-  http5xx: string;
-  httpPercentErr: string;
-  httpPercentReq: string;
+  grpc: number;
+  grpcErr: number;
+  grpcPercentErr: number;
+  http: number;
+  http3xx: number;
+  http4xx: number;
+  http5xx: number;
+  httpPercentErr: number;
+  httpPercentReq: number;
   responses: Responses;
-  tcp: string;
+  tcp: number;
+  protocol: ValidProtocols;
 }
 
 export interface DecoratedGraphNodeWrapper {


### PR DESCRIPTION
** Describe the change **

Shows the TCP edges without traffic using the `triangle-cross` shape (i.e. it looks like it has traffic but with gray color)

Depends on: https://github.com/kiali/kiali/pull/1234

** Issue reference **

[KIALI-3102](https://issues.jboss.org/browse/KIALI-3102)

** Screenshot **

Before: 
![image](https://user-images.githubusercontent.com/3845764/61007967-dee94580-a333-11e9-90e3-612acf6ee769.png)

After:
![tcp-inactive](https://user-images.githubusercontent.com/3845764/61008016-0213f500-a334-11e9-8154-f0b2509017a2.png)

