### PR TITLE
Trivial: Re-sync package.json version with back-end version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kiali/kiali-ui",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "React UI for [Kiali](https://github.com/kiali/kiali).",
   "keywords": [
     "istio service mesh",


### PR DESCRIPTION
This is re-synching version number with the one found in https://github.com/kiali/kiali/blob/master/Makefile#L6.

Because version 1.8 is the next one to be released at end of sprint.