### PR TITLE
IstioConfigList - Istio type selector now is typeahead variant

### DIFF
--- a/src/components/Filters/StatefulFilters.tsx
+++ b/src/components/Filters/StatefulFilters.tsx
@@ -229,7 +229,7 @@ export class StatefulFilters extends React.Component<StatefulFiltersProps, State
           isExpanded={this.state.isExpanded}
           aria-label="filter_select_value"
           placeholderText={currentFilterType.placeholder}
-          width={'65%'}
+          width={'auto'}
         >
           {currentFilterType.filterValues.map((filter, index) => (
             <SelectOption key={'filter_' + index} value={filter.id} label={filter.title} />
@@ -242,7 +242,7 @@ export class StatefulFilters extends React.Component<StatefulFiltersProps, State
           value={'default'}
           onChange={this.filterValueSelected}
           aria-label="filter_select_value"
-          style={{ width: '65%' }}
+          style={{ width: 'auto' }}
         >
           <FormSelectOption key={'filter_default'} value={'default'} label={currentFilterType.placeholder} />
           {currentFilterType.filterValues.map((filter, index) => (
@@ -259,7 +259,7 @@ export class StatefulFilters extends React.Component<StatefulFiltersProps, State
           placeholder={currentFilterType.placeholder}
           onChange={this.updateCurrentValue}
           onKeyPress={e => this.onValueKeyPress(e)}
-          style={{ width: '65%' }}
+          style={{ width: 'auto' }}
         />
       );
     }
@@ -323,7 +323,7 @@ export class StatefulFilters extends React.Component<StatefulFiltersProps, State
                 value={currentFilterType.id}
                 aria-label={'filter_select_type'}
                 onChange={this.selectFilterType}
-                style={{ width: '35%', backgroundColor: '#ededed', borderColor: '#bbb' }}
+                style={{ width: 'auto', backgroundColor: '#ededed', borderColor: '#bbb' }}
               >
                 {this.state.filterTypes.map(option => (
                   <FormSelectOption key={option.id} value={option.id} label={option.title} />

--- a/src/components/Filters/StatefulFilters.tsx
+++ b/src/components/Filters/StatefulFilters.tsx
@@ -5,6 +5,9 @@ import {
   ChipGroupToolbarItem,
   FormSelect,
   FormSelectOption,
+  Select,
+  SelectOption,
+  SelectVariant,
   TextInput,
   Toolbar,
   ToolbarGroup,
@@ -29,6 +32,7 @@ export interface StatefulFiltersState {
   currentFilterType: FilterType;
   activeFilters: ActiveFilter[];
   currentValue: string;
+  isExpanded: boolean;
 }
 
 export class FilterSelected {
@@ -72,6 +76,7 @@ export class StatefulFilters extends React.Component<StatefulFiltersProps, State
       currentFilterType: this.props.initialFilters[0],
       filterTypes: this.props.initialFilters,
       activeFilters: active,
+      isExpanded: false,
       currentValue: ''
     };
   }
@@ -150,7 +155,7 @@ export class StatefulFilters extends React.Component<StatefulFiltersProps, State
     }
   };
 
-  filterValueSelected = (value: string) => {
+  filterValueSelected = (_event: any, value: any) => {
     const { currentFilterType, currentValue } = this.state;
     const filterValue = currentFilterType.filterValues.filter(filter => filter.id === value)[0];
 
@@ -161,6 +166,8 @@ export class StatefulFilters extends React.Component<StatefulFiltersProps, State
     ) {
       this.filterAdded(currentFilterType, filterValue.title);
     }
+
+    this.setState({ isExpanded: false });
   };
 
   updateCurrentValue = value => {
@@ -209,13 +216,30 @@ export class StatefulFilters extends React.Component<StatefulFiltersProps, State
     if (!currentFilterType) {
       return null;
     }
-    if (currentFilterType.filterType === 'select') {
+    if (currentFilterType.filterType === 'typeahead') {
+      return (
+        <Select
+          value={'default'}
+          onSelect={this.filterValueSelected}
+          onToggle={this.onToggle}
+          variant={SelectVariant.typeahead}
+          isExpanded={this.state.isExpanded}
+          aria-label="filter_select_value"
+          placeholderText={currentFilterType.placeholder}
+          width={'65%'}
+        >
+          {currentFilterType.filterValues.map((filter, index) => (
+            <SelectOption key={'filter_' + index} value={filter.id} label={filter.title} />
+          ))}
+        </Select>
+      );
+    } else if (currentFilterType.filterType === 'select') {
       return (
         <FormSelect
           value={'default'}
           onChange={this.filterValueSelected}
           aria-label="filter_select_value"
-          style={{ width: 'auto' }}
+          style={{ width: '65%' }}
         >
           <FormSelectOption key={'filter_default'} value={'default'} label={currentFilterType.placeholder} />
           {currentFilterType.filterValues.map((filter, index) => (
@@ -232,7 +256,7 @@ export class StatefulFilters extends React.Component<StatefulFiltersProps, State
           placeholder={currentFilterType.placeholder}
           onChange={this.updateCurrentValue}
           onKeyPress={e => this.onValueKeyPress(e)}
-          style={{ width: 'auto' }}
+          style={{ width: '65%' }}
         />
       );
     }
@@ -278,6 +302,12 @@ export class StatefulFilters extends React.Component<StatefulFiltersProps, State
     );
   };
 
+  onToggle = isExpanded => {
+    this.setState({
+      isExpanded: isExpanded
+    });
+  };
+
   render() {
     const { currentFilterType, activeFilters } = this.state;
 
@@ -290,7 +320,7 @@ export class StatefulFilters extends React.Component<StatefulFiltersProps, State
                 value={currentFilterType.id}
                 aria-label={'filter_select_type'}
                 onChange={this.selectFilterType}
-                style={{ width: 'auto', backgroundColor: '#ededed', borderColor: '#bbb' }}
+                style={{ width: '35%', backgroundColor: '#ededed', borderColor: '#bbb' }}
               >
                 {this.state.filterTypes.map(option => (
                   <FormSelectOption key={option.id} value={option.id} label={option.title} />

--- a/src/components/Filters/StatefulFilters.tsx
+++ b/src/components/Filters/StatefulFilters.tsx
@@ -155,7 +155,12 @@ export class StatefulFilters extends React.Component<StatefulFiltersProps, State
     }
   };
 
-  filterValueSelected = (_event: any, value: any) => {
+  filterValueAheadSelected = (_event: any, value: any) => {
+    this.filterValueSelected(value);
+    this.setState({ isExpanded: false });
+  };
+
+  filterValueSelected = (value: any) => {
     const { currentFilterType, currentValue } = this.state;
     const filterValue = currentFilterType.filterValues.filter(filter => filter.id === value)[0];
 
@@ -166,8 +171,6 @@ export class StatefulFilters extends React.Component<StatefulFiltersProps, State
     ) {
       this.filterAdded(currentFilterType, filterValue.title);
     }
-
-    this.setState({ isExpanded: false });
   };
 
   updateCurrentValue = value => {
@@ -220,7 +223,7 @@ export class StatefulFilters extends React.Component<StatefulFiltersProps, State
       return (
         <Select
           value={'default'}
-          onSelect={this.filterValueSelected}
+          onSelect={this.filterValueAheadSelected}
           onToggle={this.onToggle}
           variant={SelectVariant.typeahead}
           isExpanded={this.state.isExpanded}

--- a/src/pages/AppList/FiltersAndSorts.ts
+++ b/src/pages/AppList/FiltersAndSorts.ts
@@ -28,7 +28,7 @@ export const sortFields: GenericSortField<AppListItem>[] = [
   },
   {
     id: 'appname',
-    title: 'App Name',
+    title: 'Name',
     isNumeric: false,
     param: 'wn',
     compare: (a, b) => a.name.localeCompare(b.name)
@@ -72,8 +72,8 @@ export const sortFields: GenericSortField<AppListItem>[] = [
 
 const appNameFilter: FilterType = {
   id: 'appname',
-  title: 'App Name',
-  placeholder: 'Filter by App Name',
+  title: 'Name',
+  placeholder: 'Filter by Name',
   filterType: TextInputTypes.text,
   action: FILTER_ACTION_APPEND,
   filterValues: []

--- a/src/pages/IstioConfigList/FiltersAndSorts.ts
+++ b/src/pages/IstioConfigList/FiltersAndSorts.ts
@@ -87,7 +87,7 @@ export const istioTypeFilter: FilterType = {
   id: 'istiotype',
   title: 'Istio Type',
   placeholder: 'Filter by Istio Type',
-  filterType: 'select',
+  filterType: 'typeahead',
   action: FILTER_ACTION_APPEND,
   filterValues: [
     {

--- a/src/pages/IstioConfigList/FiltersAndSorts.ts
+++ b/src/pages/IstioConfigList/FiltersAndSorts.ts
@@ -32,7 +32,7 @@ export const sortFields: SortField<IstioConfigItem>[] = [
   },
   {
     id: 'istioname',
-    title: 'Istio Name',
+    title: 'Name',
     isNumeric: false,
     param: 'in',
     compare: (a: IstioConfigItem, b: IstioConfigItem) => {
@@ -76,8 +76,8 @@ export const sortFields: SortField<IstioConfigItem>[] = [
 
 export const istioNameFilter: FilterType = {
   id: 'istioname',
-  title: 'Istio Name',
-  placeholder: 'Filter by Istio Name',
+  title: 'Name',
+  placeholder: 'Filter by Name',
   filterType: TextInputTypes.text,
   action: FILTER_ACTION_APPEND,
   filterValues: []
@@ -85,8 +85,8 @@ export const istioNameFilter: FilterType = {
 
 export const istioTypeFilter: FilterType = {
   id: 'istiotype',
-  title: 'Istio Type',
-  placeholder: 'Filter by Istio Type',
+  title: 'Type',
+  placeholder: 'Filter by Type',
   filterType: 'typeahead',
   action: FILTER_ACTION_APPEND,
   filterValues: [

--- a/src/pages/Overview/Filters.ts
+++ b/src/pages/Overview/Filters.ts
@@ -84,7 +84,7 @@ const summarizeHealthFilters = (healthFilters: ActiveFilter[]) => {
 export const healthFilter: FilterTypeWithFilter<NamespaceInfo> = {
   id: 'health',
   title: 'Health',
-  placeholder: 'Filter by Application Health',
+  placeholder: 'Filter by Health',
   filterType: 'select',
   action: FILTER_ACTION_APPEND,
   filterValues: healthValues,

--- a/src/pages/ServiceList/FiltersAndSorts.ts
+++ b/src/pages/ServiceList/FiltersAndSorts.ts
@@ -28,7 +28,7 @@ export const sortFields: GenericSortField<ServiceListItem>[] = [
   },
   {
     id: 'servicename',
-    title: 'Service Name',
+    title: 'Name',
     isNumeric: false,
     param: 'sn',
     compare: (a, b) => a.name.localeCompare(b.name)
@@ -105,8 +105,8 @@ export const sortFields: GenericSortField<ServiceListItem>[] = [
 
 const serviceNameFilter: FilterType = {
   id: 'servicename',
-  title: 'Service Name',
-  placeholder: 'Filter by Service Name',
+  title: 'Name',
+  placeholder: 'Filter by Name',
   filterType: TextInputTypes.text,
   action: FILTER_ACTION_APPEND,
   filterValues: []

--- a/src/pages/ServiceList/__tests__/ServiceListComponent.test.ts
+++ b/src/pages/ServiceList/__tests__/ServiceListComponent.test.ts
@@ -54,7 +54,7 @@ describe('SortField#compare', () => {
 });
 
 describe('ServiceListContainer#sortServices', () => {
-  const sortField = ServiceListFilters.sortFields.find(s => s.title === 'Service Name')!;
+  const sortField = ServiceListFilters.sortFields.find(s => s.title === 'Name')!;
   const services = [makeService('A', -1), makeService('B', -1)];
   it('should sort ascending', done => {
     ServiceListFilters.sortServices(services, sortField, true).then(sorted => {

--- a/src/pages/WorkloadList/FiltersAndSorts.ts
+++ b/src/pages/WorkloadList/FiltersAndSorts.ts
@@ -29,14 +29,14 @@ export const sortFields: GenericSortField<WorkloadListItem>[] = [
   },
   {
     id: 'workloadname',
-    title: 'Workload Name',
+    title: 'Name',
     isNumeric: false,
     param: 'wn',
     compare: (a, b) => a.name.localeCompare(b.name)
   },
   {
     id: 'workloadtype',
-    title: 'Workload Type',
+    title: 'Type',
     isNumeric: false,
     param: 'wt',
     compare: (a, b) => a.type.localeCompare(b.type)
@@ -137,8 +137,8 @@ export const sortFields: GenericSortField<WorkloadListItem>[] = [
 
 const workloadNameFilter: FilterType = {
   id: 'workloadname',
-  title: 'Workload Name',
-  placeholder: 'Filter by Workload Name',
+  title: 'Name',
+  placeholder: 'Filter by Name',
   filterType: TextInputTypes.text,
   action: FILTER_ACTION_APPEND,
   filterValues: []
@@ -164,8 +164,8 @@ const versionLabelFilter: FilterType = {
 
 const workloadTypeFilter: FilterType = {
   id: 'workloadtype',
-  title: 'Workload Type',
-  placeholder: 'Filter by Workload Type',
+  title: 'Type',
+  placeholder: 'Filter by Type',
   filterType: 'select',
   action: FILTER_ACTION_APPEND,
   filterValues: [

--- a/src/types/Filters.ts
+++ b/src/types/Filters.ts
@@ -11,7 +11,7 @@ export interface FilterType {
   id: string;
   title: string;
   placeholder: string;
-  filterType: TextInputTypes | 'select';
+  filterType: TextInputTypes | 'select' | 'typeahead';
   action: string;
   filterValues: FilterValue[];
   loader?: () => Promise<FilterValue[]>;


### PR DESCRIPTION
** Describe the change **
The list of Istio Objects has increased substantially since we started the project.
https://github.com/kiali/kiali-ui/pull/1582#issuecomment-567601410 suggested to sort types alphabetically. This is step further to ease the task of filtering objects by type.
This PRs add the ability to pick istio types by typing its name. It uses the [PF4 typeahead selector](https://www.patternfly.org/v4/documentation/core/components/select#single-with-typeahead).

** Issue reference **
https://github.com/kiali/kiali-ui/pull/1582#issuecomment-567601410

** screenshot **

![Screen recording (16)](https://user-images.githubusercontent.com/613814/71353594-ca170c00-2579-11ea-81a1-adf8f2f4f81f.gif)

