### PR TITLE
[PF4] MIgrate Actions and ACEeditor buttons from Istio Page

### DIFF
--- a/src/components/IstioActions/IstioActionsButtons.tsx
+++ b/src/components/IstioActions/IstioActionsButtons.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
-import { Button } from 'patternfly-react';
 import { TimeInMilliseconds } from '../../types/Common';
 import { connect } from 'react-redux';
 import { ThunkDispatch } from 'redux-thunk';
 import { KialiAppAction } from '../../actions/KialiAppAction';
 import { KialiAppState } from '../../store/Store';
 import { GlobalActions } from '../../actions/GlobalActions';
+import { Button, ButtonVariant } from '@patternfly/react-core';
 
 type ReduxProps = {
   setLastRefreshAt: (lastRefreshAt: TimeInMilliseconds) => void;
@@ -38,16 +38,20 @@ class IstioActionButtons extends React.Component<Props, State> {
         <span style={{ float: 'left', paddingTop: '10px', paddingBottom: '10px' }}>
           {!this.props.readOnly && (
             <span style={{ paddingRight: '5px' }}>
-              <Button bsStyle="primary" disabled={!this.props.canUpdate} onClick={this.props.onUpdate}>
+              <Button variant={ButtonVariant.primary} isDisabled={!this.props.canUpdate} onClick={this.props.onUpdate}>
                 Save
               </Button>
             </span>
           )}
           <span style={{ paddingRight: '5px' }}>
-            <Button onClick={this.handleRefresh}>Reload</Button>
+            <Button variant={ButtonVariant.secondary} onClick={this.handleRefresh}>
+              Reload
+            </Button>
           </span>
           <span style={{ paddingRight: '5px' }}>
-            <Button onClick={this.props.onCancel}>{this.props.readOnly ? 'Close' : 'Cancel'}</Button>
+            <Button variant={ButtonVariant.secondary} onClick={this.props.onCancel}>
+              {this.props.readOnly ? 'Close' : 'Cancel'}
+            </Button>
           </span>
         </span>
       </>

--- a/src/components/IstioActions/IstioActionsDropdown.tsx
+++ b/src/components/IstioActions/IstioActionsDropdown.tsx
@@ -1,7 +1,14 @@
 import * as React from 'react';
-import { MessageDialog } from 'patternfly-react';
-import { style } from 'typestyle';
-import { Dropdown, DropdownItem, DropdownPosition, DropdownToggle } from '@patternfly/react-core';
+import {
+  Button,
+  Dropdown,
+  DropdownItem,
+  DropdownPosition,
+  DropdownToggle,
+  Modal,
+  Text,
+  TextVariants
+} from '@patternfly/react-core';
 
 type Props = {
   objectKind?: string;
@@ -14,14 +21,6 @@ type State = {
   showConfirmModal: boolean;
   dropdownOpen: boolean;
 };
-
-const msgDialogStyle = style({
-  $nest: {
-    '.modal-content': {
-      fontSize: '14px'
-    }
-  }
-});
 
 class IstioActionDropdown extends React.Component<Props, State> {
   constructor(props: Props) {
@@ -76,21 +75,25 @@ class IstioActionDropdown extends React.Component<Props, State> {
             </DropdownItem>
           ]}
         />
-        <MessageDialog
-          className={msgDialogStyle}
-          show={this.state.showConfirmModal}
-          primaryAction={this.onDelete}
-          secondaryAction={this.hideConfirmModal}
-          onHide={this.hideConfirmModal}
-          primaryActionButtonContent="Delete"
-          secondaryActionButtonContent="Cancel"
-          primaryActionButtonBsStyle="danger"
+        <Modal
           title="Confirm Delete"
-          primaryContent={`Are you sure you want to delete the ${objectName} '${this.props.objectName}'? `}
-          secondaryContent="It cannot be undone. Make sure this is something you really want to do!"
-          accessibleName="deleteConfirmationDialog"
-          accessibleDescription="deleteConfirmationDialogContent"
-        />
+          isSmall={true}
+          isOpen={this.state.showConfirmModal}
+          onClose={this.hideConfirmModal}
+          actions={[
+            <Button key="cancel" variant="secondary" onClick={this.hideConfirmModal}>
+              Cancel
+            </Button>,
+            <Button key="confirm" variant="danger" onClick={this.onDelete}>
+              Delete
+            </Button>
+          ]}
+        >
+          <Text component={TextVariants.p}>
+            Are you sure you want to delete the {objectName} '{this.props.objectName}'? It cannot be undone. Make sure
+            this is something you really want to do!
+          </Text>
+        </Modal>
       </>
     );
   }

--- a/src/components/IstioActions/IstioActionsDropdown.tsx
+++ b/src/components/IstioActions/IstioActionsDropdown.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { DropdownButton, MenuItem, MessageDialog } from 'patternfly-react';
+import { MessageDialog } from 'patternfly-react';
 import { style } from 'typestyle';
+import { Dropdown, DropdownItem, DropdownPosition, DropdownToggle } from '@patternfly/react-core';
 
 type Props = {
   objectKind?: string;
@@ -11,6 +12,7 @@ type Props = {
 
 type State = {
   showConfirmModal: boolean;
+  dropdownOpen: boolean;
 };
 
 const msgDialogStyle = style({
@@ -24,17 +26,31 @@ const msgDialogStyle = style({
 class IstioActionDropdown extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
-    this.state = { showConfirmModal: false };
+    this.state = {
+      showConfirmModal: false,
+      dropdownOpen: false
+    };
   }
 
-  onAction = (key: string) => {
-    if (key === 'delete') {
-      this.setState({ showConfirmModal: true });
-    }
+  onSelect = e => {
+    console.log(e);
+    this.setState({
+      dropdownOpen: !this.state.dropdownOpen
+    });
+  };
+
+  onToggle = (dropdownState: boolean) => {
+    this.setState({
+      dropdownOpen: dropdownState
+    });
   };
 
   hideConfirmModal = () => {
     this.setState({ showConfirmModal: false });
+  };
+
+  onClickDelete = () => {
+    this.setState({ showConfirmModal: true });
   };
 
   onDelete = () => {
@@ -47,11 +63,19 @@ class IstioActionDropdown extends React.Component<Props, State> {
 
     return (
       <>
-        <DropdownButton id="actions" title="Actions" onSelect={this.onAction} pullRight={true}>
-          <MenuItem key="delete" eventKey="delete" disabled={!this.props.canDelete}>
-            Delete
-          </MenuItem>
-        </DropdownButton>
+        <Dropdown
+          id="actions"
+          title="Actions"
+          toggle={<DropdownToggle onToggle={this.onToggle}>Actions</DropdownToggle>}
+          onSelect={this.onSelect}
+          position={DropdownPosition.right}
+          isOpen={this.state.dropdownOpen}
+          dropdownItems={[
+            <DropdownItem key="delete" onClick={this.onClickDelete} isDisabled={!this.props.canDelete}>
+              Delete
+            </DropdownItem>
+          ]}
+        />
         <MessageDialog
           className={msgDialogStyle}
           show={this.state.showConfirmModal}

--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.scss
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.scss
@@ -1,10 +1,10 @@
 .istio-ace-editor {
   /*
-   * 50px is the height of the bottom toolbar (save, reload and cancel buttons)
+   * 70px is the height of the bottom toolbar (save, reload and cancel buttons)
    * 20px is the top margin of the yaml editor.
-   * So, substracting 70px from the tab content height.
+   * So, substracting 90px from the tab content height.
    */
-  --kiali-yaml-editor-height: calc(var(--kiali-details-pages-tab-content-height) - 70px);
+  --kiali-yaml-editor-height: calc(var(--kiali-details-pages-tab-content-height) - 90px);
   position: relative;
   min-height: 200px;
   border: 1px solid #8b8d8f;

--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -367,14 +367,14 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
     const tabs: JSX.Element[] = [];
     if (this.hasOverview()) {
       tabs.push(
-        <Tab title="Overview" eventKey={0}>
+        <Tab key="istio-overview" title="Overview" eventKey={0}>
           {this.state.currentTab === 'overview' ? this.renderOverview() : undefined}
         </Tab>
       );
     }
 
     tabs.push(
-      <Tab title={`YAML ${this.state.isModified ? ' * ' : ''}`} eventKey={1}>
+      <Tab key="istio-yaml" title={`YAML ${this.state.isModified ? ' * ' : ''}`} eventKey={1}>
         {this.state.currentTab === 'yaml' ? this.renderEditor() : undefined}
       </Tab>
     );


### PR DESCRIPTION
** Describe the change **
![Screen recording (4)](https://user-images.githubusercontent.com/613814/64364724-cafc5000-d013-11e9-8c6c-177391a1bd40.gif)

Includes https://github.com/kiali/kiali-ui/pull/1397, otherwise cancel button doesn't work. Merge https://github.com/kiali/kiali-ui/pull/1397 first.

Closes https://github.com/kiali/kiali/issues/1593
