### PR TITLE
KIALI-3261 Fix warnings in details view app and workloads

### DIFF
--- a/src/pages/AppDetails/AppDetailsPage.tsx
+++ b/src/pages/AppDetails/AppDetailsPage.tsx
@@ -183,7 +183,7 @@ class AppDetails extends React.Component<AppDetailsProps, AppDetailsState> {
 
   staticTabs() {
     const overTab = (
-      <Tab title="Overview" eventKey={0}>
+      <Tab title="Overview" eventKey={0} key={'Overview'}>
         {this.state.currentTab === 'info' ? (
           <AppInfo
             app={this.state.app}
@@ -198,7 +198,7 @@ class AppDetails extends React.Component<AppDetailsProps, AppDetailsState> {
     );
 
     const trafficTab = (
-      <Tab title="Traffic" eventKey={1}>
+      <Tab title="Traffic" eventKey={1} key={'Traffic'}>
         {this.state.currentTab === 'traffic' ? (
           <TrafficDetails
             trafficData={this.state.trafficData}
@@ -215,7 +215,7 @@ class AppDetails extends React.Component<AppDetailsProps, AppDetailsState> {
     );
 
     const inTab = (
-      <Tab title="Inbound metrics" eventKey={2}>
+      <Tab title="Inbound Metrics" eventKey={2} key={'Inbound Metrics'}>
         {this.state.currentTab === 'in_metrics' ? (
           <IstioMetricsContainer
             namespace={this.props.match.params.namespace}
@@ -230,7 +230,7 @@ class AppDetails extends React.Component<AppDetailsProps, AppDetailsState> {
     );
 
     const outTab = (
-      <Tab title="Outbound metrics" eventKey={3}>
+      <Tab title="Outbound Metrics" eventKey={3} key={'Outbound Metrics'}>
         {this.state.currentTab === 'out_metrics' ? (
           <IstioMetricsContainer
             namespace={this.props.match.params.namespace}

--- a/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -218,7 +218,7 @@ class WorkloadDetails extends React.Component<WorkloadDetailsPageProps, Workload
     const hasPods = this.state.workload.pods && this.state.workload.pods.length > 0;
 
     const overTab = (
-      <Tab title="Overview" eventKey={0}>
+      <Tab title="Overview" eventKey={0} key={'Overview'}>
         {this.state.currentTab === 'info' ? (
           <WorkloadInfo
             workload={this.state.workload}
@@ -235,7 +235,7 @@ class WorkloadDetails extends React.Component<WorkloadDetailsPageProps, Workload
     );
 
     const trafficTab = (
-      <Tab title="Traffic" eventKey={1}>
+      <Tab title="Traffic" eventKey={1} key={'Traffic'}>
         {this.state.currentTab === 'traffic' ? (
           <TrafficDetails
             trafficData={this.state.trafficData}
@@ -252,7 +252,7 @@ class WorkloadDetails extends React.Component<WorkloadDetailsPageProps, Workload
     );
 
     const logTab = (
-      <Tab title="Logs" eventKey={2}>
+      <Tab title="Logs" eventKey={2} key={'Logs'}>
         {this.state.currentTab === 'logs' && hasPods ? (
           <WorkloadPodLogs namespace={this.props.match.params.namespace} pods={this.state.workload.pods} />
         ) : (
@@ -263,7 +263,7 @@ class WorkloadDetails extends React.Component<WorkloadDetailsPageProps, Workload
     );
 
     const inTab = (
-      <Tab title="Inbound Metrics" eventKey={3}>
+      <Tab title="Inbound Metrics" eventKey={3} key={'Inbound Metrics'}>
         {this.state.currentTab === 'in_metrics' ? (
           <IstioMetricsContainer
             namespace={this.props.match.params.namespace}
@@ -278,7 +278,7 @@ class WorkloadDetails extends React.Component<WorkloadDetailsPageProps, Workload
     );
 
     const outTab = (
-      <Tab title="Outbound Metrics" eventKey={4}>
+      <Tab title="Outbound Metrics" eventKey={4} key={'Outbound Metrics'}>
         {this.state.currentTab === 'out_metrics' ? (
           <IstioMetricsContainer
             namespace={this.props.match.params.namespace}


### PR DESCRIPTION
https://issues.jboss.org/browse/KIALI-3261

Added keys to tabs to remvoe console warning

```bash
ndex.js:1437 Warning: Each child in an array or iterator should have a unique "key" prop.

Check the render method of `WorkloadDetails`. See https://fb.me/react-warning-keys for more information.
in ForwardRef (at WorkloadDetailsPage.tsx:221)
in WorkloadDetails (created by Connect(WorkloadDetails))
in Connect(WorkloadDetails) (created by Context.Consumer)
in Route (at RenderPage.tsx:13)
in Switch (at SwitchErrorBoundary.tsx:42)
in SwitchErrorBoundary (at RenderPage.tsx:28)
in div (at RenderPage.tsx:27)
in div (at RenderPage.tsx:39)
in RenderPage (at Navigation.tsx:116)
in section (created by PageSection)
in PageSection (at Navigation.tsx:115)
in main (created by Page)
in div (created by Page)
```