### PR TITLE
KIALI-3204 Fix blank screen issue (message center persistence problem)

### DIFF
--- a/src/store/ConfigStore.ts
+++ b/src/store/ConfigStore.ts
@@ -50,7 +50,7 @@ const userSettingsPersitFilter = whitelistInputWithInitialState(
 const persistConfig = {
   key: persistKey,
   storage: storage,
-  whitelist: ['namespaces', 'jaegerState', 'statusState', 'graph', 'userSettings', 'messageCenter'],
+  whitelist: ['namespaces', 'jaegerState', 'statusState', 'graph', 'userSettings'],
   transforms: [namespacePersistFilter, graphPersistFilter, userSettingsPersitFilter]
 };
 


### PR DESCRIPTION
https://issues.jboss.org/browse/KIALI-3204

Recently, the Message Center was included in the list of things to persist from the Redux store.

The problem is that the messageCenter part of the redux store is including fields/attributes with Date typings, which is a complex data type with attributes, methods, etc.

Apparently, redux-persis package is using string representation to persist data (at least, this is what the browser console shows). Thus, Date typed fields are being loaded as strings rather than the expected Date objects and Kiali crashes with a "toLocaleDateString is not a function" error.

This commit is excluding the message center from persistence to quickly fix the blank page issue and release patch version v1.3.1. A more elaborated solution should be implemented to properly handle persistence of the message center.