### PR TITLE
Remove PF3 notifications from ServiceInfo

### DIFF
--- a/src/components/MessageCenter/AlertToast.tsx
+++ b/src/components/MessageCenter/AlertToast.tsx
@@ -9,20 +9,22 @@ type AlertToastProps = AlertProps & {
   style?: React.CSSProperties;
   ttlms?: number;
 
-  onClose: () => void;
-  onTtl: () => void;
+  onClose?: () => void;
+  onTtl?: () => void;
 };
 
 export default class AlertToast extends React.Component<AlertToastProps> {
   ttlTimer: NodeJS.Timeout | undefined;
 
   componentDidMount() {
-    this.ttlTimer = setInterval(
-      () => {
-        this.props.onTtl();
-      },
-      this.props.ttlms ? this.props.ttlms : DEFAULT_TTLMS
-    );
+    if (this.props.onTtl) {
+      this.ttlTimer = setInterval(
+        () => {
+          this.props.onTtl!();
+        },
+        this.props.ttlms ? this.props.ttlms : DEFAULT_TTLMS
+      );
+    }
   }
 
   componentWillUnmount() {
@@ -31,6 +33,9 @@ export default class AlertToast extends React.Component<AlertToastProps> {
     }
   }
 
+  private getAction = () => {
+    return this.props.onClose ? <AlertActionCloseButton onClose={this.props.onClose} /> : <></>;
+  };
   render() {
     return (
       <Alert
@@ -38,7 +43,7 @@ export default class AlertToast extends React.Component<AlertToastProps> {
         key={this.props.message.id}
         variant={this.props.variant}
         title={this.props.message.content}
-        action={<AlertActionCloseButton onClose={this.props.onClose} />}
+        action={this.getAction()}
       />
     );
   }

--- a/src/components/MessageCenter/NotificationList.tsx
+++ b/src/components/MessageCenter/NotificationList.tsx
@@ -5,7 +5,7 @@ import AlertToast from './AlertToast';
 
 type NotificationListProps = {
   messages: NotificationMessage[];
-  onDismiss: (message: NotificationMessage, userDismissed: boolean) => void;
+  onDismiss?: (message: NotificationMessage, userDismissed: boolean) => void;
 };
 
 export default class NotificationList extends React.PureComponent<NotificationListProps> {
@@ -24,9 +24,11 @@ export default class NotificationList extends React.PureComponent<NotificationLi
             default:
               variant = AlertVariant.danger;
           }
-          const onClose = () => {
-            this.props.onDismiss(message, true);
-          };
+          const onClose = this.props.onDismiss
+            ? () => {
+                this.props.onDismiss!(message, true);
+              }
+            : undefined;
           return (
             <AlertToast
               key={'toast_' + message.id}

--- a/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -13,6 +13,8 @@ import ParameterizedTabs, { activeTab } from '../../components/Tab/Tabs';
 import ErrorBoundaryWithMessage from '../../components/ErrorBoundary/ErrorBoundaryWithMessage';
 import { Tab } from '@patternfly/react-core';
 import Validation from '../../components/Validations/Validation';
+import NotificationList from 'components/MessageCenter/NotificationList';
+import { MessageType } from 'types/MessageCenter';
 
 interface ServiceDetails extends ServiceId {
   serviceDetails: ServiceDetailsInfo;
@@ -50,8 +52,8 @@ class ServiceInfo extends React.Component<ServiceDetails, ServiceInfoState> {
   constructor(props: ServiceDetails) {
     super(props);
     this.state = {
-      error: true,
-      errorMessage: 'This is a test by jay',
+      error: false,
+      errorMessage: '',
       currentTab: activeTab(tabName, defaultTab)
     };
   }
@@ -158,16 +160,22 @@ class ServiceInfo extends React.Component<ServiceDetails, ServiceInfoState> {
 
     return (
       <>
-        {this.state.error ? (
-          <ToastNotificationList>
-            <ToastNotification type="danger">
-              <span>
-                <strong>Error </strong>
-                {this.state.errorMessage}
-              </span>
-            </ToastNotification>
-          </ToastNotificationList>
-        ) : null}
+        {this.state.error && (
+          <NotificationList
+            messages={[
+              {
+                id: 1,
+                count: 1,
+                created: new Date(),
+                seen: false,
+                type: MessageType.ERROR,
+                detail: '',
+                showDetail: false,
+                content: this.state.errorMessage
+              }
+            ]}
+          />
+        )}
         <Grid style={{ margin: '30px' }} gutter={'md'}>
           <GridItem span={12}>
             <ServiceInfoDescription

--- a/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -13,8 +13,6 @@ import ParameterizedTabs, { activeTab } from '../../components/Tab/Tabs';
 import ErrorBoundaryWithMessage from '../../components/ErrorBoundary/ErrorBoundaryWithMessage';
 import { Tab } from '@patternfly/react-core';
 import Validation from '../../components/Validations/Validation';
-import NotificationList from 'components/MessageCenter/NotificationList';
-import { MessageType } from 'types/MessageCenter';
 
 interface ServiceDetails extends ServiceId {
   serviceDetails: ServiceDetailsInfo;
@@ -26,8 +24,6 @@ interface ServiceDetails extends ServiceId {
 }
 
 type ServiceInfoState = {
-  error: boolean;
-  errorMessage: string;
   currentTab: string;
 };
 
@@ -52,8 +48,6 @@ class ServiceInfo extends React.Component<ServiceDetails, ServiceInfoState> {
   constructor(props: ServiceDetails) {
     super(props);
     this.state = {
-      error: false,
-      errorMessage: '',
       currentTab: activeTab(tabName, defaultTab)
     };
   }
@@ -159,89 +153,71 @@ class ServiceInfo extends React.Component<ServiceDetails, ServiceInfoState> {
     );
 
     return (
-      <>
-        {this.state.error && (
-          <NotificationList
-            messages={[
-              {
-                id: 1,
-                count: 1,
-                created: new Date(),
-                seen: false,
-                type: MessageType.ERROR,
-                detail: '',
-                showDetail: false,
-                content: this.state.errorMessage
-              }
-            ]}
+      <Grid style={{ margin: '30px' }} gutter={'md'}>
+        <GridItem span={12}>
+          <ServiceInfoDescription
+            name={this.props.serviceDetails.service.name}
+            namespace={this.props.namespace}
+            createdAt={this.props.serviceDetails.service.createdAt}
+            resourceVersion={this.props.serviceDetails.service.resourceVersion}
+            istioEnabled={this.props.serviceDetails.istioSidecar}
+            labels={this.props.serviceDetails.service.labels}
+            selectors={this.props.serviceDetails.service.selectors}
+            ports={this.props.serviceDetails.service.ports}
+            type={this.props.serviceDetails.service.type}
+            ip={this.props.serviceDetails.service.ip}
+            endpoints={this.props.serviceDetails.endpoints}
+            health={this.props.serviceDetails.health}
+            externalName={this.props.serviceDetails.service.externalName}
+            threeScaleServiceRule={this.props.threeScaleServiceRule}
+            validations={this.getServiceValidation()}
           />
-        )}
-        <Grid style={{ margin: '30px' }} gutter={'md'}>
-          <GridItem span={12}>
-            <ServiceInfoDescription
-              name={this.props.serviceDetails.service.name}
-              namespace={this.props.namespace}
-              createdAt={this.props.serviceDetails.service.createdAt}
-              resourceVersion={this.props.serviceDetails.service.resourceVersion}
-              istioEnabled={this.props.serviceDetails.istioSidecar}
-              labels={this.props.serviceDetails.service.labels}
-              selectors={this.props.serviceDetails.service.selectors}
-              ports={this.props.serviceDetails.service.ports}
-              type={this.props.serviceDetails.service.type}
-              ip={this.props.serviceDetails.service.ip}
-              endpoints={this.props.serviceDetails.endpoints}
-              health={this.props.serviceDetails.health}
-              externalName={this.props.serviceDetails.service.externalName}
-              threeScaleServiceRule={this.props.threeScaleServiceRule}
-              validations={this.getServiceValidation()}
-            />
-          </GridItem>
-          <GridItem span={12}>
-            <Card>
-              <CardBody>
-                <ParameterizedTabs
-                  id="service-tabs"
-                  onSelect={tabValue => {
-                    this.setState({ currentTab: tabValue });
-                  }}
-                  tabMap={paramToTab}
-                  tabName={tabName}
-                  defaultTab={defaultTab}
-                  activeTab={this.state.currentTab}
-                >
-                  <Tab eventKey={0} title={'Workloads (' + Object.keys(workloads).length + ')'}>
-                    <ErrorBoundaryWithMessage message={this.errorBoundaryMessage('Workloads')}>
-                      <ServiceInfoWorkload
-                        service={this.props.serviceDetails}
-                        workloads={workloads}
-                        namespace={this.props.namespace}
-                      />
-                    </ErrorBoundaryWithMessage>
-                  </Tab>
-                  <Tab eventKey={1} title={vsTabTitle}>
-                    <ErrorBoundaryWithMessage message={this.errorBoundaryMessage('Virtual Services')}>
-                      <ServiceInfoVirtualServices
-                        service={this.props.serviceDetails}
-                        virtualServices={vsItems}
-                        validations={validations!.virtualservice}
-                      />
-                    </ErrorBoundaryWithMessage>
-                  </Tab>
-                  <Tab eventKey={2} title={drTabTitle}>
-                    <ErrorBoundaryWithMessage message={this.errorBoundaryMessage('Destination Rules')}>
-                      <ServiceInfoDestinationRules
-                        service={this.props.serviceDetails}
-                        destinationRules={drItems}
-                        validations={validations!.destinationrule}
-                      />
-                    </ErrorBoundaryWithMessage>
-                  </Tab>
-                </ParameterizedTabs>
-              </CardBody>
-            </Card>
-          </GridItem>
-        </Grid>
-      </>
+        </GridItem>
+        <GridItem span={12}>
+          <Card>
+            <CardBody>
+              <ParameterizedTabs
+                id="service-tabs"
+                onSelect={tabValue => {
+                  this.setState({ currentTab: tabValue });
+                }}
+                tabMap={paramToTab}
+                tabName={tabName}
+                defaultTab={defaultTab}
+                activeTab={this.state.currentTab}
+              >
+                <Tab eventKey={0} title={'Workloads (' + Object.keys(workloads).length + ')'}>
+                  <ErrorBoundaryWithMessage message={this.errorBoundaryMessage('Workloads')}>
+                    <ServiceInfoWorkload
+                      service={this.props.serviceDetails}
+                      workloads={workloads}
+                      namespace={this.props.namespace}
+                    />
+                  </ErrorBoundaryWithMessage>
+                </Tab>
+                <Tab eventKey={1} title={vsTabTitle}>
+                  <ErrorBoundaryWithMessage message={this.errorBoundaryMessage('Virtual Services')}>
+                    <ServiceInfoVirtualServices
+                      service={this.props.serviceDetails}
+                      virtualServices={vsItems}
+                      validations={validations!.virtualservice}
+                    />
+                  </ErrorBoundaryWithMessage>
+                </Tab>
+                <Tab eventKey={2} title={drTabTitle}>
+                  <ErrorBoundaryWithMessage message={this.errorBoundaryMessage('Destination Rules')}>
+                    <ServiceInfoDestinationRules
+                      service={this.props.serviceDetails}
+                      destinationRules={drItems}
+                      validations={validations!.destinationrule}
+                    />
+                  </ErrorBoundaryWithMessage>
+                </Tab>
+              </ParameterizedTabs>
+            </CardBody>
+          </Card>
+        </GridItem>
+      </Grid>
     );
   }
 }

--- a/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { style } from 'typestyle';
-import { ToastNotification, ToastNotificationList } from 'patternfly-react';
 import { Card, CardBody, Grid, GridItem } from '@patternfly/react-core';
 import ServiceId from '../../types/ServiceId';
 import ServiceInfoDescription from './ServiceInfo/ServiceInfoDescription';
@@ -51,8 +50,8 @@ class ServiceInfo extends React.Component<ServiceDetails, ServiceInfoState> {
   constructor(props: ServiceDetails) {
     super(props);
     this.state = {
-      error: false,
-      errorMessage: '',
+      error: true,
+      errorMessage: 'This is a test by jay',
       currentTab: activeTab(tabName, defaultTab)
     };
   }

--- a/src/pages/ServiceDetails/__tests__/__snapshots__/ServiceInfo.test.tsx.snap
+++ b/src/pages/ServiceDetails/__tests__/__snapshots__/ServiceInfo.test.tsx.snap
@@ -1,599 +1,165 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`#ServiceInfo render correctly with data should render serviceInfo with data 1`] = `
-<Fragment>
-  <Grid
-    gutter="md"
-    style={
-      Object {
-        "margin": "30px",
-      }
+<Grid
+  gutter="md"
+  style={
+    Object {
+      "margin": "30px",
     }
+  }
+>
+  <GridItem
+    span={12}
   >
-    <GridItem
-      span={12}
-    >
-      <ServiceInfoDescription
-        createdAt="2018-06-29T16:43:18+02:00"
-        endpoints={
-          Array [
-            Object {
-              "addresses": Array [
-                Object {
-                  "ip": "172.17.0.20",
-                  "kind": "Pod",
-                  "name": "reviews-v3-5f5bcb6765-hj46f",
-                },
-                Object {
-                  "ip": "172.17.0.21",
-                  "kind": "Pod",
-                  "name": "reviews-v2-d896b68c-jnxgm",
-                },
-                Object {
-                  "ip": "172.17.0.22",
-                  "kind": "Pod",
-                  "name": "reviews-v1-5d6696bcf7-2sls7",
-                },
-              ],
-              "ports": Array [
-                Object {
-                  "name": "http",
-                  "port": 9080,
-                  "protocol": "TCP",
-                },
-              ],
-            },
-          ]
-        }
-        externalName="my.database.example.com"
-        ip="172.30.196.248"
-        istioEnabled={true}
-        labels={
+    <ServiceInfoDescription
+      createdAt="2018-06-29T16:43:18+02:00"
+      endpoints={
+        Array [
           Object {
-            "app": "reviews",
-          }
-        }
-        name="reviews"
-        namespace="istio-system"
-        ports={
-          Array [
-            Object {
-              "name": "http",
-              "port": 9080,
-              "protocol": "TCP",
-            },
-          ]
-        }
-        resourceVersion="2652"
-        type="ClusterIP"
-      />
-    </GridItem>
-    <GridItem
-      span={12}
-    >
-      <Card>
-        <CardBody>
-          <ParameterizedTabs
-            activeTab="workloads"
-            defaultTab="workloads"
-            id="service-tabs"
-            onSelect={[Function]}
-            tabMap={
+            "addresses": Array [
               Object {
-                "destinationrules": 2,
-                "virtualservices": 1,
-                "workloads": 0,
-              }
+                "ip": "172.17.0.20",
+                "kind": "Pod",
+                "name": "reviews-v3-5f5bcb6765-hj46f",
+              },
+              Object {
+                "ip": "172.17.0.21",
+                "kind": "Pod",
+                "name": "reviews-v2-d896b68c-jnxgm",
+              },
+              Object {
+                "ip": "172.17.0.22",
+                "kind": "Pod",
+                "name": "reviews-v1-5d6696bcf7-2sls7",
+              },
+            ],
+            "ports": Array [
+              Object {
+                "name": "http",
+                "port": 9080,
+                "protocol": "TCP",
+              },
+            ],
+          },
+        ]
+      }
+      externalName="my.database.example.com"
+      ip="172.30.196.248"
+      istioEnabled={true}
+      labels={
+        Object {
+          "app": "reviews",
+        }
+      }
+      name="reviews"
+      namespace="istio-system"
+      ports={
+        Array [
+          Object {
+            "name": "http",
+            "port": 9080,
+            "protocol": "TCP",
+          },
+        ]
+      }
+      resourceVersion="2652"
+      type="ClusterIP"
+    />
+  </GridItem>
+  <GridItem
+    span={12}
+  >
+    <Card>
+      <CardBody>
+        <ParameterizedTabs
+          activeTab="workloads"
+          defaultTab="workloads"
+          id="service-tabs"
+          onSelect={[Function]}
+          tabMap={
+            Object {
+              "destinationrules": 2,
+              "virtualservices": 1,
+              "workloads": 0,
             }
-            tabName="list"
+          }
+          tabName="list"
+        >
+          <ForwardRef
+            eventKey={0}
+            title="Workloads (0)"
           >
-            <ForwardRef
-              eventKey={0}
-              title="Workloads (0)"
+            <ErrorBoundaryWithMessage
+              message="One of the Workloads associated to this service has an invalid format"
             >
-              <ErrorBoundaryWithMessage
-                message="One of the Workloads associated to this service has an invalid format"
-              >
-                <ServiceInfoWorkload
-                  namespace="istio-system"
-                  service={
-                    Object {
-                      "apiDocumentation": Object {
-                        "hasSpec": true,
-                        "type": "rest",
-                      },
-                      "destinationRules": Object {
-                        "items": Array [
-                          Object {
-                            "metadata": Object {
-                              "creationTimestamp": "2018-07-02T13:44:01+02:00",
-                              "name": "reviews",
-                              "resourceVersion": "393061",
-                            },
-                            "spec": Object {
-                              "host": "reviews",
-                              "subsets": Array [
-                                Object {
-                                  "labels": Object {
-                                    "version": "v1",
-                                  },
-                                  "name": "v1",
-                                },
-                                Object {
-                                  "labels": Object {
-                                    "version": "v2",
-                                  },
-                                  "name": "v2",
-                                },
-                                Object {
-                                  "labels": Object {
-                                    "version": "v3",
-                                  },
-                                  "name": "v3",
-                                },
-                              ],
-                              "trafficPolicy": undefined,
-                            },
-                          },
-                        ],
-                        "permissions": Object {
-                          "create": false,
-                          "delete": false,
-                          "update": false,
-                        },
-                      },
-                      "endpoints": Array [
+              <ServiceInfoWorkload
+                namespace="istio-system"
+                service={
+                  Object {
+                    "apiDocumentation": Object {
+                      "hasSpec": true,
+                      "type": "rest",
+                    },
+                    "destinationRules": Object {
+                      "items": Array [
                         Object {
-                          "addresses": Array [
-                            Object {
-                              "ip": "172.17.0.20",
-                              "kind": "Pod",
-                              "name": "reviews-v3-5f5bcb6765-hj46f",
-                            },
-                            Object {
-                              "ip": "172.17.0.21",
-                              "kind": "Pod",
-                              "name": "reviews-v2-d896b68c-jnxgm",
-                            },
-                            Object {
-                              "ip": "172.17.0.22",
-                              "kind": "Pod",
-                              "name": "reviews-v1-5d6696bcf7-2sls7",
-                            },
-                          ],
-                          "ports": Array [
-                            Object {
-                              "name": "http",
-                              "port": 9080,
-                              "protocol": "TCP",
-                            },
-                          ],
-                        },
-                      ],
-                      "health": undefined,
-                      "istioSidecar": true,
-                      "service": Object {
-                        "createdAt": "2018-06-29T16:43:18+02:00",
-                        "externalName": "my.database.example.com",
-                        "ip": "172.30.196.248",
-                        "labels": Object {
-                          "app": "reviews",
-                        },
-                        "name": "reviews",
-                        "ports": Array [
-                          Object {
-                            "name": "http",
-                            "port": 9080,
-                            "protocol": "TCP",
+                          "metadata": Object {
+                            "creationTimestamp": "2018-07-02T13:44:01+02:00",
+                            "name": "reviews",
+                            "resourceVersion": "393061",
                           },
-                        ],
-                        "resourceVersion": "2652",
-                        "type": "ClusterIP",
-                      },
-                      "validations": Object {
-                        "destinationrule": Object {
-                          "reviews": Object {
-                            "checks": Array [
+                          "spec": Object {
+                            "host": "reviews",
+                            "subsets": Array [
                               Object {
-                                "message": "This subset is not found from the host",
-                                "path": "spec/subsets[0]/version",
-                                "severity": "error",
+                                "labels": Object {
+                                  "version": "v1",
+                                },
+                                "name": "v1",
                               },
                               Object {
-                                "message": "This subset is not found from the host",
-                                "path": "spec/subsets[1]/version",
-                                "severity": "error",
+                                "labels": Object {
+                                  "version": "v2",
+                                },
+                                "name": "v2",
+                              },
+                              Object {
+                                "labels": Object {
+                                  "version": "v3",
+                                },
+                                "name": "v3",
                               },
                             ],
-                            "name": "details",
-                            "objectType": "destinationrule",
-                            "valid": false,
+                            "trafficPolicy": undefined,
                           },
-                        },
-                      },
-                      "virtualServices": Object {
-                        "items": Array [
-                          Object {
-                            "metadata": Object {
-                              "creationTimestamp": "2018-07-02T13:44:01+02:00",
-                              "name": "reviews",
-                              "resourceVersion": "393057",
-                            },
-                            "spec": Object {
-                              "gateways": undefined,
-                              "hosts": Array [
-                                "reviews",
-                              ],
-                              "http": Array [
-                                Object {
-                                  "route": Array [
-                                    Object {
-                                      "destination": Object {
-                                        "host": "reviews",
-                                        "subset": "v1",
-                                      },
-                                    },
-                                  ],
-                                },
-                              ],
-                              "tcp": undefined,
-                            },
-                          },
-                        ],
-                        "permissions": Object {
-                          "create": false,
-                          "delete": false,
-                          "update": false,
-                        },
-                      },
-                      "workloads": Array [],
-                    }
-                  }
-                  workloads={Array []}
-                />
-              </ErrorBoundaryWithMessage>
-            </ForwardRef>
-            <ForwardRef
-              eventKey={1}
-              title={
-                <React.Fragment>
-                  Virtual Services (
-                  1
-                  )
-                </React.Fragment>
-              }
-            >
-              <ErrorBoundaryWithMessage
-                message="One of the Virtual Services associated to this service has an invalid format"
-              >
-                <ServiceInfoVirtualServices
-                  service={
-                    Object {
-                      "apiDocumentation": Object {
-                        "hasSpec": true,
-                        "type": "rest",
-                      },
-                      "destinationRules": Object {
-                        "items": Array [
-                          Object {
-                            "metadata": Object {
-                              "creationTimestamp": "2018-07-02T13:44:01+02:00",
-                              "name": "reviews",
-                              "resourceVersion": "393061",
-                            },
-                            "spec": Object {
-                              "host": "reviews",
-                              "subsets": Array [
-                                Object {
-                                  "labels": Object {
-                                    "version": "v1",
-                                  },
-                                  "name": "v1",
-                                },
-                                Object {
-                                  "labels": Object {
-                                    "version": "v2",
-                                  },
-                                  "name": "v2",
-                                },
-                                Object {
-                                  "labels": Object {
-                                    "version": "v3",
-                                  },
-                                  "name": "v3",
-                                },
-                              ],
-                              "trafficPolicy": undefined,
-                            },
-                          },
-                        ],
-                        "permissions": Object {
-                          "create": false,
-                          "delete": false,
-                          "update": false,
-                        },
-                      },
-                      "endpoints": Array [
-                        Object {
-                          "addresses": Array [
-                            Object {
-                              "ip": "172.17.0.20",
-                              "kind": "Pod",
-                              "name": "reviews-v3-5f5bcb6765-hj46f",
-                            },
-                            Object {
-                              "ip": "172.17.0.21",
-                              "kind": "Pod",
-                              "name": "reviews-v2-d896b68c-jnxgm",
-                            },
-                            Object {
-                              "ip": "172.17.0.22",
-                              "kind": "Pod",
-                              "name": "reviews-v1-5d6696bcf7-2sls7",
-                            },
-                          ],
-                          "ports": Array [
-                            Object {
-                              "name": "http",
-                              "port": 9080,
-                              "protocol": "TCP",
-                            },
-                          ],
                         },
                       ],
-                      "health": undefined,
-                      "istioSidecar": true,
-                      "service": Object {
-                        "createdAt": "2018-06-29T16:43:18+02:00",
-                        "externalName": "my.database.example.com",
-                        "ip": "172.30.196.248",
-                        "labels": Object {
-                          "app": "reviews",
-                        },
-                        "name": "reviews",
-                        "ports": Array [
-                          Object {
-                            "name": "http",
-                            "port": 9080,
-                            "protocol": "TCP",
-                          },
-                        ],
-                        "resourceVersion": "2652",
-                        "type": "ClusterIP",
+                      "permissions": Object {
+                        "create": false,
+                        "delete": false,
+                        "update": false,
                       },
-                      "validations": Object {
-                        "destinationrule": Object {
-                          "reviews": Object {
-                            "checks": Array [
-                              Object {
-                                "message": "This subset is not found from the host",
-                                "path": "spec/subsets[0]/version",
-                                "severity": "error",
-                              },
-                              Object {
-                                "message": "This subset is not found from the host",
-                                "path": "spec/subsets[1]/version",
-                                "severity": "error",
-                              },
-                            ],
-                            "name": "details",
-                            "objectType": "destinationrule",
-                            "valid": false,
-                          },
-                        },
-                      },
-                      "virtualServices": Object {
-                        "items": Array [
-                          Object {
-                            "metadata": Object {
-                              "creationTimestamp": "2018-07-02T13:44:01+02:00",
-                              "name": "reviews",
-                              "resourceVersion": "393057",
-                            },
-                            "spec": Object {
-                              "gateways": undefined,
-                              "hosts": Array [
-                                "reviews",
-                              ],
-                              "http": Array [
-                                Object {
-                                  "route": Array [
-                                    Object {
-                                      "destination": Object {
-                                        "host": "reviews",
-                                        "subset": "v1",
-                                      },
-                                    },
-                                  ],
-                                },
-                              ],
-                              "tcp": undefined,
-                            },
-                          },
-                        ],
-                        "permissions": Object {
-                          "create": false,
-                          "delete": false,
-                          "update": false,
-                        },
-                      },
-                      "workloads": Array [],
-                    }
-                  }
-                  virtualServices={
-                    Array [
+                    },
+                    "endpoints": Array [
                       Object {
-                        "metadata": Object {
-                          "creationTimestamp": "2018-07-02T13:44:01+02:00",
-                          "name": "reviews",
-                          "resourceVersion": "393057",
-                        },
-                        "spec": Object {
-                          "gateways": undefined,
-                          "hosts": Array [
-                            "reviews",
-                          ],
-                          "http": Array [
-                            Object {
-                              "route": Array [
-                                Object {
-                                  "destination": Object {
-                                    "host": "reviews",
-                                    "subset": "v1",
-                                  },
-                                },
-                              ],
-                            },
-                          ],
-                          "tcp": undefined,
-                        },
-                      },
-                    ]
-                  }
-                />
-              </ErrorBoundaryWithMessage>
-            </ForwardRef>
-            <ForwardRef
-              eventKey={2}
-              title={
-                <React.Fragment>
-                  Destination Rules (
-                  1
-                  )
-                  <span
-                    className="f1uxujqj"
-                  >
-                     
-                    <Validation
-                      severity="error"
-                    />
-                  </span>
-                </React.Fragment>
-              }
-            >
-              <ErrorBoundaryWithMessage
-                message="One of the Destination Rules associated to this service has an invalid format"
-              >
-                <ServiceInfoDestinationRules
-                  destinationRules={
-                    Array [
-                      Object {
-                        "metadata": Object {
-                          "creationTimestamp": "2018-07-02T13:44:01+02:00",
-                          "name": "reviews",
-                          "resourceVersion": "393061",
-                        },
-                        "spec": Object {
-                          "host": "reviews",
-                          "subsets": Array [
-                            Object {
-                              "labels": Object {
-                                "version": "v1",
-                              },
-                              "name": "v1",
-                            },
-                            Object {
-                              "labels": Object {
-                                "version": "v2",
-                              },
-                              "name": "v2",
-                            },
-                            Object {
-                              "labels": Object {
-                                "version": "v3",
-                              },
-                              "name": "v3",
-                            },
-                          ],
-                          "trafficPolicy": undefined,
-                        },
-                      },
-                    ]
-                  }
-                  service={
-                    Object {
-                      "apiDocumentation": Object {
-                        "hasSpec": true,
-                        "type": "rest",
-                      },
-                      "destinationRules": Object {
-                        "items": Array [
+                        "addresses": Array [
                           Object {
-                            "metadata": Object {
-                              "creationTimestamp": "2018-07-02T13:44:01+02:00",
-                              "name": "reviews",
-                              "resourceVersion": "393061",
-                            },
-                            "spec": Object {
-                              "host": "reviews",
-                              "subsets": Array [
-                                Object {
-                                  "labels": Object {
-                                    "version": "v1",
-                                  },
-                                  "name": "v1",
-                                },
-                                Object {
-                                  "labels": Object {
-                                    "version": "v2",
-                                  },
-                                  "name": "v2",
-                                },
-                                Object {
-                                  "labels": Object {
-                                    "version": "v3",
-                                  },
-                                  "name": "v3",
-                                },
-                              ],
-                              "trafficPolicy": undefined,
-                            },
+                            "ip": "172.17.0.20",
+                            "kind": "Pod",
+                            "name": "reviews-v3-5f5bcb6765-hj46f",
+                          },
+                          Object {
+                            "ip": "172.17.0.21",
+                            "kind": "Pod",
+                            "name": "reviews-v2-d896b68c-jnxgm",
+                          },
+                          Object {
+                            "ip": "172.17.0.22",
+                            "kind": "Pod",
+                            "name": "reviews-v1-5d6696bcf7-2sls7",
                           },
                         ],
-                        "permissions": Object {
-                          "create": false,
-                          "delete": false,
-                          "update": false,
-                        },
-                      },
-                      "endpoints": Array [
-                        Object {
-                          "addresses": Array [
-                            Object {
-                              "ip": "172.17.0.20",
-                              "kind": "Pod",
-                              "name": "reviews-v3-5f5bcb6765-hj46f",
-                            },
-                            Object {
-                              "ip": "172.17.0.21",
-                              "kind": "Pod",
-                              "name": "reviews-v2-d896b68c-jnxgm",
-                            },
-                            Object {
-                              "ip": "172.17.0.22",
-                              "kind": "Pod",
-                              "name": "reviews-v1-5d6696bcf7-2sls7",
-                            },
-                          ],
-                          "ports": Array [
-                            Object {
-                              "name": "http",
-                              "port": 9080,
-                              "protocol": "TCP",
-                            },
-                          ],
-                        },
-                      ],
-                      "health": undefined,
-                      "istioSidecar": true,
-                      "service": Object {
-                        "createdAt": "2018-06-29T16:43:18+02:00",
-                        "externalName": "my.database.example.com",
-                        "ip": "172.30.196.248",
-                        "labels": Object {
-                          "app": "reviews",
-                        },
-                        "name": "reviews",
                         "ports": Array [
                           Object {
                             "name": "http",
@@ -601,96 +167,528 @@ exports[`#ServiceInfo render correctly with data should render serviceInfo with 
                             "protocol": "TCP",
                           },
                         ],
-                        "resourceVersion": "2652",
-                        "type": "ClusterIP",
                       },
-                      "validations": Object {
-                        "destinationrule": Object {
-                          "reviews": Object {
-                            "checks": Array [
+                    ],
+                    "health": undefined,
+                    "istioSidecar": true,
+                    "service": Object {
+                      "createdAt": "2018-06-29T16:43:18+02:00",
+                      "externalName": "my.database.example.com",
+                      "ip": "172.30.196.248",
+                      "labels": Object {
+                        "app": "reviews",
+                      },
+                      "name": "reviews",
+                      "ports": Array [
+                        Object {
+                          "name": "http",
+                          "port": 9080,
+                          "protocol": "TCP",
+                        },
+                      ],
+                      "resourceVersion": "2652",
+                      "type": "ClusterIP",
+                    },
+                    "validations": Object {
+                      "destinationrule": Object {
+                        "reviews": Object {
+                          "checks": Array [
+                            Object {
+                              "message": "This subset is not found from the host",
+                              "path": "spec/subsets[0]/version",
+                              "severity": "error",
+                            },
+                            Object {
+                              "message": "This subset is not found from the host",
+                              "path": "spec/subsets[1]/version",
+                              "severity": "error",
+                            },
+                          ],
+                          "name": "details",
+                          "objectType": "destinationrule",
+                          "valid": false,
+                        },
+                      },
+                    },
+                    "virtualServices": Object {
+                      "items": Array [
+                        Object {
+                          "metadata": Object {
+                            "creationTimestamp": "2018-07-02T13:44:01+02:00",
+                            "name": "reviews",
+                            "resourceVersion": "393057",
+                          },
+                          "spec": Object {
+                            "gateways": undefined,
+                            "hosts": Array [
+                              "reviews",
+                            ],
+                            "http": Array [
                               Object {
-                                "message": "This subset is not found from the host",
-                                "path": "spec/subsets[0]/version",
-                                "severity": "error",
-                              },
-                              Object {
-                                "message": "This subset is not found from the host",
-                                "path": "spec/subsets[1]/version",
-                                "severity": "error",
+                                "route": Array [
+                                  Object {
+                                    "destination": Object {
+                                      "host": "reviews",
+                                      "subset": "v1",
+                                    },
+                                  },
+                                ],
                               },
                             ],
-                            "name": "details",
-                            "objectType": "destinationrule",
-                            "valid": false,
+                            "tcp": undefined,
                           },
                         },
+                      ],
+                      "permissions": Object {
+                        "create": false,
+                        "delete": false,
+                        "update": false,
                       },
-                      "virtualServices": Object {
-                        "items": Array [
-                          Object {
-                            "metadata": Object {
-                              "creationTimestamp": "2018-07-02T13:44:01+02:00",
-                              "name": "reviews",
-                              "resourceVersion": "393057",
-                            },
-                            "spec": Object {
-                              "gateways": undefined,
-                              "hosts": Array [
-                                "reviews",
-                              ],
-                              "http": Array [
-                                Object {
-                                  "route": Array [
-                                    Object {
-                                      "destination": Object {
-                                        "host": "reviews",
-                                        "subset": "v1",
-                                      },
-                                    },
-                                  ],
+                    },
+                    "workloads": Array [],
+                  }
+                }
+                workloads={Array []}
+              />
+            </ErrorBoundaryWithMessage>
+          </ForwardRef>
+          <ForwardRef
+            eventKey={1}
+            title={
+              <React.Fragment>
+                Virtual Services (
+                1
+                )
+              </React.Fragment>
+            }
+          >
+            <ErrorBoundaryWithMessage
+              message="One of the Virtual Services associated to this service has an invalid format"
+            >
+              <ServiceInfoVirtualServices
+                service={
+                  Object {
+                    "apiDocumentation": Object {
+                      "hasSpec": true,
+                      "type": "rest",
+                    },
+                    "destinationRules": Object {
+                      "items": Array [
+                        Object {
+                          "metadata": Object {
+                            "creationTimestamp": "2018-07-02T13:44:01+02:00",
+                            "name": "reviews",
+                            "resourceVersion": "393061",
+                          },
+                          "spec": Object {
+                            "host": "reviews",
+                            "subsets": Array [
+                              Object {
+                                "labels": Object {
+                                  "version": "v1",
                                 },
-                              ],
-                              "tcp": undefined,
-                            },
+                                "name": "v1",
+                              },
+                              Object {
+                                "labels": Object {
+                                  "version": "v2",
+                                },
+                                "name": "v2",
+                              },
+                              Object {
+                                "labels": Object {
+                                  "version": "v3",
+                                },
+                                "name": "v3",
+                              },
+                            ],
+                            "trafficPolicy": undefined,
+                          },
+                        },
+                      ],
+                      "permissions": Object {
+                        "create": false,
+                        "delete": false,
+                        "update": false,
+                      },
+                    },
+                    "endpoints": Array [
+                      Object {
+                        "addresses": Array [
+                          Object {
+                            "ip": "172.17.0.20",
+                            "kind": "Pod",
+                            "name": "reviews-v3-5f5bcb6765-hj46f",
+                          },
+                          Object {
+                            "ip": "172.17.0.21",
+                            "kind": "Pod",
+                            "name": "reviews-v2-d896b68c-jnxgm",
+                          },
+                          Object {
+                            "ip": "172.17.0.22",
+                            "kind": "Pod",
+                            "name": "reviews-v1-5d6696bcf7-2sls7",
                           },
                         ],
-                        "permissions": Object {
-                          "create": false,
-                          "delete": false,
-                          "update": false,
+                        "ports": Array [
+                          Object {
+                            "name": "http",
+                            "port": 9080,
+                            "protocol": "TCP",
+                          },
+                        ],
+                      },
+                    ],
+                    "health": undefined,
+                    "istioSidecar": true,
+                    "service": Object {
+                      "createdAt": "2018-06-29T16:43:18+02:00",
+                      "externalName": "my.database.example.com",
+                      "ip": "172.30.196.248",
+                      "labels": Object {
+                        "app": "reviews",
+                      },
+                      "name": "reviews",
+                      "ports": Array [
+                        Object {
+                          "name": "http",
+                          "port": 9080,
+                          "protocol": "TCP",
+                        },
+                      ],
+                      "resourceVersion": "2652",
+                      "type": "ClusterIP",
+                    },
+                    "validations": Object {
+                      "destinationrule": Object {
+                        "reviews": Object {
+                          "checks": Array [
+                            Object {
+                              "message": "This subset is not found from the host",
+                              "path": "spec/subsets[0]/version",
+                              "severity": "error",
+                            },
+                            Object {
+                              "message": "This subset is not found from the host",
+                              "path": "spec/subsets[1]/version",
+                              "severity": "error",
+                            },
+                          ],
+                          "name": "details",
+                          "objectType": "destinationrule",
+                          "valid": false,
                         },
                       },
-                      "workloads": Array [],
-                    }
-                  }
-                  validations={
-                    Object {
-                      "reviews": Object {
-                        "checks": Array [
-                          Object {
-                            "message": "This subset is not found from the host",
-                            "path": "spec/subsets[0]/version",
-                            "severity": "error",
+                    },
+                    "virtualServices": Object {
+                      "items": Array [
+                        Object {
+                          "metadata": Object {
+                            "creationTimestamp": "2018-07-02T13:44:01+02:00",
+                            "name": "reviews",
+                            "resourceVersion": "393057",
                           },
+                          "spec": Object {
+                            "gateways": undefined,
+                            "hosts": Array [
+                              "reviews",
+                            ],
+                            "http": Array [
+                              Object {
+                                "route": Array [
+                                  Object {
+                                    "destination": Object {
+                                      "host": "reviews",
+                                      "subset": "v1",
+                                    },
+                                  },
+                                ],
+                              },
+                            ],
+                            "tcp": undefined,
+                          },
+                        },
+                      ],
+                      "permissions": Object {
+                        "create": false,
+                        "delete": false,
+                        "update": false,
+                      },
+                    },
+                    "workloads": Array [],
+                  }
+                }
+                virtualServices={
+                  Array [
+                    Object {
+                      "metadata": Object {
+                        "creationTimestamp": "2018-07-02T13:44:01+02:00",
+                        "name": "reviews",
+                        "resourceVersion": "393057",
+                      },
+                      "spec": Object {
+                        "gateways": undefined,
+                        "hosts": Array [
+                          "reviews",
+                        ],
+                        "http": Array [
                           Object {
-                            "message": "This subset is not found from the host",
-                            "path": "spec/subsets[1]/version",
-                            "severity": "error",
+                            "route": Array [
+                              Object {
+                                "destination": Object {
+                                  "host": "reviews",
+                                  "subset": "v1",
+                                },
+                              },
+                            ],
                           },
                         ],
-                        "name": "details",
-                        "objectType": "destinationrule",
-                        "valid": false,
+                        "tcp": undefined,
                       },
-                    }
+                    },
+                  ]
+                }
+              />
+            </ErrorBoundaryWithMessage>
+          </ForwardRef>
+          <ForwardRef
+            eventKey={2}
+            title={
+              <React.Fragment>
+                Destination Rules (
+                1
+                )
+                <span
+                  className="f1uxujqj"
+                >
+                   
+                  <Validation
+                    severity="error"
+                  />
+                </span>
+              </React.Fragment>
+            }
+          >
+            <ErrorBoundaryWithMessage
+              message="One of the Destination Rules associated to this service has an invalid format"
+            >
+              <ServiceInfoDestinationRules
+                destinationRules={
+                  Array [
+                    Object {
+                      "metadata": Object {
+                        "creationTimestamp": "2018-07-02T13:44:01+02:00",
+                        "name": "reviews",
+                        "resourceVersion": "393061",
+                      },
+                      "spec": Object {
+                        "host": "reviews",
+                        "subsets": Array [
+                          Object {
+                            "labels": Object {
+                              "version": "v1",
+                            },
+                            "name": "v1",
+                          },
+                          Object {
+                            "labels": Object {
+                              "version": "v2",
+                            },
+                            "name": "v2",
+                          },
+                          Object {
+                            "labels": Object {
+                              "version": "v3",
+                            },
+                            "name": "v3",
+                          },
+                        ],
+                        "trafficPolicy": undefined,
+                      },
+                    },
+                  ]
+                }
+                service={
+                  Object {
+                    "apiDocumentation": Object {
+                      "hasSpec": true,
+                      "type": "rest",
+                    },
+                    "destinationRules": Object {
+                      "items": Array [
+                        Object {
+                          "metadata": Object {
+                            "creationTimestamp": "2018-07-02T13:44:01+02:00",
+                            "name": "reviews",
+                            "resourceVersion": "393061",
+                          },
+                          "spec": Object {
+                            "host": "reviews",
+                            "subsets": Array [
+                              Object {
+                                "labels": Object {
+                                  "version": "v1",
+                                },
+                                "name": "v1",
+                              },
+                              Object {
+                                "labels": Object {
+                                  "version": "v2",
+                                },
+                                "name": "v2",
+                              },
+                              Object {
+                                "labels": Object {
+                                  "version": "v3",
+                                },
+                                "name": "v3",
+                              },
+                            ],
+                            "trafficPolicy": undefined,
+                          },
+                        },
+                      ],
+                      "permissions": Object {
+                        "create": false,
+                        "delete": false,
+                        "update": false,
+                      },
+                    },
+                    "endpoints": Array [
+                      Object {
+                        "addresses": Array [
+                          Object {
+                            "ip": "172.17.0.20",
+                            "kind": "Pod",
+                            "name": "reviews-v3-5f5bcb6765-hj46f",
+                          },
+                          Object {
+                            "ip": "172.17.0.21",
+                            "kind": "Pod",
+                            "name": "reviews-v2-d896b68c-jnxgm",
+                          },
+                          Object {
+                            "ip": "172.17.0.22",
+                            "kind": "Pod",
+                            "name": "reviews-v1-5d6696bcf7-2sls7",
+                          },
+                        ],
+                        "ports": Array [
+                          Object {
+                            "name": "http",
+                            "port": 9080,
+                            "protocol": "TCP",
+                          },
+                        ],
+                      },
+                    ],
+                    "health": undefined,
+                    "istioSidecar": true,
+                    "service": Object {
+                      "createdAt": "2018-06-29T16:43:18+02:00",
+                      "externalName": "my.database.example.com",
+                      "ip": "172.30.196.248",
+                      "labels": Object {
+                        "app": "reviews",
+                      },
+                      "name": "reviews",
+                      "ports": Array [
+                        Object {
+                          "name": "http",
+                          "port": 9080,
+                          "protocol": "TCP",
+                        },
+                      ],
+                      "resourceVersion": "2652",
+                      "type": "ClusterIP",
+                    },
+                    "validations": Object {
+                      "destinationrule": Object {
+                        "reviews": Object {
+                          "checks": Array [
+                            Object {
+                              "message": "This subset is not found from the host",
+                              "path": "spec/subsets[0]/version",
+                              "severity": "error",
+                            },
+                            Object {
+                              "message": "This subset is not found from the host",
+                              "path": "spec/subsets[1]/version",
+                              "severity": "error",
+                            },
+                          ],
+                          "name": "details",
+                          "objectType": "destinationrule",
+                          "valid": false,
+                        },
+                      },
+                    },
+                    "virtualServices": Object {
+                      "items": Array [
+                        Object {
+                          "metadata": Object {
+                            "creationTimestamp": "2018-07-02T13:44:01+02:00",
+                            "name": "reviews",
+                            "resourceVersion": "393057",
+                          },
+                          "spec": Object {
+                            "gateways": undefined,
+                            "hosts": Array [
+                              "reviews",
+                            ],
+                            "http": Array [
+                              Object {
+                                "route": Array [
+                                  Object {
+                                    "destination": Object {
+                                      "host": "reviews",
+                                      "subset": "v1",
+                                    },
+                                  },
+                                ],
+                              },
+                            ],
+                            "tcp": undefined,
+                          },
+                        },
+                      ],
+                      "permissions": Object {
+                        "create": false,
+                        "delete": false,
+                        "update": false,
+                      },
+                    },
+                    "workloads": Array [],
                   }
-                />
-              </ErrorBoundaryWithMessage>
-            </ForwardRef>
-          </ParameterizedTabs>
-        </CardBody>
-      </Card>
-    </GridItem>
-  </Grid>
-</Fragment>
+                }
+                validations={
+                  Object {
+                    "reviews": Object {
+                      "checks": Array [
+                        Object {
+                          "message": "This subset is not found from the host",
+                          "path": "spec/subsets[0]/version",
+                          "severity": "error",
+                        },
+                        Object {
+                          "message": "This subset is not found from the host",
+                          "path": "spec/subsets[1]/version",
+                          "severity": "error",
+                        },
+                      ],
+                      "name": "details",
+                      "objectType": "destinationrule",
+                      "valid": false,
+                    },
+                  }
+                }
+              />
+            </ErrorBoundaryWithMessage>
+          </ForwardRef>
+        </ParameterizedTabs>
+      </CardBody>
+    </Card>
+  </GridItem>
+</Grid>
 `;


### PR DESCRIPTION
On a second inspection the PF3 code ended up being unreachable.  This PR now just removes it.  The only validation needed is to make sure the service detail page renders normally, no error generation is required.

The first revision of the PR added an enhancement to our PF4 notification handling utility, that code remains in the PR because it is useful, despite no longer being used here.

Fixes https://github.com/kiali/kiali/issues/1882
