### PR TITLE
[PF4] KIALI-1635 Summary Validation popover moved to PF4

### DIFF
--- a/src/components/ConfigValidation/ConfigIndicator.tsx
+++ b/src/components/ConfigValidation/ConfigIndicator.tsx
@@ -1,17 +1,21 @@
 import * as React from 'react';
 import { ObjectValidation } from '../../types/IstioObjects';
 import { PfColors } from '../Pf/PfColors';
-import { OverlayTrigger, Popover } from 'patternfly-react';
 import { IconType } from '@patternfly/react-icons/dist/js/createIcon';
-import { ErrorCircleOIcon, WarningTriangleIcon, CheckCircleIcon } from '@patternfly/react-icons';
+import { CheckCircleIcon, ErrorCircleOIcon, WarningTriangleIcon } from '@patternfly/react-icons';
 import { createIcon } from '../Health/Helper';
 import { style } from 'typestyle';
+import { Popover } from '@patternfly/react-core';
 
 interface Props {
   id: string;
   validations: ObjectValidation[];
   definition?: boolean;
   size?: string;
+}
+
+interface State {
+  show: boolean;
 }
 
 export interface Validation {
@@ -60,7 +64,20 @@ const tooltipListStyle = style({
   margin: '0 0 0 0'
 });
 
-export class ConfigIndicator extends React.PureComponent<Props, {}> {
+export class ConfigIndicator extends React.PureComponent<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      show: false
+    };
+  }
+
+  toggleTrigger = () => {
+    this.setState({
+      show: !this.state.show
+    });
+  };
+
   numberOfChecks = (type: string) => {
     let numCheck = 0;
     this.props.validations.forEach(validation => {
@@ -131,36 +148,37 @@ export class ConfigIndicator extends React.PureComponent<Props, {}> {
       });
     }
 
+    const content = (
+      <div className={tooltipListStyle}>
+        {issuesMessages.map(cat => (
+          <div className={tooltipListStyle} key={cat}>
+            {cat}
+          </div>
+        ))}
+        {validationsInfo}
+      </div>
+    );
+
     return (
       <Popover
-        id={this.props.id + '-config-validation'}
-        title={this.getValid().name}
-        style={showDefinitions && { maxWidth: '80%', minWidth: '200px' }}
+        key={this.props.id + '-config-validation'}
+        isVisible={this.state.show}
+        enableFlip={true}
+        headerContent={this.getValid().name}
+        bodyContent={content}
       >
-        <div className={tooltipListStyle}>
-          {issuesMessages.map(cat => (
-            <div className={tooltipListStyle} key={cat}>
-              {cat}
-            </div>
-          ))}
-          {validationsInfo}
-        </div>
+        <span
+          onMouseEnter={this.toggleTrigger}
+          onMouseLeave={this.toggleTrigger}
+          style={{ color: this.getValid().color }}
+        >
+          {createIcon(this.getValid(), 'sm')}
+        </span>
       </Popover>
     );
   }
 
   render() {
-    return (
-      <span>
-        <OverlayTrigger
-          placement={'right'}
-          overlay={this.tooltipContent()}
-          trigger={['hover', 'focus']}
-          rootClose={false}
-        >
-          <span style={{ color: this.getValid().color }}>{createIcon(this.getValid(), 'sm')}</span>
-        </OverlayTrigger>
-      </span>
-    );
+    return this.tooltipContent();
   }
 }

--- a/src/components/Health/Helper.ts
+++ b/src/components/Health/Helper.ts
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import { Status } from 'types/Health';
-import { Validation } from '../ConfigValidation/ConfigIndicator';
 
 type Size = 'sm' | 'md' | 'lg' | 'xl';
 
-export const createIcon = (status: Status | Validation, size?: Size) => {
+export const createIcon = (status: Status, size?: Size) => {
   return React.createElement(status.icon, { color: status.color, size: size, className: status.class });
 };

--- a/src/components/Validations/Validation.tsx
+++ b/src/components/Validations/Validation.tsx
@@ -9,6 +9,8 @@ import './Validation.css';
 type Props = ValidationDescription & {
   messageColor?: boolean;
   size?: string;
+  textStyle?: React.CSSProperties;
+  iconStyle?: React.CSSProperties;
 };
 
 export type ValidationDescription = {
@@ -46,46 +48,47 @@ export const severityToValidation: { [severity: string]: ValidationType } = {
   correct: CorrectValidation
 };
 
-export const SMALL_SIZE = '12px';
-export const MEDIUM_SIZE = '18px';
-export const BIG_SIZE = '35px';
-export const INHERITED_SIZE = 'inherit';
-
-const sizeMapper = new Map<string, string>([
-  ['small', SMALL_SIZE],
-  ['medium', MEDIUM_SIZE],
-  ['big', BIG_SIZE],
-  ['inherited', INHERITED_SIZE]
-]);
-
 class Validation extends React.Component<Props> {
   validation() {
     return severityToValidation[this.props.severity];
   }
 
-  size() {
-    return sizeMapper.get(this.props.size || 'inherited') || INHERITED_SIZE;
+  severityColor() {
+    return { color: this.validation().color };
+  }
+
+  textStyle() {
+    const colorMessage = this.props.messageColor || false;
+    const textStyle = this.props.textStyle || {};
+    if (colorMessage) {
+      Object.assign(textStyle, this.severityColor());
+    }
+    return textStyle;
+  }
+
+  iconStyle() {
+    const iconStyle = this.props.iconStyle || {};
+    Object.assign(iconStyle, this.severityColor());
+    return iconStyle;
   }
 
   render() {
     const validation = this.validation();
     const IconComponent = validation.icon;
-    const colorMessage = this.props.messageColor || false;
-    const colorStyle = { color: validation.color };
-    const hasMessage = this.props.message;
+    const hasMessage = !!this.props.message;
     if (hasMessage) {
       return (
         <div className="validation">
           <div style={{ float: 'left', margin: '2px 0.6em 0 0' }}>
-            <IconComponent style={colorStyle} />
+            <IconComponent style={this.iconStyle()} />
           </div>
-          <Text component={TextVariants.p} style={colorMessage ? colorStyle : {}}>
+          <Text component={TextVariants.p} style={this.textStyle()}>
             {this.props.message}
           </Text>
         </div>
       );
     } else {
-      return <IconComponent style={colorStyle} />;
+      return <IconComponent style={this.severityColor()} />;
     }
   }
 }

--- a/src/components/Validations/Validation.tsx
+++ b/src/components/Validations/Validation.tsx
@@ -8,6 +8,7 @@ import './Validation.css';
 
 type Props = ValidationDescription & {
   messageColor?: boolean;
+  size?: string;
 };
 
 export type ValidationDescription = {
@@ -16,34 +17,54 @@ export type ValidationDescription = {
 };
 
 export type ValidationType = {
+  name: string;
   color: string;
   icon: IconType;
 };
 
 const ErrorValidation: ValidationType = {
+  name: 'Not Valid',
   color: PfColors.Red100,
   icon: ErrorCircleOIcon
 };
 
 const WarningValidation: ValidationType = {
+  name: 'Warning',
   color: PfColors.Orange400,
   icon: WarningTriangleIcon
 };
 
 const CorrectValidation: ValidationType = {
+  name: 'Valid',
   color: PfColors.Green400,
   icon: OkIcon
 };
 
-const severityToValidation: { [severity: string]: ValidationType } = {
+export const severityToValidation: { [severity: string]: ValidationType } = {
   error: ErrorValidation,
   warning: WarningValidation,
   correct: CorrectValidation
 };
 
+export const SMALL_SIZE = '12px';
+export const MEDIUM_SIZE = '18px';
+export const BIG_SIZE = '35px';
+export const INHERITED_SIZE = 'inherit';
+
+const sizeMapper = new Map<string, string>([
+  ['small', SMALL_SIZE],
+  ['medium', MEDIUM_SIZE],
+  ['big', BIG_SIZE],
+  ['inherited', INHERITED_SIZE]
+]);
+
 class Validation extends React.Component<Props> {
   validation() {
     return severityToValidation[this.props.severity];
+  }
+
+  size() {
+    return sizeMapper.get(this.props.size || 'inherited') || INHERITED_SIZE;
   }
 
   render() {

--- a/src/components/Validations/ValidationList.tsx
+++ b/src/components/Validations/ValidationList.tsx
@@ -10,7 +10,7 @@ type Props = {
   tooltipPosition?: TooltipPosition;
 };
 
-class TooltipValidation extends React.Component<Props> {
+class ValidationList extends React.Component<Props> {
   content() {
     return (this.props.checks || []).map((check, index) => {
       return <Validation key={'validation-check-' + index} severity={check.severity} message={check.message} />;
@@ -39,4 +39,4 @@ class TooltipValidation extends React.Component<Props> {
   }
 }
 
-export default TooltipValidation;
+export default ValidationList;

--- a/src/components/Validations/ValidationSummary.tsx
+++ b/src/components/Validations/ValidationSummary.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { ObjectValidation, ValidationTypes } from '../../types/IstioObjects';
 import { style } from 'typestyle';
 import { Text, TextVariants, Tooltip, TooltipPosition } from '@patternfly/react-core';
-import Validation, { severityToValidation } from '../Validations/Validation';
+import Validation, { severityToValidation } from './Validation';
 import { higherSeverity, highestSeverity } from '../../types/ServiceInfo';
 
 interface Props {
@@ -18,7 +18,7 @@ const tooltipListStyle = style({
   margin: '0 0 0 0'
 });
 
-export class ConfigIndicator extends React.PureComponent<Props> {
+export class ValidationSummary extends React.PureComponent<Props> {
   numberOfChecks = (type: string) => {
     let numCheck = 0;
     this.props.validations.forEach(validation => {

--- a/src/components/Validations/ValidationSummary.tsx
+++ b/src/components/Validations/ValidationSummary.tsx
@@ -97,7 +97,7 @@ export class ValidationSummary extends React.PureComponent<Props> {
   tooltipContent() {
     const validation = severityToValidation[this.severity()];
     return (
-      <div>
+      <>
         <Text component={TextVariants.h4}>
           <strong>{validation.name}</strong>
         </Text>
@@ -109,7 +109,7 @@ export class ValidationSummary extends React.PureComponent<Props> {
           ))}
           {this.validationInfo()}
         </div>
-      </div>
+      </>
     );
   }
 

--- a/src/components/VirtualList/Renderers.tsx
+++ b/src/components/VirtualList/Renderers.tsx
@@ -5,7 +5,7 @@ import { Badge, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import MissingSidecar from '../MissingSidecar/MissingSidecar';
 import { IstioTypes, Resource, TResource, hasMissingSidecar, Renderer } from './Config';
 import { DisplayMode, HealthIndicator } from '../Health/HealthIndicator';
-import { ConfigIndicator } from '../ConfigValidation/ConfigIndicator';
+import { ValidationSummary } from '../Validations/ValidationSummary';
 import { WorkloadListItem } from '../../types/Workload';
 import { dicIstioType, IstioConfigItem } from '../../types/IstioConfigList';
 import { AppListItem } from '../../types/AppList';
@@ -136,7 +136,7 @@ export const configuration: Renderer<ServiceListItem | IstioConfigItem> = (item:
   return (
     <td role="gridcell" key={'VirtuaItem_Conf_' + item.namespace + '_' + item.name}>
       {validation ? (
-        <ConfigIndicator id={item.name + '-config-validation'} validations={[validation]} size="medium" />
+        <ValidationSummary id={item.name + '-config-validation'} validations={[validation]} size="medium" />
       ) : (
         <>N/A</>
       )}

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/DestinationRuleDetail.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/DestinationRuleDetail.tsx
@@ -9,7 +9,7 @@ import { Table, TableBody, TableHeader, TableVariant } from '@patternfly/react-t
 import GlobalValidation from '../../../components/Validations/GlobalValidation';
 import { ServiceIcon } from '@patternfly/react-icons';
 import { checkForPath } from '../../../types/ServiceInfo';
-import TooltipValidation from '../../../components/Validations/TooltipValidation';
+import ValidationList from '../../../components/Validations/ValidationList';
 
 interface DestinationRuleProps {
   namespace: string;
@@ -29,7 +29,7 @@ class DestinationRuleDetail extends React.Component<DestinationRuleProps> {
 
   subsetValidation(subsetIndex: number) {
     const checks = checkForPath(this.props.validation, 'spec/subsets[' + subsetIndex + ']');
-    return <TooltipValidation checks={checks} tooltipPosition={TooltipPosition.right} />;
+    return <ValidationList checks={checks} tooltipPosition={TooltipPosition.right} />;
   }
 
   columnsSubsets() {

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceRoute.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceRoute.tsx
@@ -7,7 +7,7 @@ import { ServiceIcon } from '@patternfly/react-icons';
 import { Table, TableBody, TableHeader, TableVariant } from '@patternfly/react-table';
 import { Grid, GridItem, Text, TextVariants } from '@patternfly/react-core';
 import { ChartBullet } from '@patternfly/react-charts/dist/js/components/ChartBullet';
-import TooltipValidation from '../../../components/Validations/TooltipValidation';
+import ValidationList from '../../../components/Validations/ValidationList';
 
 interface VirtualServiceRouteProps {
   name: string;
@@ -59,7 +59,7 @@ class VirtualServiceRoute extends React.Component<VirtualServiceRouteProps> {
     rows = rows.concat(
       (route.route || []).map((routeItem, destinationIndex) => {
         const checks = this.checksFrom(this.validation(), routeItem, routeIndex, destinationIndex);
-        const validation = <TooltipValidation checks={checks} />;
+        const validation = <ValidationList checks={checks} />;
         const severity = highestSeverity(checks);
         const isValid = severity === ValidationTypes.Correct;
         let cells;

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
@@ -6,11 +6,11 @@ import { ServiceHealth } from '../../../types/Health';
 import { Endpoints } from '../../../types/ServiceInfo';
 import { ObjectCheck, ObjectValidation, Port } from '../../../types/IstioObjects';
 import { style } from 'typestyle';
-import { ConfigIndicator } from '../../../components/ConfigValidation/ConfigIndicator';
+import { ValidationSummary } from '../../../components/Validations/ValidationSummary';
 import './ServiceInfoDescription.css';
 import Labels from '../../../components/Label/Labels';
 import { ThreeScaleServiceRule } from '../../../types/ThreeScale';
-import TooltipValidation from '../../../components/Validations/TooltipValidation';
+import ValidationList from '../../../components/Validations/ValidationList';
 
 interface ServiceInfoDescriptionProps {
   name: string;
@@ -53,7 +53,7 @@ class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps
   getPortOver(portId: number): Popover {
     return (
       <div style={{ float: 'left', fontSize: '12px', padding: '3px 0.6em 0 0' }}>
-        <TooltipValidation checks={this.getPortChecks(portId)} />
+        <ValidationList checks={this.getPortChecks(portId)} />
       </div>
     );
   }
@@ -114,7 +114,7 @@ class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps
             </Col>
             <Col xs={12} sm={4} md={2} lg={2}>
               <div className="progress-description">
-                <ConfigIndicator id={this.props.name + '-config-validation'} validations={[this.getValidations()]} />
+                <ValidationSummary id={this.props.name + '-config-validation'} validations={[this.getValidations()]} />
                 <strong style={{ margin: '0.1em 0 0 0.5em' }}>Ports</strong>
               </div>
               <ul className={listStyle}>

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
@@ -6,7 +6,7 @@ import { ServiceHealth } from '../../../types/Health';
 import { Endpoints } from '../../../types/ServiceInfo';
 import { ObjectCheck, ObjectValidation, Port } from '../../../types/IstioObjects';
 import { style } from 'typestyle';
-import { ConfigIndicator, MEDIUM_SIZE } from '../../../components/ConfigValidation/ConfigIndicator';
+import { ConfigIndicator } from '../../../components/ConfigValidation/ConfigIndicator';
 import './ServiceInfoDescription.css';
 import Labels from '../../../components/Label/Labels';
 import { ThreeScaleServiceRule } from '../../../types/ThreeScale';
@@ -114,11 +114,7 @@ class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps
             </Col>
             <Col xs={12} sm={4} md={2} lg={2}>
               <div className="progress-description">
-                <ConfigIndicator
-                  id={this.props.name + '-config-validation'}
-                  validations={[this.getValidations()]}
-                  size={MEDIUM_SIZE}
-                />
+                <ConfigIndicator id={this.props.name + '-config-validation'} validations={[this.getValidations()]} />
                 <strong style={{ margin: '0.1em 0 0 0.5em' }}>Ports</strong>
               </div>
               <ul className={listStyle}>

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDestinationRules.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDestinationRules.tsx
@@ -4,7 +4,7 @@ import * as resolve from 'table-resolver';
 import LocalTime from '../../../components/Time/LocalTime';
 import DetailObject from '../../../components/Details/DetailObject';
 import { Link } from 'react-router-dom';
-import { ConfigIndicator } from '../../../components/ConfigValidation/ConfigIndicator';
+import { ValidationSummary } from '../../../components/Validations/ValidationSummary';
 import { DestinationRule, ObjectValidation, Subset } from '../../../types/IstioObjects';
 import Labels from '../../../components/Label/Labels';
 import { safeRender } from '../../../utils/SafeRender';
@@ -159,7 +159,7 @@ class ServiceInfoDestinationRules extends React.Component<ServiceInfoDestination
         id: vsIdx,
         name: this.overviewLink(destinationRule),
         status: (
-          <ConfigIndicator
+          <ValidationSummary
             id={vsIdx + '-config-validation'}
             validations={this.hasValidations(destinationRule) ? [this.validation(destinationRule)] : []}
           />

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoVirtualServices.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoVirtualServices.tsx
@@ -5,7 +5,7 @@ import { Link } from 'react-router-dom';
 import { ObjectValidation, VirtualService } from '../../../types/IstioObjects';
 import './ServiceInfoVirtualServices.css';
 import LocalTime from '../../../components/Time/LocalTime';
-import { ConfigIndicator } from '../../../components/ConfigValidation/ConfigIndicator';
+import { ValidationSummary } from '../../../components/Validations/ValidationSummary';
 
 interface ServiceInfoVirtualServicesProps {
   virtualServices?: VirtualService[];
@@ -126,7 +126,7 @@ class ServiceInfoVirtualServices extends React.Component<ServiceInfoVirtualServi
     return (this.props.virtualServices || []).map((virtualService, vsIdx) => ({
       id: vsIdx,
       status: (
-        <ConfigIndicator
+        <ValidationSummary
           id={vsIdx + '-config-validation'}
           validations={this.hasValidations(virtualService) ? [this.validation(virtualService)] : []}
         />

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
@@ -101,9 +101,8 @@ exports[`#ServiceInfoDescription render correctly with data should render servic
         <div
           className="progress-description"
         >
-          <ConfigIndicator
+          <ValidationSummary
             id="reviews-config-validation"
-            size="18px"
             validations={
               Array [
                 Object {},

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoRouteVirtualServices.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoRouteVirtualServices.test.tsx.snap
@@ -215,7 +215,7 @@ exports[`#ServiceInfoVirtualServices render correctly with data should render se
                 reviews-default
               </Link>,
               "resourceVersion": "1234",
-              "status": <ConfigIndicator
+              "status": <ValidationSummary
                 id="0-config-validation"
                 validations={Array []}
               />,

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPods.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPods.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { ObjectValidation, Pod } from '../../../types/IstioObjects';
 import { Col, Row, Table } from 'patternfly-react';
 import * as resolve from 'table-resolver';
-import { ConfigIndicator } from '../../../components/ConfigValidation/ConfigIndicator';
+import { ValidationSummary } from '../../../components/Validations/ValidationSummary';
 import Labels from '../../../components/Label/Labels';
 
 type WorkloadPodsProps = {
@@ -115,7 +115,7 @@ class WorkloadPods extends React.Component<WorkloadPodsProps> {
       }
       return {
         id: podIdx,
-        status: <ConfigIndicator id={podIdx + '-config-validation'} validations={validations} definition={true} />,
+        status: <ValidationSummary id={podIdx + '-config-validation'} validations={validations} definition={true} />,
         name: pod.name,
         createdAt: new Date(pod.createdAt).toLocaleString(),
         createdBy:


### PR DESCRIPTION
** Describe the change **

Migrating Summary validation popovers to PF4 (in Tooltip maner).

** Issue reference **

https://github.com/kiali/kiali/issues/1635

** Backwards compatible? **
yes

** Screenshot **

### SummaryValidation component:
Shows a summary of validations (warnings and errors) for one object.
This was previously implemented with a Popover. However, its behavior was changed to behaves as a Tooltip. In PF4, this behavior changes is not possible to be done, so it has been migrated to a tooltip as it follows.

![Screenshot of Kiali Console (20)](https://user-images.githubusercontent.com/613814/65041400-fc034b80-d956-11e9-96b1-4073ebfdd338.jpg)
![Screenshot of Kiali Console (21)](https://user-images.githubusercontent.com/613814/65041405-fdcd0f00-d956-11e9-8f5e-53673a9a2e85.jpg)
![Screenshot of Kiali Console (22)](https://user-images.githubusercontent.com/613814/65041412-01609600-d957-11e9-9ba1-f82bfcdce94b.jpg)

Found in:
Workloads details page:
![Screenshot of Kiali Console (23)](https://user-images.githubusercontent.com/613814/65041541-4dabd600-d957-11e9-8168-c96096dd82a7.jpg)

Service List:
![Screen recording (5)](https://user-images.githubusercontent.com/613814/65041677-9499cb80-d957-11e9-8449-4ad42316ef49.gif)

Service Details (ports field):
![Screenshot of Kiali Console (24)](https://user-images.githubusercontent.com/613814/65041644-851a8280-d957-11e9-9f67-e1c4e66776d9.jpg)

Istio Config list:
![Screen recording (6)](https://user-images.githubusercontent.com/613814/65041826-dfb3de80-d957-11e9-98f2-da4af3d4e7a1.gif)