### PR TITLE
When building the breadcrumbs, consider "." in the item name

### DIFF
--- a/src/components/BreadcrumbView/BreadcrumbView.tsx
+++ b/src/components/BreadcrumbView/BreadcrumbView.tsx
@@ -42,7 +42,7 @@ export class BreadcrumbView extends React.Component<BreadCumbViewProps, BreadCum
   }
 
   updateItem = () => {
-    const namespaceRegex = /namespaces\/([a-z0-9-]+)\/([a-z0-9-]+)\/([a-z0-9-]+)(\/([a-z0-9-]+))?(\/([a-z0-9-]+))?/;
+    const namespaceRegex = /namespaces\/([a-z0-9-]+)\/([a-z0-9-]+)\/([a-z0-9-]+)(\/([a-z0-9-.]+))?(\/([a-z0-9-]+))?/;
     const match = this.props.location.pathname.match(namespaceRegex) || [];
     const ns = match[1];
     const page = Paths[match[2].toUpperCase()];


### PR DESCRIPTION
Fixes kiali/kiali#1729

** Screenshot **

Before:
![Screenshot_2019-09-25_12-33-57](https://user-images.githubusercontent.com/3845764/65626066-8c164600-df92-11e9-83ec-f573b3e0c6e7.png)


After:

![Screenshot_2019-09-25_12-46-11](https://user-images.githubusercontent.com/3845764/65626034-802a8400-df92-11e9-9d9c-37433c64de49.png)
