### PR TITLE
Use PF4 css color variables more consistently

### DIFF
--- a/src/components/CytoscapeGraph/TrafficAnimation/TrafficRenderer.ts
+++ b/src/components/CytoscapeGraph/TrafficAnimation/TrafficRenderer.ts
@@ -1,6 +1,6 @@
 import { Point, clamp, quadraticBezier, linearInterpolation, distance, bezierLength } from '../../../utils/MathUtils';
 import { DimClass } from '../graphs/GraphStyles';
-import { PfColors } from '../../Pf/PfColors';
+import { PfColors, PfAlertColorVals } from '../../Pf/PfColors';
 import {
   TrafficPointCircleRenderer,
   TrafficPointConcentricDiamondRenderer,
@@ -63,9 +63,10 @@ enum TrafficEdgeType {
  * @returns {TrafficPointRenderer}
  */
 const getTrafficPointRendererForRpsError: (edge: any) => TrafficPointRenderer = (_edge: any) => {
+  const colorVals = PfAlertColorVals();
   return new TrafficPointConcentricDiamondRenderer(
-    new Diamond(5, PfColors.White, PfColors.Danger, 1.0),
-    new Diamond(2, PfColors.Danger, PfColors.Danger, 1.0)
+    new Diamond(5, PfColors.White, colorVals.Danger, 1.0),
+    new Diamond(2, colorVals.Danger, colorVals.Danger, 1.0)
   );
 };
 

--- a/src/components/CytoscapeGraph/TrafficAnimation/TrafficRenderer.ts
+++ b/src/components/CytoscapeGraph/TrafficAnimation/TrafficRenderer.ts
@@ -1,6 +1,6 @@
 import { Point, clamp, quadraticBezier, linearInterpolation, distance, bezierLength } from '../../../utils/MathUtils';
 import { DimClass } from '../graphs/GraphStyles';
-import { PfColors, PfAlertColorVals } from '../../Pf/PfColors';
+import { PfColors, getPFAlertColorVals } from '../../Pf/PfColors';
 import {
   TrafficPointCircleRenderer,
   TrafficPointConcentricDiamondRenderer,
@@ -63,7 +63,7 @@ enum TrafficEdgeType {
  * @returns {TrafficPointRenderer}
  */
 const getTrafficPointRendererForRpsError: (edge: any) => TrafficPointRenderer = (_edge: any) => {
-  const colorVals = PfAlertColorVals();
+  const colorVals = getPFAlertColorVals();
   return new TrafficPointConcentricDiamondRenderer(
     new Diamond(5, PfColors.White, colorVals.Danger, 1.0),
     new Diamond(2, colorVals.Danger, colorVals.Danger, 1.0)

--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -1,5 +1,11 @@
 import { style } from 'typestyle';
-import { PfColors, withAlpha, PFAlertColorValsType, PfAlertColorVals } from '../../../components/Pf/PfColors';
+import {
+  PfColors,
+  withAlpha,
+  getPFAlertColorVals,
+  PFColorVal,
+  PFAlertColorVals
+} from '../../../components/Pf/PfColors';
 import { EdgeLabelMode } from '../../../types/GraphFilter';
 import { FAILURE, DEGRADED, REQUESTS_THRESHOLDS } from '../../../types/Health';
 import {
@@ -18,10 +24,10 @@ import * as Cy from 'cytoscape';
 
 export const DimClass = 'mousedim';
 
-let EdgeColor: string;
+let EdgeColor: PFColorVal;
 const EdgeColorDead = PfColors.Black500;
-let EdgeColorDegraded: string;
-let EdgeColorFailure: string;
+let EdgeColorDegraded: PFColorVal;
+let EdgeColorFailure: PFColorVal;
 const EdgeColorTCPWithTraffic = PfColors.Blue600;
 const EdgeIconMTLS = icons.istio.mtls.ascii; // lock
 const EdgeIconDisabledMTLS = icons.istio.disabledMtls.ascii; // broken lock
@@ -113,7 +119,7 @@ export class GraphStyles {
     if (GraphStyles.colorsDefined) {
       return;
     }
-    const colorVals: PFAlertColorValsType = PfAlertColorVals();
+    const colorVals: PFAlertColorVals = getPFAlertColorVals();
     EdgeColor = colorVals.Success;
     EdgeColorDegraded = colorVals.Warning;
     EdgeColorFailure = colorVals.Danger;

--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -1,5 +1,5 @@
 import { style } from 'typestyle';
-import { PfColors, withAlpha } from '../../../components/Pf/PfColors';
+import { PfColors, withAlpha, PFAlertColorValsType, PfAlertColorVals } from '../../../components/Pf/PfColors';
 import { EdgeLabelMode } from '../../../types/GraphFilter';
 import { FAILURE, DEGRADED, REQUESTS_THRESHOLDS } from '../../../types/Health';
 import {
@@ -18,15 +18,10 @@ import * as Cy from 'cytoscape';
 
 export const DimClass = 'mousedim';
 
-// UX-specified colors, widths, etc
-const ColorDanger = PfColors.Danger; // Same as Health.FAILURE.color
-const ColorHealthy = PfColors.Success; // Same as Health.HEALTHY.color
-const ColorWarning = PfColors.Warning; // Same as Health.DEGRADED.color
-
-const EdgeColor = ColorHealthy;
+let EdgeColor: string;
 const EdgeColorDead = PfColors.Black500;
-const EdgeColorDegraded = ColorWarning;
-const EdgeColorFailure = ColorDanger;
+let EdgeColorDegraded: string;
+let EdgeColorFailure: string;
 const EdgeColorTCPWithTraffic = PfColors.Blue600;
 const EdgeIconMTLS = icons.istio.mtls.ascii; // lock
 const EdgeIconDisabledMTLS = icons.istio.disabledMtls.ascii; // broken lock
@@ -40,8 +35,8 @@ const EdgeWidthSelected = 4;
 const NodeBorderWidth = '1px';
 const NodeBorderWidthSelected = '3px';
 const NodeColorBorder = PfColors.Black400;
-const NodeColorBorderDegraded = ColorWarning;
-const NodeColorBorderFailure = ColorDanger;
+let NodeColorBorderDegraded: string;
+let NodeColorBorderFailure: string;
 const NodeColorBorderHover = PfColors.Blue300;
 const NodeColorBorderSelected = PfColors.Blue300;
 const NodeColorFill = PfColors.White;
@@ -112,6 +107,20 @@ const badgeStyle = style({
 });
 
 export class GraphStyles {
+  static colorsDefined: boolean;
+
+  static defineColors = () => {
+    if (GraphStyles.colorsDefined) {
+      return;
+    }
+    const colorVals: PFAlertColorValsType = PfAlertColorVals();
+    EdgeColor = colorVals.Success;
+    EdgeColorDegraded = colorVals.Warning;
+    EdgeColorFailure = colorVals.Danger;
+    NodeColorBorderDegraded = colorVals.Warning;
+    NodeColorBorderFailure = colorVals.Danger;
+  };
+
   static options() {
     return { wheelSensitivity: 0.1, autounselectify: false, autoungrabify: true };
   }
@@ -249,6 +258,8 @@ export class GraphStyles {
   }
 
   static styles(): Cy.Stylesheet[] {
+    GraphStyles.defineColors();
+
     const getCyGlobalData = (ele: Cy.NodeSingular | Cy.EdgeSingular): CytoscapeGlobalScratchData => {
       return ele.cy().scratch(CytoscapeGlobalScratchNamespace);
     };

--- a/src/components/Health/__tests__/HealthIndicator.test.tsx
+++ b/src/components/Health/__tests__/HealthIndicator.test.tsx
@@ -4,7 +4,7 @@ import { shallowToJson } from 'enzyme-to-json';
 
 import { HealthIndicator, DisplayMode } from '../HealthIndicator';
 import { AppHealth } from '../../../types/Health';
-import { PFColorVars } from '../../Pf/PfColors';
+import { PFAlertColor } from 'components/Pf/PfColors';
 
 describe('HealthIndicator', () => {
   it('renders when empty', () => {
@@ -31,12 +31,12 @@ describe('HealthIndicator', () => {
     let wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.SMALL} />);
     expect(shallowToJson(wrapper)).toMatchSnapshot();
     let html = wrapper.html();
-    expect(html).toContain(PFColorVars.SuccessColor);
+    expect(html).toContain(PFAlertColor.Success);
 
     // LARGE
     wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} />);
     html = wrapper.html();
-    expect(html).toContain(PFColorVars.SuccessColor);
+    expect(html).toContain(PFAlertColor.Success);
   });
 
   it('renders workloads degraded', () => {
@@ -52,12 +52,12 @@ describe('HealthIndicator', () => {
     // SMALL
     let wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.SMALL} />);
     let html = wrapper.html();
-    expect(html).toContain(PFColorVars.WarningColor);
+    expect(html).toContain(PFAlertColor.Warning);
 
     // LARGE
     wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} />);
     html = wrapper.html();
-    expect(html).toContain(PFColorVars.WarningColor);
+    expect(html).toContain(PFAlertColor.Warning);
     expect(html).toContain('1 / 10');
   });
 
@@ -74,12 +74,12 @@ describe('HealthIndicator', () => {
     // SMALL
     let wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.SMALL} />);
     let html = wrapper.html();
-    expect(html).toContain(PFColorVars.SuccessColor);
+    expect(html).toContain(PFAlertColor.Success);
 
     // LARGE
     wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} />);
     html = wrapper.html();
-    expect(html).toContain(PFColorVars.SuccessColor);
+    expect(html).toContain(PFAlertColor.Success);
     expect(html).toContain('0 / 0');
   });
 
@@ -96,12 +96,12 @@ describe('HealthIndicator', () => {
     // SMALL
     let wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.SMALL} />);
     let html = wrapper.html();
-    expect(html).toContain(PFColorVars.DangerColor);
+    expect(html).toContain(PFAlertColor.Danger);
 
     // LARGE
     wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} />);
     html = wrapper.html();
-    expect(html).toContain(PFColorVars.DangerColor);
+    expect(html).toContain(PFAlertColor.Danger);
   });
 
   it('renders error rate failure', () => {
@@ -114,12 +114,12 @@ describe('HealthIndicator', () => {
     // SMALL
     let wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.SMALL} />);
     let html = wrapper.html();
-    expect(html).toContain(PFColorVars.DangerColor);
+    expect(html).toContain(PFAlertColor.Danger);
 
     // LARGE
     wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} />);
     html = wrapper.html();
-    expect(html).toContain(PFColorVars.DangerColor);
+    expect(html).toContain(PFAlertColor.Danger);
     expect(html).toContain('Outbound: 20.00%');
     expect(html).toContain('Inbound: 10.00%');
   });

--- a/src/components/Pf/PfColors.tsx
+++ b/src/components/Pf/PfColors.tsx
@@ -89,26 +89,53 @@ export enum PfColors {
   // Kiali colors that use PF colors
   //
   Gray = Black600,
-  GrayBackground = Black150,
-
-  // Health/Alert colors https://www.patternfly.org/v4/design-guidelines/styles/colors
-  Danger = '#C9190B', // --pf-global--danger-color--100
-  DangerBackground = Red400, // --pf-global--danger-color--200
-  Info = '#73BCF7', // --pf-global--info-color--100
-  InfoBackground = Blue600, // --pf-global--info-color--200
-  Success = Green500, // --pf-global--success-color--100
-  SuccessBackground = LightGreen600, // --pf-global--success-color--200
-  Warning = Gold400, // --pf-global--warning-color--100
-  WarningBackground = Gold600 // --pf-global--warning-color--200
+  GrayBackground = Black150
 }
 
-export enum PFColorVars {
-  DangerColor = 'var(--pf-global--danger-color--100)',
-  // Patternfly has a new green that is darker but they have not yet
-  // updated the PF vars for it
-  // SuccessColor = 'var(--pf-global--success-color--100)',
-  SuccessColor = '#3e8635', // computed values like Green500 are not allowed in enum
-  WarningColor = 'var(--pf-global--warning-color--100)'
+// Health/Alert colors https://www.patternfly.org/v4/design-guidelines/styles/colors
+export type PFAlertColorValsType = {
+  Danger: string;
+  DangerBackground: string;
+  Info: string;
+  InfoBackground: string;
+  Success: string;
+  SuccessBackground: string;
+  Warning: string;
+  WarningBackground: string;
+};
+
+let pfAlertColorVals: PFAlertColorValsType | undefined;
+
+export const PfAlertColorVals = (): PFAlertColorValsType => {
+  if (!pfAlertColorVals) {
+    const root = document.documentElement;
+    pfAlertColorVals = {
+      Danger: getComputedStyle(root).getPropertyValue('--pf-global--danger-color--100'),
+      DangerBackground: getComputedStyle(root).getPropertyValue('--pf-global--danger-color--200'),
+      Info: getComputedStyle(root).getPropertyValue('--pf-global--info-color--100'),
+      InfoBackground: getComputedStyle(root).getPropertyValue('--pf-global--info-color--200'),
+      // TODO: go back to var when PF vars is properly updated
+      // Success: getComputedStyle(root).getPropertyValue('--pf-global--success-color--100'),
+      Success: '#3e8635',
+      SuccessBackground: getComputedStyle(root).getPropertyValue('--pf-global--success-color--200'),
+      Warning: getComputedStyle(root).getPropertyValue('--pf-global--warning-color--100'),
+      WarningBackground: getComputedStyle(root).getPropertyValue('--pf-global--warning-color--200')
+    };
+  }
+  return pfAlertColorVals;
+};
+
+export enum PFAlertColor {
+  Danger = 'var(${--pf-global--danger-color--100)',
+  DangerBackground = 'var(--pf-global--danger-color--200)',
+  Info = 'var(--pf-global--info-color--100)',
+  InfoBackground = 'var(--pf-global--info-color--200)',
+  // TODO: go back to var when PF vars is properly updated
+  // Success = 'var(--pf-global--success-color--100)',
+  Success = '#3e8635',
+  SuccessBackground = 'var(--pf-global--success-color--200)',
+  Warning = 'var(--pf-global--warning-color--100)',
+  WarningBackground = 'var(--pf-global--warning-color--200)'
 }
 
 export const withAlpha = (color: PfColors, hexAlpha: string) => {

--- a/src/components/Pf/PfColors.tsx
+++ b/src/components/Pf/PfColors.tsx
@@ -92,24 +92,27 @@ export enum PfColors {
   GrayBackground = Black150
 }
 
+// The hex string value of the PF CSS variable
+export type PFColorVal = string;
+
 // Health/Alert colors https://www.patternfly.org/v4/design-guidelines/styles/colors
-export type PFAlertColorValsType = {
-  Danger: string;
-  DangerBackground: string;
-  Info: string;
-  InfoBackground: string;
-  Success: string;
-  SuccessBackground: string;
-  Warning: string;
-  WarningBackground: string;
+export type PFAlertColorVals = {
+  Danger: PFColorVal;
+  DangerBackground: PFColorVal;
+  Info: PFColorVal;
+  InfoBackground: PFColorVal;
+  Success: PFColorVal;
+  SuccessBackground: PFColorVal;
+  Warning: PFColorVal;
+  WarningBackground: PFColorVal;
 };
 
-let pfAlertColorVals: PFAlertColorValsType | undefined;
+let PFAlertColorValsInstance: PFAlertColorVals | undefined;
 
-export const PfAlertColorVals = (): PFAlertColorValsType => {
-  if (!pfAlertColorVals) {
+export const getPFAlertColorVals = (): PFAlertColorVals => {
+  if (!PFAlertColorValsInstance) {
     const root = document.documentElement;
-    pfAlertColorVals = {
+    PFAlertColorValsInstance = {
       Danger: getComputedStyle(root).getPropertyValue('--pf-global--danger-color--100'),
       DangerBackground: getComputedStyle(root).getPropertyValue('--pf-global--danger-color--200'),
       Info: getComputedStyle(root).getPropertyValue('--pf-global--info-color--100'),
@@ -122,7 +125,7 @@ export const PfAlertColorVals = (): PFAlertColorValsType => {
       WarningBackground: getComputedStyle(root).getPropertyValue('--pf-global--warning-color--200')
     };
   }
-  return pfAlertColorVals;
+  return PFAlertColorValsInstance;
 };
 
 export enum PFAlertColor {

--- a/src/components/SessionTimeout/SessionTimeout.tsx
+++ b/src/components/SessionTimeout/SessionTimeout.tsx
@@ -5,7 +5,7 @@ import { AuthStrategy } from '../../types/Auth';
 import { LoginSession } from '../../store/Store';
 import * as API from '../../services/Api';
 import authenticationConfig from '../../config/AuthenticationConfig';
-import { PFColorVars } from 'components/Pf/PfColors';
+import { PFAlertColor } from 'components/Pf/PfColors';
 
 type SessionTimeoutProps = {
   onLogout: () => void;
@@ -36,7 +36,7 @@ export class SessionTimeout extends React.Component<SessionTimeoutProps, {}> {
     return (
       <Modal isOpen={this.props.show} onClose={defaultAction} actions={buttons} title={'Session Timeout'} width={'40%'}>
         <span>
-          <WarningTriangleIcon size={'xl'} color={PFColorVars.WarningColor} />
+          <WarningTriangleIcon size={'xl'} color={PFAlertColor.Warning} />
         </span>
         <span style={{ float: 'right', width: '80%' }} className={'lead'}>
           {this.textForAuthStrategy(authenticationConfig.strategy)}

--- a/src/components/SummaryPanel/RateChart.tsx
+++ b/src/components/SummaryPanel/RateChart.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Chart, ChartBar, ChartStack, ChartAxis, ChartTooltip } from '@patternfly/react-charts';
 import { VictoryLegend } from 'victory';
 
-import { PfColors, PfAlertColorVals } from '../../components/Pf/PfColors';
+import { PfColors, getPFAlertColorVals } from '../../components/Pf/PfColors';
 import { SUMMARY_PANEL_CHART_WIDTH } from '../../types/Graph';
 import * as Legend from 'components/Charts/LegendHelper';
 import { CustomFlyout } from 'components/Charts/CustomFlyout';
@@ -113,7 +113,7 @@ export class RateChart extends React.Component<Props, State> {
 }
 
 export const renderRateChartHttp = (percent2xx: number, percent3xx: number, percent4xx: number, percent5xx: number) => {
-  const colorVals = PfAlertColorVals();
+  const colorVals = getPFAlertColorVals();
   const vcLines: VCLines = [
     { name: 'OK', x: 'rate', y: percent2xx, color: colorVals.Success },
     { name: '3xx', x: 'rate', y: percent3xx, color: colorVals.Info },
@@ -133,7 +133,7 @@ export const renderRateChartHttp = (percent2xx: number, percent3xx: number, perc
 };
 
 export const renderRateChartGrpc = (percentOK: number, percentErr: number) => {
-  const colorVals = PfAlertColorVals();
+  const colorVals = getPFAlertColorVals();
   const vcLines: VCLines = [
     { name: 'OK', x: 'rate', y: percentOK, color: colorVals.Success },
     { name: 'Err', x: 'rate', y: percentErr, color: colorVals.Danger }
@@ -160,7 +160,7 @@ export const renderInOutRateChartHttp = (
   percent4xxOut: number,
   percent5xxOut: number
 ) => {
-  const colorVals = PfAlertColorVals();
+  const colorVals = getPFAlertColorVals();
   const vcLines: VCLines = [
     { name: 'OK', dp: [{ x: 'In', y: percent2xxIn }, { x: 'Out', y: percent2xxOut }], color: colorVals.Success },
     { name: '3xx', dp: [{ x: 'In', y: percent3xxIn }, { x: 'Out', y: percent3xxOut }], color: colorVals.Info },
@@ -193,7 +193,7 @@ export const renderInOutRateChartGrpc = (
   percentOKOut: number,
   percentErrOut: number
 ) => {
-  const colorVals = PfAlertColorVals();
+  const colorVals = getPFAlertColorVals();
   const vcLines: VCLines = [
     { name: 'OK', dp: [{ x: 'In', y: percentOKIn }, { x: 'Out', y: percentOKOut }], color: colorVals.Success },
     { name: 'Err', dp: [{ x: 'In', y: percentErrIn }, { x: 'Out', y: percentErrOut }], color: colorVals.Danger }

--- a/src/components/SummaryPanel/RateChart.tsx
+++ b/src/components/SummaryPanel/RateChart.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Chart, ChartBar, ChartStack, ChartAxis, ChartTooltip } from '@patternfly/react-charts';
 import { VictoryLegend } from 'victory';
 
-import { PfColors } from '../../components/Pf/PfColors';
+import { PfColors, PfAlertColorVals } from '../../components/Pf/PfColors';
 import { SUMMARY_PANEL_CHART_WIDTH } from '../../types/Graph';
 import * as Legend from 'components/Charts/LegendHelper';
 import { CustomFlyout } from 'components/Charts/CustomFlyout';
@@ -113,11 +113,12 @@ export class RateChart extends React.Component<Props, State> {
 }
 
 export const renderRateChartHttp = (percent2xx: number, percent3xx: number, percent4xx: number, percent5xx: number) => {
+  const colorVals = PfAlertColorVals();
   const vcLines: VCLines = [
-    { name: 'OK', x: 'rate', y: percent2xx, color: PfColors.Success },
-    { name: '3xx', x: 'rate', y: percent3xx, color: PfColors.Info },
-    { name: '4xx', x: 'rate', y: percent4xx, color: PfColors.DangerBackground }, // 4xx is also an error use close but distinct color
-    { name: '5xx', x: 'rate', y: percent5xx, color: PfColors.Danger }
+    { name: 'OK', x: 'rate', y: percent2xx, color: colorVals.Success },
+    { name: '3xx', x: 'rate', y: percent3xx, color: colorVals.Info },
+    { name: '4xx', x: 'rate', y: percent4xx, color: colorVals.DangerBackground }, // 4xx is also an error use close but distinct color
+    { name: '5xx', x: 'rate', y: percent5xx, color: colorVals.Danger }
   ].map(dp => {
     return {
       datapoints: [dp],
@@ -132,9 +133,10 @@ export const renderRateChartHttp = (percent2xx: number, percent3xx: number, perc
 };
 
 export const renderRateChartGrpc = (percentOK: number, percentErr: number) => {
+  const colorVals = PfAlertColorVals();
   const vcLines: VCLines = [
-    { name: 'OK', x: 'rate', y: percentOK, color: PfColors.Success },
-    { name: 'Err', x: 'rate', y: percentErr, color: PfColors.Danger }
+    { name: 'OK', x: 'rate', y: percentOK, color: colorVals.Success },
+    { name: 'Err', x: 'rate', y: percentErr, color: colorVals.Danger }
   ].map(dp => {
     return {
       datapoints: [dp],
@@ -158,15 +160,16 @@ export const renderInOutRateChartHttp = (
   percent4xxOut: number,
   percent5xxOut: number
 ) => {
+  const colorVals = PfAlertColorVals();
   const vcLines: VCLines = [
-    { name: 'OK', dp: [{ x: 'In', y: percent2xxIn }, { x: 'Out', y: percent2xxOut }], color: PfColors.Success },
-    { name: '3xx', dp: [{ x: 'In', y: percent3xxIn }, { x: 'Out', y: percent3xxOut }], color: PfColors.Info },
+    { name: 'OK', dp: [{ x: 'In', y: percent2xxIn }, { x: 'Out', y: percent2xxOut }], color: colorVals.Success },
+    { name: '3xx', dp: [{ x: 'In', y: percent3xxIn }, { x: 'Out', y: percent3xxOut }], color: colorVals.Info },
     {
       name: '4xx',
       dp: [{ x: 'In', y: percent4xxIn }, { x: 'Out', y: percent4xxOut }],
-      color: PfColors.DangerBackground
+      color: colorVals.DangerBackground
     }, // 4xx is also an error use close but distinct color
-    { name: '5xx', dp: [{ x: 'In', y: percent5xxIn }, { x: 'Out', y: percent5xxOut }], color: PfColors.Danger }
+    { name: '5xx', dp: [{ x: 'In', y: percent5xxIn }, { x: 'Out', y: percent5xxOut }], color: colorVals.Danger }
   ].map(line => {
     return {
       datapoints: line.dp.map(dp => ({
@@ -190,9 +193,10 @@ export const renderInOutRateChartGrpc = (
   percentOKOut: number,
   percentErrOut: number
 ) => {
+  const colorVals = PfAlertColorVals();
   const vcLines: VCLines = [
-    { name: 'OK', dp: [{ x: 'In', y: percentOKIn }, { x: 'Out', y: percentOKOut }], color: PfColors.Success },
-    { name: 'Err', dp: [{ x: 'In', y: percentErrIn }, { x: 'Out', y: percentErrOut }], color: PfColors.Danger }
+    { name: 'OK', dp: [{ x: 'In', y: percentOKIn }, { x: 'Out', y: percentOKOut }], color: colorVals.Success },
+    { name: 'Err', dp: [{ x: 'In', y: percentErrIn }, { x: 'Out', y: percentErrOut }], color: colorVals.Danger }
   ].map(line => {
     return {
       datapoints: line.dp.map(dp => ({

--- a/src/components/SummaryPanel/RpsChart.tsx
+++ b/src/components/SummaryPanel/RpsChart.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { style } from 'typestyle';
 import { InfoAltIcon, SquareFullIcon } from '@patternfly/react-icons';
 
-import { PfColors } from '../Pf/PfColors';
+import { PfColors, PFAlertColor } from '../Pf/PfColors';
 import { SUMMARY_PANEL_CHART_WIDTH } from '../../types/Graph';
 import { Datapoint } from '../../types/Metrics';
 import Graphing, { VCLines, VCLine, VCDataPoint } from 'utils/Graphing';
@@ -79,8 +79,8 @@ export class RpsChart extends React.Component<RpsChartTypeProp, {}> {
   }
 
   private renderContent = () => {
-    const rpsLine = Graphing.toVCLine(this.props.dataRps, 'RPS', PfColors.Info);
-    const errLine = Graphing.toVCLine(this.props.dataErrors, 'Error', PfColors.Danger);
+    const rpsLine = Graphing.toVCLine(this.props.dataRps, 'RPS', PFAlertColor.Info);
+    const errLine = Graphing.toVCLine(this.props.dataErrors, 'Error', PFAlertColor.Danger);
     if (thereIsTrafficData(rpsLine)) {
       return (
         <>

--- a/src/components/Validations/Validation.tsx
+++ b/src/components/Validations/Validation.tsx
@@ -4,7 +4,7 @@ import { IconType } from '@patternfly/react-icons/dist/js/createIcon';
 import { ValidationTypes } from '../../types/IstioObjects';
 import { Text, TextVariants } from '@patternfly/react-core';
 import './Validation.css';
-import { PFColorVars } from '../Pf/PfColors';
+import { PFAlertColor } from 'components/Pf/PfColors';
 
 type Props = ValidationDescription & {
   messageColor?: boolean;
@@ -26,19 +26,19 @@ export type ValidationType = {
 
 const ErrorValidation: ValidationType = {
   name: 'Not Valid',
-  color: PFColorVars.DangerColor,
+  color: PFAlertColor.Danger,
   icon: ExclamationCircleIcon
 };
 
 const WarningValidation: ValidationType = {
   name: 'Warning',
-  color: PFColorVars.WarningColor,
+  color: PFAlertColor.Warning,
   icon: ExclamationTriangleIcon
 };
 
 const CorrectValidation: ValidationType = {
   name: 'Valid',
-  color: PFColorVars.SuccessColor,
+  color: PFAlertColor.Success,
   icon: CheckCircleIcon
 };
 

--- a/src/config/KialiIcon.tsx
+++ b/src/config/KialiIcon.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { PfColors } from '../components/Pf/PfColors';
+import { PFAlertColor } from '../components/Pf/PfColors';
 import {
   ApplicationsIcon,
   BundleIcon,
@@ -56,20 +56,20 @@ export const KialiIcon: { [name: string]: React.FunctionComponent<IconProps> } =
   Bell: (props: IconProps) => <BellIcon className={props.className} />,
   CircuitBreaker: (props: IconProps) => <BoltIcon className={props.className} />,
   Close: (props: IconProps) => <CloseIcon className={props.className} />,
-  Error: (props: IconProps) => <ErrorCircleOIcon className={props.className} color={PfColors.Danger} />,
+  Error: (props: IconProps) => <ErrorCircleOIcon className={props.className} color={PFAlertColor.Danger} />,
   Help: (props: IconProps) => <HelpIcon className={props.className} />,
-  Info: (props: IconProps) => <InfoAltIcon className={props.className} color={PfColors.Info} />,
+  Info: (props: IconProps) => <InfoAltIcon className={props.className} color={PFAlertColor.Info} />,
   LocalTime: (props: IconProps) => <GlobeAmericasIcon className={props.className} />,
   MissingSidecar: (props: IconProps) => <BlueprintIcon className={props.className} />,
   MtlsLock: (props: IconProps) => <LockIcon className={props.className} />,
   MtlsUnlock: (props: IconProps) => <LockOpenIcon className={props.className} />,
-  Ok: (props: IconProps) => <OkIcon className={props.className} color={PfColors.Success} />,
+  Ok: (props: IconProps) => <OkIcon className={props.className} color={PFAlertColor.Success} />,
   Repository: (props: IconProps) => <RepositoryIcon className={props.className} />,
   Services: (props: IconProps) => <ServiceIcon className={props.className} />,
   Topology: (props: IconProps) => <TopologyIcon className={props.className} />,
   Unknown: (props: IconProps) => <UnknownIcon className={props.className} />,
   VirtualService: (props: IconProps) => <CodeBranchIcon className={props.className} />,
-  Warning: (props: IconProps) => <WarningTriangleIcon className={props.className} color={PfColors.Warning} />,
+  Warning: (props: IconProps) => <WarningTriangleIcon className={props.className} color={PFAlertColor.Warning} />,
   Website: (props: IconProps) => <HomeIcon className={props.className} />,
   Workloads: (props: IconProps) => <BundleIcon className={props.className} />
 };

--- a/src/types/Health.ts
+++ b/src/types/Health.ts
@@ -1,7 +1,7 @@
 import { CheckCircleIcon, ExclamationCircleIcon, ExclamationTriangleIcon, UnknownIcon } from '@patternfly/react-icons';
 import { IconType } from '@patternfly/react-icons/dist/js/createIcon';
-import { PfColors, PFColorVars } from '../components/Pf/PfColors';
 import { getName } from '../utils/RateIntervals';
+import { PFAlertColor, PfColors } from 'components/Pf/PfColors';
 
 interface HealthItem {
   status: Status;
@@ -38,21 +38,21 @@ export interface Status {
 
 export const FAILURE: Status = {
   name: 'Failure',
-  color: PFColorVars.DangerColor,
+  color: PFAlertColor.Danger,
   priority: 3,
   icon: ExclamationCircleIcon,
   class: 'icon-failure'
 };
 export const DEGRADED: Status = {
   name: 'Degraded',
-  color: PFColorVars.WarningColor,
+  color: PFAlertColor.Warning,
   priority: 2,
   icon: ExclamationTriangleIcon,
   class: 'icon-degraded'
 };
 export const HEALTHY: Status = {
   name: 'Healthy',
-  color: PFColorVars.SuccessColor,
+  color: PFAlertColor.Success,
   priority: 1,
   icon: CheckCircleIcon,
   class: 'icon-healthy'


### PR DESCRIPTION
An issue is that not every API accepts the variables and instead is wanting the hex value.  To handle this the PR provides a function to get the variable values.  The first call will determine the values (the document must exist), subsequent calls are faster.
- also, a little bit of renaming for clarity

Fixes https://github.com/kiali/kiali/issues/1839

This screenshot is just showing that the expected colors are rendered in the graph and side panel chart:
![image](https://user-images.githubusercontent.com/2104052/68794963-fd32bb00-061d-11ea-86d7-c9368beb51e6.png)
