### PR TITLE
Adjust CSS styles to fix wrong scroll on logs and yaml editor

### DIFF
--- a/src/components/Nav/Page/RenderComponentScroll.tsx
+++ b/src/components/Nav/Page/RenderComponentScroll.tsx
@@ -16,7 +16,7 @@ export class RenderComponentScroll extends React.Component<{}, { height: number 
   }
 
   updateWindowDimensions = () => {
-    this.setState({ height: window.innerHeight * 0.7 });
+    this.setState({ height: window.innerHeight * 0.8 });
   };
 
   render() {

--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.scss
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.scss
@@ -1,10 +1,10 @@
 .istio-ace-editor {
   /*
    * 70px is the height of the bottom toolbar (save, reload and cancel buttons)
-   * 20px is the top margin of the yaml editor.
-   * So, substracting 90px from the tab content height.
+   * 100px is the top margin of the yaml editor (Adjusted with RenderComponentScroll).
+   * So, substracting 170px from the tab content height.
    */
-  --kiali-yaml-editor-height: calc(var(--kiali-details-pages-tab-content-height) - 90px);
+  --kiali-yaml-editor-height: calc(var(--kiali-details-pages-tab-content-height) - 170px);
   position: relative;
   min-height: 200px;
   border: 1px solid #8b8d8f;

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
@@ -46,7 +46,8 @@ const TailLinesOptions = {
 const logsTextarea = style({
   width: '100%',
   // 75px is the height of the toolbar inside "Logs" tab
-  height: 'calc(var(--kiali-details-pages-tab-content-height) - 75px)',
+  // 200px is the height added by RenderComponentScroll
+  height: 'calc(var(--kiali-details-pages-tab-content-height) - 275px)',
   overflow: 'auto',
   resize: 'vertical',
   color: '#fff',


### PR DESCRIPTION
Fixes kiali/kiali#1955

Adjust CSS for Logs container and ACE Editor to adjust unnecessary scroll after PF4 migration.