### PR TITLE
Use native js function to format date, fixing 12am/pm issue

### DIFF
--- a/src/components/Time/LocalTime.tsx
+++ b/src/components/Time/LocalTime.tsx
@@ -6,37 +6,22 @@ interface TimeProps {
   time: string;
 }
 
-const monthAbbrs = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-
-const formatDate = (date: string) => {
-  const mdate = new Date(date);
-  const monthStr = monthAbbrs[mdate.getMonth()];
-
-  let a = 'am';
-  let hours = mdate.getHours();
-  if (hours > 12) {
-    hours -= 12;
-    a = 'pm';
-  }
-
-  const minuteStr = mdate
-    .getMinutes()
-    .toString()
-    .padStart(2, '00');
-  let timeStr = `${hours}:${minuteStr} ${a}`;
-  if (mdate.getFullYear() !== new Date().getFullYear()) {
-    timeStr = `${mdate.getFullYear()} ${timeStr}`;
-  }
-
-  return `${monthStr} ${mdate.getDate()}, ${timeStr}`;
-};
-
 export default class LocalTime extends React.Component<TimeProps> {
   render() {
     let renderedTime: string;
 
     if (this.props.time) {
-      renderedTime = formatDate(this.props.time);
+      const date = new Date(this.props.time);
+      const options = {
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit'
+      } as any;
+      if (date.getFullYear() !== new Date().getFullYear()) {
+        options.year = 'numeric';
+      }
+      renderedTime = date.toLocaleString('en-US', options);
     } else {
       renderedTime = '-';
     }


### PR DESCRIPTION
Sample output: _Oct 9, 2:42 PM_

Closes https://github.com/kiali/kiali/issues/1878
