### PR TITLE
Add `key` prop to component list

### DIFF
--- a/src/components/About/AboutUIModal.tsx
+++ b/src/components/About/AboutUIModal.tsx
@@ -76,10 +76,10 @@ class AboutUIModal extends React.Component<AboutUIModalProps, AboutUIModalState>
     const name = component.version ? component.name : `${component.name} URL`;
     const additionalInfo = this.additionalComponentInfoContent(component);
     return (
-      <>
+      <React.Fragment key={name + additionalInfo}>
         <TextListItem component="dt">{name}</TextListItem>
         <TextListItem component="dd">{additionalInfo}</TextListItem>
-      </>
+      </React.Fragment>
     );
   };
 


### PR DESCRIPTION
Fixes warning about not using `key` in  a child list for AboutUIModal

Fixes kiali/kiali#1714