### PR TITLE
FIX a Patternfly charts upgrade that broke VirtualService chart.

### DIFF
--- a/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceRoute.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceRoute.tsx
@@ -163,7 +163,8 @@ class VirtualServiceRoute extends React.Component<VirtualServiceRouteProps> {
     });
   }
 
-  bulletChartLabels(datum: any) {
+  bulletChartLabels(data: any) {
+    const datum = data.datum;
     const [percent, host, subset, port] = datum.name.split('_');
     let label = 'Max weight: 100';
     if (host) {


### PR DESCRIPTION
** Describe the change **

Latest patternfly-charts update broke the VirtualService detail page:

![Screenshot of Kiali Console (39)](https://user-images.githubusercontent.com/613814/65682125-9e5bb700-e05a-11e9-8f06-78daed7ca893.jpg)

This PR fixes that:
![Screen recording (7)](https://user-images.githubusercontent.com/613814/65682168-b8959500-e05a-11e9-81bd-3962f7ee9a9a.gif)

