### PR TITLE
UI-side support for request.host information

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeGraphUtils.ts
+++ b/src/components/CytoscapeGraph/CytoscapeGraphUtils.ts
@@ -23,6 +23,11 @@ export const CyEdge = {
   tcp: 'tcp'
 };
 
+export const CyEdgeResponses = {
+  flags: 'flags',
+  hosts: 'hosts'
+};
+
 export const CyNode = {
   app: 'app',
   destServices: 'destServices',

--- a/src/components/SummaryPanel/ResponseFlagsTable.tsx
+++ b/src/components/SummaryPanel/ResponseFlagsTable.tsx
@@ -25,7 +25,7 @@ export class ResponseFlagsTable extends React.PureComponent<ResponseFlagsTablePr
             <tr key="table-header">
               <th>Code</th>
               <th>Flags</th>
-              <th>% of Requests</th>
+              <th>% Requests</th>
             </tr>
           </thead>
           <tbody>

--- a/src/components/SummaryPanel/ResponseFlagsTable.tsx
+++ b/src/components/SummaryPanel/ResponseFlagsTable.tsx
@@ -3,7 +3,7 @@ import _ from 'lodash';
 import { Responses } from '../../types/Graph';
 import responseFlags from '../../utils/ResponseFlags';
 
-type ResponseTableProps = {
+type ResponseFlagsTableProps = {
   responses: Responses;
   title: string;
 };
@@ -15,7 +15,7 @@ interface Row {
   val: string;
 }
 
-export class ResponseTable extends React.PureComponent<ResponseTableProps> {
+export class ResponseFlagsTable extends React.PureComponent<ResponseFlagsTableProps> {
   render() {
     return (
       <>
@@ -45,8 +45,8 @@ export class ResponseTable extends React.PureComponent<ResponseTableProps> {
   private getRows = (responses: Responses): Row[] => {
     const rows: Row[] = [];
     _.keys(responses).forEach(code => {
-      _.keys(responses[code]).forEach(f => {
-        rows.push({ key: `${code} ${f}`, code: code, flags: f, val: responses[code][f] });
+      _.keys(responses[code].flags).forEach(f => {
+        rows.push({ key: `${code} ${f}`, code: code, flags: f, val: responses[code].flags[f] });
       });
     });
     return rows;

--- a/src/components/SummaryPanel/ResponseHostsTable.tsx
+++ b/src/components/SummaryPanel/ResponseHostsTable.tsx
@@ -16,27 +16,35 @@ interface Row {
 
 export class ResponseHostsTable extends React.PureComponent<ResponseHostsTableProps> {
   render() {
+    const rows = this.getRows(this.props.responses);
+
     return (
       <>
-        <strong>{this.props.title}</strong>
-        <table className="table">
-          <thead>
-            <tr key="table-header">
-              <th>Code</th>
-              <th>Host</th>
-              <th>% of Requests</th>
-            </tr>
-          </thead>
-          <tbody>
-            {this.getRows(this.props.responses).map(row => (
-              <tr key={row.key}>
-                <td>{row.code}</td>
-                <td>{row.host}</td>
-                <td>{row.val}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        {rows.length > 0 ? (
+          <>
+            <strong>{this.props.title}</strong>
+            <table className="table">
+              <thead>
+                <tr key="table-header">
+                  <th>Code</th>
+                  <th>Host</th>
+                  <th>% of Requests</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map(row => (
+                  <tr key={row.key}>
+                    <td>{row.code}</td>
+                    <td>{row.host}</td>
+                    <td>{row.val}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </>
+        ) : (
+          <>No Host Information (see FAQ)</>
+        )}
       </>
     );
   }

--- a/src/components/SummaryPanel/ResponseHostsTable.tsx
+++ b/src/components/SummaryPanel/ResponseHostsTable.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import _ from 'lodash';
+import { Responses } from '../../types/Graph';
+
+type ResponseHostsTableProps = {
+  responses: Responses;
+  title: string;
+};
+
+interface Row {
+  code: string;
+  host: string;
+  key: string;
+  val: string;
+}
+
+export class ResponseHostsTable extends React.PureComponent<ResponseHostsTableProps> {
+  render() {
+    return (
+      <>
+        <strong>{this.props.title}</strong>
+        <table className="table">
+          <thead>
+            <tr key="table-header">
+              <th>Code</th>
+              <th>Host</th>
+              <th>% of Requests</th>
+            </tr>
+          </thead>
+          <tbody>
+            {this.getRows(this.props.responses).map(row => (
+              <tr key={row.key}>
+                <td>{row.code}</td>
+                <td>{row.host}</td>
+                <td>{row.val}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </>
+    );
+  }
+
+  private getRows = (responses: Responses): Row[] => {
+    const rows: Row[] = [];
+    _.keys(responses).forEach(code => {
+      _.keys(responses[code].hosts).forEach(h => {
+        rows.push({ key: `${code} ${h}`, code: code, host: h, val: responses[code].hosts[h] });
+      });
+    });
+    return rows;
+  };
+}

--- a/src/components/SummaryPanel/ResponseHostsTable.tsx
+++ b/src/components/SummaryPanel/ResponseHostsTable.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import _ from 'lodash';
+import { style } from 'typestyle';
 import { Responses } from '../../types/Graph';
 
 type ResponseHostsTableProps = {
@@ -14,6 +15,10 @@ interface Row {
   val: string;
 }
 
+const hostStyle = style({
+  wordWrap: 'break-word'
+});
+
 export class ResponseHostsTable extends React.PureComponent<ResponseHostsTableProps> {
   render() {
     const rows = this.getRows(this.props.responses);
@@ -23,19 +28,19 @@ export class ResponseHostsTable extends React.PureComponent<ResponseHostsTablePr
         {rows.length > 0 ? (
           <>
             <strong>{this.props.title}</strong>
-            <table className="table">
+            <table className="table" style={{ tableLayout: 'fixed', width: '100%' }}>
               <thead>
                 <tr key="table-header">
-                  <th>Code</th>
-                  <th>Host</th>
-                  <th>% of Requests</th>
+                  <th style={{ width: '15%' }}>Code</th>
+                  <th style={{ width: '50%' }}>Host</th>
+                  <th style={{ width: '35%' }}>% Requests</th>
                 </tr>
               </thead>
               <tbody>
                 {rows.map(row => (
                   <tr key={row.key}>
                     <td>{row.code}</td>
-                    <td>{row.host}</td>
+                    <td className={hostStyle}>{row.host}</td>
                     <td>{row.val}</td>
                   </tr>
                 ))}
@@ -43,7 +48,7 @@ export class ResponseHostsTable extends React.PureComponent<ResponseHostsTablePr
             </table>
           </>
         ) : (
-          <>No Host Information (see FAQ)</>
+          <>No Host Information Available</>
         )}
       </>
     );

--- a/src/pages/Graph/SummaryPanelEdge.tsx
+++ b/src/pages/Graph/SummaryPanelEdge.tsx
@@ -187,8 +187,27 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
           </div>
         )}
         {isTcp && (
-          <div className="panel-body">
-            <ResponseFlagsTable title="TCP Responses:" responses={edgeData.responses} />
+          <div className={`"panel-body ${summaryBodyTabs}`}>
+            <TabContainer id="basic-tabs" defaultActiveKey="flags">
+              <div>
+                <Nav className={`nav nav-tabs nav-tabs-pf ${summaryNavTabs}`}>
+                  <NavItem eventKey="flags" title="Response flags by code">
+                    <div>Flags</div>
+                  </NavItem>
+                  <NavItem eventKey="hosts" title="Request hosts by code">
+                    <div>Hosts</div>
+                  </NavItem>
+                </Nav>
+                <TabContent style={{ paddingTop: '10px' }}>
+                  <TabPane eventKey="flags" mountOnEnter={true} unmountOnExit={true}>
+                    <ResponseFlagsTable title="TCP Responses:" responses={edgeData.responses} />
+                  </TabPane>
+                  <TabPane eventKey="hosts" mountOnEnter={true} unmountOnExit={true}>
+                    <ResponseHostsTable title="TCP Responses" responses={edgeData.responses} />
+                  </TabPane>
+                </TabContent>
+              </div>
+            </TabContainer>
             <hr />
             {this.renderCharts(edge, isGrpc, isHttp, isTcp)}
           </div>

--- a/src/pages/Graph/SummaryPanelEdge.tsx
+++ b/src/pages/Graph/SummaryPanelEdge.tsx
@@ -143,10 +143,10 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
                   <NavItem eventKey="traffic">
                     <div>Traffic</div>
                   </NavItem>
-                  <NavItem eventKey="flags">
+                  <NavItem eventKey="flags" title="Response flags by code">
                     <div>Flags</div>
                   </NavItem>
-                  <NavItem eventKey="hosts">
+                  <NavItem eventKey="hosts" title="Request hosts by code">
                     <div>Hosts</div>
                   </NavItem>
                 </Nav>

--- a/src/pages/Graph/SummaryPanelEdge.tsx
+++ b/src/pages/Graph/SummaryPanelEdge.tsx
@@ -28,7 +28,8 @@ import { Response } from '../../services/Api';
 import { CancelablePromise, makeCancelablePromise } from '../../utils/CancelablePromises';
 import { decoratedEdgeData, decoratedNodeData } from '../../components/CytoscapeGraph/CytoscapeGraphUtils';
 import { icons } from '../../config';
-import { ResponseTable } from '../../components/SummaryPanel/ResponseTable';
+import { ResponseFlagsTable } from 'components/SummaryPanel/ResponseFlagsTable';
+import { ResponseHostsTable } from 'components/SummaryPanel/ResponseHostsTable';
 
 type SummaryPanelEdgeState = {
   loading: boolean;
@@ -142,8 +143,11 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
                   <NavItem eventKey="traffic">
                     <div>Traffic</div>
                   </NavItem>
-                  <NavItem eventKey="responses">
-                    <div>Response Codes</div>
+                  <NavItem eventKey="flags">
+                    <div>Flags</div>
+                  </NavItem>
+                  <NavItem eventKey="hosts">
+                    <div>Hosts</div>
                   </NavItem>
                 </Nav>
                 <TabContent style={{ paddingTop: '10px' }}>
@@ -169,8 +173,11 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
                       </>
                     )}
                   </TabPane>
-                  <TabPane eventKey="responses" mountOnEnter={true} unmountOnExit={true}>
-                    <ResponseTable title={isGrpc ? 'GRPC codes:' : 'HTTP codes:'} responses={edgeData.responses} />
+                  <TabPane eventKey="flags" mountOnEnter={true} unmountOnExit={true}>
+                    <ResponseFlagsTable title={isGrpc ? 'GRPC codes:' : 'HTTP codes:'} responses={edgeData.responses} />
+                  </TabPane>
+                  <TabPane eventKey="hosts" mountOnEnter={true} unmountOnExit={true}>
+                    <ResponseHostsTable title={isGrpc ? 'GRPC codes:' : 'HTTP codes:'} responses={edgeData.responses} />
                   </TabPane>
                 </TabContent>
               </div>
@@ -181,7 +188,7 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
         )}
         {isTcp && (
           <div className="panel-body">
-            <ResponseTable title="TCP Responses:" responses={edgeData.responses} />
+            <ResponseFlagsTable title="TCP Responses:" responses={edgeData.responses} />
             <hr />
             {this.renderCharts(edge, isGrpc, isHttp, isTcp)}
           </div>

--- a/src/pages/Graph/SummaryPanelEdge.tsx
+++ b/src/pages/Graph/SummaryPanelEdge.tsx
@@ -146,7 +146,7 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
                   <NavItem eventKey="flags" title="Response flags by code">
                     <div>Flags</div>
                   </NavItem>
-                  <NavItem eventKey="hosts" title="Request hosts by code">
+                  <NavItem eventKey="hosts" title="Hosts by code">
                     <div>Hosts</div>
                   </NavItem>
                 </Nav>
@@ -174,10 +174,16 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
                     )}
                   </TabPane>
                   <TabPane eventKey="flags" mountOnEnter={true} unmountOnExit={true}>
-                    <ResponseFlagsTable title={isGrpc ? 'GRPC codes:' : 'HTTP codes:'} responses={edgeData.responses} />
+                    <ResponseFlagsTable
+                      title={'Response flags by ' + (isGrpc ? 'GRPC code:' : 'HTTP code:')}
+                      responses={edgeData.responses}
+                    />
                   </TabPane>
                   <TabPane eventKey="hosts" mountOnEnter={true} unmountOnExit={true}>
-                    <ResponseHostsTable title={isGrpc ? 'GRPC codes:' : 'HTTP codes:'} responses={edgeData.responses} />
+                    <ResponseHostsTable
+                      title={'Hosts by ' + (isGrpc ? 'GRPC code:' : 'HTTP code:')}
+                      responses={edgeData.responses}
+                    />
                   </TabPane>
                 </TabContent>
               </div>
@@ -194,16 +200,16 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
                   <NavItem eventKey="flags" title="Response flags by code">
                     <div>Flags</div>
                   </NavItem>
-                  <NavItem eventKey="hosts" title="Request hosts by code">
+                  <NavItem eventKey="hosts" title="Hosts by code">
                     <div>Hosts</div>
                   </NavItem>
                 </Nav>
                 <TabContent style={{ paddingTop: '10px' }}>
                   <TabPane eventKey="flags" mountOnEnter={true} unmountOnExit={true}>
-                    <ResponseFlagsTable title="TCP Responses:" responses={edgeData.responses} />
+                    <ResponseFlagsTable title="Response flags by code:" responses={edgeData.responses} />
                   </TabPane>
                   <TabPane eventKey="hosts" mountOnEnter={true} unmountOnExit={true}>
-                    <ResponseHostsTable title="TCP Responses" responses={edgeData.responses} />
+                    <ResponseHostsTable title="Hosts by code:" responses={edgeData.responses} />
                   </TabPane>
                 </TabContent>
               </div>

--- a/src/types/Graph.ts
+++ b/src/types/Graph.ts
@@ -90,12 +90,11 @@ export interface CytoscapeMouseOutEvent extends CytoscapeBaseEvent {}
 
 // Graph Structures
 
-// Responses is a map of maps, all strings. e.g.:
-// { code0: {
-//     flags0: %traffic,
-//     flags1: %traffic
-//   }}
-export type Responses = object;
+export type ResponseDetail = {
+  flags: object; // string map flags->percentageOfTraffic
+  hosts: object; // string map host->percentageOfTraffic
+};
+export type Responses = object; // map responseCode:string -> ResponseDetail
 
 type ValidProtocols = 'http' | 'grpc' | 'tcp';
 

--- a/src/types/Graph.ts
+++ b/src/types/Graph.ts
@@ -90,11 +90,22 @@ export interface CytoscapeMouseOutEvent extends CytoscapeBaseEvent {}
 
 // Graph Structures
 
-export type ResponseDetail = {
-  flags: object; // string map flags->percentageOfTraffic
-  hosts: object; // string map host->percentageOfTraffic
+type PercentageOfTrafficByFlag = {
+  [flag: string]: string;
 };
-export type Responses = object; // map responseCode:string -> ResponseDetail
+
+type PercentageOfTrafficByHost = {
+  [host: string]: string;
+};
+
+export type ResponseDetail = {
+  flags: PercentageOfTrafficByFlag;
+  hosts: PercentageOfTrafficByHost;
+};
+
+export type Responses = {
+  [responseCode: string]: ResponseDetail;
+};
 
 type ValidProtocols = 'http' | 'grpc' | 'tcp';
 


### PR DESCRIPTION
Adds an additional Tab in the edge summary to show requested host information, by response status code. 

This video shows external requests being routed to a serviceEntry, PassthroughCluster, and Unknown (i.e. BlackholeCluster).  With the **Hosts Tab** the user can now see exactly which requested host resulted in these endpoints.  Although not shown here, this information is available on all edges, revealing if nothing else, the full host name for the resulting service (e.g. reviews:9080):

![kiali#1405](https://user-images.githubusercontent.com/2104052/65147805-e3de0b80-d9ec-11e9-99a1-b4464c411faa.gif)


Server PR: https://github.com/kiali/kiali/pull/1687
Website PR: https://github.com/kiali/kiali.io/pull/167

Closes https://github.com/kiali/kiali/issues/1405