### PR TITLE
Make sidepanel rate chart graph colors more easily distinguished.

### DIFF
--- a/src/components/Pf/PfColors.tsx
+++ b/src/components/Pf/PfColors.tsx
@@ -105,6 +105,9 @@ export type PFAlertColorVals = {
   SuccessBackground: PFColorVal;
   Warning: PFColorVal;
   WarningBackground: PFColorVal;
+  // special value for rates charts where 4xx is really Danger not Warning
+  ChartWarning: PFColorVal;
+  ChartDanger: PFColorVal;
 };
 
 let PFAlertColorValsInstance: PFAlertColorVals | undefined;
@@ -122,7 +125,10 @@ export const getPFAlertColorVals = (): PFAlertColorVals => {
       Success: '#3e8635',
       SuccessBackground: getComputedStyle(root).getPropertyValue('--pf-global--success-color--200'),
       Warning: getComputedStyle(root).getPropertyValue('--pf-global--warning-color--100'),
-      WarningBackground: getComputedStyle(root).getPropertyValue('--pf-global--warning-color--200')
+      WarningBackground: getComputedStyle(root).getPropertyValue('--pf-global--warning-color--200'),
+      // special value for rates charts where 4xx is really Danger not Warning
+      ChartWarning: getComputedStyle(root).getPropertyValue('--pf-global--danger-color--100'),
+      ChartDanger: getComputedStyle(root).getPropertyValue('--pf-global--danger-color--300')
     };
   }
   return PFAlertColorValsInstance;

--- a/src/components/SummaryPanel/RateChart.tsx
+++ b/src/components/SummaryPanel/RateChart.tsx
@@ -117,8 +117,8 @@ export const renderRateChartHttp = (percent2xx: number, percent3xx: number, perc
   const vcLines: VCLines = [
     { name: 'OK', x: 'rate', y: percent2xx, color: colorVals.Success },
     { name: '3xx', x: 'rate', y: percent3xx, color: colorVals.Info },
-    { name: '4xx', x: 'rate', y: percent4xx, color: colorVals.DangerBackground }, // 4xx is also an error use close but distinct color
-    { name: '5xx', x: 'rate', y: percent5xx, color: colorVals.Danger }
+    { name: '4xx', x: 'rate', y: percent4xx, color: colorVals.ChartWarning }, // 4xx is also an error use close but distinct color
+    { name: '5xx', x: 'rate', y: percent5xx, color: colorVals.ChartDanger }
   ].map(dp => {
     return {
       datapoints: [dp],
@@ -167,9 +167,9 @@ export const renderInOutRateChartHttp = (
     {
       name: '4xx',
       dp: [{ x: 'In', y: percent4xxIn }, { x: 'Out', y: percent4xxOut }],
-      color: colorVals.DangerBackground
+      color: colorVals.ChartWarning
     }, // 4xx is also an error use close but distinct color
-    { name: '5xx', dp: [{ x: 'In', y: percent5xxIn }, { x: 'Out', y: percent5xxOut }], color: colorVals.Danger }
+    { name: '5xx', dp: [{ x: 'In', y: percent5xxIn }, { x: 'Out', y: percent5xxOut }], color: colorVals.ChartDanger }
   ].map(line => {
     return {
       datapoints: line.dp.map(dp => ({


### PR DESCRIPTION
** Describe the change **
It is currently very difficult to tell the difference between 5xx and 4xx colors in the sidepanel rate chart.
This was done on purpose because the 4xx is being treated as Errors in the context of this rate chart. However, the colors are too close together to differentiate.
This PR is what UxD approved for colors to more easily differentiate between 4xx and 5xx in the rate chart. 
The PR adds a new `WarningDanger` color for the warnings being interpreted as danger in the rate chart.

** Issue reference **
closes https://github.com/kiali/kiali/issues/2075
https://github.com/kiali/kiali-design/issues/165

** Screenshot **
**Before**:

![Graph_sidepanel_colors_for_4xx_and_5xx_too_close__hard_to_distinguish_·_Issue__165_·_kiali_kiali-design](https://user-images.githubusercontent.com/1312165/72851471-960a3600-3c60-11ea-940f-7f0c3ac1f24a.png)

**After**:

![Kiali_Console_-_Firefox_Developer_Edition](https://user-images.githubusercontent.com/1312165/73495462-71524480-436b-11ea-852e-d115c257ed1b.png)

