### PR TITLE
Disable source-mapping in builds to avoid out-of-mem

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "build": "if [ \"${KIALI_ENV}\" = \"production\" ]; then npm run build:prod; else npm run build:dev; fi",
     "build-css": "node-sass src/ --output-style compressed --include-path $npm_package_sassIncludes_src --include-path $npm_package_sassIncludes_patternfly --include-path $npm_package_sassIncludes_patternflyReact --include-path $npm_package_sassIncludes_patternflyReactExtensions --include-path $npm_package_sassIncludes_bootstrap --include-path $npm_package_sassIncludes_fontAwesome -o src/",
     "build:dev": "npm run remove-rcue; sh -ac 'source ./.env.upstream; npm run build:kiali'",
-    "build:kiali": "npm run lint && npm run copy-fonts && npm run copy-img && npm run build-css && REACT_APP_VERSION=$npm_package_version REACT_APP_NAME=$npm_package_name REACT_APP_GIT_HASH=$(git rev-parse HEAD) react-scripts build",
+    "build:kiali": "npm run lint && npm run copy-fonts && npm run copy-img && npm run build-css && REACT_APP_VERSION=$npm_package_version REACT_APP_NAME=$npm_package_name REACT_APP_GIT_HASH=$(git rev-parse HEAD) GENERATE_SOURCEMAP=false react-scripts build",
     "build:prod": "npm run restore-rcue; sh -ac 'source ./.env.downstream; npm run build:kiali'",
     "copy-fonts": "cp -r node_modules/patternfly/dist/fonts src/",
     "copy-img": "cp -r node_modules/patternfly/dist/img src/",


### PR DESCRIPTION
(See discussion on kiali-dev "OOM in javascript build")