### PR TITLE
PF4 Graph Find/Hide, including Help

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "react-bootstrap": "0.32.4",
     "react-copy-to-clipboard": "5.0.1",
     "react-dom": "16.9.0",
-    "react-draggable": "3.2.1",
     "react-flexview": "4.0.3",
     "react-floater": "0.6.4",
     "react-iframe": "1.5.0",

--- a/src/components/GraphFilter/GraphFind.tsx
+++ b/src/components/GraphFilter/GraphFind.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, FormControl, FormGroup, InputGroup, OverlayTrigger, Tooltip } from 'patternfly-react';
+import { Button, Tooltip, ButtonVariant, TextInput, Form } from '@patternfly/react-core';
 import { connect } from 'react-redux';
 import { ThunkDispatch } from 'redux-thunk';
 import { bindActionCreators } from 'redux';
@@ -14,8 +14,9 @@ import { CyData, NodeType } from '../../types/Graph';
 import { Layout, EdgeLabelMode } from 'types/GraphFilter';
 import * as AlertUtils from '../../utils/AlertUtils';
 import { KialiIcon, defaultIconStyle } from 'config/KialiIcon';
-import TourStopContainer from 'components/Tour/TourStop';
-import { GraphTourStops } from 'pages/Graph/GraphHelpTour';
+import { style } from 'typestyle';
+// import TourStopContainer from 'components/Tour/TourStop';
+// import { GraphTourStops } from 'pages/Graph/GraphHelpTour';
 
 type ReduxProps = {
   compressOnHide: boolean;
@@ -54,10 +55,10 @@ const inputWidth = {
 };
 
 // reduce toolbar padding from 20px to 10px to save space
-const thinGroupStyle = {
+const thinGroupStyle = style({
   paddingLeft: '10px',
   paddingRight: '10px'
-};
+});
 
 export class GraphFind extends React.PureComponent<GraphFindProps, GraphFindState> {
   static contextTypes = {
@@ -111,91 +112,76 @@ export class GraphFind extends React.PureComponent<GraphFindProps, GraphFindStat
   }
 
   render() {
+    const isFindValid: boolean = !(this.props.findValue.length > 0 && this.state.errorMessage.length > 0);
+    const isHideValid: boolean = !(this.props.hideValue.length > 0 && this.state.errorMessage.length > 0);
+
     return (
-      <>
-        <FormGroup style={{ flexDirection: 'row', alignItems: 'flex-start', ...thinGroupStyle }}>
-          <span className={'form-inline'}>
-            <InputGroup>
-              <TourStopContainer info={GraphTourStops.Find}>
-                <FormControl
-                  id="graph_find"
-                  name="graph_find"
-                  autoComplete="on"
-                  type="text"
-                  style={{ ...inputWidth }}
-                  inputRef={ref => {
-                    this.findInputRef = ref;
-                  }}
-                  onChange={this.updateFind}
-                  defaultValue={this.state.findInputValue}
-                  onKeyPress={this.checkSubmitFind}
-                  placeholder="Find..."
-                />
-              </TourStopContainer>
-              {this.props.findValue && (
-                <OverlayTrigger
-                  key="ot_clear_find"
-                  placement="top"
-                  trigger={['hover', 'focus']}
-                  delayShow={1000}
-                  overlay={<Tooltip id="tt_clear_find">Clear Find...</Tooltip>}
-                >
-                  <InputGroup.Button>
-                    <Button onClick={this.clearFind}>
-                      <KialiIcon.Close />
-                    </Button>
-                  </InputGroup.Button>
-                </OverlayTrigger>
-              )}
-              <FormControl
-                id="graph_hide"
-                name="graph_hide"
-                autoComplete="on"
-                type="text"
-                style={{ ...inputWidth }}
-                inputRef={ref => {
-                  this.hideInputRef = ref;
-                }}
-                onChange={this.updateHide}
-                defaultValue={this.state.hideInputValue}
-                onKeyPress={this.checkSubmitHide}
-                placeholder="Hide..."
-              />
-              {this.props.hideValue && (
-                <OverlayTrigger
-                  key="ot_clear_hide"
-                  placement="top"
-                  trigger={['hover', 'focus']}
-                  delayShow={1000}
-                  overlay={<Tooltip id="tt_clear_hide">Clear Hide...</Tooltip>}
-                >
-                  <InputGroup.Button>
-                    <Button onClick={this.clearHide}>
-                      <KialiIcon.Close />
-                    </Button>
-                  </InputGroup.Button>
-                </OverlayTrigger>
-              )}
-            </InputGroup>
+      <Form style={{ float: 'left' }} isHorizontal={true}>
+        <span className={thinGroupStyle}>
+          <TextInput
+            id="graph_find"
+            name="graph_find"
+            ref={ref => {
+              this.findInputRef = ref;
+            }}
+            style={{ ...inputWidth }}
+            type="text"
+            autoComplete="on"
+            isValid={isFindValid}
+            onChange={this.updateFind}
+            defaultValue={this.state.findInputValue}
+            onKeyPress={this.checkSubmitFind}
+            placeholder="Find..."
+          />
+          {this.props.findValue && (
+            <Tooltip key="ot_clear_find" position="top" content="Clear Find...">
+              <Button variant={ButtonVariant.control} onClick={this.clearFind}>
+                <KialiIcon.Close />
+              </Button>
+            </Tooltip>
+          )}
+          <TextInput
+            id="graph_hide"
+            name="graph_hide"
+            ref={ref => {
+              this.hideInputRef = ref;
+            }}
+            style={{ ...inputWidth }}
+            autoComplete="on"
+            isValid={isHideValid}
+            type="text"
+            onChange={this.updateHide}
+            defaultValue={this.state.hideInputValue}
+            onKeyPress={this.checkSubmitHide}
+            placeholder="Hide..."
+          />
+          {this.props.hideValue && (
+            <Tooltip key="ot_clear_hide" position="top" content="Clear Hide...">
+              <Button variant={ButtonVariant.control} onClick={this.clearHide}>
+                <KialiIcon.Close />
+              </Button>
+            </Tooltip>
+          )}
+          {this.props.showFindHelp ? (
             <GraphHelpFind onClose={this.toggleFindHelp}>
-              <OverlayTrigger
-                key={'ot_graph_find_help'}
-                placement="top"
-                overlay={<Tooltip id={'tt_graph_find_help'}>Find/Hide Help...</Tooltip>}
-              >
-                <Button bsStyle="link" style={{ paddingLeft: '6px' }} onClick={this.toggleFindHelp}>
-                  <KialiIcon.Help className={defaultIconStyle} />
-                </Button>
-              </OverlayTrigger>
+              <Button variant={ButtonVariant.link} style={{ paddingLeft: '6px' }} onClick={this.toggleFindHelp}>
+                <KialiIcon.Help className={defaultIconStyle} />
+              </Button>
             </GraphHelpFind>
-          </span>
+          ) : (
+            <Tooltip key={'ot_graph_find_help'} position="top" content="Find/Hide Help...">
+              <Button variant={ButtonVariant.link} style={{ paddingLeft: '6px' }} onClick={this.toggleFindHelp}>
+                <KialiIcon.Help className={defaultIconStyle} />
+              </Button>
+            </Tooltip>
+          )}
           {this.state.errorMessage && (
             <div>
               <span style={{ color: 'red' }}>{this.state.errorMessage}</span>
             </div>
           )}
-        </FormGroup>{' '}
-      </>
+        </span>
+      </Form>
     );
   }
 
@@ -203,19 +189,19 @@ export class GraphFind extends React.PureComponent<GraphFindProps, GraphFindStat
     this.props.toggleFindHelp();
   };
 
-  private updateFind = event => {
-    if ('' === event.target.value) {
+  private updateFind = val => {
+    if ('' === val) {
       this.clearFind();
     } else {
-      this.setState({ findInputValue: event.target.value, errorMessage: '' });
+      this.setState({ findInputValue: val, errorMessage: '' });
     }
   };
 
-  private updateHide = event => {
-    if ('' === event.target.value) {
+  private updateHide = val => {
+    if ('' === val) {
       this.clearHide();
     } else {
-      this.setState({ hideInputValue: event.target.value, errorMessage: '' });
+      this.setState({ hideInputValue: val, errorMessage: '' });
     }
   };
 
@@ -248,8 +234,11 @@ export class GraphFind extends React.PureComponent<GraphFindProps, GraphFindStat
   };
 
   private clearFind = () => {
+    console.log(`ClearFind 1 [${JSON.stringify(this.findInputRef)}]`);
+    console.log(`ClearFind 2 [${this.findInputRef.value}]`);
     // note, we don't use findInputRef.current because <FormControl> deals with refs differently than <input>
     this.findInputRef.value = '';
+    console.log(`ClearFind 3 [${this.findInputRef.value}]`);
     this.setState({ findInputValue: '', errorMessage: '' });
     this.props.setFindValue('');
   };
@@ -274,6 +263,7 @@ export class GraphFind extends React.PureComponent<GraphFindProps, GraphFindStat
 
     const cy = this.props.cyData.cyRef;
     const selector = this.parseValue(this.props.hideValue);
+
     cy.startBatch();
     if (this.hiddenElements) {
       // make visible old hide-hits
@@ -340,8 +330,10 @@ export class GraphFind extends React.PureComponent<GraphFindProps, GraphFindStat
       console.debug('Skip Find: cy not set.');
       return;
     }
+
     const cy = this.props.cyData.cyRef;
     const selector = this.parseValue(this.props.findValue);
+
     cy.startBatch();
     // unhighlight old find-hits
     cy.elements('*.find').removeClass('find');

--- a/src/components/GraphFilter/GraphFind.tsx
+++ b/src/components/GraphFilter/GraphFind.tsx
@@ -15,8 +15,8 @@ import { Layout, EdgeLabelMode } from 'types/GraphFilter';
 import * as AlertUtils from '../../utils/AlertUtils';
 import { KialiIcon, defaultIconStyle } from 'config/KialiIcon';
 import { style } from 'typestyle';
-// import TourStopContainer from 'components/Tour/TourStop';
-// import { GraphTourStops } from 'pages/Graph/GraphHelpTour';
+import TourStopContainer from 'components/Tour/TourStop';
+import { GraphTourStops } from 'pages/Graph/GraphHelpTour';
 
 type ReduxProps = {
   compressOnHide: boolean;
@@ -116,72 +116,74 @@ export class GraphFind extends React.PureComponent<GraphFindProps, GraphFindStat
     const isHideValid: boolean = !(this.props.hideValue.length > 0 && this.state.errorMessage.length > 0);
 
     return (
-      <Form style={{ float: 'left' }} isHorizontal={true}>
-        <span className={thinGroupStyle}>
-          <TextInput
-            id="graph_find"
-            name="graph_find"
-            ref={ref => {
-              this.findInputRef = ref;
-            }}
-            style={{ ...inputWidth }}
-            type="text"
-            autoComplete="on"
-            isValid={isFindValid}
-            onChange={this.updateFind}
-            defaultValue={this.state.findInputValue}
-            onKeyPress={this.checkSubmitFind}
-            placeholder="Find..."
-          />
-          {this.props.findValue && (
-            <Tooltip key="ot_clear_find" position="top" content="Clear Find...">
-              <Button variant={ButtonVariant.control} onClick={this.clearFind}>
-                <KialiIcon.Close />
-              </Button>
-            </Tooltip>
-          )}
-          <TextInput
-            id="graph_hide"
-            name="graph_hide"
-            ref={ref => {
-              this.hideInputRef = ref;
-            }}
-            style={{ ...inputWidth }}
-            autoComplete="on"
-            isValid={isHideValid}
-            type="text"
-            onChange={this.updateHide}
-            defaultValue={this.state.hideInputValue}
-            onKeyPress={this.checkSubmitHide}
-            placeholder="Hide..."
-          />
-          {this.props.hideValue && (
-            <Tooltip key="ot_clear_hide" position="top" content="Clear Hide...">
-              <Button variant={ButtonVariant.control} onClick={this.clearHide}>
-                <KialiIcon.Close />
-              </Button>
-            </Tooltip>
-          )}
-          {this.props.showFindHelp ? (
-            <GraphHelpFind onClose={this.toggleFindHelp}>
-              <Button variant={ButtonVariant.link} style={{ paddingLeft: '6px' }} onClick={this.toggleFindHelp}>
-                <KialiIcon.Help className={defaultIconStyle} />
-              </Button>
-            </GraphHelpFind>
-          ) : (
-            <Tooltip key={'ot_graph_find_help'} position="top" content="Find/Hide Help...">
-              <Button variant={ButtonVariant.link} style={{ paddingLeft: '6px' }} onClick={this.toggleFindHelp}>
-                <KialiIcon.Help className={defaultIconStyle} />
-              </Button>
-            </Tooltip>
-          )}
-          {this.state.errorMessage && (
-            <div>
-              <span style={{ color: 'red' }}>{this.state.errorMessage}</span>
-            </div>
-          )}
-        </span>
-      </Form>
+      <TourStopContainer info={GraphTourStops.Find}>
+        <Form style={{ float: 'left' }} isHorizontal={true}>
+          <span className={thinGroupStyle}>
+            <TextInput
+              id="graph_find"
+              name="graph_find"
+              ref={ref => {
+                this.findInputRef = ref;
+              }}
+              style={{ ...inputWidth }}
+              type="text"
+              autoComplete="on"
+              isValid={isFindValid}
+              onChange={this.updateFind}
+              defaultValue={this.state.findInputValue}
+              onKeyPress={this.checkSubmitFind}
+              placeholder="Find..."
+            />
+            {this.props.findValue && (
+              <Tooltip key="ot_clear_find" position="top" content="Clear Find...">
+                <Button variant={ButtonVariant.control} onClick={this.clearFind}>
+                  <KialiIcon.Close />
+                </Button>
+              </Tooltip>
+            )}
+            <TextInput
+              id="graph_hide"
+              name="graph_hide"
+              ref={ref => {
+                this.hideInputRef = ref;
+              }}
+              style={{ ...inputWidth }}
+              autoComplete="on"
+              isValid={isHideValid}
+              type="text"
+              onChange={this.updateHide}
+              defaultValue={this.state.hideInputValue}
+              onKeyPress={this.checkSubmitHide}
+              placeholder="Hide..."
+            />
+            {this.props.hideValue && (
+              <Tooltip key="ot_clear_hide" position="top" content="Clear Hide...">
+                <Button variant={ButtonVariant.control} onClick={this.clearHide}>
+                  <KialiIcon.Close />
+                </Button>
+              </Tooltip>
+            )}
+            {this.props.showFindHelp ? (
+              <GraphHelpFind onClose={this.toggleFindHelp}>
+                <Button variant={ButtonVariant.link} style={{ paddingLeft: '6px' }} onClick={this.toggleFindHelp}>
+                  <KialiIcon.Help className={defaultIconStyle} />
+                </Button>
+              </GraphHelpFind>
+            ) : (
+              <Tooltip key={'ot_graph_find_help'} position="top" content="Find/Hide Help...">
+                <Button variant={ButtonVariant.link} style={{ paddingLeft: '6px' }} onClick={this.toggleFindHelp}>
+                  <KialiIcon.Help className={defaultIconStyle} />
+                </Button>
+              </Tooltip>
+            )}
+            {this.state.errorMessage && (
+              <div>
+                <span style={{ color: 'red' }}>{this.state.errorMessage}</span>
+              </div>
+            )}
+          </span>
+        </Form>
+      </TourStopContainer>
     );
   }
 
@@ -234,18 +236,23 @@ export class GraphFind extends React.PureComponent<GraphFindProps, GraphFindStat
   };
 
   private clearFind = () => {
-    console.log(`ClearFind 1 [${JSON.stringify(this.findInputRef)}]`);
-    console.log(`ClearFind 2 [${this.findInputRef.value}]`);
-    // note, we don't use findInputRef.current because <FormControl> deals with refs differently than <input>
+    // TODO: when TextInput refs are fixed in PF4 then use the ref and remove the direct HTMLElement usage
     this.findInputRef.value = '';
-    console.log(`ClearFind 3 [${this.findInputRef.value}]`);
+    const htmlInputElement: HTMLInputElement = document.getElementById('graph_find') as HTMLInputElement;
+    if (htmlInputElement !== null) {
+      htmlInputElement.value = '';
+    }
     this.setState({ findInputValue: '', errorMessage: '' });
     this.props.setFindValue('');
   };
 
   private clearHide = () => {
-    // note, we don't use hideInputRef.current because <FormControl> deals with refs differently than <input>
+    // TODO: when TextInput refs are fixed in PF4 then use the ref and remove the direct HTMLElement usage
     this.hideInputRef.value = '';
+    const htmlInputElement: HTMLInputElement = document.getElementById('graph_hide') as HTMLInputElement;
+    if (htmlInputElement !== null) {
+      htmlInputElement.value = '';
+    }
     this.setState({ hideInputValue: '', errorMessage: '' });
     this.props.setHideValue('');
   };

--- a/src/components/GraphFilter/GraphFind.tsx
+++ b/src/components/GraphFilter/GraphFind.tsx
@@ -177,23 +177,24 @@ export class GraphFind extends React.PureComponent<GraphFindProps, GraphFindStat
                 </OverlayTrigger>
               )}
             </InputGroup>
-            <OverlayTrigger
-              key={'ot_graph_find_help'}
-              placement="top"
-              overlay={<Tooltip id={'tt_graph_find_help'}>Find/Hide Help...</Tooltip>}
-            >
-              <Button bsStyle="link" style={{ paddingLeft: '6px' }} onClick={this.toggleFindHelp}>
-                <KialiIcon.Help className={defaultIconStyle} />
-              </Button>
-            </OverlayTrigger>
+            <GraphHelpFind onClose={this.toggleFindHelp}>
+              <OverlayTrigger
+                key={'ot_graph_find_help'}
+                placement="top"
+                overlay={<Tooltip id={'tt_graph_find_help'}>Find/Hide Help...</Tooltip>}
+              >
+                <Button bsStyle="link" style={{ paddingLeft: '6px' }} onClick={this.toggleFindHelp}>
+                  <KialiIcon.Help className={defaultIconStyle} />
+                </Button>
+              </OverlayTrigger>
+            </GraphHelpFind>
           </span>
           {this.state.errorMessage && (
             <div>
               <span style={{ color: 'red' }}>{this.state.errorMessage}</span>
             </div>
           )}
-        </FormGroup>
-        {this.props.showFindHelp && <GraphHelpFind onClose={this.toggleFindHelp} />}{' '}
+        </FormGroup>{' '}
       </>
     );
   }

--- a/src/components/Tab/SimpleTabs.tsx
+++ b/src/components/Tab/SimpleTabs.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import { Tabs } from '@patternfly/react-core';
+
+// SimpleTabs is just a Tabs wrapper than encapsulates the activeTab state handling such
+// that parent components of Tabs don't have to re-render on a tab change.
+
+type SimpleTabsProps = {
+  defaultTab: number;
+  id: string;
+  mountOnEnter?: boolean;
+  unmountOnExit?: boolean;
+};
+
+interface SimpleTabsState {
+  activeTab: number;
+}
+export default class SimpleTabs extends React.Component<SimpleTabsProps, SimpleTabsState> {
+  constructor(props: SimpleTabsProps) {
+    super(props);
+    this.state = { activeTab: props.defaultTab };
+  }
+
+  private handleTabSelect = (_, index) => {
+    this.setState({ activeTab: index });
+  };
+
+  render() {
+    return (
+      <Tabs
+        id={this.props.id}
+        activeKey={this.state.activeTab}
+        onSelect={this.handleTabSelect}
+        mountOnEnter={this.props.mountOnEnter === undefined ? true : this.props.mountOnEnter}
+        unmountOnExit={this.props.unmountOnExit === undefined ? true : this.props.unmountOnExit}
+      >
+        {this.props.children}
+      </Tabs>
+    );
+  }
+}

--- a/src/pages/Graph/GraphHelpFind.tsx
+++ b/src/pages/Graph/GraphHelpFind.tsx
@@ -1,16 +1,33 @@
 import * as React from 'react';
 import Draggable from 'react-draggable';
-import { Button, Nav, NavItem, TabContainer, TabContent, TabPane, Table, TablePfProvider } from 'patternfly-react';
+import { Button, Tabs, Tab } from '@patternfly/react-core';
+import { ICell, Table, TableBody, TableHeader, TableVariant, cellWidth } from '@patternfly/react-table';
+import { CloseIcon } from '@patternfly/react-icons';
 import { style } from 'typestyle';
-import * as resolve from 'table-resolver';
-import { KialiIcon } from 'config/KialiIcon';
 
 export interface GraphHelpFindProps {
   onClose: () => void;
   className?: string;
 }
 
-export default class GraphHelpFind extends React.Component<GraphHelpFindProps> {
+interface GraphHelpFindState {
+  tabIndex: number;
+}
+
+export default class GraphHelpFind extends React.Component<GraphHelpFindProps, GraphHelpFindState> {
+  constructor(props: GraphHelpFindProps) {
+    super(props);
+    this.state = { tabIndex: 2 };
+  }
+
+  private handleTabClick = (_, index) => {
+    console.log(`Change to tab [${index}]`);
+    this.setState({
+      tabIndex: index
+    });
+  };
+
+  /*
   headerFormat = (label, { column }) => <Table.Heading className={column.property}>{label}</Table.Heading>;
   cellFormat = (value, { column }) => {
     const props = column.cell.props;
@@ -18,160 +35,114 @@ export default class GraphHelpFind extends React.Component<GraphHelpFindProps> {
 
     return <Table.Cell className={className}>{value}</Table.Cell>;
   };
+  */
 
-  edgeColumns = () => {
-    return {
-      columns: [
-        {
-          property: 'c',
-          header: {
-            label: 'Expression',
-            formatters: [this.headerFormat]
-          },
-          cell: {
-            formatters: [this.cellFormat],
-            props: {
-              align: 'text-left'
-            }
-          }
-        },
-        {
-          property: 'n',
-          header: {
-            label: 'Notes',
-            formatters: [this.headerFormat]
-          },
-          cell: {
-            formatters: [this.cellFormat],
-            props: {
-              align: 'text-left'
-            }
-          }
-        }
-      ]
-    };
+  private edgeColumns = (): ICell[] => {
+    return [{ title: 'Expression' }, { title: 'Notes' }];
+  };
+  private edgeRows = (): string[][] => {
+    return [
+      ['grpc <op> <number>', 'unit: requests per second'],
+      ['%grpcerr <op> <number>', 'range: [0..100]'],
+      ['%grpctraffic <op> <number>', 'range: [0..100]'],
+      ['http <op> <number>', 'unit: requests per second'],
+      ['%httperr <op> <number>', 'range: [0..100]'],
+      ['%httptraffic <op> <number>', 'range: [0..100]'],
+      ['protocol <op> <protocol>', 'grpc, http, tcp, etc..'],
+      ['responsetime <op> <number>', `unit: millis, will auto-enable 'response time' edge labels`],
+      ['tcp <op> <number>', 'unit: requests per second'],
+      ['mtls', `will auto-enable 'security' display option`],
+      ['traffic', 'any traffic for any protocol']
+    ];
   };
 
-  exampleColumns = () => {
-    return {
-      columns: [
-        {
-          property: 'e',
-          header: {
-            label: 'Expression',
-            formatters: [this.headerFormat]
-          },
-          cell: {
-            formatters: [this.cellFormat],
-            props: {
-              align: 'text-left'
-            }
-          }
-        },
-        {
-          property: 'd',
-          header: {
-            label: 'Description',
-            formatters: [this.headerFormat]
-          },
-          cell: {
-            formatters: [this.cellFormat],
-            props: {
-              align: 'text-left'
-            }
-          }
-        }
-      ]
-    };
+  private exampleColumns = (): ICell[] => {
+    return [{ title: 'Expression' }, { title: 'Description' }];
+  };
+  private exampleRows = (): string[][] => {
+    return [
+      ['name = reviews', `"by name": nodes with app label, service name or workload name equal to 'reviews'`],
+      ['name not contains rev', `"by name": nodes with app label, service name and workload name not containing 'rev'`],
+      ['app startswith product', `nodes with app label starting with 'product'`],
+      ['app != details and version=v1', `nodes with app label not equal to 'details' and with version equal to 'v1'`],
+      ['!sc', `nodes without a sidecar`],
+      ['httpin > 0.5', `nodes with incoming http rate > 0.5 rps`],
+      ['tcpout >= 1000', `nodes with outgoing tcp rates >= 1000 bps`],
+      ['!traffic', 'edges with no traffic'],
+      ['http > 0.5', `edges with http rate > 0.5 rps`],
+      ['rt > 500', `edges with response time > 500ms. (requires response time edge labels)`],
+      ['%httptraffic >= 50.0', `edges with >= 50% of the outgoing http request traffic of the parent`]
+    ];
   };
 
-  nodeColumns = () => {
-    return {
-      columns: [
-        {
-          property: 'c',
-          header: {
-            label: 'Expression',
-            formatters: [this.headerFormat]
-          },
-          cell: {
-            formatters: [this.cellFormat],
-            props: {
-              align: 'text-left'
-            }
-          }
-        },
-        {
-          property: 'n',
-          header: {
-            label: 'Notes',
-            formatters: [this.headerFormat]
-          },
-          cell: {
-            formatters: [this.cellFormat],
-            props: {
-              align: 'text-left'
-            }
-          }
-        }
-      ]
-    };
+  private nodeColumns = (): ICell[] => {
+    return [{ title: 'Expression' }, { title: 'Notes' }];
+  };
+  private nodeRows = (): string[][] => {
+    return [
+      ['grpcin <op> <number>', 'unit: requests per second'],
+      ['grpcout <op> <number>', 'unit: requests per second'],
+      ['httpin <op> <number>', 'unit: requests per second'],
+      ['httpout <op> <number>', 'unit: requests per second'],
+      ['name <op> <string>', 'tests against app label, service name and workload name'],
+      ['namespace <op> <namespaceName>'],
+      ['node <op> <nodeType>', 'nodeType: app | service | workload | unknown'],
+      ['service <op> <serviceName>'],
+      ['version <op> <string>'],
+      ['tcpin <op> <number>', 'unit: bytes per second'],
+      ['tcpout <op> <number>', 'unit: bytes per second'],
+      ['workload <op> <workloadName>'],
+      ['circuitbreaker'],
+      ['outside', 'is outside of requested namespaces'],
+      ['sidecar'],
+      ['serviceentry'],
+      ['trafficsource', `has only outgoing edges`],
+      ['unused', `will auto-enable 'unused nodes' display option`],
+      ['virtualservice']
+    ];
   };
 
-  noteColumns = () => {
-    return {
-      columns: [
-        {
-          property: 't',
-          header: {
-            label: 'Usage Note',
-            formatters: [this.headerFormat]
-          },
-          cell: {
-            formatters: [this.cellFormat],
-            props: {
-              align: 'textleft'
-            }
-          }
-        }
-      ]
-    };
+  private noteColumns = (): ICell[] => {
+    return [{ title: 'Usage Note', transforms: [cellWidth(10) as any], props: { style: { align: 'text-left' } } }];
+  };
+  private noteRows = (): string[][] => {
+    return [
+      ['Expressions can not combine "AND" with "OR".'],
+      ['Parentheses are not supported (or needed).'],
+      ['The "name" operand expands internally to an "OR" expression (an "AND" when negated).'],
+      ['Expressions can not combine node and edge criteria.'],
+      ['Use "<operand> = NaN" to test for no activity. Use "!= NaN" for any activity. (e.g. httpout = NaN)'],
+      [`Unary operands may optionally be prefixed with "is" or "has". (i.e. "has mtls")`],
+      ['Abbrevations: namespace|ns, service|svc, workload|wl (e.g. is wlnode)'],
+      ['Abbrevations: circuitbreaker|cb, responsetime|rt, serviceentry->se, sidecar|sc, virtualservice|vs'],
+      ['Hiding nodes will automatically hide connected edges.'],
+      ['Hiding edges will automatically hide nodes left with no visible edges.']
+    ];
   };
 
-  operatorColumns = () => {
-    return {
-      columns: [
-        {
-          property: 'o',
-          header: {
-            label: 'Operator',
-            formatters: [this.headerFormat]
-          },
-          cell: {
-            formatters: [this.cellFormat],
-            props: {
-              align: 'text-center'
-            }
-          }
-        },
-        {
-          property: 'd',
-          header: {
-            label: 'Description',
-            formatters: [this.headerFormat]
-          },
-          cell: {
-            formatters: [this.cellFormat],
-            props: {
-              align: 'text-left'
-            }
-          }
-        }
-      ]
-    };
+  private operatorColumns = (): ICell[] => {
+    return [{ title: 'Operator' }, { title: 'Description' }];
+  };
+  private operatorRows = (): string[][] => {
+    return [
+      ['! | not <unary expression>', `negation`],
+      ['=', `equals`],
+      ['!=', `not equals`],
+      ['endswith | $=', `ends with, strings only`],
+      ['!endswith | !$=', `not ends with, strings only`],
+      ['startswith | ^=', `starts with, strings only`],
+      ['!startswith | !^=', `not starts with, strings only`],
+      ['contains | *=', 'contains, strings only'],
+      ['!contains | !*=', 'not contains, strings only'],
+      ['>', `greater than`],
+      ['>=', `greater than or equals`],
+      ['<', `less than`],
+      ['<=', `less than or equals`]
+    ];
   };
 
   render() {
+    console.log('Render');
     const className = this.props.className ? this.props.className : '';
     const width = '600px';
     const maxWidth = '602px';
@@ -207,239 +178,66 @@ export default class GraphHelpFind extends React.Component<GraphHelpFindProps> {
       'expressions using the language described below. Hide takes precedence when using Find and Hide ' +
       'together. Uncheck the "Compress Hidden" display option for hidden elements to retain their space.';
 
+    console.log('Render 2');
     return (
       <Draggable handle="#helpheader" bounds="#root">
         <div className={`modal-content ${className} ${contentStyle}`}>
           <div id="helpheader" className={`modal-header ${headerStyle}`}>
-            <Button className="close" bsClass="" onClick={this.props.onClose}>
-              <KialiIcon.Close />
+            <Button className="close" onClick={this.props.onClose}>
+              <CloseIcon />
             </Button>
             <span className="modal-title">Help: Graph Find/Hide</span>
           </div>
           <div className={`modal-body ${bodyStyle}`}>
             <textarea className={`${prefaceStyle}`} readOnly={true} value={preface} />
-            <TabContainer id="basic-tabs" defaultActiveKey="notes">
-              <>
-                <Nav bsClass="nav nav-tabs nav-tabs-pf" style={{ paddingLeft: '10px' }}>
-                  <NavItem eventKey="notes">
-                    <div>Usage Notes</div>
-                  </NavItem>
-                  <NavItem eventKey="operators">
-                    <div>Operators</div>
-                  </NavItem>
-                  <NavItem eventKey="nodes">
-                    <div>Nodes</div>
-                  </NavItem>
-                  <NavItem eventKey="edges">
-                    <div>Edges</div>
-                  </NavItem>
-                  <NavItem eventKey="examples">
-                    <div>Examples</div>
-                  </NavItem>
-                </Nav>
-                <TabContent>
-                  <TabPane eventKey="notes" mountOnEnter={true} unmountOnExit={true}>
-                    <TablePfProvider
-                      striped={true}
-                      bordered={true}
-                      hover={true}
-                      dataTable={true}
-                      columns={this.noteColumns().columns}
-                    >
-                      <Table.Header headerRows={resolve.headerRows(this.noteColumns())} />
-                      <Table.Body
-                        rowKey="id"
-                        rows={[
-                          { id: 't00', t: 'Expressions can not combine "AND" with "OR".' },
-                          { id: 't05', t: 'Parentheses are not supported (or needed).' },
-                          {
-                            id: 't10',
-                            t: 'The "name" operand expands internally to an "OR" expression (an "AND" when negated).'
-                          },
-                          { id: 't30', t: 'Expressions can not combine node and edge criteria.' },
-                          {
-                            id: 't45',
-                            t:
-                              'Use "<operand> = NaN" to test for no activity. Use "!= NaN" for any activity. (e.g. httpout = NaN)'
-                          },
-                          {
-                            id: 't70',
-                            t: `Unary operands may optionally be prefixed with "is" or "has". (i.e. "has mtls")`
-                          },
-                          {
-                            id: 't80',
-                            t: 'Abbrevations: namespace|ns, service|svc, workload|wl (e.g. is wlnode)'
-                          },
-                          {
-                            id: 't90',
-                            t:
-                              'Abbrevations: circuitbreaker|cb, responsetime|rt, serviceentry->se, sidecar|sc, virtualservice|vs'
-                          },
-                          {
-                            id: 't100',
-                            t: 'Hiding nodes will automatically hide connected edges.'
-                          },
-                          {
-                            id: 't110',
-                            t: 'Hiding edges will automatically hide nodes left with no visible edges.'
-                          }
-                        ]}
-                      />
-                    </TablePfProvider>
-                  </TabPane>
-                  <TabPane eventKey="operators" mountOnEnter={true} unmountOnExit={true}>
-                    <TablePfProvider
-                      striped={true}
-                      bordered={true}
-                      hover={true}
-                      dataTable={true}
-                      columns={this.operatorColumns().columns}
-                    >
-                      <Table.Header headerRows={resolve.headerRows(this.operatorColumns())} />
-                      <Table.Body
-                        rowKey="id"
-                        rows={[
-                          { id: 'o0', o: '! | not <unary expression>', d: `negation` },
-                          { id: 'o1', o: '=', d: `equals` },
-                          { id: 'o2', o: '!=', d: `not equals` },
-                          { id: 'o3', o: 'endswith | $=', d: `ends with, strings only` },
-                          { id: 'o4', o: '!endswith | !$=', d: `not ends with, strings only` },
-                          { id: 'o5', o: 'startswith | ^=', d: `starts with, strings only` },
-                          { id: 'o6', o: '!startswith | !^=', d: `not starts with, strings only` },
-                          { id: 'o7', o: 'contains | *=', d: 'contains, strings only' },
-                          { id: 'o8', o: '!contains | !*=', d: 'not contains, strings only' },
-                          { id: 'o9', o: '>', d: `greater than` },
-                          { id: 'o10', o: '>=', d: `greater than or equals` },
-                          { id: 'o11', o: '<', d: `less than` },
-                          { id: 'o12', o: '<=', d: `less than or equals` }
-                        ]}
-                      />
-                    </TablePfProvider>
-                  </TabPane>
-                  <TabPane eventKey="nodes" mountOnEnter={true} unmountOnExit={true}>
-                    <TablePfProvider
-                      striped={true}
-                      bordered={true}
-                      hover={true}
-                      dataTable={true}
-                      columns={this.nodeColumns().columns}
-                    >
-                      <Table.Header headerRows={resolve.headerRows(this.nodeColumns())} />
-                      <Table.Body
-                        rowKey="id"
-                        rows={[
-                          { id: 'nc00', c: 'grpcin <op> <number>', n: 'unit: requests per second' },
-                          { id: 'nc10', c: 'grpcout <op> <number>', n: 'unit: requests per second' },
-                          { id: 'nc12', c: 'httpin <op> <number>', n: 'unit: requests per second' },
-                          { id: 'nc13', c: 'httpout <op> <number>', n: 'unit: requests per second' },
-                          {
-                            id: 'nc15',
-                            c: 'name <op> <string>',
-                            n: 'tests against app label, service name and workload name'
-                          },
-                          { id: 'nc20', c: 'namespace <op> <namespaceName>' },
-                          { id: 'nc25', c: 'node <op> <nodeType>', n: 'nodeType: app | service | workload | unknown' },
-                          { id: 'nc30', c: 'service <op> <serviceName>' },
-                          { id: 'nc40', c: 'version <op> <string>' },
-                          { id: 'nc50', c: 'tcpin <op> <number>', n: 'unit: bytes per second' },
-                          { id: 'nc60', c: 'tcpout <op> <number>', n: 'unit: bytes per second' },
-                          { id: 'nc70', c: 'workload <op> <workloadName>' },
-                          { id: 'nc90', c: 'circuitbreaker' },
-                          { id: 'nc100', c: 'outside', n: 'is outside of requested namespaces' },
-                          { id: 'nc110', c: 'sidecar' },
-                          { id: 'nc130', c: 'serviceentry' },
-                          { id: 'nc135', c: 'trafficsource', n: `has only outgoing edges` },
-                          { id: 'nc150', c: 'unused', n: `will auto-enable 'unused nodes' display option` },
-                          { id: 'nc160', c: 'virtualservice' }
-                        ]}
-                      />
-                    </TablePfProvider>
-                  </TabPane>
-                  <TabPane eventKey="edges" mountOnEnter={true} unmountOnExit={true}>
-                    <TablePfProvider
-                      striped={true}
-                      bordered={true}
-                      hover={true}
-                      dataTable={true}
-                      columns={this.edgeColumns().columns}
-                    >
-                      <Table.Header headerRows={resolve.headerRows(this.edgeColumns())} />
-                      <Table.Body
-                        rowKey="id"
-                        rows={[
-                          { id: 'ec00', c: 'grpc <op> <number>', n: 'unit: requests per second' },
-                          { id: 'ec10', c: '%grpcerr <op> <number>', n: 'range: [0..100]' },
-                          { id: 'ec20', c: '%grpctraffic <op> <number>', n: 'range: [0..100]' },
-                          { id: 'ec23', c: 'http <op> <number>', n: 'unit: requests per second' },
-                          { id: 'ec24', c: '%httperr <op> <number>', n: 'range: [0..100]' },
-                          { id: 'ec25', c: '%httptraffic <op> <number>', n: 'range: [0..100]' },
-                          { id: 'ec30', c: 'protocol <op> <protocol>', n: 'grpc, http, tcp, etc..' },
-                          {
-                            id: 'ec40',
-                            c: 'responsetime <op> <number>',
-                            n: `unit: millis, will auto-enable 'response time' edge labels`
-                          },
-                          { id: 'ec50', c: 'tcp <op> <number>', n: 'unit: requests per second' },
-                          { id: 'ec60', c: 'mtls', n: `will auto-enable 'security' display option` },
-                          { id: 'ec70', c: 'traffic', n: 'any traffic for any protocol' }
-                        ]}
-                      />
-                    </TablePfProvider>
-                  </TabPane>
-                  <TabPane eventKey="examples">
-                    <TablePfProvider
-                      striped={true}
-                      bordered={true}
-                      hover={true}
-                      dataTable={true}
-                      columns={this.exampleColumns().columns}
-                    >
-                      <Table.Header headerRows={resolve.headerRows(this.exampleColumns())} />
-                      <Table.Body
-                        rowKey="id"
-                        rows={[
-                          {
-                            id: 'e00',
-                            e: 'name = reviews',
-                            d: `"by name": nodes with app label, service name or workload name equal to 'reviews'`
-                          },
-                          {
-                            id: 'e10',
-                            e: 'name not contains rev',
-                            d: `"by name": nodes with app label, service name and workload name not containing 'rev'`
-                          },
-                          {
-                            id: 'e20',
-                            e: 'app startswith product',
-                            d: `nodes with app label starting with 'product'`
-                          },
-                          {
-                            id: 'e30',
-                            e: 'app != details and version=v1',
-                            d: `nodes with app label not equal to 'details' and with version equal to 'v1'`
-                          },
-                          { id: 'e40', e: '!sc', d: `nodes without a sidecar` },
-                          { id: 'e50', e: 'httpin > 0.5', d: `nodes with incoming http rate > 0.5 rps` },
-                          { id: 'e60', e: 'tcpout >= 1000', d: `nodes with outgoing tcp rates >= 1000 bps` },
-                          { id: 'e65', e: '!traffic', d: 'edges with no traffic' },
-                          { id: 'e70', e: 'http > 0.5', d: `edges with http rate > 0.5 rps` },
-                          {
-                            id: 'e80',
-                            e: 'rt > 500',
-                            d: `edges with response time > 500ms. (requires response time edge labels)`
-                          },
-                          {
-                            id: 'e90',
-                            e: '%httptraffic >= 50.0',
-                            d: `edges with >= 50% of the outgoing http request traffic of the parent`
-                          }
-                        ]}
-                      />
-                    </TablePfProvider>
-                  </TabPane>
-                </TabContent>
-              </>
-            </TabContainer>
+            <Tabs
+              id="graph_find_help_tabs"
+              activeKey={this.state.tabIndex}
+              onSelect={this.handleTabClick}
+              mountOnEnter={true}
+              unmountOnExit={true}
+            >
+              <Tab eventKey={0} title="Notes" style={{ paddingLeft: '10px' }}>
+                <Table header={<></>} variant={TableVariant.compact} cells={this.noteColumns()} rows={this.noteRows()}>
+                  <TableHeader />
+                  <TableBody />
+                </Table>
+              </Tab>
+              <Tab eventKey={1} title="Operators">
+                <Table
+                  header={<></>}
+                  variant={TableVariant.compact}
+                  cells={this.operatorColumns()}
+                  rows={this.operatorRows()}
+                >
+                  <TableHeader />
+                  <TableBody />
+                </Table>
+              </Tab>
+              <Tab eventKey={2} title="Nodes">
+                <Table header={<></>} variant={TableVariant.compact} cells={this.nodeColumns()} rows={this.nodeRows()}>
+                  <TableHeader />
+                  <TableBody />
+                </Table>
+              </Tab>
+              <Tab eventKey={3} title="Edges">
+                <Table header={<></>} variant={TableVariant.compact} cells={this.edgeColumns()} rows={this.edgeRows()}>
+                  <TableHeader />
+                  <TableBody />
+                </Table>
+              </Tab>
+              <Tab eventKey={4} title="Examples">
+                <Table
+                  header={<></>}
+                  variant={TableVariant.compact}
+                  cells={this.exampleColumns()}
+                  rows={this.exampleRows()}
+                >
+                  <TableHeader />
+                  <TableBody />
+                </Table>
+              </Tab>
+            </Tabs>
           </div>
         </div>
       </Draggable>

--- a/src/pages/Graph/GraphHelpFind.tsx
+++ b/src/pages/Graph/GraphHelpFind.tsx
@@ -31,7 +31,7 @@ export default class GraphHelpFind extends React.Component<GraphHelpFindProps> {
       color: '#fff',
       backgroundColor: '#003145',
       width: '540px',
-      height: '70px',
+      height: '71px',
       padding: '5px',
       resize: 'none'
     });

--- a/src/pages/Graph/GraphHelpFind.tsx
+++ b/src/pages/Graph/GraphHelpFind.tsx
@@ -1,32 +1,16 @@
 import * as React from 'react';
-import Draggable from 'react-draggable';
-import { Button, Tabs, Tab } from '@patternfly/react-core';
+import ReactResizeDetector from 'react-resize-detector';
+import { Tab, Popover, PopoverPosition } from '@patternfly/react-core';
 import { ICell, Table, TableBody, TableHeader, TableVariant, cellWidth } from '@patternfly/react-table';
-import { CloseIcon } from '@patternfly/react-icons';
 import { style } from 'typestyle';
+import SimpleTabs from 'components/Tab/SimpleTabs';
 
 export interface GraphHelpFindProps {
   onClose: () => void;
   className?: string;
 }
 
-interface GraphHelpFindState {
-  tabIndex: number;
-}
-
-export default class GraphHelpFind extends React.Component<GraphHelpFindProps, GraphHelpFindState> {
-  constructor(props: GraphHelpFindProps) {
-    super(props);
-    this.state = { tabIndex: 2 };
-  }
-
-  private handleTabClick = (_, index) => {
-    console.log(`Change to tab [${index}]`);
-    this.setState({
-      tabIndex: index
-    });
-  };
-
+export default class GraphHelpFind extends React.Component<GraphHelpFindProps> {
   /*
   headerFormat = (label, { column }) => <Table.Heading className={column.property}>{label}</Table.Heading>;
   cellFormat = (value, { column }) => {
@@ -36,6 +20,137 @@ export default class GraphHelpFind extends React.Component<GraphHelpFindProps, G
     return <Table.Cell className={className}>{value}</Table.Cell>;
   };
   */
+
+  private onResize = () => {
+    this.forceUpdate();
+  };
+
+  render() {
+    // const className = this.props.className ? this.props.className : '';
+    const width = '600px';
+    const maxWidth = '604px';
+    // const contentWidth = 'calc(100vw - 50px - var(--pf-c-page__sidebar--md--Width))'; // 50px prevents full coverage
+    const popoverStyle = style({
+      width: width,
+      maxWidth: maxWidth,
+      height: '550px',
+      // padding: '0',
+      // right: '0',
+      // top: '5px',
+      // zIndex: 9999,
+      // position: 'absolute',
+      overflow: 'hidden',
+      overflowX: 'auto',
+      overflowY: 'auto'
+    });
+    /*
+    const headerStyle = style({
+      width: width
+    });
+    const bodyStyle = style({
+      // width: width
+    });
+    */
+    const prefaceStyle = style({
+      fontSize: '12px',
+      color: '#fff',
+      backgroundColor: '#003145',
+      width: '540px',
+      height: '70px',
+      padding: '5px',
+      resize: 'none'
+    });
+    const preface =
+      'You can use the Find and Hide fields to highlight or hide graph edges and nodes. Each field accepts ' +
+      'expressions using the language described below. Hide takes precedence when using Find and Hide ' +
+      'together. Uncheck the "Compress Hidden" display option for hidden elements to retain their space.';
+
+    return (
+      <>
+        <ReactResizeDetector
+          refreshMode={'debounce'}
+          refreshRate={100}
+          skipOnMount={true}
+          handleWidth={true}
+          handleHeight={true}
+          onResize={this.onResize}
+        />
+        <Popover
+          className={popoverStyle}
+          position={PopoverPosition.auto}
+          headerContent={
+            <div>
+              <span>Graph Find/Hide</span>
+            </div>
+          }
+          bodyContent={
+            <div>
+              <textarea className={`${prefaceStyle}`} readOnly={true} value={preface} />
+              <SimpleTabs id="graph_find_help_tabs" defaultTab={0}>
+                <Tab eventKey={0} title="Usage Notes">
+                  <Table
+                    header={<></>}
+                    variant={TableVariant.compact}
+                    cells={this.noteColumns()}
+                    rows={this.noteRows()}
+                  >
+                    <TableHeader />
+                    <TableBody />
+                  </Table>
+                </Tab>
+                <Tab eventKey={1} title="Operators">
+                  <Table
+                    header={<></>}
+                    variant={TableVariant.compact}
+                    cells={this.operatorColumns()}
+                    rows={this.operatorRows()}
+                  >
+                    <TableHeader />
+                    <TableBody />
+                  </Table>
+                </Tab>
+                <Tab eventKey={2} title="Nodes">
+                  <Table
+                    header={<></>}
+                    variant={TableVariant.compact}
+                    cells={this.nodeColumns()}
+                    rows={this.nodeRows()}
+                  >
+                    <TableHeader />
+                    <TableBody />
+                  </Table>
+                </Tab>
+                <Tab eventKey={3} title="Edges">
+                  <Table
+                    header={<></>}
+                    variant={TableVariant.compact}
+                    cells={this.edgeColumns()}
+                    rows={this.edgeRows()}
+                  >
+                    <TableHeader />
+                    <TableBody />
+                  </Table>
+                </Tab>
+                <Tab eventKey={4} title="Examples">
+                  <Table
+                    header={<></>}
+                    variant={TableVariant.compact}
+                    cells={this.exampleColumns()}
+                    rows={this.exampleRows()}
+                  >
+                    <TableHeader />
+                    <TableBody />
+                  </Table>
+                </Tab>
+              </SimpleTabs>
+            </div>
+          }
+        >
+          <>{this.props.children}</>
+        </Popover>
+      </>
+    );
+  }
 
   private edgeColumns = (): ICell[] => {
     return [{ title: 'Expression' }, { title: 'Notes' }];
@@ -140,107 +255,4 @@ export default class GraphHelpFind extends React.Component<GraphHelpFindProps, G
       ['<=', `less than or equals`]
     ];
   };
-
-  render() {
-    console.log('Render');
-    const className = this.props.className ? this.props.className : '';
-    const width = '600px';
-    const maxWidth = '602px';
-    const contentWidth = 'calc(100vw - 50px - var(--pf-c-page__sidebar--md--Width))'; // 50px prevents full coverage
-    const contentStyle = style({
-      width: contentWidth,
-      maxWidth: maxWidth,
-      height: '550px',
-      right: '0',
-      top: '10px',
-      zIndex: 9999,
-      position: 'absolute',
-      overflow: 'hidden',
-      overflowX: 'auto',
-      overflowY: 'auto'
-    });
-    const headerStyle = style({
-      width: width
-    });
-    const bodyStyle = style({
-      width: width
-    });
-    const prefaceStyle = style({
-      width: '100%',
-      height: '77px',
-      padding: '10px',
-      resize: 'none',
-      color: '#fff',
-      backgroundColor: '#003145'
-    });
-    const preface =
-      'You can use the Find and Hide fields to highlight or hide graph edges and nodes. Each field accepts ' +
-      'expressions using the language described below. Hide takes precedence when using Find and Hide ' +
-      'together. Uncheck the "Compress Hidden" display option for hidden elements to retain their space.';
-
-    console.log('Render 2');
-    return (
-      <Draggable handle="#helpheader" bounds="#root">
-        <div className={`modal-content ${className} ${contentStyle}`}>
-          <div id="helpheader" className={`modal-header ${headerStyle}`}>
-            <Button className="close" onClick={this.props.onClose}>
-              <CloseIcon />
-            </Button>
-            <span className="modal-title">Help: Graph Find/Hide</span>
-          </div>
-          <div className={`modal-body ${bodyStyle}`}>
-            <textarea className={`${prefaceStyle}`} readOnly={true} value={preface} />
-            <Tabs
-              id="graph_find_help_tabs"
-              activeKey={this.state.tabIndex}
-              onSelect={this.handleTabClick}
-              mountOnEnter={true}
-              unmountOnExit={true}
-            >
-              <Tab eventKey={0} title="Notes" style={{ paddingLeft: '10px' }}>
-                <Table header={<></>} variant={TableVariant.compact} cells={this.noteColumns()} rows={this.noteRows()}>
-                  <TableHeader />
-                  <TableBody />
-                </Table>
-              </Tab>
-              <Tab eventKey={1} title="Operators">
-                <Table
-                  header={<></>}
-                  variant={TableVariant.compact}
-                  cells={this.operatorColumns()}
-                  rows={this.operatorRows()}
-                >
-                  <TableHeader />
-                  <TableBody />
-                </Table>
-              </Tab>
-              <Tab eventKey={2} title="Nodes">
-                <Table header={<></>} variant={TableVariant.compact} cells={this.nodeColumns()} rows={this.nodeRows()}>
-                  <TableHeader />
-                  <TableBody />
-                </Table>
-              </Tab>
-              <Tab eventKey={3} title="Edges">
-                <Table header={<></>} variant={TableVariant.compact} cells={this.edgeColumns()} rows={this.edgeRows()}>
-                  <TableHeader />
-                  <TableBody />
-                </Table>
-              </Tab>
-              <Tab eventKey={4} title="Examples">
-                <Table
-                  header={<></>}
-                  variant={TableVariant.compact}
-                  cells={this.exampleColumns()}
-                  rows={this.exampleRows()}
-                >
-                  <TableHeader />
-                  <TableBody />
-                </Table>
-              </Tab>
-            </Tabs>
-          </div>
-        </div>
-      </Draggable>
-    );
-  }
 }

--- a/src/pages/Graph/GraphHelpFind.tsx
+++ b/src/pages/Graph/GraphHelpFind.tsx
@@ -11,46 +11,21 @@ export interface GraphHelpFindProps {
 }
 
 export default class GraphHelpFind extends React.Component<GraphHelpFindProps> {
-  /*
-  headerFormat = (label, { column }) => <Table.Heading className={column.property}>{label}</Table.Heading>;
-  cellFormat = (value, { column }) => {
-    const props = column.cell.props;
-    const className = props ? props.align : '';
-
-    return <Table.Cell className={className}>{value}</Table.Cell>;
-  };
-  */
-
   private onResize = () => {
     this.forceUpdate();
   };
 
   render() {
-    // const className = this.props.className ? this.props.className : '';
     const width = '600px';
     const maxWidth = '604px';
-    // const contentWidth = 'calc(100vw - 50px - var(--pf-c-page__sidebar--md--Width))'; // 50px prevents full coverage
     const popoverStyle = style({
       width: width,
       maxWidth: maxWidth,
       height: '550px',
-      // padding: '0',
-      // right: '0',
-      // top: '5px',
-      // zIndex: 9999,
-      // position: 'absolute',
       overflow: 'hidden',
       overflowX: 'auto',
       overflowY: 'auto'
     });
-    /*
-    const headerStyle = style({
-      width: width
-    });
-    const bodyStyle = style({
-      // width: width
-    });
-    */
     const prefaceStyle = style({
       fontSize: '12px',
       color: '#fff',
@@ -78,6 +53,9 @@ export default class GraphHelpFind extends React.Component<GraphHelpFindProps> {
         <Popover
           className={popoverStyle}
           position={PopoverPosition.auto}
+          isVisible={true}
+          hideOnOutsideClick={false}
+          shouldClose={this.props.onClose}
           headerContent={
             <div>
               <span>Graph Find/Hide</span>

--- a/yarn.lock
+++ b/yarn.lock
@@ -11775,14 +11775,6 @@ react-dom@16.9.0:
     prop-types "^15.6.2"
     scheduler "^0.15.0"
 
-react-draggable@3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-3.2.1.tgz#45d09a9a227988dc85674b23ab3c75b6e820dae5"
-  integrity sha512-r+3Bs9InID2lyIEbR8UIRVtpn4jgu1ArFEZgIy8vibJjijLSdNLX7rH9U68BBVD4RD9v44RXbaK4EHLyKXzNQw==
-  dependencies:
-    classnames "^2.2.5"
-    prop-types "^15.6.0"
-
 react-error-overlay@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.1.tgz#b8d3cf9bb991c02883225c48044cb3ee20413e0f"


### PR DESCRIPTION
UPDATE: 11/5/2019
- expanding PR/Issue to include all of graph find/hide

Converts the GraphFind and GraphHelpFind components to PF4, removing PF3.
- Add PF4 design to text inputs
- Convert help from Draggable Modal to Popover
  - removes react-draggable because PF4's Tabs were unable to function inside of Draggable (I don't know why).
  - Popover gives us a more consistent look (like graph tour and tooltips) but at the expense of draggability (I'm not sure draggability is veryt PF4 anyway).  On the down-side, using PF4's Popover, Tabs and Table costs us elephant space.  I'm not css savvy enough to make the tables very compact, so vertical scrolling is going to be in play.
- I Introduced SimpleTabs util just to hide the active tab state changes from parent components.

I think this is a passable PF4 migration but I liked the old one better for its compact, organized look.

Fixes https://github.com/kiali/kiali/issues/1861

Before:
![image](https://user-images.githubusercontent.com/2104052/68225870-1654bf80-ffbf-11e9-80b1-ac445c80b0f0.png)

![image](https://user-images.githubusercontent.com/2104052/68058094-62a5b400-fcce-11e9-9912-494094da48ee.png)

After:
![image](https://user-images.githubusercontent.com/2104052/68225927-2ec4da00-ffbf-11e9-919c-65b5949c824e.png)

![image](https://user-images.githubusercontent.com/2104052/68058217-d051e000-fcce-11e9-8c89-3780ed74e9dd.png)

