### PR TITLE
[PF4] Move icon of validation to CheckCircle like MockUP

### DIFF
--- a/src/components/Validations/Validation.tsx
+++ b/src/components/Validations/Validation.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ErrorCircleOIcon, OkIcon, WarningTriangleIcon } from '@patternfly/react-icons';
+import { ErrorCircleOIcon, CheckCircleIcon, WarningTriangleIcon } from '@patternfly/react-icons';
 import { PfColors } from '../Pf/PfColors';
 import { IconType } from '@patternfly/react-icons/dist/js/createIcon';
 import { ValidationTypes } from '../../types/IstioObjects';
@@ -38,8 +38,8 @@ const WarningValidation: ValidationType = {
 
 const CorrectValidation: ValidationType = {
   name: 'Valid',
-  color: PfColors.Green400,
-  icon: OkIcon
+  color: PfColors.LightGreen400,
+  icon: CheckCircleIcon
 };
 
 export const severityToValidation: { [severity: string]: ValidationType } = {


### PR DESCRIPTION
fix https://github.com/kiali/kiali/issues/1719


In the Mockup https://marvelapp.com/i9h9g7j/screen/59315434

there is a CheckCicle with greenlight color https://patternfly-react.surge.sh/patternfly-4/icons/Icons/ we need to change the OkIcon in validation to this one


# Before
![before](https://user-images.githubusercontent.com/3019213/65508476-9a039280-ded0-11e9-92c2-ee2ce4eb4130.png)
# Now
![now](https://user-images.githubusercontent.com/3019213/65508480-9bcd5600-ded0-11e9-98bf-ff4c709a1efc.png)