### PR TITLE
Update Wizards to use FQDN

### DIFF
--- a/src/components/IstioWizards/IstioWizard.tsx
+++ b/src/components/IstioWizards/IstioWizard.tsx
@@ -15,6 +15,7 @@ import SuspendTraffic, { SuspendedRoute } from './SuspendTraffic';
 import { Rule } from './MatchingRouting/Rules';
 import {
   buildIstioConfig,
+  fqdnServiceName,
   getInitGateway,
   getInitHosts,
   getInitLoadBalancer,
@@ -37,7 +38,6 @@ import ThreeScaleIntegration from './ThreeScaleIntegration';
 import { ThreeScaleServiceRule } from '../../types/ThreeScale';
 import GatewaySelector, { GatewaySelectorState } from './GatewaySelector';
 import VirtualServiceHosts from './VirtualServiceHosts';
-import { serverConfig } from '../../config';
 
 const emptyWizardState = (fqdnServiceName: string): WizardState => {
   return {
@@ -75,7 +75,7 @@ const emptyWizardState = (fqdnServiceName: string): WizardState => {
 class IstioWizard extends React.Component<WizardProps, WizardState> {
   constructor(props: WizardProps) {
     super(props);
-    this.state = emptyWizardState(props.serviceName + '.' + props.namespace + '.' + serverConfig.istioIdentityDomain);
+    this.state = emptyWizardState(fqdnServiceName(props.serviceName, props.namespace));
   }
 
   componentDidUpdate(prevProps: WizardProps) {
@@ -139,7 +139,7 @@ class IstioWizard extends React.Component<WizardProps, WizardState> {
         vsHosts:
           initVsHosts.length > 1 || (initVsHosts.length === 1 && initVsHosts[0].length > 0)
             ? initVsHosts
-            : [this.props.serviceName + '.' + this.props.namespace + '.' + serverConfig.istioIdentityDomain],
+            : [fqdnServiceName(this.props.serviceName, this.props.namespace)],
         trafficPolicy: trafficPolicy
       });
     }
@@ -158,9 +158,7 @@ class IstioWizard extends React.Component<WizardProps, WizardState> {
   };
 
   onClose = (changed: boolean) => {
-    this.setState(
-      emptyWizardState(this.props.serviceName + '.' + this.props.namespace + '.' + serverConfig.istioIdentityDomain)
-    );
+    this.setState(emptyWizardState(fqdnServiceName(this.props.serviceName, this.props.namespace)));
     this.props.onClose(changed);
   };
 

--- a/src/components/IstioWizards/IstioWizard.tsx
+++ b/src/components/IstioWizards/IstioWizard.tsx
@@ -37,8 +37,9 @@ import ThreeScaleIntegration from './ThreeScaleIntegration';
 import { ThreeScaleServiceRule } from '../../types/ThreeScale';
 import GatewaySelector, { GatewaySelectorState } from './GatewaySelector';
 import VirtualServiceHosts from './VirtualServiceHosts';
+import { serverConfig } from '../../config';
 
-const emptyWizardState = (serviceName: string): WizardState => {
+const emptyWizardState = (fqdnServiceName: string): WizardState => {
   return {
     showWizard: false,
     showAdvanced: false,
@@ -53,7 +54,7 @@ const emptyWizardState = (serviceName: string): WizardState => {
       gateway: true
     },
     advancedOptionsValid: true,
-    vsHosts: [serviceName],
+    vsHosts: [fqdnServiceName],
     trafficPolicy: {
       tlsModified: false,
       mtlsMode: DISABLE,
@@ -74,7 +75,7 @@ const emptyWizardState = (serviceName: string): WizardState => {
 class IstioWizard extends React.Component<WizardProps, WizardState> {
   constructor(props: WizardProps) {
     super(props);
-    this.state = emptyWizardState(props.serviceName);
+    this.state = emptyWizardState(props.serviceName + '.' + props.namespace + '.' + serverConfig.istioIdentityDomain);
   }
 
   componentDidUpdate(prevProps: WizardProps) {
@@ -138,7 +139,7 @@ class IstioWizard extends React.Component<WizardProps, WizardState> {
         vsHosts:
           initVsHosts.length > 1 || (initVsHosts.length === 1 && initVsHosts[0].length > 0)
             ? initVsHosts
-            : [this.props.serviceName],
+            : [this.props.serviceName + '.' + this.props.namespace + '.' + serverConfig.istioIdentityDomain],
         trafficPolicy: trafficPolicy
       });
     }
@@ -157,7 +158,9 @@ class IstioWizard extends React.Component<WizardProps, WizardState> {
   };
 
   onClose = (changed: boolean) => {
-    this.setState(emptyWizardState(this.props.serviceName));
+    this.setState(
+      emptyWizardState(this.props.serviceName + '.' + this.props.namespace + '.' + serverConfig.istioIdentityDomain)
+    );
     this.props.onClose(changed);
   };
 

--- a/src/components/IstioWizards/IstioWizardActions.ts
+++ b/src/components/IstioWizards/IstioWizardActions.ts
@@ -197,7 +197,7 @@ export const buildIstioConfig = (
       }
     },
     spec: {
-      host: wProps.serviceName,
+      host: wProps.serviceName + '.' + wProps.namespace + '.' + serverConfig.istioIdentityDomain,
       subsets: wProps.workloads.map(workload => {
         // Using version
         const versionLabelName = serverConfig.istioLabels.versionLabelName;
@@ -264,7 +264,7 @@ export const buildIstioConfig = (
             route: wState.workloads.map(workload => {
               return {
                 destination: {
-                  host: wProps.serviceName,
+                  host: wProps.serviceName + '.' + wProps.namespace + '.' + serverConfig.istioIdentityDomain,
                   subset: wkdNameVersion[workload.name]
                 },
                 weight: workload.weight
@@ -284,7 +284,7 @@ export const buildIstioConfig = (
           for (let iRoute = 0; iRoute < rule.routes.length; iRoute++) {
             const destW: DestinationWeight = {
               destination: {
-                host: wProps.serviceName,
+                host: wProps.serviceName + '.' + wProps.namespace + '.' + serverConfig.istioIdentityDomain,
                 subset: wkdNameVersion[rule.routes[iRoute]]
               }
             };
@@ -319,7 +319,7 @@ export const buildIstioConfig = (
           const suspendedRoute = wState.suspendedRoutes[i];
           const destW: DestinationWeight = {
             destination: {
-              host: wProps.serviceName,
+              host: wProps.serviceName + '.' + wProps.namespace + '.' + serverConfig.istioIdentityDomain,
               subset: wkdNameVersion[suspendedRoute.workload]
             }
           };
@@ -341,7 +341,7 @@ export const buildIstioConfig = (
         httpRoute.route = [
           {
             destination: {
-              host: wProps.serviceName
+              host: wProps.serviceName + '.' + wProps.namespace + '.' + serverConfig.istioIdentityDomain
             }
           }
         ];

--- a/src/components/IstioWizards/IstioWizardActions.ts
+++ b/src/components/IstioWizards/IstioWizardActions.ts
@@ -82,6 +82,10 @@ const SERVICE_UNAVAILABLE = 503;
 
 export const KIALI_WIZARD_LABEL = 'kiali_wizard';
 
+export const fqdnServiceName = (serviceName: string, namespace: string): string => {
+  return serviceName + '.' + namespace + '.' + serverConfig.istioIdentityDomain;
+};
+
 const buildHTTPMatchRequest = (matches: string[]): HTTPMatchRequest[] => {
   const matchRequests: HTTPMatchRequest[] = [];
   const matchHeaders: HTTPMatchRequest = { headers: {} };
@@ -197,7 +201,7 @@ export const buildIstioConfig = (
       }
     },
     spec: {
-      host: wProps.serviceName + '.' + wProps.namespace + '.' + serverConfig.istioIdentityDomain,
+      host: fqdnServiceName(wProps.serviceName, wProps.namespace),
       subsets: wProps.workloads.map(workload => {
         // Using version
         const versionLabelName = serverConfig.istioLabels.versionLabelName;
@@ -264,7 +268,7 @@ export const buildIstioConfig = (
             route: wState.workloads.map(workload => {
               return {
                 destination: {
-                  host: wProps.serviceName + '.' + wProps.namespace + '.' + serverConfig.istioIdentityDomain,
+                  host: fqdnServiceName(wProps.serviceName, wProps.namespace),
                   subset: wkdNameVersion[workload.name]
                 },
                 weight: workload.weight
@@ -284,7 +288,7 @@ export const buildIstioConfig = (
           for (let iRoute = 0; iRoute < rule.routes.length; iRoute++) {
             const destW: DestinationWeight = {
               destination: {
-                host: wProps.serviceName + '.' + wProps.namespace + '.' + serverConfig.istioIdentityDomain,
+                host: fqdnServiceName(wProps.serviceName, wProps.namespace),
                 subset: wkdNameVersion[rule.routes[iRoute]]
               }
             };
@@ -319,7 +323,7 @@ export const buildIstioConfig = (
           const suspendedRoute = wState.suspendedRoutes[i];
           const destW: DestinationWeight = {
             destination: {
-              host: wProps.serviceName + '.' + wProps.namespace + '.' + serverConfig.istioIdentityDomain,
+              host: fqdnServiceName(wProps.serviceName, wProps.namespace),
               subset: wkdNameVersion[suspendedRoute.workload]
             }
           };
@@ -341,7 +345,7 @@ export const buildIstioConfig = (
         httpRoute.route = [
           {
             destination: {
-              host: wProps.serviceName + '.' + wProps.namespace + '.' + serverConfig.istioIdentityDomain
+              host: fqdnServiceName(wProps.serviceName, wProps.namespace)
             }
           }
         ];

--- a/src/config/ServerConfig.ts
+++ b/src/config/ServerConfig.ts
@@ -44,6 +44,7 @@ const computeValidDurations = (cfg: ComputedServerConfig) => {
 // these will be overwritten on user login.
 let serverConfig: ComputedServerConfig = {
   installationTag: 'Kiali Console',
+  istioIdentityDomain: 'svc.cluster.local',
   istioNamespace: 'istio-system',
   istioComponentNamespaces: new Map<string, string>(),
   istioLabels: {

--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Prompt, RouteComponentProps } from 'react-router-dom';
+import { Link, Prompt, RouteComponentProps } from 'react-router-dom';
 import { aceOptions, IstioConfigDetails, IstioConfigId, safeDumpOptions } from '../../types/IstioConfigDetails';
 import * as AlertUtils from '../../utils/AlertUtils';
 import * as API from '../../services/Api';
@@ -16,7 +16,7 @@ import BreadcrumbView from '../../components/BreadcrumbView/BreadcrumbView';
 import VirtualServiceDetail from './IstioObjectDetails/VirtualServiceDetail';
 import DestinationRuleDetail from './IstioObjectDetails/DestinationRuleDetail';
 import history from '../../app/History';
-import { Paths } from '../../config';
+import { Paths, serverConfig } from '../../config';
 import { MessageType } from '../../types/MessageCenter';
 import { getIstioObject, mergeJsonPatch } from '../../utils/IstioConfigUtils';
 import { style } from 'typestyle';
@@ -46,6 +46,7 @@ import { dicIstioType } from '../../types/IstioConfigList';
 import { showInMessageCenter } from '../../utils/IstioValidationUtils';
 import { PfColors } from '../../components/Pf/PfColors';
 import IstioObjectLink from '../../components/Link/IstioObjectLink';
+import { ServiceIcon } from '@patternfly/react-icons';
 
 const rightToolbarStyle = style({
   position: 'absolute',
@@ -70,6 +71,32 @@ const tabName = 'list';
 const paramToTab: { [key: string]: number } = {
   overview: 0,
   yaml: 1
+};
+
+export const serviceLink = (namespace: string, host: string, isValid: boolean): any => {
+  if (!host) {
+    return '-';
+  }
+  // TODO Full FQDN are not linked yet, it needs more checks in crossnamespace scenarios + validation of target
+  const isFqdn = host.endsWith('.' + serverConfig.istioIdentityDomain);
+  if (!isValid || !isFqdn) {
+    return host;
+  } else {
+    let linkNamespace = namespace;
+    let linkService = host;
+    if (isFqdn) {
+      // FQDN format: service.namespace.svc.cluster.local
+      const splitFqdn = host.split('.');
+      linkService = splitFqdn[0];
+      linkNamespace = splitFqdn[1];
+    }
+    return (
+      <Link to={'/namespaces/' + linkNamespace + '/services/' + linkService}>
+        {host + ' '}
+        <ServiceIcon />
+      </Link>
+    );
+  }
 };
 
 class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioConfigId>, IstioConfigDetailsState> {

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/DestinationRuleDetail.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/DestinationRuleDetail.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { DestinationRule, ObjectValidation } from '../../../types/IstioObjects';
 import LocalTime from '../../../components/Time/LocalTime';
 import DetailObject from '../../../components/Details/DetailObject';
-import { Link } from 'react-router-dom';
 import {
   Card,
   CardBody,
@@ -16,10 +15,10 @@ import {
 } from '@patternfly/react-core';
 import { Table, TableBody, TableHeader, TableVariant } from '@patternfly/react-table';
 import GlobalValidation from '../../../components/Validations/GlobalValidation';
-import { ServiceIcon } from '@patternfly/react-icons';
 import { checkForPath } from '../../../types/ServiceInfo';
 import ValidationList from '../../../components/Validations/ValidationList';
 import Labels from '../../../components/Label/Labels';
+import { serviceLink } from '../IstioConfigDetailsPage';
 
 interface DestinationRuleProps {
   namespace: string;
@@ -105,23 +104,6 @@ class DestinationRuleDetail extends React.Component<DestinationRuleProps> {
     );
   }
 
-  serviceLink(namespace: string, host: string, isValid: boolean): any {
-    if (!host) {
-      return '-';
-    }
-    // TODO Full FQDN are not linked yet, it needs more checks in crossnamespace scenarios + validation of target
-    if (host.indexOf('.') > -1 || !isValid) {
-      return host;
-    } else {
-      return (
-        <Link to={'/namespaces/' + namespace + '/services/' + host}>
-          {host + ' '}
-          <ServiceIcon />
-        </Link>
-      );
-    }
-  }
-
   rawConfig() {
     const destinationRule = this.props.destinationRule;
     const globalStatus = this.globalStatus();
@@ -145,7 +127,7 @@ class DestinationRuleDetail extends React.Component<DestinationRuleProps> {
                 {destinationRule.spec.host && (
                   <>
                     <Text component={TextVariants.h3}>Host</Text>
-                    {this.serviceLink(destinationRule.metadata.namespace || '', destinationRule.spec.host, isValid)}
+                    {serviceLink(destinationRule.metadata.namespace || '', destinationRule.spec.host, isValid)}
                   </>
                 )}
               </StackItem>

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceRoute.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceRoute.tsx
@@ -2,12 +2,11 @@ import * as React from 'react';
 import { checkForPath, highestSeverity } from '../../../types/ServiceInfo';
 import { DestinationWeight, HTTPRoute, ObjectValidation, TCPRoute, ValidationTypes } from '../../../types/IstioObjects';
 import DetailObject from '../../../components/Details/DetailObject';
-import { Link } from 'react-router-dom';
-import { ServiceIcon } from '@patternfly/react-icons';
 import { Table, TableBody, TableHeader, TableVariant } from '@patternfly/react-table';
 import { Grid, GridItem, Text, TextVariants } from '@patternfly/react-core';
 import { ChartBullet } from '@patternfly/react-charts/dist/js/components/ChartBullet';
 import ValidationList from '../../../components/Validations/ValidationList';
+import { serviceLink } from '../IstioConfigDetailsPage';
 
 interface VirtualServiceRouteProps {
   name: string;
@@ -68,7 +67,7 @@ class VirtualServiceRoute extends React.Component<VirtualServiceRouteProps> {
           const destination = routeItem.destination;
           cells = [
             { title: validation },
-            { title: this.serviceLink(this.props.namespace, destination.host, isValid) },
+            { title: serviceLink(this.props.namespace, destination.host, isValid) },
             { title: destination.subset || '-' },
             { title: destination.port ? destination.port.number || '-' : '-' },
             { title: routeItem.weight ? routeItem.weight : '-' }
@@ -88,23 +87,6 @@ class VirtualServiceRoute extends React.Component<VirtualServiceRouteProps> {
     );
 
     return rows;
-  }
-
-  serviceLink(namespace: string, host: string, isValid: boolean): any {
-    if (!host) {
-      return '-';
-    }
-    // TODO Full FQDN are not linked yet, it needs more checks in crossnamespace scenarios + validation of target
-    if (host.indexOf('.') > -1 || !isValid) {
-      return host;
-    } else {
-      return (
-        <Link to={'/namespaces/' + namespace + '/services/' + host}>
-          {host + ' '}
-          <ServiceIcon />
-        </Link>
-      );
-    }
   }
 
   validation(): ObjectValidation {

--- a/src/types/ServerConfig.ts
+++ b/src/types/ServerConfig.ts
@@ -4,6 +4,7 @@ export type IstioLabelKey = 'appLabelName' | 'versionLabelName';
 
 export interface ServerConfig {
   installationTag?: string;
+  istioIdentityDomain: string;
   istioNamespace: string;
   istioComponentNamespaces?: Map<string, string>;
   istioLabels: { [key in IstioLabelKey]: string };


### PR DESCRIPTION
Fixes kiali/kiali#1879

This PR allows Wizards to use FQDN like "reviews.bookinfo.svc.cluster.local" instead of short names "reviews" for the VirtualServices and DestinationRules generated by Kiali Actions.

