### PR TITLE
Unmount non visibible children instead to mountonenter only

### DIFF
--- a/src/pages/AppDetails/AppDetailsPage.tsx
+++ b/src/pages/AppDetails/AppDetailsPage.tsx
@@ -275,7 +275,7 @@ class AppDetails extends React.Component<AppDetailsProps, AppDetailsState> {
           defaultTab={defaultTab}
           postHandler={this.fetchTrafficDataOnTabChange}
           activeTab={this.state.currentTab}
-          mountOnEnter={true}
+          mountOnEnter={false}
           unmountOnExit={true}
         >
           {this.renderTabs()}

--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -461,7 +461,7 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
         tabName={tabName}
         defaultTab={this.defaultTab()}
         activeTab={this.state.currentTab}
-        mountOnEnter={true}
+        mountOnEnter={false}
         unmountOnExit={true}
       >
         {tabs}

--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -466,7 +466,7 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
           defaultTab={defaultTab}
           postHandler={this.fetchTrafficDataOnTabChange}
           activeTab={this.state.currentTab}
-          mountOnEnter={true}
+          mountOnEnter={false}
           unmountOnExit={true}
         >
           {tabsArray}

--- a/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -69,10 +69,11 @@ class WorkloadDetails extends React.Component<WorkloadDetailsPageProps, Workload
   }
 
   componentDidUpdate(prevProps: WorkloadDetailsPageProps) {
+    const aTab = activeTab(tabName, defaultTab);
     if (
       this.props.match.params.namespace !== prevProps.match.params.namespace ||
       this.props.match.params.workload !== prevProps.match.params.workload ||
-      this.state.currentTab !== activeTab(tabName, defaultTab) ||
+      this.state.currentTab !== aTab ||
       this.props.duration !== prevProps.duration
     ) {
       this.setState(
@@ -80,7 +81,7 @@ class WorkloadDetails extends React.Component<WorkloadDetailsPageProps, Workload
           workload: emptyWorkload,
           validations: {},
           istioEnabled: true, // true until proven otherwise
-          currentTab: activeTab(tabName, defaultTab),
+          currentTab: aTab,
           health: undefined
         },
         () => this.doRefresh()
@@ -158,7 +159,6 @@ class WorkloadDetails extends React.Component<WorkloadDetailsPageProps, Workload
 
   doRefresh = () => {
     const currentTab = this.state.currentTab;
-
     if (this.state.workload === emptyWorkload || currentTab === 'info') {
       this.setState({ trafficData: null });
       this.fetchWorkload();
@@ -241,7 +241,6 @@ class WorkloadDetails extends React.Component<WorkloadDetailsPageProps, Workload
         />
       </Tab>
     );
-
     const trafficTab = (
       <Tab title="Traffic" eventKey={1} key={'Traffic'}>
         <TrafficDetails
@@ -364,7 +363,7 @@ class WorkloadDetails extends React.Component<WorkloadDetailsPageProps, Workload
           defaultTab={defaultTab}
           postHandler={this.fetchTrafficDataOnTabChange}
           activeTab={this.state.currentTab}
-          mountOnEnter={true}
+          mountOnEnter={false}
           unmountOnExit={true}
         >
           {this.renderTabs()}


### PR DESCRIPTION
Adjust better the behaviour of the tabs.
Instead to wait to first "enter" it will "unmount" non visible tabs.

This will fix the "back button" problem in some pages and will maintain the desired behavior to not load non-visible tabs that are heavy.

Fixes kiali/kiali#1863