### PR TITLE
Fix OverviewToolbar.tsx so that TimeRangeContainer has a 'key' 

### DIFF
--- a/src/pages/Overview/OverviewToolbar.tsx
+++ b/src/pages/Overview/OverviewToolbar.tsx
@@ -132,7 +132,12 @@ export class OverviewToolbar extends React.Component<Props, State> {
         initialFilters={Filters.availableFilters}
         onFilterChange={this.props.onRefresh}
         rightToolbar={[
-          <TimeRangeContainer id="overview-time-range" disabled={false} handleRefresh={this.props.onRefresh} />
+          <TimeRangeContainer
+            key="overview-time-range"
+            id="overview-time-range"
+            disabled={false}
+            handleRefresh={this.props.onRefresh}
+          />
         ]}
       >
         <>


### PR DESCRIPTION
Fix OverviewToolbar.tsx so that TimeRangeContainer has a 'key' that React requires for array rendering.

** Describe the change **
Small but needed change for React not to complain.

fixes: https://github.com/kiali/kiali/issues/1976