### PR TITLE
KIALI-3150 Fix blank screen

### DIFF
--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,4 +1,5 @@
 import { lazy } from 'react';
+import AppDetailsPage from './pages/AppDetails/AppDetailsPage';
 import { MenuItem, Path } from './types/Routes';
 import { icons, Paths } from './config';
 import DefaultSecondaryMasthead from './components/DefaultSecondaryMasthead/DefaultSecondaryMasthead';
@@ -104,7 +105,7 @@ const pathRoutes: Path[] = [
   },
   {
     path: '/namespaces/:namespace/' + Paths.APPLICATIONS + '/:app',
-    component: lazy(() => import('./pages/AppDetails/AppDetailsPage'))
+    component: AppDetailsPage
   },
   {
     path: '/' + Paths.WORKLOADS,


### PR DESCRIPTION
https://issues.jboss.org/browse/KIALI-3150

There is some issue with details pages. Lazy loading all them produces a blank screen bug in the containerized build (dev-mode `yarn start` works fine). It's enough if one of the detail pages is not lazy loaded to have the app working fine.

For now, leaving AppDetailsPage without lazy load to fix the issue. I'll try to find what's the root cause, but doing this to not delay the fix.