### PR TITLE
KIALI-3150 Fix code splitting issue (undefined components)

### DIFF
--- a/src/components/MessageCenter/NotificationDrawer.tsx
+++ b/src/components/MessageCenter/NotificationDrawer.tsx
@@ -10,6 +10,16 @@ import {
   EmptyStateTitle,
   EmptyStateIcon
 } from 'patternfly-react';
+import PfNotificationDrawerTitle from 'patternfly-react/dist/esm/components/Notification/NotificationDrawer/NotificationDrawerTitle';
+import PfNotificationDrawerAccordion from 'patternfly-react/dist/esm/components/Notification/NotificationDrawer/NotificationDrawerAccordion/NotificationDrawerAccordion';
+import PfNotificationDrawerPanel from 'patternfly-react/dist/esm/components/Notification/NotificationDrawer/NotificationDrawerAccordion/NotificationDrawerPanel';
+import PfNotificationDrawerPanelAction from 'patternfly-react/dist/esm/components/Notification/NotificationDrawer/NotificationDrawerAccordion/NotificationDrawerPanelAction';
+import PfNotificationDrawerPanelActionLink from 'patternfly-react/dist/esm/components/Notification/NotificationDrawer/NotificationDrawerAccordion/NotificationDrawerPanelActionLink';
+import PfNotificationDrawerPanelBody from 'patternfly-react/dist/esm/components/Notification/NotificationDrawer/NotificationDrawerAccordion/NotificationDrawerPanelBody';
+import PfNotificationDrawerPanelCollapse from 'patternfly-react/dist/esm/components/Notification/NotificationDrawer/NotificationDrawerAccordion/NotificationDrawerPanelCollapse';
+import PfNotificationDrawerPanelCounter from 'patternfly-react/dist/esm/components/Notification/NotificationDrawer/NotificationDrawerAccordion/NotificationDrawerPanelCounter';
+import PfNotificationDrawerPanelHeading from 'patternfly-react/dist/esm/components/Notification/NotificationDrawer/NotificationDrawerAccordion/NotificationDrawerPanelHeading';
+import PfNotificationDrawerPanelTitle from 'patternfly-react/dist/esm/components/Notification/NotificationDrawer/NotificationDrawerAccordion/NotificationDrawerPanelTitle';
 
 import { MessageType, NotificationMessage, NotificationGroup } from '../../types/MessageCenter';
 import moment from 'moment';
@@ -113,41 +123,41 @@ class NotificationGroupWrapper extends React.PureComponent<NotificationGroupWrap
     }
 
     return (
-      <PfNotificationDrawer.Panel expanded={isExpanded}>
-        <PfNotificationDrawer.PanelHeading onClick={() => this.props.onToggle(group)}>
-          <PfNotificationDrawer.PanelTitle>
+      <PfNotificationDrawerPanel expanded={isExpanded}>
+        <PfNotificationDrawerPanelHeading onClick={() => this.props.onToggle(group)}>
+          <PfNotificationDrawerPanelTitle>
             <a className={isExpanded ? '' : 'collapsed'} aria-expanded="true">
               {group.title}
             </a>
-          </PfNotificationDrawer.PanelTitle>
-          <PfNotificationDrawer.PanelCounter text={getUnreadMessageLabel(group.messages)} />
-        </PfNotificationDrawer.PanelHeading>
+          </PfNotificationDrawerPanelTitle>
+          <PfNotificationDrawerPanelCounter text={getUnreadMessageLabel(group.messages)} />
+        </PfNotificationDrawerPanelHeading>
         <Collapse in={isExpanded}>
-          <PfNotificationDrawer.PanelCollapse>
-            <PfNotificationDrawer.PanelBody>
+          <PfNotificationDrawerPanelCollapse>
+            <PfNotificationDrawerPanelBody>
               {group.messages.length === 0 && noNotificationsMessage}
               {this.getMessages().map(message => (
                 <NotificationWrapper key={message.id} message={message} onClick={this.props.onNotificationClick} />
               ))}
-            </PfNotificationDrawer.PanelBody>
+            </PfNotificationDrawerPanelBody>
             {group.showActions && group.messages.length > 0 && (
-              <PfNotificationDrawer.PanelAction>
-                <PfNotificationDrawer.PanelActionLink className="drawer-pf-action-link">
+              <PfNotificationDrawerPanelAction>
+                <PfNotificationDrawerPanelActionLink className="drawer-pf-action-link">
                   <Button bsStyle="link" onClick={() => this.props.onMarkGroupAsRead(group)}>
                     Mark All Read
                   </Button>
-                </PfNotificationDrawer.PanelActionLink>
-                <PfNotificationDrawer.PanelActionLink data-toggle="clear-all">
+                </PfNotificationDrawerPanelActionLink>
+                <PfNotificationDrawerPanelActionLink data-toggle="clear-all">
                   <Button bsStyle="link" onClick={() => this.props.onClearGroup(group)}>
                     <Icon type="pf" name="close" />
                     Clear All
                   </Button>
-                </PfNotificationDrawer.PanelActionLink>
-              </PfNotificationDrawer.PanelAction>
+                </PfNotificationDrawerPanelActionLink>
+              </PfNotificationDrawerPanelAction>
             )}
-          </PfNotificationDrawer.PanelCollapse>
+          </PfNotificationDrawerPanelCollapse>
         </Collapse>
-      </PfNotificationDrawer.Panel>
+      </PfNotificationDrawerPanel>
     );
   }
 }
@@ -174,7 +184,7 @@ export default class NotificationDrawer extends React.PureComponent<PropsType, S
   render() {
     return (
       <PfNotificationDrawer hide={this.props.isHidden} expanded={this.props.isExpanded}>
-        <PfNotificationDrawer.Title
+        <PfNotificationDrawerTitle
           title={this.props.title}
           onExpandClick={this.props.onExpandDrawer}
           onCloseClick={this.props.onHideDrawer}
@@ -183,7 +193,7 @@ export default class NotificationDrawer extends React.PureComponent<PropsType, S
           className={drawerContainerStyle}
           maxHeight={{ type: PropertyType.VIEWPORT_HEIGHT_MINUS_TOP, margin: drawerMarginBottom }}
         >
-          <PfNotificationDrawer.Accordion>
+          <PfNotificationDrawerAccordion>
             {this.props.groups.length === 0 && noNotificationsMessage}
             {this.props.groups.map(group => {
               return (
@@ -199,7 +209,7 @@ export default class NotificationDrawer extends React.PureComponent<PropsType, S
                 />
               );
             })}
-          </PfNotificationDrawer.Accordion>
+          </PfNotificationDrawerAccordion>
         </BoundingClientAwareComponent>
       </PfNotificationDrawer>
     );

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,5 +1,4 @@
 import { lazy } from 'react';
-import AppDetailsPage from './pages/AppDetails/AppDetailsPage';
 import { MenuItem, Path } from './types/Routes';
 import { icons, Paths } from './config';
 import DefaultSecondaryMasthead from './components/DefaultSecondaryMasthead/DefaultSecondaryMasthead';
@@ -105,7 +104,7 @@ const pathRoutes: Path[] = [
   },
   {
     path: '/namespaces/:namespace/' + Paths.APPLICATIONS + '/:app',
-    component: AppDetailsPage
+    component: lazy(() => import('./pages/AppDetails/AppDetailsPage'))
   },
   {
     path: '/' + Paths.WORKLOADS,


### PR DESCRIPTION
When introducing code-splitting in Kiali, we are hitting an external bug or an unsupported scenario. The issue is either in PatternFly3 or in WebPack/Babel (or in something else).

For the NotificationDrawer component, PatternFly 3 uses the syntax that can be seen in: https://github.com/patternfly/patternfly-react/blob/patternfly-react%402.31.1/packages/patternfly-3/patternfly-react/src/components/Notification/NotificationDrawer/index.js#L21-L33

The PatternFly code is importing components and assigning them to a property of NotificationDrawer. This breaks the code-splitting mechanism and all those components assigned as properties of NotificationDrawer become undefined.

The issue is fixed by direct importing of those components in Kiali.