### PR TITLE
Add better error blank slate for istio object details

### DIFF
--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -23,6 +23,7 @@ import ParameterizedTabs, { activeTab } from '../../components/Tab/Tabs';
 import { Tab, Text, TextVariants } from '@patternfly/react-core';
 import { dicIstioType } from '../../types/IstioConfigList';
 import { showInMessageCenter } from '../../utils/IstioValidationUtils';
+import { EmptyState, EmptyStateTitle, EmptyStateIcon, EmptyStateInfo } from 'patternfly-react';
 
 const rightToolbarStyle = style({ float: 'right', marginTop: '8px' });
 
@@ -42,6 +43,12 @@ const paramToTab: { [key: string]: number } = {
   overview: 0,
   yaml: 1
 };
+const emptyStateStyle = style({
+  height: '98%',
+  marginRight: 5,
+  marginBottom: 10,
+  marginTop: 10
+});
 
 class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioConfigId>, IstioConfigDetailsState> {
   aceEditorRef: React.RefObject<AceEditor>;
@@ -366,8 +373,18 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
         );
       }
     } else {
-      // In theory it shouldn't enter here
-      return <div>{this.props.match.params.object} has not been loaded</div>;
+      // In theory it shouldn't enter here, but we show a nice error page anyway.
+
+      return (
+        <EmptyState className={emptyStateStyle}>
+          <EmptyStateIcon name="error-circle-o" />
+          <EmptyStateTitle>Error loading object `{this.props.match.params.object}`</EmptyStateTitle>
+          <EmptyStateInfo>
+            This might mean the resource is not ready yet or has been deleted and the cluster has not finished
+            propagating the changes.
+          </EmptyStateInfo>
+        </EmptyState>
+      );
     }
   };
 


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/1897

After the change:
![image](https://user-images.githubusercontent.com/14752/68422007-1bac3880-017e-11ea-99ba-7eea3ccd878a.png)