### PR TITLE
Allow customized links to Grafana (front)

### DIFF
--- a/src/components/Metrics/IstioMetrics.tsx
+++ b/src/components/Metrics/IstioMetrics.tsx
@@ -26,7 +26,7 @@ import { MessageType } from '../../types/MessageCenter';
 type MetricsState = {
   dashboard?: DashboardModel;
   labelsSettings: LabelsSettings;
-  grafanaLink?: string;
+  grafanaLinks: [string, string][];
 };
 
 type ObjectId = {
@@ -54,7 +54,7 @@ class IstioMetrics extends React.Component<IstioMetricsProps, MetricsState> {
     const settings = MetricsHelper.readMetricsSettingsFromURL();
     this.options = this.initOptions(settings);
     // Initialize active filters from URL
-    this.state = { labelsSettings: settings.labelsSettings };
+    this.state = { labelsSettings: settings.labelsSettings, grafanaLinks: [] };
   }
 
   initOptions(settings: MetricsSettings): IstioMetricsOptions {
@@ -113,7 +113,7 @@ class IstioMetrics extends React.Component<IstioMetricsProps, MetricsState> {
     }
     IstioMetrics.grafanaInfoPromise
       .then(grafanaInfo => {
-        this.setState({ grafanaLink: this.buildGrafanaLink(grafanaInfo) });
+        this.setState({ grafanaLinks: this.buildGrafanaLinks(grafanaInfo) });
       })
       .catch(err => {
         MessageCenter.addError(
@@ -125,22 +125,37 @@ class IstioMetrics extends React.Component<IstioMetricsProps, MetricsState> {
       });
   }
 
-  buildGrafanaLink(grafanaInfo) {
+  buildGrafanaLinks(grafanaInfo?: GrafanaInfo): [string, string][] {
+    const links: [string, string][] = [];
     if (grafanaInfo) {
-      switch (this.props.objectType) {
-        case MetricsObjectTypes.SERVICE:
-          return `${grafanaInfo.url}${grafanaInfo.serviceDashboardPath}?var-service=${this.props.object}.${
-            this.props.namespace
-          }.svc.cluster.local`;
-        case MetricsObjectTypes.WORKLOAD:
-          return `${grafanaInfo.url}${grafanaInfo.workloadDashboardPath}?var-namespace=${
-            this.props.namespace
-          }&var-workload=${this.props.object}`;
-        default:
-          return undefined;
-      }
+      grafanaInfo.dashboards.forEach(d => {
+        const nsvar = d.variables.namespace ? `&${d.variables.namespace}=${this.props.namespace}` : '';
+        switch (this.props.objectType) {
+          case MetricsObjectTypes.SERVICE:
+            const fullServiceName = `${this.props.object}.${this.props.namespace}.svc.cluster.local`;
+            if (d.variables.service) {
+              const url = `${d.url}?${d.variables.service}=${fullServiceName}${nsvar}`;
+              links.push([d.name, url]);
+            }
+            break;
+          case MetricsObjectTypes.WORKLOAD:
+            if (d.variables.workload) {
+              const url = `${d.url}?${d.variables.workload}=${this.props.object}${nsvar}`;
+              links.push([d.name, url]);
+            }
+            break;
+          case MetricsObjectTypes.APP:
+            if (d.variables.app) {
+              const url = `${d.url}?${d.variables.app}=${this.props.object}${nsvar}`;
+              links.push([d.name, url]);
+            }
+            break;
+          default:
+            break;
+        }
+      });
     }
-    return undefined;
+    return links;
   }
 
   onMetricsSettingsChanged = (settings: MetricsSettings) => {
@@ -203,11 +218,35 @@ class IstioMetrics extends React.Component<IstioMetricsProps, MetricsState> {
           </ToolbarItem>
         </ToolbarGroup>
         <ToolbarGroup>
-          {this.state.grafanaLink && (
+          {this.state.grafanaLinks.length === 1 && (
             <ToolbarItem style={{ borderRight: 'none' }}>
-              <a id={'grafana_link'} href={this.state.grafanaLink} target="_blank" rel="noopener noreferrer">
+              <a
+                id={'grafana_link_0'}
+                title={this.state.grafanaLinks[0][0]}
+                href={this.state.grafanaLinks[0][1]}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
                 View in Grafana <ExternalLinkAltIcon />
               </a>
+            </ToolbarItem>
+          )}
+          {this.state.grafanaLinks.length > 1 && (
+            <ToolbarItem style={{ borderRight: 'none' }}>
+              View in Grafana:&nbsp;
+              {this.state.grafanaLinks
+                .map((link, idx) => (
+                  <a
+                    id={'grafana_link_' + idx}
+                    title={link[0]}
+                    href={link[1]}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {link[0]} <ExternalLinkAltIcon />
+                  </a>
+                ))
+                .reduce((prev, curr) => [prev, ', ', curr] as any)}
             </ToolbarItem>
           )}
         </ToolbarGroup>

--- a/src/types/GrafanaInfo.ts
+++ b/src/types/GrafanaInfo.ts
@@ -1,5 +1,16 @@
 export interface GrafanaInfo {
+  dashboards: GrafanaDashboardInfo[];
+}
+
+interface GrafanaDashboardInfo {
   url: string;
-  serviceDashboardPath: string;
-  workloadDashboardPath: string;
+  name: string;
+  variables: GrafanaVariablesConfig;
+}
+
+interface GrafanaVariablesConfig {
+  app?: string;
+  namespace?: string;
+  service?: string;
+  workload?: string;
 }


### PR DESCRIPTION
- Any number of dashboards can be defined
- Now we can also have links on "app" in addition to "workload" and "service"
- No change to the nominal case: default Istio dashboards for Workload and Service are still accessible same way as before

Backend PR: https://github.com/kiali/kiali/pull/1678

Closes https://github.com/kiali/kiali/issues/1268

Picture when multiple dashboards are defined:

![img](https://i.imgur.com/xxKZoSq.png)