### PR TITLE
Move IstioConfigDetails emptyState to PF4

### DIFF
--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -25,6 +25,10 @@ import {
   Card,
   CardBody,
   CardHeader,
+  EmptyState,
+  EmptyStateIcon,
+  EmptyStateVariant,
+  EmptyStateBody,
   Grid,
   GridItem,
   GutterSize,
@@ -37,13 +41,11 @@ import {
   TitleLevel,
   TitleSize
 } from '@patternfly/react-core';
+import { KialiIcon } from '../../config/KialiIcon';
 import { dicIstioType } from '../../types/IstioConfigList';
 import { showInMessageCenter } from '../../utils/IstioValidationUtils';
-
-import { EmptyState, EmptyStateTitle, EmptyStateIcon, EmptyStateInfo } from 'patternfly-react';
-import { PfColors } from '../../components/Pf/PfColors';
+import { PFAlertColor, PfColors } from '../../components/Pf/PfColors';
 import IstioObjectLink from '../../components/Link/IstioObjectLink';
-
 
 const rightToolbarStyle = style({
   position: 'absolute',
@@ -69,12 +71,6 @@ const paramToTab: { [key: string]: number } = {
   overview: 0,
   yaml: 1
 };
-const emptyStateStyle = style({
-  height: '98%',
-  marginRight: 5,
-  marginBottom: 10,
-  marginTop: 10
-});
 
 class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioConfigId>, IstioConfigDetailsState> {
   aceEditorRef: React.RefObject<AceEditor>;
@@ -442,13 +438,15 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
       // In theory it shouldn't enter here, but we show a nice error page anyway.
 
       return (
-        <EmptyState className={emptyStateStyle}>
-          <EmptyStateIcon name="error-circle-o" />
-          <EmptyStateTitle>Error loading object `{this.props.match.params.object}`</EmptyStateTitle>
-          <EmptyStateInfo>
+        <EmptyState variant={EmptyStateVariant.full}>
+          <EmptyStateIcon color={PFAlertColor.Danger} icon={KialiIcon.Error} />
+          <Title headingLevel="h5" size="lg">
+            Error loading object {this.props.match.params.object}
+          </Title>
+          <EmptyStateBody>
             This might mean the resource is not ready yet or has been deleted and the cluster has not finished
             propagating the changes.
-          </EmptyStateInfo>
+          </EmptyStateBody>
         </EmptyState>
       );
     }

--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -440,7 +440,7 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
       return (
         <EmptyState variant={EmptyStateVariant.full}>
           <EmptyStateIcon color={PFAlertColor.Danger} icon={KialiIcon.Error} />
-          <Title headingLevel="h5" size="lg">
+          <Title headingLevel={TitleLevel.h5} size={TitleSize.lg}>
             Error loading object {this.props.match.params.object}
           </Title>
           <EmptyStateBody>

--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -44,7 +44,7 @@ import {
 import { KialiIcon } from '../../config/KialiIcon';
 import { dicIstioType } from '../../types/IstioConfigList';
 import { showInMessageCenter } from '../../utils/IstioValidationUtils';
-import { PFAlertColor, PfColors } from '../../components/Pf/PfColors';
+import { PfColors } from '../../components/Pf/PfColors';
 import IstioObjectLink from '../../components/Link/IstioObjectLink';
 
 const rightToolbarStyle = style({
@@ -439,7 +439,7 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
 
       return (
         <EmptyState variant={EmptyStateVariant.full}>
-          <EmptyStateIcon color={PFAlertColor.Danger} icon={KialiIcon.Error} />
+          <EmptyStateIcon icon={KialiIcon.Error} />
           <Title headingLevel={TitleLevel.h5} size={TitleSize.lg}>
             Error loading object {this.props.match.params.object}
           </Title>


### PR DESCRIPTION
![Screenshot from 2019-11-18 09-57-05](https://user-images.githubusercontent.com/3019213/69038630-7e0d0080-09ea-11ea-9964-a907e27e75a4.png)


This blocks migration and https://github.com/kiali/kiali/issues/1857 