### PR TITLE
[PF4] Moving tab validations to PF4

### DIFF
--- a/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react';
 import { style } from 'typestyle';
-import { Col, Icon, Row, ToastNotification, ToastNotificationList } from 'patternfly-react';
+import { Col, Row, ToastNotification, ToastNotificationList } from 'patternfly-react';
 
 import ServiceId from '../../types/ServiceId';
 import ServiceInfoDescription from './ServiceInfo/ServiceInfoDescription';
-import { ServiceDetailsInfo, severityToIconName, validationToSeverity } from '../../types/ServiceInfo';
+import { ServiceDetailsInfo, validationToSeverity } from '../../types/ServiceInfo';
 import ServiceInfoVirtualServices from './ServiceInfo/ServiceInfoVirtualServices';
 import ServiceInfoDestinationRules from './ServiceInfo/ServiceInfoDestinationRules';
 import ServiceInfoWorkload from './ServiceInfo/ServiceInfoWorkload';
-import { ObjectValidation, Validations } from '../../types/IstioObjects';
+import { ObjectValidation, Validations, ValidationTypes } from '../../types/IstioObjects';
 import IstioWizardDropdown from '../../components/IstioWizards/IstioWizardDropdown';
 import { ThreeScaleInfo, ThreeScaleServiceRule } from '../../types/ThreeScale';
 import { DurationDropdownContainer } from '../../components/DurationDropdown/DurationDropdown';
@@ -16,6 +16,7 @@ import RefreshButtonContainer from '../../components/Refresh/RefreshButton';
 import ParameterizedTabs, { activeTab } from '../../components/Tab/Tabs';
 import ErrorBoundaryWithMessage from '../../components/ErrorBoundary/ErrorBoundaryWithMessage';
 import { Tab } from '@patternfly/react-core';
+import Validation from '../../components/Validations/Validation';
 
 interface ServiceDetails extends ServiceId {
   serviceDetails: ServiceDetailsInfo;
@@ -112,19 +113,19 @@ class ServiceInfo extends React.Component<ServiceDetails, ServiceInfoState> {
     const destinationRules = this.props.serviceDetails.destinationRules || [];
     const validations = this.props.validations || {};
     const validationChecks = this.validationChecks();
-    const getSeverityIcon: any = (severity: string = 'error') => (
+    const getSeverityIcon: any = (severity: ValidationTypes = ValidationTypes.Error) => (
       <span className={tabIconStyle}>
         {' '}
-        <Icon type="pf" name={severityToIconName(severity)} />
+        <Validation severity={severity} />
       </span>
     );
 
     const getValidationIcon = (keys: string[], type: string) => {
-      let severity = 'warning';
+      let severity = ValidationTypes.Warning;
       keys.forEach(key => {
         const validationsForIcon = (this.props.validations || {})![type][key];
-        if (validationToSeverity(validationsForIcon) === 'error') {
-          severity = 'error';
+        if (validationToSeverity(validationsForIcon) === ValidationTypes.Error) {
+          severity = ValidationTypes.Error;
         }
       });
       return getSeverityIcon(severity);

--- a/src/pages/ServiceDetails/__tests__/__snapshots__/ServiceInfo.test.tsx.snap
+++ b/src/pages/ServiceDetails/__tests__/__snapshots__/ServiceInfo.test.tsx.snap
@@ -301,9 +301,8 @@ exports[`#ServiceInfo render correctly with data should render serviceInfo with 
                   className="f1uxujqj"
                 >
                    
-                  <Icon
-                    name="error-circle-o"
-                    type="pf"
+                  <Validation
+                    severity="error"
                   />
                 </span>
               </React.Fragment>

--- a/src/pages/WorkloadDetails/WorkloadInfo.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo.tsx
@@ -1,17 +1,18 @@
 import * as React from 'react';
 import { style } from 'typestyle';
-import { Validations } from '../../types/IstioObjects';
-import { Col, Icon, Row } from 'patternfly-react';
+import { Validations, ValidationTypes } from '../../types/IstioObjects';
+import { Col, Row } from 'patternfly-react';
 import WorkloadDescription from './WorkloadInfo/WorkloadDescription';
 import WorkloadPods from './WorkloadInfo/WorkloadPods';
 import WorkloadServices from './WorkloadInfo/WorkloadServices';
-import { severityToIconName, validationToSeverity } from '../../types/ServiceInfo';
+import { validationToSeverity } from '../../types/ServiceInfo';
 import { WorkloadHealth } from '../../types/Health';
 import { Workload } from '../../types/Workload';
 import { DurationDropdownContainer } from '../../components/DurationDropdown/DurationDropdown';
 import RefreshButtonContainer from '../../components/Refresh/RefreshButton';
 import { Tab } from '@patternfly/react-core';
 import ParameterizedTabs, { activeTab } from '../../components/Tab/Tabs';
+import Validation from '../../components/Validations/Validation';
 
 type WorkloadInfoProps = {
   workload: Workload;
@@ -85,19 +86,19 @@ class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInfoState>
     const services = workload.services || [];
     const validationChecks = this.validationChecks();
 
-    const getSeverityIcon: any = (severity: string = 'error') => (
+    const getSeverityIcon: any = (severity: ValidationTypes = ValidationTypes.Error) => (
       <span className={tabIconStyle}>
         {' '}
-        <Icon type="pf" name={severityToIconName(severity)} />
+        <Validation severity={severity} />
       </span>
     );
 
     const getValidationIcon = (keys: string[], type: string) => {
-      let severity = 'warning';
+      let severity = ValidationTypes.Warning;
       keys.forEach(key => {
         const validations = this.props.validations![type][key];
-        if (validationToSeverity(validations) === 'error') {
-          severity = 'error';
+        if (validationToSeverity(validations) === ValidationTypes.Error) {
+          severity = ValidationTypes.Error;
         }
       });
       return getSeverityIcon(severity);

--- a/src/types/ServiceInfo.ts
+++ b/src/types/ServiceInfo.ts
@@ -112,20 +112,20 @@ export const highestSeverity = (checks: ObjectCheck[]): ValidationTypes => {
   return severity;
 };
 
-const numberOfChecks = (type: string, object: ObjectValidation) =>
+const numberOfChecks = (type: ValidationTypes, object: ObjectValidation) =>
   (object && object.checks ? object.checks : []).filter(i => i.severity === type).length;
 
-export const validationToSeverity = (object: ObjectValidation): string => {
-  const warnChecks = numberOfChecks('warning', object);
-  const errChecks = numberOfChecks('error', object);
+export const validationToSeverity = (object: ObjectValidation): ValidationTypes => {
+  const warnChecks = numberOfChecks(ValidationTypes.Warning, object);
+  const errChecks = numberOfChecks(ValidationTypes.Error, object);
 
   return object && object.valid
-    ? 'correct'
+    ? ValidationTypes.Correct
     : object && !object.valid && errChecks > 0
-    ? 'error'
+    ? ValidationTypes.Error
     : object && !object.valid && warnChecks > 0
-    ? 'warning'
-    : 'correct';
+    ? ValidationTypes.Warning
+    : ValidationTypes.Correct;
 };
 
 export const checkForPath = (object: ObjectValidation | undefined, path: string): ObjectCheck[] => {


### PR DESCRIPTION
** Describe the change **

Both ServiceDetails and WorkloadDetails page has tabs with validation icons.
This PR changes those icons to new validation components.

** Issue reference **
https://github.com/kiali/kiali/issues/1635

** Backwards compatible? **
yes.

** Screenshot **
![Screenshot of Kiali Console (29)](https://user-images.githubusercontent.com/613814/65320950-4ed14300-dba3-11e9-8e6f-df1999e71244.jpg)

![Screenshot of Kiali Console (30)](https://user-images.githubusercontent.com/613814/65321004-68728a80-dba3-11e9-8be3-1d0f3c17500d.jpg)

Closes https://github.com/kiali/kiali/issues/1635
