### PR TITLE
Add namespace validation status in graph side panel header

### DIFF
--- a/src/components/Validations/ValidationSummary.tsx
+++ b/src/components/Validations/ValidationSummary.tsx
@@ -13,8 +13,9 @@ interface Props {
 }
 
 const tooltipListStyle = style({
+  textAlign: 'left',
   border: 0,
-  padding: '0 0 0 0',
+  padding: '0 0 0 1em',
   margin: '0 0 0 0'
 });
 
@@ -56,14 +57,13 @@ export class ValidationSummary extends React.PureComponent<Props> {
     const validation = severityToValidation[this.severity()];
     return (
       <>
-        <Text component={TextVariants.h4}>
-          <strong>{validation.name}</strong>
+        <Text style={{ textAlign: 'left', textEmphasis: 'strong' }} component={TextVariants.h4}>
+          Istio Config Validation
         </Text>
+        <Text style={{ textAlign: 'left', textEmphasis: 'strong', paddingLeft: '1em' }}>{validation.name}</Text>
         <div className={tooltipListStyle}>
           {this.severitySummary().map(cat => (
-            <div className={tooltipListStyle} key={cat}>
-              {cat}
-            </div>
+            <div key={cat}>{cat}</div>
           ))}
         </div>
       </>

--- a/src/config/KialiIcon.tsx
+++ b/src/config/KialiIcon.tsx
@@ -27,7 +27,8 @@ import {
   AngleDoubleRightIcon,
   RepositoryIcon,
   AngleDownIcon,
-  HomeIcon
+  HomeIcon,
+  PficonTemplateIcon
 } from '@patternfly/react-icons';
 import { style } from 'typestyle';
 
@@ -59,6 +60,7 @@ export const KialiIcon: { [name: string]: React.FunctionComponent<IconProps> } =
   Error: (props: IconProps) => <ErrorCircleOIcon className={props.className} color={PFAlertColor.Danger} />,
   Help: (props: IconProps) => <HelpIcon className={props.className} />,
   Info: (props: IconProps) => <InfoAltIcon className={props.className} color={PFAlertColor.Info} />,
+  IstioConfig: (props: IconProps) => <PficonTemplateIcon className={props.className} />,
   LocalTime: (props: IconProps) => <GlobeAmericasIcon className={props.className} />,
   MissingSidecar: (props: IconProps) => <BlueprintIcon className={props.className} />,
   MtlsLock: (props: IconProps) => <LockIcon className={props.className} />,

--- a/src/pages/Graph/SummaryLink.tsx
+++ b/src/pages/Graph/SummaryLink.tsx
@@ -3,15 +3,45 @@ import { Link } from 'react-router-dom';
 import { NodeType, DecoratedGraphNodeData, GraphNodeData } from '../../types/Graph';
 import { CyNode, decoratedNodeData } from '../../components/CytoscapeGraph/CytoscapeGraphUtils';
 import { KialiIcon } from 'config/KialiIcon';
+import { Tooltip, Badge, PopoverPosition } from '@patternfly/react-core';
+import { Health } from 'types/Health';
+import { HealthIndicator, DisplayMode } from 'components/Health/HealthIndicator';
 
 const getTitle = (nodeData: DecoratedGraphNodeData) => {
-  if (nodeData.nodeType === NodeType.UNKNOWN) {
-    return 'Traffic Source';
+  switch (nodeData.nodeType) {
+    case NodeType.APP:
+      return (
+        <Tooltip content={<>Application</>}>
+          <Badge className="virtualitem_badge_definition">A</Badge>
+        </Tooltip>
+      );
+    case NodeType.SERVICE:
+      return !!nodeData.isServiceEntry ? (
+        <Tooltip
+          content={
+            <>{nodeData.isServiceEntry === 'MESH_EXTERNAL' ? 'External Service Entry' : 'Internal Service Entry'}</>
+          }
+        >
+          <Badge className="virtualitem_badge_definition">SE</Badge>
+        </Tooltip>
+      ) : (
+        <Tooltip content={<>Service</>}>
+          <Badge className="virtualitem_badge_definition">S</Badge>
+        </Tooltip>
+      );
+    case NodeType.WORKLOAD:
+      return (
+        <Tooltip content={<>Workload</>}>
+          <Badge className="virtualitem_badge_definition">W</Badge>
+        </Tooltip>
+      );
+    default:
+      return (
+        <Tooltip content={<>Unknown</>}>
+          <Badge className="virtualitem_badge_definition">U</Badge>
+        </Tooltip>
+      );
   }
-  if (nodeData.nodeType === NodeType.SERVICE && nodeData.isServiceEntry !== undefined) {
-    return nodeData.isServiceEntry === 'MESH_EXTERNAL' ? 'External Service Entry' : 'Internal Service Entry';
-  }
-  return nodeData.nodeType.charAt(0).toUpperCase() + nodeData.nodeType.slice(1);
 };
 
 const getLink = (nodeData: GraphNodeData, nodeType?: NodeType) => {
@@ -80,13 +110,25 @@ export const RenderLink = (props: RenderLinkProps) => {
   );
 };
 
-export const renderTitle = (nodeData: DecoratedGraphNodeData) => {
+export const renderTitle = (nodeData: DecoratedGraphNodeData, health?: Health) => {
   const link = getLink(nodeData);
 
   return (
-    <>
-      <strong>{getTitle(nodeData)}:</strong> {link} {nodeData.isInaccessible && <KialiIcon.MtlsLock />}
-    </>
+    <span>
+      <span style={{ paddingRight: '0.5em' }}>
+        {getTitle(nodeData)}
+        {link}
+      </span>
+      {nodeData.isInaccessible && <KialiIcon.MtlsLock />}
+      {health && (
+        <HealthIndicator
+          id="graph-health-indicator"
+          mode={DisplayMode.SMALL}
+          health={health}
+          tooltipPlacement={PopoverPosition.left}
+        />
+      )}
+    </span>
   );
 };
 

--- a/src/pages/Graph/SummaryPanelCommon.tsx
+++ b/src/pages/Graph/SummaryPanelCommon.tsx
@@ -23,6 +23,11 @@ export const summaryHeader: React.CSSProperties = {
   backgroundColor: PfColors.White
 };
 
+export const summaryLabels = style({
+  marginTop: '5px',
+  marginBottom: '5px'
+});
+
 export const summaryBodyTabs = style({
   padding: '10px 15px 0 15px'
 });
@@ -152,12 +157,15 @@ export const renderNodeInfo = (nodeData: DecoratedGraphNodeData) => {
   const hasVersion = hasNamespace && nodeData.version;
   return (
     <>
-      <div style={{ paddingBottom: '3px', paddingTop: '3px' }}>
+      <div className={`label-collection ${summaryLabels}`}>
         {hasNamespace && <Badge>Namespace: {nodeData.namespace}</Badge>}
         {hasVersion && (
-          <Badge>
-            {serverConfig.istioLabels.versionLabelName}: {nodeData.version!}
-          </Badge>
+          <>
+            <br />
+            <Badge style={{ marginTop: '2px' }}>
+              {serverConfig.istioLabels.versionLabelName}: {nodeData.version!}
+            </Badge>
+          </>
         )}
       </div>
     </>

--- a/src/pages/Graph/SummaryPanelEdge.tsx
+++ b/src/pages/Graph/SummaryPanelEdge.tsx
@@ -134,7 +134,6 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
       return (
         <div className="panel-heading label-collection" style={summaryHeader}>
           <strong>{prefix}</strong> {renderTitle(nodeData)}
-          <br />
           {renderNodeInfo(nodeData)}
         </div>
       );
@@ -146,8 +145,8 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
 
     return (
       <div ref={this.mainDivRef} className="panel panel-default" style={SummaryPanelEdge.panelStyle}>
-        <HeadingBlock prefix="From" node={source} />
-        <HeadingBlock prefix="To" node={dest} />
+        <HeadingBlock prefix="" node={source} />
+        <HeadingBlock prefix="" node={dest} />
         {isMtls && <MTLSBlock />}
         {(isGrpc || isHttp) && (
           <div className={summaryBodyTabs}>

--- a/src/pages/Graph/SummaryPanelNode.tsx
+++ b/src/pages/Graph/SummaryPanelNode.tsx
@@ -29,13 +29,11 @@ import {
   mergeMetricsResponses,
   summaryHeader
 } from './SummaryPanelCommon';
-import { HealthIndicator, DisplayMode } from '../../components/Health/HealthIndicator';
 import { Health } from '../../types/Health';
 import { CancelablePromise, makeCancelablePromise } from '../../utils/CancelablePromises';
 import { Response } from '../../services/Api';
 import { Reporter } from '../../types/MetricsOptions';
 import { CyNode, decoratedNodeData } from '../../components/CytoscapeGraph/CytoscapeGraphUtils';
-import { PopoverPosition } from '@patternfly/react-core';
 import { KialiIcon } from 'config/KialiIcon';
 
 type SummaryPanelNodeMetricsState = {
@@ -311,20 +309,7 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
     return (
       <div ref={this.mainDivRef} className="panel panel-default" style={SummaryPanelNode.panelStyle}>
         <div className="panel-heading" style={summaryHeader}>
-          {this.state.healthLoading ? (
-            // Remove glitch while health is being reloaded
-            <span style={{ width: 18, height: 17, display: 'inline-block' }} />
-          ) : (
-            this.state.health && (
-              <HealthIndicator
-                id="graph-health-indicator"
-                mode={DisplayMode.SMALL}
-                health={this.state.health}
-                tooltipPlacement={PopoverPosition.left}
-              />
-            )
-          )}
-          <span> {renderTitle(nodeData)}</span>
+          {renderTitle(nodeData, this.state.health)}
           {renderNodeInfo(nodeData)}
           {this.renderBadgeSummary(nodeData.hasCB, nodeData.hasVS, nodeData.hasMissingSC, nodeData.isDead)}
         </div>

--- a/src/pages/Overview/Sorts.ts
+++ b/src/pages/Overview/Sorts.ts
@@ -80,6 +80,36 @@ export const sortFields: SortField<NamespaceInfo>[] = [
       // default comparison fallback
       return a.name.localeCompare(b.name);
     }
+  },
+  {
+    id: 'config',
+    title: 'Istio Config',
+    isNumeric: false,
+    param: 'ic',
+    compare: (a: NamespaceInfo, b: NamespaceInfo) => {
+      if (a.validations && b.validations) {
+        if (a.validations.errors === b.validations.errors) {
+          if (a.validations.warnings === b.validations.warnings) {
+            return a.name.localeCompare(b.name);
+          } else if (a.validations.warnings > b.validations.warnings) {
+            return -1;
+          } else {
+            return 1;
+          }
+        } else if (a.validations.errors > b.validations.errors) {
+          return -1;
+        } else {
+          return 1;
+        }
+      } else if (a.validations) {
+        return -1;
+      } else if (b.validations) {
+        return 1;
+      }
+
+      // default comparison fallback
+      return a.name.localeCompare(b.name);
+    }
   }
 ];
 


### PR DESCRIPTION
- apply UX design as part of this work as it helps with the overall display of the new information.
- apply UX design to other graph side panel headers for consistency
  - replace text with PF kiali badges
  - replace text links with icon links and add icon link for config
  - consistent placement of health/inaccessible/validation(todo) icons
  - consistent spacing
  - improved handling of version labels
- apply latest pattern for state handling in graph summary (this was missed when node/edge/group summaries were updated)
- downgrade a console log to debug
- tweak validation tooltips to be more descriptive/easier to understand outside of overview page

Fixes https://github.com/kiali/kiali/issues/1941

@xeviknal This PR changes the validation status tooltip format a little by adding a title describing this information below.  This is because in the side panel there is no space for a text title.  It looks like this, Is it OK? 

![image](https://user-images.githubusercontent.com/2104052/69279207-df330080-0bb1-11ea-90d9-573a56424dc0.png)


Before Video (see side panel header):
![kiali#1941-before](https://user-images.githubusercontent.com/2104052/69279591-ae9f9680-0bb2-11ea-84df-84f8f51acca1.gif)

After Video:
![kiali#1941-after](https://user-images.githubusercontent.com/2104052/69279604-b828fe80-0bb2-11ea-9f1c-c1c902eedf5c.gif)
