### PR TITLE
KIALI-2618 Saves graph filterState values

### DIFF
--- a/src/components/GraphFilter/GraphFind.tsx
+++ b/src/components/GraphFilter/GraphFind.tsx
@@ -75,7 +75,8 @@ export class GraphFind extends React.PureComponent<GraphFindProps, GraphFindStat
     const findChanged = this.props.findValue !== prevProps.findValue;
     const hideChanged = this.props.hideValue !== prevProps.hideValue;
     const graphChanged =
-      this.props.cyData && prevProps.cyData && this.props.cyData.updateTimestamp !== prevProps.cyData.updateTimestamp;
+      (!prevProps.cyData && this.props.cyData) ||
+      (this.props.cyData && prevProps.cyData && this.props.cyData.updateTimestamp !== prevProps.cyData.updateTimestamp);
 
     // make sure the value is updated if there was a change
     if (findChanged) {

--- a/src/components/GraphFilter/GraphRefresh.tsx
+++ b/src/components/GraphFilter/GraphRefresh.tsx
@@ -49,13 +49,11 @@ export class GraphRefresh extends React.PureComponent<GraphRefreshProps> {
     if (urlPollInterval !== undefined && urlPollInterval !== props.refreshInterval) {
       props.setRefreshInterval(urlPollInterval);
     }
-    HistoryManager.setParam(URLParam.DURATION, String(this.props.duration));
     HistoryManager.setParam(URLParam.POLL_INTERVAL, String(this.props.refreshInterval));
   }
 
   componentDidUpdate() {
     // ensure redux state and URL are aligned
-    HistoryManager.setParam(URLParam.DURATION, String(this.props.duration));
     HistoryManager.setParam(URLParam.POLL_INTERVAL, String(this.props.refreshInterval));
   }
 

--- a/src/pages/Overview/OverviewToolbar.tsx
+++ b/src/pages/Overview/OverviewToolbar.tsx
@@ -68,7 +68,6 @@ export class OverviewToolbar extends React.Component<Props, State> {
     if (urlPollInterval !== undefined && urlPollInterval !== props.refreshInterval) {
       props.setRefreshInterval(urlPollInterval);
     }
-    HistoryManager.setParam(URLParam.DURATION, String(this.props.duration));
     HistoryManager.setParam(URLParam.POLL_INTERVAL, String(this.props.refreshInterval));
 
     this.state = {
@@ -80,7 +79,6 @@ export class OverviewToolbar extends React.Component<Props, State> {
 
   componentDidUpdate(prevProps: Props) {
     // ensure redux state and URL are aligned
-    HistoryManager.setParam(URLParam.DURATION, String(this.props.duration));
     HistoryManager.setParam(URLParam.POLL_INTERVAL, String(this.props.refreshInterval));
 
     const urlSortField = ListPagesHelper.currentSortField(Sorts.sortFields);

--- a/src/reducers/GraphDataState.ts
+++ b/src/reducers/GraphDataState.ts
@@ -7,6 +7,7 @@ import { EdgeLabelMode } from '../types/GraphFilter';
 import { GraphType } from '../types/Graph';
 import { GraphFilterActions } from '../actions/GraphFilterActions';
 import { DagreGraph } from '../components/CytoscapeGraph/graphs/DagreGraph';
+import { updateState } from '../utils/Reducer';
 
 export const INITIAL_GRAPH_STATE: GraphState = {
   cyData: null,
@@ -39,127 +40,171 @@ export const INITIAL_GRAPH_STATE: GraphState = {
 
 // This Reducer allows changes to the 'graphDataState' portion of Redux Store
 const graphDataState = (state: GraphState = INITIAL_GRAPH_STATE, action: KialiAppAction): GraphState => {
-  const newState: GraphState = {
-    ...state
-  };
-
   switch (action.type) {
     case getType(GraphDataActions.getGraphDataStart):
-      newState.isLoading = true;
-      newState.isError = false;
-      break;
+      return updateState(state, { isError: false, isLoading: true });
     case getType(GraphDataActions.getGraphDataSuccess):
-      newState.isLoading = false;
-      newState.isError = false;
-      newState.graphDataDuration = action.payload.graphDuration;
-      newState.graphDataTimestamp = action.payload.timestamp;
-      newState.graphData = action.payload.graphData;
-      break;
+      return updateState(state, {
+        isLoading: false,
+        isError: false,
+        graphDataDuration: action.payload.graphDuration,
+        graphDataTimestamp: action.payload.timestamp,
+        graphData: action.payload.graphData
+      });
     case getType(GraphDataActions.getGraphDataFailure):
-      newState.isLoading = false;
-      newState.isError = true;
-      newState.error = action.payload.error;
-      break;
+      return updateState(state, {
+        isLoading: false,
+        isError: true,
+        error: action.payload.error
+      });
     case getType(GraphDataActions.getGraphDataWithoutNamespaces):
-      newState.isLoading = false;
-      newState.isError = false;
-      newState.error = INITIAL_GRAPH_STATE.error;
-      newState.graphData = INITIAL_GRAPH_STATE.graphData;
-      newState.graphDataDuration = INITIAL_GRAPH_STATE.graphDataDuration;
-      newState.graphDataTimestamp = INITIAL_GRAPH_STATE.graphDataTimestamp;
-      newState.summaryData = INITIAL_GRAPH_STATE.summaryData;
-      break;
+      return updateState(state, {
+        isLoading: false,
+        isError: false,
+        error: INITIAL_GRAPH_STATE.error,
+        graphData: INITIAL_GRAPH_STATE.graphData,
+        graphDataDuration: INITIAL_GRAPH_STATE.graphDataDuration,
+        graphDataTimestamp: INITIAL_GRAPH_STATE.graphDataTimestamp,
+        summaryData: INITIAL_GRAPH_STATE.summaryData
+      });
     case getType(GraphActions.changed):
-      newState.graphData = INITIAL_GRAPH_STATE.graphData;
-      newState.graphDataDuration = INITIAL_GRAPH_STATE.graphDataDuration;
-      newState.graphDataTimestamp = INITIAL_GRAPH_STATE.graphDataTimestamp;
-      newState.summaryData = INITIAL_GRAPH_STATE.summaryData;
-      break;
+      return updateState(state, {
+        graphData: INITIAL_GRAPH_STATE.graphData,
+        graphDataDuration: INITIAL_GRAPH_STATE.graphDataDuration,
+        graphDataTimestamp: INITIAL_GRAPH_STATE.graphDataTimestamp,
+        summaryData: INITIAL_GRAPH_STATE.summaryData
+      });
     case getType(GraphActions.setLayout):
-      newState.layout = action.payload;
-      break;
+      return updateState(state, { layout: action.payload });
     case getType(GraphActions.setNode):
-      newState.node = action.payload;
-      // TODO: This should be handled in GraphPage.ComponentDidUpdate (Init graph on node change)
-      newState.graphData = INITIAL_GRAPH_STATE.graphData;
-      newState.graphDataDuration = INITIAL_GRAPH_STATE.graphDataDuration;
-      newState.graphDataTimestamp = INITIAL_GRAPH_STATE.graphDataTimestamp;
-      newState.summaryData = INITIAL_GRAPH_STATE.summaryData;
-      break;
+      return updateState(state, {
+        node: action.payload,
+        // TODO: This should be handled in GraphPage.ComponentDidUpdate (Init graph on node change)
+        graphData: INITIAL_GRAPH_STATE.graphData,
+        graphDataDuration: INITIAL_GRAPH_STATE.graphDataDuration,
+        graphDataTimestamp: INITIAL_GRAPH_STATE.graphDataTimestamp,
+        summaryData: INITIAL_GRAPH_STATE.summaryData
+      });
     case getType(GraphActions.updateGraph):
-      newState.cyData = {
-        updateTimestamp: action.payload.updateTimestamp,
-        cyRef: action.payload.cyRef
-      };
-      break;
+      return updateState(state, {
+        cyData: updateState(state.cyData, {
+          updateTimestamp: action.payload.updateTimestamp,
+          cyRef: action.payload.cyRef
+        })
+      });
     case getType(GraphActions.updateSummary):
-      newState.summaryData = {
-        summaryType: action.payload.summaryType,
-        summaryTarget: action.payload.summaryTarget
-      };
-      break;
+      return updateState(state, {
+        summaryData: updateState(state.summaryData, {
+          summaryType: action.payload.summaryType,
+          summaryTarget: action.payload.summaryTarget
+        })
+      });
     // Filter actions
     //
     case getType(GraphFilterActions.setEdgelLabelMode):
-      newState.filterState.edgeLabelMode = action.payload;
-      break;
+      return updateState(state, {
+        filterState: updateState(state.filterState, {
+          edgeLabelMode: action.payload
+        })
+      });
     case getType(GraphFilterActions.setFindValue):
-      newState.filterState.findValue = action.payload;
-      break;
+      return updateState(state, {
+        filterState: updateState(state.filterState, {
+          findValue: action.payload
+        })
+      });
     case getType(GraphFilterActions.setGraphType):
-      newState.filterState.graphType = action.payload;
-      // TODO: This should be handled in GraphPage.ComponentDidUpdate (Init graph on type change)
-      newState.graphData = INITIAL_GRAPH_STATE.graphData;
-      newState.graphDataDuration = INITIAL_GRAPH_STATE.graphDataDuration;
-      newState.graphDataTimestamp = INITIAL_GRAPH_STATE.graphDataTimestamp;
-      newState.summaryData = INITIAL_GRAPH_STATE.summaryData;
-      break;
+      return updateState(state, {
+        filterState: updateState(state.filterState, {
+          graphType: action.payload
+        }),
+        // TODO: This should be handled in GraphPage.ComponentDidUpdate (Init graph on type change)
+        graphData: INITIAL_GRAPH_STATE.graphData,
+        graphDataDuration: INITIAL_GRAPH_STATE.graphDataDuration,
+        graphDataTimestamp: INITIAL_GRAPH_STATE.graphDataTimestamp,
+        summaryData: INITIAL_GRAPH_STATE.summaryData
+      });
     case getType(GraphFilterActions.setHideValue):
-      newState.filterState.hideValue = action.payload;
-      break;
+      return updateState(state, {
+        filterState: updateState(state.filterState, {
+          hideValue: action.payload
+        })
+      });
     case getType(GraphFilterActions.setShowUnusedNodes):
-      newState.filterState.showUnusedNodes = action.payload;
-      break;
+      return updateState(state, {
+        filterState: updateState(state.filterState, {
+          showUnusedNodes: action.payload
+        })
+      });
     case getType(GraphFilterActions.toggleFindHelp):
-      newState.filterState.showFindHelp = !state.filterState.showFindHelp;
-      break;
+      return updateState(state, {
+        filterState: updateState(state.filterState, {
+          showFindHelp: !state.filterState.showFindHelp
+        })
+      });
     case getType(GraphFilterActions.toggleGraphNodeLabel):
-      newState.filterState.showNodeLabels = !state.filterState.showNodeLabels;
-      break;
+      return updateState(state, {
+        filterState: updateState(state.filterState, {
+          showNodeLabels: !state.filterState.showNodeLabels
+        })
+      });
     case getType(GraphFilterActions.toggleGraphCircuitBreakers):
-      newState.filterState.showCircuitBreakers = !state.filterState.showCircuitBreakers;
-      break;
+      return updateState(state, {
+        filterState: updateState(state.filterState, {
+          showCircuitBreakers: !state.filterState.showCircuitBreakers
+        })
+      });
     case getType(GraphFilterActions.toggleGraphVirtualServices):
-      newState.filterState.showVirtualServices = !state.filterState.showVirtualServices;
-      break;
+      return updateState(state, {
+        filterState: updateState(state.filterState, {
+          showVirtualServices: !state.filterState.showVirtualServices
+        })
+      });
     case getType(GraphFilterActions.toggleGraphMissingSidecars):
-      newState.filterState.showMissingSidecars = !state.filterState.showMissingSidecars;
-      break;
+      return updateState(state, {
+        filterState: updateState(state.filterState, {
+          showMissingSidecars: !state.filterState.showMissingSidecars
+        })
+      });
     case getType(GraphFilterActions.toggleGraphSecurity):
-      newState.filterState.showSecurity = !state.filterState.showSecurity;
-      break;
+      return updateState(state, {
+        filterState: updateState(state.filterState, {
+          showSecurity: !state.filterState.showSecurity
+        })
+      });
     case getType(GraphFilterActions.toggleLegend):
-      newState.filterState.showLegend = !state.filterState.showLegend;
-      break;
+      return updateState(state, {
+        filterState: updateState(state.filterState, {
+          showLegend: !state.filterState.showLegend
+        })
+      });
     case getType(GraphFilterActions.toggleServiceNodes):
-      newState.filterState.showServiceNodes = !state.filterState.showServiceNodes;
-      // TODO: This should be handled in GraphPage.ComponentDidUpdate (Init graph on serviceNodeschange)
-      newState.graphData = INITIAL_GRAPH_STATE.graphData;
-      newState.graphDataDuration = INITIAL_GRAPH_STATE.graphDataDuration;
-      newState.graphDataTimestamp = INITIAL_GRAPH_STATE.graphDataTimestamp;
-      newState.summaryData = INITIAL_GRAPH_STATE.summaryData;
-      break;
+      return updateState(state, {
+        filterState: updateState(state.filterState, {
+          showServiceNodes: !state.filterState.showServiceNodes
+        }),
+        // TODO: This should be handled in GraphPage.ComponentDidUpdate (Init graph on type change)
+        graphData: INITIAL_GRAPH_STATE.graphData,
+        graphDataDuration: INITIAL_GRAPH_STATE.graphDataDuration,
+        graphDataTimestamp: INITIAL_GRAPH_STATE.graphDataTimestamp,
+        summaryData: INITIAL_GRAPH_STATE.summaryData
+      });
     case getType(GraphFilterActions.toggleTrafficAnimation):
-      newState.filterState.showTrafficAnimation = !state.filterState.showTrafficAnimation;
-      break;
+      return updateState(state, {
+        filterState: updateState(state.filterState, {
+          showTrafficAnimation: !state.filterState.showTrafficAnimation
+        })
+      });
     case getType(GraphFilterActions.toggleUnusedNodes):
-      newState.filterState.showUnusedNodes = !state.filterState.showUnusedNodes;
-      break;
+      return updateState(state, {
+        filterState: updateState(state.filterState, {
+          showUnusedNodes: !state.filterState.showUnusedNodes
+        })
+      });
     default:
-      break;
+      // Return unmodified state if there are no changes.
+      return state;
   }
-
-  return newState;
 };
 
 export default graphDataState;

--- a/src/store/ConfigStore.ts
+++ b/src/store/ConfigStore.ts
@@ -39,11 +39,13 @@ const namespacePersistFilter = whitelistInputWithInitialState(
   INITIAL_NAMESPACE_STATE
 );
 
+const graphPersistFilter = whitelistInputWithInitialState('graph', ['filterState'], INITIAL_GRAPH_STATE);
+
 const persistConfig = {
   key: persistKey,
   storage: storage,
-  whitelist: ['namespaces', 'jaegerState', 'statusState'],
-  transforms: [namespacePersistFilter]
+  whitelist: ['namespaces', 'jaegerState', 'statusState', 'graph'],
+  transforms: [namespacePersistFilter, graphPersistFilter]
 };
 
 const composeEnhancers =


### PR DESCRIPTION
** Describe the change **

Saves in local storage the filterState values from redux:

 edgeLabelMode, findValue, graphType, hideValue, showCircuitBreakers,
 showFindHelp, showLegend, showMissingSidecars, showNodeLabels,
 showSecurity, showServiceNodes, showTrafficAnimation,
 showUnusedNodes, showVirtualServices

** Issue reference **

https://issues.jboss.org/browse/KIALI-2618

** Backwards compatible? **

[ ] Is your pull-request introducing changes in behaviour? 
Is persiting filterState values to localstorage


** Screenshot **

No UI changes
