### PR TITLE
Use Grafana Links in custom dashboards

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "postinstall": "sed -i -E 's#\\[.*eslint-config-react-app.*\\]#['\\'$PWD/.eslintrc\\'']#g' node_modules/react-scripts/config/webpack*.js"
   },
   "dependencies": {
-    "@kiali/k-charted-pf4": "0.2.2",
+    "@kiali/k-charted-pf4": "0.2.3-rc0",
     "@patternfly/patternfly": "2.4.1",
     "@patternfly/react-charts": "4.9.2",
     "@patternfly/react-core": "3.89.2",

--- a/src/components/Metrics/CustomMetrics.tsx
+++ b/src/components/Metrics/CustomMetrics.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { RouteComponentProps, withRouter } from 'react-router';
 import { Toolbar, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
-import { Dashboard, DashboardModel, DashboardQuery, Aggregator } from '@kiali/k-charted-pf4';
+import { Dashboard, DashboardModel, DashboardQuery, Aggregator, ExternalLink } from '@kiali/k-charted-pf4';
 
 import { serverConfig } from '../../config/ServerConfig';
 import history from '../../app/History';
@@ -17,13 +17,13 @@ import { MetricsSettings, LabelsSettings } from '../MetricsOptions/MetricsSettin
 import { MetricsSettingsDropdown } from '../MetricsOptions/MetricsSettingsDropdown';
 import MetricsRawAggregation from '../MetricsOptions/MetricsRawAggregation';
 import MetricsDuration from '../MetricsOptions/MetricsDuration';
-import { GrafanaLinks, Link } from './GrafanaLinks';
+import { GrafanaLinks } from './GrafanaLinks';
 import { MetricsObjectTypes } from 'types/Metrics';
 
 type MetricsState = {
   dashboard?: DashboardModel;
   labelsSettings: LabelsSettings;
-  grafanaLinks: Link[];
+  grafanaLinks: ExternalLink[];
 };
 
 type CustomMetricsProps = RouteComponentProps<{}> & {
@@ -71,7 +71,7 @@ export class CustomMetrics extends React.Component<CustomMetricsProps, MetricsSt
         this.setState({
           dashboard: response.data,
           labelsSettings: labelsSettings,
-          grafanaLinks: GrafanaLinks.buildGrafanaLinks(response.data.externalLinks, this.props.namespace, this.props.app, MetricsObjectTypes.APP, this.props.version)
+          grafanaLinks: response.data.externalLinks
         });
       })
       .catch(error => {
@@ -146,7 +146,13 @@ export class CustomMetrics extends React.Component<CustomMetricsProps, MetricsSt
           </ToolbarItem>
         </ToolbarGroup>
         <ToolbarGroup>
-          <GrafanaLinks links={this.state.grafanaLinks}/>
+          <GrafanaLinks
+            links={this.state.grafanaLinks}
+            namespace={this.props.namespace}
+            object={this.props.app}
+            objectType={MetricsObjectTypes.APP}
+            version={this.props.version}
+          />
         </ToolbarGroup>
         <ToolbarGroup style={{ marginLeft: 'auto', marginRight: 0 }}>
           <ToolbarItem>

--- a/src/components/Metrics/CustomMetrics.tsx
+++ b/src/components/Metrics/CustomMetrics.tsx
@@ -17,10 +17,13 @@ import { MetricsSettings, LabelsSettings } from '../MetricsOptions/MetricsSettin
 import { MetricsSettingsDropdown } from '../MetricsOptions/MetricsSettingsDropdown';
 import MetricsRawAggregation from '../MetricsOptions/MetricsRawAggregation';
 import MetricsDuration from '../MetricsOptions/MetricsDuration';
+import { GrafanaLinks, Link } from './GrafanaLinks';
+import { MetricsObjectTypes } from 'types/Metrics';
 
 type MetricsState = {
   dashboard?: DashboardModel;
   labelsSettings: LabelsSettings;
+  grafanaLinks: Link[];
 };
 
 type CustomMetricsProps = RouteComponentProps<{}> & {
@@ -39,7 +42,7 @@ export class CustomMetrics extends React.Component<CustomMetricsProps, MetricsSt
     const settings = MetricsHelper.readMetricsSettingsFromURL();
     this.options = this.initOptions(settings);
     // Initialize active filters from URL
-    this.state = { labelsSettings: settings.labelsSettings };
+    this.state = { labelsSettings: settings.labelsSettings, grafanaLinks: [] };
   }
 
   initOptions(settings: MetricsSettings): DashboardQuery {
@@ -67,13 +70,12 @@ export class CustomMetrics extends React.Component<CustomMetricsProps, MetricsSt
         const labelsSettings = MetricsHelper.extractLabelsSettings(response.data, this.state.labelsSettings);
         this.setState({
           dashboard: response.data,
-          labelsSettings: labelsSettings
+          labelsSettings: labelsSettings,
+          grafanaLinks: GrafanaLinks.buildGrafanaLinks(response.data.externalLinks, this.props.namespace, this.props.app, MetricsObjectTypes.APP, this.props.version)
         });
       })
       .catch(error => {
         MessageCenter.addError('Could not fetch custom dashboard.', error);
-        // TODO: is this console logging necessary?
-        console.error(error);
       });
   };
 
@@ -142,6 +144,9 @@ export class CustomMetrics extends React.Component<CustomMetricsProps, MetricsSt
           <ToolbarItem>
             <MetricsRawAggregation onChanged={this.onRawAggregationChanged} />
           </ToolbarItem>
+        </ToolbarGroup>
+        <ToolbarGroup>
+          <GrafanaLinks links={this.state.grafanaLinks}/>
         </ToolbarGroup>
         <ToolbarGroup style={{ marginLeft: 'auto', marginRight: 0 }}>
           <ToolbarItem>

--- a/src/components/Metrics/GrafanaLinks.tsx
+++ b/src/components/Metrics/GrafanaLinks.tsx
@@ -5,21 +5,23 @@ import { ExternalLink } from '@kiali/k-charted-pf4';
 
 import { MetricsObjectTypes } from '../../types/Metrics';
 
-export type Link = [string, string];
-
 type Props = {
-  links: Link[];
+  links: ExternalLink[];
+  namespace: string;
+  object: string;
+  objectType: MetricsObjectTypes;
+  version?: string;
 };
 
 export class GrafanaLinks extends React.PureComponent<Props, {}> {
-  static buildGrafanaLinks(modelLinks: ExternalLink[], namespace: string, object: string, objectType: MetricsObjectTypes, version?: string): Link[] {
+  private buildGrafanaLinks(): [string, string][] {
     const links: [string, string][] = [];
-    modelLinks.forEach(d => {
-      const nsvar = d.variables.namespace ? `&${d.variables.namespace}=${namespace}` : '';
-      const vervar = d.variables.version && version ? `&${d.variables.version}=${version}` : '';
-      switch (objectType) {
+    this.props.links.forEach(d => {
+      const nsvar = d.variables.namespace ? `&${d.variables.namespace}=${this.props.namespace}` : '';
+      const vervar = d.variables.version && this.props.version ? `&${d.variables.version}=${this.props.version}` : '';
+      switch (this.props.objectType) {
         case MetricsObjectTypes.SERVICE:
-          const fullServiceName = `${object}.${namespace}.svc.cluster.local`;
+          const fullServiceName = `${this.props.object}.${this.props.namespace}.svc.cluster.local`;
           if (d.variables.service) {
             const url = `${d.url}?${d.variables.service}=${fullServiceName}${nsvar}${vervar}`;
             links.push([d.name, url]);
@@ -27,13 +29,13 @@ export class GrafanaLinks extends React.PureComponent<Props, {}> {
           break;
         case MetricsObjectTypes.WORKLOAD:
           if (d.variables.workload) {
-            const url = `${d.url}?${d.variables.workload}=${object}${nsvar}${vervar}`;
+            const url = `${d.url}?${d.variables.workload}=${this.props.object}${nsvar}${vervar}`;
             links.push([d.name, url]);
           }
           break;
         case MetricsObjectTypes.APP:
           if (d.variables.app) {
-            const url = `${d.url}?${d.variables.app}=${object}${nsvar}${vervar}`;
+            const url = `${d.url}?${d.variables.app}=${this.props.object}${nsvar}${vervar}`;
             links.push([d.name, url]);
           }
           break;
@@ -45,33 +47,22 @@ export class GrafanaLinks extends React.PureComponent<Props, {}> {
   }
 
   render() {
+    const links = this.buildGrafanaLinks();
     return (
       <>
-        {this.props.links.length === 1 && (
+        {links.length === 1 && (
           <ToolbarItem style={{ borderRight: 'none' }}>
-            <a
-              id={'grafana_link_0'}
-              title={this.props.links[0][0]}
-              href={this.props.links[0][1]}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
+            <a id={'grafana_link_0'} title={links[0][0]} href={links[0][1]} target="_blank" rel="noopener noreferrer">
               View in Grafana <ExternalLinkAltIcon />
             </a>
           </ToolbarItem>
         )}
-        {this.props.links.length > 1 && (
+        {links.length > 1 && (
           <ToolbarItem style={{ borderRight: 'none' }}>
             View in Grafana:&nbsp;
-            {this.props.links
+            {links
               .map((link, idx) => (
-                <a
-                  id={'grafana_link_' + idx}
-                  title={link[0]}
-                  href={link[1]}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
+                <a id={'grafana_link_' + idx} title={link[0]} href={link[1]} target="_blank" rel="noopener noreferrer">
                   {link[0]} <ExternalLinkAltIcon />
                 </a>
               ))

--- a/src/components/Metrics/GrafanaLinks.tsx
+++ b/src/components/Metrics/GrafanaLinks.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+import { ToolbarItem } from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { ExternalLink } from '@kiali/k-charted-pf4';
+
+import { MetricsObjectTypes } from '../../types/Metrics';
+
+export type Link = [string, string];
+
+type Props = {
+  links: Link[];
+};
+
+export class GrafanaLinks extends React.PureComponent<Props, {}> {
+  static buildGrafanaLinks(modelLinks: ExternalLink[], namespace: string, object: string, objectType: MetricsObjectTypes, version?: string): Link[] {
+    const links: [string, string][] = [];
+    modelLinks.forEach(d => {
+      const nsvar = d.variables.namespace ? `&${d.variables.namespace}=${namespace}` : '';
+      const vervar = d.variables.version && version ? `&${d.variables.version}=${version}` : '';
+      switch (objectType) {
+        case MetricsObjectTypes.SERVICE:
+          const fullServiceName = `${object}.${namespace}.svc.cluster.local`;
+          if (d.variables.service) {
+            const url = `${d.url}?${d.variables.service}=${fullServiceName}${nsvar}${vervar}`;
+            links.push([d.name, url]);
+          }
+          break;
+        case MetricsObjectTypes.WORKLOAD:
+          if (d.variables.workload) {
+            const url = `${d.url}?${d.variables.workload}=${object}${nsvar}${vervar}`;
+            links.push([d.name, url]);
+          }
+          break;
+        case MetricsObjectTypes.APP:
+          if (d.variables.app) {
+            const url = `${d.url}?${d.variables.app}=${object}${nsvar}${vervar}`;
+            links.push([d.name, url]);
+          }
+          break;
+        default:
+          break;
+      }
+    });
+    return links;
+  }
+
+  render() {
+    return (
+      <>
+        {this.props.links.length === 1 && (
+          <ToolbarItem style={{ borderRight: 'none' }}>
+            <a
+              id={'grafana_link_0'}
+              title={this.props.links[0][0]}
+              href={this.props.links[0][1]}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              View in Grafana <ExternalLinkAltIcon />
+            </a>
+          </ToolbarItem>
+        )}
+        {this.props.links.length > 1 && (
+          <ToolbarItem style={{ borderRight: 'none' }}>
+            View in Grafana:&nbsp;
+            {this.props.links
+              .map((link, idx) => (
+                <a
+                  id={'grafana_link_' + idx}
+                  title={link[0]}
+                  href={link[1]}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {link[0]} <ExternalLinkAltIcon />
+                </a>
+              ))
+              .reduce((prev, curr) => [prev, ', ', curr] as any)}
+          </ToolbarItem>
+        )}
+      </>
+    );
+  }
+}

--- a/src/components/Metrics/IstioMetrics.tsx
+++ b/src/components/Metrics/IstioMetrics.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { RouteComponentProps, withRouter } from 'react-router';
 import { Toolbar, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
-import { Dashboard, DashboardModel } from '@kiali/k-charted-pf4';
+import { Dashboard, DashboardModel, ExternalLink } from '@kiali/k-charted-pf4';
 import { style } from 'typestyle';
 
 import RefreshContainer from '../../components/Refresh/Refresh';
@@ -21,12 +21,12 @@ import history from '../../app/History';
 import { MetricsObjectTypes } from '../../types/Metrics';
 import { GrafanaInfo } from '../../types/GrafanaInfo';
 import { MessageType } from '../../types/MessageCenter';
-import { GrafanaLinks, Link } from './GrafanaLinks';
+import { GrafanaLinks } from './GrafanaLinks';
 
 type MetricsState = {
   dashboard?: DashboardModel;
   labelsSettings: LabelsSettings;
-  grafanaLinks: Link[];
+  grafanaLinks: ExternalLink[];
 };
 
 type ObjectId = {
@@ -112,8 +112,7 @@ class IstioMetrics extends React.Component<IstioMetricsProps, MetricsState> {
     IstioMetrics.grafanaInfoPromise
       .then(grafanaInfo => {
         if (grafanaInfo) {
-          const links = GrafanaLinks.buildGrafanaLinks(grafanaInfo.externalLinks, this.props.namespace, this.props.object, this.props.objectType);
-          this.setState({ grafanaLinks: links });
+          this.setState({ grafanaLinks: grafanaInfo.externalLinks });
         } else {
           this.setState({ grafanaLinks: [] });
         }
@@ -188,7 +187,12 @@ class IstioMetrics extends React.Component<IstioMetricsProps, MetricsState> {
           </ToolbarItem>
         </ToolbarGroup>
         <ToolbarGroup>
-          <GrafanaLinks links={this.state.grafanaLinks}/>
+          <GrafanaLinks
+            links={this.state.grafanaLinks}
+            namespace={this.props.namespace}
+            object={this.props.object}
+            objectType={this.props.objectType}
+          />
         </ToolbarGroup>
         <ToolbarGroup style={{ marginLeft: 'auto', marginRight: 0 }}>
           <ToolbarItem>

--- a/src/components/Metrics/IstioMetrics.tsx
+++ b/src/components/Metrics/IstioMetrics.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { RouteComponentProps, withRouter } from 'react-router';
 import { Toolbar, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
-import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { Dashboard, DashboardModel } from '@kiali/k-charted-pf4';
 import { style } from 'typestyle';
 
@@ -22,11 +21,12 @@ import history from '../../app/History';
 import { MetricsObjectTypes } from '../../types/Metrics';
 import { GrafanaInfo } from '../../types/GrafanaInfo';
 import { MessageType } from '../../types/MessageCenter';
+import { GrafanaLinks, Link } from './GrafanaLinks';
 
 type MetricsState = {
   dashboard?: DashboardModel;
   labelsSettings: LabelsSettings;
-  grafanaLinks: [string, string][];
+  grafanaLinks: Link[];
 };
 
 type ObjectId = {
@@ -96,8 +96,6 @@ class IstioMetrics extends React.Component<IstioMetricsProps, MetricsState> {
       })
       .catch(error => {
         MessageCenter.addError('Could not fetch metrics.', error);
-        // TODO: Is this console logging necessary?
-        console.error(error);
         throw error;
       });
   };
@@ -113,7 +111,12 @@ class IstioMetrics extends React.Component<IstioMetricsProps, MetricsState> {
     }
     IstioMetrics.grafanaInfoPromise
       .then(grafanaInfo => {
-        this.setState({ grafanaLinks: this.buildGrafanaLinks(grafanaInfo) });
+        if (grafanaInfo) {
+          const links = GrafanaLinks.buildGrafanaLinks(grafanaInfo.externalLinks, this.props.namespace, this.props.object, this.props.objectType);
+          this.setState({ grafanaLinks: links });
+        } else {
+          this.setState({ grafanaLinks: [] });
+        }
       })
       .catch(err => {
         MessageCenter.addError(
@@ -123,39 +126,6 @@ class IstioMetrics extends React.Component<IstioMetricsProps, MetricsState> {
           MessageType.INFO
         );
       });
-  }
-
-  buildGrafanaLinks(grafanaInfo?: GrafanaInfo): [string, string][] {
-    const links: [string, string][] = [];
-    if (grafanaInfo) {
-      grafanaInfo.dashboards.forEach(d => {
-        const nsvar = d.variables.namespace ? `&${d.variables.namespace}=${this.props.namespace}` : '';
-        switch (this.props.objectType) {
-          case MetricsObjectTypes.SERVICE:
-            const fullServiceName = `${this.props.object}.${this.props.namespace}.svc.cluster.local`;
-            if (d.variables.service) {
-              const url = `${d.url}?${d.variables.service}=${fullServiceName}${nsvar}`;
-              links.push([d.name, url]);
-            }
-            break;
-          case MetricsObjectTypes.WORKLOAD:
-            if (d.variables.workload) {
-              const url = `${d.url}?${d.variables.workload}=${this.props.object}${nsvar}`;
-              links.push([d.name, url]);
-            }
-            break;
-          case MetricsObjectTypes.APP:
-            if (d.variables.app) {
-              const url = `${d.url}?${d.variables.app}=${this.props.object}${nsvar}`;
-              links.push([d.name, url]);
-            }
-            break;
-          default:
-            break;
-        }
-      });
-    }
-    return links;
   }
 
   onMetricsSettingsChanged = (settings: MetricsSettings) => {
@@ -218,37 +188,7 @@ class IstioMetrics extends React.Component<IstioMetricsProps, MetricsState> {
           </ToolbarItem>
         </ToolbarGroup>
         <ToolbarGroup>
-          {this.state.grafanaLinks.length === 1 && (
-            <ToolbarItem style={{ borderRight: 'none' }}>
-              <a
-                id={'grafana_link_0'}
-                title={this.state.grafanaLinks[0][0]}
-                href={this.state.grafanaLinks[0][1]}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                View in Grafana <ExternalLinkAltIcon />
-              </a>
-            </ToolbarItem>
-          )}
-          {this.state.grafanaLinks.length > 1 && (
-            <ToolbarItem style={{ borderRight: 'none' }}>
-              View in Grafana:&nbsp;
-              {this.state.grafanaLinks
-                .map((link, idx) => (
-                  <a
-                    id={'grafana_link_' + idx}
-                    title={link[0]}
-                    href={link[1]}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    {link[0]} <ExternalLinkAltIcon />
-                  </a>
-                ))
-                .reduce((prev, curr) => [prev, ', ', curr] as any)}
-            </ToolbarItem>
-          )}
+          <GrafanaLinks links={this.state.grafanaLinks}/>
         </ToolbarGroup>
         <ToolbarGroup style={{ marginLeft: 'auto', marginRight: 0 }}>
           <ToolbarItem>

--- a/src/components/Metrics/__tests__/CustomMetrics.test.tsx
+++ b/src/components/Metrics/__tests__/CustomMetrics.test.tsx
@@ -42,7 +42,7 @@ describe('Custom metrics', () => {
   });
 
   it('mounts and loads empty metrics', done => {
-    mockCustomDashboard({ title: 'foo', aggregations: [], charts: [] })
+    mockCustomDashboard({ title: 'foo', aggregations: [], charts: [], externalLinks: [] })
       .then(() => {
         mounted!.update();
         expect(mounted!.find('GridItem')).toHaveLength(0);

--- a/src/components/Metrics/__tests__/IstioMetrics.test.tsx
+++ b/src/components/Metrics/__tests__/IstioMetrics.test.tsx
@@ -9,6 +9,7 @@ import IstioMetrics from '../IstioMetrics';
 import * as API from '../../../services/Api';
 import { store } from '../../../store/ConfigStore';
 import { MetricsObjectTypes } from '../../../types/Metrics';
+import { GrafanaInfo } from 'types/GrafanaInfo';
 
 let mounted: ReactWrapper<any, any> | null;
 
@@ -37,7 +38,7 @@ const mockWorkloadDashboard = (dashboard: DashboardModel): Promise<void> => {
   return mockAPIToPromise('getWorkloadDashboard', dashboard);
 };
 
-const mockGrafanaInfo = (info: any): Promise<any> => {
+const mockGrafanaInfo = (info: GrafanaInfo): Promise<any> => {
   return mockAPIToPromise('getGrafanaInfo', info);
 };
 
@@ -105,7 +106,7 @@ describe('Metrics for a service', () => {
   });
 
   it('renders initial layout', () => {
-    mockGrafanaInfo({});
+    mockGrafanaInfo({ externalLinks: [] });
     const wrapper = shallow(
       <Provider store={store}>
         <MemoryRouter>
@@ -128,7 +129,7 @@ describe('Metrics for a service', () => {
 
   it('mounts and loads empty metrics', done => {
     const allMocksDone = [
-      mockServiceDashboard({ title: 'foo', aggregations: [], charts: [] })
+      mockServiceDashboard({ title: 'foo', aggregations: [], charts: [], externalLinks: [] })
         .then(() => {
           mounted!.update();
           expect(mounted!.find('GridItem')).toHaveLength(0);
@@ -165,7 +166,8 @@ describe('Metrics for a service', () => {
           createHistogramChart('m3'),
           createHistogramChart('m5'),
           createHistogramChart('m7')
-        ]
+        ],
+        externalLinks: []
       })
         .then(() => {
           mounted!.update();
@@ -225,7 +227,7 @@ describe('Inbound Metrics for a workload', () => {
 
   it('mounts and loads empty metrics', done => {
     const allMocksDone = [
-      mockWorkloadDashboard({ title: 'foo', aggregations: [], charts: [] })
+      mockWorkloadDashboard({ title: 'foo', aggregations: [], charts: [], externalLinks: [] })
         .then(() => {
           mounted!.update();
           expect(mounted!.find('GridItem')).toHaveLength(0);
@@ -262,7 +264,8 @@ describe('Inbound Metrics for a workload', () => {
           createHistogramChart('m3'),
           createHistogramChart('m5'),
           createHistogramChart('m7')
-        ]
+        ],
+        externalLinks: []
       })
         .then(() => {
           mounted!.update();

--- a/src/types/GrafanaInfo.ts
+++ b/src/types/GrafanaInfo.ts
@@ -1,16 +1,5 @@
+import { ExternalLink } from '@kiali/k-charted-pf4';
+
 export interface GrafanaInfo {
-  dashboards: GrafanaDashboardInfo[];
-}
-
-interface GrafanaDashboardInfo {
-  url: string;
-  name: string;
-  variables: GrafanaVariablesConfig;
-}
-
-interface GrafanaVariablesConfig {
-  app?: string;
-  namespace?: string;
-  service?: string;
-  workload?: string;
+  externalLinks: ExternalLink[];
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1151,10 +1151,10 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^12.0.9"
 
-"@kiali/k-charted-pf4@0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@kiali/k-charted-pf4/-/k-charted-pf4-0.2.2.tgz#1979b263b341b017e28477d73b67d03a84f264df"
-  integrity sha512-OXOmQZZ8XX7G7YD/71YJkaZc6UvoQLb64OQ3q5DA/FWq8HB8W749xfmuIlUITYujzXMFeN2oPhqwGWCu/rqOOQ==
+"@kiali/k-charted-pf4@0.2.3-rc0":
+  version "0.2.3-rc0"
+  resolved "https://registry.yarnpkg.com/@kiali/k-charted-pf4/-/k-charted-pf4-0.2.3-rc0.tgz#c097e9c4b3e273275264b5e98a159c57136bbe33"
+  integrity sha512-Dt0+ysoL2HSwXYX5jKs6Gm9VzBggZ7AUdL9CxTEx0n8XF4r1QTtWgpw+3VEYwVgpQT8g7je9vhZOP/xYburLrw==
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"


### PR DESCRIPTION
New GrafanaLinks component used in both IstioMetrics and CustomMetrics pages

WIP: needs https://github.com/kiali/k-charted/pull/50 + k-charted bump
Backend PR: https://github.com/kiali/kiali/pull/1691
     
Part of kiali/kiali#1676