### PR TITLE
Make the cytoscape bottom toolbar more readable

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeToolbar.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeToolbar.tsx
@@ -71,14 +71,26 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps>
       <Toolbar className={cytoscapeToolbarStyle}>
         <ToolbarItem>
           <Tooltip content="Zoom In">
-            <Button id="toolbar_zoom_in" className={buttonStyle} variant="plain" onClick={this.zoomIn}>
+            <Button
+              id="toolbar_zoom_in"
+              aria-label="Zoom In"
+              className={buttonStyle}
+              variant="plain"
+              onClick={this.zoomIn}
+            >
               <SearchPlusIcon />
             </Button>
           </Tooltip>
         </ToolbarItem>
         <ToolbarItem>
           <Tooltip content="Zoom Out">
-            <Button id="toolbar_zoom_out" className={buttonStyle} variant="plain" onClick={this.zoomOut}>
+            <Button
+              id="toolbar_zoom_out"
+              aria-label="Zoom Out"
+              className={buttonStyle}
+              variant="plain"
+              onClick={this.zoomOut}
+            >
               <SearchMinusIcon />
             </Button>
           </Tooltip>
@@ -87,6 +99,7 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps>
           <Tooltip content="Zoom to Fit">
             <Button
               id="toolbar_graph_fit"
+              aria-label="Zoom to Fit"
               className={[cytoscapeToolbarPadStyle, buttonStyle].join(' ')}
               variant="plain"
               onClick={this.fit}
@@ -100,6 +113,7 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps>
           <Tooltip content={'Layout default ' + DagreGraph.getLayout().name}>
             <Button
               id="toolbar_layout_default"
+              aria-label="Graph Layout Default Style"
               className={buttonStyle}
               variant="plain"
               onClick={() => {
@@ -121,6 +135,7 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps>
             <Tooltip content={'Layout 1 ' + CoseGraph.getLayout().name}>
               <Button
                 id="toolbar_layout1"
+                aria-label="Graph Layout Style 1"
                 className={buttonStyle}
                 variant="plain"
                 onClick={() => {
@@ -143,6 +158,7 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps>
           <Tooltip content={'Layout 2 ' + ColaGraph.getLayout().name}>
             <Button
               id="toolbar_layout2"
+              aria-label="Graph Layout Style 2"
               className={buttonStyle}
               variant="plain"
               onClick={() => {
@@ -165,6 +181,7 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps>
             <Button
               variant="primary"
               id="toolbar_toggle_legend"
+              aria-label="Show Legend"
               onClick={this.props.toggleLegend}
               isActive={this.props.showLegend}
               className={cytoscapeToolbarPadStyle}

--- a/src/components/CytoscapeGraph/CytoscapeToolbar.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeToolbar.tsx
@@ -37,6 +37,9 @@ const buttonStyle = style({
   backgroundColor: PfColors.White,
   marginRight: '1px'
 });
+const selectedTopologyButtonStyle = style({
+  color: PfColors.Blue300
+});
 const cytoscapeToolbarStyle = style({
   padding: '7px 10px'
 });
@@ -104,7 +107,11 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps>
               }}
               isActive={this.props.layout.name === DagreGraph.getLayout().name}
             >
-              <TopologyIcon />
+              <TopologyIcon
+                className={
+                  this.props.layout.name === DagreGraph.getLayout().name ? selectedTopologyButtonStyle : undefined
+                }
+              />
             </Button>
           </Tooltip>
         </ToolbarItem>
@@ -121,7 +128,12 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps>
                 }}
                 isActive={this.props.layout.name === CoseGraph.getLayout().name}
               >
-                <TopologyIcon /> 1
+                <TopologyIcon
+                  className={
+                    this.props.layout.name === CoseGraph.getLayout().name ? selectedTopologyButtonStyle : undefined
+                  }
+                />{' '}
+                1
               </Button>
             </Tooltip>
           </ToolbarItem>
@@ -138,7 +150,12 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps>
               }}
               isActive={this.props.layout.name === ColaGraph.getLayout().name}
             >
-              <TopologyIcon /> 2
+              <TopologyIcon
+                className={
+                  this.props.layout.name === ColaGraph.getLayout().name ? selectedTopologyButtonStyle : undefined
+                }
+              />{' '}
+              2
             </Button>
           </Tooltip>
         </ToolbarItem>


### PR DESCRIPTION
** Describe the change **
The graph toolbar is difficult to read and very difficult to tell what layout is currently selected.


fixes https://github.com/kiali/kiali/issues/2001

** Screenshot **
Before:
![Make_the_cytoscape_bottom_toolbar_more_readable_·_Issue__2001_·_kiali_kiali](https://user-images.githubusercontent.com/1312165/70172437-84a3a500-1685-11ea-8244-9f55f628e1ec.png)


After:
![Kiali_Console_and_Kiali_Console_and_Simplenote](https://user-images.githubusercontent.com/1312165/70172340-532ad980-1685-11ea-89e1-bc4877858921.png)

