### PR TITLE
Undo filter renaming on List Pages

### DIFF
--- a/src/pages/AppList/FiltersAndSorts.ts
+++ b/src/pages/AppList/FiltersAndSorts.ts
@@ -28,7 +28,7 @@ export const sortFields: GenericSortField<AppListItem>[] = [
   },
   {
     id: 'appname',
-    title: 'Name',
+    title: 'App Name',
     isNumeric: false,
     param: 'wn',
     compare: (a, b) => a.name.localeCompare(b.name)
@@ -72,8 +72,8 @@ export const sortFields: GenericSortField<AppListItem>[] = [
 
 const appNameFilter: FilterType = {
   id: 'appname',
-  title: 'Name',
-  placeholder: 'Filter by Name',
+  title: 'App Name',
+  placeholder: 'Filter by App Name',
   filterType: TextInputTypes.text,
   action: FILTER_ACTION_APPEND,
   filterValues: []

--- a/src/pages/IstioConfigList/FiltersAndSorts.ts
+++ b/src/pages/IstioConfigList/FiltersAndSorts.ts
@@ -32,7 +32,7 @@ export const sortFields: SortField<IstioConfigItem>[] = [
   },
   {
     id: 'istioname',
-    title: 'Name',
+    title: 'Istio Name',
     isNumeric: false,
     param: 'in',
     compare: (a: IstioConfigItem, b: IstioConfigItem) => {
@@ -76,8 +76,8 @@ export const sortFields: SortField<IstioConfigItem>[] = [
 
 export const istioNameFilter: FilterType = {
   id: 'istioname',
-  title: 'Name',
-  placeholder: 'Filter by Name',
+  title: 'Istio Name',
+  placeholder: 'Filter by Istio Name',
   filterType: TextInputTypes.text,
   action: FILTER_ACTION_APPEND,
   filterValues: []
@@ -85,8 +85,8 @@ export const istioNameFilter: FilterType = {
 
 export const istioTypeFilter: FilterType = {
   id: 'istiotype',
-  title: 'Type',
-  placeholder: 'Filter by Type',
+  title: 'Istio Type',
+  placeholder: 'Filter by Istio Type',
   filterType: 'typeahead',
   action: FILTER_ACTION_APPEND,
   filterValues: [

--- a/src/pages/Overview/Filters.ts
+++ b/src/pages/Overview/Filters.ts
@@ -84,7 +84,7 @@ const summarizeHealthFilters = (healthFilters: ActiveFilter[]) => {
 export const healthFilter: FilterTypeWithFilter<NamespaceInfo> = {
   id: 'health',
   title: 'Health',
-  placeholder: 'Filter by Health',
+  placeholder: 'Filter by Application Health',
   filterType: 'select',
   action: FILTER_ACTION_APPEND,
   filterValues: healthValues,

--- a/src/pages/ServiceList/FiltersAndSorts.ts
+++ b/src/pages/ServiceList/FiltersAndSorts.ts
@@ -28,7 +28,7 @@ export const sortFields: GenericSortField<ServiceListItem>[] = [
   },
   {
     id: 'servicename',
-    title: 'Name',
+    title: 'Service Name',
     isNumeric: false,
     param: 'sn',
     compare: (a, b) => a.name.localeCompare(b.name)
@@ -105,8 +105,8 @@ export const sortFields: GenericSortField<ServiceListItem>[] = [
 
 const serviceNameFilter: FilterType = {
   id: 'servicename',
-  title: 'Name',
-  placeholder: 'Filter by Name',
+  title: 'Service Name',
+  placeholder: 'Filter by Service Name',
   filterType: TextInputTypes.text,
   action: FILTER_ACTION_APPEND,
   filterValues: []

--- a/src/pages/ServiceList/__tests__/ServiceListComponent.test.ts
+++ b/src/pages/ServiceList/__tests__/ServiceListComponent.test.ts
@@ -54,7 +54,7 @@ describe('SortField#compare', () => {
 });
 
 describe('ServiceListContainer#sortServices', () => {
-  const sortField = ServiceListFilters.sortFields.find(s => s.title === 'Name')!;
+  const sortField = ServiceListFilters.sortFields.find(s => s.title === 'Service Name')!;
   const services = [makeService('A', -1), makeService('B', -1)];
   it('should sort ascending', done => {
     ServiceListFilters.sortServices(services, sortField, true).then(sorted => {

--- a/src/pages/WorkloadList/FiltersAndSorts.ts
+++ b/src/pages/WorkloadList/FiltersAndSorts.ts
@@ -29,14 +29,14 @@ export const sortFields: GenericSortField<WorkloadListItem>[] = [
   },
   {
     id: 'workloadname',
-    title: 'Name',
+    title: 'Workload Name',
     isNumeric: false,
     param: 'wn',
     compare: (a, b) => a.name.localeCompare(b.name)
   },
   {
     id: 'workloadtype',
-    title: 'Type',
+    title: 'Workload Type',
     isNumeric: false,
     param: 'wt',
     compare: (a, b) => a.type.localeCompare(b.type)
@@ -137,8 +137,8 @@ export const sortFields: GenericSortField<WorkloadListItem>[] = [
 
 const workloadNameFilter: FilterType = {
   id: 'workloadname',
-  title: 'Name',
-  placeholder: 'Filter by Name',
+  title: 'Workload Name',
+  placeholder: 'Filter by Workload Name',
   filterType: TextInputTypes.text,
   action: FILTER_ACTION_APPEND,
   filterValues: []
@@ -164,8 +164,8 @@ const versionLabelFilter: FilterType = {
 
 const workloadTypeFilter: FilterType = {
   id: 'workloadtype',
-  title: 'Type',
-  placeholder: 'Filter by Type',
+  title: 'Workload Type',
+  placeholder: 'Filter by Workload Type',
   filterType: 'select',
   action: FILTER_ACTION_APPEND,
   filterValues: [


### PR DESCRIPTION
** Describe the change **

When there are two filters with same names, the filter keeps applied between pages. That is the case of Name filter for Services/Apps/Workloads.

The bug was introduced here: https://github.com/kiali/kiali-ui/pull/1590