### PR TITLE
KIALI-3127 Move breadcrumb to PF4

### DIFF
--- a/src/components/BreadcrumbView/BreadcrumbView.tsx
+++ b/src/components/BreadcrumbView/BreadcrumbView.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Paths } from '../../config';
 import { Link } from 'react-router-dom';
-import { Breadcrumb } from 'patternfly-react';
+import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
 import { ActiveFilter } from '../../types/Filters';
 import { FilterSelected } from '../Filters/StatefulFilters';
 import { dicIstioType } from '../../types/IstioConfigList';
@@ -97,37 +97,39 @@ export class BreadcrumbView extends React.Component<BreadCumbViewProps, BreadCum
     const { namespace, itemName, item, istioType, pathItem } = this.state;
     const isIstio = this.isIstio();
     const linkItem = isIstio ? (
-      <Breadcrumb.Item componentClass="span" active={true}>
+      <BreadcrumbItem isActive={true}>
         {itemName}: {item}
-      </Breadcrumb.Item>
+      </BreadcrumbItem>
     ) : (
-      <Breadcrumb.Item componentClass="span">
+      <BreadcrumbItem isActive={true}>
         <Link to={this.getItemPage()} onClick={this.cleanFilters}>
           {itemName}: {item}
         </Link>
-      </Breadcrumb.Item>
+      </BreadcrumbItem>
     );
     return (
-      <Breadcrumb title={true}>
-        <Breadcrumb.Item componentClass="span">
-          <Link to={`/${pathItem}`} onClick={this.cleanFilters}>
-            {isIstio ? IstioName : BreadcrumbView.capitalize(pathItem)}
-          </Link>
-        </Breadcrumb.Item>
-        <Breadcrumb.Item componentClass="span">
-          <Link to={`/${pathItem}?namespaces=${namespace}`} onClick={this.cleanFilters}>
-            Namespace: {namespace}
-          </Link>
-        </Breadcrumb.Item>
-        {isIstio && (
-          <Breadcrumb.Item componentClass="span">
-            <Link to={`/${pathItem}?namespaces=${namespace}`} onClick={this.updateTypeFilter}>
-              {itemName} Type: {istioType}
+      <div className="breadcrumb">
+        <Breadcrumb>
+          <BreadcrumbItem>
+            <Link to={`/${pathItem}`} onClick={this.cleanFilters}>
+              {isIstio ? IstioName : BreadcrumbView.capitalize(pathItem)}
             </Link>
-          </Breadcrumb.Item>
-        )}
-        {linkItem}
-      </Breadcrumb>
+          </BreadcrumbItem>
+          <BreadcrumbItem>
+            <Link to={`/${pathItem}?namespaces=${namespace}`} onClick={this.cleanFilters}>
+              Namespace: {namespace}
+            </Link>
+          </BreadcrumbItem>
+          {isIstio && (
+            <BreadcrumbItem>
+              <Link to={`/${pathItem}?namespaces=${namespace}`} onClick={this.updateTypeFilter}>
+                {itemName} Type: {istioType}
+              </Link>
+            </BreadcrumbItem>
+          )}
+          {linkItem}
+        </Breadcrumb>
+      </div>
     );
   }
 }


### PR DESCRIPTION
** Describe the change **
Migrate the breadcrumb to PF4.

Breadcrumb is something shared between many detail pages. I think we should add it first before having two of us developing it at the same time.

** Screenshot **

![Screen recording](https://user-images.githubusercontent.com/613814/61289432-a16c3880-a7c9-11e9-8980-780c2b6e33a4.gif)

