### PR TITLE
KIALI-3138 Assign an Id to DropdownToggle to avoid computed ID on render

### DIFF
--- a/src/components/Nav/Masthead/UserDropdown.tsx
+++ b/src/components/Nav/Masthead/UserDropdown.tsx
@@ -128,7 +128,11 @@ class UserDropdownConnected extends React.Component<UserProps, UserState> {
             position="right"
             onSelect={this.onDropdownSelect}
             isOpen={isDropdownOpen}
-            toggle={<DropdownToggle onToggle={this.onDropdownToggle}>{this.props.session.username}</DropdownToggle>}
+            toggle={
+              <DropdownToggle id={'user-dropdown-toggle'} onToggle={this.onDropdownToggle}>
+                {this.props.session.username}
+              </DropdownToggle>
+            }
             dropdownItems={[userDropdownItems]}
           />
         )}


### PR DESCRIPTION
** Describe the change **

Assigns and id to the DropdownToggle on the UserDropdown.

** Issue reference **

https://issues.jboss.org/browse/KIALI-3138

** Screenshot **

No real visual changes in the UI, but the generated code changes less

Before:
![image](https://user-images.githubusercontent.com/3845764/61416069-26358000-a8b8-11e9-8feb-3612e8f9c99a.png)


After:
The same, but the id is always "user_logout_option"
