### PR TITLE
Change the background from gray to white on the Metrics Settings dropdown

### DIFF
--- a/src/components/MetricsOptions/MetricsSettingsDropdown.tsx
+++ b/src/components/MetricsOptions/MetricsSettingsDropdown.tsx
@@ -12,6 +12,7 @@ import {
   prettyLabelValues,
   combineLabelsSettings
 } from 'components/Metrics/Helper';
+import { PfColors } from '../Pf/PfColors';
 
 interface Props {
   onChanged: (state: MetricsSettings) => void;
@@ -122,7 +123,7 @@ export class MetricsSettingsDropdown extends React.Component<Props, State> {
       >
         {/* TODO: Remove the class="pf-c-dropdown__menu-item" attribute which is fixing a sizing issue in PF.
          * https://github.com/patternfly/patternfly-react/issues/3156 */}
-        <div style={{ paddingLeft: '10px' }} className="pf-c-dropdown__menu-item">
+        <div style={{ paddingLeft: '10px', backgroundColor: PfColors.White }} className="pf-c-dropdown__menu-item">
           {hasLabels && this.renderLabelOptions()}
           {hasHistograms && this.renderHistogramOptions()}
         </div>


### PR DESCRIPTION
** Describe the change **
This fixes the gray hover over the 

background that occurs with the Metrics Settings dropdown when selected.

fixes: https://github.com/kiali/kiali/issues/1895

** Screenshot **

Before:
![before](https://user-images.githubusercontent.com/1312165/68356949-a2064300-00c8-11ea-9ba0-00e187ae5fba.png)


After:
![Kiali_Console](https://user-images.githubusercontent.com/1312165/68356914-7edb9380-00c8-11ea-8643-d1202169893b.png)
