### PR TITLE
Sparklines: show several colors on tooltip (hacky)

### DIFF
--- a/src/components/Charts/CustomFlyout.tsx
+++ b/src/components/Charts/CustomFlyout.tsx
@@ -1,17 +1,6 @@
 import * as React from 'react';
 import { Flyout } from 'victory';
 
-const squareSize = 10;
-
 export const CustomFlyout = (props: any) => {
-  const { width, center, datum } = props;
-  const left = center.x - width / 2;
-  const top = center.y - squareSize / 2;
-  const extraWidth = squareSize + 5;
-  return (
-    <>
-      <Flyout {...props} width={width + extraWidth} style={{ ...props.style, fillOpacity: 0.6 }} />
-      <rect width={squareSize} height={squareSize} x={left} y={top} style={{ fill: datum.color }} />
-    </>
-  );
+  return <Flyout {...props} width={props.width + 15} style={{ ...props.style, stroke: 'none', fillOpacity: 0.6 }} />;
 };

--- a/src/components/Charts/CustomLabel.tsx
+++ b/src/components/Charts/CustomLabel.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { VictoryLabel } from 'victory';
+
+const squareSize = 10;
+const dy = 15;
+
+export const CustomLabel = (props: any & { colors: string[] }) => {
+  const colors: string[] = [];
+  const texts: string[] = [];
+  props.text.forEach(t => {
+    const parts = t.split('@');
+    if (parts.length === 2) {
+      colors.push(props.colors[+parts[0]]);
+      texts.push(parts[1]);
+    } else {
+      colors.push('');
+      texts.push(t);
+    }
+  });
+  const x = props.x - 10 - 4 * Math.max(...texts.map(t => t.length));
+  const startY = 3 + props.y - (texts.length * dy) / 2;
+  return (
+    <>
+      {colors.map((color, idx) => {
+        if (color !== '') {
+          return <rect width={squareSize} height={squareSize} x={x} y={startY + dy * idx} style={{ fill: color }} />;
+        }
+        return null;
+      })}
+      <VictoryLabel {...props} text={texts} textAnchor="start" />
+    </>
+  );
+};


### PR DESCRIPTION
See inline comment for hack description.
Note that I'll suggest a patch in victory to get a better solution

Fixes https://github.com/kiali/kiali/issues/2097

![Capture d’écran de 2020-01-20 19-36-11](https://user-images.githubusercontent.com/2153442/72750766-014efc00-3bbe-11ea-8d82-363acfceaf04.png)
