### PR TITLE
Replace use of OS label styling in side panel with PF4 badge styling

### DIFF
--- a/src/pages/Graph/SummaryPanelCommon.tsx
+++ b/src/pages/Graph/SummaryPanelCommon.tsx
@@ -9,9 +9,9 @@ import * as M from '../../types/Metrics';
 import graphUtils from '../../utils/Graphing';
 import { Metric } from '../../types/Metrics';
 import { Response } from '../../services/Api';
-import Label from '../../components/Label/Label';
 import { serverConfig } from '../../config/ServerConfig';
 import { decoratedNodeData } from 'components/CytoscapeGraph/CytoscapeGraphUtils';
+import { Badge } from '@patternfly/react-core';
 
 export enum NodeMetricType {
   APP = 1,
@@ -149,15 +149,19 @@ export const getDatapoints = (
   return graphUtils.toC3Columns(series, title);
 };
 
-export const renderLabels = (nodeData: DecoratedGraphNodeData) => {
+export const renderNodeInfo = (nodeData: DecoratedGraphNodeData) => {
   const hasNamespace =
     nodeData.nodeType !== NodeType.UNKNOWN && !(nodeData.nodeType === NodeType.SERVICE && nodeData.isServiceEntry);
   const hasVersion = hasNamespace && nodeData.version;
   return (
     <>
-      <div className="label-collection" style={{ paddingTop: '3px' }}>
-        {hasNamespace && <Label name="namespace" value={nodeData.namespace} />}
-        {hasVersion && <Label name={serverConfig.istioLabels.versionLabelName} value={nodeData.version!} />}
+      <div style={{ paddingBottom: '3px', paddingTop: '3px' }}>
+        {hasNamespace && <Badge>Namespace: {nodeData.namespace}</Badge>}
+        {hasVersion && (
+          <Badge>
+            {serverConfig.istioLabels.versionLabelName}: {nodeData.version!}
+          </Badge>
+        )}
       </div>
     </>
   );

--- a/src/pages/Graph/SummaryPanelEdge.tsx
+++ b/src/pages/Graph/SummaryPanelEdge.tsx
@@ -19,7 +19,7 @@ import {
   getNodeMetricType,
   renderNoTraffic,
   NodeMetricType,
-  renderLabels,
+  renderNodeInfo,
   summaryBodyTabs,
   summaryNavTabs
 } from './SummaryPanelCommon';
@@ -118,7 +118,7 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
         <div className="panel-heading label-collection">
           <strong>{prefix}</strong> {renderTitle(nodeData)}
           <br />
-          {renderLabels(nodeData)}
+          {renderNodeInfo(nodeData)}
         </div>
       );
     };

--- a/src/pages/Graph/SummaryPanelNode.tsx
+++ b/src/pages/Graph/SummaryPanelNode.tsx
@@ -25,7 +25,7 @@ import {
   getDatapoints,
   getNodeMetrics,
   getNodeMetricType,
-  renderLabels,
+  renderNodeInfo,
   renderNoTraffic,
   mergeMetricsResponses
 } from './SummaryPanelCommon';
@@ -310,7 +310,7 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
             )
           )}
           <span> {renderTitle(nodeData)}</span>
-          {renderLabels(nodeData)}
+          {renderNodeInfo(nodeData)}
           {this.renderBadgeSummary(nodeData.hasCB, nodeData.hasVS, nodeData.hasMissingSC, nodeData.isDead)}
         </div>
         <div className="panel-body">


### PR DESCRIPTION
- The node info does not reflect the actual set of OS badges on the k8s object
  and so OS badge styling was confusing.  Simple Badge styling is still
  visually striking while not being misleading.

Fixes https://github.com/kiali/kiali/issues/1392


@serenamarie125 Because we are not actually displaying OS labels I've used a different styling, this is using PF4 Badge, what do you think:

Productpage Service Node:
![image](https://user-images.githubusercontent.com/2104052/64458345-1a4d8980-d0c3-11e9-9a76-b813e025666f.png)

Productpage Versioned App Node:
![image](https://user-images.githubusercontent.com/2104052/64458384-305b4a00-d0c3-11e9-8009-7c43f6e3fc3b.png)

The connecting Edge:
![image](https://user-images.githubusercontent.com/2104052/64458407-41a45680-d0c3-11e9-8cd3-c65ce61765bd.png)
