### PR TITLE
Service Details load Error when Jaeger is configured wrongly

### DIFF
--- a/src/app/AuthenticationController.tsx
+++ b/src/app/AuthenticationController.tsx
@@ -136,9 +136,9 @@ class AuthenticationController extends React.Component<AuthenticationControllerP
       namespaceSelector: jaegerInfo.namespaceSelector,
       integrationMessage: jaegerInfo.integrationMessage
     };
-    
+
     if (jaegerState.integrationMessage !== '') {
-      MessageCenterActions.addMessage(jaegerState.integrationMessage, '', 'jaeger', MessageType.INFO);
+      AlertUtils.addError(jaegerState.integrationMessage, undefined, 'default', MessageType.INFO);
     }
     this.props.setJaegerInfo(jaegerState);
   };

--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -243,7 +243,7 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
           serviceDetailsInfo: results,
           validations: this.addFormatValidation(results, results.validations)
         });
-        if (results.errorTraces === -1 && this.props.jaegerUrl !== '') {
+        if (results.errorTraces === -1 && this.props.jaegerIntegration) {
           AlertUtils.add(
             'Could not fetch Traces in the service ' +
               this.props.match.params.service +


### PR DESCRIPTION
backport to v1.12

jaeger error didn't appear in MessageCenter.

Now we can see the message related with the integration.

Fix: kiali/kiali#2155