### PR TITLE
KIALI-3224 Make graph legend ability to scroll more obvious.

### DIFF
--- a/src/components/GraphFilter/GraphLegend.tsx
+++ b/src/components/GraphFilter/GraphLegend.tsx
@@ -41,7 +41,8 @@ export default class GraphLegend extends React.Component<GraphLegendProps, Graph
     const bodyStyle = style({
       width: this.state.width,
       height: this.state.height,
-      overflowY: 'auto'
+      overflowY: 'scroll',
+      overflowX: 'hidden'
     });
 
     const legendListStyle = style({
@@ -74,20 +75,25 @@ export default class GraphLegend extends React.Component<GraphLegendProps, Graph
     });
 
     return (
-      <div>
+      <>
         {legendData.map((legendItem: GraphLegendItem) => (
           <div key={legendItem.title} className={legendColumnHeadingStyle}>
             {legendItem.title}
-            {this.renderLegendRowItems(legendItem.data)}
+            {GraphLegend.renderLegendRowItems(legendItem.data)}
           </div>
         ))}
-      </div>
+      </>
     );
   }
 
-  renderLegendRowItems(legendData: GraphLegendItemRow[]) {
+  static renderLegendRowItems(legendData: GraphLegendItemRow[]) {
+    const legendRowStyle = style({
+      overflowY: 'scroll'
+    });
     return (
-      <>{legendData.map((legendItemRow: GraphLegendItemRow) => GraphLegend.renderLegendIconAndLabel(legendItemRow))}</>
+      <div className={legendRowStyle}>
+        {legendData.map((legendItemRow: GraphLegendItemRow) => GraphLegend.renderLegendIconAndLabel(legendItemRow))}
+      </div>
     );
   }
 
@@ -109,9 +115,7 @@ export default class GraphLegend extends React.Component<GraphLegendProps, Graph
 
     return (
       <div key={legendItemRow.icon} className={legendItemContainerStyle}>
-        <span>
-          <img alt={legendItemRow.label} src={legendItemRow.icon} />
-        </span>
+        <img alt={legendItemRow.label} src={legendItemRow.icon} />
         <span className={legendItemLabelStyle}>{legendItemRow.label}</span>
       </div>
     );

--- a/src/components/GraphFilter/__tests__/__snapshots__/GraphLegend.test.tsx.snap
+++ b/src/components/GraphFilter/__tests__/__snapshots__/GraphLegend.test.tsx.snap
@@ -56,27 +56,27 @@ exports[`GraphLegend test should render correctly 1`] = `
       </span>
     </div>
     <div
-      className="modal-body fcv2ebm"
+      className="modal-body f1tcmhuq"
     >
       <div
         className="fkhz08q"
       >
-        <div>
+        <div
+          className="f16bk411"
+          key="Node Shapes"
+        >
+          Node Shapes
           <div
-            className="f16bk411"
-            key="Node Shapes"
+            className="f1g1h5kq"
           >
-            Node Shapes
             <div
               className="fdu14ne"
               key="node.svg"
             >
-              <span>
-                <img
-                  alt="Workload"
-                  src="node.svg"
-                />
-              </span>
+              <img
+                alt="Workload"
+                src="node.svg"
+              />
               <span
                 className="f10gr8bt"
               >
@@ -87,12 +87,10 @@ exports[`GraphLegend test should render correctly 1`] = `
               className="fdu14ne"
               key="app.svg"
             >
-              <span>
-                <img
-                  alt="App"
-                  src="app.svg"
-                />
-              </span>
+              <img
+                alt="App"
+                src="app.svg"
+              />
               <span
                 className="f10gr8bt"
               >
@@ -103,12 +101,10 @@ exports[`GraphLegend test should render correctly 1`] = `
               className="fdu14ne"
               key="unknown.svg"
             >
-              <span>
-                <img
-                  alt="Unknown Source"
-                  src="unknown.svg"
-                />
-              </span>
+              <img
+                alt="Unknown Source"
+                src="unknown.svg"
+              />
               <span
                 className="f10gr8bt"
               >
@@ -119,12 +115,10 @@ exports[`GraphLegend test should render correctly 1`] = `
               className="fdu14ne"
               key="service.svg"
             >
-              <span>
-                <img
-                  alt="Service"
-                  src="service.svg"
-                />
-              </span>
+              <img
+                alt="Service"
+                src="service.svg"
+              />
               <span
                 className="f10gr8bt"
               >
@@ -135,12 +129,10 @@ exports[`GraphLegend test should render correctly 1`] = `
               className="fdu14ne"
               key="service-entry.svg"
             >
-              <span>
-                <img
-                  alt="Service Entry"
-                  src="service-entry.svg"
-                />
-              </span>
+              <img
+                alt="Service Entry"
+                src="service-entry.svg"
+              />
               <span
                 className="f10gr8bt"
               >
@@ -148,21 +140,23 @@ exports[`GraphLegend test should render correctly 1`] = `
               </span>
             </div>
           </div>
+        </div>
+        <div
+          className="f16bk411"
+          key="Node Colors"
+        >
+          Node Colors
           <div
-            className="f16bk411"
-            key="Node Colors"
+            className="f1g1h5kq"
           >
-            Node Colors
             <div
               className="fdu14ne"
               key="node-color-normal.svg"
             >
-              <span>
-                <img
-                  alt="Normal"
-                  src="node-color-normal.svg"
-                />
-              </span>
+              <img
+                alt="Normal"
+                src="node-color-normal.svg"
+              />
               <span
                 className="f10gr8bt"
               >
@@ -173,12 +167,10 @@ exports[`GraphLegend test should render correctly 1`] = `
               className="fdu14ne"
               key="node-color-warning.svg"
             >
-              <span>
-                <img
-                  alt="Warning"
-                  src="node-color-warning.svg"
-                />
-              </span>
+              <img
+                alt="Warning"
+                src="node-color-warning.svg"
+              />
               <span
                 className="f10gr8bt"
               >
@@ -189,12 +181,10 @@ exports[`GraphLegend test should render correctly 1`] = `
               className="fdu14ne"
               key="node-color-error.svg"
             >
-              <span>
-                <img
-                  alt="Error"
-                  src="node-color-error.svg"
-                />
-              </span>
+              <img
+                alt="Error"
+                src="node-color-error.svg"
+              />
               <span
                 className="f10gr8bt"
               >
@@ -205,12 +195,10 @@ exports[`GraphLegend test should render correctly 1`] = `
               className="fdu14ne"
               key="node-color-unused.svg"
             >
-              <span>
-                <img
-                  alt="Unused"
-                  src="node-color-unused.svg"
-                />
-              </span>
+              <img
+                alt="Unused"
+                src="node-color-unused.svg"
+              />
               <span
                 className="f10gr8bt"
               >
@@ -218,21 +206,23 @@ exports[`GraphLegend test should render correctly 1`] = `
               </span>
             </div>
           </div>
+        </div>
+        <div
+          className="f16bk411"
+          key="Node Background"
+        >
+          Node Background
           <div
-            className="f16bk411"
-            key="Node Background"
+            className="f1g1h5kq"
           >
-            Node Background
             <div
               className="fdu14ne"
               key="external-namespace.svg"
             >
-              <span>
-                <img
-                  alt="External Namespace"
-                  src="external-namespace.svg"
-                />
-              </span>
+              <img
+                alt="External Namespace"
+                src="external-namespace.svg"
+              />
               <span
                 className="f10gr8bt"
               >
@@ -243,12 +233,10 @@ exports[`GraphLegend test should render correctly 1`] = `
               className="fdu14ne"
               key="restricted-namespace.svg"
             >
-              <span>
-                <img
-                  alt="Restricted Namespace"
-                  src="restricted-namespace.svg"
-                />
-              </span>
+              <img
+                alt="Restricted Namespace"
+                src="restricted-namespace.svg"
+              />
               <span
                 className="f10gr8bt"
               >
@@ -256,21 +244,23 @@ exports[`GraphLegend test should render correctly 1`] = `
               </span>
             </div>
           </div>
+        </div>
+        <div
+          className="f16bk411"
+          key="Edges"
+        >
+          Edges
           <div
-            className="f16bk411"
-            key="Edges"
+            className="f1g1h5kq"
           >
-            Edges
             <div
               className="fdu14ne"
               key="edge-error.svg"
             >
-              <span>
-                <img
-                  alt="20% Error"
-                  src="edge-error.svg"
-                />
-              </span>
+              <img
+                alt="20% Error"
+                src="edge-error.svg"
+              />
               <span
                 className="f10gr8bt"
               >
@@ -281,12 +271,10 @@ exports[`GraphLegend test should render correctly 1`] = `
               className="fdu14ne"
               key="edge-warn.svg"
             >
-              <span>
-                <img
-                  alt="0.1 - 20% Error"
-                  src="edge-warn.svg"
-                />
-              </span>
+              <img
+                alt="0.1 - 20% Error"
+                src="edge-warn.svg"
+              />
               <span
                 className="f10gr8bt"
               >
@@ -297,12 +285,10 @@ exports[`GraphLegend test should render correctly 1`] = `
               className="fdu14ne"
               key="edge-normal.svg"
             >
-              <span>
-                <img
-                  alt="0.1 Error"
-                  src="edge-normal.svg"
-                />
-              </span>
+              <img
+                alt="0.1 Error"
+                src="edge-normal.svg"
+              />
               <span
                 className="f10gr8bt"
               >
@@ -313,12 +299,10 @@ exports[`GraphLegend test should render correctly 1`] = `
               className="fdu14ne"
               key="edge-tcp.svg"
             >
-              <span>
-                <img
-                  alt="TCP Connection"
-                  src="edge-tcp.svg"
-                />
-              </span>
+              <img
+                alt="TCP Connection"
+                src="edge-tcp.svg"
+              />
               <span
                 className="f10gr8bt"
               >
@@ -329,12 +313,10 @@ exports[`GraphLegend test should render correctly 1`] = `
               className="fdu14ne"
               key="edge-idle.svg"
             >
-              <span>
-                <img
-                  alt="Idle"
-                  src="edge-idle.svg"
-                />
-              </span>
+              <img
+                alt="Idle"
+                src="edge-idle.svg"
+              />
               <span
                 className="f10gr8bt"
               >
@@ -345,12 +327,10 @@ exports[`GraphLegend test should render correctly 1`] = `
               className="fdu14ne"
               key="mtls-badge.svg"
             >
-              <span>
-                <img
-                  alt="mTLS (badge)"
-                  src="mtls-badge.svg"
-                />
-              </span>
+              <img
+                alt="mTLS (badge)"
+                src="mtls-badge.svg"
+              />
               <span
                 className="f10gr8bt"
               >
@@ -358,21 +338,23 @@ exports[`GraphLegend test should render correctly 1`] = `
               </span>
             </div>
           </div>
+        </div>
+        <div
+          className="f16bk411"
+          key="Traffic Animation"
+        >
+          Traffic Animation
           <div
-            className="f16bk411"
-            key="Traffic Animation"
+            className="f1g1h5kq"
           >
-            Traffic Animation
             <div
               className="fdu14ne"
               key="traffic-normal-request.svg"
             >
-              <span>
-                <img
-                  alt="Normal Request"
-                  src="traffic-normal-request.svg"
-                />
-              </span>
+              <img
+                alt="Normal Request"
+                src="traffic-normal-request.svg"
+              />
               <span
                 className="f10gr8bt"
               >
@@ -383,12 +365,10 @@ exports[`GraphLegend test should render correctly 1`] = `
               className="fdu14ne"
               key="traffic-failed-request.svg"
             >
-              <span>
-                <img
-                  alt="Failed Request"
-                  src="traffic-failed-request.svg"
-                />
-              </span>
+              <img
+                alt="Failed Request"
+                src="traffic-failed-request.svg"
+              />
               <span
                 className="f10gr8bt"
               >
@@ -399,12 +379,10 @@ exports[`GraphLegend test should render correctly 1`] = `
               className="fdu14ne"
               key="traffic-tcp.svg"
             >
-              <span>
-                <img
-                  alt="TCP Traffic"
-                  src="traffic-tcp.svg"
-                />
-              </span>
+              <img
+                alt="TCP Traffic"
+                src="traffic-tcp.svg"
+              />
               <span
                 className="f10gr8bt"
               >
@@ -412,21 +390,23 @@ exports[`GraphLegend test should render correctly 1`] = `
               </span>
             </div>
           </div>
+        </div>
+        <div
+          className="f16bk411"
+          key="Node Badges"
+        >
+          Node Badges
           <div
-            className="f16bk411"
-            key="Node Badges"
+            className="f1g1h5kq"
           >
-            Node Badges
             <div
               className="fdu14ne"
               key="node-badge-circuit-breaker.svg"
             >
-              <span>
-                <img
-                  alt="Circuit Breaker"
-                  src="node-badge-circuit-breaker.svg"
-                />
-              </span>
+              <img
+                alt="Circuit Breaker"
+                src="node-badge-circuit-breaker.svg"
+              />
               <span
                 className="f10gr8bt"
               >
@@ -437,12 +417,10 @@ exports[`GraphLegend test should render correctly 1`] = `
               className="fdu14ne"
               key="node-badge-missing-sidecar.svg"
             >
-              <span>
-                <img
-                  alt="Missing Sidecar"
-                  src="node-badge-missing-sidecar.svg"
-                />
-              </span>
+              <img
+                alt="Missing Sidecar"
+                src="node-badge-missing-sidecar.svg"
+              />
               <span
                 className="f10gr8bt"
               >
@@ -453,12 +431,10 @@ exports[`GraphLegend test should render correctly 1`] = `
               className="fdu14ne"
               key="node-badge-virtual-services.svg"
             >
-              <span>
-                <img
-                  alt="Virtual Services"
-                  src="node-badge-virtual-services.svg"
-                />
-              </span>
+              <img
+                alt="Virtual Services"
+                src="node-badge-virtual-services.svg"
+              />
               <span
                 className="f10gr8bt"
               >


### PR DESCRIPTION
** Describe the change **
The current graph legend is not obvious that it is scrollable. That is, until you hover over the legend and start scrolling, only then does a scrollbar appear. This PR makes the scroll present at all times.


** Issue reference **

https://issues.jboss.org/browse/KIALI-3224

** Backwards compatible? **
Yes
[ ] Is your pull-request introducing changes in behaviour?
No

** Screenshot **

Before: 
![legend-scroll](https://user-images.githubusercontent.com/1312165/63123689-6a22b000-bf5e-11e9-861c-0d0b71117f9f.gif)

