### PR TITLE
Fix Kiosk mode not working

### DIFF
--- a/src/styles/_overrides.scss
+++ b/src/styles/_overrides.scss
@@ -354,3 +354,16 @@ Inline Alerts: background transparent
 .stack_service_details {
   height: 20%;
 }
+
+/*
+Kiosk mode
+*/
+html.kiosk {
+  #page-sidebar {
+    display: none;
+  }
+
+  header[role='banner'] {
+    display: none;
+  }
+}


### PR DESCRIPTION
Because of the PF4 migration, styles changed a lot and, most likely, PF3 Kiosk mode styles lost effect. The new PF4 styles for Kiosk mode were omitted. This is adding the required styles for Kiosk mode to properly work.

Fixes kiali/kiali#1758.