### PR TITLE
Health and validations icon colors now are down to 100

### DIFF
--- a/src/components/Health/__tests__/__snapshots__/HealthIndicator.test.tsx.snap
+++ b/src/components/Health/__tests__/__snapshots__/HealthIndicator.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`HealthIndicator renders healthy 1`] = `
                   Object {
                     "status": Object {
                       "class": "icon-healthy",
-                      "color": "var(--pf-global--success-color--200)",
+                      "color": "var(--pf-global--success-color--100)",
                       "icon": [Function],
                       "name": "Healthy",
                       "priority": 1,
@@ -29,7 +29,7 @@ exports[`HealthIndicator renders healthy 1`] = `
                   Object {
                     "status": Object {
                       "class": "icon-healthy",
-                      "color": "var(--pf-global--success-color--200)",
+                      "color": "var(--pf-global--success-color--100)",
                       "icon": [Function],
                       "name": "Healthy",
                       "priority": 1,
@@ -39,7 +39,7 @@ exports[`HealthIndicator renders healthy 1`] = `
                 ],
                 "status": Object {
                   "class": "icon-healthy",
-                  "color": "var(--pf-global--success-color--200)",
+                  "color": "var(--pf-global--success-color--100)",
                   "icon": [Function],
                   "name": "Healthy",
                   "priority": 1,
@@ -100,7 +100,7 @@ exports[`HealthIndicator renders healthy 1`] = `
 >
   <CheckCircleIcon
     className="icon-healthy"
-    color="var(--pf-global--success-color--200)"
+    color="var(--pf-global--success-color--100)"
     noVerticalAlign={false}
     size="sm"
     title={null}

--- a/src/components/Pf/PfColors.tsx
+++ b/src/components/Pf/PfColors.tsx
@@ -90,7 +90,7 @@ export enum PfColors {
 }
 
 export enum PFColorVars {
-  DangerColor = 'var(--pf-global--danger-color--200)',
-  WarningColor = 'var(--pf-global--warning-color--200)',
-  SuccessColor = 'var(--pf-global--success-color--200)'
+  DangerColor = 'var(--pf-global--danger-color--100)',
+  WarningColor = 'var(--pf-global--warning-color--100)',
+  SuccessColor = 'var(--pf-global--success-color--100)'
 }


### PR DESCRIPTION
** Describe the change **

Changing colors to first palette of colors: 100 instead of 200.

Following this color guide: https://www.patternfly.org/v4/design-guidelines/styles/colors

** Screenshot **
Previous:
![Screenshot of Kiali Console (55)](https://user-images.githubusercontent.com/613814/65956437-aea0d700-e44a-11e9-87f8-f7cf4e66c95e.jpg)

Now:
![Screenshot of Kiali Console (54)](https://user-images.githubusercontent.com/613814/65956319-5ff33d00-e44a-11e9-9d47-80fc231538b7.jpg)

