### PR TITLE
Fix overview sort field name from 'Status' to 'Health'

### DIFF
--- a/src/pages/Overview/Sorts.ts
+++ b/src/pages/Overview/Sorts.ts
@@ -11,7 +11,7 @@ export const sortFields: SortField<NamespaceInfo>[] = [
   },
   {
     id: 'health',
-    title: 'Status',
+    title: 'Health',
     isNumeric: false,
     param: 'h',
     compare: (a: NamespaceInfo, b: NamespaceInfo) => {


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/2047