### PR TITLE
Remove lint in build:prod

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
   "scripts": {
     "build": "if [ \"${KIALI_ENV}\" = \"production\" ]; then npm run build:prod; else npm run build:dev; fi",
     "build-css": "node-sass src/ --output-style compressed --include-path $npm_package_sassIncludes_src --include-path $npm_package_sassIncludes_patternfly --include-path $npm_package_sassIncludes_patternflyReact --include-path $npm_package_sassIncludes_patternflyReactExtensions --include-path $npm_package_sassIncludes_bootstrap --include-path $npm_package_sassIncludes_fontAwesome -o src/",
-    "build:dev": "sh -ac 'source ./.env.upstream; npm run build:kiali'",
-    "build:kiali": "npm run lint && npm run copy-fonts && npm run copy-img && npm run build-css && REACT_APP_VERSION=$npm_package_version REACT_APP_NAME=$npm_package_name REACT_APP_GIT_HASH=$(git rev-parse HEAD) GENERATE_SOURCEMAP=false react-scripts build",
+    "build:dev": "sh -ac 'source ./.env.upstream; npm run lint && npm run build:kiali'",
+    "build:kiali": "npm run copy-fonts && npm run copy-img && npm run build-css && REACT_APP_VERSION=$npm_package_version REACT_APP_NAME=$npm_package_name REACT_APP_GIT_HASH=$(git rev-parse HEAD) GENERATE_SOURCEMAP=false react-scripts build",
     "build:prod": "sh -ac 'source ./.env.downstream; npm run build:kiali'",
     "copy-fonts": "cp -r node_modules/patternfly/dist/fonts src/",
     "copy-img": "cp -r node_modules/patternfly/dist/img src/",


### PR DESCRIPTION
we have the lint:precommit task and the lint task in build:dev (executed by travis) we don't need execute again lint in the build:prod.


All the code in the project has passed eslint so it has no sense pass it again in the prod build.
