### PR TITLE
Add referenced istio objects to validations

### DIFF
--- a/src/components/Link/IstioObjectLink.tsx
+++ b/src/components/Link/IstioObjectLink.tsx
@@ -19,7 +19,7 @@ const IstioObjectLink = (props: Props) => {
   if (!!subType) {
     to = to + '/' + istioType + '/' + subType + '/' + name;
   } else {
-    to = to + '/' + istioType.slug + '/' + name;
+    to = to + '/' + istioType.url + '/' + name;
   }
 
   return (

--- a/src/components/Link/IstioObjectLink.tsx
+++ b/src/components/Link/IstioObjectLink.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { Paths } from '../../config';
+import { Link } from 'react-router-dom';
+import { Badge, Tooltip, TooltipPosition } from '@patternfly/react-core';
+import { IstioTypes } from '../VirtualList/Config';
+
+interface Props {
+  name: string;
+  namespace: string;
+  type: string;
+}
+
+const IstioObjectLink = (props: Props) => {
+  const { name, namespace, type } = props;
+  //const objectType = type.charAt(0).toUpperCase() + type.slice(1);
+  const istioType = IstioTypes[type];
+  const url = '/namespaces/' + namespace + '/' + Paths.ISTIO + '/' + istioType.slug + '/' + name;
+  return (
+    <>
+      <Tooltip position={TooltipPosition.top} content={<>{istioType.name}</>}>
+        <Badge className={'virtualitem_badge_definition'}>{istioType.icon}</Badge>
+      </Tooltip>
+      <Link to={url}>
+        {namespace}/{name}
+      </Link>
+    </>
+  );
+};
+
+export default IstioObjectLink;

--- a/src/components/Link/IstioObjectLink.tsx
+++ b/src/components/Link/IstioObjectLink.tsx
@@ -8,18 +8,26 @@ interface Props {
   name: string;
   namespace: string;
   type: string;
+  subType?: string;
 }
 
 const IstioObjectLink = (props: Props) => {
-  const { name, namespace, type } = props;
+  const { name, namespace, type, subType } = props;
   const istioType = IstioTypes[type];
-  const url = '/namespaces/' + namespace + '/' + Paths.ISTIO + '/' + istioType.slug + '/' + name;
+  let to = '/namespaces/' + namespace + '/' + Paths.ISTIO;
+
+  if (!!subType) {
+    to = to + '/' + istioType + '/' + subType + '/' + name;
+  } else {
+    to = to + '/' + istioType.slug + '/' + name;
+  }
+
   return (
     <>
       <Tooltip position={TooltipPosition.top} content={<>{istioType.name}</>}>
         <Badge className={'virtualitem_badge_definition'}>{istioType.icon}</Badge>
       </Tooltip>
-      <Link to={url}>
+      <Link to={to}>
         {namespace}/{name}
       </Link>
     </>

--- a/src/components/Link/IstioObjectLink.tsx
+++ b/src/components/Link/IstioObjectLink.tsx
@@ -12,7 +12,6 @@ interface Props {
 
 const IstioObjectLink = (props: Props) => {
   const { name, namespace, type } = props;
-  //const objectType = type.charAt(0).toUpperCase() + type.slice(1);
   const istioType = IstioTypes[type];
   const url = '/namespaces/' + namespace + '/' + Paths.ISTIO + '/' + istioType.slug + '/' + name;
   return (

--- a/src/components/VirtualList/Config.ts
+++ b/src/components/VirtualList/Config.ts
@@ -116,24 +116,24 @@ const istioType: ResourceType<IstioConfigItem> = {
 };
 
 export const IstioTypes = {
-  gateway: { name: 'Gateway', icon: 'G' },
-  virtualservice: { name: 'VirtualService', icon: 'VS' },
-  destinationrule: { name: 'DestinationRule', icon: 'DR' },
-  serviceentry: { name: 'ServiceEntry', icon: 'SE' },
-  rule: { name: 'Rule', icon: 'R' },
-  adapter: { name: 'Adapter', icon: 'A' },
-  template: { name: 'Template', icon: 'T' },
-  quotaspec: { name: 'QuotaSpec', icon: 'QS' },
-  quotaspecbinding: { name: 'QuotaSpecBinding', icon: 'QSB' },
-  policy: { name: 'Policy', icon: 'P' },
-  meshpolicy: { name: 'MeshPolicy', icon: 'MP' },
-  servicemeshpolicy: { name: 'ServiceMeshPolicy', icon: 'SMP' },
-  clusterrbacconfig: { name: 'ClusterRbacConfig', icon: 'CRC' },
-  rbacconfig: { name: 'RbacConfig', icon: 'RC' },
-  servicemeshrbacconfig: { name: 'ServiceMeshRbacConfig', icon: 'SRC' },
-  sidecar: { name: 'Sidecar', icon: 'S' },
-  servicerole: { name: 'ServiceRole', icon: 'SR' },
-  servicerolebinding: { name: 'ServiceRoleBinding', icon: 'SRB' }
+  gateway: { name: 'Gateway', slug: 'gateways', icon: 'G' },
+  virtualservice: { name: 'VirtualService', slug: 'virtualservices', icon: 'VS' },
+  destinationrule: { name: 'DestinationRule', slug: 'destinationrules', icon: 'DR' },
+  serviceentry: { name: 'ServiceEntry', slug: 'serviceentries', icon: 'SE' },
+  rule: { name: 'Rule', slug: 'rules', icon: 'R' },
+  adapter: { name: 'Adapter', slug: 'adapters', icon: 'A' },
+  template: { name: 'Template', slug: 'templates', icon: 'T' },
+  quotaspec: { name: 'QuotaSpec', slug: 'quotaspecs', icon: 'QS' },
+  quotaspecbinding: { name: 'QuotaSpecBinding', slug: 'quotaspecbindings', icon: 'QSB' },
+  policy: { name: 'Policy', slug: 'policies', icon: 'P' },
+  meshpolicy: { name: 'MeshPolicy', slug: 'meshpolicies', icon: 'MP' },
+  servicemeshpolicy: { name: 'ServiceMeshPolicy', slug: 'servicemeshpolicy', icon: 'SMP' },
+  clusterrbacconfig: { name: 'ClusterRbacConfig', slug: 'clusterrbacconfigs', icon: 'CRC' },
+  rbacconfig: { name: 'RbacConfig', slug: 'rbacconfigs', icon: 'RC' },
+  servicemeshrbacconfig: { name: 'ServiceMeshRbacConfig', slug: 'servicemeshrbacconfigs', icon: 'SRC' },
+  sidecar: { name: 'Sidecar', slug: 'sidercars', icon: 'S' },
+  servicerole: { name: 'ServiceRole', slug: 'serviceroles', icon: 'SR' },
+  servicerolebinding: { name: 'ServiceRoleBinding', slug: 'servicerolebindings', icon: 'SRB' }
 };
 
 export type Resource = {

--- a/src/components/VirtualList/Config.ts
+++ b/src/components/VirtualList/Config.ts
@@ -116,24 +116,24 @@ const istioType: ResourceType<IstioConfigItem> = {
 };
 
 export const IstioTypes = {
-  gateway: { name: 'Gateway', slug: 'gateways', icon: 'G' },
-  virtualservice: { name: 'VirtualService', slug: 'virtualservices', icon: 'VS' },
-  destinationrule: { name: 'DestinationRule', slug: 'destinationrules', icon: 'DR' },
-  serviceentry: { name: 'ServiceEntry', slug: 'serviceentries', icon: 'SE' },
-  rule: { name: 'Rule', slug: 'rules', icon: 'R' },
-  adapter: { name: 'Adapter', slug: 'adapters', icon: 'A' },
-  template: { name: 'Template', slug: 'templates', icon: 'T' },
-  quotaspec: { name: 'QuotaSpec', slug: 'quotaspecs', icon: 'QS' },
-  quotaspecbinding: { name: 'QuotaSpecBinding', slug: 'quotaspecbindings', icon: 'QSB' },
-  policy: { name: 'Policy', slug: 'policies', icon: 'P' },
-  meshpolicy: { name: 'MeshPolicy', slug: 'meshpolicies', icon: 'MP' },
-  servicemeshpolicy: { name: 'ServiceMeshPolicy', slug: 'servicemeshpolicy', icon: 'SMP' },
-  clusterrbacconfig: { name: 'ClusterRbacConfig', slug: 'clusterrbacconfigs', icon: 'CRC' },
-  rbacconfig: { name: 'RbacConfig', slug: 'rbacconfigs', icon: 'RC' },
-  servicemeshrbacconfig: { name: 'ServiceMeshRbacConfig', slug: 'servicemeshrbacconfigs', icon: 'SRC' },
-  sidecar: { name: 'Sidecar', slug: 'sidercars', icon: 'S' },
-  servicerole: { name: 'ServiceRole', slug: 'serviceroles', icon: 'SR' },
-  servicerolebinding: { name: 'ServiceRoleBinding', slug: 'servicerolebindings', icon: 'SRB' }
+  gateway: { name: 'Gateway', url: 'gateways', icon: 'G' },
+  virtualservice: { name: 'VirtualService', url: 'virtualservices', icon: 'VS' },
+  destinationrule: { name: 'DestinationRule', url: 'destinationrules', icon: 'DR' },
+  serviceentry: { name: 'ServiceEntry', url: 'serviceentries', icon: 'SE' },
+  rule: { name: 'Rule', url: 'rules', icon: 'R' },
+  adapter: { name: 'Adapter', url: 'adapters', icon: 'A' },
+  template: { name: 'Template', url: 'templates', icon: 'T' },
+  quotaspec: { name: 'QuotaSpec', url: 'quotaspecs', icon: 'QS' },
+  quotaspecbinding: { name: 'QuotaSpecBinding', url: 'quotaspecbindings', icon: 'QSB' },
+  policy: { name: 'Policy', url: 'policies', icon: 'P' },
+  meshpolicy: { name: 'MeshPolicy', url: 'meshpolicies', icon: 'MP' },
+  servicemeshpolicy: { name: 'ServiceMeshPolicy', url: 'servicemeshpolicy', icon: 'SMP' },
+  clusterrbacconfig: { name: 'ClusterRbacConfig', url: 'clusterrbacconfigs', icon: 'CRC' },
+  rbacconfig: { name: 'RbacConfig', url: 'rbacconfigs', icon: 'RC' },
+  servicemeshrbacconfig: { name: 'ServiceMeshRbacConfig', url: 'servicemeshrbacconfigs', icon: 'SRC' },
+  sidecar: { name: 'Sidecar', url: 'sidercars', icon: 'S' },
+  servicerole: { name: 'ServiceRole', url: 'serviceroles', icon: 'SR' },
+  servicerolebinding: { name: 'ServiceRoleBinding', url: 'servicerolebindings', icon: 'SRB' }
 };
 
 export type Resource = {

--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -6,7 +6,7 @@ import * as API from '../../services/Api';
 import AceEditor from 'react-ace';
 import 'brace/mode/yaml';
 import 'brace/theme/eclipse';
-import { ObjectValidation } from '../../types/IstioObjects';
+import { ObjectReference, ObjectValidation } from '../../types/IstioObjects';
 import { AceValidations, jsYaml, parseKialiValidations, parseYamlValidations } from '../../types/AceValidations';
 import IstioActionDropdown from '../../components/IstioActions/IstioActionsDropdown';
 import { RenderHeader } from '../../components/Nav/Page';
@@ -21,10 +21,26 @@ import { MessageType } from '../../types/MessageCenter';
 import { getIstioObject, mergeJsonPatch } from '../../utils/IstioConfigUtils';
 import { style } from 'typestyle';
 import ParameterizedTabs, { activeTab } from '../../components/Tab/Tabs';
-import { Tab, Text, TextVariants } from '@patternfly/react-core';
+import {
+  Card,
+  CardBody,
+  CardHeader,
+  Grid,
+  GridItem,
+  GutterSize,
+  Stack,
+  StackItem,
+  Tab,
+  Text,
+  TextVariants,
+  Title,
+  TitleLevel,
+  TitleSize
+} from '@patternfly/react-core';
 import { dicIstioType } from '../../types/IstioConfigList';
 import { showInMessageCenter } from '../../utils/IstioValidationUtils';
 import { PfColors } from '../../components/Pf/PfColors';
+import IstioObjectLink from '../../components/Link/IstioObjectLink';
 
 const rightToolbarStyle = style({
   position: 'absolute',
@@ -276,8 +292,14 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
     return istioObject ? jsYaml.safeDump(istioObject, safeDumpOptions) : '';
   };
 
+  objectReferences = (): ObjectReference[] => {
+    const istioValidations: ObjectValidation = this.state.istioValidations || ({} as ObjectValidation);
+    return istioValidations.references || ([] as ObjectReference[]);
+  };
+
   renderEditor = () => {
     const yamlSource = this.fetchYaml();
+    const objectReferences = this.objectReferences();
     let editorValidations: AceValidations = {
       markers: [],
       annotations: []
@@ -293,23 +315,51 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
 
     return (
       <div className="container-fluid container-cards-pf">
-        {this.state.istioObjectDetails ? (
-          <AceEditor
-            ref={this.aceEditorRef}
-            mode="yaml"
-            theme="eclipse"
-            onChange={this.onEditorChange}
-            width={'100%'}
-            height={'var(--kiali-yaml-editor-height)'}
-            className={'istio-ace-editor'}
-            readOnly={!this.canUpdate()}
-            setOptions={aceOptions}
-            value={this.state.istioObjectDetails ? yamlSource : undefined}
-            annotations={editorValidations.annotations}
-            markers={editorValidations.markers}
-          />
-        ) : null}
-        {this.renderActionButtons()}
+        <Grid gutter={GutterSize.md}>
+          <GridItem span={9}>
+            {this.state.istioObjectDetails ? (
+              <AceEditor
+                ref={this.aceEditorRef}
+                mode="yaml"
+                theme="eclipse"
+                onChange={this.onEditorChange}
+                width={'100%'}
+                height={'var(--kiali-yaml-editor-height)'}
+                className={'istio-ace-editor'}
+                readOnly={!this.canUpdate()}
+                setOptions={aceOptions}
+                value={this.state.istioObjectDetails ? yamlSource : undefined}
+                annotations={editorValidations.annotations}
+                markers={editorValidations.markers}
+              />
+            ) : null}
+          </GridItem>
+          <GridItem span={3}>
+            <Card>
+              <CardHeader>
+                <Title headingLevel={TitleLevel.h3} size={TitleSize.xl}>
+                  Validation references
+                </Title>
+              </CardHeader>
+              <CardBody>
+                <Stack>
+                  {objectReferences.map((reference, i) => {
+                    return (
+                      <StackItem key={'rel-object-' + i}>
+                        <IstioObjectLink
+                          name={reference.name}
+                          type={reference.objectType}
+                          namespace={reference.namespace}
+                        />
+                      </StackItem>
+                    );
+                  })}
+                </Stack>
+              </CardBody>
+            </Card>
+          </GridItem>
+          <GridItem span={12}>{this.renderActionButtons()}</GridItem>
+        </Grid>
       </div>
     );
   };

--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -364,8 +364,8 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
           ) : (
             undefined
           )}
-          <GridItem span={12}>{this.renderActionButtons()}</GridItem>
         </Grid>
+        {this.renderActionButtons()}
       </div>
     );
   };

--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -300,6 +300,8 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
   renderEditor = () => {
     const yamlSource = this.fetchYaml();
     const objectReferences = this.objectReferences();
+    const refPresent = objectReferences.length > 0;
+    const editorSpan = refPresent ? 9 : 12;
     let editorValidations: AceValidations = {
       markers: [],
       annotations: []
@@ -316,7 +318,7 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
     return (
       <div className="container-fluid container-cards-pf">
         <Grid gutter={GutterSize.md}>
-          <GridItem span={9}>
+          <GridItem span={editorSpan}>
             {this.state.istioObjectDetails ? (
               <AceEditor
                 ref={this.aceEditorRef}
@@ -334,30 +336,34 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
               />
             ) : null}
           </GridItem>
-          <GridItem span={3}>
-            <Card>
-              <CardHeader>
-                <Title headingLevel={TitleLevel.h3} size={TitleSize.xl}>
-                  Validation references
-                </Title>
-              </CardHeader>
-              <CardBody>
-                <Stack>
-                  {objectReferences.map((reference, i) => {
-                    return (
-                      <StackItem key={'rel-object-' + i}>
-                        <IstioObjectLink
-                          name={reference.name}
-                          type={reference.objectType}
-                          namespace={reference.namespace}
-                        />
-                      </StackItem>
-                    );
-                  })}
-                </Stack>
-              </CardBody>
-            </Card>
-          </GridItem>
+          {refPresent ? (
+            <GridItem span={3}>
+              <Card>
+                <CardHeader>
+                  <Title headingLevel={TitleLevel.h3} size={TitleSize.xl}>
+                    Validation references
+                  </Title>
+                </CardHeader>
+                <CardBody>
+                  <Stack>
+                    {objectReferences.map((reference, i) => {
+                      return (
+                        <StackItem key={'rel-object-' + i}>
+                          <IstioObjectLink
+                            name={reference.name}
+                            type={reference.objectType}
+                            namespace={reference.namespace}
+                          />
+                        </StackItem>
+                      );
+                    })}
+                  </Stack>
+                </CardBody>
+              </Card>
+            </GridItem>
+          ) : (
+            undefined
+          )}
           <GridItem span={12}>{this.renderActionButtons()}</GridItem>
         </Grid>
       </div>

--- a/src/types/IstioObjects.ts
+++ b/src/types/IstioObjects.ts
@@ -57,12 +57,19 @@ export interface ObjectValidation {
   objectType: string;
   valid: boolean;
   checks: ObjectCheck[];
+  references?: ObjectReference[];
 }
 
 export interface ObjectCheck {
   message: string;
   severity: ValidationTypes;
   path: string;
+}
+
+export interface ObjectReference {
+  objectType: string;
+  name: string;
+  namespace: string;
 }
 
 export interface Reference {


### PR DESCRIPTION
** Describe the change **

Kiali has now istio object referenced in some validations. For example, multi match gateways validation. This PR adds visual list of references in the editor page, as a sidebar.

Closes https://github.com/kiali/kiali/issues/1419
Backend changes: https://github.com/kiali/kiali/pull/1912

P.S.: Adding the sidebar makes space for other referenced items (not exclusively from validations). It just popped in my mind this old jira: https://issues.jboss.org/browse/KIALI-1883

** Issue reference **
#1419

** Backwards compatible? **
yes

** Screenshot **

![Screen-recording-_14_](https://user-images.githubusercontent.com/613814/68133547-e1922b00-ff20-11e9-9664-13cd3c564cb9.gif)

Editor page with referenced objects:
![Screenshot of Kiali Console (75)](https://user-images.githubusercontent.com/613814/68131847-0a64f100-ff1e-11e9-9bce-1567a3d1b3e3.jpg)

Editor page without referenced objects:
![Screenshot of Kiali Console (77)](https://user-images.githubusercontent.com/613814/68131981-3bddbc80-ff1e-11e9-915d-6ac7a6906e10.jpg)

Editor page without validations:
![Screenshot of Kiali Console (76)](https://user-images.githubusercontent.com/613814/68131846-09cc5a80-ff1e-11e9-8e03-62b0ceb7865f.jpg)
