### PR TITLE
KIALI-1400 Save state between sessions

### DIFF
--- a/src/store/ConfigStore.ts
+++ b/src/store/ConfigStore.ts
@@ -39,13 +39,19 @@ const namespacePersistFilter = whitelistInputWithInitialState(
   INITIAL_NAMESPACE_STATE
 );
 
-const graphPersistFilter = whitelistInputWithInitialState('graph', ['filterState'], INITIAL_GRAPH_STATE);
+const graphPersistFilter = whitelistInputWithInitialState('graph', ['filterState', 'layout'], INITIAL_GRAPH_STATE);
+
+const userSettingsPersitFilter = whitelistInputWithInitialState(
+  'userSettings',
+  ['duration', 'refreshInterval'],
+  INITIAL_USER_SETTINGS_STATE
+);
 
 const persistConfig = {
   key: persistKey,
   storage: storage,
-  whitelist: ['namespaces', 'jaegerState', 'statusState', 'graph'],
-  transforms: [namespacePersistFilter, graphPersistFilter]
+  whitelist: ['namespaces', 'jaegerState', 'statusState', 'graph', 'userSettings', 'messageCenter'],
+  transforms: [namespacePersistFilter, graphPersistFilter, userSettingsPersitFilter]
 };
 
 const composeEnhancers =


### PR DESCRIPTION
 - Adds: duration, refreshInterval and graph.layout

I added the messageCenter there, but someone else thinks that it could hold obsolete information (or maybe sensitive information?) so that data is restored on login.

https://github.com/kiali/kiali-ui/blob/d6a7fb41efaf523ec1e87f08b53c4c36a56fa354/src/reducers/MessageCenter.ts#L173-L176

Anyone thinks we should save the messagecenter or is OK to just clean it?

** Issue reference **

https://issues.jboss.org/browse/KIALI-1400

** Backwards compatible? **

[ ] Is your pull-request introducing changes in behaviour?
No

** Screenshot **

No visual changes
