### PR TITLE
Support MUTUAL Tls method in Wizard with extended form

### DIFF
--- a/src/components/IstioWizards/IstioWizard.tsx
+++ b/src/components/IstioWizards/IstioWizard.tsx
@@ -59,6 +59,9 @@ class IstioWizard extends React.Component<WizardProps, WizardState> {
       trafficPolicy: {
         tlsModified: false,
         mtlsMode: DISABLE,
+        clientCertificate: '',
+        privateKey: '',
+        caCertificates: '',
         addLoadBalancer: false,
         simpleLB: false,
         consistentHashType: ConsistentHashType.HTTP_HEADER_NAME,
@@ -87,7 +90,9 @@ class IstioWizard extends React.Component<WizardProps, WizardState> {
           break;
       }
       const initVsHosts = getInitHosts(this.props.virtualServices);
-      const initMtlsMode = getInitTlsMode(this.props.destinationRules);
+      const [initMtlsMode, initClientCertificate, initPrivateKey, initCaCertificates] = getInitTlsMode(
+        this.props.destinationRules
+      );
       const initLoadBalancer = getInitLoadBalancer(this.props.destinationRules);
       let initConsistentHashType = ConsistentHashType.HTTP_HEADER_NAME;
       if (initLoadBalancer && initLoadBalancer.consistentHash) {
@@ -102,6 +107,9 @@ class IstioWizard extends React.Component<WizardProps, WizardState> {
       const trafficPolicy: TrafficPolicyState = {
         tlsModified: initMtlsMode !== '',
         mtlsMode: initMtlsMode !== '' ? initMtlsMode : DISABLE,
+        clientCertificate: initClientCertificate,
+        privateKey: initPrivateKey,
+        caCertificates: initCaCertificates,
         addLoadBalancer: initLoadBalancer !== undefined,
         simpleLB: initLoadBalancer !== undefined && initLoadBalancer.simple !== undefined,
         consistentHashType: initConsistentHashType,
@@ -378,6 +386,9 @@ class IstioWizard extends React.Component<WizardProps, WizardState> {
             <VirtualServiceHosts vsHosts={this.state.vsHosts} onVsHostsChange={this.onVsHosts} />
             <TrafficPolicyContainer
               mtlsMode={this.state.trafficPolicy.mtlsMode}
+              clientCertificate={this.state.trafficPolicy.clientCertificate}
+              privateKey={this.state.trafficPolicy.privateKey}
+              caCertificates={this.state.trafficPolicy.caCertificates}
               hasLoadBalancer={this.state.trafficPolicy.addLoadBalancer}
               loadBalancer={this.state.trafficPolicy.loadBalancer}
               nsWideStatus={this.props.tlsStatus}

--- a/src/components/IstioWizards/IstioWizard.tsx
+++ b/src/components/IstioWizards/IstioWizard.tsx
@@ -243,6 +243,7 @@ class IstioWizard extends React.Component<WizardProps, WizardState> {
     this.setState(prevState => {
       // At the moment this callback only updates the valid of the loadbalancer
       // tls is always true, but I maintain it on the structure for consistency
+      prevState.valid.tls = valid;
       prevState.valid.lb = valid;
       return {
         valid: prevState.valid,

--- a/src/components/IstioWizards/TrafficPolicy.tsx
+++ b/src/components/IstioWizards/TrafficPolicy.tsx
@@ -8,11 +8,13 @@ import { HTTPCookie, LoadBalancerSettings } from '../../types/IstioObjects';
 
 export const DISABLE = 'DISABLE';
 export const ISTIO_MUTUAL = 'ISTIO_MUTUAL';
+export const SIMPLE = 'SIMPLE';
+export const MUTUAL = 'MUTUAL';
 export const ROUND_ROBIN = 'ROUND_ROBIN';
 
 export const loadBalancerSimple: string[] = [ROUND_ROBIN, 'LEAST_CONN', 'RANDOM', 'PASSTHROUGH'];
 
-export const mTLSMode: string[] = [DISABLE, ISTIO_MUTUAL, 'SIMPLE'];
+export const mTLSMode: string[] = [DISABLE, ISTIO_MUTUAL, SIMPLE, MUTUAL];
 
 type ReduxProps = {
   meshWideStatus: string;
@@ -20,6 +22,9 @@ type ReduxProps = {
 
 type Props = ReduxProps & {
   mtlsMode: string;
+  clientCertificate: string;
+  privateKey: string;
+  caCertificates: string;
   hasLoadBalancer: boolean;
   loadBalancer: LoadBalancerSettings;
   onTrafficPolicyChange: (valid: boolean, trafficPolicy: TrafficPolicyState) => void;
@@ -35,6 +40,9 @@ export enum ConsistentHashType {
 export type TrafficPolicyState = {
   tlsModified: boolean;
   mtlsMode: string;
+  clientCertificate: string;
+  privateKey: string;
+  caCertificates: string;
   addLoadBalancer: boolean;
   simpleLB: boolean;
   consistentHashType: ConsistentHashType;
@@ -45,6 +53,9 @@ const durationRegex = /^[0-9]*(\.[0-9]+)?s?$/;
 
 enum TrafficPolicyForm {
   TLS,
+  TLS_CLIENT_CERTIFICATE,
+  TLS_PRIVATE_KEY,
+  TLS_CA_CERTIFICATES,
   LB_SWITCH,
   LB_SIMPLE,
   LB_SELECT,
@@ -70,6 +81,9 @@ class TrafficPolicy extends React.Component<Props, TrafficPolicyState> {
     this.state = {
       tlsModified: false,
       mtlsMode: props.mtlsMode,
+      clientCertificate: props.clientCertificate,
+      privateKey: props.privateKey,
+      caCertificates: props.caCertificates,
       addLoadBalancer: props.hasLoadBalancer,
       simpleLB: props.loadBalancer && props.loadBalancer.simple !== undefined && props.loadBalancer.simple !== null,
       consistentHashType: consistentHashType,
@@ -157,6 +171,33 @@ class TrafficPolicy extends React.Component<Props, TrafficPolicyState> {
           {
             tlsModified: true,
             mtlsMode: value
+          },
+          () => this.props.onTrafficPolicyChange(true, this.state)
+        );
+        break;
+      case TrafficPolicyForm.TLS_CLIENT_CERTIFICATE:
+        this.setState(
+          {
+            tlsModified: true,
+            clientCertificate: value
+          },
+          () => this.props.onTrafficPolicyChange(true, this.state)
+        );
+        break;
+      case TrafficPolicyForm.TLS_PRIVATE_KEY:
+        this.setState(
+          {
+            tlsModified: true,
+            privateKey: value
+          },
+          () => this.props.onTrafficPolicyChange(true, this.state)
+        );
+        break;
+      case TrafficPolicyForm.TLS_CA_CERTIFICATES:
+        this.setState(
+          {
+            tlsModified: true,
+            caCertificates: value
           },
           () => this.props.onTrafficPolicyChange(true, this.state)
         );
@@ -296,6 +337,44 @@ class TrafficPolicy extends React.Component<Props, TrafficPolicyState> {
             ))}
           </FormSelect>
         </FormGroup>
+        {this.state.mtlsMode === MUTUAL && (
+          <>
+            <FormGroup
+              label="Client Certificate"
+              fieldId="clientCertificate"
+              isValid={this.state.clientCertificate.length > 0}
+              helperTextInvalid="Client Certificate must be non empty"
+            >
+              <TextInput
+                value={this.state.clientCertificate}
+                onChange={value => this.onFormChange(TrafficPolicyForm.TLS_CLIENT_CERTIFICATE, value)}
+                id="clientCertificate"
+                name="clientCertificate"
+              />
+            </FormGroup>
+            <FormGroup
+              label="Private Key"
+              fieldId="privateKey"
+              isValid={this.state.privateKey.length > 0}
+              helperTextInvalid="Private Key must be non empty"
+            >
+              <TextInput
+                value={this.state.privateKey}
+                onChange={value => this.onFormChange(TrafficPolicyForm.TLS_PRIVATE_KEY, value)}
+                id="privateKey"
+                name="privateKey"
+              />
+            </FormGroup>
+            <FormGroup label="CA Certificates" fieldId="caCertificates">
+              <TextInput
+                value={this.state.caCertificates}
+                onChange={value => this.onFormChange(TrafficPolicyForm.TLS_CA_CERTIFICATES, value)}
+                id="caCertificates"
+                name="caCertificates"
+              />
+            </FormGroup>
+          </>
+        )}
         <FormGroup label="Add LoadBalancer" fieldId="advanced-lbSwitch">
           <Switch
             id="advanced-lbSwitch"

--- a/src/components/IstioWizards/TrafficPolicy.tsx
+++ b/src/components/IstioWizards/TrafficPolicy.tsx
@@ -217,7 +217,13 @@ class TrafficPolicy extends React.Component<Props, TrafficPolicyState> {
             tlsModified: true,
             caCertificates: value
           },
-          () => this.props.onTrafficPolicyChange(true, this.state)
+          () =>
+            this.props.onTrafficPolicyChange(
+              this.state.mtlsMode === MUTUAL &&
+                this.state.clientCertificate.length > 0 &&
+                this.state.privateKey.length > 0,
+              this.state
+            )
         );
         break;
       case TrafficPolicyForm.LB_SWITCH:

--- a/src/components/IstioWizards/TrafficPolicy.tsx
+++ b/src/components/IstioWizards/TrafficPolicy.tsx
@@ -172,7 +172,13 @@ class TrafficPolicy extends React.Component<Props, TrafficPolicyState> {
             tlsModified: true,
             mtlsMode: value
           },
-          () => this.props.onTrafficPolicyChange(true, this.state)
+          () =>
+            this.props.onTrafficPolicyChange(
+              this.state.mtlsMode === MUTUAL
+                ? this.state.clientCertificate.length > 0 && this.state.privateKey.length > 0
+                : true,
+              this.state
+            )
         );
         break;
       case TrafficPolicyForm.TLS_CLIENT_CERTIFICATE:
@@ -181,7 +187,13 @@ class TrafficPolicy extends React.Component<Props, TrafficPolicyState> {
             tlsModified: true,
             clientCertificate: value
           },
-          () => this.props.onTrafficPolicyChange(true, this.state)
+          () =>
+            this.props.onTrafficPolicyChange(
+              this.state.mtlsMode === MUTUAL &&
+                this.state.clientCertificate.length > 0 &&
+                this.state.privateKey.length > 0,
+              this.state
+            )
         );
         break;
       case TrafficPolicyForm.TLS_PRIVATE_KEY:
@@ -190,7 +202,13 @@ class TrafficPolicy extends React.Component<Props, TrafficPolicyState> {
             tlsModified: true,
             privateKey: value
           },
-          () => this.props.onTrafficPolicyChange(true, this.state)
+          () =>
+            this.props.onTrafficPolicyChange(
+              this.state.mtlsMode === MUTUAL &&
+                this.state.clientCertificate.length > 0 &&
+                this.state.privateKey.length > 0,
+              this.state
+            )
         );
         break;
       case TrafficPolicyForm.TLS_CA_CERTIFICATES:

--- a/src/types/IstioObjects.ts
+++ b/src/types/IstioObjects.ts
@@ -251,11 +251,11 @@ export interface OutlierDetection {
 
 export interface TLSSettings {
   mode: string;
-  clientCertificate?: string;
-  privateKey?: string;
-  caCertificates?: string;
-  subjectAltNames?: string[];
-  sni?: string;
+  clientCertificate?: string | null;
+  privateKey?: string | null;
+  caCertificates?: string | null;
+  subjectAltNames?: string[] | null;
+  sni?: string | null;
 }
 
 export interface TrafficPolicy {


### PR DESCRIPTION
Fixes kiali/kiali#1847

It adds support for MUTUAL TLS setup in DestinationRules from Wizards.
When selecting MUTUAL, Wizard adds extra form to describe the custom certificates.

![image](https://user-images.githubusercontent.com/1662329/68218957-765e5c80-ffe5-11e9-97d1-e2652ee3e1ac.png)

