### PR TITLE
Add structure to create new Istio config resources at namespace level

### DIFF
--- a/src/components/DefaultSecondaryMasthead/DefaultSecondaryMasthead.tsx
+++ b/src/components/DefaultSecondaryMasthead/DefaultSecondaryMasthead.tsx
@@ -3,15 +3,19 @@ import { Title } from '@patternfly/react-core';
 import SecondaryMasthead from '../Nav/SecondaryMasthead';
 import NamespaceDropdownContainer from '../NamespaceDropdown';
 
-const titleShow = ['applications', 'workloads', 'services', 'istio'];
+const titles = ['applications', 'workloads', 'services', 'istio', 'istio/new'];
 export default class DefaultSecondaryMasthead extends React.Component {
   showTitle() {
     const path = window.location.pathname.replace('/console/', '');
 
-    if (titleShow.includes(path)) {
+    if (titles.includes(path)) {
+      let title = path.charAt(0).toUpperCase() + path.slice(1);
+      if (path === 'istio/new') {
+        title = 'Create New Istio Config';
+      }
       return (
         <Title headingLevel="h1" size="4xl" style={{ margin: '20px 0 20px' }}>
-          {path.charAt(0).toUpperCase() + path.slice(1)}
+          {title}
         </Title>
       );
     }

--- a/src/components/IstioActions/IstioActionsDropdown.tsx
+++ b/src/components/IstioActions/IstioActionsDropdown.tsx
@@ -31,8 +31,7 @@ class IstioActionDropdown extends React.Component<Props, State> {
     };
   }
 
-  onSelect = e => {
-    console.log(e);
+  onSelect = _ => {
     this.setState({
       dropdownOpen: !this.state.dropdownOpen
     });

--- a/src/components/IstioActions/IstioActionsNamespaceDropdown.tsx
+++ b/src/components/IstioActions/IstioActionsNamespaceDropdown.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import { Dropdown, DropdownItem, DropdownPosition, DropdownToggle } from '@patternfly/react-core';
+import history from '../../app/History';
+
+type Props = {};
+
+type State = {
+  dropdownOpen: boolean;
+};
+
+class IstioActionsNamespaceDropdown extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      dropdownOpen: false
+    };
+  }
+
+  onSelect = _ => {
+    this.setState({
+      dropdownOpen: !this.state.dropdownOpen
+    });
+  };
+
+  onToggle = (dropdownState: boolean) => {
+    this.setState({
+      dropdownOpen: dropdownState
+    });
+  };
+
+  onClickCreate = () => {
+    history.push('/istio/new');
+  };
+
+  render() {
+    return (
+      <Dropdown
+        id="actions"
+        title="Actions"
+        toggle={<DropdownToggle onToggle={this.onToggle}>Actions</DropdownToggle>}
+        onSelect={this.onSelect}
+        position={DropdownPosition.right}
+        isOpen={this.state.dropdownOpen}
+        dropdownItems={[
+          <DropdownItem key="createIstioConfig" onClick={this.onClickCreate}>
+            Create New Istio Config
+          </DropdownItem>
+        ]}
+      />
+    );
+  }
+}
+
+export default IstioActionsNamespaceDropdown;

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -111,6 +111,7 @@ const conf = {
         `api/namespaces/${namespace}/istio/${objectType}/${object}`,
       istioConfigDetailSubtype: (namespace: string, objectType: string, objectSubtype: string, object: string) =>
         `api/namespaces/${namespace}/istio/${objectType}/${objectSubtype}/${object}`,
+      istioPermissions: 'api/istio/permissions',
       jaeger: 'api/jaeger',
       jaegerTraces: (namespace: string, service: string) => `api/namespaces/${namespace}/services/${service}/traces`,
       jaegerTrace: (namespace: string, service: string, idTrace: string) =>

--- a/src/pages/IstioConfigList/IstioConfigListComponent.tsx
+++ b/src/pages/IstioConfigList/IstioConfigListComponent.tsx
@@ -23,6 +23,7 @@ import RefreshButtonContainer from '../../components/Refresh/RefreshButton';
 import { VirtualList } from '../../components/VirtualList/VirtualList';
 import { showInMessageCenter } from '../../utils/IstioValidationUtils';
 import { ObjectValidation } from '../../types/IstioObjects';
+import IstioActionsNamespaceDropdown from '../../components/IstioActions/IstioActionsNamespaceDropdown';
 
 interface IstioConfigListComponentState extends FilterComponent.State<IstioConfigItem> {}
 interface IstioConfigListComponentProps extends FilterComponent.Props<IstioConfigItem> {
@@ -172,7 +173,10 @@ class IstioConfigListComponent extends FilterComponent.Component<
         <StatefulFilters
           initialFilters={IstioConfigListFilters.availableFilters}
           onFilterChange={this.onFilterChange}
-          rightToolbar={[<RefreshButtonContainer key={'Refresh'} handleRefresh={this.updateListItems} />]}
+          rightToolbar={[
+            <RefreshButtonContainer key={'Refresh'} handleRefresh={this.updateListItems} />,
+            <IstioActionsNamespaceDropdown />
+          ]}
         />
       </VirtualList>
     );

--- a/src/pages/IstioConfigNew/GatewayForm.tsx
+++ b/src/pages/IstioConfigNew/GatewayForm.tsx
@@ -1,0 +1,247 @@
+import * as React from 'react';
+import { ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
+import { Button, FormSelect, FormSelectOption, TextInput } from '@patternfly/react-core';
+import { style } from 'typestyle';
+import { PfColors } from '../../components/Pf/PfColors';
+
+const headerCells: ICell[] = [
+  {
+    title: 'Hosts',
+    props: {}
+  },
+  {
+    title: 'Port Number',
+    props: {}
+  },
+  {
+    title: 'Port Name',
+    props: {}
+  },
+  {
+    title: 'Port Protocol',
+    props: {}
+  },
+  {
+    title: '',
+    props: {}
+  }
+];
+
+const protocols = ['HTTP', 'HTTPS', 'GRPC', 'HTTP2', 'MONGO', 'TCP', 'TLS'];
+
+const noGatewayServerStyle = style({
+  marginTop: 15,
+  color: PfColors.Red100
+});
+
+type Props = {
+  gatewayServers: GatewayServer[];
+  onAdd: (server: GatewayServer) => void;
+  onRemove: (index: number) => void;
+};
+
+export type GatewayServer = {
+  hosts: string[];
+  portNumber: string;
+  portName: string;
+  portProtocol: string;
+};
+
+type State = {
+  addGatewayServer: GatewayServer;
+};
+
+class GatewayForm extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      addGatewayServer: {
+        hosts: [],
+        portNumber: '80',
+        portName: 'http',
+        portProtocol: 'HTTP'
+      }
+    };
+  }
+
+  // @ts-ignore
+  actionResolver = (rowData, { rowIndex }) => {
+    const removeAction = {
+      title: 'Remove Server',
+      // @ts-ignore
+      onClick: (event, rowIndex, rowData, extraData) => {
+        this.props.onRemove(rowIndex);
+      }
+    };
+    if (rowIndex < this.props.gatewayServers.length) {
+      return [removeAction];
+    }
+    return [];
+  };
+
+  onAddHosts = (value: string, _) => {
+    this.setState(prevState => ({
+      addGatewayServer: {
+        hosts: value.trim().length === 0 ? [] : value.split(',').map(host => host.trim()),
+        portNumber: prevState.addGatewayServer.portNumber,
+        portName: prevState.addGatewayServer.portName,
+        portProtocol: prevState.addGatewayServer.portProtocol
+      }
+    }));
+  };
+
+  onAddPortNumber = (value: string, _) => {
+    this.setState(prevState => ({
+      addGatewayServer: {
+        hosts: prevState.addGatewayServer.hosts,
+        portNumber: value.trim(),
+        portName: prevState.addGatewayServer.portName,
+        portProtocol: prevState.addGatewayServer.portProtocol
+      }
+    }));
+  };
+
+  onAddPortName = (value: string, _) => {
+    this.setState(prevState => ({
+      addGatewayServer: {
+        hosts: prevState.addGatewayServer.hosts,
+        portNumber: prevState.addGatewayServer.portNumber,
+        portName: value.trim(),
+        portProtocol: prevState.addGatewayServer.portProtocol
+      }
+    }));
+  };
+
+  onAddPortProtocol = (value: string, _) => {
+    this.setState(prevState => ({
+      addGatewayServer: {
+        hosts: prevState.addGatewayServer.hosts,
+        portNumber: prevState.addGatewayServer.portNumber,
+        portName: prevState.addGatewayServer.portName,
+        portProtocol: value.trim()
+      }
+    }));
+  };
+
+  onAddServer = () => {
+    this.props.onAdd(this.state.addGatewayServer);
+    this.setState({
+      addGatewayServer: {
+        hosts: [],
+        portNumber: '80',
+        portName: 'http',
+        portProtocol: 'HTTP'
+      }
+    });
+  };
+
+  rows() {
+    return this.props.gatewayServers
+      .map((gw, i) => ({
+        key: 'gw' + i,
+        cells: [
+          <>
+            {gw.hosts.map(host => (
+              <div>{host}</div>
+            ))}
+          </>,
+          <>{gw.portNumber}</>,
+          <>{gw.portName}</>,
+          <>{gw.portProtocol}</>,
+          ''
+        ]
+      }))
+      .concat([
+        {
+          key: 'gwNew',
+          cells: [
+            <>
+              <TextInput
+                value={this.state.addGatewayServer.hosts.join(',')}
+                type="text"
+                id="addHosts"
+                aria-describedby="add hosts"
+                name="addHosts"
+                onChange={this.onAddHosts}
+                isValid={this.state.addGatewayServer.hosts.length > 0}
+              />
+            </>,
+            <>
+              <TextInput
+                value={this.state.addGatewayServer.portNumber}
+                type="number"
+                id="addPortNumber"
+                aria-describedby="add port number"
+                name="addPortNumber"
+                onChange={this.onAddPortNumber}
+                isValid={
+                  this.state.addGatewayServer.portNumber.length > 0 &&
+                  !isNaN(Number(this.state.addGatewayServer.portNumber))
+                }
+              />
+            </>,
+            <>
+              <TextInput
+                value={this.state.addGatewayServer.portName}
+                type="text"
+                id="addPortName"
+                aria-describedby="add port name"
+                name="addPortName"
+                onChange={this.onAddPortName}
+                isValid={this.state.addGatewayServer.portName.length > 0}
+              />
+            </>,
+            <>
+              <FormSelect
+                value={this.state.addGatewayServer.portProtocol}
+                id="addPortProtocol"
+                name="addPortProtocol"
+                onChange={this.onAddPortProtocol}
+              >
+                {protocols.map((option, index) => (
+                  <FormSelectOption isDisabled={false} key={index} value={option} label={option} />
+                ))}
+              </FormSelect>
+            </>,
+            <>
+              <Button
+                variant="secondary"
+                isDisabled={
+                  this.state.addGatewayServer.hosts.length === 0 ||
+                  this.state.addGatewayServer.portNumber.length === 0 ||
+                  this.state.addGatewayServer.portName.length === 0 ||
+                  isNaN(Number(this.state.addGatewayServer.portNumber))
+                }
+                onClick={this.onAddServer}
+              >
+                Add Server
+              </Button>
+            </>
+          ]
+        }
+      ]);
+  }
+
+  render() {
+    return (
+      <>
+        Servers defined:
+        <Table
+          aria-label="Gateway Servers"
+          cells={headerCells}
+          rows={this.rows()}
+          // @ts-ignore
+          actionResolver={this.actionResolver}
+        >
+          <TableHeader />
+          <TableBody />
+        </Table>
+        {this.props.gatewayServers.length === 0 && (
+          <div className={noGatewayServerStyle}>Gateway has no Servers Defined</div>
+        )}
+      </>
+    );
+  }
+}
+
+export default GatewayForm;

--- a/src/pages/IstioConfigNew/GatewayForm.tsx
+++ b/src/pages/IstioConfigNew/GatewayForm.tsx
@@ -168,11 +168,11 @@ class GatewayForm extends React.Component<Props, State> {
   rows() {
     return this.props.gatewayServers
       .map((gw, i) => ({
-        key: 'gw' + i,
+        key: 'gatewayServer' + i,
         cells: [
           <>
-            {gw.hosts.map(host => (
-              <div key={'gwHost_' + host}>{host}</div>
+            {gw.hosts.map((host, j) => (
+              <div key={'gwHost_' + i + '_' + j}>{host}</div>
             ))}
           </>,
           <>{gw.portNumber}</>,
@@ -190,12 +190,17 @@ class GatewayForm extends React.Component<Props, State> {
                 value={this.state.addGatewayServer.hosts.join(',')}
                 type="text"
                 id="addHosts"
+                key="addHosts"
                 aria-describedby="add hosts"
                 name="addHosts"
                 onChange={this.onAddHosts}
                 isValid={this.state.validHosts}
               />
-              {!this.state.validHosts && <div className={noGatewayServerStyle}>{hostsHelperText}</div>}
+              {!this.state.validHosts && (
+                <div key="hostsHelperText" className={noGatewayServerStyle}>
+                  {hostsHelperText}
+                </div>
+              )}
             </>,
             <>
               <TextInput
@@ -230,12 +235,13 @@ class GatewayForm extends React.Component<Props, State> {
                 onChange={this.onAddPortProtocol}
               >
                 {protocols.map((option, index) => (
-                  <FormSelectOption isDisabled={false} key={index} value={option} label={option} />
+                  <FormSelectOption isDisabled={false} key={'p' + index} value={option} label={option} />
                 ))}
               </FormSelect>
             </>,
             <>
               <Button
+                id="addServerBtn"
                 variant="secondary"
                 isDisabled={
                   !this.state.validHosts ||

--- a/src/pages/IstioConfigNew/GatewayForm.tsx
+++ b/src/pages/IstioConfigNew/GatewayForm.tsx
@@ -47,6 +47,11 @@ export type GatewayServer = {
   portProtocol: string;
 };
 
+// Gateway and Sidecar states are consolidated in the parent page
+export type GatewayState = {
+  gatewayServers: GatewayServer[];
+};
+
 type State = {
   addGatewayServer: GatewayServer;
 };

--- a/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
+++ b/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
@@ -1,0 +1,160 @@
+import * as React from 'react';
+import { KialiAppState } from '../../store/Store';
+import { activeNamespacesSelector } from '../../store/Selectors';
+import { connect } from 'react-redux';
+import Namespace from '../../types/Namespace';
+import { ActionGroup, Button, Form, FormGroup, FormSelect, FormSelectOption, TextInput } from '@patternfly/react-core';
+import { RenderContent } from '../../components/Nav/Page';
+import { style } from 'typestyle';
+import GatewayForm, { GatewayServer } from './GatewayForm';
+import SidecarForm from './SidecarForm';
+
+type Props = {
+  activeNamespaces: Namespace[];
+};
+
+type State = {
+  istioResource: string;
+  name: string;
+  gatewayServers: GatewayServer[];
+};
+
+const formPadding = style({ padding: '30px 20px 30px 20px' });
+
+const GATEWAY = 'Gateway';
+const SIDECAR = 'Sidecar';
+
+const istioResourceOptions = [
+  { value: GATEWAY, label: GATEWAY, disabled: false },
+  { value: SIDECAR, label: SIDECAR, disabled: false }
+];
+
+class IstioConfigNewPage extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      istioResource: istioResourceOptions[0].value,
+      name: '',
+      gatewayServers: []
+    };
+  }
+  onIstioResourceChange = (value, _) => {
+    this.setState({
+      istioResource: value,
+      name: ''
+    });
+  };
+
+  onNameChange = (value, _) => {
+    this.setState({
+      name: value
+    });
+  };
+
+  onIstioResourceCreate = () => {
+    console.log('TODELETE Create the resource selected');
+  };
+
+  render() {
+    const isNameValid = this.state.name.length > 0;
+    const isNamespacesValid = this.props.activeNamespaces.length > 0;
+    const isGatewayFormValid = this.state.istioResource === GATEWAY && this.state.gatewayServers.length > 0;
+    const isFutureFormsValid = false;
+    const isFormValid = isNameValid && isNamespacesValid && (isGatewayFormValid || isFutureFormsValid);
+    return (
+      <RenderContent>
+        <Form className={formPadding} isHorizontal={true}>
+          <FormGroup label="Istio Resource" fieldId="istio-resource">
+            <FormSelect
+              value={this.state.istioResource}
+              onChange={this.onIstioResourceChange}
+              id="istio-resource"
+              name="istio-resource"
+            >
+              {istioResourceOptions.map((option, index) => (
+                <FormSelectOption isDisabled={option.disabled} key={index} value={option.value} label={option.label} />
+              ))}
+            </FormSelect>
+          </FormGroup>
+          <FormGroup
+            label="Name"
+            isRequired={true}
+            fieldId="name"
+            helperText={this.state.istioResource + ' name'}
+            helperTextInvalid={this.state.istioResource + ' name is required'}
+            isValid={isNameValid}
+          >
+            <TextInput
+              value={this.state.name}
+              isRequired={true}
+              type="text"
+              id="name"
+              aria-describedby="name"
+              name="name"
+              onChange={this.onNameChange}
+              isValid={isNameValid}
+            />
+          </FormGroup>
+          <FormGroup
+            label="Namespaces"
+            isRequired={true}
+            fieldId="namespaces"
+            helperText={'Select namespace(s) where this configuration will be applied'}
+            helperTextInvalid={'At least one namespace should be selected'}
+            isValid={isNamespacesValid}
+          >
+            <TextInput
+              value={this.props.activeNamespaces.map(n => n.name).join(',')}
+              isRequired={true}
+              type="text"
+              id="namespaces"
+              aria-describedby="namespaces"
+              name="namespaces"
+              isDisabled={true}
+              isValid={isNamespacesValid}
+            />
+          </FormGroup>
+          {this.state.istioResource === GATEWAY && (
+            <GatewayForm
+              gatewayServers={this.state.gatewayServers}
+              onAdd={gatewayServer => {
+                this.setState(prevState => {
+                  prevState.gatewayServers.push(gatewayServer);
+                  return {
+                    gatewayServers: prevState.gatewayServers
+                  };
+                });
+              }}
+              onRemove={index => {
+                this.setState(prevState => {
+                  prevState.gatewayServers.splice(index, 1);
+                  return {
+                    gatewayServers: prevState.gatewayServers
+                  };
+                });
+              }}
+            />
+          )}
+          {this.state.istioResource === SIDECAR && <SidecarForm />}
+          <ActionGroup>
+            <Button variant="primary" isDisabled={!isFormValid}>
+              Create
+            </Button>
+            <Button variant="secondary">Cancel</Button>
+          </ActionGroup>
+        </Form>
+      </RenderContent>
+    );
+  }
+}
+
+const mapStateToProps = (state: KialiAppState) => ({
+  activeNamespaces: activeNamespacesSelector(state)
+});
+
+const IstioConfigNewPageContainer = connect(
+  mapStateToProps,
+  null
+)(IstioConfigNewPage);
+
+export default IstioConfigNewPageContainer;

--- a/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
+++ b/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
@@ -95,25 +95,30 @@ class IstioConfigNewPage extends React.Component<Props, State> {
   };
 
   fetchPermissions = () => {
-    this.promises
-      .register('permissions', API.getIstioPermissions(this.props.activeNamespaces.map(n => n.name)))
-      .then(permResponse => {
-        this.setState(
-          {
-            istioPermissions: permResponse.data
-          },
-          () => {
-            this.props.activeNamespaces.forEach(ns => {
-              if (!this.canCreate(ns.name)) {
-                AlertUtils.addInfo('User has not permissions to create Istio Config on namespace: ' + ns.name);
-              }
-            });
+    if (this.props.activeNamespaces.length > 0) {
+      this.promises
+        .register('permissions', API.getIstioPermissions(this.props.activeNamespaces.map(n => n.name)))
+        .then(permResponse => {
+          this.setState(
+            {
+              istioPermissions: permResponse.data
+            },
+            () => {
+              this.props.activeNamespaces.forEach(ns => {
+                if (!this.canCreate(ns.name)) {
+                  AlertUtils.addInfo('User has not permissions to create Istio Config on namespace: ' + ns.name);
+                }
+              });
+            }
+          );
+        })
+        .catch(error => {
+          // Canceled errors are expected on this query when page is unmounted
+          if (!error.isCanceled) {
+            AlertUtils.addError('Could not fetch Permissions.', error);
           }
-        );
-      })
-      .catch(error => {
-        AlertUtils.addError('Could not fetch Service Details.', error);
-      });
+        });
+    }
   };
 
   onIstioResourceChange = (value, _) => {
@@ -130,7 +135,6 @@ class IstioConfigNewPage extends React.Component<Props, State> {
   };
 
   onIstioResourceCreate = () => {
-    console.log('DELETE onIstioResourceCreate ' + this.state.istioResource);
     switch (this.state.istioResource) {
       case GATEWAY:
         this.promises

--- a/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
+++ b/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
@@ -7,7 +7,8 @@ import { ActionGroup, Button, Form, FormGroup, FormSelect, FormSelectOption, Tex
 import { RenderContent } from '../../components/Nav/Page';
 import { style } from 'typestyle';
 import GatewayForm, { GatewayServer } from './GatewayForm';
-import SidecarForm from './SidecarForm';
+import SidecarForm, { EgressHost } from './SidecarForm';
+import { serverConfig } from '../../config';
 
 type Props = {
   activeNamespaces: Namespace[];
@@ -16,7 +17,10 @@ type Props = {
 type State = {
   istioResource: string;
   name: string;
+  // Gateway state
   gatewayServers: GatewayServer[];
+  // Sidecar state
+  egressHosts: EgressHost[];
 };
 
 const formPadding = style({ padding: '30px 20px 30px 20px' });
@@ -35,7 +39,13 @@ class IstioConfigNewPage extends React.Component<Props, State> {
     this.state = {
       istioResource: istioResourceOptions[0].value,
       name: '',
-      gatewayServers: []
+      gatewayServers: [],
+      egressHosts: [
+        // Init with the istio-system/* for sidecar
+        {
+          host: serverConfig.istioNamespace + '/*'
+        }
+      ]
     };
   }
   onIstioResourceChange = (value, _) => {
@@ -135,7 +145,27 @@ class IstioConfigNewPage extends React.Component<Props, State> {
               }}
             />
           )}
-          {this.state.istioResource === SIDECAR && <SidecarForm />}
+          {this.state.istioResource === SIDECAR && (
+            <SidecarForm
+              egressHosts={this.state.egressHosts}
+              onAdd={egressHost => {
+                this.setState(prevState => {
+                  prevState.egressHosts.push(egressHost);
+                  return {
+                    egressHosts: prevState.egressHosts
+                  };
+                });
+              }}
+              onRemove={index => {
+                this.setState(prevState => {
+                  prevState.egressHosts.splice(index, 1);
+                  return {
+                    egressHosts: prevState.egressHosts
+                  };
+                });
+              }}
+            />
+          )}
           <ActionGroup>
             <Button variant="primary" isDisabled={!isFormValid}>
               Create

--- a/src/pages/IstioConfigNew/SidecarForm.tsx
+++ b/src/pages/IstioConfigNew/SidecarForm.tsx
@@ -26,8 +26,23 @@ export type EgressHost = {
 
 type Props = {
   egressHosts: EgressHost[];
-  onAdd: (host: EgressHost) => void;
-  onRemove: (index: number) => void;
+  addWorkloadSelector: boolean;
+  workloadSelectorLabels: string;
+  onAddEgressHost: (host: EgressHost) => void;
+  onChangeSelector: (
+    addWorkloadSelector: boolean,
+    workloadSelectorValid: boolean,
+    workloadSelectorLabels: string
+  ) => void;
+  onRemoveEgressHost: (index: number) => void;
+};
+
+// Gateway and Sidecar states are consolidated in the parent page
+export type SidecarState = {
+  egressHosts: EgressHost[];
+  addWorkloadSelector: boolean;
+  workloadSelectorValid: boolean;
+  workloadSelectorLabels: string;
 };
 
 type State = {
@@ -55,8 +70,8 @@ class SidecarForm extends React.Component<Props, State> {
     const removeAction = {
       title: 'Remove Server',
       // @ts-ignore
-      onClick: (event, rowIndex, rowData, extraData) => {
-        this.props.onRemove(rowIndex);
+      onClick: (event, rowIndex, _rowData, _extraData) => {
+        this.props.onRemoveEgressHost(rowIndex);
       }
     };
     if (rowIndex < this.props.egressHosts.length) {
@@ -74,7 +89,7 @@ class SidecarForm extends React.Component<Props, State> {
   };
 
   onAddEgressHost = () => {
-    this.props.onAdd(this.state.addEgressHost);
+    this.props.onAddEgressHost(this.state.addEgressHost);
     this.setState({
       addEgressHost: {
         host: ''
@@ -110,10 +125,19 @@ class SidecarForm extends React.Component<Props, State> {
         break;
       }
     }
-    this.setState({
-      workloadSelectorValid: isValid,
-      workloadSelectorLabels: value
-    });
+    this.setState(
+      {
+        workloadSelectorValid: isValid,
+        workloadSelectorLabels: value
+      },
+      () => {
+        this.props.onChangeSelector(
+          this.state.addWorkloadSelector,
+          this.state.workloadSelectorValid,
+          this.state.workloadSelectorLabels
+        );
+      }
+    );
   };
 
   rows() {
@@ -172,9 +196,18 @@ class SidecarForm extends React.Component<Props, State> {
             labelOff={' '}
             isChecked={this.state.addWorkloadSelector}
             onChange={() => {
-              this.setState(prevState => ({
-                addWorkloadSelector: !prevState.addWorkloadSelector
-              }));
+              this.setState(
+                prevState => ({
+                  addWorkloadSelector: !prevState.addWorkloadSelector
+                }),
+                () => {
+                  this.props.onChangeSelector(
+                    this.state.addWorkloadSelector,
+                    this.state.workloadSelectorValid,
+                    this.state.workloadSelectorLabels
+                  );
+                }
+              );
             }}
           />
         </FormGroup>

--- a/src/pages/IstioConfigNew/SidecarForm.tsx
+++ b/src/pages/IstioConfigNew/SidecarForm.tsx
@@ -1,8 +1,206 @@
 import * as React from 'react';
+import { ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
+import { style } from 'typestyle';
+import { PfColors } from '../../components/Pf/PfColors';
+import { Button, FormGroup, Switch, TextInput } from '@patternfly/react-core';
 
-class SidecarForm extends React.Component {
+const headerCells: ICell[] = [
+  {
+    title: 'Egress Host',
+    props: {}
+  },
+  {
+    title: '',
+    props: {}
+  }
+];
+
+const noEgressHostsStyle = style({
+  marginTop: 15,
+  color: PfColors.Red100
+});
+
+export type EgressHost = {
+  host: string;
+};
+
+type Props = {
+  egressHosts: EgressHost[];
+  onAdd: (host: EgressHost) => void;
+  onRemove: (index: number) => void;
+};
+
+type State = {
+  addEgressHost: EgressHost;
+  addWorkloadSelector: boolean;
+  workloadSelectorValid: boolean;
+  workloadSelectorLabels: string;
+};
+
+class SidecarForm extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      addEgressHost: {
+        host: ''
+      },
+      addWorkloadSelector: false,
+      workloadSelectorValid: false,
+      workloadSelectorLabels: ''
+    };
+  }
+
+  // @ts-ignore
+  actionResolver = (rowData, { rowIndex }) => {
+    const removeAction = {
+      title: 'Remove Server',
+      // @ts-ignore
+      onClick: (event, rowIndex, rowData, extraData) => {
+        this.props.onRemove(rowIndex);
+      }
+    };
+    if (rowIndex < this.props.egressHosts.length) {
+      return [removeAction];
+    }
+    return [];
+  };
+
+  onAddHost = (value: string, _) => {
+    this.setState({
+      addEgressHost: {
+        host: value.trim()
+      }
+    });
+  };
+
+  onAddEgressHost = () => {
+    this.props.onAdd(this.state.addEgressHost);
+    this.setState({
+      addEgressHost: {
+        host: ''
+      }
+    });
+  };
+
+  addWorkloadLabels = (value: string, _) => {
+    if (value.length === 0) {
+      this.setState({
+        workloadSelectorValid: false,
+        workloadSelectorLabels: ''
+      });
+      return;
+    }
+    value = value.trim();
+    const labels: string[] = value.split(',');
+    let isValid = true;
+    // Some smoke validation rules for the labels
+    for (let i = 0; i < labels.length; i++) {
+      const label = labels[i];
+      if (label.indexOf('=') < 0) {
+        isValid = false;
+        break;
+      }
+      const splitLabel: string[] = label.split('=');
+      if (splitLabel.length !== 2) {
+        isValid = false;
+        break;
+      }
+      if (splitLabel[0].trim().length === 0 || splitLabel[1].trim().length === 0) {
+        isValid = false;
+        break;
+      }
+    }
+    this.setState({
+      workloadSelectorValid: isValid,
+      workloadSelectorLabels: value
+    });
+  };
+
+  rows() {
+    return this.props.egressHosts
+      .map((eHost, i) => ({
+        key: 'eH' + i,
+        cells: [<>{eHost.host}</>, '']
+      }))
+      .concat([
+        {
+          key: 'egressHostNew',
+          cells: [
+            <>
+              <TextInput
+                value={this.state.addEgressHost.host}
+                type="text"
+                id="addEgressHost"
+                aria-describedby="add egress host"
+                name="addHost"
+                onChange={this.onAddHost}
+                isValid={this.state.addEgressHost.host.length > 0}
+              />
+            </>,
+            <>
+              <Button
+                variant="secondary"
+                isDisabled={this.state.addEgressHost.host.length === 0}
+                onClick={this.onAddEgressHost}
+              >
+                Add Egress Host
+              </Button>
+            </>
+          ]
+        }
+      ]);
+  }
+
   render() {
-    return <>Sidecar Form</>;
+    return (
+      <>
+        Egress hosts defined:
+        <Table
+          aria-label="Egress Hosts"
+          cells={headerCells}
+          rows={this.rows()}
+          // @ts-ignore
+          actionResolver={this.actionResolver}
+        >
+          <TableHeader />
+          <TableBody />
+        </Table>
+        <FormGroup label="Add Workload Selector" fieldId="workloadSelectorSwitch">
+          <Switch
+            id="workloadSelectorSwitch"
+            label={' '}
+            labelOff={' '}
+            isChecked={this.state.addWorkloadSelector}
+            onChange={() => {
+              this.setState(prevState => ({
+                addWorkloadSelector: !prevState.addWorkloadSelector
+              }));
+            }}
+          />
+        </FormGroup>
+        {this.state.addWorkloadSelector && (
+          <FormGroup
+            fieldId="workloadLabels"
+            label="Labels"
+            helperText="One or more labels to select a workload where Sidecar is applied. Enter a label in the format <label>=<value>. Enter one or multiple labels separated by comma."
+            helperTextInvalid="Invalid labels format: One or more labels to select a workload where Sidecar is applied. Enter a label in the format <label>=<value>. Enter one or multiple labels separated by comma."
+            isValid={this.state.workloadSelectorValid}
+          >
+            <TextInput
+              id="gwHosts"
+              name="gwHosts"
+              isDisabled={!this.state.addWorkloadSelector}
+              value={this.state.workloadSelectorLabels}
+              onChange={this.addWorkloadLabels}
+              isValid={this.state.workloadSelectorValid}
+            />
+          </FormGroup>
+        )}
+        {this.props.egressHosts.length === 0 && (
+          <div className={noEgressHostsStyle}>Sidecar has no Egress Hosts Defined</div>
+        )}
+      </>
+    );
   }
 }
 

--- a/src/pages/IstioConfigNew/SidecarForm.tsx
+++ b/src/pages/IstioConfigNew/SidecarForm.tsx
@@ -156,19 +156,24 @@ class SidecarForm extends React.Component<Props, State> {
       }))
       .concat([
         {
-          key: 'egressHostNew',
+          key: 'eHNew',
           cells: [
             <>
               <TextInput
                 value={this.state.addEgressHost.host}
                 type="text"
                 id="addEgressHost"
+                key="addEgressHost"
                 aria-describedby="add egress host"
                 name="addHost"
                 onChange={this.onAddHost}
                 isValid={this.state.validEgressHost}
               />
-              {!this.state.validEgressHost && <div className={noEgressHostsStyle}>{hostsHelperText}</div>}
+              {!this.state.validEgressHost && (
+                <div key="hostsHelperText" className={noEgressHostsStyle}>
+                  {hostsHelperText}
+                </div>
+              )}
             </>,
             <>
               <Button variant="secondary" isDisabled={!this.state.validEgressHost} onClick={this.onAddEgressHost}>

--- a/src/pages/IstioConfigNew/SidecarForm.tsx
+++ b/src/pages/IstioConfigNew/SidecarForm.tsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+class SidecarForm extends React.Component {
+  render() {
+    return <>Sidecar Form</>;
+  }
+}
+
+export default SidecarForm;

--- a/src/pages/IstioConfigNew/SidecarForm.tsx
+++ b/src/pages/IstioConfigNew/SidecarForm.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
-import { ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
+import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
 import { style } from 'typestyle';
 import { PfColors } from '../../components/Pf/PfColors';
 import { Button, FormGroup, Switch, TextInput } from '@patternfly/react-core';
+import { isServerHostValid } from '../../utils/IstioConfigUtils';
 
 const headerCells: ICell[] = [
   {
     title: 'Egress Host',
+    transforms: [cellWidth(60) as any],
     props: {}
   },
   {
@@ -19,6 +21,8 @@ const noEgressHostsStyle = style({
   marginTop: 15,
   color: PfColors.Red100
 });
+
+const hostsHelperText = 'Enter a valid FQDN host.';
 
 export type EgressHost = {
   host: string;
@@ -50,6 +54,7 @@ type State = {
   addWorkloadSelector: boolean;
   workloadSelectorValid: boolean;
   workloadSelectorLabels: string;
+  validEgressHost: boolean;
 };
 
 class SidecarForm extends React.Component<Props, State> {
@@ -61,7 +66,8 @@ class SidecarForm extends React.Component<Props, State> {
       },
       addWorkloadSelector: false,
       workloadSelectorValid: false,
-      workloadSelectorLabels: ''
+      workloadSelectorLabels: '',
+      validEgressHost: false
     };
   }
 
@@ -81,10 +87,12 @@ class SidecarForm extends React.Component<Props, State> {
   };
 
   onAddHost = (value: string, _) => {
+    const host = value.trim();
     this.setState({
       addEgressHost: {
-        host: value.trim()
-      }
+        host: host
+      },
+      validEgressHost: isServerHostValid(host)
     });
   };
 
@@ -158,15 +166,12 @@ class SidecarForm extends React.Component<Props, State> {
                 aria-describedby="add egress host"
                 name="addHost"
                 onChange={this.onAddHost}
-                isValid={this.state.addEgressHost.host.length > 0}
+                isValid={this.state.validEgressHost}
               />
+              {!this.state.validEgressHost && <div className={noEgressHostsStyle}>{hostsHelperText}</div>}
             </>,
             <>
-              <Button
-                variant="secondary"
-                isDisabled={this.state.addEgressHost.host.length === 0}
-                onClick={this.onAddEgressHost}
-              >
+              <Button variant="secondary" isDisabled={!this.state.validEgressHost} onClick={this.onAddEgressHost}>
                 Add Egress Host
               </Button>
             </>

--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -161,7 +161,7 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
   }
 
   componentDidMount() {
-    this.doRefresh();
+    this.promises.cancelAll();
   }
 
   componentDidUpdate(prevProps: ServiceDetailsProps, _prevState: ServiceDetailsState) {

--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -161,7 +161,7 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
   }
 
   componentDidMount() {
-    this.promises.cancelAll();
+    this.doRefresh();
   }
 
   componentDidUpdate(prevProps: ServiceDetailsProps, _prevState: ServiceDetailsState) {

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -11,6 +11,7 @@ import GraphPageContainer from './pages/Graph/GraphPage';
 import { icons, Paths } from './config';
 import ServiceDetailsPageContainer from './pages/ServiceDetails/ServiceDetailsPage';
 import DefaultSecondaryMasthead from './components/DefaultSecondaryMasthead/DefaultSecondaryMasthead';
+import IstioConfigNewPageContainer from './pages/IstioConfigNew/IstioConfigNewPage';
 
 /**
  * Return array of objects that describe vertical menu
@@ -51,7 +52,7 @@ const navItems: MenuItem[] = [
     iconClass: icons.menu.istioConfig,
     title: 'Istio Config',
     to: '/' + Paths.ISTIO,
-    pathsActive: [new RegExp('^/namespaces/(.*)/' + Paths.ISTIO + '/(.*)')]
+    pathsActive: [new RegExp('^/namespaces/(.*)/' + Paths.ISTIO + '/(.*)'), new RegExp('/' + Paths.ISTIO + '/new')]
   },
   {
     iconClass: icons.menu.distributedTracing,
@@ -119,6 +120,10 @@ const pathRoutes: Path[] = [
   {
     path: '/namespaces/:namespace/' + Paths.WORKLOADS + '/:workload',
     component: WorkloadDetailsPage
+  },
+  {
+    path: '/' + Paths.ISTIO + '/new',
+    component: IstioConfigNewPageContainer
   },
   {
     path: '/' + Paths.ISTIO,

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -4,7 +4,7 @@ import { DashboardModel, DashboardQuery } from '@kiali/k-charted-pf4';
 import Namespace from '../types/Namespace';
 import { IstioMetricsOptions } from '../types/MetricsOptions';
 import { Metrics } from '../types/Metrics';
-import { IstioConfigDetails } from '../types/IstioConfigDetails';
+import { IstioConfigDetails, IstioPermissions } from '../types/IstioConfigDetails';
 import { IstioConfigList } from '../types/IstioConfigList';
 import { Workload, WorkloadNamespaceResponse } from '../types/Workload';
 import { ServiceDetailsInfo } from '../types/ServiceInfo';
@@ -523,4 +523,8 @@ export const deleteThreeScaleServiceRule = (namespace: string, service: string) 
 
 export const getServiceSpans = (namespace: string, service: string, params: TracingQuery) => {
   return newRequest<Span[]>(HTTP_VERBS.GET, urls.serviceSpans(namespace, service), params, {});
+};
+
+export const getIstioPermissions = (namespaces: string[]) => {
+  return newRequest<IstioPermissions>(HTTP_VERBS.GET, urls.istioPermissions, { namespaces: namespaces.join(',') }, {});
 };

--- a/src/types/IstioConfigDetails.ts
+++ b/src/types/IstioConfigDetails.ts
@@ -69,3 +69,9 @@ export interface ParsedSearch {
   type?: string;
   name?: string;
 }
+
+export interface IstioPermissions {
+  [namespace: string]: {
+    [type: string]: ResourcePermissions;
+  };
+}

--- a/src/types/IstioObjects.ts
+++ b/src/types/IstioObjects.ts
@@ -410,8 +410,8 @@ export interface WorkloadSelector {
 
 export interface SidecarSpec {
   workloadSelector?: WorkloadSelector;
-  ingress?: IstioIngressListener;
-  egress?: IstioEgressListener;
+  ingress?: IstioIngressListener[];
+  egress?: IstioEgressListener[];
 }
 
 export interface Sidecar extends IstioObject {

--- a/src/utils/IstioConfigUtils.ts
+++ b/src/utils/IstioConfigUtils.ts
@@ -64,3 +64,39 @@ export const getIstioObject = (istioObjectDetails?: IstioConfigDetails) => {
   }
   return istioObject;
 };
+
+const nsRegexp = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[-a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
+const hostRegexp = /(?=^.{4,253}$)(^((?!-)(([a-zA-Z0-9-]{0,62}[a-zA-Z0-9])|\*)\.)+[a-zA-Z]{2,63}$)/;
+
+// Used to check if Sidecar and Gateway host expressions are valid
+export const isServerHostValid = (serverHost: string): boolean => {
+  if (serverHost.length === 0) {
+    return false;
+  }
+  // <namespace>/<host>
+  const parts = serverHost.split('/');
+  // More than one /
+  if (parts.length > 2) {
+    return false;
+  }
+  // parts[0] is a dns
+  let dnsValid = true;
+  let hostValid = true;
+  let dns = '';
+  let host = '';
+  if (parts.length === 2) {
+    dns = parts[0];
+    host = parts[1];
+
+    if (dns !== '.' && dns !== '*') {
+      dnsValid = parts[0].search(nsRegexp) === 0;
+    }
+  } else {
+    host = parts[0];
+  }
+
+  if (host !== '*') {
+    hostValid = host.search(hostRegexp) === 0;
+  }
+  return dnsValid && hostValid;
+};

--- a/src/utils/__tests__/IstioConfigUtils.test.ts
+++ b/src/utils/__tests__/IstioConfigUtils.test.ts
@@ -1,4 +1,4 @@
-import { mergeJsonPatch } from '../IstioConfigUtils';
+import { isServerHostValid, mergeJsonPatch } from '../IstioConfigUtils';
 
 describe('Validate JSON Patchs', () => {
   const gateway: object = {
@@ -43,7 +43,7 @@ describe('Validate JSON Patchs', () => {
     }
   };
 
-  it('Dummy test', () => {
+  it('Basic Test', () => {
     mergeJsonPatch(gatewayModified, gateway);
 
     // tslint:disable-next-line
@@ -51,5 +51,34 @@ describe('Validate JSON Patchs', () => {
 
     // tslint:disable-next-line
     expect(gatewayModified['spec']['selector']['istio']).toBeNull();
+  });
+});
+
+describe('Validate Gateway/Sidecar Server Host ', () => {
+  it('No Namespace prefix', () => {
+    expect(isServerHostValid('*')).toBeTruthy();
+    expect(isServerHostValid('productpage')).toBeFalsy();
+    expect(isServerHostValid('productpage.example.com')).toBeTruthy();
+    expect(isServerHostValid('*.example.com')).toBeTruthy();
+  });
+
+  it('Namespace prefix', () => {
+    expect(isServerHostValid('bookinfo/*')).toBeTruthy();
+    expect(isServerHostValid('*/*')).toBeTruthy();
+    expect(isServerHostValid('./*')).toBeTruthy();
+    expect(isServerHostValid('bookinfo/productpage')).toBeFalsy();
+    expect(isServerHostValid('*/productpage')).toBeFalsy();
+    expect(isServerHostValid('./productpage')).toBeFalsy();
+    expect(isServerHostValid('bookinfo/productpage.example.com')).toBeTruthy();
+    expect(isServerHostValid('*/productpage.example.com')).toBeTruthy();
+    expect(isServerHostValid('./productpage.example.com')).toBeTruthy();
+    expect(isServerHostValid('bookinfo/*.example.com')).toBeTruthy();
+    expect(isServerHostValid('*/*.example.com')).toBeTruthy();
+    expect(isServerHostValid('./*.example.com')).toBeTruthy();
+  });
+
+  it('Catch bad urls', () => {
+    expect(isServerHostValid('bookinfo//reviews')).toBeFalsy();
+    expect(isServerHostValid('bookinf*/reviews')).toBeFalsy();
   });
 });


### PR DESCRIPTION
Today, Kiali creates IstioConfig at Service details level only using "context" wizards, where Services/Workloads are combined in a high level abstraction to allow user to define Istio configuration in a set of driven scenarios.

This new PR allows to create objects that are out of the context of a Service, for example, on this work we have introduced Gateways and Sidecars.

This new option is enabled at Istio Config list level:
![image](https://user-images.githubusercontent.com/1662329/73010974-b8908080-3e13-11ea-861d-3b2bde7805e4.png)

It moves to a new Form page where user can select the type of resource to create:
![image](https://user-images.githubusercontent.com/1662329/73010491-d27d9380-3e12-11ea-8ac5-aaf037c1e139.png)

On this first step, only Gateways and Sidecars can be generated. 
Another goal of this work is to structure these subforms in a way that is easy to add more.
Also, the forms don't cover all the potential scenarios (some objects as Sidecars may have huge combination of possibilities) but to simplify the creation of the most common use cases (forms have been designed based on common examples). 
In any case, once a resource is created, the user can only update it using YAML, as this form are used only for creation step.

For Gateways:
![image](https://user-images.githubusercontent.com/1662329/73010789-5a639d80-3e13-11ea-80cc-03d1b58dc3c2.png)

For Sidecars:
![image](https://user-images.githubusercontent.com/1662329/73010837-75361200-3e13-11ea-9266-e7676e86ff55.png)

Validation of input fields are supported and permissions are checked per user/serviceaccount as usual.

Fixes kiali/kiali#1537
Fixes kiali/kiali#1380