### PR TITLE
Remove capitalize class from DetailObject component

### DIFF
--- a/src/components/Details/DetailObject.tsx
+++ b/src/components/Details/DetailObject.tsx
@@ -54,7 +54,7 @@ class DetailObject extends React.Component<DetailObjectProps> {
             this.label(name, value)
           ) : (
             <span>
-              <span className="text-capitalize">{name ? `[${name}]` : name}</span> {value.toString()}
+              <span>{name ? `[${name}]` : name}</span> {value.toString()}
             </span>
           )}
         </div>
@@ -85,7 +85,7 @@ class DetailObject extends React.Component<DetailObjectProps> {
 
     return childrenList.length > 0 ? (
       <div>
-        <strong className="text-capitalize">{name}</strong>
+        <strong>{name}</strong>
         {depth === 0 && !!this.props.validation && this.props.validation.message ? (
           <Validation
             severity={this.props.validation.severity}

--- a/src/components/Details/__tests__/DetailObject.test.tsx
+++ b/src/components/Details/__tests__/DetailObject.test.tsx
@@ -32,13 +32,13 @@ describe('DetailObject test', () => {
     expect(shallowToJson(wrapper)).toBeDefined();
     expect(shallowToJson(wrapper)).toMatchSnapshot();
 
-    expect(wrapper.html()).toContain('<span class="text-capitalize">[host]</span>');
-    expect(wrapper.html()).toContain('<span class="text-capitalize">[subset]</span>');
-    expect(wrapper.html()).toContain('<span class="text-capitalize">[weight]</span>');
+    expect(wrapper.html()).toContain('<span>[host]</span>');
+    expect(wrapper.html()).toContain('<span>[subset]</span>');
+    expect(wrapper.html()).toContain('<span>[weight]</span>');
 
-    expect(wrapper.html()).toContain('<strong class="text-capitalize">port</strong>');
-    expect(wrapper.html()).toContain('<span class="text-capitalize">[number]</span>');
-    expect(wrapper.html()).toContain('<span class="text-capitalize">[name]</span>');
+    expect(wrapper.html()).toContain('<strong>port</strong>');
+    expect(wrapper.html()).toContain('<span>[number]</span>');
+    expect(wrapper.html()).toContain('<span>[name]</span>');
   });
 
   it("doesn't print excluded fields", () => {
@@ -49,13 +49,13 @@ describe('DetailObject test', () => {
     expect(shallowToJson(wrapper)).toBeDefined();
     expect(shallowToJson(wrapper)).toMatchSnapshot();
 
-    expect(wrapper.html()).toContain('<span class="text-capitalize">[host]</span>');
-    expect(wrapper.html()).toContain('<span class="text-capitalize">[subset]</span>');
-    expect(wrapper.html()).toContain('<span class="text-capitalize">[weight]</span>');
+    expect(wrapper.html()).toContain('<span>[host]</span>');
+    expect(wrapper.html()).toContain('<span>[subset]</span>');
+    expect(wrapper.html()).toContain('<span>[weight]</span>');
 
-    expect(wrapper.html()).not.toContain('<strong class="text-capitalize">port</strong>');
-    expect(wrapper.html()).not.toContain('<span class="text-capitalize">[number]</span>');
-    expect(wrapper.html()).not.toContain('<span class="text-capitalize">[name]</span>');
+    expect(wrapper.html()).not.toContain('<strong>port</strong>');
+    expect(wrapper.html()).not.toContain('<span>[number]</span>');
+    expect(wrapper.html()).not.toContain('<span>[name]</span>');
   });
 
   it('prints an alert message', () => {

--- a/src/components/Details/__tests__/__snapshots__/DetailObject.test.tsx.snap
+++ b/src/components/Details/__tests__/__snapshots__/DetailObject.test.tsx.snap
@@ -3,9 +3,7 @@
 exports[`DetailObject test doesn't print any alert message 1`] = `
 <div>
   <div>
-    <strong
-      className="text-capitalize"
-    >
+    <strong>
       nodejs
     </strong>
     <ul
@@ -15,9 +13,7 @@ exports[`DetailObject test doesn't print any alert message 1`] = `
         key="key_sssssssss_k0"
       >
         <div>
-          <strong
-            className="text-capitalize"
-          >
+          <strong>
             destination
           </strong>
           <ul
@@ -30,9 +26,7 @@ exports[`DetailObject test doesn't print any alert message 1`] = `
                 className="label-collection"
               >
                 <span>
-                  <span
-                    className="text-capitalize"
-                  >
+                  <span>
                     [host]
                   </span>
                    
@@ -47,9 +41,7 @@ exports[`DetailObject test doesn't print any alert message 1`] = `
                 className="label-collection"
               >
                 <span>
-                  <span
-                    className="text-capitalize"
-                  >
+                  <span>
                     [subset]
                   </span>
                    
@@ -61,9 +53,7 @@ exports[`DetailObject test doesn't print any alert message 1`] = `
               key="key_sssssssss_k2"
             >
               <div>
-                <strong
-                  className="text-capitalize"
-                >
+                <strong>
                   port
                 </strong>
                 <ul
@@ -76,9 +66,7 @@ exports[`DetailObject test doesn't print any alert message 1`] = `
                       className="label-collection"
                     >
                       <span>
-                        <span
-                          className="text-capitalize"
-                        >
+                        <span>
                           [number]
                         </span>
                          
@@ -93,9 +81,7 @@ exports[`DetailObject test doesn't print any alert message 1`] = `
                       className="label-collection"
                     >
                       <span>
-                        <span
-                          className="text-capitalize"
-                        >
+                        <span>
                           [name]
                         </span>
                          
@@ -116,9 +102,7 @@ exports[`DetailObject test doesn't print any alert message 1`] = `
           className="label-collection"
         >
           <span>
-            <span
-              className="text-capitalize"
-            >
+            <span>
               [weight]
             </span>
              
@@ -134,9 +118,7 @@ exports[`DetailObject test doesn't print any alert message 1`] = `
 exports[`DetailObject test doesn't print excluded fields 1`] = `
 <div>
   <div>
-    <strong
-      className="text-capitalize"
-    >
+    <strong>
       nodejs
     </strong>
     <ul
@@ -146,9 +128,7 @@ exports[`DetailObject test doesn't print excluded fields 1`] = `
         key="key_sssssssss_k0"
       >
         <div>
-          <strong
-            className="text-capitalize"
-          >
+          <strong>
             destination
           </strong>
           <ul
@@ -161,9 +141,7 @@ exports[`DetailObject test doesn't print excluded fields 1`] = `
                 className="label-collection"
               >
                 <span>
-                  <span
-                    className="text-capitalize"
-                  >
+                  <span>
                     [host]
                   </span>
                    
@@ -178,9 +156,7 @@ exports[`DetailObject test doesn't print excluded fields 1`] = `
                 className="label-collection"
               >
                 <span>
-                  <span
-                    className="text-capitalize"
-                  >
+                  <span>
                     [subset]
                   </span>
                    
@@ -201,9 +177,7 @@ exports[`DetailObject test doesn't print excluded fields 1`] = `
           className="label-collection"
         >
           <span>
-            <span
-              className="text-capitalize"
-            >
+            <span>
               [weight]
             </span>
              
@@ -219,9 +193,7 @@ exports[`DetailObject test doesn't print excluded fields 1`] = `
 exports[`DetailObject test prints a nested list with all attributes in the detail 1`] = `
 <div>
   <div>
-    <strong
-      className="text-capitalize"
-    >
+    <strong>
       nodejs
     </strong>
     <ul
@@ -231,9 +203,7 @@ exports[`DetailObject test prints a nested list with all attributes in the detai
         key="key_sssssssss_k0"
       >
         <div>
-          <strong
-            className="text-capitalize"
-          >
+          <strong>
             destination
           </strong>
           <ul
@@ -246,9 +216,7 @@ exports[`DetailObject test prints a nested list with all attributes in the detai
                 className="label-collection"
               >
                 <span>
-                  <span
-                    className="text-capitalize"
-                  >
+                  <span>
                     [host]
                   </span>
                    
@@ -263,9 +231,7 @@ exports[`DetailObject test prints a nested list with all attributes in the detai
                 className="label-collection"
               >
                 <span>
-                  <span
-                    className="text-capitalize"
-                  >
+                  <span>
                     [subset]
                   </span>
                    
@@ -277,9 +243,7 @@ exports[`DetailObject test prints a nested list with all attributes in the detai
               key="key_sssssssss_k2"
             >
               <div>
-                <strong
-                  className="text-capitalize"
-                >
+                <strong>
                   port
                 </strong>
                 <ul
@@ -292,9 +256,7 @@ exports[`DetailObject test prints a nested list with all attributes in the detai
                       className="label-collection"
                     >
                       <span>
-                        <span
-                          className="text-capitalize"
-                        >
+                        <span>
                           [number]
                         </span>
                          
@@ -309,9 +271,7 @@ exports[`DetailObject test prints a nested list with all attributes in the detai
                       className="label-collection"
                     >
                       <span>
-                        <span
-                          className="text-capitalize"
-                        >
+                        <span>
                           [name]
                         </span>
                          
@@ -332,9 +292,7 @@ exports[`DetailObject test prints a nested list with all attributes in the detai
           className="label-collection"
         >
           <span>
-            <span
-              className="text-capitalize"
-            >
+            <span>
               [weight]
             </span>
              
@@ -350,9 +308,7 @@ exports[`DetailObject test prints a nested list with all attributes in the detai
 exports[`DetailObject test prints an alert message 1`] = `
 <div>
   <div>
-    <strong
-      className="text-capitalize"
-    >
+    <strong>
       nodejs
     </strong>
     <Validation
@@ -367,9 +323,7 @@ exports[`DetailObject test prints an alert message 1`] = `
         key="key_sssssssss_k0"
       >
         <div>
-          <strong
-            className="text-capitalize"
-          >
+          <strong>
             destination
           </strong>
           <ul
@@ -382,9 +336,7 @@ exports[`DetailObject test prints an alert message 1`] = `
                 className="label-collection"
               >
                 <span>
-                  <span
-                    className="text-capitalize"
-                  >
+                  <span>
                     [host]
                   </span>
                    
@@ -399,9 +351,7 @@ exports[`DetailObject test prints an alert message 1`] = `
                 className="label-collection"
               >
                 <span>
-                  <span
-                    className="text-capitalize"
-                  >
+                  <span>
                     [subset]
                   </span>
                    
@@ -413,9 +363,7 @@ exports[`DetailObject test prints an alert message 1`] = `
               key="key_sssssssss_k2"
             >
               <div>
-                <strong
-                  className="text-capitalize"
-                >
+                <strong>
                   port
                 </strong>
                 <ul
@@ -428,9 +376,7 @@ exports[`DetailObject test prints an alert message 1`] = `
                       className="label-collection"
                     >
                       <span>
-                        <span
-                          className="text-capitalize"
-                        >
+                        <span>
                           [number]
                         </span>
                          
@@ -445,9 +391,7 @@ exports[`DetailObject test prints an alert message 1`] = `
                       className="label-collection"
                     >
                       <span>
-                        <span
-                          className="text-capitalize"
-                        >
+                        <span>
                           [name]
                         </span>
                          
@@ -468,9 +412,7 @@ exports[`DetailObject test prints an alert message 1`] = `
           className="label-collection"
         >
           <span>
-            <span
-              className="text-capitalize"
-            >
+            <span>
               [weight]
             </span>
              


### PR DESCRIPTION
** Describe the change **

Remove the `text-capitalize` class from the DetailObject component. Because the match rule's keys are case-sensitive, users cannot distinguish if their original case when using `text-capitalize` class.

** Screenshot **

Before change:
![Jietu20200119-111038](https://user-images.githubusercontent.com/5144108/72674119-28b6a380-3aae-11ea-80b0-844d6d98013f.jpg)

After change:

![Jietu20200119-112510](https://user-images.githubusercontent.com/5144108/72674140-65829a80-3aae-11ea-87b6-ef624a45930e.jpg)
