### PR TITLE
Patternfly-fourize graph page

### DIFF
--- a/src/pages/Graph/GraphPage.tsx
+++ b/src/pages/Graph/GraphPage.tsx
@@ -99,8 +99,7 @@ export type GraphPageProps = RouteComponentProps<Partial<GraphURLPathProps>> & R
 const NUMBER_OF_DATAPOINTS = 30;
 
 const breadcrumbStyle = style({
-  marginTop: '10px',
-  marginBottom: '-7px'
+  marginTop: '10px'
 });
 
 const containerStyle = style({
@@ -321,14 +320,14 @@ export class GraphPage extends React.Component<GraphPageProps> {
                   </Button>
                 </Tooltip>
               </BreadcrumbItem>
-              {this.props.graphTimestamp > 0 && (
-                <span className={'pull-right'}>
-                  {new Date(graphStart).toLocaleDateString(undefined, timeDisplayOptions)}
-                  {' ... '}
-                  {new Date(graphEnd).toLocaleDateString(undefined, timeDisplayOptions)}
-                </span>
-              )}
             </Breadcrumb>
+            {this.props.graphTimestamp > 0 && (
+              <span className={'pull-right'}>
+                {new Date(graphStart).toLocaleDateString(undefined, timeDisplayOptions)}
+                {' ... '}
+                {new Date(graphEnd).toLocaleDateString(undefined, timeDisplayOptions)}
+              </span>
+            )}
           </div>
           <div>
             {/* Use empty div to reset the flex, this component doesn't seem to like that. It renders all its contents in the center */}

--- a/src/pages/Graph/GraphPage.tsx
+++ b/src/pages/Graph/GraphPage.tsx
@@ -330,7 +330,6 @@ export class GraphPage extends React.Component<GraphPageProps> {
             )}
           </div>
           <div>
-            {/* Use empty div to reset the flex, this component doesn't seem to like that. It renders all its contents in the center */}
             <GraphFilterContainer disabled={this.props.isLoading} onRefresh={this.handleRefreshClick} />
           </div>
           <FlexView grow={true} className={cytoscapeGraphWrapperDivStyle}>

--- a/src/pages/Graph/GraphPage.tsx
+++ b/src/pages/Graph/GraphPage.tsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { ThunkDispatch } from 'redux-thunk';
 import { RouteComponentProps } from 'react-router-dom';
 import FlexView from 'react-flexview';
-import { Breadcrumb, Button, OverlayTrigger, Tooltip } from 'patternfly-react';
+import { Breadcrumb, BreadcrumbItem, Button, Title, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { style } from 'typestyle';
 import { store } from '../../store/ConfigStore';
 import { DurationInSeconds, PollIntervalInMs, TimeInMilliseconds, TimeInSeconds } from '../../types/Common';
@@ -303,21 +303,19 @@ export class GraphPage extends React.Component<GraphPageProps> {
       <>
         <FlexView className={conStyle} column={true}>
           <div>
-            <Breadcrumb title={true}>
-              <Breadcrumb.Item active={true}>
-                {this.props.node && this.props.node.nodeType !== NodeType.UNKNOWN
-                  ? `Graph for ${this.props.node.nodeType}: ${this.getTitle(this.props.node)}`
-                  : 'Graph'}
-                <OverlayTrigger
-                  key={'graph-tour-help-ot'}
-                  placement="right"
-                  overlay={<Tooltip id={'graph-tour-help-tt'}>Graph help tour...</Tooltip>}
-                >
-                  <Button bsStyle="link" style={{ paddingLeft: '6px' }} onClick={this.toggleHelp}>
+            <Breadcrumb>
+              <BreadcrumbItem isActive={true}>
+                <Title headingLevel="h4" size="xl">
+                  {this.props.node && this.props.node.nodeType !== NodeType.UNKNOWN
+                    ? `Graph for ${this.props.node.nodeType}: ${this.getTitle(this.props.node)}`
+                    : 'Graph'}
+                </Title>
+                <Tooltip key={'graph-tour-help-ot'} position={TooltipPosition.right} content="Graph help tour...">
+                  <Button variant="link" style={{ paddingLeft: '6px' }} onClick={this.toggleHelp}>
                     <KialiIcon.Help className={defaultIconStyle} />
                   </Button>
-                </OverlayTrigger>
-              </Breadcrumb.Item>
+                </Tooltip>
+              </BreadcrumbItem>
               {this.props.graphTimestamp > 0 && (
                 <span className={'pull-right'}>
                   {new Date(graphStart).toLocaleDateString(undefined, timeDisplayOptions)}

--- a/src/pages/Graph/GraphPage.tsx
+++ b/src/pages/Graph/GraphPage.tsx
@@ -98,6 +98,11 @@ export type GraphPageProps = RouteComponentProps<Partial<GraphURLPathProps>> & R
 
 const NUMBER_OF_DATAPOINTS = 30;
 
+const breadcrumbStyle = style({
+  marginTop: '10px',
+  marginBottom: '-7px'
+});
+
 const containerStyle = style({
   minHeight: '350px',
   // TODO: try flexbox to remove this calc
@@ -302,7 +307,7 @@ export class GraphPage extends React.Component<GraphPageProps> {
     return (
       <>
         <FlexView className={conStyle} column={true}>
-          <div>
+          <div className={breadcrumbStyle}>
             <Breadcrumb>
               <BreadcrumbItem isActive={true}>
                 <Title headingLevel="h4" size="xl">


### PR DESCRIPTION
Finish PF4 migration of the graph page by removing import of patternfly-react and migrating the breadcrumb to PF4.

BEFORE:

![image](https://user-images.githubusercontent.com/23639005/68511350-5d4ee900-023b-11ea-9740-d7578d29a5bd.png)

AFTER:

![image](https://user-images.githubusercontent.com/23639005/68511362-65a72400-023b-11ea-9af1-2de2c1ef7eb9.png)

Related to kiali/kiali#1588