### PR TITLE
Fix styling for app box summary

### DIFF
--- a/src/pages/Graph/SummaryPanelGroup.tsx
+++ b/src/pages/Graph/SummaryPanelGroup.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
+import { Badge } from '@patternfly/react-core';
 import { Icon } from 'patternfly-react';
-
 import { InOutRateTableGrpc, InOutRateTableHttp } from '../../components/SummaryPanel/InOutRateTable';
 import { RpsChart, TcpChart } from '../../components/SummaryPanel/RpsChart';
 import { NodeType, SummaryPanelPropType } from '../../types/Graph';
@@ -15,7 +15,6 @@ import {
   renderNoTraffic
 } from './SummaryPanelCommon';
 import { DisplayMode, HealthIndicator } from '../../components/Health/HealthIndicator';
-import Label from '../../components/Label/Label';
 import { Health } from '../../types/Health';
 import { Response } from '../../services/Api';
 import { Metrics } from '../../types/Metrics';
@@ -123,7 +122,7 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
           )}
           <span> {renderTitle(nodeData)}</span>
           <div className="label-collection" style={{ paddingTop: '3px' }}>
-            <Label name="namespace" value={namespace} key={namespace} />
+            <Badge>namespace: {namespace}</Badge>
             {this.renderVersionBadges()}
           </div>
           {this.renderBadgeSummary(group)}
@@ -225,11 +224,9 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
       .children(`node[${CyNode.version}]`)
       .toArray()
       .map((c, _i) => (
-        <Label
-          key={c.data(CyNode.version)}
-          name={serverConfig.istioLabels.versionLabelName}
-          value={c.data(CyNode.version)}
-        />
+        <Badge>
+          {serverConfig.istioLabels.versionLabelName}: value={c.data(CyNode.version)}
+        </Badge>
       ));
   };
 


### PR DESCRIPTION
Don't use OS label styling in the summary panel because we're not displaying a set of labels, just descriptive information.  Instead use PF4 Badges:

![image](https://user-images.githubusercontent.com/2104052/65633764-d73c5300-dfaa-11e9-8914-c7f74ee64440.png)

Note that other node types, and edges, have previously been updated.  The App Box was an oversight.  It should now be consistent with the other summary panels.

Fixes https://github.com/kiali/kiali/issues/1709
