### PR TITLE
[v1.7] RpsChart: Fix array out of bound

### DIFF
--- a/src/components/SummaryPanel/RpsChart.tsx
+++ b/src/components/SummaryPanel/RpsChart.tsx
@@ -104,7 +104,7 @@ export class RpsChart extends React.Component<RpsChartTypeProp, {}> {
       minRps = sample < minRps ? sample : minRps;
       maxRps = sample > maxRps ? sample : maxRps;
       if (sample !== 0) {
-        errSample = i <= dataErrors.length ? dataErrors[i].y : 0;
+        errSample = i < dataErrors.length ? dataErrors[i].y : 0;
         const errPct = (100 * errSample) / sample;
         if (isNaN(minPctErr) || errPct < minPctErr) {
           minPctErr = errPct;


### PR DESCRIPTION
Backport https://github.com/kiali/kiali/issues/1800 on 1.7
