### PR TITLE
Implement token authentication

### DIFF
--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -1,7 +1,18 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { ThunkDispatch } from 'redux-thunk';
-import { Button, ListItem, LoginFooterItem, LoginForm, LoginPage as LoginNext } from '@patternfly/react-core';
+import {
+  ActionGroup,
+  Button,
+  Form,
+  FormGroup,
+  FormHelperText,
+  ListItem,
+  LoginFooterItem,
+  LoginForm,
+  LoginPage as LoginNext,
+  TextInput
+} from '@patternfly/react-core';
 import { ExclamationCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { KialiAppState, LoginSession, LoginStatus } from '../../store/Store';
 import { AuthStrategy } from '../../types/Auth';
@@ -25,6 +36,7 @@ type LoginState = {
   password: string;
   isValidUsername: boolean;
   isValidPassword: boolean;
+  isValidToken: boolean;
   filledInputs: boolean;
   showHelperText: boolean;
   errorInput?: string;
@@ -42,6 +54,7 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
       password: '',
       isValidUsername: true,
       isValidPassword: true,
+      isValidToken: true,
       filledInputs: false,
       showHelperText: false,
       errorInput: ''
@@ -72,6 +85,25 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
     if (authenticationConfig.strategy === AuthStrategy.openshift) {
       // If we are using OpenShift OAuth, take the user back to the OpenShift OAuth login
       window.location.href = authenticationConfig.authorizationEndpoint!;
+    } else if (authenticationConfig.strategy === AuthStrategy.token) {
+      if (this.state.password.trim().length !== 0 && this.props.authenticate) {
+        this.props.authenticate('', this.state.password);
+        this.setState({
+          showHelperText: false,
+          errorInput: '',
+          isValidToken: true,
+          filledInputs: true
+        });
+      } else {
+        let message = 'Please, provide a Service Account token.';
+
+        this.setState({
+          showHelperText: true,
+          errorInput: message,
+          isValidToken: false,
+          filledInputs: false
+        });
+      }
     } else {
       this.setState({
         isValidUsername: !!this.state.username,
@@ -155,13 +187,15 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
 
     const messages = this.getHelperMessage();
     const isLoggingIn = this.props.isPostLoginPerforming || this.props.status === LoginStatus.logging;
+    const isLoginBtnDisabled =
+      isLoggingIn || (this.props.postLoginErrorMsg !== undefined && this.props.postLoginErrorMsg.length !== 0);
 
     // Unfortunately, typescripg typings are wrong in the PatternFly
     // library. So, this casts LoginForm as "any" so that it is
     // possible to use the "isLoginButtonDisabled" property.
-    const Form = LoginForm as any;
+    const CredentialsForm = LoginForm as any;
     const loginForm = (
-      <Form
+      <CredentialsForm
         usernameLabel="Username"
         showHelperText={this.state.showHelperText || this.props.message !== '' || messages.length > 0}
         helperText={<>{messages}</>}
@@ -176,7 +210,7 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
         onLoginButtonClick={(e: any) => this.handleSubmit(e)}
         style={{ marginTop: '10px' }}
         loginButtonLabel={isLoggingIn ? 'Logging in...' : undefined}
-        isLoginButtonDisabled={isLoggingIn || this.props.postLoginErrorMsg}
+        isLoginButtonDisabled={isLoginBtnDisabled}
       />
     );
 
@@ -190,6 +224,43 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
         </ListItem>
       </>
     );
+
+    let loginPane: React.ReactFragment;
+    if (authenticationConfig.strategy === AuthStrategy.login || authenticationConfig.strategy === AuthStrategy.ldap) {
+      loginPane = loginForm;
+    } else if (authenticationConfig.strategy === AuthStrategy.token) {
+      loginPane = (
+        <Form>
+          <FormHelperText
+            isError={!this.state.isValidToken || this.props.status === LoginStatus.error}
+            isHidden={!this.state.showHelperText && this.props.message === '' && messages.length === 0}
+          >
+            {messages}
+          </FormHelperText>
+          <FormGroup fieldId="token" label="Token" isRequired={true}>
+            <TextInput id="token" type="password" onChange={this.handlePasswordChange} isRequired={true} />
+          </FormGroup>
+          <ActionGroup>
+            <Button
+              type="submit"
+              onClick={this.handleSubmit}
+              isDisabled={isLoginBtnDisabled}
+              style={{ width: '100%' }}
+              variant="primary"
+            >
+              Log In
+            </Button>
+          </ActionGroup>
+        </Form>
+      );
+    } else {
+      loginPane = (
+        <Button onClick={this.handleSubmit} style={{ width: '100%' }} variant="primary">
+          {loginLabel}
+        </Button>
+      );
+    }
+
     return (
       <LoginNext
         footerListVariants="inline"
@@ -199,13 +270,7 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
         textContent="Service Mesh Observability."
         loginTitle="Log in Kiali"
       >
-        {authenticationConfig.strategy === AuthStrategy.login || authenticationConfig.strategy === AuthStrategy.ldap ? (
-          loginForm
-        ) : (
-          <Button onClick={this.handleSubmit} style={{ width: '100%' }} variant="primary">
-            {loginLabel}
-          </Button>
-        )}
+        {loginPane}
       </LoginNext>
     );
   }

--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -95,7 +95,7 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
           filledInputs: true
         });
       } else {
-        let message = 'Please, provide a Service Account token.';
+        const message = 'Please, provide a Service Account token.';
 
         this.setState({
           showHelperText: true,
@@ -187,15 +187,11 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
 
     const messages = this.getHelperMessage();
     const isLoggingIn = this.props.isPostLoginPerforming || this.props.status === LoginStatus.logging;
-    const isLoginBtnDisabled =
+    const isLoginButtonDisabled =
       isLoggingIn || (this.props.postLoginErrorMsg !== undefined && this.props.postLoginErrorMsg.length !== 0);
 
-    // Unfortunately, typescripg typings are wrong in the PatternFly
-    // library. So, this casts LoginForm as "any" so that it is
-    // possible to use the "isLoginButtonDisabled" property.
-    const CredentialsForm = LoginForm as any;
     const loginForm = (
-      <CredentialsForm
+      <LoginForm
         usernameLabel="Username"
         showHelperText={this.state.showHelperText || this.props.message !== '' || messages.length > 0}
         helperText={<>{messages}</>}
@@ -210,7 +206,7 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
         onLoginButtonClick={(e: any) => this.handleSubmit(e)}
         style={{ marginTop: '10px' }}
         loginButtonLabel={isLoggingIn ? 'Logging in...' : undefined}
-        isLoginButtonDisabled={isLoginBtnDisabled}
+        isLoginButtonDisabled={isLoginButtonDisabled}
       />
     );
 
@@ -244,7 +240,7 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
             <Button
               type="submit"
               onClick={this.handleSubmit}
-              isDisabled={isLoginBtnDisabled}
+              isDisabled={isLoginButtonDisabled}
               style={{ width: '100%' }}
               variant="primary"
             >

--- a/src/pages/Login/__tests__/__snapshots__/LoginPage.test.tsx.snap
+++ b/src/pages/Login/__tests__/__snapshots__/LoginPage.test.tsx.snap
@@ -28,6 +28,7 @@ exports[`#LoginPage render correctly should render LoginPage 1`] = `
 >
   <LoginForm
     helperText={<React.Fragment />}
+    isLoginButtonDisabled={false}
     isValidPassword={true}
     isValidUsername={true}
     onChangePassword={[Function]}

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -68,6 +68,7 @@ const newRequest = <P>(method: HTTP_VERBS, url: string, queryParams: any, data: 
 interface LoginRequest {
   username: UserName;
   password: Password;
+  token: Password;
 }
 
 /** Requests */
@@ -76,13 +77,17 @@ export const extendSession = () => {
 };
 
 export const login = async (
-  request: LoginRequest = { username: ANONYMOUS_USER, password: 'anonymous' }
+  request: LoginRequest = { username: ANONYMOUS_USER, password: 'anonymous', token: '' }
 ): Promise<Response<LoginSession>> => {
+  const params = new URLSearchParams();
+  params.append('token', request.token);
+
   return axios({
-    method: HTTP_VERBS.GET,
+    method: HTTP_VERBS.POST,
     url: urls.authenticate,
     headers: getHeaders(),
-    auth: basicAuth(request.username, request.password)
+    auth: basicAuth(request.username, request.password),
+    data: params
   });
 };
 

--- a/src/services/Login.ts
+++ b/src/services/Login.ts
@@ -58,7 +58,22 @@ class WebLogin implements LoginStrategy<WebLoginData> {
   }
 
   public async perform(request: DispatchRequest<WebLoginData>): Promise<LoginResult> {
-    const session = (await API.login(request.data)).data;
+    const session = (await API.login({ token: '', ...request.data })).data;
+
+    return {
+      status: AuthResult.SUCCESS,
+      session: session
+    };
+  }
+}
+
+class TokenLogin implements LoginStrategy<WebLoginData> {
+  public async prepare(_info: AuthConfig) {
+    return AuthResult.CONTINUE;
+  }
+
+  public async perform(request: DispatchRequest<WebLoginData>): Promise<LoginResult> {
+    const session = (await API.login({ username: '', password: '', token: request.data.password })).data;
 
     return {
       status: AuthResult.SUCCESS,
@@ -73,7 +88,7 @@ class LdapLogin implements LoginStrategy<WebLoginData> {
   }
 
   public async perform(request: DispatchRequest<WebLoginData>): Promise<LoginResult> {
-    const session = (await API.login(request.data)).data;
+    const session = (await API.login({ token: '', ...request.data })).data;
 
     return {
       status: AuthResult.SUCCESS,
@@ -121,6 +136,7 @@ export class LoginDispatcher {
     this.strategyMapping.set(AuthStrategy.login, new WebLogin());
     this.strategyMapping.set(AuthStrategy.openshift, new OpenshiftLogin());
     this.strategyMapping.set(AuthStrategy.ldap, new LdapLogin());
+    this.strategyMapping.set(AuthStrategy.token, new TokenLogin());
   }
 
   public async prepare(): Promise<AuthResult> {

--- a/src/services/__tests__/ApiMethods.test.tsx.ts
+++ b/src/services/__tests__/ApiMethods.test.tsx.ts
@@ -77,7 +77,7 @@ describe('#Test Methods return a Promise', () => {
   };
 
   it('#login', () => {
-    const result = API.login({ username: 'admin', password: 'admin' });
+    const result = API.login({ username: 'admin', password: 'admin', token: '' });
     evaluatePromise(result);
   });
 

--- a/src/types/Auth.ts
+++ b/src/types/Auth.ts
@@ -14,7 +14,8 @@ export enum AuthStrategy {
   login = 'login',
   anonymous = 'anonymous',
   openshift = 'openshift',
-  ldap = 'ldap'
+  ldap = 'ldap',
+  token = 'token'
 }
 
 // Stores the result of a computation:


### PR DESCRIPTION
This is providing a new login screen with only one "Token" field. The user is expected to paste a service account token to login into Kiali.
    
The UI will pass the provided token to the back-end. In turn, the back-end will provide a cookie as usual (if the Token is valid). The back-end should use the provided token during the session of the user to make calls to the Kubernetes/OpenShift API, so that the cluster's RBAC takes effect.

![image](https://user-images.githubusercontent.com/23639005/69889931-396e4880-12b9-11ea-81cf-90701fcf4492.png)
    
Fixes kiali/kiali#1139