### PR TITLE
For loop edges, try to avoid overlap with other edges

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -49,6 +49,7 @@ import GraphThunkActions from '../../actions/GraphThunkActions';
 import * as MessageCenterUtils from '../../utils/MessageCenter';
 import FocusAnimation from './FocusAnimation';
 import { CytoscapeContextMenuWrapper, NodeContextMenuType, EdgeContextMenuType } from './CytoscapeContextMenu';
+import { angleBetweenVectors, squaredDistance, normalize } from '../../utils/MathUtils';
 
 type ReduxProps = {
   activeNamespaces: Namespace[];
@@ -457,6 +458,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
     cy.on('layoutstop', (_evt: any) => {
       // Don't allow a large zoom if the graph has a few nodes (nodes would look too big).
       this.safeFit(cy);
+      this.fixLoopOverlap(cy);
     });
 
     cy.ready((evt: any) => {
@@ -858,6 +860,90 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
         }
         console.error(`Could not fetch health for [${ele.data(CyNode.nodeType)}] [${key}]: ${API.getErrorString(err)}`);
       });
+  }
+
+  private fixLoopOverlap(cy: any) {
+    cy.$(':loop').forEach(loop => {
+      const node = loop.source();
+      const otherEdges = node.connectedEdges().subtract(loop);
+      const minDistance = 1;
+
+      // Default values in rads (taken from cytoscape docs)
+      const DEFAULT_LOOP_SWEEP = -1.5707;
+      const DEFAULT_LOOP_DIRECTION = -0.7854;
+
+      loop.style('loop-direction', DEFAULT_LOOP_DIRECTION);
+      loop.style('loop-sweep', DEFAULT_LOOP_SWEEP);
+
+      let found = false;
+      otherEdges.forEach(edge => {
+        const testPoint = edge.source().same(node) ? edge.sourceEndpoint() : edge.targetEndpoint();
+        if (
+          squaredDistance(testPoint, loop.sourceEndpoint()) <= minDistance ||
+          squaredDistance(testPoint, loop.targetEndpoint()) <= minDistance
+        ) {
+          found = true;
+        }
+      });
+
+      if (!found) {
+        return;
+      }
+
+      if (otherEdges.length === 1) {
+        const loopDirection = loop.numericStyle('loop-direction') - loop.numericStyle('loop-sweep') * 0.5;
+        loop.style('loop-direction', loopDirection);
+        return;
+      }
+
+      // Compute every angle, sort it and find the best place to place the loop
+      const usedAngles: number[] = [];
+
+      otherEdges.forEach(edge => {
+        const testPoint = edge.source().same(node) ? edge.sourceEndpoint() : edge.targetEndpoint();
+        const angle = angleBetweenVectors(
+          normalize({ x: testPoint.x - node.position().x, y: testPoint.y - node.position().y }),
+          { x: 0, y: 1 }
+        );
+        usedAngles.push(angle < 0 ? angle + 2 * Math.PI : angle);
+      });
+
+      usedAngles.sort((a, b) => a - b);
+
+      // Try to fit in the longest arc
+      let maxArc = {
+        start: 0,
+        end: 0,
+        value: 0
+      };
+      for (let i = 0; i < usedAngles.length; ++i) {
+        const start = i === 0 ? usedAngles[usedAngles.length - 1] : usedAngles[i - 1];
+        const end = usedAngles[i];
+        const arc = Math.abs(start - end);
+        if (arc > maxArc.value) {
+          maxArc.value = arc;
+          maxArc.start = start;
+          maxArc.end = end;
+        }
+      }
+
+      // If the max arc is 1.0 radians, the node is already too busy, ignore it
+      if (maxArc.value < 1.0) {
+        return;
+      }
+
+      if (maxArc.start > maxArc.end) {
+        maxArc.start += Math.PI * 2;
+      }
+
+      if (maxArc.value <= -DEFAULT_LOOP_SWEEP) {
+        // Make it slightly smaller to be able to fit
+        loop.style('loop-sweep', -maxArc.value * 0.9);
+        maxArc.start += maxArc.value * 0.05;
+        maxArc.end -= maxArc.value * 0.05;
+      }
+      loop.style('loop-direction', maxArc.start + (maxArc.end - maxArc.start) * 0.5);
+    });
   }
 }
 

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -877,6 +877,7 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
 
       let found = false;
       // Check if we have any other edge that overlaps with any of our loop edges
+      // this uses cytoscape forEach (https://js.cytoscape.org/#eles.forEach)
       otherEdges.forEach(edge => {
         const testPoint = edge.source().same(node) ? edge.sourceEndpoint() : edge.targetEndpoint();
         if (
@@ -884,9 +885,9 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
           squaredDistance(testPoint, loop.targetEndpoint()) <= minDistance
         ) {
           found = true;
-          return false; // break the cytoscape forEach
+          return false; // break the inner cytoscape forEach
         }
-        return true;
+        return; // return to avoid typescript error about "not all code paths return a value"
       });
 
       if (!found) {

--- a/src/utils/MathUtils.ts
+++ b/src/utils/MathUtils.ts
@@ -3,6 +3,8 @@ export interface Point {
   y: number;
 }
 
+type Vector = Point;
+
 // Restricts value x to [min, max], if outside, moves to the nearest available value.
 export const clamp = (x, min, max) => {
   return x < min ? min : x > max ? max : x;
@@ -56,4 +58,21 @@ export const bezierLength = (p0: Point, p1: Point, p2: Point) => {
 
 export const distance = (p0: Point, p1: Point) => {
   return Math.sqrt(Math.pow(p0.x - p1.x, 2) + Math.pow(p0.y - p1.y, 2));
+};
+
+export const squaredDistance = (p0: Point, p1: Point) => {
+  return Math.pow(p0.x - p1.x, 2) + Math.pow(p0.y - p1.y, 2);
+};
+
+export const normalize = (v1: Vector): Vector => {
+  const norm = Math.sqrt(v1.x * v1.x + v1.y * v1.y);
+  return {
+    x: v1.x / norm,
+    y: v1.y / norm
+  };
+};
+
+// http://www.euclideanspace.com/maths/algebra/vectors/angleBetween/index.htm
+export const angleBetweenVectors = (v1: Vector, v2: Vector) => {
+  return Math.atan2(v2.y, v2.x) - Math.atan2(v1.y, v1.x);
 };


### PR DESCRIPTION
** Describe the change **

It tries to move the loop edges when it finds overlaps with other edges

Fixes kiali/kiali#1610

** Screenshot **

Before:

![Screenshot_2019-10-14_11-39-54](https://user-images.githubusercontent.com/3845764/66768144-861bd280-ee77-11e9-8559-6286645a6b6a.png)

After:
![Screenshot_2019-10-14_11-21-38](https://user-images.githubusercontent.com/3845764/66768147-86b46900-ee77-11e9-8824-604d0dc9d418.png)

Before:
![Screenshot_2019-10-14_11-39-36](https://user-images.githubusercontent.com/3845764/66768145-861bd280-ee77-11e9-9ce0-c6384ad90bd1.png)

After:

![Screenshot_2019-10-14_11-21-56](https://user-images.githubusercontent.com/3845764/66768146-86b46900-ee77-11e9-8dc9-a57e104539fa.png)




