### PR TITLE
KIALI-3256 [PF4] Migrate Refresh Button

### DIFF
--- a/src/components/Refresh/RefreshButton.tsx
+++ b/src/components/Refresh/RefreshButton.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { Button, Icon } from 'patternfly-react';
+import { Button, Tooltip } from '@patternfly/react-core';
+import { SyncAltIcon } from '@patternfly/react-icons';
 import { TimeInMilliseconds } from '../../types/Common';
 import { KialiAppAction } from '../../actions/KialiAppAction';
 import { KialiAppState } from '../../store/Store';
 import { ThunkDispatch } from 'redux-thunk';
 import { GlobalActions } from '../../actions/GlobalActions';
-import { style } from 'typestyle';
 
 type ComponentProps = {
   id?: string;
@@ -20,10 +20,6 @@ type ReduxProps = {
 
 type Props = ComponentProps & ReduxProps;
 
-const refreshButtonStyle = style({
-  marginLeft: '0.5em'
-});
-
 class RefreshButton extends React.Component<Props> {
   getElementId() {
     return this.props.id || 'refresh_button';
@@ -35,14 +31,17 @@ class RefreshButton extends React.Component<Props> {
 
   render() {
     return (
-      <Button
-        id={this.getElementId()}
-        onClick={this.handleRefresh}
-        disabled={this.getDisabled()}
-        className={refreshButtonStyle}
-      >
-        <Icon name="refresh" />
-      </Button>
+      <Tooltip content={<>Refresh</>}>
+        <Button
+          id={this.getElementId()}
+          onClick={this.handleRefresh}
+          isDisabled={this.getDisabled()}
+          aria-label="Action"
+          variant="plain"
+        >
+          <SyncAltIcon />
+        </Button>
+      </Tooltip>
     );
   }
 


### PR DESCRIPTION
Fix https://github.com/kiali/kiali/issues/1598

Require https://github.com/kiali/kiali-ui/pull/1383

## Applications List view
![Screenshot from 2019-08-29 10-41-44](https://user-images.githubusercontent.com/3019213/63925066-b9321000-ca49-11e9-9fb4-306a362543f5.png)

## Graph View
![Screenshot from 2019-08-29 10-37-59](https://user-images.githubusercontent.com/3019213/63925067-b9caa680-ca49-11e9-96bc-8ecdd029f88c.png)
## Icon change
### New Icon
![Screenshot from 2019-08-29 14-48-02](https://user-images.githubusercontent.com/3019213/63941506-1b037180-ca6c-11e9-9e07-205290099393.png)

### Old Icon
![Screenshot from 2019-08-29 10-37-38](https://user-images.githubusercontent.com/3019213/63925069-b9caa680-ca49-11e9-9a41-8c44015fc251.png)
## Overview view
### Overview old
![Screenshot from 2019-08-29 10-37-30](https://user-images.githubusercontent.com/3019213/63925070-b9caa680-ca49-11e9-9fca-05a865935217.png)
### Overview new 
![Screenshot from 2019-08-29 10-37-15](https://user-images.githubusercontent.com/3019213/63925071-b9caa680-ca49-11e9-9029-d72897beb4f5.png)
