### PR TITLE
Add back Graph Replay lost commit for final UX tweaks

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeToolbar.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeToolbar.tsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { ThunkDispatch } from 'redux-thunk';
 import { KialiAppState } from '../../store/Store';
-import { PfColors } from '../Pf/PfColors';
+import { PfColors, PFKialiColor } from '../Pf/PfColors';
 import * as CytoscapeGraphUtils from './CytoscapeGraphUtils';
 import { Layout } from '../../types/Graph';
 import { ColaGraph } from './graphs/ColaGraph';
@@ -38,7 +38,7 @@ const buttonStyle = style({
   marginRight: '1px'
 });
 const selectedTopologyButtonStyle = style({
-  color: PfColors.Blue300
+  color: PFKialiColor.Active
 });
 const cytoscapeToolbarStyle = style({
   padding: '7px 10px'

--- a/src/components/Pf/PfColors.tsx
+++ b/src/components/Pf/PfColors.tsx
@@ -141,6 +141,12 @@ export enum PFAlertColor {
   WarningBackground = 'var(--pf-global--warning-color--200)'
 }
 
+export enum PFKialiColor {
+  Active = 'var(--pf-global--active-color--400)',
+  ActiveText = 'var(--pf-global--primary-color--200)',
+  Replay = 'var(--pf-global--active-color--300)'
+}
+
 export const withAlpha = (color: PfColors, hexAlpha: string) => {
   return color + hexAlpha;
 };

--- a/src/components/Time/Replay.tsx
+++ b/src/components/Time/Replay.tsx
@@ -15,7 +15,7 @@ import { KialiIcon, defaultIconStyle } from 'config/KialiIcon';
 import { style } from 'typestyle';
 import { toString } from './Utils';
 import { serverConfig } from 'config';
-import { PfColors } from 'components/Pf/PfColors';
+import { PFKialiColor } from 'components/Pf/PfColors';
 
 type ReduxProps = {
   duration: DurationInSeconds;
@@ -46,12 +46,8 @@ type ReplaySpeed = {
   text: string;
 };
 
-export const ReplayColor = PfColors.LightBlue300;
-
 export const replayBorder = style({
-  borderLeftStyle: 'solid',
-  borderColor: ReplayColor,
-  borderWidth: '3px'
+  borderLeft: `solid 5px ${PFKialiColor.Replay}`
 });
 
 // key represents replay interval in milliseconds
@@ -95,8 +91,8 @@ const isCustomStyle = style({
   height: '36px'
 });
 
-const isCustomFocusStyle = style({
-  color: ReplayColor
+const isCustomActiveStyle = style({
+  color: PFKialiColor.Active
 });
 
 const replayStyle = style({
@@ -117,8 +113,8 @@ const speedStyle = style({
   padding: '0 2px 2px 2px'
 });
 
-const speedFocusStyle = style({
-  color: ReplayColor,
+const speedActiveStyle = style({
+  color: PFKialiColor.ActiveText,
   fontWeight: 'bolder'
 });
 
@@ -253,7 +249,7 @@ export class Replay extends React.PureComponent<ReplayProps, ReplayState> {
         >
           <Button className={isCustomStyle} variant={ButtonVariant.control} onClick={this.toggleCustomStartTime}>
             <KialiIcon.UserClock
-              className={this.state.isCustomStartTime ? `${defaultIconStyle} ${isCustomFocusStyle}` : defaultIconStyle}
+              className={this.state.isCustomStartTime ? `${defaultIconStyle} ${isCustomActiveStyle}` : defaultIconStyle}
             />
           </Button>
         </Tooltip>
@@ -419,17 +415,17 @@ export class Replay extends React.PureComponent<ReplayProps, ReplayState> {
   };
 
   private speedButton = (replaySpeed: ReplaySpeed, isLast: boolean): React.ReactFragment => {
-    const isFocus = this.state.replaySpeed === replaySpeed.speed;
+    const isActive = this.state.replaySpeed === replaySpeed.speed;
     return (
       <>
         <Button
           key={`speed-${replaySpeed.text}`}
           className={speedStyle}
           variant={ButtonVariant.plain}
-          isFocus={isFocus}
+          isActive={isActive}
           onClick={() => this.setReplaySpeed(replaySpeed.speed)}
         >
-          <Text className={isFocus ? speedFocusStyle : undefined}>{replaySpeed.text}</Text>
+          <Text className={isActive ? speedActiveStyle : undefined}>{replaySpeed.text}</Text>
         </Button>
         {!isLast && <div className={vrStyle} />}
       </>

--- a/src/components/Time/_Time.scss
+++ b/src/components/Time/_Time.scss
@@ -10,3 +10,6 @@ Overrides for Replay use of the Slider component.
     padding-right: 175px;
   }
 }
+#replay-slider-div .slider-selection {
+  background: var(--pf-global--active-color--300); // should match PFKialiColor.Replay
+}

--- a/src/pages/Graph/GraphPage.tsx
+++ b/src/pages/Graph/GraphPage.tsx
@@ -36,7 +36,7 @@ import GraphDataThunkActions from '../../actions/GraphDataThunkActions';
 import { GraphActions } from '../../actions/GraphActions';
 import { GraphToolbarActions } from '../../actions/GraphToolbarActions';
 import { NodeContextMenuContainer } from '../../components/CytoscapeGraph/ContextMenu/NodeContextMenu';
-import { PfColors } from 'components/Pf/PfColors';
+import { PfColors, PFKialiColor } from 'components/Pf/PfColors';
 import { TourActions } from 'actions/TourActions';
 import TourStopContainer, { TourInfo, getNextTourStop } from 'components/Tour/TourStop';
 import { arrayEquals } from 'utils/Common';
@@ -45,7 +45,7 @@ import GraphTour, { GraphTourStops } from './GraphHelpTour';
 import { getErrorString } from 'services/Api';
 import { Chip, Badge } from '@patternfly/react-core';
 import { toRangeString } from 'components/Time/Utils';
-import { ReplayColor, replayBorder } from 'components/Time/Replay';
+import { replayBorder } from 'components/Time/Replay';
 
 // GraphURLPathProps holds path variable values.  Currenly all path variables are relevant only to a node graph
 type GraphURLPathProps = {
@@ -136,7 +136,7 @@ const whiteBackground = style({
 });
 
 const replayBackground = style({
-  backgroundColor: ReplayColor
+  backgroundColor: PFKialiColor.Replay
 });
 
 const graphLegendStyle = style({


### PR DESCRIPTION
I lost my final commit when squashing the PR for Graph Replay.  This adds it back.

Addendum to kiali#1421 (PR #1585)

- thicken replay border
- set replay color to --pf-global--active-color--300
  - border
  - slider selection background (I added it here for consistency)
  - badged time range background
- set active speed to --pf-global--primary-color--200
- set active custom start icon to --pf-global--active-color--400
  - also, for consistency, set same for active layout icon in cytoscape toolbar
