### PR TITLE
KIALI-2938 MessageCenter improvements and detail handling

### DIFF
--- a/src/actions/GraphDataThunkActions.ts
+++ b/src/actions/GraphDataThunkActions.ts
@@ -6,7 +6,7 @@ import { GraphType, GroupByType, NodeParamsType } from '../types/Graph';
 import { AppenderString, DurationInSeconds } from '../types/Common';
 import { KialiAppAction } from './KialiAppAction';
 import { GraphDataActions } from './GraphDataActions';
-import { MessageCenterActions } from './MessageCenterActions';
+import * as MessageCenter from '../utils/MessageCenter';
 import { EdgeLabelMode } from '../types/GraphFilter';
 import * as API from '../services/Api';
 import { serverConfig } from '../config/ServerConfig';
@@ -87,17 +87,11 @@ const GraphDataThunkActions = {
             dispatch(GraphDataActions.getGraphDataSuccess(timestamp, graphDuration, graphData));
           },
           error => {
-            let emsg: string;
             if (error.isCanceled) {
               return;
             }
-            if (error.response && error.response.data && error.response.data.error) {
-              emsg = 'Cannot load the graph: ' + error.response.data.error;
-            } else {
-              emsg = 'Cannot load the graph: ' + error.toString();
-            }
-            dispatch(MessageCenterActions.addMessage(emsg));
-            dispatch(GraphDataActions.getGraphDataFailure(emsg));
+            MessageCenter.addError('Cannot load the graph', error);
+            dispatch(GraphDataActions.getGraphDataFailure(`Cannot load the graph: ${API.getErrorString(error)}`));
           }
         );
       }
@@ -112,17 +106,11 @@ const GraphDataThunkActions = {
           dispatch(GraphDataActions.getGraphDataSuccess(timestamp, graphDuration, graphData));
         },
         error => {
-          let emsg: string;
           if (error.isCanceled) {
             return;
           }
-          if (error.response && error.response.data && error.response.data.error) {
-            emsg = 'Cannot load the graph: ' + error.response.data.error;
-          } else {
-            emsg = 'Cannot load the graph: ' + error.toString();
-          }
-          dispatch(MessageCenterActions.addMessage(emsg));
-          dispatch(GraphDataActions.getGraphDataFailure(emsg));
+          MessageCenter.addError('Cannot load the graph', error);
+          dispatch(GraphDataActions.getGraphDataFailure(`Cannot load the graph: ${API.getErrorString(error)}`));
         }
       );
     };

--- a/src/actions/LoginThunkActions.ts
+++ b/src/actions/LoginThunkActions.ts
@@ -5,8 +5,8 @@ import * as API from '../services/Api';
 import * as Login from '../services/Login';
 import { AuthResult, AuthStrategy } from '../types/Auth';
 import { KialiDispatch } from '../types/Redux';
-import { MessageCenterActions } from './MessageCenterActions';
 import authenticationConfig from '../config/AuthenticationConfig';
+import * as MessageCenter from '../utils/MessageCenter';
 
 const Dispatcher = new Login.LoginDispatcher();
 
@@ -80,7 +80,7 @@ const LoginThunkActions = {
           dispatch(LoginActions.logoutSuccess());
         }
       } catch (err) {
-        dispatch(MessageCenterActions.addMessage(API.getErrorMsg('Logout failed', err)));
+        MessageCenter.addError('Logout failed', err);
       }
     };
   }

--- a/src/actions/MessageCenterActions.ts
+++ b/src/actions/MessageCenterActions.ts
@@ -12,8 +12,12 @@ const toNumberArray = (n: numberOrNumberArray) => (Array.isArray(n) ? n : [n]);
 export const MessageCenterActions = {
   addMessage: createAction(
     ActionKeys.MC_ADD_MESSAGE,
-    resolve => (content: string, groupId: string = DEFAULT_GROUP_ID, messageType: MessageType = DEFAULT_MESSAGE_TYPE) =>
-      resolve({ content, groupId, messageType })
+    resolve => (
+      content: string,
+      details: string,
+      groupId: string = DEFAULT_GROUP_ID,
+      messageType: MessageType = DEFAULT_MESSAGE_TYPE
+    ) => resolve({ content, details, groupId, messageType })
   ),
   removeMessage: createAction(ActionKeys.MC_REMOVE_MESSAGE, resolve => (messageId: numberOrNumberArray) =>
     resolve({ messageId: toNumberArray(messageId) })

--- a/src/actions/MessageCenterActions.ts
+++ b/src/actions/MessageCenterActions.ts
@@ -14,10 +14,10 @@ export const MessageCenterActions = {
     ActionKeys.MC_ADD_MESSAGE,
     resolve => (
       content: string,
-      details: string,
+      detail: string,
       groupId: string = DEFAULT_GROUP_ID,
       messageType: MessageType = DEFAULT_MESSAGE_TYPE
-    ) => resolve({ content, details, groupId, messageType })
+    ) => resolve({ content, detail, groupId, messageType })
   ),
   removeMessage: createAction(ActionKeys.MC_REMOVE_MESSAGE, resolve => (messageId: numberOrNumberArray) =>
     resolve({ messageId: toNumberArray(messageId) })

--- a/src/actions/__tests__/MessageCenterAction.test.ts
+++ b/src/actions/__tests__/MessageCenterAction.test.ts
@@ -12,10 +12,11 @@ describe('MessageCenterActions', () => {
   it('should add a message', () => {
     const expectedPayload = {
       content: 'my message',
+      detail: 'my detail',
       groupId: 'great-messages',
       messageType: MessageType.WARNING
     };
-    const action = MessageCenterActions.addMessage('my message', 'great-messages', MessageType.WARNING);
+    const action = MessageCenterActions.addMessage('my message', 'my detail', 'great-messages', MessageType.WARNING);
     expect(action.payload).toEqual(expectedPayload);
   });
   it('should remove a single message', () => {

--- a/src/app/AuthenticationController.tsx
+++ b/src/app/AuthenticationController.tsx
@@ -101,14 +101,15 @@ class AuthenticationController extends React.Component<AuthenticationControllerP
       const getStatusPromise = API.getStatus()
         .then(response => this.props.setServerStatus(response.data))
         .catch(error => {
-          MessageCenter.add(API.getErrorMsg('Error fetching status.', error), 'default', MessageType.WARNING);
+          MessageCenter.addError('Error fetching server status.', error, 'default', MessageType.WARNING);
         });
       const getGrafanaInfoPromise = API.getGrafanaInfo()
         .then(response => this.props.setGrafanaInfo(response.data))
         .catch(error => {
           this.props.setGrafanaInfo(null);
-          MessageCenter.add(
-            API.getInfoMsg('Could not fetch Grafana info. Turning off links to Grafana.', error),
+          MessageCenter.addError(
+            'Could not fetch Grafana info. Turning off links to Grafana.',
+            error,
             'default',
             MessageType.INFO
           );
@@ -117,8 +118,9 @@ class AuthenticationController extends React.Component<AuthenticationControllerP
         .then(response => this.setJaegerInfo(response.data))
         .catch(error => {
           this.props.setJaegerInfo(null);
-          MessageCenter.add(
-            API.getInfoMsg('Could not fetch Jaeger info. Turning off Jaeger integration.', error),
+          MessageCenter.addError(
+            'Could not fetch Jaeger info. Turning off Jaeger integration.',
+            error,
             'default',
             MessageType.INFO
           );
@@ -166,7 +168,7 @@ const processServerStatus = (dispatch: KialiDispatch, serverStatus: ServerStatus
   );
 
   serverStatus.warningMessages.forEach(wMsg => {
-    dispatch(MessageCenterActions.addMessage(wMsg, 'systemErrors', MessageType.WARNING));
+    dispatch(MessageCenterActions.addMessage(wMsg, '', 'systemErrors', MessageType.WARNING));
   });
 };
 

--- a/src/app/StartupInitializer.tsx
+++ b/src/app/StartupInitializer.tsx
@@ -58,7 +58,7 @@ class InitializerComponent extends React.Component<InitializerComponentProps, In
       }
 
       this.setState({
-        errorMsg: API.getErrorMsg('Initialization failed', err),
+        errorMsg: `Initialization failed: ${API.getErrorString(err)}`,
         errorDetails: errDetails
       });
     }

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -751,7 +751,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
         if (this.isElementValid(ele)) {
           ele.removeClass(`${H.DEGRADED.name}  ${H.FAILURE.name} ${H.HEALTHY.name}`);
         }
-        console.error(API.getErrorMsg(`Could not fetch health for [${ele.data(CyNode.nodeType)}] [${key}]`, err));
+        console.error(`Could not fetch health for [${ele.data(CyNode.nodeType)}] [${key}]: ${API.getErrorString(err)}`);
       });
   }
 }

--- a/src/components/IstioWizards/IstioWizard.tsx
+++ b/src/components/IstioWizards/IstioWizard.tsx
@@ -224,8 +224,9 @@ class IstioWizard extends React.Component<WizardProps, WizardState> {
         this.props.onClose(true);
       })
       .catch(error => {
-        MessageCenter.add(
-          API.getErrorMsg('Could not ' + (this.props.update ? 'update' : 'create') + ' Istio config objects.', error)
+        MessageCenter.addError(
+          'Could not ' + (this.props.update ? 'update' : 'create') + ' Istio config objects.',
+          error
         );
         this.props.onClose(true);
       });

--- a/src/components/IstioWizards/IstioWizardDropdown.tsx
+++ b/src/components/IstioWizards/IstioWizardDropdown.tsx
@@ -176,7 +176,7 @@ class IstioWizardDropdown extends React.Component<Props, State> {
         this.props.onChange();
       })
       .catch(error => {
-        MessageCenter.add(API.getErrorMsg('Could not delete Istio config objects', error));
+        MessageCenter.addError('Could not delete Istio config objects.', error);
         this.setState({
           isDeleting: false
         });

--- a/src/components/IstioWizards/ThreeScaleIntegration.tsx
+++ b/src/components/IstioWizards/ThreeScaleIntegration.tsx
@@ -110,7 +110,7 @@ class ThreeScaleIntegration extends React.Component<Props, State> {
         );
       })
       .catch(error => {
-        MessageCenter.add(API.getErrorMsg('Could not fetch ThreeScaleHandlers', error));
+        MessageCenter.addError('Could not fetch ThreeScaleHandlers.', error);
       });
   };
 
@@ -143,7 +143,7 @@ class ThreeScaleIntegration extends React.Component<Props, State> {
         );
       })
       .catch(error => {
-        MessageCenter.add(API.getErrorMsg('Could not update ThreeScaleHandlers', error));
+        MessageCenter.addError('Could not update ThreeScaleHandlers.', error);
       });
   };
 
@@ -176,7 +176,7 @@ class ThreeScaleIntegration extends React.Component<Props, State> {
         );
       })
       .catch(error => {
-        MessageCenter.add(API.getErrorMsg('Could not delete ThreeScaleHandlers', error));
+        MessageCenter.addError('Could not delete ThreeScaleHandlers.', error);
       });
   };
 
@@ -270,7 +270,7 @@ class ThreeScaleIntegration extends React.Component<Props, State> {
         );
       })
       .catch(error => {
-        MessageCenter.add(API.getErrorMsg('Could not create ThreeScaleHandlers', error));
+        MessageCenter.addError('Could not create ThreeScaleHandlers.', error);
       });
   };
 

--- a/src/components/ListPage/ListComponent.tsx
+++ b/src/components/ListPage/ListComponent.tsx
@@ -41,7 +41,8 @@ export abstract class Component<P extends Props<R>, S extends State<R>, R> exten
   };
 
   handleAxiosError(message: string, error: AxiosError) {
-    const errMsg = API.getErrorMsg(message, error);
+    const errMsg = `${message}: ${API.getErrorString(error)}`;
+    // TODO: Do we really need this console logging?
     console.error(errMsg);
     this.handleError(errMsg);
   }

--- a/src/components/MTls/MeshMTLSStatus.tsx
+++ b/src/components/MTls/MeshMTLSStatus.tsx
@@ -65,17 +65,9 @@ class MeshMTLSStatus extends React.Component<Props> {
         // User without namespaces can't have access to mTLS information. Reduce severity to info.
         const informative = this.props.namespaces && this.props.namespaces.length < 1;
         if (informative) {
-          MessageCenter.add(
-            API.getInfoMsg('Mesh-wide mTLS status feature disabled.', error),
-            'default',
-            MessageType.INFO
-          );
+          MessageCenter.addError('Mesh-wide mTLS status feature disabled.', error, 'default', MessageType.INFO);
         } else {
-          MessageCenter.add(
-            API.getErrorMsg('Error fetching Mesh-wide mTLS status.', error),
-            'default',
-            MessageType.ERROR
-          );
+          MessageCenter.addError('Error fetching Mesh-wide mTLS status.', error, 'default', MessageType.ERROR);
         }
       });
   };

--- a/src/components/MessageCenter/NotificationDrawer.tsx
+++ b/src/components/MessageCenter/NotificationDrawer.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Collapse } from 'react-bootstrap';
-
+import { Expandable } from '@patternfly/react-core';
 import { MessageType, NotificationMessage, NotificationGroup } from '../../types/MessageCenter';
 import moment from 'moment';
 import {
@@ -63,14 +63,41 @@ type NotificationWrapperPropsType = {
   onClick: (message: NotificationMessage) => void;
 };
 
-class NotificationWrapper extends React.PureComponent<NotificationWrapperPropsType, StatelessType> {
+type NotificationWrapperStateType = {
+  isExpanded: boolean;
+};
+
+class NotificationWrapper extends React.PureComponent<NotificationWrapperPropsType, NotificationWrapperStateType> {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isExpanded: false
+    };
+  }
+
+  onToggle = () => {
+    this.setState({
+      isExpanded: !this.state.isExpanded
+    });
+  };
+
   render() {
+    const { isExpanded } = this.state;
     return (
       <Pf.Notification seen={this.props.message.seen} onClick={() => this.props.onClick(this.props.message)}>
         <Pf.Icon className="pull-left" type="pf" name={typeForPfIcon(this.props.message.type)} />
         <Pf.Notification.Content>
           <Pf.Notification.Message>
             {this.props.message.content}
+            {this.props.message.detail && (
+              <Expandable
+                toggleText={isExpanded ? 'Hide Detail' : 'Show Detail'}
+                onToggle={this.onToggle}
+                isExpanded={isExpanded}
+              >
+                <pre>{this.props.message.detail}</pre>
+              </Expandable>
+            )}
             {this.props.message.count > 1 && (
               <div>
                 {this.props.message.count} {moment().from(this.props.message.firstTriggered)}

--- a/src/components/MessageCenter/NotificationDrawer.tsx
+++ b/src/components/MessageCenter/NotificationDrawer.tsx
@@ -76,9 +76,9 @@ class NotificationWrapper extends React.PureComponent<NotificationWrapperPropsTy
   }
 
   onToggle = () => {
-    this.setState({
-      isExpanded: !this.state.isExpanded
-    });
+    this.setState(state => ({
+      isExpanded: !state.isExpanded
+    }));
   };
 
   render() {

--- a/src/components/Metrics/CustomMetrics.tsx
+++ b/src/components/Metrics/CustomMetrics.tsx
@@ -76,7 +76,8 @@ class CustomMetrics extends React.Component<CustomMetricsProps, MetricsState> {
         });
       })
       .catch(error => {
-        MessageCenter.add(API.getErrorMsg('Cannot fetch custom dashboard', error));
+        MessageCenter.addError('Could not fetch custom dashboard.', error);
+        // TODO: is this console logging necessary?
         console.error(error);
       });
   };

--- a/src/components/Metrics/IstioMetrics.tsx
+++ b/src/components/Metrics/IstioMetrics.tsx
@@ -92,7 +92,8 @@ class IstioMetrics extends React.Component<IstioMetricsProps, MetricsState> {
         });
       })
       .catch(error => {
-        MessageCenter.add(API.getErrorMsg('Cannot fetch metrics', error));
+        MessageCenter.addError('Could not fetch metrics.', error);
+        // TODO: Is this console logging necessary?
         console.error(error);
         throw error;
       });

--- a/src/helpers/TrafficDetailsHelper.ts
+++ b/src/helpers/TrafficDetailsHelper.ts
@@ -17,7 +17,7 @@ export const fetchTrafficDetails = (
       return response.data;
     },
     error => {
-      MessageCenter.add(API.getErrorMsg('Could not fetch traffic data', error));
+      MessageCenter.addError('Could not fetch traffic data.', error);
       return undefined;
     }
   );

--- a/src/pages/AppDetails/AppDetailsPage.tsx
+++ b/src/pages/AppDetails/AppDetailsPage.tsx
@@ -96,7 +96,7 @@ class AppDetails extends React.Component<AppDetailsProps, AppDetailsState> {
       })
       .then(health => this.setState({ health: health }))
       .catch(error => {
-        MessageCenter.add(API.getErrorMsg('Could not fetch App Details', error));
+        MessageCenter.addError('Could not fetch App Details.', error);
       });
   };
 

--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -69,7 +69,7 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
         });
       })
       .catch(error => {
-        MessageCenter.add(API.getErrorMsg('Could not fetch IstioConfig details', error));
+        MessageCenter.addError('Could not fetch IstioConfig details.', error);
       });
   };
 
@@ -149,7 +149,7 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
     deletePromise
       .then(_r => this.backToList())
       .catch(error => {
-        MessageCenter.add(API.getErrorMsg('Could not delete IstioConfig details.', error));
+        MessageCenter.addError('Could not delete IstioConfig details.', error);
       });
   };
 
@@ -184,7 +184,7 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
           this.fetchIstioObjectDetails();
         })
         .catch(error => {
-          MessageCenter.add(API.getErrorMsg('Could not update IstioConfig details.', error));
+          MessageCenter.addError('Could not update IstioConfig details.', error);
         });
     });
   };

--- a/src/pages/Overview/OverviewPage.tsx
+++ b/src/pages/Overview/OverviewPage.tsx
@@ -144,7 +144,11 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
           }
         );
       })
-      .catch(namespacesError => this.handleAxiosError('Could not fetch namespace list', namespacesError));
+      .catch(namespacesError => {
+        if (!namespacesError.isCanceled) {
+          this.handleAxiosError('Could not fetch namespace list', namespacesError);
+        }
+      });
   };
 
   fetchHealth(isAscending: boolean, sortField: SortField<NamespaceInfo>, type: OverviewType) {
@@ -278,7 +282,7 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
   }
 
   handleAxiosError(message: string, error: AxiosError) {
-    ListPagesHelper.handleError(API.getErrorMsg(message, error));
+    ListPagesHelper.handleError(`${message}: ${API.getErrorString(error)}`);
   }
 
   sort = (sortField: SortField<NamespaceInfo>, isAscending: boolean) => {

--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -197,11 +197,11 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
             });
           })
           .catch(gwError => {
-            MessageCenter.add(API.getErrorMsg('Could not fetch Namespaces list', gwError));
+            MessageCenter.addError('Could not fetch Namespaces list.', gwError);
           });
       })
       .catch(error => {
-        MessageCenter.add(API.getErrorMsg('Could not fetch Namespaces list', error));
+        MessageCenter.addError('Could not fetch Namespaces list.', error);
       });
 
     API.getServiceDetail(this.props.match.params.namespace, this.props.match.params.service, true, this.props.duration)
@@ -223,7 +223,7 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
         }
       })
       .catch(error => {
-        MessageCenter.add(API.getErrorMsg('Could not fetch Service Details', error));
+        MessageCenter.addError('Could not fetch Service Details.', error);
       });
 
     API.getThreeScaleInfo()
@@ -244,14 +244,15 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
               });
               // Only log 500 errors. 404 response is a valid response on this composition case
               if (error.response && error.response.status >= 500) {
-                MessageCenter.add(API.getErrorMsg('Could not fetch ThreeScaleServiceRule', error));
+                MessageCenter.addError('Could not fetch ThreeScaleServiceRule.', error);
               }
             });
         }
       })
       .catch(error => {
-        MessageCenter.add(
-          API.getInfoMsg('Could not fetch 3scale info. Turning off 3scale integration.', error),
+        MessageCenter.addError(
+          'Could not fetch 3scale info. Turning off 3scale integration.',
+          error,
           'default',
           MessageType.INFO
         );

--- a/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -177,7 +177,7 @@ class WorkloadDetails extends React.Component<WorkloadDetailsPageProps, Workload
       })
       .then(health => this.setState({ health: health }))
       .catch(error => {
-        MessageCenter.add(API.getErrorMsg('Could not fetch Workload', error));
+        MessageCenter.addError('Could not fetch Workload.', error);
       });
   };
 

--- a/src/reducers/MessageCenter.ts
+++ b/src/reducers/MessageCenter.ts
@@ -33,6 +33,7 @@ export const INITIAL_MESSAGE_CENTER_STATE: MessageCenterState = {
 const createMessage = (
   id: number,
   content: string,
+  detail: string,
   type: MessageType,
   count: number,
   created: Date,
@@ -41,6 +42,7 @@ const createMessage = (
   return {
     id,
     content,
+    detail,
     type,
     count,
     show_notification: type === MessageType.ERROR || type === MessageType.WARNING || type === MessageType.SUCCESS,
@@ -74,7 +76,7 @@ const Messages = (
 ): MessageCenterState => {
   switch (action.type) {
     case getType(MessageCenterActions.addMessage): {
-      const { groupId, content, messageType } = action.payload;
+      const { content, detail, groupId, messageType } = action.payload;
 
       const groups = state.groups.map(group => {
         if (group.id === groupId) {
@@ -93,6 +95,7 @@ const Messages = (
             newMessage = createMessage(
               state.nextId,
               content,
+              detail,
               messageType,
               existingMessage.count + 1,
               new Date(),
@@ -106,7 +109,7 @@ const Messages = (
 
             group = { ...group, messages: filteredArray.concat(newMessage) };
           } else {
-            newMessage = createMessage(state.nextId, content, messageType, 1, new Date(), undefined);
+            newMessage = createMessage(state.nextId, content, detail, messageType, 1, new Date(), undefined);
             group = { ...group, messages: group.messages.concat(newMessage) };
           }
 

--- a/src/reducers/__tests__/MessageCenterReducer.test.ts
+++ b/src/reducers/__tests__/MessageCenterReducer.test.ts
@@ -59,7 +59,7 @@ describe('MessageCenter reducer', () => {
           hidden: true,
           nextId: 0
         },
-        MessageCenterActions.addMessage('my new message', 'default', MessageType.WARNING)
+        MessageCenterActions.addMessage('my new message', 'my detail', 'default', MessageType.WARNING)
       )
     ).toEqual({
       expanded: false,
@@ -73,6 +73,7 @@ describe('MessageCenter reducer', () => {
               seen: false,
               show_notification: true,
               content: 'my new message',
+              detail: 'my detail',
               type: MessageType.WARNING,
               count: 1,
               firstTriggered: undefined,
@@ -105,6 +106,7 @@ describe('MessageCenter reducer', () => {
                   seen: false,
                   show_notification: true,
                   content: 'my new message',
+                  detail: 'my detail',
                   type: MessageType.WARNING,
                   count: 1,
                   firstTriggered: undefined,
@@ -119,7 +121,7 @@ describe('MessageCenter reducer', () => {
           hidden: true,
           nextId: 0
         },
-        MessageCenterActions.addMessage('my new message', 'default', MessageType.WARNING)
+        MessageCenterActions.addMessage('my new message', 'my detail', 'default', MessageType.WARNING)
       )
     ).toEqual({
       expanded: false,
@@ -133,6 +135,7 @@ describe('MessageCenter reducer', () => {
               seen: false,
               show_notification: true,
               content: 'my new message',
+              detail: 'my detail',
               type: MessageType.WARNING,
               count: 2,
               firstTriggered: date,
@@ -167,6 +170,7 @@ describe('MessageCenter reducer', () => {
                   seen: false,
                   show_notification: true,
                   content: 'my new message',
+                  detail: 'my detail',
                   type: MessageType.WARNING,
                   count: 1,
                   created: date
@@ -176,6 +180,7 @@ describe('MessageCenter reducer', () => {
                   seen: true,
                   show_notification: false,
                   content: 'other message',
+                  detail: 'my detail',
                   type: MessageType.ERROR,
                   count: 1,
                   created: date
@@ -185,6 +190,7 @@ describe('MessageCenter reducer', () => {
                   seen: true,
                   show_notification: false,
                   content: 'other',
+                  detail: 'my detail',
                   type: MessageType.INFO,
                   count: 1,
                   created: date
@@ -210,6 +216,7 @@ describe('MessageCenter reducer', () => {
               seen: true,
               show_notification: false,
               content: 'other message',
+              detail: 'my detail',
               type: MessageType.ERROR,
               count: 1,
               created: date
@@ -243,6 +250,7 @@ describe('MessageCenter reducer', () => {
                   seen: false,
                   show_notification: true,
                   content: 'my new message',
+                  detail: 'my detail',
                   type: MessageType.WARNING,
                   count: 1,
                   created: date
@@ -252,6 +260,7 @@ describe('MessageCenter reducer', () => {
                   seen: true,
                   show_notification: false,
                   content: 'other message',
+                  detail: 'my detail',
                   type: MessageType.ERROR,
                   count: 1,
                   created: date
@@ -261,6 +270,7 @@ describe('MessageCenter reducer', () => {
                   seen: false,
                   show_notification: false,
                   content: 'other',
+                  detail: 'my detail',
                   type: MessageType.INFO,
                   count: 1,
                   created: date
@@ -286,6 +296,7 @@ describe('MessageCenter reducer', () => {
               seen: true,
               show_notification: false,
               content: 'my new message',
+              detail: 'my detail',
               type: MessageType.WARNING,
               count: 1,
               created: date
@@ -295,6 +306,7 @@ describe('MessageCenter reducer', () => {
               seen: true,
               show_notification: false,
               content: 'other message',
+              detail: 'my detail',
               type: MessageType.ERROR,
               count: 1,
               created: date
@@ -304,6 +316,7 @@ describe('MessageCenter reducer', () => {
               seen: false,
               show_notification: false,
               content: 'other',
+              detail: 'my detail',
               type: MessageType.INFO,
               count: 1,
               created: date
@@ -337,6 +350,7 @@ describe('MessageCenter reducer', () => {
                   seen: false,
                   show_notification: true,
                   content: 'my new message',
+                  detail: 'my detail',
                   type: MessageType.WARNING,
                   count: 1,
                   created: date
@@ -346,6 +360,7 @@ describe('MessageCenter reducer', () => {
                   seen: false,
                   show_notification: true,
                   content: 'other message',
+                  detail: 'my detail',
                   type: MessageType.ERROR,
                   count: 1,
                   created: date
@@ -371,6 +386,7 @@ describe('MessageCenter reducer', () => {
               seen: false,
               show_notification: false,
               content: 'my new message',
+              detail: 'my detail',
               type: MessageType.WARNING,
               count: 1,
               created: date
@@ -380,6 +396,7 @@ describe('MessageCenter reducer', () => {
               seen: false,
               show_notification: true,
               content: 'other message',
+              detail: 'my detail',
               type: MessageType.ERROR,
               count: 1,
               created: date

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -449,7 +449,7 @@ export const getErrorString = (error: AxiosError): string => {
     if (error.response.statusText) {
       let errorString = error.response.statusText;
       if (error.response.status === 401) {
-        errorString += ' Has your session expired? Try logging in again.';
+        errorString += ': Has your session expired? Try logging in again.';
       }
       return errorString;
     }

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -441,27 +441,29 @@ export const getPodLogs = (
   return newRequest<PodLogs>(HTTP_VERBS.GET, urls.podLogs(namespace, name), params, {});
 };
 
-export const getMessage = (type: string, msg: string, error: AxiosError) => {
-  let errorMessage = msg;
+export const getErrorString = (error: AxiosError): string => {
   if (error && error.response) {
     if (error.response.data && error.response.data.error) {
-      errorMessage = `${msg}, ${type}: [ ${error.response.data.error} ]`;
-    } else if (error.response.statusText) {
-      errorMessage = `${msg}, ${type}: [ ${error.response.statusText} ]`;
+      return error.response.data.error;
+    }
+    if (error.response.statusText) {
+      let errorString = error.response.statusText;
       if (error.response.status === 401) {
-        errorMessage += ' Has your session expired? Try logging in again.';
+        errorString += ' Has your session expired? Try logging in again.';
       }
+      return errorString;
     }
   }
-  return errorMessage;
+  return '';
 };
 
-export const getInfoMsg = (msg: string, error: AxiosError) => {
-  return getMessage('Info', msg, error);
-};
-
-export const getErrorMsg = (msg: string, error: AxiosError) => {
-  return getMessage('Error', msg, error);
+export const getErrorDetail = (error: AxiosError): string => {
+  if (error && error.response) {
+    if (error.response.data && error.response.data.detail) {
+      return error.response.data.detail;
+    }
+  }
+  return '';
 };
 
 export const getThreeScaleInfo = () => {

--- a/src/services/__tests__/ApiMethods.test.tsx.ts
+++ b/src/services/__tests__/ApiMethods.test.tsx.ts
@@ -2,8 +2,7 @@ import * as API from '../Api';
 import { AxiosError } from 'axios';
 import { IstioMetricsOptions } from '../../types/MetricsOptions';
 
-describe('#GetErrorMessage', () => {
-  const errormsg = 'Error sample';
+describe('#GetErrorString', () => {
   it('should return an error message with status', () => {
     const axErr: AxiosError = {
       config: { method: 'GET' },
@@ -17,7 +16,7 @@ describe('#GetErrorMessage', () => {
         config: {}
       }
     };
-    expect(API.getErrorMsg(errormsg, axErr)).toEqual(`${errormsg}, Error: [ InternalError ]`);
+    expect(API.getErrorString(axErr)).toEqual(`InternalError`);
   });
   it('should return an error message with data', () => {
     const responseServerError = 'Internal Error';
@@ -33,7 +32,24 @@ describe('#GetErrorMessage', () => {
         config: {}
       }
     };
-    expect(API.getErrorMsg(errormsg, axErr)).toEqual(`${errormsg}, Error: [ ${responseServerError} ]`);
+    expect(API.getErrorString(axErr)).toEqual(`${responseServerError}`);
+  });
+  it('should return a detail error message with data', () => {
+    const responseServerError = 'Internal Error';
+    const responseServerDetail = 'Error Detail';
+    const axErr: AxiosError = {
+      config: { method: 'GET' },
+      name: 'AxiosError',
+      message: 'Error in Response',
+      response: {
+        data: { error: responseServerError, detail: responseServerDetail },
+        status: 400,
+        statusText: 'InternalError',
+        headers: null,
+        config: {}
+      }
+    };
+    expect(API.getErrorDetail(axErr)).toEqual(`${responseServerDetail}`);
   });
   it('should return specific error message for unauthorized', () => {
     const axErr: AxiosError = {
@@ -48,9 +64,7 @@ describe('#GetErrorMessage', () => {
         config: {}
       }
     };
-    expect(API.getErrorMsg(errormsg, axErr)).toEqual(
-      `${errormsg}, Error: [ Unauthorized ] Has your session expired? Try logging in again.`
-    );
+    expect(API.getErrorString(axErr)).toEqual(`Unauthorized: Has your session expired? Try logging in again.`);
   });
 });
 

--- a/src/types/MessageCenter.ts
+++ b/src/types/MessageCenter.ts
@@ -10,6 +10,7 @@ export interface NotificationMessage {
   seen: boolean;
   type: MessageType;
   content: string;
+  detail: string;
   created: Date;
   firstTriggered?: Date; // when was it first triggered
   count: number; // how many times did this message occur

--- a/src/utils/MessageCenter.ts
+++ b/src/utils/MessageCenter.ts
@@ -3,5 +3,9 @@ import { MessageType } from '../types/MessageCenter';
 import { MessageCenterActions } from '../actions/MessageCenterActions';
 
 export const add = (content: string, group?: string, type?: MessageType) => {
-  store.dispatch(MessageCenterActions.addMessage(content, group, type));
+  store.dispatch(MessageCenterActions.addMessage(content, '', group, type));
+};
+
+export const addDetailed = (content: string, details: string, group?: string, type?: MessageType) => {
+  store.dispatch(MessageCenterActions.addMessage(content, details, group, type));
 };

--- a/src/utils/MessageCenter.ts
+++ b/src/utils/MessageCenter.ts
@@ -1,11 +1,33 @@
 import { store } from '../store/ConfigStore';
 import { MessageType } from '../types/MessageCenter';
 import { MessageCenterActions } from '../actions/MessageCenterActions';
+import { AxiosError } from 'axios';
+import * as API from '../services/Api';
 
 export const add = (content: string, group?: string, type?: MessageType) => {
   store.dispatch(MessageCenterActions.addMessage(content, '', group, type));
 };
 
-export const addDetailed = (content: string, details: string, group?: string, type?: MessageType) => {
-  store.dispatch(MessageCenterActions.addMessage(content, details, group, type));
+export const addDetail = (content: string, detail: string, group?: string, type?: MessageType) => {
+  store.dispatch(MessageCenterActions.addMessage(content, detail, group, type));
+};
+
+export const addError = (message: string, error: AxiosError, group?: string, type?: MessageType) => {
+  const errorString: string = API.getErrorString(error);
+  const errorDetail: string = API.getErrorDetail(error);
+  let finalMessage: string = message;
+  let finalDetail: string = errorString;
+  let finalType: MessageType = type ? type : MessageType.ERROR;
+  if (message) {
+    // combine error string and detail into a single detail
+    if (errorString && errorDetail) {
+      finalDetail = `${errorString}\nAdditional Detail:\n${errorDetail}`;
+    } else if (errorDetail) {
+      finalDetail = errorDetail;
+    }
+  } else {
+    finalMessage = errorString;
+    finalDetail = errorDetail;
+  }
+  addDetail(finalMessage, finalDetail, group, finalType);
 };


### PR DESCRIPTION
- hide additional detail inside an expandable for a cleaner toast and list
    - consistently use MessageCenter utils to format and dispatch notifications
      - use new addError() consistenly when reporting AxiosError
      - feature the message, when supplied, hiding error and additional detail
      - feature error when message not supplied, hiding any additional detail
 - remove unnecessary API.getMessage, getErrorMessage, getInfoMessage
   - severity is already shown via icon
   - replace with API.getErrorString, getErrorDetail

*** SERVER PR: https://github.com/kiali/kiali/pull/1319