### PR TITLE
Do not mount metrics pages when they're not visible

### DIFF
--- a/src/pages/AppDetails/AppDetailsPage.tsx
+++ b/src/pages/AppDetails/AppDetailsPage.tsx
@@ -168,11 +168,15 @@ class AppDetails extends React.Component<AppDetailsProps, AppDetailsState> {
 
         const tab = (
           <Tab title={dashboard.title} key={dashboard.template} eventKey={tabKey}>
-            <CustomMetricsContainer
-              namespace={this.props.match.params.namespace}
-              app={this.props.match.params.app}
-              template={dashboard.template}
-            />
+            {this.state.currentTab === dashboard.template ? (
+              <CustomMetricsContainer
+                namespace={this.props.match.params.namespace}
+                app={this.props.match.params.app}
+                template={dashboard.template}
+              />
+            ) : (
+              undefined
+            )}
           </Tab>
         );
         tabs.push(tab);


### PR DESCRIPTION
Code is similar to what is done in WorkloadDetails page

Closes https://github.com/kiali/kiali/issues/1654
