### PR TITLE
IstioConfigList can't filter by 2 or more names

### DIFF
--- a/src/pages/IstioConfigList/FiltersAndSorts.ts
+++ b/src/pages/IstioConfigList/FiltersAndSorts.ts
@@ -1,6 +1,6 @@
 import { SortField } from '../../types/SortFilters';
 import { IstioConfigItem } from '../../types/IstioConfigList';
-import { FILTER_ACTION_APPEND, FILTER_ACTION_UPDATE, FilterType } from '../../types/Filters';
+import { FILTER_ACTION_APPEND, FilterType } from '../../types/Filters';
 
 export namespace IstioConfigListFilters {
   export const getType = (item: IstioConfigItem): string => {
@@ -78,7 +78,7 @@ export namespace IstioConfigListFilters {
     title: 'Istio Name',
     placeholder: 'Filter by Istio Name',
     filterType: 'text',
-    action: FILTER_ACTION_UPDATE,
+    action: FILTER_ACTION_APPEND,
     filterValues: []
   };
 


### PR DESCRIPTION
Backport of https://github.com/kiali/kiali/issues/1585 in v1.0 branch.

Master has changed and we need to check if the issue is still happening there.


