### PR TITLE
Make sparkline tooltips overflowing (svg scope)

### DIFF
--- a/src/components/Charts/Charts.scss
+++ b/src/components/Charts/Charts.scss
@@ -1,0 +1,3 @@
+.pf-c-chart svg {
+  overflow: visible !important;
+}

--- a/src/components/Charts/CustomFlyout.tsx
+++ b/src/components/Charts/CustomFlyout.tsx
@@ -4,19 +4,13 @@ import { Flyout } from 'victory';
 const squareSize = 10;
 
 export const CustomFlyout = (props: any) => {
-  const { x, width, center, datum } = props;
+  const { width, center, datum } = props;
   const left = center.x - width / 2;
   const top = center.y - squareSize / 2;
   const extraWidth = squareSize + 5;
   return (
     <>
-      <Flyout
-        {...props}
-        width={width + extraWidth}
-        x={x - extraWidth}
-        center={{ x: center.x - extraWidth / 2, y: center.y }}
-        style={{ ...props.style, fillOpacity: 0.6 }}
-      />
+      <Flyout {...props} width={width + extraWidth} style={{ ...props.style, fillOpacity: 0.6 }} />
       <rect width={squareSize} height={squareSize} x={left} y={top} style={{ fill: datum.color }} />
     </>
   );

--- a/src/components/Charts/SparklineChart.tsx
+++ b/src/components/Charts/SparklineChart.tsx
@@ -15,6 +15,8 @@ import { PfColors } from 'components/Pf/PfColors';
 import * as Legend from './LegendHelper';
 import { CustomFlyout } from './CustomFlyout';
 
+import './Charts.css';
+
 type Props = ChartProps & {
   name: string;
   series: VCLines;


### PR DESCRIPTION
Also fix an issue with the tooltip arrow not pointing exactly to the hovered datapoint

Fixes https://github.com/kiali/kiali/issues/2068
