### PR TITLE
Trivial: Better align the Graph Legend Close box.

### DIFF
--- a/src/components/GraphFilter/GraphLegend.tsx
+++ b/src/components/GraphFilter/GraphLegend.tsx
@@ -10,14 +10,14 @@ export interface GraphLegendProps {
   isMTLSEnabled: boolean;
 }
 
-const width = '300px';
+const width = '200px';
 
 export default class GraphLegend extends React.Component<GraphLegendProps> {
   render() {
     const legendBoxStyle = style({
       margin: '1em 0 4em 0',
       padding: '1em',
-      border: '1px solid gray',
+      border: '1px solid #EDEDED',
       overflow: 'hidden',
       overflowX: 'auto',
       overflowY: 'auto'
@@ -28,7 +28,8 @@ export default class GraphLegend extends React.Component<GraphLegendProps> {
     });
 
     const legendTextHeadingStyle = style({
-      fontWeight: 'bold'
+      fontWeight: 'bold',
+      fontSize: '16px'
     });
 
     const bodyStyle = style({
@@ -67,7 +68,8 @@ export default class GraphLegend extends React.Component<GraphLegendProps> {
 
   renderGraphLegendList(legendData: GraphLegendItem[]) {
     const legendColumnHeadingStyle = style({
-      paddingTop: '1.25em'
+      paddingTop: '1.25em',
+      fontSize: '14px'
     });
     const aStyle = style({
       height: '100%',
@@ -102,9 +104,10 @@ export default class GraphLegend extends React.Component<GraphLegendProps> {
     });
 
     const legendItemLabelStyle = style({
-      fontSize: '1em',
+      fontSize: '12px',
       fontWeight: 'normal',
-      width: '175px'
+      width: '130px',
+      marginTop: '3px'
     });
 
     return (

--- a/src/components/GraphFilter/GraphLegend.tsx
+++ b/src/components/GraphFilter/GraphLegend.tsx
@@ -41,11 +41,16 @@ export default class GraphLegend extends React.Component<GraphLegendProps> {
       flexDirection: 'column'
     });
 
+    const closeBoxStyle = style({
+      float: 'right',
+      marginTop: '-7px'
+    });
+
     return (
       <div className={legendBoxStyle}>
         <div className={headerStyle}>
           <span className={legendTextHeadingStyle}>Legend</span>
-          <span className="pull-right">
+          <span className={closeBoxStyle}>
             <Tooltip content="Close Legend">
               <Button id="legend_close" variant="plain" onClick={this.props.closeLegend}>
                 <CloseIcon />

--- a/src/components/GraphFilter/__tests__/__snapshots__/GraphLegend.test.tsx.snap
+++ b/src/components/GraphFilter/__tests__/__snapshots__/GraphLegend.test.tsx.snap
@@ -2,13 +2,13 @@
 
 exports[`GraphLegend test should render correctly 1`] = `
 <div
-  className="fwzhvy7"
+  className="fqvou5s"
 >
   <div
-    className="fiy3v8i"
+    className="f1xvjjtv"
   >
     <span
-      className="f13vslg"
+      className="f1i76bsh"
     >
       Legend
     </span>
@@ -58,16 +58,16 @@ exports[`GraphLegend test should render correctly 1`] = `
     </span>
   </div>
   <div
-    className="fxms5gz"
+    className="f1hnvrw2"
   >
     <div
       className="fkhz08q"
     >
       <div
-        className="fc9v04o"
+        className="fls9dm1"
       >
         <div
-          className="fot2cu0"
+          className="f1unvj7z"
           key="Node Shapes"
         >
           Node Shapes
@@ -82,7 +82,7 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="f1643rh"
+              className="f1hob5wc"
             >
               Workload
             </span>
@@ -98,7 +98,7 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="f1643rh"
+              className="f1hob5wc"
             >
               App
             </span>
@@ -114,7 +114,7 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="f1643rh"
+              className="f1hob5wc"
             >
               Unknown Source
             </span>
@@ -130,7 +130,7 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="f1643rh"
+              className="f1hob5wc"
             >
               Service
             </span>
@@ -146,14 +146,14 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="f1643rh"
+              className="f1hob5wc"
             >
               Service Entry
             </span>
           </div>
         </div>
         <div
-          className="fot2cu0"
+          className="f1unvj7z"
           key="Node Colors"
         >
           Node Colors
@@ -168,7 +168,7 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="f1643rh"
+              className="f1hob5wc"
             >
               Normal
             </span>
@@ -184,7 +184,7 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="f1643rh"
+              className="f1hob5wc"
             >
               Warning
             </span>
@@ -200,7 +200,7 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="f1643rh"
+              className="f1hob5wc"
             >
               Error
             </span>
@@ -216,14 +216,14 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="f1643rh"
+              className="f1hob5wc"
             >
               Unused
             </span>
           </div>
         </div>
         <div
-          className="fot2cu0"
+          className="f1unvj7z"
           key="Node Background"
         >
           Node Background
@@ -238,7 +238,7 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="f1643rh"
+              className="f1hob5wc"
             >
               External Namespace
             </span>
@@ -254,14 +254,14 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="f1643rh"
+              className="f1hob5wc"
             >
               Restricted Namespace
             </span>
           </div>
         </div>
         <div
-          className="fot2cu0"
+          className="f1unvj7z"
           key="Edges"
         >
           Edges
@@ -276,7 +276,7 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="f1643rh"
+              className="f1hob5wc"
             >
               20% Error
             </span>
@@ -292,7 +292,7 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="f1643rh"
+              className="f1hob5wc"
             >
               0.1 - 20% Error
             </span>
@@ -308,7 +308,7 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="f1643rh"
+              className="f1hob5wc"
             >
               0.1 Error
             </span>
@@ -324,7 +324,7 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="f1643rh"
+              className="f1hob5wc"
             >
               TCP Connection
             </span>
@@ -340,7 +340,7 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="f1643rh"
+              className="f1hob5wc"
             >
               Idle
             </span>
@@ -356,14 +356,14 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="f1643rh"
+              className="f1hob5wc"
             >
               mTLS (badge)
             </span>
           </div>
         </div>
         <div
-          className="fot2cu0"
+          className="f1unvj7z"
           key="Traffic Animation"
         >
           Traffic Animation
@@ -378,7 +378,7 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="f1643rh"
+              className="f1hob5wc"
             >
               Normal Request
             </span>
@@ -394,7 +394,7 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="f1643rh"
+              className="f1hob5wc"
             >
               Failed Request
             </span>
@@ -410,14 +410,14 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="f1643rh"
+              className="f1hob5wc"
             >
               TCP Traffic
             </span>
           </div>
         </div>
         <div
-          className="fot2cu0"
+          className="f1unvj7z"
           key="Node Badges"
         >
           Node Badges
@@ -432,7 +432,7 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="f1643rh"
+              className="f1hob5wc"
             >
               Circuit Breaker
             </span>
@@ -448,7 +448,7 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="f1643rh"
+              className="f1hob5wc"
             >
               Missing Sidecar
             </span>
@@ -464,7 +464,7 @@ exports[`GraphLegend test should render correctly 1`] = `
               />
             </span>
             <span
-              className="f1643rh"
+              className="f1hob5wc"
             >
               Virtual Services
             </span>

--- a/src/components/GraphFilter/__tests__/__snapshots__/GraphLegend.test.tsx.snap
+++ b/src/components/GraphFilter/__tests__/__snapshots__/GraphLegend.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`GraphLegend test should render correctly 1`] = `
       Legend
     </span>
     <span
-      className="pull-right"
+      className="f1vrdyv8"
     >
       <Tooltip
         appendTo={[Function]}


### PR DESCRIPTION
** Describe the change **
This is a very small alignment fix to the graph legend close box as it looked a bit off. Now it is in better alignment with the Legend Title.


** Backwards compatible? **
yes

[ ] Is your pull-request introducing changes in behaviour?
no

** Screenshot **

**Before**:

![close-box](https://user-images.githubusercontent.com/1312165/65635553-676f9d80-df95-11e9-8d36-dba1e616a8b3.png)


**After**:

![full-legend](https://user-images.githubusercontent.com/1312165/65635276-def0fd00-df94-11e9-9279-126cd00a2d4a.png)

