### PR TITLE
KIALI-3178 rename response-time sparkline legend labels to be consistent with k-charted

### DIFF
--- a/src/pages/Graph/SummaryPanelEdge.tsx
+++ b/src/pages/Graph/SummaryPanelEdge.tsx
@@ -330,28 +330,28 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
           );
           rtAvg = this.getNodeDataPoints(
             histograms.request_duration.avg,
-            'Average',
+            'avg',
             sourceMetricType,
             destMetricType,
             sourceData
           );
           rtMed = this.getNodeDataPoints(
             histograms.request_duration['0.5'],
-            'Median',
+            'p50',
             sourceMetricType,
             destMetricType,
             sourceData
           );
           rt95 = this.getNodeDataPoints(
             histograms.request_duration['0.95'],
-            '95th',
+            'p95',
             sourceMetricType,
             destMetricType,
             sourceData
           );
           rt99 = this.getNodeDataPoints(
             histograms.request_duration['0.99'],
-            '99th',
+            'p99',
             sourceMetricType,
             destMetricType,
             sourceData


### PR DESCRIPTION

After:

![image](https://user-images.githubusercontent.com/2104052/62215304-af4abd80-b374-11e9-9b04-ac7c5a3c12d0.png)

