### PR TITLE
1567 Fix Icon size, add icon to title, use path to accept relative specs

### DIFF
--- a/src/components/ApiDocumentation/ApiDocumentation.tsx
+++ b/src/components/ApiDocumentation/ApiDocumentation.tsx
@@ -22,6 +22,7 @@ declare global {
 
 interface ApiDocumentationProps {
   apiType: string;
+  apiPath: string;
   namespace: string;
   service: string;
 }
@@ -33,7 +34,7 @@ export class ApiDocumentation extends React.Component<ApiDocumentationProps> {
     return (
       <div>
         <rapi-doc
-          spec-url={urls.serviceApiDocumentation(this.props.namespace, this.props.service)}
+          spec-url={urls.serviceApiDocumentation(this.props.namespace, this.props.service, this.props.apiPath)}
           show-header="false"
           show-info="false"
           allow-authentication="false"

--- a/src/components/ApiDocumentation/ApiTypeIndicator.tsx
+++ b/src/components/ApiDocumentation/ApiTypeIndicator.tsx
@@ -18,7 +18,7 @@ const nameToSource = new Map<string, string>([
 const iconStyle = style({
   marginTop: -2,
   marginRight: 6,
-  width: 30
+  height: 30
 });
 
 export class ApiTypeIndicator extends React.Component<Props> {

--- a/src/components/Pf/PfTitle.tsx
+++ b/src/components/Pf/PfTitle.tsx
@@ -5,6 +5,7 @@ import { ServiceIcon, BundleIcon, ApplicationsIcon } from '@patternfly/react-ico
 import { CytoscapeGraphSelectorBuilder } from '../CytoscapeGraph/CytoscapeGraphSelector';
 import { style } from 'typestyle';
 import { NodeType } from '../../types/Graph';
+import { ApiTypeIndicator } from '../ApiDocumentation/ApiTypeIndicator';
 
 const PfTitleStyle = style({
   fontSize: '19px',
@@ -19,6 +20,7 @@ interface PfTitleProps {
     search: string;
   };
   istio?: boolean;
+  apiType?: string;
 }
 
 interface PfTitleState {
@@ -115,6 +117,11 @@ class PfTitle extends React.Component<PfTitleProps, PfTitleState> {
     return (
       <h2 className={PfTitleStyle}>
         {this.state.icon} {this.state.name}
+        {this.props.apiType !== undefined && this.props.apiType !== '' && (
+          <span style={{ marginLeft: '10px' }}>
+            <ApiTypeIndicator apiType={this.props.apiType} />
+          </span>
+        )}
         {this.state.name && this.props.istio !== undefined && !this.props.istio && (
           <span style={{ marginLeft: '10px' }}>
             <MissingSidecar namespace={this.state.namespace} />

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -98,8 +98,8 @@ const conf = {
       service: (namespace: string, service: string) => `api/namespaces/${namespace}/services/${service}`,
       serviceGraphElements: (namespace: string, service: string) =>
         `api/namespaces/${namespace}/services/${service}/graph`,
-      serviceApiDocumentation: (namespace: string, service: string) =>
-        `api/namespaces/${namespace}/services/${service}/apispec`,
+      serviceApiDocumentation: (namespace: string, service: string, path: string) =>
+        `api/namespaces/${namespace}/services/${service}/apispec/${path}`,
       serviceHealth: (namespace: string, service: string) => `api/namespaces/${namespace}/services/${service}/health`,
       serviceMetrics: (namespace: string, service: string) => `api/namespaces/${namespace}/services/${service}/metrics`,
       serviceDashboard: (namespace: string, service: string) =>

--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -83,7 +83,7 @@ const emptyService: ServiceDetailsInfo = {
   validations: {},
   apiDocumentation: {
     type: '',
-    hasSpec: false
+    path: ''
   },
   additionalDetails: []
 };
@@ -95,7 +95,8 @@ const tabIndex: { [tab: string]: number } = {
   info: 0,
   traffic: 1,
   metrics: 2,
-  traces: 3
+  traces: 3,
+  api: 4
 };
 
 class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetailsState> {
@@ -435,12 +436,13 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
       tabsArray.push(jaegerTag);
     }
 
-    if (this.state.serviceDetailsInfo.apiDocumentation && this.state.serviceDetailsInfo.apiDocumentation.hasSpec) {
+    if (this.state.serviceDetailsInfo.apiDocumentation && this.state.serviceDetailsInfo.apiDocumentation.path !=='') {
       const docTabIndex = tabsArray.length;
       const docTab: any = (
         <Tab eventKey={docTabIndex} title={'API Doc'} key="API Doc">
           <ApiDocumentation
             apiType={this.state.serviceDetailsInfo.apiDocumentation.type}
+            apiPath={this.state.serviceDetailsInfo.apiDocumentation.path}
             namespace={this.props.match.params.namespace}
             service={this.props.match.params.service}
           />
@@ -453,7 +455,7 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
       <>
         <RenderHeader>
           <BreadcrumbView location={this.props.location} />
-          <PfTitle location={this.props.location} istio={this.state.serviceDetailsInfo.istioSidecar} />
+          <PfTitle location={this.props.location} istio={this.state.serviceDetailsInfo.istioSidecar} apiType={this.state.serviceDetailsInfo.apiDocumentation ? this.state.serviceDetailsInfo.apiDocumentation.type : ''} />
           {this.renderActions()}
         </RenderHeader>
         <ParameterizedTabs

--- a/src/services/__mockData__/getServiceDetail.ts
+++ b/src/services/__mockData__/getServiceDetail.ts
@@ -50,7 +50,7 @@ export const SERVICE_DETAILS: ServiceDetailsInfo = {
     }
   ],
   apiDocumentation: {
-    hasSpec: true,
+    path: '/api.json',
     type: 'rest'
   },
   virtualServices: {

--- a/src/types/ServiceInfo.ts
+++ b/src/types/ServiceInfo.ts
@@ -33,7 +33,7 @@ export interface WorkloadOverview {
 
 export interface ApiDocumentation {
   type: string;
-  hasSpec: boolean;
+  path: string;
 }
 
 export interface Service {


### PR DESCRIPTION
** Describe the change **

- Use height to size apidocs icons so GRPC is displayed properly
- Add API Icon to Title  of ServiceDetails page
- Use path to allow relative spec fetching from UI

** Issue reference **

https://github.com/kiali/kiali/issues/1567

** Backwards compatible? **

Needs backend https://github.com/kiali/kiali/pull/1815
