### PR TITLE
Add support for Node.js 12 LTS 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 dist: trusty
 node_js:
-  - '10'
+  - '12'
 cache:
   yarn: true
   directories:

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "@types/enzyme": "3.10.3",
     "@types/jest": "23.3.10",
     "@types/lodash": "4.14.123",
-    "@types/node": "11.11.4",
+    "@types/node": "12.12.14",
     "@types/react": "16.9.2",
     "@types/react-dom": "16.8.5",
     "@types/react-redux": "7.1.2",
@@ -144,7 +144,7 @@
     "hoist-non-react-statics": "3.3.0"
   },
   "engines": {
-    "node": ">=10.0.0 && <11",
+    "node": ">=10.0.0 && <13",
     "npm": ">=6.0.0 ",
     "yarn": ">=1.0.0 "
   },

--- a/src/pages/Overview/__tests__/OverviewPage.test.tsx
+++ b/src/pages/Overview/__tests__/OverviewPage.test.tsx
@@ -27,7 +27,7 @@ const mockAPIToPromise = (func: keyof typeof API, obj: any, encapsData: boolean)
           } catch (e) {
             reject(e);
           }
-        }, 1);
+        }, 2);
       });
     });
   });

--- a/src/pages/Overview/__tests__/OverviewPage.test.tsx
+++ b/src/pages/Overview/__tests__/OverviewPage.test.tsx
@@ -41,6 +41,11 @@ const mockNamespaceHealth = (obj: NamespaceAppHealth): Promise<void> => {
   return mockAPIToPromise('getNamespaceAppHealth', obj, false);
 };
 
+// Ignore other calls
+mockAPIToPromise('getNamespaceMetrics', null, false);
+mockAPIToPromise('getNamespaceTls', null, false);
+mockAPIToPromise('getNamespaceValidations', null, false);
+
 let mounted: ReactWrapper<any, any> | null;
 
 const mountPage = () => {
@@ -227,7 +232,7 @@ describe('Overview page', () => {
     mountPage();
   });
 
-  xit('filters namespaces info name no match', done => {
+  it('filters namespaces info name no match', done => {
     FilterSelected.setSelected([
       {
         category: 'Name',
@@ -242,7 +247,7 @@ describe('Overview page', () => {
     mountPage();
   });
 
-  xit('filters namespaces info name and health match', done => {
+  it('filters namespaces info name and health match', done => {
     FilterSelected.setSelected([
       {
         category: 'Name',
@@ -268,7 +273,7 @@ describe('Overview page', () => {
     mountPage();
   });
 
-  xit('filters namespaces info name and health no match', done => {
+  it('filters namespaces info name and health no match', done => {
     FilterSelected.setSelected([
       {
         category: 'Name',

--- a/src/pages/Overview/__tests__/OverviewPage.test.tsx
+++ b/src/pages/Overview/__tests__/OverviewPage.test.tsx
@@ -227,7 +227,7 @@ describe('Overview page', () => {
     mountPage();
   });
 
-  it('filters namespaces info name no match', done => {
+  xit('filters namespaces info name no match', done => {
     FilterSelected.setSelected([
       {
         category: 'Name',
@@ -242,7 +242,7 @@ describe('Overview page', () => {
     mountPage();
   });
 
-  it('filters namespaces info name and health match', done => {
+  xit('filters namespaces info name and health match', done => {
     FilterSelected.setSelected([
       {
         category: 'Name',
@@ -268,7 +268,7 @@ describe('Overview page', () => {
     mountPage();
   });
 
-  it('filters namespaces info name and health no match', done => {
+  xit('filters namespaces info name and health no match', done => {
     FilterSelected.setSelected([
       {
         category: 'Name',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1738,10 +1738,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.18.tgz#1d3ca764718915584fcd9f6344621b7672665c67"
   integrity sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==
 
-"@types/node@11.11.4":
-  version "11.11.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.11.4.tgz#8808bd5a82bbf6f5d412eff1c228d178e7c24bb3"
-  integrity sha512-02tIL+QIi/RW4E5xILdoAMjeJ9kYq5t5S2vciUdFPXv/ikFTb0zK8q9vXkg4+WAJuYXGiVT1H28AkD2C+IkXVw==
+"@types/node@12.12.14":
+  version "12.12.14"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.14.tgz#1c1d6e3c75dba466e0326948d56e8bd72a1903d2"
+  integrity sha512-u/SJDyXwuihpwjXy7hOOghagLEV1KdAST6syfnOk6QZAMzZuWZqXy5aYYZbh8Jdpd4escVFP0MvftHNDb9pruA==
 
 "@types/prop-types@*":
   version "15.5.8"


### PR DESCRIPTION
** Describe the change **
Now that Node.js 12.x is LTS we need to support that as well as the existing LTS which is 10.x

** Issue reference **
fixes: kiali/kiali#1946

** Backwards compatible? **
Looks like it is backward compatible with 10.x

[ ] Is your pull-request introducing changes in behaviour?
No

