### PR TITLE
KIALI-3213 More type-safety on Virtual Lists

### DIFF
--- a/src/components/VirtualList/Config.ts
+++ b/src/components/VirtualList/Config.ts
@@ -1,93 +1,118 @@
 import deepFreeze from 'deep-freeze';
+import { sortable } from '@patternfly/react-table';
+
 import { AppListItem } from '../../types/AppList';
 import { WorkloadListItem } from '../../types/Workload';
 import { ServiceListItem } from '../../types/ServiceList';
-import { sortable } from '@patternfly/react-table';
 import { IstioConfigItem } from '../../types/IstioConfigList';
 import { serverConfig } from '../../config';
+import * as Renderers from './Renderers';
+import { Health } from '../../types/Health';
 
 export type SortResource = AppListItem | WorkloadListItem | ServiceListItem;
 export type TResource = SortResource | IstioConfigItem;
+export type Renderer<R extends TResource> = (
+  item: R,
+  config: Resource,
+  icon: string,
+  health?: Health
+) => JSX.Element | undefined;
+
+// Health type guard
+export function hasHealth(r: TResource): r is SortResource {
+  return (r as SortResource).healthPromise !== undefined;
+}
 
 export const hasMissingSidecar = (r: SortResource): boolean => {
   return r.namespace !== serverConfig.istioNamespace && !r.istioSidecar;
 };
 
-type ResourceType = {
+type ResourceType<R extends TResource> = {
   name: string;
   column: string;
   param?: string;
   transforms?: any;
+  renderer: Renderer<R>;
 };
 
-const item: ResourceType = {
+const item: ResourceType<TResource> = {
   name: 'Item',
   param: 'wn',
   column: 'Name',
-  transforms: [sortable]
+  transforms: [sortable],
+  renderer: Renderers.item
 };
 
-const serviceItem: ResourceType = {
+const serviceItem: ResourceType<ServiceListItem> = {
   name: 'Item',
   param: 'sn',
   column: 'Name',
-  transforms: [sortable]
+  transforms: [sortable],
+  renderer: Renderers.item
 };
 
-const istioItem: ResourceType = {
+const istioItem: ResourceType<IstioConfigItem> = {
   name: 'Item',
   param: 'in',
   column: 'Name',
-  transforms: [sortable]
+  transforms: [sortable],
+  renderer: Renderers.item
 };
 
-const namespace: ResourceType = {
+const namespace: ResourceType<TResource> = {
   name: 'Namespace',
   param: 'ns',
   column: 'Namespace',
-  transforms: [sortable]
+  transforms: [sortable],
+  renderer: Renderers.namespace
 };
 
-const health: ResourceType = {
+const health: ResourceType<TResource> = {
   name: 'Health',
   param: 'he',
   column: 'Health',
-  transforms: [sortable]
+  transforms: [sortable],
+  renderer: Renderers.health
 };
 
-const details: ResourceType = {
+const details: ResourceType<AppListItem | WorkloadListItem | ServiceListItem> = {
   name: 'Details',
   param: 'is',
   column: 'Details',
-  transforms: [sortable]
+  transforms: [sortable],
+  renderer: Renderers.details
 };
 
-const configuration: ResourceType = {
+const configuration: ResourceType<ServiceListItem | IstioConfigItem> = {
   name: 'Configuration',
   param: 'cv',
   column: 'Configuration',
-  transforms: [sortable]
+  transforms: [sortable],
+  renderer: Renderers.configuration
 };
 
-const labelValidation: ResourceType = {
+const labelValidation: ResourceType<WorkloadListItem> = {
   name: 'LabelValidation',
   param: 'lb',
   column: 'Label Validation',
-  transforms: [sortable]
+  transforms: [sortable],
+  renderer: Renderers.labelValidation
 };
 
-const workloadType: ResourceType = {
+const workloadType: ResourceType<WorkloadListItem> = {
   name: 'WorkloadType',
   param: 'wt',
   column: 'Type',
-  transforms: [sortable]
+  transforms: [sortable],
+  renderer: Renderers.workloadType
 };
 
-const istioType: ResourceType = {
+const istioType: ResourceType<IstioConfigItem> = {
   name: 'IstioType',
   param: 'it',
   column: 'Type',
-  transforms: [sortable]
+  transforms: [sortable],
+  renderer: Renderers.istioType
 };
 
 export const IstioTypes = {
@@ -111,7 +136,7 @@ export const IstioTypes = {
 
 export type Resource = {
   name: string;
-  columns: ResourceType[];
+  columns: ResourceType<any>[];
   caption?: string;
   icon?: string;
 };

--- a/src/components/VirtualList/Renderers.tsx
+++ b/src/components/VirtualList/Renderers.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { Badge, Tooltip, TooltipPosition } from '@patternfly/react-core';
 
 import MissingSidecar from '../MissingSidecar/MissingSidecar';
-import { IstioTypes, Resource, TResource, hasMissingSidecar } from './Config';
+import { IstioTypes, Resource, TResource, hasMissingSidecar, Renderer } from './Config';
 import { DisplayMode, HealthIndicator } from '../Health/HealthIndicator';
 import { ConfigIndicator } from '../ConfigValidation/ConfigIndicator';
 import { WorkloadListItem } from '../../types/Workload';
@@ -11,6 +11,7 @@ import { dicIstioType, IstioConfigItem } from '../../types/IstioConfigList';
 import { AppListItem } from '../../types/AppList';
 import { ServiceListItem } from '../../types/ServiceList';
 import { ApiTypeIndicator } from '../ApiDocumentation/ApiTypeIndicator';
+import { Health } from '../../types/Health';
 
 // Links
 
@@ -37,7 +38,9 @@ const getIstioLink = (item: TResource) => {
 };
 
 // Cells
-export const Details = (item: AppListItem | WorkloadListItem | ServiceListItem) => {
+export const details: Renderer<AppListItem | WorkloadListItem | ServiceListItem> = (
+  item: AppListItem | WorkloadListItem | ServiceListItem
+) => {
   return (
     <td role="gridcell" key={'VirtuaItem_Details_' + item.namespace + '_' + item.name}>
       {hasMissingSidecar(item) && <MissingSidecar />}{' '}
@@ -46,7 +49,7 @@ export const Details = (item: AppListItem | WorkloadListItem | ServiceListItem) 
   );
 };
 
-export const Item = (item: TResource, config: Resource, icon: string) => {
+export const item: Renderer<TResource> = (item: TResource, config: Resource, icon: string) => {
   const key = 'link_definition_' + config.name + '_' + item.namespace + '_' + item.name;
   let itemName = config.name.charAt(0).toUpperCase() + config.name.slice(1);
   if (config.name === 'istio') {
@@ -64,7 +67,7 @@ export const Item = (item: TResource, config: Resource, icon: string) => {
   );
 };
 
-export const Namespace = (item: TResource) => {
+export const namespace: Renderer<TResource> = (item: TResource) => {
   return (
     <td role="gridcell" key={'VirtuaItem_Namespace_' + item.namespace + '_' + item.name}>
       <Tooltip position={TooltipPosition.top} content={<>Namespace</>}>
@@ -75,7 +78,7 @@ export const Namespace = (item: TResource) => {
   );
 };
 
-export const Health = (item: TResource, __: Resource, _: string, health: any) => {
+export const health: Renderer<TResource> = (item: TResource, __: Resource, _: string, health?: Health) => {
   return (
     health && (
       <td role="gridcell" key={'VirtuaItem_Health_' + item.namespace + '_' + item.name}>
@@ -85,7 +88,7 @@ export const Health = (item: TResource, __: Resource, _: string, health: any) =>
   );
 };
 
-export const LabelValidation = (item: WorkloadListItem, __: Resource, _: string, ___: any) => {
+export const labelValidation: Renderer<WorkloadListItem> = (item: WorkloadListItem) => {
   const appLabel = item.appLabel;
   const versionLabel = item.versionLabel;
   return (
@@ -110,7 +113,7 @@ export const LabelValidation = (item: WorkloadListItem, __: Resource, _: string,
   );
 };
 
-export const WorkloadType = (item: WorkloadListItem) => {
+export const workloadType: Renderer<WorkloadListItem> = (item: WorkloadListItem) => {
   return (
     <td role="gridcell" key={'VirtuaItem_WorkloadType_' + item.namespace + '_' + item.name}>
       {item.type}
@@ -118,7 +121,7 @@ export const WorkloadType = (item: WorkloadListItem) => {
   );
 };
 
-export const IstioType = (item: IstioConfigItem) => {
+export const istioType: Renderer<IstioConfigItem> = (item: IstioConfigItem) => {
   const type = item.type;
   const object = IstioTypes[type];
   return (
@@ -128,7 +131,7 @@ export const IstioType = (item: IstioConfigItem) => {
   );
 };
 
-export const Configuration = (item: ServiceListItem | IstioConfigItem) => {
+export const configuration: Renderer<ServiceListItem | IstioConfigItem> = (item: ServiceListItem | IstioConfigItem) => {
   const validation = item.validation;
   return (
     <td role="gridcell" key={'VirtuaItem_Conf_' + item.namespace + '_' + item.name}>

--- a/src/components/VirtualList/VirtualList.tsx
+++ b/src/components/VirtualList/VirtualList.tsx
@@ -2,12 +2,12 @@ import * as React from 'react';
 import { Table, TableHeader, TableGridBreakpoint } from '@patternfly/react-table';
 import VirtualTable from './VirtualTable';
 import history, { HistoryManager, URLParam } from '../../app/History';
-import { config, Resource } from './Config';
+import { config, Resource, TResource } from './Config';
 
 type Direction = 'asc' | 'desc' | undefined;
 
-type VirtualListProps = {
-  rows: any[];
+type VirtualListProps<R> = {
+  rows: R[];
   scrollFilters?: boolean;
   updateItems: () => void;
 };
@@ -26,12 +26,12 @@ type VirtualListState = {
 // get the type of list user request
 const listRegex = /\/([a-z0-9-]+)/;
 
-export class VirtualList extends React.Component<VirtualListProps, VirtualListState> {
-  constructor(props: VirtualListProps) {
+export class VirtualList<R extends TResource> extends React.Component<VirtualListProps<R>, VirtualListState> {
+  constructor(props: VirtualListProps<R>) {
     super(props);
     const match = history.location.pathname.match(listRegex) || [];
     const type = match[1] || '';
-    const conf = config[type];
+    const conf = config[type] as Resource;
     const columns =
       conf.columns && config.headerTable
         ? conf.columns.map(info =>
@@ -81,7 +81,7 @@ export class VirtualList extends React.Component<VirtualListProps, VirtualListSt
     const { sortBy, columns, conf } = this.state;
     const tableProps = {
       cells: columns,
-      rows: rows,
+      rows: [],
       gridBreakPoint: TableGridBreakpoint.none,
       role: 'presentation',
       caption: conf.caption ? conf.caption : undefined


### PR DESCRIPTION
- Formalized type Renderer
- Strong link between ResourceType and Renderer
- Type guard on TResource w/ health ("hasHealth"), health not "any" anymore
- Generic on ResourceType, Renderer, VirtualList to avoid use of "any"

JIRA: https://issues.jboss.org/browse/KIALI-3213