### PR TITLE
Application Details, the missing Istio Sidecar is so close to workload name

### DIFF
--- a/src/components/MissingSidecar/MissingSidecar.tsx
+++ b/src/components/MissingSidecar/MissingSidecar.tsx
@@ -12,13 +12,14 @@ type MissingSidecarProps = {
   icon: IconType;
   color: string;
   namespace: string;
+  style?: React.CSSProperties;
 };
 
 const MissingSidecar = (props: MissingSidecarProps) => {
-  const { text, textTooltip, icon, namespace, color, tooltip, ...otherProps } = props;
+  const { text, textTooltip, icon, namespace, color, tooltip, style, ...otherProps } = props;
 
   const iconComponent = (
-    <span {...otherProps}>
+    <span style={style} {...otherProps}>
       {React.createElement(icon, { style: { color: color } })}
       {!tooltip && <span style={{ marginLeft: '5px' }}>{text}</span>}
     </span>

--- a/src/pages/AppDetails/AppInfo/AppDescription.tsx
+++ b/src/pages/AppDetails/AppInfo/AppDescription.tsx
@@ -57,8 +57,10 @@ class AppDescription extends React.Component<AppDescriptionProps, AppDescription
   renderWorkloadItem(namespace: string, workload: AppWorkload) {
     return (
       <ListItem key={`AppWorkload_${workload.workloadName}`}>
-        <Link to={this.workloadLink(namespace, workload.workloadName)}>{workload.workloadName}</Link>{' '}
-        {!workload.istioSidecar && <MissingSidecar namespace={namespace} tooltip={true} text={''} />}
+        <Link to={this.workloadLink(namespace, workload.workloadName)}>{workload.workloadName}</Link>
+        {!workload.istioSidecar && (
+          <MissingSidecar namespace={namespace} tooltip={true} style={{ marginLeft: '10px' }} text={''} />
+        )}
       </ListItem>
     );
   }

--- a/src/pages/AppDetails/AppInfo/AppDescription.tsx
+++ b/src/pages/AppDetails/AppInfo/AppDescription.tsx
@@ -57,7 +57,7 @@ class AppDescription extends React.Component<AppDescriptionProps, AppDescription
   renderWorkloadItem(namespace: string, workload: AppWorkload) {
     return (
       <ListItem key={`AppWorkload_${workload.workloadName}`}>
-        <Link to={this.workloadLink(namespace, workload.workloadName)}>{workload.workloadName}</Link>
+        <Link to={this.workloadLink(namespace, workload.workloadName)}>{workload.workloadName}</Link>{' '}
         {!workload.istioSidecar && <MissingSidecar namespace={namespace} tooltip={true} text={''} />}
       </ListItem>
     );


### PR DESCRIPTION
Fix https://github.com/kiali/kiali/issues/1852

## Before
![app_details_view](https://user-images.githubusercontent.com/3019213/67755060-c498bc00-fa37-11e9-81d4-2e45bb34a7c0.png)

## Now
![now](https://user-images.githubusercontent.com/3019213/67756961-3c1c1a80-fa3b-11e9-966d-e17dd5ab1819.png)
