### PR TITLE
Fix compiler issues in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "analyze": "source-map-explorer build/static/js/main.*",
     "prettier": "prettier --write \"{src/**/*.{js,jsx,ts,tsx,json,yml,css,scss},travis.yml,*.json}\"",
     "snyk-protect": "snyk protect",
+    "tsc": "tsc -p .",
     "postinstall": "sed -i -E 's#\\[.*eslint-config-react-app.*\\]#['\\'$PWD/.eslintrc\\'']#g' node_modules/react-scripts/config/webpack*.js"
   },
   "dependencies": {

--- a/src/components/GraphFilter/__tests__/GraphFind.test.tsx
+++ b/src/components/GraphFilter/__tests__/GraphFind.test.tsx
@@ -30,6 +30,8 @@ describe('Parse find value test', () => {
         toggleFindHelp={testHandler}
         toggleGraphSecurity={testHandler}
         toggleUnusedNodes={testHandler}
+        compressOnHide={false}
+        layout={{ name: '' }}
       />
     );
 

--- a/src/components/IstioWizards/__tests__/UtilRegexp.test.ts
+++ b/src/components/IstioWizards/__tests__/UtilRegexp.test.ts
@@ -42,3 +42,7 @@ describe('Should check a complex regexp name', () => {
     expect(result).toBe(-1);
   });
 });
+
+// To avoid TS error: "All files must be modules when the '--isolatedModules' flag is provided"
+const dummy = 0;
+export default dummy;

--- a/src/components/MessageCenter/__tests__/MessageCenter.test.tsx
+++ b/src/components/MessageCenter/__tests__/MessageCenter.test.tsx
@@ -20,7 +20,9 @@ describe('MessageCenter', () => {
           type: MessageType.ERROR,
           count: 0,
           show_notification: true,
-          created: new Date()
+          created: new Date(),
+          detail: '',
+          showDetail: false
         },
         {
           id: 2,
@@ -28,7 +30,9 @@ describe('MessageCenter', () => {
           content: 'hide me',
           type: MessageType.ERROR,
           count: 0,
-          created: new Date()
+          created: new Date(),
+          detail: '',
+          showDetail: false
         }
       ]
     },
@@ -45,7 +49,9 @@ describe('MessageCenter', () => {
           type: MessageType.SUCCESS,
           count: 0,
           show_notification: true,
-          created: new Date()
+          created: new Date(),
+          detail: '',
+          showDetail: false
         }
       ]
     }
@@ -62,6 +68,7 @@ describe('MessageCenter', () => {
         onClearGroup={() => console.log('onClearGroup')}
         onNotificationClick={() => console.log('onNotificationClick')}
         onDismissNotification={() => console.log('onDismissNotification')}
+        onNotificationToggleDetail={() => console.log('onNotificationToggleDetail')}
         groups={groupMessages}
       />
     );

--- a/src/components/Metrics/__tests__/IstioMetrics.test.tsx
+++ b/src/components/Metrics/__tests__/IstioMetrics.test.tsx
@@ -117,11 +117,6 @@ describe('Metrics for a service', () => {
                 object="svc"
                 objectType={MetricsObjectTypes.SERVICE}
                 direction={'inbound'}
-                grafanaInfo={{
-                  url: 'http://172.30.139.113:3000',
-                  serviceDashboardPath: '/dashboard/db/istio-dashboard',
-                  workloadDashboardPath: '/dashboard/db/istio-dashboard'
-                }}
               />
             )}
           />
@@ -152,11 +147,6 @@ describe('Metrics for a service', () => {
                 object="svc"
                 objectType={MetricsObjectTypes.SERVICE}
                 direction={'inbound'}
-                grafanaInfo={{
-                  url: 'http://172.30.139.113:3000',
-                  serviceDashboardPath: '/dashboard/db/istio-dashboard',
-                  workloadDashboardPath: '/dashboard/db/istio-dashboard'
-                }}
               />
             )}
           />
@@ -195,11 +185,6 @@ describe('Metrics for a service', () => {
                 object="svc"
                 objectType={MetricsObjectTypes.SERVICE}
                 direction={'inbound'}
-                grafanaInfo={{
-                  url: 'http://172.30.139.113:3000',
-                  serviceDashboardPath: '/dashboard/db/istio-dashboard',
-                  workloadDashboardPath: '/dashboard/db/istio-dashboard'
-                }}
               />
             )}
           />
@@ -230,11 +215,6 @@ describe('Inbound Metrics for a workload', () => {
               object="svc"
               objectType={MetricsObjectTypes.WORKLOAD}
               direction={'inbound'}
-              grafanaInfo={{
-                url: 'http://172.30.139.113:3000',
-                serviceDashboardPath: '/dashboard/db/istio-dashboard',
-                workloadDashboardPath: '/dashboard/db/istio-dashboard'
-              }}
             />
           )}
         />
@@ -264,11 +244,6 @@ describe('Inbound Metrics for a workload', () => {
                 object="svc"
                 objectType={MetricsObjectTypes.WORKLOAD}
                 direction={'inbound'}
-                grafanaInfo={{
-                  url: 'http://172.30.139.113:3000',
-                  serviceDashboardPath: '/dashboard/db/istio-dashboard',
-                  workloadDashboardPath: '/dashboard/db/istio-dashboard'
-                }}
               />
             )}
           />
@@ -307,11 +282,6 @@ describe('Inbound Metrics for a workload', () => {
                 object="svc"
                 objectType={MetricsObjectTypes.WORKLOAD}
                 direction={'inbound'}
-                grafanaInfo={{
-                  url: 'http://172.30.139.113:3000',
-                  serviceDashboardPath: '/dashboard/db/istio-dashboard',
-                  workloadDashboardPath: '/dashboard/db/istio-dashboard'
-                }}
               />
             )}
           />

--- a/src/components/Metrics/__tests__/TrafficDetails.test.tsx
+++ b/src/components/Metrics/__tests__/TrafficDetails.test.tsx
@@ -37,7 +37,7 @@ describe('TrafficDetails', () => {
               source: tuple[0].id,
               target: tuple[1].id,
               traffic: {
-                protocol: ''
+                protocol: 'http'
               }
             }
           })
@@ -60,7 +60,7 @@ describe('TrafficDetails', () => {
     workload: name,
     traffic: [
       {
-        protocol: ''
+        protocol: 'http'
       }
     ]
   });
@@ -72,7 +72,7 @@ describe('TrafficDetails', () => {
     service: name,
     traffic: [
       {
-        protocol: ''
+        protocol: 'http'
       }
     ]
   });

--- a/src/pages/Overview/__tests__/OverviewPage.test.tsx
+++ b/src/pages/Overview/__tests__/OverviewPage.test.tsx
@@ -64,7 +64,7 @@ describe('Overview page', () => {
   });
 
   it('renders initial layout', () => {
-    const wrapper = shallow(<OverviewPage meshStatus={MTLSStatuses.NOT_ENABLED} />);
+    const wrapper = shallow(<OverviewPage meshStatus={MTLSStatuses.NOT_ENABLED} navCollapse={false} />);
     expect(shallowToJson(wrapper)).toMatchSnapshot();
   });
 


### PR DESCRIPTION
The react-script build that we use won't compile our test files anymore so they can be broken (although they're not failing because runtime JS is still OK)

I'm fixing these errors but we should find a solution to make them being compiled again.

For the time being I'm just adding "tsc" as a script in package.json to run manual compilation.
