### PR TITLE
Add incoming traffic summary to graph side panel

### DIFF
--- a/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
+++ b/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
@@ -6,6 +6,7 @@ import { style } from 'typestyle';
 import { KialiAppState } from '../../../store/Store';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
+import { NodeType } from 'types/Graph';
 
 type ReduxProps = {
   jaegerIntegration: boolean;
@@ -111,7 +112,7 @@ export class NodeContextMenu extends React.PureComponent<Props> {
 
   render() {
     // Disable context menu if we are dealing with a unknown or an inaccessible node
-    if (this.props.nodeType === 'unknown' || this.props.isInaccessible) {
+    if (this.props.nodeType === NodeType.UNKNOWN || this.props.isInaccessible) {
       this.props.contextMenu.disable();
       return null;
     }

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -35,7 +35,8 @@ import {
   DecoratedGraphElements,
   GraphType,
   NodeParamsType,
-  NodeType
+  NodeType,
+  UNKNOWN
 } from '../../types/Graph';
 import { EdgeLabelMode, Layout } from '../../types/GraphFilter';
 import * as H from '../../types/Health';
@@ -185,7 +186,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
       switch (node.nodeType) {
         case NodeType.APP:
           selector = selector + "[app = '" + node.app + "']";
-          if (node.version && node.version !== 'unknown') {
+          if (node.version && node.version !== UNKNOWN) {
             selector = selector + "[version = '" + node.version + "']";
           }
           break;
@@ -685,11 +686,11 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
         return;
       }
       const namespace = ele.data(CyNode.namespace);
-      const namespaceOk = namespace && namespace !== '' && namespace !== 'unknown';
+      const namespaceOk = namespace && namespace !== '' && namespace !== UNKNOWN;
       // incomplete telemetry can result in an unknown namespace, if so set nodeType UNKNOWN
       const nodeType = namespaceOk ? ele.data(CyNode.nodeType) : NodeType.UNKNOWN;
       const workload = ele.data(CyNode.workload);
-      const workloadOk = workload && workload !== '' && workload !== 'unknown';
+      const workloadOk = workload && workload !== '' && workload !== UNKNOWN;
       // use workload health when workload is set and valid (workload nodes or versionApp nodes)
       const useWorkloadHealth = nodeType === NodeType.WORKLOAD || (nodeType === NodeType.APP && workloadOk);
 

--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -1,7 +1,13 @@
 import { PfColors } from '../../../components/Pf/PfColors';
 import { EdgeLabelMode } from '../../../types/GraphFilter';
 import { FAILURE, DEGRADED, REQUESTS_THRESHOLDS } from '../../../types/Health';
-import { GraphType, NodeType, CytoscapeGlobalScratchNamespace, CytoscapeGlobalScratchData } from '../../../types/Graph';
+import {
+  GraphType,
+  NodeType,
+  CytoscapeGlobalScratchNamespace,
+  CytoscapeGlobalScratchData,
+  UNKNOWN
+} from '../../../types/Graph';
 import { icons } from '../../../config';
 import NodeImageTopology from '../../../assets/img/node-background-topology.png';
 import NodeImageKey from '../../../assets/img/node-background-key.png';
@@ -227,7 +233,7 @@ export class GraphStyles {
             case NodeType.APP:
               if (cyGlobal.graphType === GraphType.APP) {
                 content = app;
-              } else if (version && version !== 'unknown') {
+              } else if (version && version !== UNKNOWN) {
                 content = version;
               } else {
                 content = workload ? `${workload}` : `${app}`;
@@ -249,7 +255,7 @@ export class GraphStyles {
           }
           switch (nodeType) {
             case NodeType.APP:
-              if (cyGlobal.graphType === GraphType.APP || isGroup || version === 'unknown') {
+              if (cyGlobal.graphType === GraphType.APP || isGroup || version === UNKNOWN) {
                 contentArray.unshift(app);
               } else {
                 contentArray.unshift(version);
@@ -260,7 +266,7 @@ export class GraphStyles {
               contentArray.unshift(service);
               break;
             case NodeType.UNKNOWN:
-              contentArray.unshift('unknown');
+              contentArray.unshift(UNKNOWN);
               break;
             case NodeType.WORKLOAD:
               contentArray.unshift(workload);

--- a/src/components/GraphFilter/GraphFind.tsx
+++ b/src/components/GraphFilter/GraphFind.tsx
@@ -10,7 +10,7 @@ import { KialiAppAction } from '../../actions/KialiAppAction';
 import GraphHelpFind from '../../pages/Graph/GraphHelpFind';
 import { CyNode, CyEdge } from '../CytoscapeGraph/CytoscapeGraphUtils';
 import * as CytoscapeGraphUtils from '../CytoscapeGraph/CytoscapeGraphUtils';
-import { CyData } from '../../types/Graph';
+import { CyData, NodeType } from '../../types/Graph';
 import { Layout } from 'types/GraphFilter';
 
 type ReduxProps = {
@@ -483,19 +483,19 @@ export class GraphFind extends React.PureComponent<GraphFindProps, GraphFindStat
         let nodeType = val.toLowerCase();
         switch (nodeType) {
           case 'svc':
-            nodeType = 'service';
+            nodeType = NodeType.SERVICE;
             break;
           case 'wl':
-            nodeType = 'workload';
+            nodeType = NodeType.WORKLOAD;
             break;
           default:
             break; // no-op
         }
         switch (nodeType) {
-          case 'app':
-          case 'service':
-          case 'workload':
-          case 'unknown':
+          case NodeType.APP:
+          case NodeType.SERVICE:
+          case NodeType.WORKLOAD:
+          case NodeType.UNKNOWN:
             return { target: 'node', selector: `[${CyNode.nodeType} ${op} "${nodeType}"]` };
           default:
             this.setErrorMsg(`Invalid node type [${nodeType}]. Expected app | service | unknown | workload`);

--- a/src/components/SummaryPanel/RateChart.tsx
+++ b/src/components/SummaryPanel/RateChart.tsx
@@ -136,10 +136,10 @@ export class RateChartHttp extends React.Component<RateChartHttpPropType> {
         data={{
           groups: [['OK', '3xx', '4xx', '5xx']],
           columns: [
-            ['OK', this.props.percent2xx],
-            ['3xx', this.props.percent3xx],
-            ['4xx', this.props.percent4xx],
-            ['5xx', this.props.percent5xx]
+            ['OK', this.props.percent2xx.toFixed(2)],
+            ['3xx', this.props.percent3xx.toFixed(2)],
+            ['4xx', this.props.percent4xx.toFixed(2)],
+            ['5xx', this.props.percent5xx.toFixed(2)]
           ],
           // order: 'asc',
           colors: {

--- a/src/pages/Graph/GraphPage.tsx
+++ b/src/pages/Graph/GraphPage.tsx
@@ -9,7 +9,7 @@ import { style } from 'typestyle';
 import { store } from '../../store/ConfigStore';
 import { DurationInSeconds, PollIntervalInMs, TimeInMilliseconds, TimeInSeconds } from '../../types/Common';
 import Namespace from '../../types/Namespace';
-import { GraphType, NodeParamsType, NodeType, SummaryData } from '../../types/Graph';
+import { GraphType, NodeParamsType, NodeType, SummaryData, UNKNOWN } from '../../types/Graph';
 import { EdgeLabelMode, Layout } from '../../types/GraphFilter';
 import { computePrometheusRateParams } from '../../services/Prometheus';
 import { CancelablePromise, makeCancelablePromise } from '../../utils/CancelablePromises';
@@ -150,13 +150,13 @@ export class GraphPage extends React.Component<GraphPageProps, GraphPageState> {
 
   static getNodeParamsFromProps(props: RouteComponentProps<Partial<GraphURLPathProps>>): NodeParamsType | undefined {
     const app = props.match.params.app;
-    const appOk = app && app !== 'unknown' && app !== 'undefined';
+    const appOk = app && app !== UNKNOWN && app !== 'undefined';
     const namespace = props.match.params.namespace;
-    const namespaceOk = namespace && namespace !== 'unknown' && namespace !== 'undefined';
+    const namespaceOk = namespace && namespace !== UNKNOWN && namespace !== 'undefined';
     const service = props.match.params.service;
-    const serviceOk = service && service !== 'unknown' && service !== 'undefined';
+    const serviceOk = service && service !== UNKNOWN && service !== 'undefined';
     const workload = props.match.params.workload;
-    const workloadOk = workload && workload !== 'unknown' && workload !== 'undefined';
+    const workloadOk = workload && workload !== UNKNOWN && workload !== 'undefined';
     if (!appOk && !namespaceOk && !serviceOk && !workloadOk) {
       return;
     }
@@ -379,7 +379,7 @@ export class GraphPage extends React.Component<GraphPageProps, GraphPageState> {
   private getTitle(node: NodeParamsType) {
     if (node.nodeType === NodeType.APP) {
       let title = node.app;
-      if (node.version && node.version !== 'unknown') {
+      if (node.version && node.version !== UNKNOWN) {
         title += ' - ' + node.version;
       }
 

--- a/src/pages/Graph/SummaryPanelCommon.tsx
+++ b/src/pages/Graph/SummaryPanelCommon.tsx
@@ -19,7 +19,11 @@ export enum NodeMetricType {
   SERVICE = 3
 }
 
-export const panelNavTabs = style({
+export const summaryBodyTabs = style({
+  padding: '0 15px 15px'
+});
+
+export const summaryNavTabs = style({
   fontSize: '13px',
   paddingLeft: '1.5em'
 });

--- a/src/pages/Graph/SummaryPanelCommon.tsx
+++ b/src/pages/Graph/SummaryPanelCommon.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Icon } from 'patternfly-react';
+import { style } from 'typestyle';
 import { NodeType, SummaryPanelPropType, Protocol, DecoratedGraphNodeData } from '../../types/Graph';
 import { Health, healthNotAvailable } from '../../types/Health';
 import { IstioMetricsOptions, Reporter, Direction } from '../../types/MetricsOptions';
@@ -17,6 +18,11 @@ export enum NodeMetricType {
   WORKLOAD = 2,
   SERVICE = 3
 }
+
+export const panelNavTabs = style({
+  fontSize: '13px',
+  paddingLeft: '1.5em'
+});
 
 export const shouldRefreshData = (prevProps: SummaryPanelPropType, nextProps: SummaryPanelPropType) => {
   return (

--- a/src/pages/Graph/SummaryPanelEdge.tsx
+++ b/src/pages/Graph/SummaryPanelEdge.tsx
@@ -20,7 +20,8 @@ import {
   renderNoTraffic,
   NodeMetricType,
   renderLabels,
-  panelNavTabs
+  summaryBodyTabs,
+  summaryNavTabs
 } from './SummaryPanelCommon';
 import { MetricGroup, Metric, Metrics } from '../../types/Metrics';
 import { Response } from '../../services/Api';
@@ -132,13 +133,10 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
         <HeadingBlock prefix="To" node={dest} />
         {isMtls && <MTLSBlock />}
         {(isGrpc || isHttp) && (
-          <div
-            className="panel-body"
-            style={{ padding: '0px', paddingLeft: '15px', paddingRight: '15px', paddingBottom: '15px' }}
-          >
+          <div className={`"panel-body ${summaryBodyTabs}`}>
             <TabContainer id="basic-tabs" defaultActiveKey="traffic">
               <div>
-                <Nav className={`nav nav-tabs nav-tabs-pf ${panelNavTabs}`}>
+                <Nav className={`nav nav-tabs nav-tabs-pf ${summaryNavTabs}`}>
                   <NavItem eventKey="traffic">
                     <div>Traffic</div>
                   </NavItem>

--- a/src/pages/Graph/SummaryPanelEdge.tsx
+++ b/src/pages/Graph/SummaryPanelEdge.tsx
@@ -3,7 +3,14 @@ import { Icon, Nav, NavItem, TabContainer, TabContent, TabPane } from 'patternfl
 import { RateTableGrpc, RateTableHttp } from '../../components/SummaryPanel/RateTable';
 import { RpsChart, TcpChart } from '../../components/SummaryPanel/RpsChart';
 import ResponseTimeChart from '../../components/SummaryPanel/ResponseTimeChart';
-import { GraphType, NodeType, Protocol, SummaryPanelPropType, DecoratedGraphNodeData } from '../../types/Graph';
+import {
+  GraphType,
+  NodeType,
+  Protocol,
+  SummaryPanelPropType,
+  DecoratedGraphNodeData,
+  UNKNOWN
+} from '../../types/Graph';
 import { renderTitle } from './SummaryLink';
 import {
   shouldRefreshData,
@@ -12,7 +19,8 @@ import {
   getNodeMetricType,
   renderNoTraffic,
   NodeMetricType,
-  renderLabels
+  renderLabels,
+  panelNavTabs
 } from './SummaryPanelCommon';
 import { MetricGroup, Metric, Metrics } from '../../types/Metrics';
 import { Response } from '../../services/Api';
@@ -130,7 +138,7 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
           >
             <TabContainer id="basic-tabs" defaultActiveKey="traffic">
               <div>
-                <Nav bsClass="nav nav-tabs nav-tabs-pf" style={{ paddingLeft: '20px' }}>
+                <Nav className={`nav nav-tabs nav-tabs-pf ${panelNavTabs}`}>
                   <NavItem eventKey="traffic">
                     <div>Traffic</div>
                   </NavItem>
@@ -229,7 +237,7 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
     }
     const comparator = (metric: Metric) => {
       if (this.isSpecialServiceDest(destMetricType)) {
-        return metric[sourceLabel] === sourceValue && metric.destination_workload === 'unknown';
+        return metric[sourceLabel] === sourceValue && metric.destination_workload === UNKNOWN;
       }
       return metric[sourceLabel] === sourceValue;
     };

--- a/src/pages/Graph/SummaryPanelGraph.tsx
+++ b/src/pages/Graph/SummaryPanelGraph.tsx
@@ -6,7 +6,13 @@ import { RpsChart, TcpChart } from '../../components/SummaryPanel/RpsChart';
 import { SummaryPanelPropType, NodeType } from '../../types/Graph';
 import { getAccumulatedTrafficRateGrpc, getAccumulatedTrafficRateHttp } from '../../utils/TrafficRate';
 import * as API from '../../services/Api';
-import { shouldRefreshData, getDatapoints, mergeMetricsResponses, panelNavTabs } from './SummaryPanelCommon';
+import {
+  shouldRefreshData,
+  getDatapoints,
+  mergeMetricsResponses,
+  summaryBodyTabs,
+  summaryNavTabs
+} from './SummaryPanelCommon';
 import { Response } from '../../services/Api';
 import { Metrics } from '../../types/Metrics';
 import { IstioMetricsOptions } from '../../types/MetricsOptions';
@@ -105,13 +111,10 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
           {this.props.namespaces.map(namespace => namespace.name).join(', ')}
           {this.renderTopologySummary(numSvc, numWorkloads, numApps, numEdges)}
         </div>
-        <div
-          className="panel-body"
-          style={{ padding: '0px', paddingLeft: '15px', paddingRight: '15px', paddingBottom: '15px' }}
-        >
+        <div className={`"panel-body ${summaryBodyTabs}`}>
           <TabContainer id="basic-tabs" defaultActiveKey="incoming">
             <div>
-              <Nav className={`nav nav-tabs nav-tabs-pf ${panelNavTabs}`}>
+              <Nav className={`nav nav-tabs nav-tabs-pf ${summaryNavTabs}`}>
                 <NavItem eventKey="incoming">
                   <div>Incoming </div>
                 </NavItem>
@@ -125,6 +128,11 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
               <TabContent style={{ paddingTop: '10px' }}>
                 <TabPane eventKey="incoming" mountOnEnter={true} unmountOnExit={true}>
                   <>
+                    {incomingRateGrpc.rate === 0 && incomingRateHttp.rate === 0 && (
+                      <>
+                        <Icon type="pf" name="info" /> No incoming traffic.
+                      </>
+                    )}
                     {incomingRateGrpc.rate > 0 && (
                       <RateTableGrpc
                         title="GRPC Traffic (requests per second):"
@@ -149,6 +157,11 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
                 </TabPane>
                 <TabPane eventKey="outgoing" mountOnEnter={true} unmountOnExit={true}>
                   <>
+                    {outgoingRateGrpc.rate === 0 && outgoingRateHttp.rate === 0 && (
+                      <>
+                        <Icon type="pf" name="info" /> No outgoing traffic.
+                      </>
+                    )}
                     {outgoingRateGrpc.rate > 0 && (
                       <RateTableGrpc
                         title="GRPC Traffic (requests per second):"
@@ -173,6 +186,11 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
                 </TabPane>
                 <TabPane eventKey="total" mountOnEnter={true} unmountOnExit={true}>
                   <>
+                    {totalRateGrpc.rate === 0 && totalRateHttp.rate === 0 && (
+                      <>
+                        <Icon type="pf" name="info" /> No traffic.
+                      </>
+                    )}
                     {totalRateGrpc.rate > 0 && (
                       <RateTableGrpc
                         title="GRPC Traffic (requests per second):"

--- a/src/pages/Graph/SummaryPanelGraph.tsx
+++ b/src/pages/Graph/SummaryPanelGraph.tsx
@@ -1,17 +1,18 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
+import { Icon, Nav, NavItem, TabContainer, TabContent, TabPane } from 'patternfly-react';
 import { RateTableGrpc, RateTableHttp } from '../../components/SummaryPanel/RateTable';
 import { RpsChart, TcpChart } from '../../components/SummaryPanel/RpsChart';
 import { SummaryPanelPropType, NodeType } from '../../types/Graph';
 import { getAccumulatedTrafficRateGrpc, getAccumulatedTrafficRateHttp } from '../../utils/TrafficRate';
 import * as API from '../../services/Api';
-import { Icon } from 'patternfly-react';
 import { shouldRefreshData, getDatapoints, mergeMetricsResponses } from './SummaryPanelCommon';
 import { Response } from '../../services/Api';
 import { Metrics } from '../../types/Metrics';
 import { IstioMetricsOptions } from '../../types/MetricsOptions';
 import { CancelablePromise, makeCancelablePromise } from '../../utils/CancelablePromises';
 import { Paths } from '../../config';
+import { CyNode } from 'components/CytoscapeGraph/CytoscapeGraphUtils';
 
 type SummaryPanelGraphState = {
   loading: boolean;
@@ -85,8 +86,11 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
     const numEdges = cy.edges().size();
     // when getting accumulated traffic rates don't count requests from injected service nodes
     const nonServiceEdges = cy.$(`node[nodeType != "${NodeType.SERVICE}"][!isGroup]`).edgesTo('*');
-    const trafficRateGrpc = getAccumulatedTrafficRateGrpc(nonServiceEdges);
-    const trafficRateHttp = getAccumulatedTrafficRateHttp(nonServiceEdges);
+    const totalRateGrpc = getAccumulatedTrafficRateGrpc(nonServiceEdges);
+    const totalRateHttp = getAccumulatedTrafficRateHttp(nonServiceEdges);
+    const incomingEdges = cy.$(`node[?${CyNode.isRoot}]`).edgesTo('*');
+    const incomingRateGrpc = getAccumulatedTrafficRateGrpc(incomingEdges);
+    const incomingRateHttp = getAccumulatedTrafficRateHttp(incomingEdges);
 
     return (
       <div className="panel panel-default" style={SummaryPanelGraph.panelStyle}>
@@ -95,31 +99,74 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
           {this.props.namespaces.map(namespace => namespace.name).join(', ')}
           {this.renderTopologySummary(numSvc, numWorkloads, numApps, numEdges)}
         </div>
-        <div className="panel-body">
-          <div>
-            {trafficRateGrpc.rate > 0 && (
-              <RateTableGrpc
-                title="GRPC Traffic (requests per second):"
-                rate={trafficRateGrpc.rate}
-                rateErr={trafficRateGrpc.rateErr}
-              />
-            )}
-            {trafficRateHttp.rate > 0 && (
-              <RateTableHttp
-                title="HTTP Traffic (requests per second):"
-                rate={trafficRateHttp.rate}
-                rate3xx={trafficRateHttp.rate3xx}
-                rate4xx={trafficRateHttp.rate4xx}
-                rate5xx={trafficRateHttp.rate5xx}
-              />
-            )}
-            {this.shouldShowRPSChart() && (
-              <div>
-                <hr />
-                {this.renderRpsChart()}
-              </div>
-            )}
-          </div>
+        <div
+          className="panel-body"
+          style={{ padding: '0px', paddingLeft: '15px', paddingRight: '15px', paddingBottom: '15px' }}
+        >
+          <TabContainer id="basic-tabs" defaultActiveKey="incoming">
+            <div>
+              <Nav bsClass="nav nav-tabs nav-tabs-pf" style={{ paddingLeft: '20px' }}>
+                <NavItem eventKey="incoming">
+                  <div>Incoming </div>
+                </NavItem>
+                <NavItem eventKey="total">
+                  <div>Total</div>
+                </NavItem>
+              </Nav>
+              <TabContent style={{ paddingTop: '10px' }}>
+                <TabPane eventKey="incoming" mountOnEnter={true} unmountOnExit={true}>
+                  <>
+                    {incomingRateGrpc.rate > 0 && (
+                      <RateTableGrpc
+                        title="GRPC Traffic (requests per second):"
+                        rate={incomingRateGrpc.rate}
+                        rateErr={incomingRateGrpc.rateErr}
+                      />
+                    )}
+                    {incomingRateHttp.rate > 0 && (
+                      <RateTableHttp
+                        title="HTTP Traffic (requests per second):"
+                        rate={incomingRateHttp.rate}
+                        rate3xx={incomingRateHttp.rate3xx}
+                        rate4xx={incomingRateHttp.rate4xx}
+                        rate5xx={incomingRateHttp.rate5xx}
+                      />
+                    )}
+                    {
+                      // We don't show a sparkline here because we need to aggregate the traffic of an
+                      // ad hoc set of [root] nodes. We don't have backend support for that aggregation.
+                    }
+                  </>
+                </TabPane>
+                <TabPane eventKey="total" mountOnEnter={true} unmountOnExit={true}>
+                  <>
+                    {totalRateGrpc.rate > 0 && (
+                      <RateTableGrpc
+                        title="GRPC Traffic (requests per second):"
+                        rate={totalRateGrpc.rate}
+                        rateErr={totalRateGrpc.rateErr}
+                      />
+                    )}
+                    {totalRateHttp.rate > 0 && (
+                      <RateTableHttp
+                        title="HTTP Traffic (requests per second):"
+                        rate={totalRateHttp.rate}
+                        rate3xx={totalRateHttp.rate3xx}
+                        rate4xx={totalRateHttp.rate4xx}
+                        rate5xx={totalRateHttp.rate5xx}
+                      />
+                    )}
+                    {this.shouldShowRPSChart() && (
+                      <div>
+                        <hr />
+                        {this.renderRpsChart()}
+                      </div>
+                    )}
+                  </>
+                </TabPane>
+              </TabContent>
+            </div>
+          </TabContainer>
         </div>
       </div>
     );

--- a/src/pages/Graph/SummaryPanelNode.tsx
+++ b/src/pages/Graph/SummaryPanelNode.tsx
@@ -9,7 +9,14 @@ import {
 } from '../../utils/TrafficRate';
 import { InOutRateTableGrpc, InOutRateTableHttp } from '../../components/SummaryPanel/InOutRateTable';
 import { RpsChart, TcpChart } from '../../components/SummaryPanel/RpsChart';
-import { GraphType, NodeType, SummaryPanelPropType, Protocol, DecoratedGraphNodeData } from '../../types/Graph';
+import {
+  GraphType,
+  NodeType,
+  SummaryPanelPropType,
+  Protocol,
+  DecoratedGraphNodeData,
+  UNKNOWN
+} from '../../types/Graph';
 import { Metrics, Metric } from '../../types/Metrics';
 import {
   shouldRefreshData,
@@ -228,7 +235,7 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
     };
     if (this.isServiceDestCornerCase(nodeMetricType)) {
       comparator = (metric: Metric, protocol?: Protocol) => {
-        return (protocol ? metric.request_protocol === protocol : true) && metric.destination_workload === 'unknown';
+        return (protocol ? metric.request_protocol === protocol : true) && metric.destination_workload === UNKNOWN;
       };
     } else if (data.isRoot) {
       comparator = (metric: Metric, protocol?: Protocol) => {

--- a/src/types/Graph.ts
+++ b/src/types/Graph.ts
@@ -52,6 +52,8 @@ export enum NodeType {
   WORKLOAD = 'workload'
 }
 
+export const UNKNOWN = 'unknown';
+
 export interface NodeParamsType {
   app: string;
   namespace: Namespace;


### PR DESCRIPTION
- This new default summary provides a quick summary of client requests.
  - add tabbed view to toggle between "Incoming" and "Total" traffic.
- also, fix a long-standing precision rendering issue in the chart

![kiali-gh-1422](https://user-images.githubusercontent.com/2104052/63888934-efba4d00-c9ad-11e9-9266-42eec909e886.gif)

Fixes https://github.com/kiali/kiali/issues/1422