### PR TITLE
[PF4] KIALI-1635 Migrate validations to PF4 from Istio Page

### DIFF
--- a/src/components/Details/DetailObject.tsx
+++ b/src/components/Details/DetailObject.tsx
@@ -1,20 +1,14 @@
 import * as React from 'react';
 import Label from '../Label/Label';
-import { Icon } from 'patternfly-react';
 import './DetailObject.css';
+import Validation, { ValidationDescription } from '../Validations/Validation';
 
 interface DetailObjectProps {
   name: string;
   detail: any;
   labels?: string[];
   exclude?: string[];
-  validation?: Validation;
-}
-
-interface Validation {
-  message: string;
-  icon: string;
-  color: string;
+  validation?: ValidationDescription;
 }
 
 class DetailObject extends React.Component<DetailObjectProps> {
@@ -93,11 +87,11 @@ class DetailObject extends React.Component<DetailObjectProps> {
       <div>
         <strong className="text-capitalize">{name}</strong>
         {depth === 0 && !!this.props.validation && this.props.validation.message ? (
-          <div>
-            <p style={{ color: this.props.validation.color }}>
-              <Icon type="pf" name={this.props.validation.icon} /> {this.props.validation.message}
-            </p>
-          </div>
+          <Validation
+            severity={this.props.validation.severity}
+            message={this.props.validation.message}
+            messageColor={true}
+          />
         ) : (
           undefined
         )}

--- a/src/components/Details/__tests__/DetailObject.test.tsx
+++ b/src/components/Details/__tests__/DetailObject.test.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
-import { Icon } from 'patternfly-react';
 import { default as DetailObject } from '../DetailObject';
-import { PfColors } from '../../Pf/PfColors';
-import { DestinationWeight } from '../../../types/IstioObjects';
+import { DestinationWeight, ValidationTypes } from '../../../types/IstioObjects';
 import { shallowToJson } from 'enzyme-to-json';
+import Validation from '../../Validations/Validation';
 
 describe('DetailObject test', () => {
   const detail: DestinationWeight = {
@@ -62,8 +61,7 @@ describe('DetailObject test', () => {
   it('prints an alert message', () => {
     const validation = {
       message: 'Not all checks passed',
-      icon: 'error-circle-o',
-      color: PfColors.Red400
+      severity: ValidationTypes.Error
     };
 
     mockRandom();
@@ -73,17 +71,16 @@ describe('DetailObject test', () => {
     expect(shallowToJson(wrapper)).toBeDefined();
     expect(shallowToJson(wrapper)).toMatchSnapshot();
 
-    const iconWrapper = wrapper.find(Icon);
-    expect(iconWrapper.prop('type')).toEqual('pf');
-    expect(iconWrapper.prop('name')).toEqual(validation.icon);
-    expect(iconWrapper.parent().html()).toContain(validation.message);
+    const iconWrapper = wrapper.find(Validation);
+    expect(iconWrapper.prop('severity')).toEqual(validation.severity);
+    expect(iconWrapper.prop('message')).toEqual(validation.message);
+    expect(iconWrapper.prop('messageColor')).toEqual(true);
   });
 
   it("doesn't print any alert message", () => {
     const validation = {
       message: '',
-      icon: 'error-circle-o',
-      color: PfColors.Red400
+      severity: ValidationTypes.Error
     };
 
     mockRandom();
@@ -93,7 +90,7 @@ describe('DetailObject test', () => {
     expect(shallowToJson(wrapper)).toBeDefined();
     expect(shallowToJson(wrapper)).toMatchSnapshot();
 
-    const iconWrapper = wrapper.find(Icon);
+    const iconWrapper = wrapper.find(Validation);
     expect(iconWrapper.length).toEqual(0);
   });
 });

--- a/src/components/Details/__tests__/__snapshots__/DetailObject.test.tsx.snap
+++ b/src/components/Details/__tests__/__snapshots__/DetailObject.test.tsx.snap
@@ -355,22 +355,11 @@ exports[`DetailObject test prints an alert message 1`] = `
     >
       nodejs
     </strong>
-    <div>
-      <p
-        style={
-          Object {
-            "color": "#470000",
-          }
-        }
-      >
-        <Icon
-          name="error-circle-o"
-          type="pf"
-        />
-         
-        Not all checks passed
-      </p>
-    </div>
+    <Validation
+      message="Not all checks passed"
+      messageColor={true}
+      severity="error"
+    />
     <ul
       className="details"
     >

--- a/src/components/Validations/GlobalValidation.tsx
+++ b/src/components/Validations/GlobalValidation.tsx
@@ -73,7 +73,7 @@ class GlobalValidation extends React.Component<Props> {
   }
 
   render() {
-    return <Validation severity={this.severity()} message={this.message()} colorMessage={true} />;
+    return <Validation severity={this.severity()} message={this.message()} messageColor={true} />;
   }
 }
 

--- a/src/components/Validations/GlobalValidation.tsx
+++ b/src/components/Validations/GlobalValidation.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { ObjectCheck, ObjectValidation, ValidationTypes } from '../../types/IstioObjects';
+import Validation from './Validation';
+
+type Props = {
+  validation?: ObjectValidation;
+};
+
+class GlobalValidation extends React.Component<Props> {
+  isValid(): boolean {
+    return !!this.props.validation && this.props.validation.valid;
+  }
+
+  numberOfChecks(type: string): number {
+    const object = this.props.validation;
+    let count = 0;
+
+    if (object) {
+      count = (object && object.checks ? object.checks : []).filter(i => i.severity === type).length;
+    }
+
+    return count;
+  }
+
+  severity(): ValidationTypes {
+    if (!this.props.validation) {
+      return ValidationTypes.Error;
+    }
+
+    const object = this.props.validation;
+    const warnChecks = this.numberOfChecks(ValidationTypes.Warning);
+    const errChecks = this.numberOfChecks(ValidationTypes.Error);
+
+    let validation: ValidationTypes = ValidationTypes.Correct;
+    if (!object.valid) {
+      if (errChecks > 0) {
+        validation = ValidationTypes.Error;
+      } else if (warnChecks > 0) {
+        validation = ValidationTypes.Warning;
+      }
+    }
+
+    return validation;
+  }
+
+  checkForPath(path: string): ObjectCheck[] {
+    const object = this.props.validation;
+
+    if (!object || !object.checks) {
+      return [];
+    }
+
+    const check = object.checks.filter(item => {
+      return item.path === path;
+    });
+
+    return check;
+  }
+
+  globalChecks(): ObjectCheck[] {
+    return this.checkForPath('');
+  }
+
+  message(): string {
+    const checks = this.globalChecks();
+    let message = checks.map(check => check.message).join(',');
+
+    if (!message.length && !this.isValid()) {
+      message = 'Not all checks passed!';
+    }
+
+    return message;
+  }
+
+  render() {
+    return <Validation severity={this.severity()} message={this.message()} colorMessage={true} />;
+  }
+}
+
+export default GlobalValidation;

--- a/src/components/Validations/TooltipValidation.tsx
+++ b/src/components/Validations/TooltipValidation.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Tooltip, TooltipPosition } from '@patternfly/react-core';
+import { ObjectCheck, ValidationTypes } from '../../types/IstioObjects';
+import Validation from './Validation';
+import { highestSeverity } from '../../types/ServiceInfo';
+
+type Props = {
+  checks?: ObjectCheck[];
+  showValid?: boolean;
+};
+
+class TooltipValidation extends React.Component<Props> {
+  content() {
+    return (this.props.checks || []).map((check, index) => {
+      return <Validation key={'validation-check-' + index} severity={check.severity} message={check.message} />;
+    });
+  }
+
+  render() {
+    const severity = highestSeverity(this.props.checks || []);
+    const isValid = severity === ValidationTypes.Correct;
+    const tooltip = (
+      <Tooltip
+        aria-label={'Validations list'}
+        position={TooltipPosition.left}
+        enableFlip={true}
+        content={this.content()}
+      >
+        <Validation severity={severity} />
+      </Tooltip>
+    );
+
+    if (!isValid || (isValid && this.props.showValid)) {
+      return tooltip;
+    } else {
+      return '';
+    }
+  }
+}
+
+export default TooltipValidation;

--- a/src/components/Validations/TooltipValidation.tsx
+++ b/src/components/Validations/TooltipValidation.tsx
@@ -7,6 +7,7 @@ import { highestSeverity } from '../../types/ServiceInfo';
 type Props = {
   checks?: ObjectCheck[];
   showValid?: boolean;
+  tooltipPosition?: TooltipPosition;
 };
 
 class TooltipValidation extends React.Component<Props> {
@@ -22,7 +23,7 @@ class TooltipValidation extends React.Component<Props> {
     const tooltip = (
       <Tooltip
         aria-label={'Validations list'}
-        position={TooltipPosition.left}
+        position={this.props.tooltipPosition || TooltipPosition.left}
         enableFlip={true}
         content={this.content()}
       >

--- a/src/components/Validations/Validation.scss
+++ b/src/components/Validations/Validation.scss
@@ -1,0 +1,7 @@
+.validation {
+  text-align: left;
+
+  &:last-child p {
+    margin: 0;
+  }
+}

--- a/src/components/Validations/Validation.tsx
+++ b/src/components/Validations/Validation.tsx
@@ -53,8 +53,8 @@ class Validation extends React.Component<Props> {
     const hasMessage = this.props.message;
     if (hasMessage) {
       return (
-        <div>
-          <div style={{ float: 'left', margin: '2px 5px 0 0' }}>
+        <div style={{ textAlign: 'left' }}>
+          <div style={{ float: 'left', margin: '2px 0.6em 0 0' }}>
             <IconComponent style={colorStyle} />
           </div>
           <Text component={TextVariants.p} style={colorMessage ? colorStyle : {}}>

--- a/src/components/Validations/Validation.tsx
+++ b/src/components/Validations/Validation.tsx
@@ -3,11 +3,15 @@ import { ErrorCircleOIcon, OkIcon, WarningTriangleIcon } from '@patternfly/react
 import { PfColors } from '../Pf/PfColors';
 import { IconType } from '@patternfly/react-icons/dist/js/createIcon';
 import { ValidationTypes } from '../../types/IstioObjects';
+import { Text, TextVariants } from '@patternfly/react-core';
 
-type Props = {
+type Props = ValidationDescription & {
+  messageColor?: boolean;
+};
+
+export type ValidationDescription = {
   severity: ValidationTypes;
   message?: string;
-  colorMessage?: boolean;
 };
 
 export type ValidationType = {
@@ -44,18 +48,18 @@ class Validation extends React.Component<Props> {
   render() {
     const validation = this.validation();
     const IconComponent = validation.icon;
-    const colorMessage: boolean = !!this.props.colorMessage;
+    const colorMessage = this.props.messageColor || false;
     const colorStyle = { color: validation.color };
     const hasMessage = this.props.message;
     if (hasMessage) {
       return (
         <div>
-          <div style={{ width: '20px', float: 'left', height: '100%' }}>
+          <div style={{ float: 'left', margin: '2px 5px 0 0' }}>
             <IconComponent style={colorStyle} />
           </div>
-          <div style={{ width: '180px' }}>
-            <p style={colorMessage ? colorStyle : {}}>{this.props.message}</p>
-          </div>
+          <Text component={TextVariants.p} style={colorMessage ? colorStyle : {}}>
+            {this.props.message}
+          </Text>
         </div>
       );
     } else {

--- a/src/components/Validations/Validation.tsx
+++ b/src/components/Validations/Validation.tsx
@@ -4,6 +4,7 @@ import { PfColors } from '../Pf/PfColors';
 import { IconType } from '@patternfly/react-icons/dist/js/createIcon';
 import { ValidationTypes } from '../../types/IstioObjects';
 import { Text, TextVariants } from '@patternfly/react-core';
+import './Validation.css';
 
 type Props = ValidationDescription & {
   messageColor?: boolean;
@@ -53,7 +54,7 @@ class Validation extends React.Component<Props> {
     const hasMessage = this.props.message;
     if (hasMessage) {
       return (
-        <div style={{ textAlign: 'left' }}>
+        <div className="validation">
           <div style={{ float: 'left', margin: '2px 0.6em 0 0' }}>
             <IconComponent style={colorStyle} />
           </div>

--- a/src/components/Validations/Validation.tsx
+++ b/src/components/Validations/Validation.tsx
@@ -1,20 +1,16 @@
 import React from 'react';
-import { ObjectCheck, ObjectValidation } from '../../types/IstioObjects';
 import { ErrorCircleOIcon, OkIcon, WarningTriangleIcon } from '@patternfly/react-icons';
 import { PfColors } from '../Pf/PfColors';
 import { IconType } from '@patternfly/react-icons/dist/js/createIcon';
+import { ValidationTypes } from '../../types/IstioObjects';
 
 type Props = {
-  validation?: ObjectValidation;
+  severity: ValidationTypes;
+  message?: string;
+  colorMessage?: boolean;
 };
 
-enum ValidationTypes {
-  Error = 'error',
-  Warning = 'warning',
-  Correct = 'correct'
-}
-
-type ValidationType = {
+export type ValidationType = {
   color: string;
   icon: IconType;
 };
@@ -34,83 +30,43 @@ const CorrectValidation: ValidationType = {
   icon: OkIcon
 };
 
+const severityToValidation: { [severity: string]: ValidationType } = {
+  error: ErrorValidation,
+  warning: WarningValidation,
+  correct: CorrectValidation
+};
+
 class Validation extends React.Component<Props> {
-  isValid(): boolean {
-    return !!this.props.validation && this.props.validation.valid;
-  }
-
-  numberOfChecks(type: string): number {
-    const object = this.props.validation;
-    let count = 0;
-
-    if (object) {
-      count = (object && object.checks ? object.checks : []).filter(i => i.severity === type).length;
-    }
-
-    return count;
-  }
-
-  validation(): ValidationType {
-    if (!this.props.validation) {
-      return ErrorValidation;
-    }
-
-    const object = this.props.validation;
-    const warnChecks = this.numberOfChecks(ValidationTypes.Warning);
-    const errChecks = this.numberOfChecks(ValidationTypes.Error);
-
-    let validation: ValidationType = CorrectValidation;
-    if (!object.valid) {
-      if (errChecks > 0) {
-        validation = ErrorValidation;
-      } else if (warnChecks > 0) {
-        validation = WarningValidation;
-      }
-    }
-
-    return validation;
-  }
-
-  checkForPath(path: string): ObjectCheck[] {
-    const object = this.props.validation;
-
-    if (!object || !object.checks) {
-      return [];
-    }
-
-    const check = object.checks.filter(item => {
-      return item.path === path;
-    });
-
-    return check;
-  }
-
-  globalChecks(): ObjectCheck[] {
-    return this.checkForPath('');
-  }
-
-  message(): string {
-    const checks = this.globalChecks();
-    let message = checks.map(check => check.message).join(',');
-
-    if (!message.length && !this.isValid()) {
-      message = 'Not all checks passed!';
-    }
-
-    return message;
+  validation() {
+    return severityToValidation[this.props.severity];
   }
 
   render() {
     const validation = this.validation();
-    const ValidationIcon = validation.icon;
-
-    return (
-      <>
-        <p style={{ color: validation.color }}>
-          <ValidationIcon /> {this.message()}
-        </p>
-      </>
-    );
+    const IconComponent = validation.icon;
+    const colorMessage: boolean = !!this.props.colorMessage;
+    const colorStyle = { color: validation.color };
+    const hasMessage = this.props.message;
+    if (hasMessage) {
+      return (
+        <div>
+          <div style={{ width: '20px', float: 'left', height: '100%' }}>
+            <IconComponent style={colorStyle} />
+          </div>
+          <div style={{ width: '180px' }}>
+            <p style={colorMessage ? colorStyle : {}}>{this.props.message}</p>
+          </div>
+        </div>
+      );
+    } else {
+      return (
+        <>
+          <p style={colorMessage ? colorStyle : {}}>
+            <IconComponent style={!colorMessage ? colorStyle : {}} />
+          </p>
+        </>
+      );
+    }
   }
 }
 

--- a/src/components/Validations/Validation.tsx
+++ b/src/components/Validations/Validation.tsx
@@ -64,13 +64,7 @@ class Validation extends React.Component<Props> {
         </div>
       );
     } else {
-      return (
-        <>
-          <p style={colorMessage ? colorStyle : {}}>
-            <IconComponent style={!colorMessage ? colorStyle : {}} />
-          </p>
-        </>
-      );
+      return <IconComponent style={colorStyle} />;
     }
   }
 }

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/DestinationRuleDetail.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/DestinationRuleDetail.tsx
@@ -4,10 +4,12 @@ import LocalTime from '../../../components/Time/LocalTime';
 import DetailObject from '../../../components/Details/DetailObject';
 import Label from '../../../components/Label/Label';
 import { Link } from 'react-router-dom';
-import { Card, CardBody, Grid, GridItem, Text, TextVariants } from '@patternfly/react-core';
+import { Card, CardBody, Grid, GridItem, Text, TextVariants, TooltipPosition } from '@patternfly/react-core';
 import { Table, TableBody, TableHeader, TableVariant } from '@patternfly/react-table';
 import GlobalValidation from '../../../components/Validations/GlobalValidation';
 import { ServiceIcon } from '@patternfly/react-icons';
+import { checkForPath } from '../../../types/ServiceInfo';
+import TooltipValidation from '../../../components/Validations/TooltipValidation';
 
 interface DestinationRuleProps {
   namespace: string;
@@ -25,8 +27,17 @@ class DestinationRuleDetail extends React.Component<DestinationRuleProps> {
     }
   }
 
+  subsetValidation(subsetIndex: number) {
+    const checks = checkForPath(this.props.validation, 'spec/subsets[' + subsetIndex + ']');
+    return <TooltipValidation checks={checks} tooltipPosition={TooltipPosition.right} />;
+  }
+
   columnsSubsets() {
     return [
+      {
+        title: 'Status',
+        props: {}
+      },
       {
         title: 'Name',
         props: {}
@@ -44,9 +55,10 @@ class DestinationRuleDetail extends React.Component<DestinationRuleProps> {
 
   rowsSubset() {
     const subsets = this.props.destinationRule.spec.subsets || [];
-    return subsets.map(subset => ({
+    return subsets.map((subset, index) => ({
       cells: [
-        subset.name,
+        { title: this.subsetValidation(index) },
+        { title: subset.name },
         {
           title: subset.labels
             ? Object.keys(subset.labels).map(key => <Label key={key} name={key} value={subset.labels[key]} />)

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/DestinationRuleDetail.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/DestinationRuleDetail.tsx
@@ -114,7 +114,7 @@ class DestinationRuleDetail extends React.Component<DestinationRuleProps> {
   rawConfig() {
     const destinationRule = this.props.destinationRule;
     const globalStatus = this.globalStatus();
-    const isValid = globalStatus ? true : false;
+    const isValid = !globalStatus;
     return (
       <GridItem span={6}>
         <Card>

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/DestinationRuleDetail.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/DestinationRuleDetail.tsx
@@ -6,7 +6,7 @@ import Label from '../../../components/Label/Label';
 import { Link } from 'react-router-dom';
 import { Card, CardBody, Grid, GridItem, Text, TextVariants } from '@patternfly/react-core';
 import { Table, TableBody, TableHeader, TableVariant } from '@patternfly/react-table';
-import Validation from '../../../components/Validations/Validation';
+import GlobalValidation from '../../../components/Validations/GlobalValidation';
 import { ServiceIcon } from '@patternfly/react-icons';
 
 interface DestinationRuleProps {
@@ -19,7 +19,7 @@ class DestinationRuleDetail extends React.Component<DestinationRuleProps> {
   globalStatus() {
     const validation = this.props.validation;
     if (validation && !validation.valid) {
-      return <Validation validation={validation} />;
+      return <GlobalValidation validation={validation} />;
     } else {
       return undefined;
     }

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceDetail.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceDetail.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { checkForPath, highestSeverity, severityToColor, severityToIconName } from '../../../types/ServiceInfo';
+import { checkForPath, highestSeverity } from '../../../types/ServiceInfo';
 import { Host, ObjectValidation, VirtualService } from '../../../types/IstioObjects';
 import LocalTime from '../../../components/Time/LocalTime';
 import DetailObject from '../../../components/Details/DetailObject';
@@ -34,8 +34,7 @@ class VirtualServiceDetail extends React.Component<VirtualServiceProps> {
 
     return {
       message: checks.map(check => check.message).join(','),
-      icon: severityToIconName(severity),
-      color: severityToColor(severity)
+      severity
     };
   }
 

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceDetail.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceDetail.tsx
@@ -6,7 +6,7 @@ import DetailObject from '../../../components/Details/DetailObject';
 import VirtualServiceRoute from './VirtualServiceRoute';
 import { Link } from 'react-router-dom';
 import { Card, CardBody, Grid, GridItem, Text, TextVariants } from '@patternfly/react-core';
-import Validation from '../../../components/Validations/Validation';
+import GlobalValidation from '../../../components/Validations/GlobalValidation';
 
 interface VirtualServiceProps {
   namespace: string;
@@ -22,7 +22,7 @@ class VirtualServiceDetail extends React.Component<VirtualServiceProps> {
   globalStatus() {
     const validation = this.props.validation;
     if (validation && !validation.valid) {
-      return <Validation validation={validation} />;
+      return <GlobalValidation validation={validation} />;
     } else {
       return undefined;
     }

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceRoute.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceRoute.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { checkForPath, highestSeverity, severityToColor, severityToIconName } from '../../../types/ServiceInfo';
+import { checkForPath, highestSeverity } from '../../../types/ServiceInfo';
 import { DestinationWeight, HTTPRoute, ObjectValidation, TCPRoute, ValidationTypes } from '../../../types/IstioObjects';
 import DetailObject from '../../../components/Details/DetailObject';
 import { Link } from 'react-router-dom';
@@ -211,8 +211,7 @@ class VirtualServiceRoute extends React.Component<VirtualServiceRouteProps> {
 
     return {
       message: checks.map(check => check.message).join(','),
-      icon: severityToIconName(severity),
-      color: severityToColor(severity)
+      severity
     };
   }
 

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceRoute.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceRoute.tsx
@@ -5,7 +5,7 @@ import DetailObject from '../../../components/Details/DetailObject';
 import { Link } from 'react-router-dom';
 import { ServiceIcon } from '@patternfly/react-icons';
 import { Table, TableBody, TableHeader, TableVariant } from '@patternfly/react-table';
-import { Grid, GridItem } from '@patternfly/react-core';
+import { Grid, GridItem, Text, TextVariants } from '@patternfly/react-core';
 import { ChartBullet } from '@patternfly/react-charts/dist/js/components/ChartBullet';
 import TooltipValidation from '../../../components/Validations/TooltipValidation';
 
@@ -219,12 +219,8 @@ class VirtualServiceRoute extends React.Component<VirtualServiceRouteProps> {
     return (this.props.routes || []).map((route, i) => (
       <Grid key={'virtualservice-rule' + i}>
         <GridItem sm={12} md={12} lg={4}>
-          <DetailObject
-            name={this.props.kind + ' Route'}
-            detail={route}
-            exclude={['route']}
-            validation={this.routeStatusMessage(route, i)}
-          />
+          <Text component={TextVariants.h3}>{this.props.kind + ' Route'}</Text>
+          <DetailObject name={''} detail={route} exclude={['route']} validation={this.routeStatusMessage(route, i)} />
         </GridItem>
         <GridItem sm={12} md={12} lg={8}>
           {this.renderTable(route, i)}

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceRoute.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceRoute.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import { checkForPath, highestSeverity, severityToColor, severityToIconName } from '../../../types/ServiceInfo';
-import { DestinationWeight, HTTPRoute, ObjectCheck, ObjectValidation, TCPRoute } from '../../../types/IstioObjects';
-import { Icon } from 'patternfly-react';
+import { DestinationWeight, HTTPRoute, ObjectValidation, TCPRoute, ValidationTypes } from '../../../types/IstioObjects';
 import DetailObject from '../../../components/Details/DetailObject';
 import { Link } from 'react-router-dom';
 import { ServiceIcon } from '@patternfly/react-icons';
 import { Table, TableBody, TableHeader, TableVariant } from '@patternfly/react-table';
-import { Grid, GridItem, Tooltip, TooltipPosition } from '@patternfly/react-core';
+import { Grid, GridItem } from '@patternfly/react-core';
 import { ChartBullet } from '@patternfly/react-charts/dist/js/components/ChartBullet';
+import TooltipValidation from '../../../components/Validations/TooltipValidation';
 
 interface VirtualServiceRouteProps {
   name: string;
@@ -58,22 +58,32 @@ class VirtualServiceRoute extends React.Component<VirtualServiceRouteProps> {
 
     rows = rows.concat(
       (route.route || []).map((routeItem, destinationIndex) => {
-        const statusFrom = this.statusFrom(this.validation(), routeItem, routeIndex, destinationIndex);
-        const isValid = statusFrom === '' ? true : false;
-        let cells = [{ title: statusFrom }];
+        const checks = this.checksFrom(this.validation(), routeItem, routeIndex, destinationIndex);
+        const validation = <TooltipValidation checks={checks} />;
+        const severity = highestSeverity(checks);
+        const isValid = severity === ValidationTypes.Correct;
+        let cells;
 
         if (routeItem.destination) {
           const destination = routeItem.destination;
-          cells = cells.concat([
+          cells = [
+            { title: validation },
             { title: this.serviceLink(this.props.namespace, destination.host, isValid) },
             { title: destination.subset || '-' },
-            { title: destination.port ? destination.port.number || '-' : '-' }
-          ]);
+            { title: destination.port ? destination.port.number || '-' : '-' },
+            { title: routeItem.weight ? routeItem.weight : '-' }
+          ];
         } else {
-          cells = cells.concat([{ title: '-' }, { title: '-' }, { title: '-' }]);
+          cells = [
+            { title: validation },
+            { title: '-' },
+            { title: '-' },
+            { title: '-' },
+            { title: routeItem.weight ? routeItem.weight : '-' }
+          ];
         }
 
-        return cells.concat([{ title: routeItem.weight ? routeItem.weight : '-' }]);
+        return cells;
       })
     );
 
@@ -101,7 +111,7 @@ class VirtualServiceRoute extends React.Component<VirtualServiceRouteProps> {
     return this.props.validation ? this.props.validation : ({} as ObjectValidation);
   }
 
-  statusFrom(validation: ObjectValidation, routeItem: DestinationWeight, routeIndex: number, destinationIndex: number) {
+  checksFrom(validation: ObjectValidation, routeItem: DestinationWeight, routeIndex: number, destinationIndex: number) {
     const checks = checkForPath(
       validation,
       'spec/' +
@@ -113,6 +123,7 @@ class VirtualServiceRoute extends React.Component<VirtualServiceRouteProps> {
         ']/weight/' +
         routeItem.weight
     );
+
     checks.push(
       ...checkForPath(
         validation,
@@ -120,38 +131,20 @@ class VirtualServiceRoute extends React.Component<VirtualServiceRouteProps> {
       )
     );
 
-    const severity = highestSeverity(checks);
-    const iconName = severity ? severityToIconName(severity) : 'ok';
-    if (iconName !== 'ok') {
-      return (
-        <Tooltip
-          aria-label={'Validations for route ' + routeIndex + ' and destination ' + destinationIndex}
-          position={TooltipPosition.left}
-          enableFlip={true}
-          content={this.infotipContent(checks)}
-        >
-          <Icon type="pf" name={iconName} />
-        </Tooltip>
-      );
-    } else {
-      return '';
-    }
-  }
-
-  infotipContent(checks: ObjectCheck[]) {
-    return checks.map((check, index) => {
-      return this.objectCheckToHtml(check, index);
-    });
-  }
-
-  objectCheckToHtml(object: ObjectCheck, i: number) {
-    return (
-      <div key={'validation-check-' + i}>
-        <Icon type="pf" name={severityToIconName(object.severity)} />
-        {'  '}
-        {object.message}
-      </div>
+    checks.push(
+      ...checkForPath(
+        validation,
+        'spec/' +
+          this.props.kind.toLowerCase() +
+          '[' +
+          routeIndex +
+          ']/route[' +
+          destinationIndex +
+          ']/destination/host'
+      )
     );
+
+    return checks;
   }
 
   bulletChartValues(routes: TCPRoute | HTTPRoute) {

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
@@ -110,7 +110,13 @@ exports[`#ServiceInfoDescription render correctly with data should render servic
               ]
             }
           />
-          <strong>
+          <strong
+            style={
+              Object {
+                "margin": "0.1em 0 0 0.5em",
+              }
+            }
+          >
             Ports
           </strong>
         </div>

--- a/src/pages/ServiceDetails/ServiceInfo/types/DestinationRuleValidator.ts
+++ b/src/pages/ServiceDetails/ServiceInfo/types/DestinationRuleValidator.ts
@@ -1,4 +1,4 @@
-import { DestinationRule } from '../../../../types/IstioObjects';
+import { DestinationRule, ValidationTypes } from '../../../../types/IstioObjects';
 import SubsetValidator from './SubsetValidator';
 
 export default class DestinationRuleValidator {
@@ -56,7 +56,7 @@ export default class DestinationRuleValidator {
     if (!this.isValid()) {
       return {
         message: 'This destination rule has format problems in field ' + this.unformattedField,
-        severity: 'error',
+        severity: ValidationTypes.Error,
         path: ''
       };
     }

--- a/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as API from '../../services/Api';
 import { RouteComponentProps } from 'react-router-dom';
 import { emptyWorkload, Workload, WorkloadId } from '../../types/Workload';
-import { ObjectCheck, Validations } from '../../types/IstioObjects';
+import { ObjectCheck, Validations, ValidationTypes } from '../../types/IstioObjects';
 import WorkloadInfo from './WorkloadInfo';
 import * as MessageCenter from '../../utils/MessageCenter';
 import IstioMetricsContainer from '../../components/Metrics/IstioMetrics';
@@ -93,12 +93,20 @@ class WorkloadDetails extends React.Component<WorkloadDetailsPageProps, Workload
 
   // All information for validations is fetched in the workload, no need to add another call
   workloadValidations(workload: Workload): Validations {
-    const noIstiosidecar: ObjectCheck = { message: 'Pod has no Istio sidecar', severity: 'warning', path: '' };
-    const noAppLabel: ObjectCheck = { message: 'Pod has no app label', severity: 'warning', path: '' };
-    const noVersionLabel: ObjectCheck = { message: 'Pod has no version label', severity: 'warning', path: '' };
-    const pendingPod: ObjectCheck = { message: 'Pod is in Pending Phase', severity: 'warning', path: '' };
-    const unknownPod: ObjectCheck = { message: 'Pod is in Unknown Phase', severity: 'warning', path: '' };
-    const failedPod: ObjectCheck = { message: 'Pod is in Failed Phase', severity: 'error', path: '' };
+    const noIstiosidecar: ObjectCheck = {
+      message: 'Pod has no Istio sidecar',
+      severity: ValidationTypes.Warning,
+      path: ''
+    };
+    const noAppLabel: ObjectCheck = { message: 'Pod has no app label', severity: ValidationTypes.Warning, path: '' };
+    const noVersionLabel: ObjectCheck = {
+      message: 'Pod has no version label',
+      severity: ValidationTypes.Warning,
+      path: ''
+    };
+    const pendingPod: ObjectCheck = { message: 'Pod is in Pending Phase', severity: ValidationTypes.Warning, path: '' };
+    const unknownPod: ObjectCheck = { message: 'Pod is in Unknown Phase', severity: ValidationTypes.Warning, path: '' };
+    const failedPod: ObjectCheck = { message: 'Pod is in Failed Phase', severity: ValidationTypes.Error, path: '' };
 
     const validations: Validations = {};
     if (workload.pods.length > 0) {

--- a/src/services/__mockData__/getServiceDetail.ts
+++ b/src/services/__mockData__/getServiceDetail.ts
@@ -1,4 +1,5 @@
 import { ServiceDetailsInfo } from '../../types/ServiceInfo';
+import { ValidationTypes } from '../../types/IstioObjects';
 
 export const SERVICE_DETAILS: ServiceDetailsInfo = {
   service: {
@@ -136,12 +137,12 @@ export const SERVICE_DETAILS: ServiceDetailsInfo = {
         checks: [
           {
             message: 'This subset is not found from the host',
-            severity: 'error',
+            severity: ValidationTypes.Error,
             path: 'spec/subsets[0]/version'
           },
           {
             message: 'This subset is not found from the host',
-            severity: 'error',
+            severity: ValidationTypes.Error,
             path: 'spec/subsets[1]/version'
           }
         ]

--- a/src/types/IstioObjects.ts
+++ b/src/types/IstioObjects.ts
@@ -46,6 +46,12 @@ export interface IstioObject {
 // validations are grouped per 'objectType' first in the first map and 'name' in the inner map
 export type Validations = { [key1: string]: { [key2: string]: ObjectValidation } };
 
+export enum ValidationTypes {
+  Error = 'error',
+  Warning = 'warning',
+  Correct = 'correct'
+}
+
 export interface ObjectValidation {
   name: string;
   objectType: string;
@@ -55,7 +61,7 @@ export interface ObjectValidation {
 
 export interface ObjectCheck {
   message: string;
-  severity: string;
+  severity: ValidationTypes;
   path: string;
 }
 

--- a/src/types/ServiceInfo.ts
+++ b/src/types/ServiceInfo.ts
@@ -7,6 +7,7 @@ import {
   Pod,
   Port,
   Validations,
+  ValidationTypes,
   VirtualServices
 } from './IstioObjects';
 import { TLSStatus } from './TLSStatus';
@@ -112,12 +113,12 @@ export const severityToColor = (severity: string): string => {
   return color;
 };
 
-export const higherSeverity = (a: string, b: string): boolean => {
+export const higherSeverity = (a: ValidationTypes, b: ValidationTypes): boolean => {
   return higherThan.includes(a + '-' + b);
 };
 
-export const highestSeverity = (checks: ObjectCheck[]): string => {
-  let severity = 'correct';
+export const highestSeverity = (checks: ObjectCheck[]): ValidationTypes => {
+  let severity: ValidationTypes = ValidationTypes.Correct;
 
   checks.forEach(check => {
     if (higherSeverity(check.severity, severity)) {

--- a/src/types/ServiceInfo.ts
+++ b/src/types/ServiceInfo.ts
@@ -1,5 +1,4 @@
 import { ServiceHealth } from './Health';
-import { PfColors } from '../components/Pf/PfColors';
 import {
   DestinationRules,
   ObjectCheck,
@@ -88,13 +87,6 @@ const IconSeverityMap = new Map<string, string>([
   ['correct', 'ok']
 ]);
 
-const ColorSeverityMap = new Map<string, string>([
-  ['error', PfColors.Red100],
-  ['warning', PfColors.Orange400],
-  ['improvement', PfColors.Blue400],
-  ['correct', PfColors.Green400]
-]);
-
 export const severityToIconName = (severity: string): string => {
   let iconName = IconSeverityMap.get(severity);
   if (!iconName) {
@@ -102,15 +94,6 @@ export const severityToIconName = (severity: string): string => {
   }
 
   return iconName;
-};
-
-export const severityToColor = (severity: string): string => {
-  let color = ColorSeverityMap.get(severity);
-  if (!color) {
-    color = 'black';
-  }
-
-  return color;
 };
 
 export const higherSeverity = (a: ValidationTypes, b: ValidationTypes): boolean => {


### PR DESCRIPTION
** Describe the change **

Migrating all Validation icons, tooltips and so on.

** Issue reference **

https://github.com/kiali/kiali/issues/1635

** Backwards compatible? **
yes

** Screenshot **

### TooltipValidation component:
Shows the list of all the validations for a group of checkers.
![Screenshot of Kiali Console (25)](https://user-images.githubusercontent.com/613814/65042176-9912b400-d958-11e9-9747-a0b7da8f5c54.jpg)

![Screenshot of Kiali Console (26)](https://user-images.githubusercontent.com/613814/65042179-9adc7780-d958-11e9-85ad-9510efea1088.jpg)

### GlobalValidation:
Only shows the status of the whole object.

![Screenshot of Kiali Console (27)](https://user-images.githubusercontent.com/613814/65042357-f9a1f100-d958-11e9-84a3-b23f5734e067.jpg)

![Screenshot of Kiali Console (28)](https://user-images.githubusercontent.com/613814/65042778-e4799200-d959-11e9-8bd2-7589aa1d1293.jpg)