### PR TITLE
Use mountOnEnter and unmountOnExit for PF Tabs

### DIFF
--- a/src/components/Tab/Tabs.tsx
+++ b/src/components/Tab/Tabs.tsx
@@ -3,13 +3,15 @@ import { TabProps, Tabs } from '@patternfly/react-core';
 import history from '../../app/History';
 
 type TabsProps = {
-  id: string;
-  tabMap: { [key: string]: number };
-  tabName: string;
-  defaultTab: string;
   activeTab: string;
+  defaultTab: string;
+  id: string;
+  mountOnEnter?: boolean;
   onSelect: (tabName: string) => void;
   postHandler?: (tabName: string) => void;
+  tabMap: { [key: string]: number };
+  tabName: string;
+  unmountOnExit?: boolean;
 };
 
 export const activeTab = (tabName: string, defaultTab: string): string => {
@@ -97,6 +99,8 @@ export default class ParameterizedTabs extends React.Component<TabsProps> {
             this.tabTransitionHandler(ek as number);
           }
         }}
+        mountOnEnter={this.props.mountOnEnter}
+        unmountOnExit={this.props.unmountOnExit}
       >
         {this.props.children}
       </Tabs>

--- a/src/components/Tab/Tabs.tsx
+++ b/src/components/Tab/Tabs.tsx
@@ -99,8 +99,8 @@ export default class ParameterizedTabs extends React.Component<TabsProps> {
             this.tabTransitionHandler(ek as number);
           }
         }}
-        mountOnEnter={this.props.mountOnEnter}
-        unmountOnExit={this.props.unmountOnExit}
+        mountOnEnter={this.props.mountOnEnter === undefined ? true : this.props.mountOnEnter}
+        unmountOnExit={this.props.unmountOnExit === undefined ? true : this.props.unmountOnExit}
       >
         {this.props.children}
       </Tabs>

--- a/src/pages/AppDetails/AppDetailsPage.tsx
+++ b/src/pages/AppDetails/AppDetailsPage.tsx
@@ -170,15 +170,11 @@ class AppDetails extends React.Component<AppDetailsProps, AppDetailsState> {
 
         const tab = (
           <Tab title={dashboard.title} key={dashboard.template} eventKey={tabKey}>
-            {this.state.currentTab === dashboard.template ? (
-              <CustomMetricsContainer
-                namespace={this.props.match.params.namespace}
-                app={this.props.match.params.app}
-                template={dashboard.template}
-              />
-            ) : (
-              undefined
-            )}
+            <CustomMetricsContainer
+              namespace={this.props.match.params.namespace}
+              app={this.props.match.params.app}
+              template={dashboard.template}
+            />
           </Tab>
         );
         tabs.push(tab);
@@ -192,56 +188,40 @@ class AppDetails extends React.Component<AppDetailsProps, AppDetailsState> {
   staticTabs() {
     const overTab = (
       <Tab title="Overview" eventKey={0} key={'Overview'}>
-        {this.state.currentTab === 'info' ? (
-          <AppInfo app={this.state.app} namespace={this.props.match.params.namespace} health={this.state.health} />
-        ) : (
-          undefined
-        )}
+        <AppInfo app={this.state.app} namespace={this.props.match.params.namespace} health={this.state.health} />
       </Tab>
     );
 
     const trafficTab = (
       <Tab title="Traffic" eventKey={1} key={'Traffic'}>
-        {this.state.currentTab === 'traffic' ? (
-          <TrafficDetails
-            trafficData={this.state.trafficData}
-            itemType={MetricsObjectTypes.APP}
-            namespace={this.state.app.namespace.name}
-            appName={this.state.app.name}
-          />
-        ) : (
-          undefined
-        )}
+        <TrafficDetails
+          trafficData={this.state.trafficData}
+          itemType={MetricsObjectTypes.APP}
+          namespace={this.state.app.namespace.name}
+          appName={this.state.app.name}
+        />
       </Tab>
     );
 
     const inTab = (
       <Tab title="Inbound Metrics" eventKey={2} key={'Inbound Metrics'}>
-        {this.state.currentTab === 'in_metrics' ? (
-          <IstioMetricsContainer
-            namespace={this.props.match.params.namespace}
-            object={this.props.match.params.app}
-            objectType={MetricsObjectTypes.APP}
-            direction={'inbound'}
-          />
-        ) : (
-          undefined
-        )}
+        <IstioMetricsContainer
+          namespace={this.props.match.params.namespace}
+          object={this.props.match.params.app}
+          objectType={MetricsObjectTypes.APP}
+          direction={'inbound'}
+        />
       </Tab>
     );
 
     const outTab = (
       <Tab title="Outbound Metrics" eventKey={3} key={'Outbound Metrics'}>
-        {this.state.currentTab === 'out_metrics' ? (
-          <IstioMetricsContainer
-            namespace={this.props.match.params.namespace}
-            object={this.props.match.params.app}
-            objectType={MetricsObjectTypes.APP}
-            direction={'outbound'}
-          />
-        ) : (
-          undefined
-        )}
+        <IstioMetricsContainer
+          namespace={this.props.match.params.namespace}
+          object={this.props.match.params.app}
+          objectType={MetricsObjectTypes.APP}
+          direction={'outbound'}
+        />
       </Tab>
     );
 
@@ -292,6 +272,8 @@ class AppDetails extends React.Component<AppDetailsProps, AppDetailsState> {
           defaultTab={defaultTab}
           postHandler={this.fetchTrafficDataOnTabChange}
           activeTab={this.state.currentTab}
+          mountOnEnter={true}
+          unmountOnExit={true}
         >
           {this.renderTabs()}
         </ParameterizedTabs>

--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -199,7 +199,7 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
           this.props.match.params.object
         );
     deletePromise
-      .then(_r => this.backToList())
+      .then(() => this.backToList())
       .catch(error => {
         MessageCenter.addError('Could not delete IstioConfig details.', error);
       });
@@ -223,7 +223,7 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
             jsonPatch
           );
       updatePromise
-        .then(_r => {
+        .then(() => {
           const targetMessage =
             this.props.match.params.namespace +
             ' / ' +
@@ -308,7 +308,7 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
 
   renderActionButtons = () => {
     // User won't save if file has yaml errors
-    const yamlErrors = this.state.yamlValidations && this.state.yamlValidations.markers.length > 0 ? true : false;
+    const yamlErrors = !!(this.state.yamlValidations && this.state.yamlValidations.markers.length > 0);
     return (
       <IstioActionButtonsContainer
         objectName={this.props.match.params.object}
@@ -376,14 +376,14 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
     if (this.hasOverview()) {
       tabs.push(
         <Tab key="istio-overview" title="Overview" eventKey={0}>
-          {this.state.currentTab === 'overview' ? this.renderOverview() : undefined}
+          {this.renderOverview()}
         </Tab>
       );
     }
 
     tabs.push(
       <Tab key="istio-yaml" title={`YAML ${this.state.isModified ? ' * ' : ''}`} eventKey={1}>
-        {this.state.currentTab === 'yaml' ? this.renderEditor() : undefined}
+        {this.renderEditor()}
       </Tab>
     );
 
@@ -397,6 +397,8 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
         tabName={tabName}
         defaultTab={this.defaultTab()}
         activeTab={this.state.currentTab}
+        mountOnEnter={true}
+        unmountOnExit={true}
       >
         {tabs}
       </ParameterizedTabs>

--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -296,7 +296,7 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
   };
 
   addFormatValidation(details: ServiceDetailsInfo, validations: Validations): Validations {
-    details.destinationRules.items.forEach((destinationRule, _index, _ary) => {
+    details.destinationRules.items.forEach(destinationRule => {
       const dr = new DestinationRuleValidator(destinationRule);
       const formatValidation = dr.formatValidation();
 
@@ -356,46 +356,39 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
   }
 
   render() {
-    const currentTab = this.state.currentTab;
     const errorTraces = this.state.serviceDetailsInfo.errorTraces;
     const overviewTab = (
       <Tab eventKey={0} title="Overview" key="Overview">
-        {currentTab === 'info' && (
-          <ServiceInfo
-            namespace={this.props.match.params.namespace}
-            service={this.props.match.params.service}
-            serviceDetails={this.state.serviceDetailsInfo}
-            gateways={this.state.gateways}
-            validations={this.state.validations}
-            onRefresh={this.doRefresh}
-            threeScaleInfo={this.state.threeScaleInfo}
-            threeScaleServiceRule={this.state.threeScaleServiceRule}
-          />
-        )}
+        <ServiceInfo
+          namespace={this.props.match.params.namespace}
+          service={this.props.match.params.service}
+          serviceDetails={this.state.serviceDetailsInfo}
+          gateways={this.state.gateways}
+          validations={this.state.validations}
+          onRefresh={this.doRefresh}
+          threeScaleInfo={this.state.threeScaleInfo}
+          threeScaleServiceRule={this.state.threeScaleServiceRule}
+        />
       </Tab>
     );
     const trafficTab = (
       <Tab eventKey={1} title="Traffic" key="Traffic">
-        {currentTab === 'traffic' && (
-          <TrafficDetails
-            trafficData={this.state.trafficData}
-            itemType={MetricsObjectTypes.SERVICE}
-            namespace={this.props.match.params.namespace}
-            serviceName={this.props.match.params.service}
-          />
-        )}
+        <TrafficDetails
+          trafficData={this.state.trafficData}
+          itemType={MetricsObjectTypes.SERVICE}
+          namespace={this.props.match.params.namespace}
+          serviceName={this.props.match.params.service}
+        />
       </Tab>
     );
     const inboundMetricsTab = (
       <Tab eventKey={2} title="Inbound Metrics" key="Inbound Metrics">
-        {currentTab === 'metrics' && (
-          <IstioMetricsContainer
-            namespace={this.props.match.params.namespace}
-            object={this.props.match.params.service}
-            objectType={MetricsObjectTypes.SERVICE}
-            direction={'inbound'}
-          />
-        )}
+        <IstioMetricsContainer
+          namespace={this.props.match.params.namespace}
+          object={this.props.match.params.service}
+          objectType={MetricsObjectTypes.SERVICE}
+          direction={'inbound'}
+        />
       </Tab>
     );
 
@@ -409,13 +402,11 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
         const jaegerTitle: string = errorTraces && errorTraces > 0 ? 'Error Traces (' + errorTraces + ')' : 'Traces';
         jaegerTag = (
           <Tab eventKey={3} style={{ textAlign: 'center' }} title={jaegerTitle} key="traces">
-            {currentTab === 'traces' && (
-              <ServiceTraces
-                namespace={this.props.match.params.namespace}
-                service={this.props.match.params.service}
-                errorTags={errorTraces ? errorTraces > -1 : false}
-              />
-            )}
+            <ServiceTraces
+              namespace={this.props.match.params.namespace}
+              service={this.props.match.params.service}
+              errorTags={errorTraces ? errorTraces > -1 : false}
+            />
           </Tab>
         );
       } else {
@@ -468,6 +459,8 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
           defaultTab={defaultTab}
           postHandler={this.fetchTrafficDataOnTabChange}
           activeTab={this.state.currentTab}
+          mountOnEnter={true}
+          unmountOnExit={true}
         >
           {tabsArray}
         </ParameterizedTabs>

--- a/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -231,73 +231,56 @@ class WorkloadDetails extends React.Component<WorkloadDetailsPageProps, Workload
 
     const overTab = (
       <Tab title="Overview" eventKey={0} key={'Overview'}>
-        {this.state.currentTab === 'info' ? (
-          <WorkloadInfo
-            workload={this.state.workload}
-            namespace={this.props.match.params.namespace}
-            validations={this.state.validations}
-            istioEnabled={this.state.istioEnabled}
-            health={this.state.health}
-          />
-        ) : (
-          undefined
-        )}
+        <WorkloadInfo
+          workload={this.state.workload}
+          namespace={this.props.match.params.namespace}
+          validations={this.state.validations}
+          istioEnabled={this.state.istioEnabled}
+          health={this.state.health}
+        />
       </Tab>
     );
 
     const trafficTab = (
       <Tab title="Traffic" eventKey={1} key={'Traffic'}>
-        {this.state.currentTab === 'traffic' ? (
-          <TrafficDetails
-            trafficData={this.state.trafficData}
-            itemType={MetricsObjectTypes.WORKLOAD}
-            namespace={this.props.match.params.namespace}
-            workloadName={this.state.workload.name}
-          />
-        ) : (
-          undefined
-        )}
+        <TrafficDetails
+          trafficData={this.state.trafficData}
+          itemType={MetricsObjectTypes.WORKLOAD}
+          namespace={this.props.match.params.namespace}
+          workloadName={this.state.workload.name}
+        />
       </Tab>
     );
 
     const logTab = (
       <Tab title="Logs" eventKey={2} key={'Logs'}>
-        {this.state.currentTab === 'logs' && hasPods ? (
+        {hasPods ? (
           <WorkloadPodLogs namespace={this.props.match.params.namespace} pods={this.state.workload.pods} />
         ) : (
           'There are no logs to display because the workload has no pods.'
-        )}
         )}
       </Tab>
     );
 
     const inTab = (
       <Tab title="Inbound Metrics" eventKey={3} key={'Inbound Metrics'}>
-        {this.state.currentTab === 'in_metrics' ? (
-          <IstioMetricsContainer
-            namespace={this.props.match.params.namespace}
-            object={this.props.match.params.workload}
-            objectType={MetricsObjectTypes.WORKLOAD}
-            direction={'inbound'}
-          />
-        ) : (
-          undefined
-        )}
+        <IstioMetricsContainer
+          namespace={this.props.match.params.namespace}
+          object={this.props.match.params.workload}
+          objectType={MetricsObjectTypes.WORKLOAD}
+          direction={'inbound'}
+        />
       </Tab>
     );
 
     const outTab = (
       <Tab title="Outbound Metrics" eventKey={4} key={'Outbound Metrics'}>
-        {this.state.currentTab === 'out_metrics' ? (
-          <IstioMetricsContainer
-            namespace={this.props.match.params.namespace}
-            object={this.props.match.params.workload}
-            objectType={MetricsObjectTypes.WORKLOAD}
-            direction={'outbound'}
-          />
-        ) : (
-          undefined
-        )}
+        <IstioMetricsContainer
+          namespace={this.props.match.params.namespace}
+          object={this.props.match.params.workload}
+          objectType={MetricsObjectTypes.WORKLOAD}
+          direction={'outbound'}
+        />
       </Tab>
     );
 
@@ -319,16 +302,12 @@ class WorkloadDetails extends React.Component<WorkloadDetailsPageProps, Workload
           paramToTab[dashboard.template] = tabKey;
           const tab = (
             <Tab key={dashboard.template} title={dashboard.title} eventKey={tabKey}>
-              {this.state.currentTab === dashboard.template ? (
-                <CustomMetricsContainer
-                  namespace={this.props.match.params.namespace}
-                  app={app}
-                  version={version}
-                  template={dashboard.template}
-                />
-              ) : (
-                undefined
-              )}
+              <CustomMetricsContainer
+                namespace={this.props.match.params.namespace}
+                app={app}
+                version={version}
+                template={dashboard.template}
+              />
             </Tab>
           );
           tabs.push(tab);
@@ -382,6 +361,8 @@ class WorkloadDetails extends React.Component<WorkloadDetailsPageProps, Workload
           defaultTab={defaultTab}
           postHandler={this.fetchTrafficDataOnTabChange}
           activeTab={this.state.currentTab}
+          mountOnEnter={true}
+          unmountOnExit={true}
         >
           {this.renderTabs()}
         </ParameterizedTabs>


### PR DESCRIPTION
Removing workaround to render DOM only if tabs are visible.
Workaround was due a missing feature in older versions of PF4.

Closes kiali/kiali#1716.