### PR TITLE
Kiali#1631 Polyfills window.customElements

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@patternfly/react-table": "2.16.4",
     "@patternfly/react-tokens": "2.6.21",
     "@patternfly/react-virtualized-extension": "1.1.97",
+    "@webcomponents/custom-elements": "1.2.4",
     "axios": "0.18.1",
     "csstips": "0.3.0",
     "csx": "9.0.0",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,4 @@
+import './polyfills';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import App from './app/App';

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -1,0 +1,3 @@
+// Polyfills window.customElements; currently required for Firefox ESR
+// It can be removed once is supported
+import '@webcomponents/custom-elements';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2042,6 +2042,11 @@
     "@webassemblyjs/wast-parser" "1.8.5"
     "@xtuc/long" "4.2.2"
 
+"@webcomponents/custom-elements@1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@webcomponents/custom-elements/-/custom-elements-1.2.4.tgz#7074543155396114617722724d6f6cb7b3800a14"
+  integrity sha512-WiTlgz6/kuwajYIcgyq64rSlCtb2AvbxwwrExP3wr6rKbJ72I3hi/sb4KdGUumfC+isDn2F0btZGk4MnWpyO1Q==
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"


### PR DESCRIPTION
 - This is currently required for Firefox ESR

Fixes kiali/kiali#1631

** Describe the change **

Adds polyfills for missing function customElements
