### PR TITLE
Re-enable tooltips in overview sparklines, upgrade k-charted

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,9 +63,9 @@
     "postinstall": "sed -i -E 's#\\[.*eslint-config-react-app.*\\]#['\\'$PWD/.eslintrc\\'']#g' node_modules/react-scripts/config/webpack*.js"
   },
   "dependencies": {
-    "@kiali/k-charted-pf4": "0.2.3-rc0",
+    "@kiali/k-charted-pf4": "0.3.0-rc0",
     "@patternfly/patternfly": "2.4.1",
-    "@patternfly/react-charts": "4.9.2",
+    "@patternfly/react-charts": "5.0.4",
     "@patternfly/react-core": "3.89.2",
     "@patternfly/react-styles": "3.5.16",
     "@patternfly/react-table": "2.17.5",

--- a/src/pages/Overview/OverviewCardBars.tsx
+++ b/src/pages/Overview/OverviewCardBars.tsx
@@ -38,6 +38,11 @@ class OverviewCardBars extends React.Component<Props, State> {
   }
 
   render() {
+    const hiddenAxisStyle = {
+      axis: { stroke: 'none' },
+      ticks: { stroke: 'none' },
+      tickLabels: { stroke: 'none', fill: 'none' }
+    };
     return (
       <div ref={this.containerRef}>
         <Chart height={50} width={this.state.width} padding={{ top: 20, left: 5, right: 5, bottom: 0 }}>
@@ -46,8 +51,8 @@ class OverviewCardBars extends React.Component<Props, State> {
             <ChartBar horizontal={true} barWidth={16} data={[{ y: this.props.status.inWarning.length }]} />
             <ChartBar horizontal={true} barWidth={16} data={[{ y: this.props.status.inSuccess.length }]} />
           </ChartStack>
-          <ChartAxis style={{ axis: { strokeWidth: 0 } }} />
-          <ChartAxis style={{ axis: { strokeWidth: 0 } }} dependentAxis={true} />
+          <ChartAxis style={hiddenAxisStyle} />
+          <ChartAxis style={hiddenAxisStyle} dependentAxis={true} />
         </Chart>
       </div>
     );

--- a/src/pages/Overview/OverviewCardSparkline.tsx
+++ b/src/pages/Overview/OverviewCardSparkline.tsx
@@ -1,5 +1,12 @@
 import * as React from 'react';
-import { Chart, ChartArea, ChartThemeColor, ChartAxis } from '@patternfly/react-charts';
+import {
+  Chart,
+  ChartArea,
+  ChartThemeColor,
+  ChartAxis,
+  ChartTooltip,
+  ChartVoronoiContainer
+} from '@patternfly/react-charts';
 
 import { DurationInSeconds } from '../../types/Common';
 import { TimeSeries } from '../../types/Metrics';
@@ -13,6 +20,22 @@ type Props = {
 
 type State = {
   width: number;
+};
+
+const createContainer = () => {
+  const props = {
+    constrainToVisibleArea: true
+  };
+  const tooltip = <ChartTooltip style={{ stroke: 'none', fill: 'white' }} renderInPortal={true} {...props} />;
+  return (
+    <ChartVoronoiContainer
+      labels={obj => `${obj.datum.x.toLocaleTimeString()}\n${obj.datum.y} RPS`}
+      labelComponent={tooltip}
+      // We blacklist "parent" as a workaround to avoid the VictoryVoronoiContainer crashing.
+      // See https://github.com/FormidableLabs/victory/issues/1355
+      voronoiBlacklist={['parent']}
+    />
+  );
 };
 
 class OverviewCardSparkline extends React.Component<Props, State> {
@@ -54,6 +77,7 @@ class OverviewCardSparkline extends React.Component<Props, State> {
               padding={0}
               themeColor={ChartThemeColor.multi}
               scale={{ x: 'time' }}
+              containerComponent={createContainer()}
             >
               {data.series.map((serie, idx) => (
                 <ChartArea key={'serie-' + idx} data={serie} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -1151,10 +1151,10 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^12.0.9"
 
-"@kiali/k-charted-pf4@0.2.3-rc0":
-  version "0.2.3-rc0"
-  resolved "https://registry.yarnpkg.com/@kiali/k-charted-pf4/-/k-charted-pf4-0.2.3-rc0.tgz#c097e9c4b3e273275264b5e98a159c57136bbe33"
-  integrity sha512-Dt0+ysoL2HSwXYX5jKs6Gm9VzBggZ7AUdL9CxTEx0n8XF4r1QTtWgpw+3VEYwVgpQT8g7je9vhZOP/xYburLrw==
+"@kiali/k-charted-pf4@0.3.0-rc0":
+  version "0.3.0-rc0"
+  resolved "https://registry.yarnpkg.com/@kiali/k-charted-pf4/-/k-charted-pf4-0.3.0-rc0.tgz#b07b2c84500f559924817b3796eaf444d3a8b656"
+  integrity sha512-9w5OPPfwnmkRmLGAAaGeK1aRdo1OCm16SB5PD5LNEzgRpCCLYCe6LGVWzgtKkDx1vF6jN86uqKR3KrWfpAbRyA==
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -1179,25 +1179,29 @@
   resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-2.26.1.tgz#d554e4a5e1f042bfb27b3df77d37ddb388bbc594"
   integrity sha512-htCkY40ONRMn9ECE+C+J1ADqlCNbPjJNUpMJ2unvgj0cpnfTVi0snHiDb4lKVcxG7d3jGg5x24hGmVmvkJ9MGw==
 
+"@patternfly/patternfly@2.33.0":
+  version "2.33.0"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-2.33.0.tgz#00bd0e39be1757bafeaffda3e63859960c4c25b6"
+  integrity sha512-TvHf6euQZBibG6NhkiDKMGkLvnPz6I7r5kGwZVBRtp0eCQPvSfqV+Sns6869Hap4Hfacjm39qz7LxYuU4W34Pw==
+
 "@patternfly/patternfly@2.4.1":
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-2.4.1.tgz#2b82e946ec2cdf5a78535ba2b9d514151688dc2d"
   integrity sha512-VoL6Fsid7scdsf1w8TZ9JckTjVIHzWQBMHptOv2jHjrLlxTwMGPmyh8AnvRYhqWa5nUSA//jZaR8vMyliJl9TQ==
 
-"@patternfly/react-charts@4.9.2":
-  version "4.9.2"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-charts/-/react-charts-4.9.2.tgz#597be561652cca662b77d3ecb5433c503153be58"
-  integrity sha512-axZDEKuHdhf0BpBkG4J/4Nn+MUNa9HaTloyS37NfHzchvUdNmNavl1xRN9v8fI34GuNkA9I3qtQn1qP7hb8Yyg==
+"@patternfly/react-charts@5.0.4":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-charts/-/react-charts-5.0.4.tgz#5ae3663b490b9d0b128c7a271c7fba50f78ec418"
+  integrity sha512-0ApZss92my9h9H2cwb3GrhNWj1SJgUzNrzJRh5dLZv3mfbSsWawWNMhOEBGgAcGYrg+jam+chBOqg0adOLCuzw==
   dependencies:
-    "@patternfly/react-styles" "^3.5.17"
-  optionalDependencies:
-    "@types/lodash" "^4.14.132"
-    "@types/victory" "^31.0.18"
+    "@patternfly/patternfly" "2.33.0"
+    "@patternfly/react-styles" "^3.5.25"
+    "@patternfly/react-tokens" "^2.6.29"
     hoist-non-react-statics "^3.3.0"
     lodash "^4.17.11"
-    victory "^32.2.3"
-    victory-core "^32.2.3"
-    victory-legend "^32.2.3"
+    victory "^33.0.5"
+    victory-core "^33.0.1"
+    victory-legend "^33.0.1"
 
 "@patternfly/react-core@3.89.2":
   version "3.89.2"
@@ -1316,10 +1320,10 @@
     resolve-from "^4.0.0"
     typescript "3.4.5"
 
-"@patternfly/react-styles@^3.5.17":
-  version "3.5.17"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-3.5.17.tgz#52178d72d09134d3b9c5619a457b090813a9dc44"
-  integrity sha512-LMWduKWePmwRFM1ZqpKSCIVU0n4WIp0+sUmd5HVDObIHf3feXv5IXWKDIChKEF2sqZU6afssGhbJvCpvc2PiOQ==
+"@patternfly/react-styles@^3.5.25":
+  version "3.5.26"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-3.5.26.tgz#8b25d2f8d61e4a424b183e5e9562323399c36461"
+  integrity sha512-e8Z6zeqVKSZdLO2xyzFqfrA8uWVoCN8WkUlnyNlzxbf9mE4BnD6gTSC9cD8nPJqoxXjuioj1J2hhtprhJtrcCg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0-beta.48"
     camel-case "^3.0.0"
@@ -1387,6 +1391,11 @@
   version "2.6.17"
   resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-2.6.17.tgz#349a087d91f5595f328f46c80abe9126ba28b0f1"
   integrity sha512-aZHwd5FHNsSrKxJgGF8B1ge4Z7gPRyo/dgJbFMBSdVGikf4AdhgMNEGdrXagSr5yfF2DLkl8rx9mQlDVtLXnBA==
+
+"@patternfly/react-tokens@^2.6.29":
+  version "2.6.30"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-2.6.30.tgz#e1d6a83bf59989ec7636eef73ce7191aa7fba33b"
+  integrity sha512-pDFSONwM3fHAeYQ1m6JdqnBrSkNxcNAiMkPP5YOdnj0cgi2Q9zfOkM/Y++uVIATqO/jQ2f0rrAqL7eIh2QoQhg==
 
 "@patternfly/react-virtualized-extension@1.1.97":
   version "1.1.97"
@@ -1835,11 +1844,6 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.123.tgz#39be5d211478c8dd3bdae98ee75bb7efe4abfe4d"
   integrity sha512-pQvPkc4Nltyx7G1Ww45OjVqUsJP4UsZm+GWJpigXgkikZqJgRm4c48g027o6tdgubWHwFRF15iFd+Y4Pmqv6+Q==
 
-"@types/lodash@^4.14.132":
-  version "4.14.136"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.136.tgz#413e85089046b865d960c9ff1d400e04c31ab60f"
-  integrity sha512-0GJhzBdvsW2RUccNHOBkabI8HZVdOXmXbXhuKlDEd5Vv12P7oAVGfomGp3Ne21o5D/qu1WmthlNKFaoZJJeErA==
-
 "@types/node@*":
   version "10.12.18"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.18.tgz#1d3ca764718915584fcd9f6344621b7672665c67"
@@ -1914,13 +1918,6 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
-
-"@types/victory@^31.0.18":
-  version "31.0.20"
-  resolved "https://registry.yarnpkg.com/@types/victory/-/victory-31.0.20.tgz#205fae42b76b4fc28973c911cbc6d00f10963a6c"
-  integrity sha512-cjMUp/YE48Y5rP/U60VmPtFslLfRGxpty3nz2+3CvXhxR9HZ9TcePqW/vzMO0kuFxO+LYS9QBYDPEUHJDdg5Ng==
-  dependencies:
-    "@types/react" "*"
 
 "@types/yargs@^12.0.2", "@types/yargs@^12.0.9":
   version "12.0.12"
@@ -14799,285 +14796,285 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-victory-area@^32.3.2:
-  version "32.3.2"
-  resolved "https://registry.yarnpkg.com/victory-area/-/victory-area-32.3.2.tgz#3c0e6c9d5480b4f570810f28a1d9ea2fd0e23ffb"
-  integrity sha512-KonmBC4RdzdHU9hylIUS4Fa3m89P2K+ds27YC4s0Grb97q4FGzBivnkJqIlXJQgsYlIojK1YlUwpcBXKEUHYvQ==
+victory-area@^33.0.6:
+  version "33.0.6"
+  resolved "https://registry.yarnpkg.com/victory-area/-/victory-area-33.0.6.tgz#50509a2b037a894f76ad1fd20b2c6634538c901c"
+  integrity sha512-fzC8ApT3bNx6sDK9OqSGIH7oTtcsvGmGlv0BRTzGtzumyrDkA+3lD4MrowJPIFRzbOQFsvz9MiRRX9QaeyY0Jw==
   dependencies:
     d3-shape "^1.2.0"
-    lodash "^4.17.11"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^32.3.2"
+    victory-core "^33.0.6"
 
-victory-axis@^32.3.2:
-  version "32.3.2"
-  resolved "https://registry.yarnpkg.com/victory-axis/-/victory-axis-32.3.2.tgz#e061aa0628e41a44fed96b28f724011a05e15ce7"
-  integrity sha512-rIf1h1EbiZY9GVS3IKFW5JDAlYaeDng3vVdjQq8dDo3LU4LJzWGMgD/RT4+skldbeCCTz0qYpjggwSgjRjv8Ew==
+victory-axis@^33.0.6:
+  version "33.0.6"
+  resolved "https://registry.yarnpkg.com/victory-axis/-/victory-axis-33.0.6.tgz#e40054ada95ac25cb209094e43689897b5aeca4c"
+  integrity sha512-G0ee9EnZsNwU/t79oRqPu6uqEU+RemL485LoQFmufGZvXz36TWUYQV1mCMBACxzznhPOO3HJ2/2BFTuadON6dA==
   dependencies:
-    lodash "^4.17.11"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^32.3.2"
+    victory-core "^33.0.6"
 
-victory-bar@^32.3.2:
-  version "32.3.2"
-  resolved "https://registry.yarnpkg.com/victory-bar/-/victory-bar-32.3.2.tgz#7268551c6f9cb00346ceb067f39a94a9f85eff6e"
-  integrity sha512-Z0rYAF3NU1FfeUqv0p8RH1HpV70F1G6H+3p0MofPnuVKQNtCc/NruJ9ZaS9IYxexdbiuYaFIx1ozd9cFpdAW8A==
+victory-bar@^33.0.6:
+  version "33.0.6"
+  resolved "https://registry.yarnpkg.com/victory-bar/-/victory-bar-33.0.6.tgz#0ff21f118bf5721e080e17c9cb71112785b931cc"
+  integrity sha512-V58iGp90c30WkQZZVbEcsPRDRcWtzwfp77xgpwiRSn6AQMBLz/7VxYR2eelRxhvCf7120A6N/CVRUfyrQv3HRA==
   dependencies:
     d3-shape "^1.2.0"
-    lodash "^4.17.11"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^32.3.2"
+    victory-core "^33.0.6"
 
-victory-box-plot@^32.3.2:
-  version "32.3.2"
-  resolved "https://registry.yarnpkg.com/victory-box-plot/-/victory-box-plot-32.3.2.tgz#a48bcd0c0ca6dce281a6539b53bf74bce1a2d24d"
-  integrity sha512-ECrc2W5OxN6pBkFLlmT+qj94nfphmZm40XAp1AcdvvUYF/EKEmb0RyvhhBemK5r2syDjFBLFOgIxrdOT8n9FYA==
+victory-box-plot@^33.0.6:
+  version "33.0.6"
+  resolved "https://registry.yarnpkg.com/victory-box-plot/-/victory-box-plot-33.0.6.tgz#4833718c4dd2136afd7d27660c426c17f268d094"
+  integrity sha512-kV4zr0Bsmp22I958Bds/ABzDNojm/2Tou3yNbmM9e92T9o59eIIS8MWWUEGKN/9sDywJRBAHDzU5zRxMbL+IzA==
   dependencies:
     d3-array "^1.2.0"
-    lodash "^4.17.11"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^32.3.2"
+    victory-core "^33.0.6"
 
-victory-brush-container@^32.3.2:
-  version "32.3.2"
-  resolved "https://registry.yarnpkg.com/victory-brush-container/-/victory-brush-container-32.3.2.tgz#a3421bf69892fd74d67405e0134d79cc8fa54486"
-  integrity sha512-ESD1DXzmt+wT6sA7JEIue+e2MxhKxG8H/i+sHAYuqxhGhXdV/zA952mjcyzx3PTZPaopHXd0s6MukM1aWbOZCA==
+victory-brush-container@^33.0.6:
+  version "33.0.6"
+  resolved "https://registry.yarnpkg.com/victory-brush-container/-/victory-brush-container-33.0.6.tgz#c2c426190512ec62a3c1843fa7c18c2cb98f7124"
+  integrity sha512-CSxD5Iq7KeAIN0BbYbybMhJ+aoXXnb0jZnE3/WSoQ5BZI2WK3nnlpU3B9auOzHE8fE6ad/xhAaxCwREja9MbCg==
   dependencies:
-    lodash "^4.17.11"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^32.3.2"
+    victory-core "^33.0.6"
 
-victory-brush-line@^32.3.2:
-  version "32.3.2"
-  resolved "https://registry.yarnpkg.com/victory-brush-line/-/victory-brush-line-32.3.2.tgz#17cc5dc2b4693177a4998ee6beb9a6912a9d4175"
-  integrity sha512-yj3+qoFFnQZnNtIX+J6zGjOEUkNaVKmkqQ4PDK3NHef3OUmkQsOQgladyVPjc4vtCRWb5d+9TvVjCcosUYiytw==
+victory-brush-line@^33.0.6:
+  version "33.0.6"
+  resolved "https://registry.yarnpkg.com/victory-brush-line/-/victory-brush-line-33.0.6.tgz#57836615b7fc3c835ef7e874c72a50d375dc308e"
+  integrity sha512-Bi69NJdmFNh7Qv5dB1S0dml6U8yJdAAo8mCPjBwY1S8N2IlFnZ3BZ1YsmHcN5aBCaVan9jzFO2nSva2w0tkYvw==
   dependencies:
-    lodash "^4.17.11"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^32.3.2"
+    victory-core "^33.0.6"
 
-victory-candlestick@^32.3.2:
-  version "32.3.2"
-  resolved "https://registry.yarnpkg.com/victory-candlestick/-/victory-candlestick-32.3.2.tgz#873fd02b3dc13df2a30f6c6378568e6e2583f1bf"
-  integrity sha512-yplTlyDmjS5C/VOt6nFsieGzZn6lwixRI7MX5Qe5t4LLSuyY/E+b+9oya8mimo1e7s4N/hbaXo7eVEDXGExuCw==
+victory-candlestick@^33.0.6:
+  version "33.0.6"
+  resolved "https://registry.yarnpkg.com/victory-candlestick/-/victory-candlestick-33.0.6.tgz#a0a68b9e7f37731be30e528bcdc32e8abf3582b3"
+  integrity sha512-+mQI70v941TlFXM+8dRjWtmOYX53rZuwIz+wGu6B0ujvMJ71jeGWEK6yaKvzM+fVjCWgmifTz7L1+mb4hLl9XA==
   dependencies:
-    lodash "^4.17.11"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^32.3.2"
+    victory-core "^33.0.6"
 
-victory-chart@^32.3.2:
-  version "32.3.2"
-  resolved "https://registry.yarnpkg.com/victory-chart/-/victory-chart-32.3.2.tgz#4781141fbd233f5d1c4a03474bfd679f5f5e48e8"
-  integrity sha512-xL8FUl9EYspHWw8XIQTrFhyQAMuHidIiYsyf2920bFgZB+DPLO8zhQHMVhhjnWNVgw4gVoW3Xx7XS2YXNmmLFg==
+victory-chart@^33.0.6:
+  version "33.0.6"
+  resolved "https://registry.yarnpkg.com/victory-chart/-/victory-chart-33.0.6.tgz#74577604509b6011b8df16de741bc8e0281ee6d6"
+  integrity sha512-PsIwEcnzH28vnTVn0+9NfmLAJm5zZ8QX7EKsNpVZNNDOvqWLwe8vqW3ZQGJ7DCZ6Gu6kxu9p7NkZg+PYESYBsg==
   dependencies:
-    lodash "^4.17.11"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
-    victory-axis "^32.3.2"
-    victory-core "^32.3.2"
-    victory-polar-axis "^32.3.2"
-    victory-shared-events "^32.3.2"
+    victory-axis "^33.0.6"
+    victory-core "^33.0.6"
+    victory-polar-axis "^33.0.6"
+    victory-shared-events "^33.0.6"
 
-victory-core@^32.2.3, victory-core@^32.3.2:
-  version "32.3.2"
-  resolved "https://registry.yarnpkg.com/victory-core/-/victory-core-32.3.2.tgz#6e2150b0b2807ffcd73106786c43f78f000e90c7"
-  integrity sha512-HXlxQOacxCuZqhXgalyz71ftLOmtOLvfaIUKTBaGqUFbaLFVhcTBwqWBM+xa7gnjOhgr/VjR5apx2X/Rr8jdgA==
+victory-core@^33.0.1, victory-core@^33.0.6:
+  version "33.0.6"
+  resolved "https://registry.yarnpkg.com/victory-core/-/victory-core-33.0.6.tgz#c1b464934e3c31336762539515d7e90e3ea997a4"
+  integrity sha512-FquX3yW88c1tzdkIWB2XeO2bVrI02P1+oBobiF6Zh8EpBHYf9auqEzTYgc/DIqlg+5jcwOkZlzjwAPHg56SD9w==
   dependencies:
     d3-ease "^1.0.0"
     d3-interpolate "^1.1.1"
     d3-scale "^1.0.0"
     d3-shape "^1.2.0"
     d3-timer "^1.0.0"
-    lodash "^4.17.11"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
 
-victory-create-container@^32.3.3:
-  version "32.3.3"
-  resolved "https://registry.yarnpkg.com/victory-create-container/-/victory-create-container-32.3.3.tgz#a47235db0b194f455300611126f93ca9444501df"
-  integrity sha512-Y0NqvPAAbNgyVoU2hwz+6E4Df/qa5QV7S4OpvOyljZut/Q/R0Lx9QlGsdpz6qI1veNGvQfP0KyDiKof4kFieRg==
+victory-create-container@^33.0.6:
+  version "33.0.6"
+  resolved "https://registry.yarnpkg.com/victory-create-container/-/victory-create-container-33.0.6.tgz#325ed1197268aa9e0c5a224c9727f416ebc52993"
+  integrity sha512-jjV2eCvxxFKyLfBRspVj6XGPMYrrvH1yWRUzasnwnEj/44GldlFCdtjKFdKo5YKbY1EloKoBFMC9caN589ai0w==
   dependencies:
-    lodash "^4.17.11"
-    victory-brush-container "^32.3.2"
-    victory-core "^32.3.2"
-    victory-cursor-container "^32.3.2"
-    victory-selection-container "^32.3.2"
-    victory-voronoi-container "^32.3.3"
-    victory-zoom-container "^32.3.2"
+    lodash "^4.17.15"
+    victory-brush-container "^33.0.6"
+    victory-core "^33.0.6"
+    victory-cursor-container "^33.0.6"
+    victory-selection-container "^33.0.6"
+    victory-voronoi-container "^33.0.6"
+    victory-zoom-container "^33.0.6"
 
-victory-cursor-container@^32.3.2:
-  version "32.3.2"
-  resolved "https://registry.yarnpkg.com/victory-cursor-container/-/victory-cursor-container-32.3.2.tgz#ca49bccdc0d9cf9b587d89e77eda753f75e9e73f"
-  integrity sha512-w5ocJVLBhPMBliJNdUBIe+BSlTJQufrtF+WiT0g9V+b32hMAiNQuG4W/bH91Mjko8mHuJnTtawBMbdgz1KGQAQ==
+victory-cursor-container@^33.0.6:
+  version "33.0.6"
+  resolved "https://registry.yarnpkg.com/victory-cursor-container/-/victory-cursor-container-33.0.6.tgz#5e3470c725b142d695fc5d8218411a3668b22f6c"
+  integrity sha512-KOGR24nlZh1FAIPCCOYMy74CBGoIentAPrbX28aWkHtrXN+ZaPh2DOilEhyxh6GdoCCfxhwugJCQX8SgvMtfUw==
   dependencies:
-    lodash "^4.17.11"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^32.3.2"
+    victory-core "^33.0.6"
 
-victory-errorbar@^32.3.2:
-  version "32.3.2"
-  resolved "https://registry.yarnpkg.com/victory-errorbar/-/victory-errorbar-32.3.2.tgz#497c9749eb4fa6ee5134b0ba6d32761537189277"
-  integrity sha512-tv6euhdhFT0iL4z2BV024HqNHCcXfNso7qjJErs1AjITCMFs/6/UbZ4VWOdAq8xTmqHDCdyd8zFiGtbpuSODDQ==
+victory-errorbar@^33.0.6:
+  version "33.0.6"
+  resolved "https://registry.yarnpkg.com/victory-errorbar/-/victory-errorbar-33.0.6.tgz#c53ef199d61d80c0a55ed0d05dca86c66096feb3"
+  integrity sha512-u7BWPUiA7Te8iHq5P13BABVIK4/70OgBfVdCnuABH+XrtOKq/T0/GfmqS9RjgOfOviYVrPIOoMiWl7MJwUDPtA==
   dependencies:
-    lodash "^4.17.11"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^32.3.2"
+    victory-core "^33.0.6"
 
-victory-group@^32.3.2:
-  version "32.3.2"
-  resolved "https://registry.yarnpkg.com/victory-group/-/victory-group-32.3.2.tgz#c79fa4c087c386f63f3acd40158002762c37d743"
-  integrity sha512-N47GVC2AW7NA9oV9UNFpRcrX2XSABUU2yoG68chnaZvNrkGxCBlkz3Y6RpxZkEkXo/VX49u/JaDLQOVhhhlM3w==
+victory-group@^33.0.6:
+  version "33.0.6"
+  resolved "https://registry.yarnpkg.com/victory-group/-/victory-group-33.0.6.tgz#cbec56e7d9a05546e8954cbfaaa96c043bdedca5"
+  integrity sha512-6c6A4I3PwT7x/YS6HEA92yAftIRWXgFRcSw1w/DgWz2r2UhY6D/3JMM3iF9RbyAqaRLOZR2CPv7PtwLfNJ8I3w==
   dependencies:
-    lodash "^4.17.11"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
-    victory-core "^32.3.2"
+    victory-core "^33.0.6"
 
-victory-legend@^32.2.3, victory-legend@^32.3.2:
-  version "32.3.2"
-  resolved "https://registry.yarnpkg.com/victory-legend/-/victory-legend-32.3.2.tgz#494ddf3035804650dcd06de744caf5cb32552aa3"
-  integrity sha512-JAnlrepPUzK7FWFLQPDw/TVtC/ZweUpOYM5fL9rlOw4eX7suTHVu1pjhqOaHLK0CZXOc2uJeJe9L8TZZmRK4Gw==
+victory-legend@^33.0.1, victory-legend@^33.0.6:
+  version "33.0.6"
+  resolved "https://registry.yarnpkg.com/victory-legend/-/victory-legend-33.0.6.tgz#42606df36c2dd86109f6e15c2460bd08c53bf916"
+  integrity sha512-mAed28nFzz3mV4aWgXr+21VFJ3JlPQ++zJaiuu4GivAinNY44TPml71rFmTebRZpBrF2Ohj1TNpEfszWYP/xVw==
   dependencies:
-    lodash "^4.17.11"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^32.3.2"
+    victory-core "^33.0.6"
 
-victory-line@^32.3.2:
-  version "32.3.2"
-  resolved "https://registry.yarnpkg.com/victory-line/-/victory-line-32.3.2.tgz#b5580febf04c0c7ae3abe5b86d8ba08bcf6a699d"
-  integrity sha512-5Mk5c+7kQw/An+TgCPOzgaYxUxtfAtt9ZGVuwJ7ru02ieL9Ev0S8Q8jJdmj9vIPE4eG60ZuumzovLz+8Mw+elQ==
+victory-line@^33.0.6:
+  version "33.0.6"
+  resolved "https://registry.yarnpkg.com/victory-line/-/victory-line-33.0.6.tgz#c5dcaf89b3b1ba843135354a17027338425b123b"
+  integrity sha512-8pJqiRc2Do7r9r9c/zi+FtW1YyqnV9TmEmiB8ESnKpVu+nqxlFyuowsiI3h9qIkIOqInQf7cBmNh7uUWwVPsmw==
   dependencies:
     d3-shape "^1.2.0"
-    lodash "^4.17.11"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^32.3.2"
+    victory-core "^33.0.6"
 
-victory-pie@^32.3.2:
-  version "32.3.2"
-  resolved "https://registry.yarnpkg.com/victory-pie/-/victory-pie-32.3.2.tgz#873e5e38ed381f9a8e97070df772a8746799f7b4"
-  integrity sha512-naNoPWWHJjt4L6rHZ5U0/L2slUKkGLqQu2OnKU8/Zfbr2pBi2JXfHLFD8RIk6v+H1zApiqpU5ID+pp05u7o7/Q==
+victory-pie@^33.0.6:
+  version "33.0.6"
+  resolved "https://registry.yarnpkg.com/victory-pie/-/victory-pie-33.0.6.tgz#c3e3bb251358068cd54b7bff0400b54ada6c1940"
+  integrity sha512-2J5ZK1/Ke+S4bvtNuZYP9Xa1EPzuXDY7Qd0b3VOcAbpnVjTLDqp0SLpdMiXr4eTq0puwVhAp5VFyCuYs9FS4sQ==
   dependencies:
     d3-shape "^1.0.0"
-    lodash "^4.17.11"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^32.3.2"
+    victory-core "^33.0.6"
 
-victory-polar-axis@^32.3.2:
-  version "32.3.2"
-  resolved "https://registry.yarnpkg.com/victory-polar-axis/-/victory-polar-axis-32.3.2.tgz#fb134ccb1a75410ce904c131d38a33b7b43a3b51"
-  integrity sha512-2lNMEzJvDLfn720q3CyhyMGZeZRPA3C0fp3WbNyTDx9h6y1L9fDdPHtLSQRURx1UZOLDwHCHdNTD1TtNiH8txg==
+victory-polar-axis@^33.0.6:
+  version "33.0.6"
+  resolved "https://registry.yarnpkg.com/victory-polar-axis/-/victory-polar-axis-33.0.6.tgz#b41fdca9768ce3d3dada09366d1fa0e18838c523"
+  integrity sha512-++vPJjIWx3uSRAVPul7Lk+tXm8vxwPqmC6QiL5y9bO4yLs/M2FkRNf7HJQdQmCzcX/Ls9WUUbS4479C/TFwBlw==
   dependencies:
-    lodash "^4.17.11"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^32.3.2"
+    victory-core "^33.0.6"
 
-victory-scatter@^32.3.2:
-  version "32.3.2"
-  resolved "https://registry.yarnpkg.com/victory-scatter/-/victory-scatter-32.3.2.tgz#7cad3c7bf18f9c7d067a10caf873941904998128"
-  integrity sha512-5tw4CnLae0NBvQg5le7OS1KhB9O3HpXgntmK/R76+6L1DOUbuIiV+LOe6XyQYlPm1yX+dF8t1P93O3ykbqWyRg==
+victory-scatter@^33.0.6:
+  version "33.0.6"
+  resolved "https://registry.yarnpkg.com/victory-scatter/-/victory-scatter-33.0.6.tgz#90f381bcae2c7797ab6e2013ac41517b3a6efdaa"
+  integrity sha512-L2vJjnWq3lrCbIAE8CMzTggecQISvPHyZdwUEJ0L2Y53x/0VrrFX4Q1PCFetRK6laPLHS5en5cLxlPZk2wI1QA==
   dependencies:
-    lodash "^4.17.11"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^32.3.2"
+    victory-core "^33.0.6"
 
-victory-selection-container@^32.3.2:
-  version "32.3.2"
-  resolved "https://registry.yarnpkg.com/victory-selection-container/-/victory-selection-container-32.3.2.tgz#aec9bd24de3e292032242a2e58e9e4511384726f"
-  integrity sha512-imJjWYGkRm01SGxrpbbDEW16xZpVMW0/rKFzOr0ZVZHxmP7VkEx24f7futbX+DuXEYNxDO15imLOtMYXA4yhRg==
+victory-selection-container@^33.0.6:
+  version "33.0.6"
+  resolved "https://registry.yarnpkg.com/victory-selection-container/-/victory-selection-container-33.0.6.tgz#3bc4532dc6d7ee782dcee41db2bdd1d41807e49f"
+  integrity sha512-7YivssEXpFLBoTg/84tqs5jTBn7xqvO53P1Wb4GR+qJYEC3GjlVXJ9zFiYcfBU5UPVvMuptd4/fEUEu39Vmf0Q==
   dependencies:
-    lodash "^4.17.11"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^32.3.2"
+    victory-core "^33.0.6"
 
-victory-shared-events@^32.3.2:
-  version "32.3.2"
-  resolved "https://registry.yarnpkg.com/victory-shared-events/-/victory-shared-events-32.3.2.tgz#cf31aadf55e9974669aa1bcb7d9bfdaad9d33d8b"
-  integrity sha512-Yilbcsh5YO2QHPdpxBIRIDNO9vDKb8ml5AxuUXpJcGgAH8uaASJCKj8VjQGHWH/REnJ9u0pJuC50dB6wtPuiiw==
+victory-shared-events@^33.0.6:
+  version "33.0.6"
+  resolved "https://registry.yarnpkg.com/victory-shared-events/-/victory-shared-events-33.0.6.tgz#1b07ff5ddf58ffdcc1f6315351748a6a2796bab9"
+  integrity sha512-/277OZ29HbwzdBJZUtWPsQ59ZgVqZ7WxaiRCJIbmS1BFSl2PhPXwOqZiC2E/zaAbpab4gO3vTyYXfjyVlMswRg==
   dependencies:
-    lodash "^4.17.11"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
-    victory-core "^32.3.2"
+    victory-core "^33.0.6"
 
-victory-stack@^32.3.2:
-  version "32.3.2"
-  resolved "https://registry.yarnpkg.com/victory-stack/-/victory-stack-32.3.2.tgz#fa9b2dae04e092795b69c4b190e52ffdf7f81de9"
-  integrity sha512-6H8Lt9OV6PYYjQI1Z2Rh5ulDhuESmP5+EIli2SZxeUqMWi2z6RbGcKCM46EMv7hTLO7CPH7FyBeTblKZeghbsA==
+victory-stack@^33.0.6:
+  version "33.0.6"
+  resolved "https://registry.yarnpkg.com/victory-stack/-/victory-stack-33.0.6.tgz#0e1ce2cdd50333199796e1436710253b3ca2b7e1"
+  integrity sha512-waZm23nE1AHxyY/yqamqxq2LczFZ2iVElzW6RF6iB2C28jZqF/K9Ee4h1C/uT0z2p5zAJwqdGm5SJBheJofsUw==
   dependencies:
-    lodash "^4.17.11"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
     react-fast-compare "^2.0.0"
-    victory-core "^32.3.2"
+    victory-core "^33.0.6"
 
-victory-tooltip@^32.3.2:
-  version "32.3.2"
-  resolved "https://registry.yarnpkg.com/victory-tooltip/-/victory-tooltip-32.3.2.tgz#14c04787a1947e504f3fc032ba4e1f69c2b98644"
-  integrity sha512-t4HUDrC2pEVSa7wJxDtyEUK0ngvgzmT4uplytVx6AvIS476Q47SYvLU1q667FLCKWbjR1yZHCcPOhO3+79akAw==
+victory-tooltip@^33.0.6:
+  version "33.0.6"
+  resolved "https://registry.yarnpkg.com/victory-tooltip/-/victory-tooltip-33.0.6.tgz#38c682f95a029dd02e2e48e8f4ce9c4a8ae1d013"
+  integrity sha512-UgPrcWD8/SnIovXnE/d0MK6dzH9a4K/4Vl6PUpRcUjkOtJqieIfV7PRGK7OTpbeuneNX0fjZsof5KloB8jTlJA==
   dependencies:
-    lodash "^4.17.11"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^32.3.2"
+    victory-core "^33.0.6"
 
-victory-voronoi-container@^32.3.3:
-  version "32.3.3"
-  resolved "https://registry.yarnpkg.com/victory-voronoi-container/-/victory-voronoi-container-32.3.3.tgz#c8c99f9ce54c2d6508b35cb242150c71b4c9da9e"
-  integrity sha512-eNFOJbM3cUZb6t83xBT3O0MT5FGlX9oxO6WMUs7kZUSMGUa5by2vjV9lJ2FdL70Ix1qnMZDpyP2aYs4vMIWGZw==
+victory-voronoi-container@^33.0.6:
+  version "33.0.6"
+  resolved "https://registry.yarnpkg.com/victory-voronoi-container/-/victory-voronoi-container-33.0.6.tgz#5c693d0c8a14c52a7d2aad5225f7f57579000954"
+  integrity sha512-4Upi372pOtHDYI+9t+5dvlWDK7UNotWJdvNda5z/NFhKLbrySIdm9tluoJY9pCwOsEbm2do8CGluKYu7viuh4g==
   dependencies:
     delaunay-find "0.0.3"
-    lodash "^4.17.11"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^32.3.2"
-    victory-tooltip "^32.3.2"
+    victory-core "^33.0.6"
+    victory-tooltip "^33.0.6"
 
-victory-voronoi@^32.3.2:
-  version "32.3.2"
-  resolved "https://registry.yarnpkg.com/victory-voronoi/-/victory-voronoi-32.3.2.tgz#4abe8b170f5f1f1bf9e9bf5e492113b0bc1f0f02"
-  integrity sha512-Q7yTF0e1srAIfOprDAv2O8oDzmv21Y+6reslZrPOZiNISl5cxqfBQWmZJISVRoVQ/MOAF8jV5UHbq37o5914PQ==
+victory-voronoi@^33.0.6:
+  version "33.0.6"
+  resolved "https://registry.yarnpkg.com/victory-voronoi/-/victory-voronoi-33.0.6.tgz#e706c02dcc6648b950768b70d3edc633fb26b2cc"
+  integrity sha512-V3nzDq/4U+mR1q9w5bne/HF8kNNimJjmCyFwveoSqx30ethTCllsSUQnj12Ibo08Wqv5GJwrPXblD7y3sEfGlg==
   dependencies:
     d3-voronoi "^1.1.2"
-    lodash "^4.17.11"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^32.3.2"
+    victory-core "^33.0.6"
 
-victory-zoom-container@^32.3.2:
-  version "32.3.2"
-  resolved "https://registry.yarnpkg.com/victory-zoom-container/-/victory-zoom-container-32.3.2.tgz#834d022898991b7620856d86a3485eb0e18a473d"
-  integrity sha512-XWSOwjs+kscRdf1rbonXJK+AKjWANq6E9EfQgSkfvn+nCNoRd06SffczM3EaiSVoo9R8JevEsfywblh6hQ5jQA==
+victory-zoom-container@^33.0.6:
+  version "33.0.6"
+  resolved "https://registry.yarnpkg.com/victory-zoom-container/-/victory-zoom-container-33.0.6.tgz#854c7a39ca355c93a5cd20e3dae488ec4c91fbf9"
+  integrity sha512-T40F+WDUdcYe+1zqsVG3vvStDsx0uaQ/tq4Y2jglcvO1iPah6nJgkI5BjPUYpbAjCP91WoMoKpzzvHFuV/hRWg==
   dependencies:
-    lodash "^4.17.11"
+    lodash "^4.17.15"
     prop-types "^15.5.8"
-    victory-core "^32.3.2"
+    victory-core "^33.0.6"
 
-victory@^32.2.3:
-  version "32.3.3"
-  resolved "https://registry.yarnpkg.com/victory/-/victory-32.3.3.tgz#cd3cb338d572faffdba84cf9be1a7838a0e7d132"
-  integrity sha512-JlHRC+EpA3Tst8LNMzGV3P1CG0TJ+/U/1ka/NPLIPpWd7ZqXxTmYlpnBTpFLm3tQmWTpiOm2tTQ867LtZ3JGQw==
+victory@^33.0.5:
+  version "33.0.6"
+  resolved "https://registry.yarnpkg.com/victory/-/victory-33.0.6.tgz#c341a565518fc3856a489299178cee43656ae6c2"
+  integrity sha512-jlFKSWWrQANM0at6ymvSKRr+16nZjoRb8KHpTyR8t822I1sDKp+6fFcmv+QvTfErVw4ZJteirv/ZDhYBsMhT7A==
   dependencies:
-    victory-area "^32.3.2"
-    victory-axis "^32.3.2"
-    victory-bar "^32.3.2"
-    victory-box-plot "^32.3.2"
-    victory-brush-container "^32.3.2"
-    victory-brush-line "^32.3.2"
-    victory-candlestick "^32.3.2"
-    victory-chart "^32.3.2"
-    victory-core "^32.3.2"
-    victory-create-container "^32.3.3"
-    victory-cursor-container "^32.3.2"
-    victory-errorbar "^32.3.2"
-    victory-group "^32.3.2"
-    victory-legend "^32.3.2"
-    victory-line "^32.3.2"
-    victory-pie "^32.3.2"
-    victory-polar-axis "^32.3.2"
-    victory-scatter "^32.3.2"
-    victory-selection-container "^32.3.2"
-    victory-shared-events "^32.3.2"
-    victory-stack "^32.3.2"
-    victory-tooltip "^32.3.2"
-    victory-voronoi "^32.3.2"
-    victory-voronoi-container "^32.3.3"
-    victory-zoom-container "^32.3.2"
+    victory-area "^33.0.6"
+    victory-axis "^33.0.6"
+    victory-bar "^33.0.6"
+    victory-box-plot "^33.0.6"
+    victory-brush-container "^33.0.6"
+    victory-brush-line "^33.0.6"
+    victory-candlestick "^33.0.6"
+    victory-chart "^33.0.6"
+    victory-core "^33.0.6"
+    victory-create-container "^33.0.6"
+    victory-cursor-container "^33.0.6"
+    victory-errorbar "^33.0.6"
+    victory-group "^33.0.6"
+    victory-legend "^33.0.6"
+    victory-line "^33.0.6"
+    victory-pie "^33.0.6"
+    victory-polar-axis "^33.0.6"
+    victory-scatter "^33.0.6"
+    victory-selection-container "^33.0.6"
+    victory-shared-events "^33.0.6"
+    victory-stack "^33.0.6"
+    victory-tooltip "^33.0.6"
+    victory-voronoi "^33.0.6"
+    victory-voronoi-container "^33.0.6"
+    victory-zoom-container "^33.0.6"
 
 visibilityjs@2.0.2:
   version "2.0.2"


### PR DESCRIPTION
- This is possible by upgrading victory/react-charts and using new prop constrainToVisibleArea
- Also fix an issue with axis on bars charts not being hidden as expected (not sure if this issue was introduced with the lib version upgrade)
- The k-charted upgrade allows the same improvement with tooltips in metrics pages (see https://github.com/kiali/k-charted/pull/54)

Closes https://github.com/kiali/kiali/issues/1702

![Capture d’écran de 2019-09-25 14-24-28](https://user-images.githubusercontent.com/2153442/65601166-dce16b00-dfa1-11e9-9a1f-ae60666f6412.png)

