### PR TITLE
Fix Overview Page, message not centered

### DIFF
--- a/src/pages/Overview/OverviewPage.tsx
+++ b/src/pages/Overview/OverviewPage.tsx
@@ -7,6 +7,7 @@ import {
   CardBody,
   EmptyState,
   EmptyStateBody,
+  EmptyStateVariant,
   Grid,
   GridItem,
   Title
@@ -337,7 +338,7 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
           </Grid>
         ) : (
           <div style={{ backgroundColor: '#f5f5f5' }}>
-            <EmptyState className={emptyStateStyle}>
+            <EmptyState className={emptyStateStyle} variant={EmptyStateVariant.full}>
               <Title headingLevel="h5" size="lg" style={{ marginTop: '50px' }}>
                 No unfiltered namespaces
               </Title>

--- a/src/pages/Overview/__tests__/__snapshots__/OverviewPage.test.tsx.snap
+++ b/src/pages/Overview/__tests__/__snapshots__/OverviewPage.test.tsx.snap
@@ -33,6 +33,7 @@ exports[`Overview page renders initial layout 1`] = `
   >
     <EmptyState
       className="fu1tihc"
+      variant="full"
     >
       <Title
         headingLevel="h5"


### PR DESCRIPTION
Fix https://github.com/kiali/kiali/issues/1896

## Before
![Screenshot from 2019-11-07 09-31-20](https://user-images.githubusercontent.com/3019213/68372583-783d3280-0141-11ea-8115-1240bfc2d3ea.png)
## Now
![Screenshot from 2019-11-15 11-51-40](https://user-images.githubusercontent.com/3019213/68938298-5f1a2e80-079e-11ea-86fe-115cb85c31fa.png)
