### PR TITLE
Change the PfColors to reflect new darker green color for success/chart.

### DIFF
--- a/src/components/Health/__tests__/__snapshots__/HealthIndicator.test.tsx.snap
+++ b/src/components/Health/__tests__/__snapshots__/HealthIndicator.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`HealthIndicator renders healthy 1`] = `
                 Object {
                   "status": Object {
                     "class": "icon-healthy",
-                    "color": "var(--pf-global--success-color--100)",
+                    "color": "#3e8635",
                     "icon": [Function],
                     "name": "Healthy",
                     "priority": 1,
@@ -24,7 +24,7 @@ exports[`HealthIndicator renders healthy 1`] = `
                 Object {
                   "status": Object {
                     "class": "icon-healthy",
-                    "color": "var(--pf-global--success-color--100)",
+                    "color": "#3e8635",
                     "icon": [Function],
                     "name": "Healthy",
                     "priority": 1,
@@ -34,7 +34,7 @@ exports[`HealthIndicator renders healthy 1`] = `
               ],
               "status": Object {
                 "class": "icon-healthy",
-                "color": "var(--pf-global--success-color--100)",
+                "color": "#3e8635",
                 "icon": [Function],
                 "name": "Healthy",
                 "priority": 1,
@@ -116,7 +116,7 @@ exports[`HealthIndicator renders healthy 1`] = `
 >
   <CheckCircleIcon
     className="icon-healthy"
-    color="var(--pf-global--success-color--100)"
+    color="#3e8635"
     noVerticalAlign={false}
     size="sm"
     title={null}

--- a/src/components/Pf/PfColors.tsx
+++ b/src/components/Pf/PfColors.tsx
@@ -36,7 +36,7 @@ export enum PfColors {
   Green200 = '#9ecf99',
   Green300 = '#6ec664',
   Green400 = '#3f9c35',
-  Green500 = '#2d7623',
+  Green500 = '#3e8635',
   Green600 = '#1e4f18',
   Green700 = '#0f280d',
   LightBlue100 = '#beedf9',
@@ -96,7 +96,7 @@ export enum PfColors {
   DangerBackground = Red400, // --pf-global--danger-color--200
   Info = '#73BCF7', // --pf-global--info-color--100
   InfoBackground = Blue600, // --pf-global--info-color--200
-  Success = LightGreen400, // --pf-global--success-color--100
+  Success = Green500, // --pf-global--success-color--100
   SuccessBackground = LightGreen600, // --pf-global--success-color--200
   Warning = Gold400, // --pf-global--warning-color--100
   WarningBackground = Gold600 // --pf-global--warning-color--200
@@ -104,7 +104,10 @@ export enum PfColors {
 
 export enum PFColorVars {
   DangerColor = 'var(--pf-global--danger-color--100)',
-  SuccessColor = 'var(--pf-global--success-color--100)',
+  // Patternfly has a new green that is darker but they have not yet
+  // updated the PF vars for it
+  // SuccessColor = 'var(--pf-global--success-color--100)',
+  SuccessColor = '#3e8635', // computed values like Green500 are not allowed in enum
   WarningColor = 'var(--pf-global--warning-color--100)'
 }
 


### PR DESCRIPTION
** Describe the change **
Change the success green to a darker green instead of the lime green. The Patternfly folks have provided us with a new color.

Although patternfly has not published a new css variable for green yet (meaing --pf-global--success-color--100 is not correct for now).

![Screenshot from 2019-11-01 07-41-47](https://user-images.githubusercontent.com/1312165/68032697-7116b000-fc7b-11e9-94f9-a5d11a3f8df0.png)


closes https://github.com/kiali/kiali/issues/1862
