### PR TITLE
KIALI-3135 Add more typesafety to node/edge data

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeGraphUtils.ts
+++ b/src/components/CytoscapeGraph/CytoscapeGraphUtils.ts
@@ -1,6 +1,6 @@
 import { Layout } from '../../types/GraphFilter';
 import * as LayoutDictionary from './graphs/LayoutDictionary';
-import { CytoscapeGlobalScratchNamespace } from '../../types/Graph';
+import { CytoscapeGlobalScratchNamespace, DecoratedGraphEdgeData, DecoratedGraphNodeData } from '../../types/Graph';
 import { DagreGraph } from './graphs/DagreGraph';
 
 export const CyEdge = {
@@ -87,4 +87,12 @@ export const runLayout = (cy: any, layout: Layout) => {
   }
 
   cy.scratch(CytoscapeGlobalScratchNamespace).showNodeLabels = showNodeLabels;
+};
+
+export const edgeData = (ele: any): DecoratedGraphEdgeData => {
+  return ele.data();
+};
+
+export const nodeData = (ele: any): DecoratedGraphNodeData => {
+  return ele.data();
 };

--- a/src/store/Selectors/GraphData.ts
+++ b/src/store/Selectors/GraphData.ts
@@ -31,7 +31,7 @@ export const decorateGraphData = (graphData: GraphElements): DecoratedGraphEleme
       http5xx: NaN,
       httpPercentErr: NaN,
       httpPercentReq: NaN,
-      isMTLS: '-1',
+      isMTLS: -1,
       protocol: undefined,
       responses: undefined,
       responseTime: NaN,
@@ -91,9 +91,10 @@ export const decorateGraphData = (graphData: GraphElements): DecoratedGraphEleme
     }
   };
 
-  const propertiesToNumber = object => {
+  const propertiesToNumber = (object: Object, keys?: string[]) => {
     const objectWithNumbers = { ...object };
-    for (const key of Object.keys(objectWithNumbers)) {
+    const targetKeys = keys ? keys : Object.keys(objectWithNumbers);
+    for (const key of targetKeys) {
       objectWithNumbers[key] = Number(objectWithNumbers[key]);
     }
     return objectWithNumbers;
@@ -131,7 +132,8 @@ export const decorateGraphData = (graphData: GraphElements): DecoratedGraphEleme
               responses: traffic.responses,
               ...edgeProtocolDefaults[traffic.protocol],
               ...propertiesToNumber(traffic.rates),
-              ...edgeData
+              // Base properties that need to be cast as number.
+              ...propertiesToNumber(edgeData, ['isMtls', 'responseTime'])
             };
           }
           decoratedEdge.data = { protocol: traffic.protocol, ...decoratedEdge.data };

--- a/src/types/Graph.ts
+++ b/src/types/Graph.ts
@@ -168,8 +168,8 @@ export interface GraphEdgeData {
   source: string;
   target: string;
   traffic?: ProtocolTraffic;
-  responseTime?: string;
-  isMTLS?: string;
+  responseTime?: number;
+  isMTLS?: number;
 }
 
 export interface GraphNodeWrapper {
@@ -211,6 +211,7 @@ export interface DecoratedGraphEdgeData extends GraphEdgeData {
   grpc: number;
   grpcErr: number;
   grpcPercentErr: number;
+  grpcPercentReq: number;
   http: number;
   http3xx: number;
   http4xx: number;
@@ -220,6 +221,13 @@ export interface DecoratedGraphEdgeData extends GraphEdgeData {
   responses: Responses;
   tcp: number;
   protocol: ValidProtocols;
+
+  // During the decoration process, we make non-optional some number attributes (giving them a default value)
+  // Default value NaN
+  responseTime: number;
+
+  // Default value -1
+  isMTLS: number;
 }
 
 export interface DecoratedGraphNodeWrapper {

--- a/src/utils/TrafficRate.ts
+++ b/src/utils/TrafficRate.ts
@@ -2,11 +2,16 @@ import { CyNode, CyEdge } from '../components/CytoscapeGraph/CytoscapeGraphUtils
 
 const safeRate = (rate: any) => (isNaN(rate) ? 0.0 : Number(rate));
 
-const NODE_GRPC_IN = {
+type TRAFFIC_GRPC = {
+  RATE: string;
+  RATEERR: string;
+};
+
+const NODE_GRPC_IN: TRAFFIC_GRPC = {
   RATE: CyNode.grpcIn,
   RATEERR: CyNode.grpcInErr
 };
-const EDGE_GRPC = {
+const EDGE_GRPC: TRAFFIC_GRPC = {
   RATE: CyEdge.grpc,
   RATEERR: CyEdge.grpcErr
 };
@@ -16,7 +21,7 @@ export interface TrafficRateGrpc {
   rateErr: number;
 }
 
-export const getTrafficRateGrpc = (element: any, trafficType: any = NODE_GRPC_IN): TrafficRateGrpc => {
+export const getTrafficRateGrpc = (element: any, trafficType: TRAFFIC_GRPC = NODE_GRPC_IN): TrafficRateGrpc => {
   return {
     rate: safeRate(element.data(trafficType.RATE)),
     rateErr: safeRate(element.data(trafficType.RATEERR))
@@ -35,13 +40,20 @@ export const getAccumulatedTrafficRateGrpc = (elements): TrafficRateGrpc => {
   );
 };
 
-const NODE_HTTP_IN = {
+type TRAFFIC_HTTP = {
+  RATE: string;
+  RATE3XX: string;
+  RATE4XX: string;
+  RATE5XX: string;
+};
+
+const NODE_HTTP_IN: TRAFFIC_HTTP = {
   RATE: CyNode.httpIn,
   RATE3XX: CyNode.httpIn3xx,
   RATE4XX: CyNode.httpIn4xx,
   RATE5XX: CyNode.httpIn5xx
 };
-const EDGE_HTTP = {
+const EDGE_HTTP: TRAFFIC_HTTP = {
   RATE: CyEdge.http,
   RATE3XX: CyEdge.http3xx,
   RATE4XX: CyEdge.http4xx,
@@ -55,7 +67,7 @@ export interface TrafficRateHttp {
   rate5xx: number;
 }
 
-export const getTrafficRateHttp = (element: any, trafficType: any = NODE_HTTP_IN): TrafficRateHttp => {
+export const getTrafficRateHttp = (element: any, trafficType: TRAFFIC_HTTP = NODE_HTTP_IN): TrafficRateHttp => {
   return {
     rate: safeRate(element.data(trafficType.RATE)),
     rate3xx: safeRate(element.data(trafficType.RATE3XX)),


### PR DESCRIPTION
** Describe the change **

Reduce direct calls to `ele.data(field)` and instead use the typesafe version of the call.
This adds more type safety, but we would need to close the loop (in a different PR) to ensure that the data we are receiving is in sync with our definitions. 
Probably something at runtime that can warns/errs about any difference found.

** Issue reference **

https://issues.jboss.org/browse/KIALI-3135

There are no visual changes.