### PR TITLE
Adapting validation icon colors to new PF4 color palette

### DIFF
--- a/src/components/Pf/PfColors.tsx
+++ b/src/components/Pf/PfColors.tsx
@@ -88,3 +88,9 @@ export enum PfColors {
   // Kiali colors that use PF colors
   Gray = '#72767b' // Black600
 }
+
+export enum PFColorVars {
+  DangerColor = '--pf-global--danger-color--100',
+  WarningColor = '--pf-global--warning-color--100',
+  SuccessColor = '--pf-global--success-color--100'
+}

--- a/src/components/Validations/Validation.tsx
+++ b/src/components/Validations/Validation.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { ErrorCircleOIcon, CheckCircleIcon, WarningTriangleIcon } from '@patternfly/react-icons';
-import { PfColors } from '../Pf/PfColors';
+import { CheckCircleIcon, ExclamationCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { IconType } from '@patternfly/react-icons/dist/js/createIcon';
 import { ValidationTypes } from '../../types/IstioObjects';
 import { Text, TextVariants } from '@patternfly/react-core';
 import './Validation.css';
+import { PFColorVars } from '../Pf/PfColors';
 
 type Props = ValidationDescription & {
   messageColor?: boolean;
@@ -26,19 +26,19 @@ export type ValidationType = {
 
 const ErrorValidation: ValidationType = {
   name: 'Not Valid',
-  color: PfColors.Red100,
-  icon: ErrorCircleOIcon
+  color: PFColorVars.DangerColor,
+  icon: ExclamationCircleIcon
 };
 
 const WarningValidation: ValidationType = {
   name: 'Warning',
-  color: PfColors.Orange400,
-  icon: WarningTriangleIcon
+  color: PFColorVars.WarningColor,
+  icon: ExclamationTriangleIcon
 };
 
 const CorrectValidation: ValidationType = {
   name: 'Valid',
-  color: PfColors.LightGreen400,
+  color: PFColorVars.SuccessColor,
   icon: CheckCircleIcon
 };
 
@@ -54,7 +54,7 @@ class Validation extends React.Component<Props> {
   }
 
   severityColor() {
-    return { color: this.validation().color };
+    return { color: `var(${this.validation().color})` };
   }
 
   textStyle() {


### PR DESCRIPTION
** Describe the change **

All validations colors are following the alert color palette from PF4: https://www.patternfly.org/v4/design-guidelines/styles/colors

Closes https://github.com/kiali/kiali/issues/1719

** Issue reference **
https://github.com/kiali/kiali/issues/1719

** Backwards compatible? **
yes

** Screenshot **

![Screenshot of Kiali Console (45)](https://user-images.githubusercontent.com/613814/65697159-bfcc9b00-e07a-11e9-9e97-696b07c1ee57.jpg)

![Screenshot of Kiali Console (46)](https://user-images.githubusercontent.com/613814/65697165-c1965e80-e07a-11e9-9977-a1229a6006df.jpg)
