### PR TITLE
[PF4] Replace PF3 icons with PF4 icons via KialiIcon.tsx.

### DIFF
--- a/src/components/About/AboutUIModal.tsx
+++ b/src/components/About/AboutUIModal.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { AboutModal, TextContent, TextList, TextListItem, Title, Button } from '@patternfly/react-core';
-import * as icons from '@patternfly/react-icons';
 import { Component, Status, StatusKey } from '../../types/StatusState';
 import { config, kialiLogo } from '../../config';
+import { style } from 'typestyle';
+import { KialiIcon } from 'config/KialiIcon';
 
 type AboutUIModalState = {
   showModal: boolean;
@@ -12,6 +13,10 @@ type AboutUIModalProps = {
   status: Status;
   components: Component[];
 };
+
+const iconStyle = style({
+  marginRight: '10px'
+});
 
 class AboutUIModal extends React.Component<AboutUIModalProps, AboutUIModalState> {
   constructor(props: AboutUIModalProps) {
@@ -104,11 +109,10 @@ class AboutUIModal extends React.Component<AboutUIModalProps, AboutUIModalState>
 
   private renderWebsiteLink = () => {
     if (config.about && config.about.website) {
-      const Icon = icons[config.about.website.icon];
       return (
         // @ts-ignore
         <Button component="a" href={config.about.website.url} variant="link" target="_blank">
-          <Icon style={{ marginRight: '10px' }} />
+          <KialiIcon.Website className={iconStyle} />
           {config.about.website.linkText}
         </Button>
       );
@@ -119,11 +123,10 @@ class AboutUIModal extends React.Component<AboutUIModalProps, AboutUIModalState>
 
   private renderProjectLink = () => {
     if (config.about && config.about.project) {
-      const Icon = icons[config.about.project.icon];
       return (
         // @ts-ignore
         <Button component="a" href={config.about.project.url} variant="link" target="_blank">
-          <Icon style={{ marginRight: '10px' }} />
+          <KialiIcon.Repository className={iconStyle} />
           {config.about.project.linkText}
         </Button>
       );

--- a/src/components/GraphFilter/GraphFind.tsx
+++ b/src/components/GraphFilter/GraphFind.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, FormControl, FormGroup, Icon, InputGroup, OverlayTrigger, Tooltip } from 'patternfly-react';
+import { Button, FormControl, FormGroup, InputGroup, OverlayTrigger, Tooltip } from 'patternfly-react';
 import { connect } from 'react-redux';
 import { ThunkDispatch } from 'redux-thunk';
 import { bindActionCreators } from 'redux';
@@ -13,6 +13,7 @@ import * as CytoscapeGraphUtils from '../CytoscapeGraph/CytoscapeGraphUtils';
 import { CyData, NodeType } from '../../types/Graph';
 import { Layout, EdgeLabelMode } from 'types/GraphFilter';
 import * as AlertUtils from '../../utils/AlertUtils';
+import { KialiIcon } from 'config/KialiIcon';
 
 type ReduxProps = {
   compressOnHide: boolean;
@@ -137,7 +138,7 @@ export class GraphFind extends React.PureComponent<GraphFindProps, GraphFindStat
                 >
                   <InputGroup.Button>
                     <Button onClick={this.clearFind}>
-                      <Icon name="close" type="fa" />
+                      <KialiIcon.Close />
                     </Button>
                   </InputGroup.Button>
                 </OverlayTrigger>
@@ -166,7 +167,7 @@ export class GraphFind extends React.PureComponent<GraphFindProps, GraphFindStat
                 >
                   <InputGroup.Button>
                     <Button onClick={this.clearHide}>
-                      <Icon name="close" type="fa" />
+                      <KialiIcon.Close />
                     </Button>
                   </InputGroup.Button>
                 </OverlayTrigger>
@@ -178,7 +179,7 @@ export class GraphFind extends React.PureComponent<GraphFindProps, GraphFindStat
               overlay={<Tooltip id={'tt_graph_find_help'}>Find/Hide Help...</Tooltip>}
             >
               <Button bsStyle="link" style={{ paddingLeft: '6px' }} onClick={this.toggleFindHelp}>
-                <Icon name="help" type="pf" />
+                <KialiIcon.Help />
               </Button>
             </OverlayTrigger>
           </span>

--- a/src/components/NamespaceDropdown.tsx
+++ b/src/components/NamespaceDropdown.tsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { ThunkDispatch } from 'redux-thunk';
 import _ from 'lodash';
 import { style } from 'typestyle';
-import { Button, FormControl, Icon, InputGroup, OverlayTrigger, Popover } from 'patternfly-react';
+import { Button, FormControl, InputGroup, OverlayTrigger, Popover } from 'patternfly-react';
 import { KialiAppState } from '../store/Store';
 import { activeNamespacesSelector, namespaceFilterSelector, namespaceItemsSelector } from '../store/Selectors';
 import { KialiAppAction } from '../actions/KialiAppAction';
@@ -16,6 +16,7 @@ import {
   BoundingClientAwareComponent,
   PropertyType
 } from './BoundingClientAwareComponent/BoundingClientAwareComponent';
+import { KialiIcon } from 'config/KialiIcon';
 
 const namespaceButtonColors = {
   backgroundColor: PfColors.White,
@@ -162,7 +163,7 @@ export class NamespaceDropdown extends React.PureComponent<NamespaceDropdownProp
               {this.props.filter !== '' && (
                 <InputGroup.Button>
                   <Button onClick={this.clearFilter}>
-                    <Icon name="close" />
+                    <KialiIcon.Close />
                   </Button>
                 </InputGroup.Button>
               )}
@@ -196,7 +197,7 @@ export class NamespaceDropdown extends React.PureComponent<NamespaceDropdownProp
         rootClose={true}
       >
         <Button bsClass={`btn btn-link btn-lg  ${namespaceButtonStyle}`} id="namespace-selector">
-          {this.namespaceButtonText()} <Icon name="angle-down" />
+          {this.namespaceButtonText()} <KialiIcon.AngleDown />
         </Button>
       </OverlayTrigger>
     );

--- a/src/components/Tour/Tour.tsx
+++ b/src/components/Tour/Tour.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
-import { Button, Icon } from 'patternfly-react';
+import { Button } from 'patternfly-react';
 import { PfColors } from '../Pf/PfColors';
 import ReactResizeDetector from 'react-resize-detector';
 import { style } from 'typestyle';
+import { KialiIcon } from 'config/KialiIcon';
 
 // We have to import it like this, because current index.d.ts file is broken for this component.
 const Floater = require('react-floater').default;
@@ -66,7 +67,7 @@ const BackButton = (props: TourProps) => {
   }
   return (
     <Button className={buttonTextStyle} onClick={props.onBack}>
-      <Icon type="fa" name="angle-left" /> Back
+      <KialiIcon.AngleLeft /> Back
     </Button>
   );
 };
@@ -78,7 +79,7 @@ const NextButton = (props: TourProps) => {
         'Done'
       ) : (
         <>
-          Next <Icon type="fa" name="angle-right" />
+          Next <KialiIcon.AngleRight />
         </>
       )}
     </Button>
@@ -97,7 +98,7 @@ const TourModal = (props: TourProps, step: Step) => {
           {StepNumber(props.stepNumber)}
           <span className="modal-title">{step.name}</span>
           <Button className="close" bsClass="default" onClick={props.onClose}>
-            <Icon title="Close" type="pf" name="close" />
+            <KialiIcon.Close />
           </Button>
         </div>
         <div className={`modal-body ${modalBody}`}>{step.description}</div>

--- a/src/config/KialiIcon.tsx
+++ b/src/config/KialiIcon.tsx
@@ -18,9 +18,16 @@ import {
   BlueprintIcon,
   AngleDoubleUpIcon,
   AngleDoubleDownIcon,
+  CloseIcon,
+  AngleRightIcon,
+  AngleLeftIcon,
+  HelpIcon,
   BellIcon,
   AngleDoubleLeftIcon,
-  AngleDoubleRightIcon
+  AngleDoubleRightIcon,
+  RepositoryIcon,
+  AngleDownIcon,
+  HomeIcon
 } from '@patternfly/react-icons';
 import { style } from 'typestyle';
 
@@ -38,21 +45,28 @@ export const KialiIcon: { [name: string]: React.FunctionComponent<IconProps> } =
   AngleDoubleLeft: (props: IconProps) => <AngleDoubleLeftIcon className={props.className} />,
   AngleDoubleRight: (props: IconProps) => <AngleDoubleRightIcon className={props.className} />,
   AngleDoubleUp: (props: IconProps) => <AngleDoubleUpIcon className={props.className} />,
+  AngleLeft: (props: IconProps) => <AngleLeftIcon className={props.className} />,
+  AngleRight: (props: IconProps) => <AngleRightIcon className={props.className} />,
+  AngleDown: (props: IconProps) => <AngleDownIcon className={props.className} />,
   Applications: (props: IconProps) => <ApplicationsIcon className={props.className} />,
   Bell: (props: IconProps) => <BellIcon className={props.className} />,
   CircuitBreaker: (props: IconProps) => <BoltIcon className={props.className} />,
+  Close: (props: IconProps) => <CloseIcon className={props.className} />,
   Error: (props: IconProps) => <ErrorCircleOIcon className={props.className} color={PfColors.Danger} />,
+  Help: (props: IconProps) => <HelpIcon className={props.className} />,
   Info: (props: IconProps) => <InfoAltIcon className={props.className} color={PfColors.Info} />,
-  Ok: (props: IconProps) => <OkIcon className={props.className} color={PfColors.Success} />,
   LocalTime: (props: IconProps) => <GlobeAmericasIcon className={props.className} />,
-  MissingSidecar: (props: IconProps) => <CodeBranchIcon className={props.className} />,
+  MissingSidecar: (props: IconProps) => <BlueprintIcon className={props.className} />,
   MtlsLock: (props: IconProps) => <LockIcon className={props.className} />,
   MtlsUnlock: (props: IconProps) => <LockOpenIcon className={props.className} />,
+  Ok: (props: IconProps) => <OkIcon className={props.className} color={PfColors.Success} />,
+  Repository: (props: IconProps) => <RepositoryIcon className={props.className} />,
   Services: (props: IconProps) => <ServiceIcon className={props.className} />,
   Topology: (props: IconProps) => <TopologyIcon className={props.className} />,
   Unknown: (props: IconProps) => <UnknownIcon className={props.className} />,
-  VirtualService: (props: IconProps) => <BlueprintIcon className={props.className} />,
+  VirtualService: (props: IconProps) => <CodeBranchIcon className={props.className} />,
   Warning: (props: IconProps) => <WarningTriangleIcon className={props.className} color={PfColors.Warning} />,
+  Website: (props: IconProps) => <HomeIcon className={props.className} />,
   Workloads: (props: IconProps) => <BundleIcon className={props.className} />
 };
 

--- a/src/pages/Graph/GraphHelpFind.tsx
+++ b/src/pages/Graph/GraphHelpFind.tsx
@@ -1,18 +1,9 @@
 import * as React from 'react';
 import Draggable from 'react-draggable';
-import {
-  Button,
-  Icon,
-  Nav,
-  NavItem,
-  TabContainer,
-  TabContent,
-  TabPane,
-  Table,
-  TablePfProvider
-} from 'patternfly-react';
+import { Button, Nav, NavItem, TabContainer, TabContent, TabPane, Table, TablePfProvider } from 'patternfly-react';
 import { style } from 'typestyle';
 import * as resolve from 'table-resolver';
+import { KialiIcon } from 'config/KialiIcon';
 
 export interface GraphHelpFindProps {
   onClose: () => void;
@@ -221,7 +212,7 @@ export default class GraphHelpFind extends React.Component<GraphHelpFindProps> {
         <div className={`modal-content ${className} ${contentStyle}`}>
           <div id="helpheader" className={`modal-header ${headerStyle}`}>
             <Button className="close" bsClass="" onClick={this.props.onClose}>
-              <Icon title="Close" type="pf" name="close" />
+              <KialiIcon.Close />
             </Button>
             <span className="modal-title">Help: Graph Find/Hide</span>
           </div>

--- a/src/pages/Graph/GraphPage.tsx
+++ b/src/pages/Graph/GraphPage.tsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { ThunkDispatch } from 'redux-thunk';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import FlexView from 'react-flexview';
-import { Breadcrumb, Button, Icon, OverlayTrigger, Tooltip } from 'patternfly-react';
+import { Breadcrumb, Button, OverlayTrigger, Tooltip } from 'patternfly-react';
 import { style } from 'typestyle';
 import { store } from '../../store/ConfigStore';
 import { DurationInSeconds, PollIntervalInMs, TimeInMilliseconds, TimeInSeconds } from '../../types/Common';
@@ -42,6 +42,7 @@ import { GraphFilterActions } from '../../actions/GraphFilterActions';
 import { NodeContextMenuContainer } from '../../components/CytoscapeGraph/ContextMenu/NodeContextMenu';
 import { GlobalActions } from '../../actions/GlobalActions';
 import { PfColors } from 'components/Pf/PfColors';
+import { KialiIcon } from 'config/KialiIcon';
 
 // GraphURLPathProps holds path variable values.  Currenly all path variables are relevant only to a node graph
 type GraphURLPathProps = {
@@ -314,7 +315,7 @@ export class GraphPage extends React.Component<GraphPageProps, GraphPageState> {
                   overlay={<Tooltip id={'graph-tour-help-tt'}>Graph help tour...</Tooltip>}
                 >
                   <Button bsStyle="link" style={{ paddingLeft: '6px' }} onClick={this.toggleHelp}>
-                    <Icon type="pf" name="help" />
+                    <KialiIcon.Help />
                   </Button>
                 </OverlayTrigger>
               </Breadcrumb.Item>

--- a/src/pages/Graph/SummaryLink.tsx
+++ b/src/pages/Graph/SummaryLink.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { Icon } from 'patternfly-react';
 import { NodeType, DecoratedGraphNodeData, GraphNodeData } from '../../types/Graph';
 import { CyNode, decoratedNodeData } from '../../components/CytoscapeGraph/CytoscapeGraphUtils';
+import { KialiIcon } from 'config/KialiIcon';
 
 const getTitle = (nodeData: DecoratedGraphNodeData) => {
   if (nodeData.nodeType === NodeType.UNKNOWN) {
@@ -72,7 +72,9 @@ export const RenderLink = (props: RenderLinkProps) => {
     <>
       {link}
       {props.nodeData.isInaccessible && (
-        <Icon key="link-icon" name="private" type="pf" style={{ paddingLeft: '2px', width: '10px' }} />
+        <span style={{ paddingLeft: '2px' }}>
+          <KialiIcon.MtlsLock />
+        </span>
       )}
     </>
   );
@@ -83,8 +85,7 @@ export const renderTitle = (nodeData: DecoratedGraphNodeData) => {
 
   return (
     <>
-      <strong>{getTitle(nodeData)}:</strong> {link}{' '}
-      {nodeData.isInaccessible && <Icon name="private" type="pf" style={{ paddingLeft: '2px', width: '10px' }} />}
+      <strong>{getTitle(nodeData)}:</strong> {link} {nodeData.isInaccessible && <KialiIcon.MtlsLock />}
     </>
   );
 };

--- a/src/pages/Graph/SummaryPanel.tsx
+++ b/src/pages/Graph/SummaryPanel.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
-import { Icon } from 'patternfly-react';
 import { style } from 'typestyle';
 import { SummaryPanelPropType } from '../../types/Graph';
 import SummaryPanelEdge from './SummaryPanelEdge';
 import SummaryPanelGraph from './SummaryPanelGraph';
 import SummaryPanelGroup from './SummaryPanelGroup';
 import SummaryPanelNode from './SummaryPanelNode';
+import { KialiIcon } from 'config/KialiIcon';
 
 type SummaryPanelState = {
   isVisible: boolean;
@@ -69,11 +69,11 @@ export default class SummaryPanel extends React.Component<MainSummaryPanelPropTy
         <div className={toggleSidePanelStyle} onClick={this.togglePanel}>
           {this.state.isVisible ? (
             <>
-              <Icon name="angle-double-down" /> Hide
+              <KialiIcon.AngleDoubleDown /> Hide
             </>
           ) : (
             <>
-              <Icon name="angle-double-up" /> Show
+              <KialiIcon.AngleDoubleUp /> Show
             </>
           )}
         </div>

--- a/src/pages/Graph/SummaryPanelCommon.tsx
+++ b/src/pages/Graph/SummaryPanelCommon.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Icon } from 'patternfly-react';
 import { style } from 'typestyle';
 import { NodeType, SummaryPanelPropType, Protocol, DecoratedGraphNodeData } from '../../types/Graph';
 import { Health, healthNotAvailable } from '../../types/Health';
@@ -12,6 +11,7 @@ import { serverConfig } from '../../config/ServerConfig';
 import { decoratedNodeData } from 'components/CytoscapeGraph/CytoscapeGraphUtils';
 import { Badge } from '@patternfly/react-core';
 import { PfColors } from 'components/Pf/PfColors';
+import { KialiIcon } from 'config/KialiIcon';
 
 export enum NodeMetricType {
   APP = 1,
@@ -173,7 +173,7 @@ export const renderNoTraffic = (protocol?: string) => {
   return (
     <>
       <div>
-        <Icon type="pf" name="info" /> No {protocol ? protocol : ''} traffic logged.
+        <KialiIcon.Info /> No {protocol ? protocol : ''} traffic logged.
       </div>
     </>
   );

--- a/src/pages/Graph/SummaryPanelEdge.tsx
+++ b/src/pages/Graph/SummaryPanelEdge.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Icon, Nav, NavItem, TabContainer, TabContent, TabPane } from 'patternfly-react';
+import { Nav, NavItem, TabContainer, TabContent, TabPane } from 'patternfly-react';
 import { RateTableGrpc, RateTableHttp } from '../../components/SummaryPanel/RateTable';
 import { RpsChart, TcpChart } from '../../components/SummaryPanel/RpsChart';
 import { ResponseTimeChart, ResponseTimeUnit } from '../../components/SummaryPanel/ResponseTimeChart';
@@ -28,9 +28,9 @@ import { MetricGroup, Metric, Metrics, Datapoint } from '../../types/Metrics';
 import { Response } from '../../services/Api';
 import { CancelablePromise, makeCancelablePromise } from '../../utils/CancelablePromises';
 import { decoratedEdgeData, decoratedNodeData } from '../../components/CytoscapeGraph/CytoscapeGraphUtils';
-import { icons } from '../../config';
 import { ResponseFlagsTable } from 'components/SummaryPanel/ResponseFlagsTable';
 import { ResponseHostsTable } from 'components/SummaryPanel/ResponseHostsTable';
+import { KialiIcon } from 'config/KialiIcon';
 
 type SummaryPanelEdgeState = {
   loading: boolean;
@@ -424,14 +424,14 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
     if (!this.hasSupportedCharts(edge)) {
       return isGrpc || isHttp ? (
         <>
-          <Icon type="pf" name="info" /> Service graphs do not support service-to-service aggregate sparklines. See the
-          chart above for aggregate traffic or use the workload graph type to observe individual workload-to-service
-          edge sparklines.
+          <KialiIcon.Info /> Service graphs do not support service-to-service aggregate sparklines. See the chart above
+          for aggregate traffic or use the workload graph type to observe individual workload-to-service edge
+          sparklines.
         </>
       ) : (
         <>
-          <Icon type="pf" name="info" /> Service graphs do not support service-to-service aggregate sparklines. Use the
-          workload graph type to observe individual workload-to-service edge sparklines.
+          <KialiIcon.Info /> Service graphs do not support service-to-service aggregate sparklines. Use the workload
+          graph type to observe individual workload-to-service edge sparklines.
         </>
       );
     }
@@ -441,15 +441,14 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
     if (target.isInaccessible) {
       return (
         <>
-          <Icon type="pf" name="info" /> Sparkline charts cannot be shown because the destination is inaccessible.
+          <KialiIcon.Info /> Sparkline charts cannot be shown because the destination is inaccessible.
         </>
       );
     }
     if (source.isServiceEntry || target.isServiceEntry) {
       return (
         <>
-          <Icon type="pf" name="info" /> Sparkline charts cannot be shown because the source or destination is a
-          serviceEntry.
+          <KialiIcon.Info /> Sparkline charts cannot be shown because the source or destination is a serviceEntry.
         </>
       );
     }
@@ -461,7 +460,7 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
     if (this.state.metricsLoadError) {
       return (
         <div>
-          <Icon type="pf" name="warning-triangle-o" /> <strong>Error loading metrics: </strong>
+          <KialiIcon.Warning /> <strong>Error loading metrics: </strong>
           {this.state.metricsLoadError}
         </div>
       );
@@ -529,7 +528,7 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
       <>
         {isMtls && (
           <div>
-            <Icon name={icons.istio.mtls.name} type={icons.istio.mtls.type} style={{ width: '10px' }} />
+            <KialiIcon.MtlsLock />
             <span style={{ paddingLeft: '6px' }}>{mtls}</span>
           </div>
         )}

--- a/src/pages/Graph/SummaryPanelGraph.tsx
+++ b/src/pages/Graph/SummaryPanelGraph.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { Icon, Nav, NavItem, TabContainer, TabContent, TabPane } from 'patternfly-react';
+import { Nav, NavItem, TabContainer, TabContent, TabPane } from 'patternfly-react';
 import { RateTableGrpc, RateTableHttp } from '../../components/SummaryPanel/RateTable';
 import { RpsChart, TcpChart } from '../../components/SummaryPanel/RpsChart';
 import { SummaryPanelPropType, NodeType } from '../../types/Graph';
@@ -20,6 +20,8 @@ import { IstioMetricsOptions } from '../../types/MetricsOptions';
 import { CancelablePromise, makeCancelablePromise } from '../../utils/CancelablePromises';
 import { Paths } from '../../config';
 import { CyNode } from '../../components/CytoscapeGraph/CytoscapeGraphUtils';
+import { KialiIcon } from 'config/KialiIcon';
+import { style } from 'typestyle';
 
 type SummaryPanelGraphState = {
   loading: boolean;
@@ -29,6 +31,10 @@ type SummaryPanelGraphState = {
   tcpReceived: Datapoint[];
   metricsLoadError: string | null;
 };
+
+const topologyStyle = style({
+  padding: '0 1em'
+});
 
 export default class SummaryPanelGraph extends React.Component<SummaryPanelPropType, SummaryPanelGraphState> {
   static readonly panelStyle = {
@@ -131,7 +137,7 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
                   <>
                     {incomingRateGrpc.rate === 0 && incomingRateHttp.rate === 0 && (
                       <>
-                        <Icon type="pf" name="info" /> No incoming traffic.
+                        <KialiIcon.Info /> No incoming traffic.
                       </>
                     )}
                     {incomingRateGrpc.rate > 0 && (
@@ -160,7 +166,7 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
                   <>
                     {outgoingRateGrpc.rate === 0 && outgoingRateHttp.rate === 0 && (
                       <>
-                        <Icon type="pf" name="info" /> No outgoing traffic.
+                        <KialiIcon.Info /> No outgoing traffic.
                       </>
                     )}
                     {outgoingRateGrpc.rate > 0 && (
@@ -189,7 +195,7 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
                   <>
                     {totalRateGrpc.rate === 0 && totalRateHttp.rate === 0 && (
                       <>
-                        <Icon type="pf" name="info" /> No traffic.
+                        <KialiIcon.Info /> No traffic.
                       </>
                     )}
                     {totalRateGrpc.rate > 0 && (
@@ -331,7 +337,7 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
       <br />
       {numApps > 0 && (
         <>
-          <Icon name="applications" type="pf" style={{ padding: '0 1em' }} />
+          <KialiIcon.Applications className={topologyStyle} />
           {numApps.toString()} {numApps === 1 ? 'app ' : 'apps '}
           {numVersions > 0 && `(${numVersions} versions)`}
           <br />
@@ -339,21 +345,21 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
       )}
       {numSvc > 0 && (
         <>
-          <Icon name="service" type="pf" style={{ padding: '0 1em' }} />
+          <KialiIcon.Services className={topologyStyle} />
           {numSvc.toString()} {numSvc === 1 ? 'service' : 'services'}
           <br />
         </>
       )}
       {numWorkloads > 0 && (
         <>
-          <Icon name="bundle" type="pf" style={{ padding: '0 1em' }} />
+          <KialiIcon.Workloads className={topologyStyle} />
           {numWorkloads.toString()} {numWorkloads === 1 ? 'workload' : 'workloads'}
           <br />
         </>
       )}
       {numEdges > 0 && (
         <>
-          <Icon name="topology" type="pf" style={{ padding: '0 1em' }} />
+          <KialiIcon.Topology />
           {numEdges.toString()} {numEdges === 1 ? 'edge' : 'edges'}
         </>
       )}
@@ -366,7 +372,7 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
     } else if (this.state.metricsLoadError) {
       return (
         <div>
-          <Icon type="pf" name="warning-triangle-o" /> <strong>Error loading metrics: </strong>
+          <KialiIcon.Warning /> <strong>Error loading metrics: </strong>
           {this.state.metricsLoadError}
         </div>
       );

--- a/src/pages/Graph/SummaryPanelGraph.tsx
+++ b/src/pages/Graph/SummaryPanelGraph.tsx
@@ -33,7 +33,7 @@ type SummaryPanelGraphState = {
 };
 
 const topologyStyle = style({
-  padding: '0 1em'
+  margin: '0 1em'
 });
 
 export default class SummaryPanelGraph extends React.Component<SummaryPanelPropType, SummaryPanelGraphState> {
@@ -359,7 +359,7 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
       )}
       {numEdges > 0 && (
         <>
-          <KialiIcon.Topology />
+          <KialiIcon.Topology className={topologyStyle} />
           {numEdges.toString()} {numEdges === 1 ? 'edge' : 'edges'}
         </>
       )}

--- a/src/pages/Graph/SummaryPanelGroup.tsx
+++ b/src/pages/Graph/SummaryPanelGroup.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { Badge, PopoverPosition } from '@patternfly/react-core';
-import { Icon } from 'patternfly-react';
 import { InOutRateTableGrpc, InOutRateTableHttp } from '../../components/SummaryPanel/InOutRateTable';
 import { RpsChart, TcpChart } from '../../components/SummaryPanel/RpsChart';
 import { NodeType, SummaryPanelPropType } from '../../types/Graph';
@@ -23,7 +22,7 @@ import { Reporter } from '../../types/MetricsOptions';
 import { CancelablePromise, makeCancelablePromise } from '../../utils/CancelablePromises';
 import { serverConfig } from '../../config/ServerConfig';
 import { CyNode, decoratedNodeData } from '../../components/CytoscapeGraph/CytoscapeGraphUtils';
-import { icons } from '../../config';
+import { KialiIcon } from 'config/KialiIcon';
 
 type SummaryPanelGroupState = {
   loading: boolean;
@@ -146,7 +145,7 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
           {/* TODO: link to App Details charts when available
            <p style={{ textAlign: 'right' }}>
             <Link to={`/namespaces/${namespace}/services/${app}?tab=metrics&groupings=local+version%2Cresponse+code`}>
-              View detailed charts <Icon name="angle-double-right" />
+              View detailed charts <KialiIcon.AngleDoubleRight />
             </Link>
           </p> */}
           {this.hasGrpcTraffic(group) ? this.renderGrpcRates(group) : renderNoTraffic('GRPC')}
@@ -239,21 +238,13 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
       <>
         {hasCB && (
           <div>
-            <Icon
-              name={icons.istio.circuitBreaker.name}
-              type={icons.istio.circuitBreaker.type}
-              style={{ width: '10px' }}
-            />
+            <KialiIcon.CircuitBreaker />
             <span style={{ paddingLeft: '4px' }}>Has Circuit Breaker</span>
           </div>
         )}
         {hasVS && (
           <div>
-            <Icon
-              name={icons.istio.virtualService.name}
-              type={icons.istio.virtualService.type}
-              style={{ width: '10px' }}
-            />
+            <KialiIcon.VirtualService />
             <span style={{ paddingLeft: '4px' }}>Has Virtual Service</span>
           </div>
         )}
@@ -309,7 +300,7 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
     } else if (this.state.metricsLoadError) {
       return (
         <div>
-          <Icon type="pf" name="warning-triangle-o" /> <strong>Error loading metrics: </strong>
+          <KialiIcon.Warning /> <strong>Error loading metrics: </strong>
           {this.state.metricsLoadError}
         </div>
       );

--- a/src/pages/Graph/SummaryPanelNode.tsx
+++ b/src/pages/Graph/SummaryPanelNode.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { renderDestServicesLinks, RenderLink, renderTitle } from './SummaryLink';
-import { Icon } from 'patternfly-react';
 import {
   getAccumulatedTrafficRateGrpc,
   getAccumulatedTrafficRateHttp,
@@ -35,7 +34,6 @@ import { Health } from '../../types/Health';
 import { CancelablePromise, makeCancelablePromise } from '../../utils/CancelablePromises';
 import { Response } from '../../services/Api';
 import { Reporter } from '../../types/MetricsOptions';
-import { icons } from '../../config/Icons';
 import { CyNode, decoratedNodeData } from '../../components/CytoscapeGraph/CytoscapeGraphUtils';
 import { PopoverPosition } from '@patternfly/react-core';
 import { KialiIcon } from 'config/KialiIcon';
@@ -340,7 +338,7 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
           {nodeType !== NodeType.UNKNOWN && (
             <p style={{ textAlign: 'right' }}>
               <Link to={`/namespaces/${namespace}/services/${app}?tab=metrics&groupings=local+version%2Cresponse+code`}>
-                View detailed charts <Icon name="angle-double-right" />
+                View detailed charts <KialiIcon.AngleDoubleRight />
               </Link>
             </p>
           )} */}
@@ -410,7 +408,7 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
       return (
         <>
           <div>
-            <Icon type="pf" name="info" /> Sparkline charts cannot be shown because the selected node is inaccessible.
+            <KialiIcon.Info /> Sparkline charts cannot be shown because the selected node is inaccessible.
             <hr />
           </div>
         </>
@@ -419,7 +417,7 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
       return (
         <>
           <div>
-            <Icon type="pf" name="info" /> Sparkline charts cannot be shown because the selected node is a serviceEntry.
+            <KialiIcon.Info /> Sparkline charts cannot be shown because the selected node is a serviceEntry.
             <hr />
           </div>
         </>
@@ -431,7 +429,7 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
     if (this.state.metricsLoadError) {
       return (
         <div>
-          <Icon type="pf" name="warning-triangle-o" /> <strong>Error loading metrics: </strong>
+          <KialiIcon.Warning /> <strong>Error loading metrics: </strong>
           {this.state.metricsLoadError}
         </div>
       );
@@ -462,7 +460,7 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
           {serviceWithUnknownSource && (
             <>
               <div>
-                <Icon type="pf" name="info" /> Traffic from unknown not included. Use edge for details.
+                <KialiIcon.Info /> Traffic from unknown not included. Use edge for details.
               </div>
             </>
           )}
@@ -475,7 +473,7 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
           {this.isIstioOutgoingCornerCase(node) && (
             <>
               <div>
-                <Icon type="pf" name="info" /> Traffic to Istio namespaces not included. Use edge for details.
+                <KialiIcon.Info /> Traffic to Istio namespaces not included. Use edge for details.
               </div>
             </>
           )}
@@ -495,7 +493,7 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
           {serviceWithUnknownSource && (
             <>
               <div>
-                <Icon type="pf" name="info" /> Traffic from unknown not included. Use edge for details.
+                <KialiIcon.Info /> Traffic from unknown not included. Use edge for details.
               </div>
             </>
           )}
@@ -508,7 +506,7 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
           {this.isIstioOutgoingCornerCase(node) && (
             <>
               <div>
-                <Icon type="pf" name="info" /> Traffic to Istio namespaces not included. Use edge for details.
+                <KialiIcon.Info />" /> Traffic to Istio namespaces not included. Use edge for details.
               </div>
             </>
           )}
@@ -551,37 +549,27 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
       <>
         {hasCB && (
           <div>
-            <Icon
-              name={icons.istio.circuitBreaker.name}
-              type={icons.istio.circuitBreaker.type}
-              style={{ width: '10px' }}
-            />
+            <KialiIcon.CircuitBreaker />
             <span style={{ paddingLeft: '4px' }}>Has Circuit Breaker</span>
           </div>
         )}
         {hasVS && (
           <div>
-            <Icon
-              name={icons.istio.virtualService.name}
-              type={icons.istio.virtualService.type}
-              style={{ width: '10px' }}
-            />
+            <KialiIcon.VirtualService />
             <span style={{ paddingLeft: '4px' }}>Has Virtual Service</span>
           </div>
         )}
         {hasMissingSC && (
           <div>
-            <Icon
-              name={icons.istio.missingSidecar.name}
-              type={icons.istio.missingSidecar.type}
-              style={{ width: '10px', marginRight: '5px' }}
-            />
+            <KialiIcon.MissingSidecar />
             <span style={{ paddingLeft: '4px' }}>Has Missing Sidecar</span>
           </div>
         )}
         {isDead && (
           <div>
-            <Icon type="pf" name="info" style={{ width: '10px', marginRight: '5px' }} />
+            <span style={{ marginRight: '5px' }}>
+              <KialiIcon.Info />
+            </span>
             <span style={{ paddingLeft: '4px' }}>Has No Running Pods</span>
           </div>
         )}


### PR DESCRIPTION
** Describe the change **
Replacing all of the PF3 icons with PF4 icons via KialiIcon.tsx .

closes https://github.com/kiali/kiali/issues/1825