### PR TITLE
Set Missing Istio Sidecar Icon in the same line in service details

### DIFF
--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoWorkload.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoWorkload.tsx
@@ -46,9 +46,13 @@ class ServiceInfoWorkload extends React.Component<ServiceInfoWorkloadProps> {
           to={`/namespaces/${this.props.namespace}/workloads/${workload.name}`}
           key={'ServiceWorkloadItem_' + this.props.namespace + '_' + workload.name}
         >
-          <Text component={TextVariants.p}>{workload.name}</Text>
+          <Text component={TextVariants.p}>
+            {workload.name}{' '}
+            {!workload.istioSidecar && (
+              <MissingSidecar namespace={this.props.namespace} style={{ marginLeft: '10px' }} tooltip={true} />
+            )}
+          </Text>
         </Link>
-        {!workload.istioSidecar && <MissingSidecar namespace={this.props.namespace} tooltip={true} />}
       </span>
     );
   }

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoWorkloads.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoWorkloads.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`#ServiceInfoWorkload render correctly with data should render service p
                           component="p"
                         >
                           reviews-v2
+                           
                         </Text>
                       </Link>
                     </span>,
@@ -104,6 +105,7 @@ exports[`#ServiceInfoWorkload render correctly with data should render service p
                           component="p"
                         >
                           reviews-v3
+                           
                         </Text>
                       </Link>
                     </span>,
@@ -142,6 +144,7 @@ exports[`#ServiceInfoWorkload render correctly with data should render service p
                           component="p"
                         >
                           reviews-v1
+                           
                         </Text>
                       </Link>
                     </span>,


### PR DESCRIPTION
Require: https://github.com/kiali/kiali-ui/pull/1512

## Before
![service_details_icon_missing](https://user-images.githubusercontent.com/3019213/67754954-99ae6800-fa37-11e9-8e49-136776c1a784.png)

## Now
![now](https://user-images.githubusercontent.com/3019213/67758231-97e7a300-fa3d-11e9-92b0-35f7559b5377.png)
