### PR TITLE
migrate breadcrumb to PF4 in lists

### DIFF
--- a/src/pages/AppList/AppListPage.tsx
+++ b/src/pages/AppList/AppListPage.tsx
@@ -1,14 +1,18 @@
 import * as React from 'react';
-import { Breadcrumb } from 'patternfly-react';
 import * as FilterHelper from '../../components/FilterList/FilterHelper';
 import AppListContainer from './AppListComponent';
 import * as AppListFilters from './FiltersAndSorts';
+import { Breadcrumb, BreadcrumbItem, Title } from '@patternfly/react-core';
 
 const AppListPage: React.SFC<{}> = () => {
   return (
     <>
-      <Breadcrumb title={true}>
-        <Breadcrumb.Item active={true}>Applications</Breadcrumb.Item>
+      <Breadcrumb style={{ margin: '10px 0px 10px 0px' }}>
+        <BreadcrumbItem isActive={true}>
+          <Title headingLevel="h4" size="xl">
+            Applications
+          </Title>
+        </BreadcrumbItem>
       </Breadcrumb>
       <AppListContainer
         currentSortField={FilterHelper.currentSortField(AppListFilters.sortFields)}

--- a/src/pages/IstioConfigList/IstioConfigListPage.tsx
+++ b/src/pages/IstioConfigList/IstioConfigListPage.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Breadcrumb } from 'patternfly-react';
+import { Breadcrumb, BreadcrumbItem, Title } from '@patternfly/react-core';
 import * as FilterHelper from '../../components/FilterList/FilterHelper';
 import * as IstioConfigListFilters from './FiltersAndSorts';
 import IstioConfigListContainer from './IstioConfigListComponent';
@@ -7,8 +7,12 @@ import IstioConfigListContainer from './IstioConfigListComponent';
 const IstioConfigListPage: React.SFC<{}> = () => {
   return (
     <>
-      <Breadcrumb title={true}>
-        <Breadcrumb.Item active={true}>Istio Config</Breadcrumb.Item>
+      <Breadcrumb style={{ margin: '10px 0px 10px 0px' }}>
+        <BreadcrumbItem isActive={true}>
+          <Title headingLevel="h4" size="xl">
+            Istio Config
+          </Title>
+        </BreadcrumbItem>
       </Breadcrumb>
       <IstioConfigListContainer
         currentSortField={FilterHelper.currentSortField(IstioConfigListFilters.sortFields)}

--- a/src/pages/ServiceList/ServiceListPage.tsx
+++ b/src/pages/ServiceList/ServiceListPage.tsx
@@ -1,14 +1,18 @@
 import * as React from 'react';
 import ServiceListContainer from '../../pages/ServiceList/ServiceListComponent';
-import { Breadcrumb } from 'patternfly-react';
 import * as FilterHelper from '../../components/FilterList/FilterHelper';
 import * as ServiceListFilters from './FiltersAndSorts';
+import { Breadcrumb, BreadcrumbItem, Title } from '@patternfly/react-core';
 
 const ServiceListPage: React.SFC<{}> = () => {
   return (
     <>
-      <Breadcrumb title={true}>
-        <Breadcrumb.Item active={true}>Services</Breadcrumb.Item>
+      <Breadcrumb style={{ margin: '10px 0px 10px 0px' }}>
+        <BreadcrumbItem isActive={true}>
+          <Title headingLevel="h4" size="xl">
+            Services
+          </Title>
+        </BreadcrumbItem>
       </Breadcrumb>
       <ServiceListContainer
         currentSortField={FilterHelper.currentSortField(ServiceListFilters.sortFields)}

--- a/src/pages/WorkloadList/WorkloadListPage.tsx
+++ b/src/pages/WorkloadList/WorkloadListPage.tsx
@@ -1,14 +1,18 @@
 import * as React from 'react';
-import { Breadcrumb } from 'patternfly-react';
 import * as FilterHelper from '../../components/FilterList/FilterHelper';
 import WorkloadListContainer from './WorkloadListComponent';
 import * as WorkloadListFilters from './FiltersAndSorts';
+import { Breadcrumb, BreadcrumbItem, Title } from '@patternfly/react-core';
 
 const WorkloadListPage: React.SFC<{}> = () => {
   return (
     <>
-      <Breadcrumb title={true}>
-        <Breadcrumb.Item active={true}>Workloads</Breadcrumb.Item>
+      <Breadcrumb style={{ margin: '10px 0px 10px 0px' }}>
+        <BreadcrumbItem isActive={true}>
+          <Title headingLevel="h4" size="xl">
+            Workloads
+          </Title>
+        </BreadcrumbItem>
       </Breadcrumb>
       <WorkloadListContainer
         currentSortField={FilterHelper.currentSortField(WorkloadListFilters.sortFields)}


### PR DESCRIPTION
Related with old tracker JIRA [PF4] Migrate Breadcrumb

## Before
![Before](https://user-images.githubusercontent.com/3019213/66826142-09a6f380-ef4c-11e9-9944-3f8fa94c2fa9.png)
## Now
![now](https://user-images.githubusercontent.com/3019213/66826141-090e5d00-ef4c-11e9-8ede-a5383e84bbe6.png)

