### PR TITLE
Fix durations not filtered for retention

### DIFF
--- a/src/config/ServerConfig.ts
+++ b/src/config/ServerConfig.ts
@@ -14,7 +14,7 @@ const toDurations = (tupleArray: [number, string][]): Durations => {
   return obj;
 };
 
-let durationsTuples: [number, string][] = [
+const durationsTuples: [number, string][] = [
   [60, 'Last 1m'],
   [300, 'Last 5m'],
   [600, 'Last 10m'],
@@ -29,15 +29,16 @@ let durationsTuples: [number, string][] = [
 ];
 
 const computeValidDurations = (cfg: ComputedServerConfig) => {
+  let filtered = durationsTuples;
   if (cfg.prometheus.storageTsdbRetention) {
     // Make sure we'll keep at least one item
     if (cfg.prometheus.storageTsdbRetention <= durationsTuples[0][0]) {
-      durationsTuples = [durationsTuples[0]];
+      filtered = [durationsTuples[0]];
     } else {
-      durationsTuples = durationsTuples.filter(d => d[0] <= cfg.prometheus.storageTsdbRetention!);
+      filtered = durationsTuples.filter(d => d[0] <= cfg.prometheus.storageTsdbRetention!);
     }
   }
-  cfg.durations = toDurations(durationsTuples);
+  cfg.durations = toDurations(filtered);
 };
 
 // Set some defaults. Mainly used in tests, because


### PR DESCRIPTION
The initial durations list was not a constant and was overwritten for a default retention (6h). When server config is fetched, the first-pass filtering did already cause the loss of higher duration values.

Fixes https://github.com/kiali/kiali/issues/2072

Here's what I have after this fix:

![Capture d’écran de 2020-01-08 15-25-02](https://user-images.githubusercontent.com/2153442/71986123-32c5e000-322c-11ea-9c8e-c96a89930604.png)

cc @suraj77foru 
