### PR TITLE
Hack - one-pixel domain padding to prevent clipping

### DIFF
--- a/src/components/Charts/SparklineChart.tsx
+++ b/src/components/Charts/SparklineChart.tsx
@@ -123,6 +123,8 @@ export class SparklineChart extends React.Component<Props, State> {
         padding={padding}
         events={events}
         containerComponent={container}
+        // Hack: 1 pxl on Y domain padding to prevent harsh clipping (https://github.com/kiali/kiali/issues/2069)
+        domainPadding={{ y: 1 }}
       >
         <ChartAxis tickCount={15} style={hiddenAxisStyle} />
         <ChartAxis dependentAxis={true} style={hiddenAxisStyle} />


### PR DESCRIPTION
This is for sparkline charts (not k-charted)

Fixes https://github.com/kiali/kiali/issues/2069

*Before*:
![Capture d’écran de 2020-01-08 14-45-13](https://user-images.githubusercontent.com/2153442/71982936-f8f1db00-3225-11ea-9ed3-1900787510c8.png)

*After*:
![Capture d’écran de 2020-01-08 14-45-40](https://user-images.githubusercontent.com/2153442/71982940-fbeccb80-3225-11ea-9d3b-223e329595fb.png)

