### PR TITLE
Remove link redundancy in cards of Overview page

### DIFF
--- a/src/pages/Overview/OverviewCardLinks.tsx
+++ b/src/pages/Overview/OverviewCardLinks.tsx
@@ -20,40 +20,63 @@ const iconStyle = style({
 class OverviewCardLinks extends React.Component<Props> {
   render() {
     const tooltipProps = { distance: 10, entryDelay: 100, exitDelay: 100 };
-    return (
-      <div style={{ marginTop: '10px' }}>
-        <Tooltip key="ot_graph" content={<>Go to graph</>} {...tooltipProps}>
-          <Link
-            to={`/graph/namespaces?namespaces=${this.props.name}&graphType=${this.toGraphType(
-              this.props.overviewType
-            )}`}
-            className={iconStyle}
-          >
-            <TopologyIcon />
-          </Link>
-        </Tooltip>
+    let links: React.ReactNodeArray = [];
+
+    // Link to the graph page
+    links.push(
+      <Tooltip key="ot_graph" content={<>Go to graph</>} {...tooltipProps}>
+        <Link
+          to={`/graph/namespaces?namespaces=${this.props.name}&graphType=${this.toGraphType(this.props.overviewType)}`}
+          className={iconStyle}
+        >
+          <TopologyIcon />
+        </Link>
+      </Tooltip>
+    );
+
+    // Link to the apps list
+    if (this.props.overviewType !== 'app') {
+      links.push(
         <Tooltip key="ot_apps" content={<>Go to applications</>} {...tooltipProps}>
           <Link to={`/${Paths.APPLICATIONS}?namespaces=` + this.props.name} className={iconStyle}>
             <ApplicationsIcon />
           </Link>
         </Tooltip>
+      );
+    }
+
+    // Link to the workloads list
+    if (this.props.overviewType !== 'workload') {
+      links.push(
         <Tooltip key="ot_workloads" content={<>Go to workloads</>} {...tooltipProps}>
           <Link to={`/${Paths.WORKLOADS}?namespaces=` + this.props.name} className={iconStyle}>
             <BundleIcon />
           </Link>
         </Tooltip>
+      );
+    }
+
+    // Link to the services list
+    if (this.props.overviewType !== 'service') {
+      links.push(
         <Tooltip key="ot_services" content={<>Go to services</>} {...tooltipProps}>
           <Link to={`/${Paths.SERVICES}?namespaces=` + this.props.name} className={iconStyle}>
             <ServiceIcon />
           </Link>
         </Tooltip>
-        <Tooltip key="ot_istio" content={<>Go to Istio config</>} {...tooltipProps}>
-          <Link to={`/${Paths.ISTIO}?namespaces=` + this.props.name} className={iconStyle}>
-            <PficonTemplateIcon />
-          </Link>
-        </Tooltip>
-      </div>
+      );
+    }
+
+    // Link to the Istio Config list
+    links.push(
+      <Tooltip key="ot_istio" content={<>Go to Istio config</>} {...tooltipProps}>
+        <Link to={`/${Paths.ISTIO}?namespaces=` + this.props.name} className={iconStyle}>
+          <PficonTemplateIcon />
+        </Link>
+      </Tooltip>
     );
+
+    return <div style={{ marginTop: '10px' }}>{links}</div>;
   }
 
   private toGraphType = (overviewType: OverviewType): string => {

--- a/src/pages/Overview/__tests__/OverviewCardLinks.test.tsx
+++ b/src/pages/Overview/__tests__/OverviewCardLinks.test.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import OverviewCardLinks from '../OverviewCardLinks';
+import { Tooltip } from '@patternfly/react-core';
+
+describe('Overview page card links', () => {
+  it('does not render link to apps list when overview type is app', () => {
+    const wrapper = shallow(<OverviewCardLinks name="bookinfo" overviewType="app" />);
+
+    const tooltips = wrapper.find(Tooltip);
+    const keys = tooltips.map(node => node.key()).join();
+
+    expect(keys).toBe('ot_graph,ot_workloads,ot_services,ot_istio');
+  });
+
+  it('does not render link to workloads list when overview type is workload', () => {
+    const wrapper = shallow(<OverviewCardLinks name="bookinfo" overviewType="workload" />);
+
+    const tooltips = wrapper.find(Tooltip);
+    const keys = tooltips.map(node => node.key()).join();
+
+    expect(keys).toBe('ot_graph,ot_apps,ot_services,ot_istio');
+  });
+
+  it('does not render link to services list when overview type is service', () => {
+    const wrapper = shallow(<OverviewCardLinks name="bookinfo" overviewType="service" />);
+
+    const tooltips = wrapper.find(Tooltip);
+    const keys = tooltips.map(node => node.key()).join();
+
+    expect(keys).toBe('ot_graph,ot_apps,ot_workloads,ot_istio');
+  });
+});


### PR DESCRIPTION
Implements hiding a redundant link in the links area of the cards of the Overview page. Hidden item is redundant because the middle of the card has a text based on the view type which is a link to the relevant list page.

![Peek 2019-12-11 14-51](https://user-images.githubusercontent.com/23639005/70664871-eab59c80-1c30-11ea-84a2-e9b693209965.gif)

Fixes kiali/kiali#1474