### PR TITLE
Makes links clickable in the about page

### DIFF
--- a/src/components/About/AboutUIModal.tsx
+++ b/src/components/About/AboutUIModal.tsx
@@ -64,25 +64,43 @@ class AboutUIModal extends React.Component<AboutUIModalProps, AboutUIModalState>
           <Title size="xl" style={{ padding: '20px 0px 20px' }}>
             Components
           </Title>
-          <TextList component="dl">
-            {this.props.components &&
-              this.props.components.map(component => (
-                <React.Fragment key={`${component.name}_${component.version}`}>
-                  <TextListItem key={component.name} component="dt">
-                    {component.version ? component.name : `${component.name}URL`}
-                  </TextListItem>
-                  <TextListItem key={component.version} component="dd">{`${
-                    component.version ? component.version : ''
-                  } ${component.version ? (component.url ? `(${component.url})` : '') : component.url}`}</TextListItem>
-                </React.Fragment>
-              ))}
-          </TextList>
+          <TextList component="dl">{this.props.components && this.props.components.map(this.renderComponent)}</TextList>
           {this.renderWebsiteLink()}
           {this.renderProjectLink()}
         </TextContent>
       </AboutModal>
     );
   }
+
+  private renderComponent = (component: Component) => {
+    const name = component.version ? component.name : `${component.name} URL`;
+    const additionalInfo = this.additionalComponentInfoContent(component);
+    return (
+      <>
+        <TextListItem component="dt">{name}</TextListItem>
+        <TextListItem component="dd">{additionalInfo}</TextListItem>
+      </>
+    );
+  };
+
+  private additionalComponentInfoContent = (component: Component) => {
+    if (!component.version && !component.url) {
+      return 'N/A';
+    }
+    const version = component.version ? component.version : '';
+    const url = component.url ? (
+      <a href={component.url} target="_blank" rel="noopener noreferrer">
+        {component.url}
+      </a>
+    ) : (
+      ''
+    );
+    return (
+      <>
+        {version} {url}
+      </>
+    );
+  };
 
   private renderWebsiteLink = () => {
     if (config.about && config.about.website) {


### PR DESCRIPTION
 If the url is not set, display N/A instead of "undefined"

Fixes kiali/kiali#1652

** Describe the change **

Show the links in the about box as a link and not plain text.

** Screenshot **

Before:
![Screenshot_2019-09-17_17-27-35](https://user-images.githubusercontent.com/3845764/65084294-72f90e00-d970-11e9-9b8e-8bb156690f44.png)


After:
![Screenshot_2019-09-17_17-18-30](https://user-images.githubusercontent.com/3845764/65084262-59f05d00-d970-11e9-90f0-f97e4e8a7a78.png)

