### PR TITLE
Support request_duration_milliseconds for latency reporting in mixer-less telemetry

### DIFF
--- a/src/components/SummaryPanel/ResponseTimeChart.tsx
+++ b/src/components/SummaryPanel/ResponseTimeChart.tsx
@@ -4,12 +4,13 @@ import { PfColors } from '../../components/Pf/PfColors';
 import { SUMMARY_PANEL_CHART_WIDTH } from '../../types/Graph';
 
 type ResponseTimeChartTypeProp = {
+  hide?: boolean;
   label: string;
   rtAvg: [string | number][];
   rtMed: [string | number][];
   rt95: [string | number][];
   rt99: [string | number][];
-  hide?: boolean;
+  units: 's' | 'ms';
 };
 
 export default class ResponseTimeChart extends React.Component<ResponseTimeChartTypeProp, {}> {
@@ -17,10 +18,10 @@ export default class ResponseTimeChart extends React.Component<ResponseTimeChart
     return this.props.rtAvg && this.props.rtAvg.length > 1 && this.props.rtAvg[0].length > 1;
   };
 
-  // The prom data is in seconds but we want to report response times in millis when the user hovers
+  // The prom data may be in seconds but we want to report response times in millis when the user hovers
   // Convert the data points to millis.  The 'datums' is a bit complicated, it is a 2-dimensional array
   // that has 'x' arrays that hold timestamps of the datapoints for the x-axis.  And datapoint arrays that
-  // hold the data for the quantiles.  We need only convert the data poiints.  A datums array can look like:
+  // hold the data for the quantiles.  We need only convert the data points.  A datums array can look like:
   // [['x', 123, 456, 789],
   //  ['avg', 0.10, 0.20, 0.30]
   //  ...
@@ -52,12 +53,19 @@ export default class ResponseTimeChart extends React.Component<ResponseTimeChart
       y: { show: false }
     };
 
+    const columns =
+      this.props.units === 's'
+        ? (this.toMillis(this.props.rtAvg) as [string | number][])
+            .concat(this.toMillis(this.props.rtMed) as [string | number][])
+            .concat(this.toMillis(this.props.rt95) as [string | number][])
+            .concat(this.toMillis(this.props.rt99) as [string | number][])
+        : (this.props.rtAvg as [string | number][])
+            .concat(this.props.rtMed as [string | number][])
+            .concat(this.props.rt95 as [string | number][])
+            .concat(this.props.rt99 as [string | number][]);
     const chartData = {
       x: 'x',
-      columns: (this.toMillis(this.props.rtAvg) as [string | number][])
-        .concat(this.toMillis(this.props.rtMed) as [string | number][])
-        .concat(this.toMillis(this.props.rt95) as [string | number][])
-        .concat(this.toMillis(this.props.rt99) as [string | number][]),
+      columns: columns,
       type: 'area-spline',
       hide: ['Average', 'Median', '99th']
     };

--- a/src/components/SummaryPanel/ResponseTimeChart.tsx
+++ b/src/components/SummaryPanel/ResponseTimeChart.tsx
@@ -3,6 +3,7 @@ import { AreaChart, Icon } from 'patternfly-react';
 import { PfColors } from '../../components/Pf/PfColors';
 import { SUMMARY_PANEL_CHART_WIDTH } from '../../types/Graph';
 
+export type ResponseTimeUnit = 's' | 'ms';
 type ResponseTimeChartTypeProp = {
   hide?: boolean;
   label: string;
@@ -10,10 +11,10 @@ type ResponseTimeChartTypeProp = {
   rtMed: [string | number][];
   rt95: [string | number][];
   rt99: [string | number][];
-  units: 's' | 'ms';
+  unit: ResponseTimeUnit;
 };
 
-export default class ResponseTimeChart extends React.Component<ResponseTimeChartTypeProp, {}> {
+export class ResponseTimeChart extends React.Component<ResponseTimeChartTypeProp, {}> {
   thereIsTrafficData = () => {
     return this.props.rtAvg && this.props.rtAvg.length > 1 && this.props.rtAvg[0].length > 1;
   };
@@ -54,7 +55,7 @@ export default class ResponseTimeChart extends React.Component<ResponseTimeChart
     };
 
     const columns =
-      this.props.units === 's'
+      this.props.unit === 's'
         ? (this.toMillis(this.props.rtAvg) as [string | number][])
             .concat(this.toMillis(this.props.rtMed) as [string | number][])
             .concat(this.toMillis(this.props.rt95) as [string | number][])

--- a/src/pages/Graph/SummaryPanelEdge.tsx
+++ b/src/pages/Graph/SummaryPanelEdge.tsx
@@ -389,7 +389,7 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
         continue;
       }
       for (let i = 1; i < datum.length; i++) {
-        if (datum[i] !== 'NaN' && datum[i] !== NaN) {
+        if (!isNaN(Number(datum[i]))) {
           return false;
         }
       }


### PR DESCRIPTION
Istio 1.3.0 experimental introduces mixer-less telemetry. In this new approach latency is reported via
a new metric: request_duration_milliseconds, as opposed to what has has been done with request_duration (in seconds).

I'm not aware of a way to drive off config to know which will be in service for a time period, so until the legacy metric is removed we need to support both. This makes for some sort-of-hacky code.

I'm not really asking reviewers to run the code with mixer-less, rather to ensure no regression using the existing telemetry.  On the UI side this means the graph edge summary sparklines should work normally.

https://github.com/kiali/kiali/issues/1694

Server PR: https://github.com/kiali/kiali/pull/1711