### PR TITLE
Fix zoom buttons on the graph

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -790,6 +790,6 @@ const CytoscapeGraphContainer = connect(
   mapStateToProps,
   mapDispatchToProps,
   null,
-  { forwardRef: true } // Allows to use getWrappedInstance to get the ref
+  { forwardRef: true }
 )(CytoscapeGraph);
 export default CytoscapeGraphContainer;

--- a/src/components/Nav/Masthead/HelpDropdown.tsx
+++ b/src/components/Nav/Masthead/HelpDropdown.tsx
@@ -36,7 +36,7 @@ class HelpDropdownContainer extends React.Component<HelpDropdownProps, HelpDropd
 
   openDebugInformation = () => {
     // Using wrapped component, so we have to get the wrappedInstance
-    this.debugInformation.current!.getWrappedInstance().open();
+    this.debugInformation.current!.open();
   };
 
   onDropdownToggle = isDropdownOpen => {

--- a/src/pages/Graph/GraphPage.tsx
+++ b/src/pages/Graph/GraphPage.tsx
@@ -394,8 +394,7 @@ export class GraphPage extends React.Component<GraphPageProps, GraphPageState> {
   }
 
   private setCytoscapeGraph(cytoscapeGraph: any) {
-    this.cytoscapeGraphRef.current =
-      cytoscapeGraph && cytoscapeGraph.getWrappedInstance ? cytoscapeGraph.getWrappedInstance() : null;
+    this.cytoscapeGraphRef.current = cytoscapeGraph;
   }
 
   private loadGraphDataFromBackend = () => {


### PR DESCRIPTION
In Redux 6.0 `getWrappedInstance()` got removed, so it is always false,
and always sets the ref as null, so broken buttons.

Reference:

https://medium.com/@mehran.khan/using-refs-with-react-redux-6-how-to-use-refs-on-connected-components-4b80d4ea7300

Fixes https://github.com/kiali/kiali/issues/1661