### PR TITLE
Fix Logs page, message error not centered

### DIFF
--- a/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -22,7 +22,7 @@ import { DurationInSeconds } from '../../types/Common';
 import { connect } from 'react-redux';
 import { KialiAppState } from '../../store/Store';
 import { durationSelector } from '../../store/Selectors';
-import { Tab } from '@patternfly/react-core';
+import { EmptyState, EmptyStateBody, EmptyStateVariant, Tab, Title } from '@patternfly/react-core';
 import ParameterizedTabs, { activeTab } from '../../components/Tab/Tabs';
 import { DurationDropdownContainer } from '../../components/DurationDropdown/DurationDropdown';
 import RefreshButtonContainer from '../../components/Refresh/RefreshButton';
@@ -258,7 +258,12 @@ class WorkloadDetails extends React.Component<WorkloadDetailsPageProps, Workload
         {hasPods ? (
           <WorkloadPodLogs namespace={this.props.match.params.namespace} pods={this.state.workload.pods} />
         ) : (
-          'There are no logs to display because the workload has no pods.'
+          <EmptyState variant={EmptyStateVariant.full}>
+            <Title headingLevel="h5" size="lg">
+              No logs for Workload {this.state.workload.name}
+            </Title>
+            <EmptyStateBody>There are no logs to display because the workload has no pods.</EmptyStateBody>
+          </EmptyState>
         )}
       </Tab>
     );


### PR DESCRIPTION
Fix https://github.com/kiali/kiali/issues/1898

## Before ![logs_error](https://user-images.githubusercontent.com/3019213/68387211-1b9c4080-015e-11ea-8958-f5dd9132169b.png)

## Now
![Screenshot from 2019-11-15 12-05-01](https://user-images.githubusercontent.com/3019213/68939266-70fcd100-07a0-11ea-9999-b12101e9ba5a.png)
