### PR TITLE
[minor] Fix small issue rendering runtimes list & bump k-charted

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "postinstall": "sed -i -E 's#\\[.*eslint-config-react-app.*\\]#['\\'$PWD/.eslintrc\\'']#g' node_modules/react-scripts/config/webpack*.js"
   },
   "dependencies": {
-    "@kiali/k-charted-pf4": "0.3.0",
+    "@kiali/k-charted-pf4": "0.3.1-rc1",
     "@patternfly/patternfly": "2.36.0",
     "@patternfly/react-charts": "5.0.13",
     "@patternfly/react-core": "3.112.3",

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadDescription.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadDescription.tsx
@@ -48,6 +48,7 @@ class WorkloadDescription extends React.Component<WorkloadDescriptionProps, Work
       workload &&
       ['Deployment', 'ReplicaSet', 'ReplicationController', 'DeploymentConfig', 'StatefulSet'].indexOf(workload.type) >=
         0;
+    const runtimes = workload.runtimes.map(r => r.name).filter(name => name !== '');
     return workload ? (
       <Grid gutter="md">
         <GridItem span={6}>
@@ -82,12 +83,11 @@ class WorkloadDescription extends React.Component<WorkloadDescriptionProps, Work
                     </StackItem>
                   );
                 })}
-                {workload.runtimes.length > 0 && (
+                {runtimes.length > 0 && (
                   <StackItem id="runtimes">
                     <Text component={TextVariants.h3}> Runtimes</Text>
-                    {workload.runtimes
-                      .filter(r => r.name !== '')
-                      .map((rt, idx) => this.renderLogo(rt.name, idx))
+                    {runtimes
+                      .map((rt, idx) => this.renderLogo(rt, idx))
                       .reduce(
                         (list: JSX.Element[], elem) =>
                           list.length > 0 ? [...list, <span key="sep"> | </span>, elem] : [elem],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1176,10 +1176,10 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@kiali/k-charted-pf4@0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@kiali/k-charted-pf4/-/k-charted-pf4-0.3.0.tgz#de7bc69f026e64f6b892c6ea911e03f6ec0921ad"
-  integrity sha512-vcakV+b2BC/UurqAfe2+JtbAuVMn1Q442SbhMuONTQvxGbaSa158QxVgzTmi4o32O8jjLkQ8/uQ3ogCyyh7jFQ==
+"@kiali/k-charted-pf4@0.3.1-rc1":
+  version "0.3.1-rc1"
+  resolved "https://registry.yarnpkg.com/@kiali/k-charted-pf4/-/k-charted-pf4-0.3.1-rc1.tgz#ce5de3d1ef6b95f9cf95a51f1077215f3c4d2b5e"
+  integrity sha512-eSGS7N9aTL2jVZkWWY5EFFwscaicd8Eu4oiEN7gGlo3ni00/z2jnOO0FKrHELYOBbH20rLZzuITG8aBJB4cjYg==
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"


### PR DESCRIPTION
- The issue in runtimes list occurs when we display alone a custom dashboard with empty runtime name, such as the Envoy one => the "Runtime" title was being written with nothing below.

- Also bump k-charted 0.3.1-rc1 to integrate https://github.com/kiali/k-charted/pull/57 (release will come later / waiting for tracing work)