### PR TITLE
Error boundaries on workload list

### DIFF
--- a/src/components/ErrorBoundary/ErrorBoundaryWithMessage.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundaryWithMessage.tsx
@@ -11,7 +11,7 @@ export default class ErrorBoundaryWithMessage extends React.Component<MessagePro
     return (
       <Card>
         <CardBody>
-          <Alert variant="warning" title={this.props.message || 'Something went wrong rending this component'}>
+          <Alert variant="warning" title={this.props.message || 'Something went wrong rendering this component'}>
             {' '}
           </Alert>
         </CardBody>

--- a/src/pages/WorkloadDetails/WorkloadInfo.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo.tsx
@@ -10,6 +10,7 @@ import { Workload } from '../../types/Workload';
 import { Grid, GridItem, Tab } from '@patternfly/react-core';
 import ParameterizedTabs, { activeTab } from '../../components/Tab/Tabs';
 import Validation from '../../components/Validations/Validation';
+import ErrorBoundaryWithMessage from '../../components/ErrorBoundary/ErrorBoundaryWithMessage';
 
 type WorkloadInfoProps = {
   workload: Workload;
@@ -73,6 +74,10 @@ class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInfoState>
     return validationChecks;
   }
 
+  errorBoundaryMessage(resourceName: string) {
+    return `One of the ${resourceName} associated to this workload has an invalid format`;
+  }
+
   render() {
     const workload = this.props.workload;
     const pods = workload.pods || [];
@@ -128,19 +133,23 @@ class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInfoState>
             activeTab={this.state.currentTab}
           >
             <Tab title={podTabTitle} eventKey={0}>
-              <WorkloadPods
-                namespace={this.props.namespace}
-                workload={this.props.workload.name}
-                pods={pods}
-                validations={this.props.validations!.pod}
-              />
+              <ErrorBoundaryWithMessage message={this.errorBoundaryMessage('Pods')}>
+                <WorkloadPods
+                  namespace={this.props.namespace}
+                  workload={this.props.workload.name}
+                  pods={pods}
+                  validations={this.props.validations!.pod}
+                />
+              </ErrorBoundaryWithMessage>
             </Tab>
-            <Tab title={'Services (' + services.length + ')'} eventKey={1}>
-              <WorkloadServices
-                services={services}
-                workload={this.props.workload.name}
-                namespace={this.props.namespace}
-              />
+            <Tab title={`Services (${services.length})`} eventKey={1}>
+              <ErrorBoundaryWithMessage message={this.errorBoundaryMessage('Services')}>
+                <WorkloadServices
+                  services={services}
+                  workload={this.props.workload.name}
+                  namespace={this.props.namespace}
+                />
+              </ErrorBoundaryWithMessage>
             </Tab>
           </ParameterizedTabs>
         </GridItem>


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/1899

One thing to keep in mind when testing this is that the errors still appear during development (that's intencional, see https://stackoverflow.com/questions/52096804/react-still-showing-errors-after-catching-with-errorboundary).

This is what happens if you have an error:

![image](https://user-images.githubusercontent.com/14752/68418984-219f1b00-0178-11ea-9980-2f6fa81b7502.png)
