### PR TITLE
Fix a console error on SparklineChart

### DIFF
--- a/src/components/Charts/SparklineChart.tsx
+++ b/src/components/Charts/SparklineChart.tsx
@@ -35,7 +35,7 @@ export class SparklineChart extends React.Component<Props, State> {
     if (props.width === undefined) {
       this.containerRef = React.createRef<HTMLDivElement>();
     }
-    this.state = { width: props.width || 0, hiddenSeries: new Set() };
+    this.state = { width: props.width || 1, hiddenSeries: new Set() };
   }
 
   handleResize = () => {


### PR DESCRIPTION
Closes: https://github.com/kiali/kiali/issues/1928

Fixes the following error on the overview graphs:

![error1](https://user-images.githubusercontent.com/14752/70548270-047fb280-1b51-11ea-95cb-7e8ebe07ee38.png)

This does not fix the other error that appears, even with this fix (another issue is going to be created for it):

![error2](https://user-images.githubusercontent.com/14752/70548311-17928280-1b51-11ea-98e6-b5bdcaaa67ee.png)