### PR TITLE
Create Pf4Icon function to consolidate all of the icons into a single place

### DIFF
--- a/src/config/KialiIcon.tsx
+++ b/src/config/KialiIcon.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { PfColors } from '../components/Pf/PfColors';
+import {
+  ApplicationsIcon,
+  BundleIcon,
+  ErrorCircleOIcon,
+  InfoAltIcon,
+  OkIcon,
+  ServiceIcon,
+  TopologyIcon,
+  UnknownIcon,
+  WarningTriangleIcon,
+  CodeBranchIcon,
+  BoltIcon,
+  LockIcon,
+  LockOpenIcon
+} from '@patternfly/react-icons';
+
+export const KialiIcon = {
+  Info: () => <InfoAltIcon />,
+  Ok: () => <OkIcon color={PfColors.Green400} />,
+  Warning: () => <WarningTriangleIcon color={PfColors.Orange400} />,
+  Error: () => <ErrorCircleOIcon color={PfColors.Red100} />,
+  Unknown: () => <UnknownIcon />,
+  Topology: () => <TopologyIcon />,
+  Service: () => <ServiceIcon />,
+  Applications: () => <ApplicationsIcon />,
+  Bundle: () => <BundleIcon />,
+  CircuitBreaker: () => <BoltIcon />,
+  MissingSidecar: () => <CodeBranchIcon />,
+  MtlsLock: () => <LockIcon />,
+  MtlsUnlock: () => <LockOpenIcon />
+};

--- a/src/pages/Graph/SummaryPanelNode.tsx
+++ b/src/pages/Graph/SummaryPanelNode.tsx
@@ -37,6 +37,7 @@ import { Reporter } from '../../types/MetricsOptions';
 import { icons } from '../../config/Icons';
 import { CyNode, decoratedNodeData } from '../../components/CytoscapeGraph/CytoscapeGraphUtils';
 import { PopoverPosition } from '@patternfly/react-core';
+import { KialiIcon } from 'config/KialiIcon';
 
 type SummaryPanelStateType = {
   loading: boolean;
@@ -399,7 +400,7 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
       return (
         <>
           <div>
-            <Icon type="pf" name="info" /> Sparkline charts not supported for unknown node. Use edge for details.
+            <KialiIcon.Info /> Sparkline charts not supported for unknown node. Use edge for details.
             <hr />
           </div>
         </>


### PR DESCRIPTION
Create a typesafe way to reuse Pf4Icons across Kiali-ui.  Also, makes changing the icons globally, very easy.

To use:
```
<div>
            <KialiIcon.Info /> Sparkline charts not supported for unknown node. Use edge for details.
            <hr />
</div>
```

** Issue reference **
closes https://github.com/kiali/kiali/issues/1813
