### PR TITLE
Fix performance issues in VirtualTables

### DIFF
--- a/src/components/VirtualList/Renderers.tsx
+++ b/src/components/VirtualList/Renderers.tsx
@@ -87,11 +87,9 @@ export const namespace: Renderer<TResource> = (item: TResource) => {
 
 export const health: Renderer<TResource> = (item: TResource, __: Resource, _: string, health?: Health) => {
   return (
-    health && (
-      <td role="gridcell" key={'VirtuaItem_Health_' + item.namespace + '_' + item.name}>
-        <HealthIndicator id={item.name} health={health} mode={DisplayMode.SMALL} />
-      </td>
-    )
+    <td role="gridcell" key={'VirtuaItem_Health_' + item.namespace + '_' + item.name}>
+      {health && <HealthIndicator id={item.name} health={health} mode={DisplayMode.SMALL} />}
+    </td>
   );
 };
 

--- a/src/components/VirtualList/VirtualList.tsx
+++ b/src/components/VirtualList/VirtualList.tsx
@@ -73,7 +73,6 @@ export class VirtualList<R extends TResource> extends React.Component<VirtualLis
       HistoryManager.setParam(URLParam.DIRECTION, direction);
     }
     HistoryManager.setParam(URLParam.SORT, String(this.state.conf.columns[index].param));
-    this.props.updateItems();
   };
 
   render() {


### PR DESCRIPTION
When sorting, there is a duplicated query of the backend.
When health is not yet calculated, we render an empty cell, to avoid that table content is moved when promises are resolved, that improves the effect of "no waiting".

Closes kiali/kiali#1845