### PR TITLE
Introduce 'is present' syntax sugar for Matching Routing

### DIFF
--- a/src/components/IstioWizards/MatchingRouting/MatchBuilder.tsx
+++ b/src/components/IstioWizards/MatchingRouting/MatchBuilder.tsx
@@ -31,6 +31,10 @@ export const EXACT = 'exact';
 export const PREFIX = 'prefix';
 export const REGEX = 'regex';
 
+// Pseudo operator
+export const PRESENCE = 'is present';
+export const ANYTHING = '/^.*$/';
+
 const opOptions: string[] = [EXACT, PREFIX, REGEX];
 
 const placeholderText = {
@@ -63,6 +67,7 @@ class MatchBuilder extends React.Component<Props, State> {
   };
 
   render() {
+    const renderOpOptions: string[] = this.props.category === HEADERS ? [PRESENCE, ...opOptions] : opOptions;
     return (
       <InputGroup>
         <Dropdown
@@ -93,7 +98,7 @@ class MatchBuilder extends React.Component<Props, State> {
         <Dropdown
           toggle={<DropdownToggle onToggle={this.onOperatorToggle}>{this.props.operator}</DropdownToggle>}
           isOpen={this.state.isOperatorDropdown}
-          dropdownItems={opOptions.map((op, index) => (
+          dropdownItems={renderOpOptions.map((op, index) => (
             <DropdownItem
               key={op + '_' + index}
               value={op}
@@ -107,12 +112,14 @@ class MatchBuilder extends React.Component<Props, State> {
             </DropdownItem>
           ))}
         />
-        <TextInput
-          id="match-value-id"
-          value={this.props.matchValue}
-          onChange={this.props.onMatchValueChange}
-          placeholder={placeholderText[this.props.category]}
-        />
+        {this.props.operator !== PRESENCE && (
+          <TextInput
+            id="match-value-id"
+            value={this.props.matchValue}
+            onChange={this.props.onMatchValueChange}
+            placeholder={placeholderText[this.props.category]}
+          />
+        )}
         <Button disabled={!this.props.isValid} onClick={this.props.onAddMatch}>
           Add Match
         </Button>

--- a/src/components/IstioWizards/MatchingRouting/MatchBuilder.tsx
+++ b/src/components/IstioWizards/MatchingRouting/MatchBuilder.tsx
@@ -33,7 +33,7 @@ export const REGEX = 'regex';
 
 // Pseudo operator
 export const PRESENCE = 'is present';
-export const ANYTHING = '/^.*$/';
+export const ANYTHING = '^.*$';
 
 const opOptions: string[] = [EXACT, PREFIX, REGEX];
 


### PR DESCRIPTION
Fixes kiali/kiali#1368

This PR introduces a "sugar syntax" in the Mathing Routing, declaring a "pseudo-operator" called "is present" that is translated to a generic regex were creating rules:

![image](https://user-images.githubusercontent.com/1662329/69443246-52717980-0d4e-11ea-9c9e-5c66535d104d.png)

Note that we don't propagate the "is present" operator in all layers, because Wizard creates VirtualServices and DestinationRules that user can edit manually, so at the end user needs to know that "is present" === "/^.*$/" but I guess it's a compromise to help them to edit. Also, this only applies to headers.

Not yet finished, it's just a prototype tested locally.

