### PR TITLE
Fix regression, ensure NamespaceDropdown refreshes accessible namespaces

### DIFF
--- a/src/components/NamespaceDropdown.tsx
+++ b/src/components/NamespaceDropdown.tsx
@@ -140,6 +140,9 @@ export class NamespaceDropdown extends React.PureComponent<NamespaceDropdownProp
   }
 
   private onToggle = isOpen => {
+    if (isOpen) {
+      this.props.refresh();
+    }
     this.setState({
       isOpen
     });


### PR DESCRIPTION

I tested this locally using a kiali-operator not installed with **, by editing the Kiali CR to add/drop a namespace (default for example) while sitting on a page using the NamespaceDropdown (like graph).  Before it would not update, now it does.

Fixes https://github.com/kiali/kiali/issues/1901