### PR TITLE
KIALI-3160 Ignore sidecar and label violations for istio objects

### DIFF
--- a/src/components/MissingSidecar/MissingSidecar.tsx
+++ b/src/components/MissingSidecar/MissingSidecar.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { Icon, OverlayTrigger, Tooltip } from 'patternfly-react';
-import { icons } from '../../config';
+import { icons, serverConfig } from '../../config';
 
 const MissingSidecar = props => {
-  const { style, text, textTooltip, type, name, color, tooltip, ...otherProps } = props;
+  const { style, text, textTooltip, type, name, namespace, color, tooltip, ...otherProps } = props;
 
   const iconComponent = (
     <span style={style} {...otherProps}>
@@ -12,6 +12,11 @@ const MissingSidecar = props => {
       {!tooltip && <span style={{ marginLeft: '5px' }}>{text}</span>}
     </span>
   );
+
+  if (namespace === serverConfig.istioNamespace) {
+    return <></>;
+  }
+
   return tooltip ? (
     <OverlayTrigger
       overlay={

--- a/src/components/Pf/PfTitle.tsx
+++ b/src/components/Pf/PfTitle.tsx
@@ -117,7 +117,7 @@ class PfTitle extends React.Component<PfTitleProps, PfTitleState> {
         {this.state.icon} {this.state.name}
         {this.state.name && this.props.istio !== undefined && !this.props.istio && (
           <span style={{ marginLeft: '10px' }}>
-            <MissingSidecar />
+            <MissingSidecar namespace={this.state.namespace} />
           </span>
         )}
         {this.state.name && (

--- a/src/pages/AppDetails/AppInfo/AppDescription.tsx
+++ b/src/pages/AppDetails/AppInfo/AppDescription.tsx
@@ -58,7 +58,9 @@ class AppDescription extends React.Component<AppDescriptionProps, AppDescription
         <div className="ServiceList-Title">
           <div className="component-label">
             Workload{' '}
-            {!workload.istioSidecar && <MissingSidecar style={{ marginLeft: '10px' }} tooltip={true} text={''} />}
+            {!workload.istioSidecar && (
+              <MissingSidecar namespace={namespace} style={{ marginLeft: '10px' }} tooltip={true} text={''} />
+            )}
           </div>
           <Link to={this.workloadLink(namespace, workload.workloadName)}>{workload.workloadName}</Link>
         </div>

--- a/src/pages/AppList/ItemDescription.tsx
+++ b/src/pages/AppList/ItemDescription.tsx
@@ -55,7 +55,7 @@ export default class ItemDescription extends React.PureComponent<Props, State> {
           <HealthIndicator id={this.props.item.name} health={this.state.health} mode={DisplayMode.SMALL} />
         </Col>
         <Col xs={12} sm={12} md={4} lg={4}>
-          {!this.props.item.istioSidecar && <MissingSidecar />}
+          {!this.props.item.istioSidecar && <MissingSidecar namespace={this.props.item.namespace} />}
         </Col>
         <Col xs={12} sm={12} md={4} lg={4} />
       </Row>

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoWorkload.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoWorkload.tsx
@@ -88,7 +88,9 @@ class ServiceInfoWorkload extends React.Component<ServiceInfoWorkloadProps> {
         >
           {workload.name}
         </Link>
-        {!workload.istioSidecar && <MissingSidecar tooltip={true} style={{ marginLeft: '10px' }} />}
+        {!workload.istioSidecar && (
+          <MissingSidecar namespace={this.props.namespace} tooltip={true} style={{ marginLeft: '10px' }} />
+        )}
       </span>
     );
   }

--- a/src/pages/ServiceList/ItemDescription.tsx
+++ b/src/pages/ServiceList/ItemDescription.tsx
@@ -56,7 +56,7 @@ export default class ItemDescription extends React.PureComponent<Props, State> {
           <HealthIndicator id={this.props.item.name} health={this.state.health} mode={DisplayMode.SMALL} />
         </Col>
         <Col xs={12} sm={12} md={4} lg={4}>
-          {!this.props.item.istioSidecar && <MissingSidecar />}
+          {!this.props.item.istioSidecar && <MissingSidecar namespace={this.props.item.namespace} />}
         </Col>
         <Col xs={12} sm={12} md={4} lg={4}>
           <strong>Config: </strong>{' '}

--- a/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -87,18 +87,20 @@ class WorkloadDetails extends React.Component<WorkloadDetailsPageProps, Workload
           valid: true,
           checks: []
         };
-        if (!pod.istioContainers || pod.istioContainers.length === 0) {
-          validations.pod[pod.name].checks.push(noIstiosidecar);
-        }
-        if (!pod.labels) {
-          validations.pod[pod.name].checks.push(noAppLabel);
-          validations.pod[pod.name].checks.push(noVersionLabel);
-        } else {
-          if (!pod.appLabel) {
-            validations.pod[pod.name].checks.push(noAppLabel);
+        if (this.props.match.params.namespace !== serverConfig.istioNamespace) {
+          if (!pod.istioContainers || pod.istioContainers.length === 0) {
+            validations.pod[pod.name].checks.push(noIstiosidecar);
           }
-          if (!pod.versionLabel) {
+          if (!pod.labels) {
+            validations.pod[pod.name].checks.push(noAppLabel);
             validations.pod[pod.name].checks.push(noVersionLabel);
+          } else {
+            if (!pod.appLabel) {
+              validations.pod[pod.name].checks.push(noAppLabel);
+            }
+            if (!pod.versionLabel) {
+              validations.pod[pod.name].checks.push(noVersionLabel);
+            }
           }
         }
         switch (pod.status) {

--- a/src/pages/WorkloadList/ItemDescription.tsx
+++ b/src/pages/WorkloadList/ItemDescription.tsx
@@ -78,7 +78,7 @@ class ItemDescription extends React.Component<ItemDescriptionProps, ItemDescript
           )}
         </Col>
         <Col xs={12} sm={12} md={4} lg={4}>
-          {!object.istioSidecar && <MissingSidecar />}
+          {!object.istioSidecar && <MissingSidecar namespace={namespace} />}
         </Col>
         <Col xs={12} sm={12} md={4} lg={4}>
           {object.appLabel || object.versionLabel ? (


### PR DESCRIPTION
The [istio] control plane objects should not be expected to conform to the
same expectations of the data plane (mesh) objects.

For objects in the istio namespace (i.e. control plane):
- Remove missing sidecar info from App/Workload/Service lists.
- Remove missing sidecar info from App/Workload/Service details.
- Remove missing sidecar and label violation warnings from Workload detail.

Before:
![kiali-3160-before](https://user-images.githubusercontent.com/2104052/62324556-d2aa6100-b477-11e9-8ca7-55aa06e5a2d8.gif)

After:
![kiali-3160-after](https://user-images.githubusercontent.com/2104052/62324568-d807ab80-b477-11e9-8554-434282251325.gif)
