### PR TITLE
Make Graph Settings display settings more consistent 

### DIFF
--- a/src/pages/Graph/GraphToolbar/GraphSettings.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphSettings.tsx
@@ -168,7 +168,7 @@ class GraphSettings extends React.PureComponent<GraphSettingsProps, GraphSetting
         isGrouped={true}
         selections={selection}
       >
-        <SelectGroup label="" key="visibilityLayers">
+        <SelectGroup label="Show" key="visibilityLayers">
           {visibilityLayers.map((item: VisibilityLayersType) => (
             <SelectOption
               isChecked={item.value}
@@ -179,7 +179,7 @@ class GraphSettings extends React.PureComponent<GraphSettingsProps, GraphSetting
             />
           ))}
         </SelectGroup>
-        <SelectGroup label="Badges" key="badges">
+        <SelectGroup label="Show Badges" key="badges">
           {badges.map((item: VisibilityLayersType) => (
             <SelectOption isChecked={item.value} key={item.id} value={item.labelText} onClick={item.onChange} />
           ))}


### PR DESCRIPTION
The **visiibility** section of the Graph Settings **Display** dropdown doesn't have a label like the **Badges** section.

** Describe the change **

Make GraphSettings display settings more consistent 
by adding a 'Visibility' group heading label to match the 'Badges' group heading label.
It looked a little off without the balance of the visibility section; then they look similar.


** Backwards compatible? **
Yes

[ ] Is your pull-request introducing changes in behaviour?
No

** Screenshot **
Before:
![Kiali_Console](https://user-images.githubusercontent.com/1312165/70942717-228f5c00-2004-11ea-8344-4a1d12e79176.png)


After:
<img width="255" alt="Kiali_Console" src="https://user-images.githubusercontent.com/1312165/71202480-2bc13880-2251-11ea-890e-49cfade91c6e.png">


