### PR TITLE
UX suggestions for Health card in detail pages

### DIFF
--- a/src/components/Health/Health.scss
+++ b/src/components/Health/Health.scss
@@ -17,3 +17,7 @@ svg:not(:root).icon-na {
   border-width: 1px;
   text-align: left;
 }
+.health_indicator .pf-c-content ul {
+  margin-bottom: var(--pf-c-content--ul--MarginTop);
+  margin-top: 0;
+}

--- a/src/components/Health/HealthDetails.tsx
+++ b/src/components/Health/HealthDetails.tsx
@@ -14,7 +14,7 @@ export class HealthDetails extends React.PureComponent<Props, {}> {
     return health.items.map((item, idx) => {
       return (
         <div key={idx}>
-          <strong>{' ' + item.title}</strong>
+          <strong>{' ' + item.title + (item.text && item.text.length > 0 ? ': ' : '')}</strong>
           {item.text}
           {item.children && (
             <ul style={{ listStyleType: 'none', paddingLeft: 12 }}>

--- a/src/components/Health/HealthDetails.tsx
+++ b/src/components/Health/HealthDetails.tsx
@@ -14,10 +14,7 @@ export class HealthDetails extends React.PureComponent<Props, {}> {
     return health.items.map((item, idx) => {
       return (
         <div key={idx}>
-          <strong>
-            {createIcon(item.status)}
-            {' ' + item.title + ': '}
-          </strong>
+          <strong>{' ' + item.title}</strong>
           {item.text}
           {item.children && (
             <ul style={{ listStyleType: 'none', paddingLeft: 12 }}>

--- a/src/components/Health/__tests__/__snapshots__/HealthDetails.test.tsx.snap
+++ b/src/components/Health/__tests__/__snapshots__/HealthDetails.test.tsx.snap
@@ -5,16 +5,30 @@ exports[`HealthDetails renders deployments failure 1`] = `
   key="0"
 >
   <strong>
-    <UnknownIcon
-      className="icon-na"
-      color="#72767b"
-      noVerticalAlign={false}
-      size="sm"
-      title={null}
-    />
-     Error Rate over last 1m: 
+     Error Rate over last 1m
   </strong>
-  No requests
+  <ul
+    style={
+      Object {
+        "listStyleType": "none",
+        "paddingLeft": 12,
+      }
+    }
+  >
+    <li
+      key="0"
+    >
+      <UnknownIcon
+        className="icon-na"
+        color="#72767b"
+        noVerticalAlign={false}
+        size="sm"
+        title={null}
+      />
+       
+      Inbound: No requests
+    </li>
+  </ul>
 </div>
 `;
 
@@ -23,15 +37,29 @@ exports[`HealthDetails renders healthy 1`] = `
   key="0"
 >
   <strong>
-    <UnknownIcon
-      className="icon-na"
-      color="#72767b"
-      noVerticalAlign={false}
-      size="sm"
-      title={null}
-    />
-     Error Rate over last 1m: 
+     Error Rate over last 1m
   </strong>
-  No requests
+  <ul
+    style={
+      Object {
+        "listStyleType": "none",
+        "paddingLeft": 12,
+      }
+    }
+  >
+    <li
+      key="0"
+    >
+      <UnknownIcon
+        className="icon-na"
+        color="#72767b"
+        noVerticalAlign={false}
+        size="sm"
+        title={null}
+      />
+       
+      Inbound: No requests
+    </li>
+  </ul>
 </div>
 `;

--- a/src/components/Health/__tests__/__snapshots__/HealthIndicator.test.tsx.snap
+++ b/src/components/Health/__tests__/__snapshots__/HealthIndicator.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`HealthIndicator renders healthy 1`] = `
                   "name": "Healthy",
                   "priority": 1,
                 },
-                "title": "Pods Status",
+                "title": "Pod Status",
               },
               Object {
                 "children": Array [

--- a/src/pages/AppDetails/AppInfo/AppDescription.tsx
+++ b/src/pages/AppDetails/AppInfo/AppDescription.tsx
@@ -146,7 +146,7 @@ class AppDescription extends React.Component<AppDescriptionProps, AppDescription
               </Title>
               <Stack>
                 <StackItem id="health" className={'stack_service_details'}>
-                  <Text component={TextVariants.h3}> Health</Text>
+                  <Text component={TextVariants.h3}> Overall Health</Text>
                   <HealthIndicator
                     id={app.name}
                     health={this.props.health}

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
@@ -121,7 +121,7 @@ class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps
               </Title>
               <Stack className={'stack_service_details'}>
                 <StackItem id={'health'}>
-                  <Text component={TextVariants.h3}> Health </Text>
+                  <Text component={TextVariants.h3}> Overall Health </Text>
                   <HealthIndicator id={this.props.name} health={this.props.health} mode={DisplayMode.LARGE} />
                 </StackItem>
               </Stack>

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
@@ -106,7 +106,7 @@ exports[`#ServiceInfoDescription render correctly with data should render servic
             <Text
               component="h3"
             >
-               Health 
+               Overall Health 
             </Text>
             <HealthIndicator
               id="reviews"

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadDescription.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadDescription.tsx
@@ -108,7 +108,7 @@ class WorkloadDescription extends React.Component<WorkloadDescriptionProps, Work
               </Title>
               <Stack>
                 <StackItem id="health" className={'stack_service_details'}>
-                  <Text component={TextVariants.h3}> Health</Text>
+                  <Text component={TextVariants.h3}> Overall Health</Text>
                   <HealthIndicator
                     id={workload.name}
                     health={this.props.health}

--- a/src/pages/WorkloadDetails/WorkloadInfo/__tests__/__snapshots__/WorkloadDescription.test.tsx.snap
+++ b/src/pages/WorkloadDetails/WorkloadInfo/__tests__/__snapshots__/WorkloadDescription.test.tsx.snap
@@ -125,7 +125,7 @@ exports[`WorkloadDescription should render with runtimes 1`] = `
             <Text
               component="h3"
             >
-               Health
+               Overall Health
             </Text>
             <HealthIndicator
               id=""


### PR DESCRIPTION
* change "Health" to "Overall Health"
* change "Pods Status" to "Pod Status"
* remove the colon after "Pods Status" & "Error Rate over last 5m"
* remove the icons from "Pods Status" & "Error Rate over last 5m"

In screenshot left is BEFORE, right is AFTER the changes. I had to change the workloads and services cards to have children and keep the health icon in those cases. I hope that's OK; if not, I may need to do a 2nd iteration in the UXD call to check how to deal with those cases.

![image](https://user-images.githubusercontent.com/23639005/72098966-35d0d700-32e5-11ea-9bb1-008c77f813df.png)

Fixes kiali/kiali#1720