### PR TITLE
Move health indicator popover to PF4

### DIFF
--- a/src/components/Health/HealthIndicator.tsx
+++ b/src/components/Health/HealthIndicator.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { OverlayTrigger, Popover } from 'patternfly-react';
+import { Popover, PopoverPosition } from '@patternfly/react-core';
 import { HealthDetails } from './HealthDetails';
 import * as H from '../../types/Health';
 import { createIcon } from './Helper';
@@ -15,7 +15,7 @@ interface Props {
   id: string;
   health?: H.Health;
   mode: DisplayMode;
-  tooltipPlacement?: string;
+  tooltipPlacement?: PopoverPosition;
 }
 
 interface HealthState {
@@ -69,20 +69,15 @@ export class HealthIndicator extends React.PureComponent<Props, HealthState> {
   }
 
   renderPopover(health: H.Health, icon: JSX.Element) {
-    const popover = (
-      <Popover id={this.props.id + '-health-tooltip'} title={this.state.globalStatus.name}>
-        <HealthDetails health={health} />
-      </Popover>
-    );
     return (
-      <OverlayTrigger
-        placement={this.props.tooltipPlacement || 'right'}
-        overlay={popover}
-        trigger={['hover', 'focus']}
-        rootClose={false}
+      <Popover
+        aria-label={'Health indicator'}
+        headerContent={this.state.globalStatus.name}
+        bodyContent={<HealthDetails health={health} />}
+        position={this.props.tooltipPlacement || PopoverPosition.auto}
       >
         {icon}
-      </OverlayTrigger>
+      </Popover>
     );
   }
 }

--- a/src/components/Health/__tests__/__snapshots__/HealthIndicator.test.tsx.snap
+++ b/src/components/Health/__tests__/__snapshots__/HealthIndicator.test.tsx.snap
@@ -1,102 +1,117 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`HealthIndicator renders healthy 1`] = `
-<OverlayTrigger
-  defaultOverlayShown={false}
-  overlay={
-    <Popover
-      bsClass="popover"
-      id="svc-health-tooltip"
-      placement="right"
-      title="Healthy"
-    >
-      <HealthDetails
-        health={
-          AppHealth {
-            "items": Array [
-              Object {
-                "children": Array [
-                  Object {
-                    "status": Object {
-                      "class": "icon-healthy",
-                      "color": "var(--pf-global--success-color--100)",
-                      "icon": [Function],
-                      "name": "Healthy",
-                      "priority": 1,
-                    },
-                    "text": "A: 1 / 1",
+<Popover
+  appendTo={[Function]}
+  aria-label="Health indicator"
+  bodyContent={
+    <HealthDetails
+      health={
+        AppHealth {
+          "items": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "status": Object {
+                    "class": "icon-healthy",
+                    "color": "var(--pf-global--success-color--100)",
+                    "icon": [Function],
+                    "name": "Healthy",
+                    "priority": 1,
                   },
-                  Object {
-                    "status": Object {
-                      "class": "icon-healthy",
-                      "color": "var(--pf-global--success-color--100)",
-                      "icon": [Function],
-                      "name": "Healthy",
-                      "priority": 1,
-                    },
-                    "text": "B: 2 / 2",
-                  },
-                ],
-                "status": Object {
-                  "class": "icon-healthy",
-                  "color": "var(--pf-global--success-color--100)",
-                  "icon": [Function],
-                  "name": "Healthy",
-                  "priority": 1,
+                  "text": "A: 1 / 1",
                 },
-                "title": "Pods Status",
-              },
-              Object {
-                "children": Array [
-                  Object {
-                    "status": Object {
-                      "class": "icon-na",
-                      "color": "#72767b",
-                      "icon": [Function],
-                      "name": "No health information",
-                      "priority": 0,
-                    },
-                    "text": "Inbound: No requests",
+                Object {
+                  "status": Object {
+                    "class": "icon-healthy",
+                    "color": "var(--pf-global--success-color--100)",
+                    "icon": [Function],
+                    "name": "Healthy",
+                    "priority": 1,
                   },
-                  Object {
-                    "status": Object {
-                      "class": "icon-na",
-                      "color": "#72767b",
-                      "icon": [Function],
-                      "name": "No health information",
-                      "priority": 0,
-                    },
-                    "text": "Outbound: No requests",
-                  },
-                ],
-                "status": Object {
-                  "class": "icon-na",
-                  "color": "#72767b",
-                  "icon": [Function],
-                  "name": "No health information",
-                  "priority": 0,
+                  "text": "B: 2 / 2",
                 },
-                "title": "Error Rate over last 10m",
+              ],
+              "status": Object {
+                "class": "icon-healthy",
+                "color": "var(--pf-global--success-color--100)",
+                "icon": [Function],
+                "name": "Healthy",
+                "priority": 1,
               },
-            ],
-            "requests": Object {
-              "errorRatio": -1,
-              "inboundErrorRatio": -1,
-              "outboundErrorRatio": -1,
+              "title": "Pods Status",
             },
-          }
+            Object {
+              "children": Array [
+                Object {
+                  "status": Object {
+                    "class": "icon-na",
+                    "color": "#72767b",
+                    "icon": [Function],
+                    "name": "No health information",
+                    "priority": 0,
+                  },
+                  "text": "Inbound: No requests",
+                },
+                Object {
+                  "status": Object {
+                    "class": "icon-na",
+                    "color": "#72767b",
+                    "icon": [Function],
+                    "name": "No health information",
+                    "priority": 0,
+                  },
+                  "text": "Outbound: No requests",
+                },
+              ],
+              "status": Object {
+                "class": "icon-na",
+                "color": "#72767b",
+                "icon": [Function],
+                "name": "No health information",
+                "priority": 0,
+              },
+              "title": "Error Rate over last 10m",
+            },
+          ],
+          "requests": Object {
+            "errorRatio": -1,
+            "inboundErrorRatio": -1,
+            "outboundErrorRatio": -1,
+          },
         }
-      />
-    </Popover>
+      }
+    />
   }
-  placement="right"
-  rootClose={false}
-  trigger={
+  boundary="window"
+  className=""
+  closeBtnAriaLabel="Close"
+  distance={25}
+  enableFlip={true}
+  flipBehavior={
     Array [
-      "hover",
-      "focus",
+      "top",
+      "right",
+      "bottom",
+      "left",
+      "top",
+      "right",
+      "bottom",
     ]
   }
+  footerContent={null}
+  headerContent="Healthy"
+  hideOnOutsideClick={true}
+  isVisible={null}
+  maxWidth="calc(2rem + 18.75rem)"
+  onHidden={[Function]}
+  onHide={[Function]}
+  onMount={[Function]}
+  onShow={[Function]}
+  onShown={[Function]}
+  position="auto"
+  shouldClose={[Function]}
+  zIndex={9999}
 >
   <CheckCircleIcon
     className="icon-healthy"
@@ -105,5 +120,5 @@ exports[`HealthIndicator renders healthy 1`] = `
     size="sm"
     title={null}
   />
-</OverlayTrigger>
+</Popover>
 `;

--- a/src/pages/AppDetails/AppInfo/AppDescription.tsx
+++ b/src/pages/AppDetails/AppInfo/AppDescription.tsx
@@ -140,12 +140,7 @@ class AppDescription extends React.Component<AppDescriptionProps, AppDescription
                 <Text component={TextVariants.h2}>Health Overview</Text>
                 <strong>Health</strong>
               </div>
-              <HealthIndicator
-                id={app.name}
-                health={this.props.health}
-                mode={DisplayMode.LARGE}
-                tooltipPlacement="left"
-              />
+              <HealthIndicator id={app.name} health={this.props.health} mode={DisplayMode.LARGE} />
             </CardBody>
           </Card>
         </GridItem>

--- a/src/pages/Graph/SummaryPanelGroup.tsx
+++ b/src/pages/Graph/SummaryPanelGroup.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Badge } from '@patternfly/react-core';
+import { Badge, PopoverPosition } from '@patternfly/react-core';
 import { Icon } from 'patternfly-react';
 import { InOutRateTableGrpc, InOutRateTableHttp } from '../../components/SummaryPanel/InOutRateTable';
 import { RpsChart, TcpChart } from '../../components/SummaryPanel/RpsChart';
@@ -116,7 +116,7 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
                 id="graph-health-indicator"
                 mode={DisplayMode.SMALL}
                 health={this.state.health}
-                tooltipPlacement="left"
+                tooltipPlacement={PopoverPosition.left}
               />
             )
           )}

--- a/src/pages/Graph/SummaryPanelNode.tsx
+++ b/src/pages/Graph/SummaryPanelNode.tsx
@@ -36,6 +36,7 @@ import { Response } from '../../services/Api';
 import { Reporter } from '../../types/MetricsOptions';
 import { icons } from '../../config/Icons';
 import { CyNode, decoratedNodeData } from '../../components/CytoscapeGraph/CytoscapeGraphUtils';
+import { PopoverPosition } from '@patternfly/react-core';
 
 type SummaryPanelStateType = {
   loading: boolean;
@@ -305,7 +306,7 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
                 id="graph-health-indicator"
                 mode={DisplayMode.SMALL}
                 health={this.state.health}
-                tooltipPlacement="left"
+                tooltipPlacement={PopoverPosition.left}
               />
             )
           )}

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
@@ -112,12 +112,7 @@ class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps
               <Stack className={'stack_service_details'}>
                 <StackItem id={'health'}>
                   <Text component={TextVariants.h3}> Health </Text>
-                  <HealthIndicator
-                    id={this.props.name}
-                    health={this.props.health}
-                    mode={DisplayMode.LARGE}
-                    tooltipPlacement="left"
-                  />
+                  <HealthIndicator id={this.props.name} health={this.props.health} mode={DisplayMode.LARGE} />
                 </StackItem>
               </Stack>
               <Title headingLevel="h3" size="2xl" style={{ marginTop: '60px' }}>

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
@@ -111,7 +111,6 @@ exports[`#ServiceInfoDescription render correctly with data should render servic
             <HealthIndicator
               id="reviews"
               mode={0}
-              tooltipPlacement="left"
             />
           </StackItem>
         </Stack>

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadDescription.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadDescription.tsx
@@ -77,12 +77,7 @@ class WorkloadDescription extends React.Component<WorkloadDescriptionProps, Work
               <div className="progress-description">
                 <strong>Health</strong>
               </div>
-              <HealthIndicator
-                id={workload.name}
-                health={this.props.health}
-                mode={DisplayMode.LARGE}
-                tooltipPlacement="left"
-              />
+              <HealthIndicator id={workload.name} health={this.props.health} mode={DisplayMode.LARGE} />
             </Col>
           </Row>
         </div>

--- a/src/pages/WorkloadDetails/WorkloadInfo/__tests__/__snapshots__/WorkloadDescription.test.tsx.snap
+++ b/src/pages/WorkloadDetails/WorkloadInfo/__tests__/__snapshots__/WorkloadDescription.test.tsx.snap
@@ -106,7 +106,6 @@ exports[`WorkloadDescription should render with runtimes 1`] = `
         <HealthIndicator
           id="myworkload"
           mode={0}
-          tooltipPlacement="left"
         />
       </Col>
     </Row>


### PR DESCRIPTION
Relates to https://github.com/kiali/kiali/issues/1720 (but without mockup implementation)

Please note, there's a small regression, it seems in PF4 popovers cannot be triggered on mouseenter anymore. Also, it creates some divergence with the istio config indicator which uses Tooltip instead of Popover. I also tried Tooltip but it's supposed to be used for small texts - not the case here. Also, text in tooltips are centered, which is not desirable for health. Probably this needs to be harmonised.

![Capture d’écran de 2019-10-11 10-08-26](https://user-images.githubusercontent.com/2153442/66635297-31761e80-ec0f-11e9-9dfa-62079b12f1b4.png)
