### PR TITLE
KIALI-3198 Migrate charts in overview cards to pf4

### DIFF
--- a/src/pages/Overview/OverviewCardBars.tsx
+++ b/src/pages/Overview/OverviewCardBars.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import { Chart, ChartBar, ChartStack, ChartAxis } from '@patternfly/react-charts';
+
+import { NamespaceStatus } from './NamespaceInfo';
+import { FAILURE, DEGRADED, HEALTHY } from '../../types/Health';
+
+type Props = {
+  status: NamespaceStatus;
+};
+
+type State = {
+  width: number;
+};
+
+class OverviewCardBars extends React.Component<Props, State> {
+  containerRef = React.createRef<HTMLDivElement>();
+
+  constructor(props: Props) {
+    super(props);
+    this.state = { width: 0 };
+  }
+
+  handleResize = () => {
+    if (this.containerRef.current) {
+      this.setState({ width: this.containerRef.current.clientWidth });
+    }
+  };
+
+  componentDidMount() {
+    setTimeout(() => {
+      this.handleResize();
+      window.addEventListener('resize', this.handleResize);
+    });
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.handleResize);
+  }
+
+  render() {
+    return (
+      <div ref={this.containerRef}>
+        <Chart height={50} width={this.state.width} padding={{ top: 20, left: 5, right: 5, bottom: 0 }}>
+          <ChartStack colorScale={[FAILURE.color, DEGRADED.color, HEALTHY.color]} xOffset={10}>
+            <ChartBar horizontal={true} barWidth={16} data={[{ y: this.props.status.inError.length }]} />
+            <ChartBar horizontal={true} barWidth={16} data={[{ y: this.props.status.inWarning.length }]} />
+            <ChartBar horizontal={true} barWidth={16} data={[{ y: this.props.status.inSuccess.length }]} />
+          </ChartStack>
+          <ChartAxis style={{ axis: { strokeWidth: 0 } }} />
+          <ChartAxis style={{ axis: { strokeWidth: 0 } }} dependentAxis={true} />
+        </Chart>
+      </div>
+    );
+  }
+}
+
+export default OverviewCardBars;

--- a/src/pages/Overview/OverviewCardContentExpanded.tsx
+++ b/src/pages/Overview/OverviewCardContentExpanded.tsx
@@ -1,10 +1,5 @@
 import * as React from 'react';
-import {
-  AggregateStatusNotification,
-  AggregateStatusNotifications,
-  StackedBarChart,
-  SparklineChart
-} from 'patternfly-react';
+import { AggregateStatusNotification, AggregateStatusNotifications } from 'patternfly-react';
 import { Link } from 'react-router-dom';
 import { DEGRADED, FAILURE, HEALTHY } from '../../types/Health';
 import OverviewStatus from './OverviewStatus';
@@ -13,9 +8,9 @@ import { NamespaceStatus } from './NamespaceInfo';
 import { switchType } from './OverviewHelper';
 import { Paths } from '../../config';
 import { TimeSeries } from '../../types/Metrics';
-import graphUtils from '../../utils/Graphing';
 import { DurationInSeconds } from '../../types/Common';
-import { getName } from '../../utils/RateIntervals';
+import OverviewCardSparkline from './OverviewCardSparkline';
+import OverviewCardBars from './OverviewCardBars';
 
 type Props = {
   name: string;
@@ -40,7 +35,7 @@ class OverviewCardContentExpanded extends React.Component<Props> {
             verticalAlign: 'top'
           }}
         >
-          {this.renderRight()}
+          <OverviewCardSparkline metrics={this.props.metrics} duration={this.props.duration} />
         </div>
       </>
     );
@@ -72,27 +67,7 @@ class OverviewCardContentExpanded extends React.Component<Props> {
     return (
       <>
         {mainLink}
-        <StackedBarChart
-          style={{ paddingLeft: 13 }}
-          id={'card-barchart-' + name}
-          size={{ height: 50 }}
-          axis={{ rotated: true, x: { show: false, categories: ['Health'], type: 'category' }, y: { show: false } }}
-          grid={{ x: { show: false }, y: { show: false } }}
-          tooltip={{ show: false }}
-          data={{
-            groups: [[FAILURE.name, DEGRADED.name, HEALTHY.name]],
-            columns: [
-              [FAILURE.name, status.inError.length],
-              [DEGRADED.name, status.inWarning.length],
-              [HEALTHY.name, status.inSuccess.length]
-            ],
-            order: null,
-            type: 'bar'
-          }}
-          color={{ pattern: [FAILURE.color, DEGRADED.color, HEALTHY.color] }}
-          bar={{ width: 20 }}
-          legend={{ hide: true }}
-        />
+        <OverviewCardBars status={this.props.status} />
         <AggregateStatusNotifications style={{ marginTop: -20, position: 'relative' }}>
           {status.inError.length > 0 && (
             <OverviewStatus
@@ -124,26 +99,6 @@ class OverviewCardContentExpanded extends React.Component<Props> {
         </AggregateStatusNotifications>
       </>
     );
-  }
-
-  renderRight(): JSX.Element {
-    if (this.props.metrics && this.props.metrics.length > 0) {
-      return (
-        <>
-          {'Traffic, ' + getName(this.props.duration).toLowerCase()}
-          <SparklineChart
-            id={'card-sparkline-' + this.props.name}
-            data={{ x: 'x', columns: graphUtils.toC3Columns(this.props.metrics, 'RPS'), type: 'area' }}
-            tooltip={{}}
-            axis={{
-              x: { show: false, type: 'timeseries', tick: { format: '%H:%M:%S' } },
-              y: { show: false }
-            }}
-          />
-        </>
-      );
-    }
-    return <div style={{ marginTop: 20 }}>No traffic</div>;
   }
 }
 

--- a/src/pages/Overview/OverviewCardSparkline.tsx
+++ b/src/pages/Overview/OverviewCardSparkline.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react';
+import { Chart, ChartArea, ChartThemeColor, ChartAxis } from '@patternfly/react-charts';
+
+import { DurationInSeconds } from '../../types/Common';
+import { TimeSeries } from '../../types/Metrics';
+import graphUtils from '../../utils/Graphing';
+import { getName } from '../../utils/RateIntervals';
+
+type Props = {
+  metrics?: TimeSeries[];
+  duration: DurationInSeconds;
+};
+
+type State = {
+  width: number;
+};
+
+class OverviewCardSparkline extends React.Component<Props, State> {
+  containerRef = React.createRef<HTMLDivElement>();
+
+  constructor(props: Props) {
+    super(props);
+    this.state = { width: 0 };
+  }
+
+  handleResize = () => {
+    if (this.containerRef.current) {
+      this.setState({ width: this.containerRef.current.clientWidth });
+    }
+  };
+
+  componentDidMount() {
+    setTimeout(() => {
+      this.handleResize();
+      window.addEventListener('resize', this.handleResize);
+    });
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.handleResize);
+  }
+
+  render() {
+    if (this.props.metrics && this.props.metrics.length > 0) {
+      const data = graphUtils.toVCLines(this.props.metrics);
+
+      return (
+        <div ref={this.containerRef}>
+          {'Traffic, ' + getName(this.props.duration).toLowerCase()}
+          <div className="area-chart-overflow">
+            <Chart
+              height={60}
+              width={this.state.width}
+              padding={0}
+              themeColor={ChartThemeColor.multi}
+              scale={{ x: 'time' }}
+            >
+              {data.series.map((serie, idx) => (
+                <ChartArea key={'serie-' + idx} data={serie} />
+              ))}
+              <ChartAxis tickCount={5} tickFormat={() => ''} />
+              <ChartAxis dependentAxis={true} tickFormat={() => ''} />
+            </Chart>
+          </div>
+        </div>
+      );
+    }
+    return <div style={{ marginTop: 20 }}>No traffic</div>;
+  }
+}
+
+export default OverviewCardSparkline;

--- a/src/utils/Graphing.ts
+++ b/src/utils/Graphing.ts
@@ -19,5 +19,21 @@ export default {
 
     // timestamps + data is the format required by C3 (all concatenated: an array with arrays)
     return [xseries, ...yseries];
+  },
+
+  toVCLines(ts: TimeSeries[]) {
+    return {
+      series: ts.map(line => {
+        return line.values
+          .map(dp => {
+            return {
+              name: line.name!,
+              x: new Date(dp[0] * 1000) as any,
+              y: Number(dp[1])
+            };
+          })
+          .filter(dp => !isNaN(dp.y));
+      })
+    };
   }
 };


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/KIALI-3198

There's:
- sparkline chart
- bars chart

Splitting in dedicated components by the way.

!Note!: there's a regression with PF3 charts: we don't have tooltips here on the sparkline. So it now only represents a trend but we cannot really read values for it. This is because I couldn't find a good way to display tooltips on victory charts especially when the chart is small, because it requires huge padding around the chart to not be cut on borders.

I think we should investigate alternatives, such as a fixed-position tooltip, or debugging/forking victory's voronoi to "clamp" tooltip on borders, or maybe no tooltip but show y-axis values...
