### PR TITLE
Fix health tooltip so that first two tooltips show in Virtual Scroll.

### DIFF
--- a/src/components/Health/HealthIndicator.tsx
+++ b/src/components/Health/HealthIndicator.tsx
@@ -80,7 +80,9 @@ export class HealthIndicator extends React.PureComponent<Props, HealthState> {
       <Tooltip
         aria-label={'Health indicator'}
         content={this.renderHealthTooltip(health)}
-        position={PopoverPosition.auto}
+        boundary={'scrollParent'}
+        position={PopoverPosition.bottom}
+        enableFlip={true}
         className={'health_indicator'}
       >
         {icon}

--- a/src/components/Health/__tests__/__snapshots__/HealthIndicator.test.tsx.snap
+++ b/src/components/Health/__tests__/__snapshots__/HealthIndicator.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`HealthIndicator renders healthy 1`] = `
   appendTo={[Function]}
   aria="describedby"
   aria-label="Health indicator"
-  boundary="window"
+  boundary="scrollParent"
   className="health_indicator"
   content={
     <TextContent>
@@ -111,7 +111,7 @@ exports[`HealthIndicator renders healthy 1`] = `
   isAppLauncher={false}
   isVisible={false}
   maxWidth="18.75rem"
-  position="auto"
+  position="bottom"
   tippyProps={Object {}}
   trigger="mouseenter focus"
   zIndex={9999}


### PR DESCRIPTION
** Describe the change **
The first two health icons do not have tooltips (all the rest show up fine).

** Issue reference **
fixes: https://github.com/kiali/kiali/issues/1935
