### PR TITLE
Migrate mTLS icons and tooltips to PF4

### DIFF
--- a/src/components/MTls/MTLSIcon.tsx
+++ b/src/components/MTls/MTLSIcon.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { OverlayTrigger, Tooltip } from 'patternfly-react';
-
+import { Tooltip, TooltipPosition } from '@patternfly/react-core';
 import fullIcon from '../../assets/img/mtls-status-full.svg';
 import hollowIcon from '../../assets/img/mtls-status-partial.svg';
 import fullIconDark from '../../assets/img/mtls-status-full-dark.svg';
@@ -11,8 +10,8 @@ export { fullIcon, hollowIcon, fullIconDark, hollowIconDark };
 type Props = {
   icon: string;
   iconClassName: string;
-  overlayText: string;
-  overlayPosition: string;
+  tooltipText: string;
+  tooltipPosition: TooltipPosition;
 };
 
 export enum MTLSIconTypes {
@@ -30,24 +29,20 @@ const nameToSource = new Map<string, string>([
 ]);
 
 class MTLSIcon extends React.Component<Props> {
-  infotipContent() {
-    return <Tooltip id={'mtls-status-masthead'}>{this.props.overlayText}</Tooltip>;
-  }
-
   render() {
     return (
-      <OverlayTrigger
-        placement={this.props.overlayPosition}
-        overlay={this.infotipContent()}
-        trigger={['hover', 'focus']}
-        rootClose={false}
+      <Tooltip
+        aria-label={'mTLS status'}
+        position={this.props.tooltipPosition}
+        enableFlip={true}
+        content={this.props.tooltipText}
       >
         <img
           className={this.props.iconClassName}
           src={nameToSource.get(this.props.icon)}
-          alt={this.props.overlayPosition}
+          alt={this.props.tooltipPosition}
         />
-      </OverlayTrigger>
+      </Tooltip>
     );
   }
 }

--- a/src/components/MTls/MTLSStatus.tsx
+++ b/src/components/MTls/MTLSStatus.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
 
 import { default as MTLSIcon } from './MTLSIcon';
+import { TooltipPosition } from '@patternfly/react-core';
 
 type Props = {
   status: string;
   statusDescriptors: Map<string, StatusDescriptor>;
   className?: string;
-  overlayPosition?: string;
+  overlayPosition?: TooltipPosition;
 };
 
 export type StatusDescriptor = {
@@ -39,7 +40,7 @@ class MTLSStatus extends React.Component<Props> {
   }
 
   overlayPosition() {
-    return this.props.overlayPosition || 'left';
+    return this.props.overlayPosition || TooltipPosition.left;
   }
 
   iconClassName() {
@@ -52,8 +53,8 @@ class MTLSStatus extends React.Component<Props> {
         <MTLSIcon
           icon={this.icon()}
           iconClassName={this.iconClassName()}
-          overlayText={this.message()}
-          overlayPosition={this.overlayPosition()}
+          tooltipText={this.message()}
+          tooltipPosition={this.overlayPosition()}
         />
       );
     }

--- a/src/components/MTls/MeshMTLSStatus.tsx
+++ b/src/components/MTls/MeshMTLSStatus.tsx
@@ -83,7 +83,7 @@ class MeshMTLSStatus extends React.Component<Props> {
   render() {
     return (
       <div className={this.iconStyle()}>
-        <MTLSStatus status={this.props.status} statusDescriptors={statusDescriptors} overlayPosition={'left'} />
+        <MTLSStatus status={this.props.status} statusDescriptors={statusDescriptors} />
       </div>
     );
   }

--- a/src/components/MTls/NamespaceMTLSStatus.tsx
+++ b/src/components/MTls/NamespaceMTLSStatus.tsx
@@ -40,14 +40,7 @@ class NamespaceMTLSStatus extends React.Component<Props> {
   }
 
   render() {
-    return (
-      <MTLSStatus
-        status={this.props.status}
-        className={this.iconStyle()}
-        statusDescriptors={statusDescriptors}
-        overlayPosition={'left'}
-      />
-    );
+    return <MTLSStatus status={this.props.status} className={this.iconStyle()} statusDescriptors={statusDescriptors} />;
   }
 }
 

--- a/src/components/MTls/__tests__/MTLSIcon.test.tsx
+++ b/src/components/MTls/__tests__/MTLSIcon.test.tsx
@@ -2,10 +2,16 @@ import * as React from 'react';
 import { shallow } from 'enzyme';
 import MTLSIcon, { MTLSIconTypes } from '../MTLSIcon';
 import { shallowToJson } from 'enzyme-to-json';
+import { TooltipPosition } from '@patternfly/react-core';
 
 const mockIcon = (icon: string) => {
   const component = (
-    <MTLSIcon icon={icon} iconClassName={'className'} overlayText={'Overlay Test'} overlayPosition={'left'} />
+    <MTLSIcon
+      icon={icon}
+      iconClassName={'className'}
+      tooltipText={'Overlay Test'}
+      tooltipPosition={TooltipPosition.right}
+    />
   );
   return shallow(component);
 };
@@ -17,18 +23,16 @@ describe('when Icon is LOCK_FULL', () => {
     expect(shallowToJson(wrapper)).toBeDefined();
     expect(shallowToJson(wrapper)).toMatchSnapshot();
 
-    expect(wrapper.name()).toEqual('OverlayTrigger');
-    expect(wrapper.props().placement).toEqual('left');
+    expect(wrapper.name()).toEqual('Tooltip');
+    console.log(wrapper.props());
+    console.log(wrapper);
+    expect(wrapper.props().position).toEqual('right');
+    expect(wrapper.props().content).toEqual('Overlay Test');
 
     expect(wrapper.children()).toBeDefined();
     expect(wrapper.children().name()).toEqual('img');
     expect(wrapper.children().prop('className')).toEqual('className');
     expect(wrapper.children().prop('src')).toEqual('mtls-status-full.svg');
-
-    const overlay = wrapper.props().overlay;
-    expect(overlay.props.bsClass).toEqual('tooltip');
-    expect(overlay.props.placement).toEqual('right');
-    expect(overlay.props.children).toContain('Overlay Test');
   });
 });
 

--- a/src/components/MTls/__tests__/__snapshots__/MTLSIcon.test.tsx.snap
+++ b/src/components/MTls/__tests__/__snapshots__/MTLSIcon.test.tsx.snap
@@ -1,30 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`when Icon is LOCK_FULL MTLSIcon renders properly 1`] = `
-<OverlayTrigger
-  defaultOverlayShown={false}
-  overlay={
-    <Tooltip
-      bsClass="tooltip"
-      id="mtls-status-masthead"
-      placement="right"
-    >
-      Overlay Test
-    </Tooltip>
-  }
-  placement="left"
-  rootClose={false}
-  trigger={
+<Tooltip
+  appendTo={[Function]}
+  aria="describedby"
+  aria-label="mTLS status"
+  boundary="window"
+  className=""
+  content="Overlay Test"
+  distance={15}
+  enableFlip={true}
+  entryDelay={500}
+  exitDelay={500}
+  flipBehavior={
     Array [
-      "hover",
-      "focus",
+      "top",
+      "right",
+      "bottom",
+      "left",
+      "top",
+      "right",
+      "bottom",
     ]
   }
+  isAppLauncher={false}
+  maxWidth="18.75rem"
+  position="right"
+  trigger="mouseenter focus"
+  zIndex={9999}
 >
   <img
-    alt="left"
+    alt="right"
     className="className"
     src="mtls-status-full.svg"
   />
-</OverlayTrigger>
+</Tooltip>
 `;


### PR DESCRIPTION
** Describe the change **

Migration of mTLS tooltips from masthead and overview page.

** Issue reference **

Closes https://github.com/kiali/kiali/issues/1735

** Backwards compatible? **
yes

** Screenshot **
![Screenshot of Kiali Console (44)](https://user-images.githubusercontent.com/613814/65685544-838d4080-e062-11e9-8318-1b3ab49d0eeb.jpg)
![Screenshot of Kiali Console (43)](https://user-images.githubusercontent.com/613814/65685545-838d4080-e062-11e9-8a47-4bc47190eea3.jpg)
![Screenshot of Kiali Console (42)](https://user-images.githubusercontent.com/613814/65685546-838d4080-e062-11e9-94d3-54715cf81fb6.jpg)
![Screenshot of Kiali Console (41)](https://user-images.githubusercontent.com/613814/65685548-838d4080-e062-11e9-8aae-2b49944d6e04.jpg)

