### PR TITLE
Host link in DR/VS details page: Support svc.ns format

### DIFF
--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -77,11 +77,10 @@ export const serviceLink = (namespace: string, host: string, isValid: boolean): 
   if (!host) {
     return '-';
   }
-  // TODO Full FQDN are not linked yet, it needs more checks in crossnamespace scenarios + validation of target
   const isFqdn = host.endsWith('.' + serverConfig.istioIdentityDomain);
-  if (!isValid || !isFqdn) {
-    return host;
-  } else {
+  const isShortName = host.split('.').length === 2;
+  const showLink = isValid && (isFqdn || isShortName);
+  if (showLink) {
     let linkNamespace = namespace;
     let linkService = host;
     if (isFqdn) {
@@ -96,6 +95,8 @@ export const serviceLink = (namespace: string, host: string, isValid: boolean): 
         <ServiceIcon />
       </Link>
     );
+  } else {
+    return host;
   }
 };
 


### PR DESCRIPTION
** Describe the change **

Fix link to services on DR and VS when two parts shortname is shown:
![71243791-5ecb0100-2311-11ea-946f-cef93843b643](https://user-images.githubusercontent.com/613814/71357141-e9676680-2584-11ea-9deb-202e6653e440.png)

** Issue reference **

https://github.com/kiali/kiali/pull/2036#issuecomment-567852163
