### PR TITLE
Read server config for 3scale rendering

### DIFF
--- a/src/components/IstioWizards/ThreeScaleIntegration.tsx
+++ b/src/components/IstioWizards/ThreeScaleIntegration.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { ThreeScaleHandler, ThreeScaleServiceRule } from '../../types/ThreeScale';
 import {
-  ActionGroup,
   Badge,
   Button,
   DataList,
@@ -12,14 +11,8 @@ import {
   DataListToggle,
   DataListContent,
   DataListItemCells,
-  Dropdown,
-  DropdownItem,
-  DropdownPosition,
-  Expandable,
   Form,
   FormGroup,
-  KebabToggle,
-  TextInput,
   Tooltip,
   TooltipPosition
 } from '@patternfly/react-core';
@@ -47,8 +40,6 @@ type State = {
   handlersExpanded: string[];
   actionsToggle: string[];
 };
-
-const k8sRegExpName = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[-a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
 
 const noHandlerStyle = style({
   marginTop: 15,
@@ -114,72 +105,6 @@ class ThreeScaleIntegration extends React.Component<Props, State> {
       });
   };
 
-  onUpdateHandler = (id: number) => {
-    const handler = this.state.threeScaleHandlers[id];
-    const patch = {
-      name: handler.name,
-      serviceId: handler.serviceId,
-      accessToken: handler.accessToken,
-      systemUrl: handler.systemUrl
-    };
-    API.updateThreeScaleHandler(this.state.threeScaleHandlers[id].name, JSON.stringify(patch))
-      .then(results => {
-        this.setState(
-          prevState => {
-            return {
-              threeScaleHandlers: results.data.map(h => {
-                return {
-                  name: h.name,
-                  serviceId: h.serviceId,
-                  accessToken: h.accessToken,
-                  systemUrl: h.systemUrl,
-                  modified: false
-                };
-              }),
-              threeScaleServiceRule: prevState.threeScaleServiceRule
-            };
-          },
-          () => this.props.onChange(true, this.state.threeScaleServiceRule)
-        );
-      })
-      .catch(error => {
-        AlertUtils.addError('Could not update ThreeScaleHandlers.', error);
-      });
-  };
-
-  onDeleteHandler = (handlerName: string) => {
-    API.deleteThreeScaleHandler(handlerName)
-      .then(results => {
-        this.setState(
-          prevState => {
-            return {
-              threeScaleHandlers: results.data.map(h => {
-                return {
-                  name: h.name,
-                  serviceId: h.serviceId,
-                  accessToken: h.accessToken,
-                  systemUrl: h.systemUrl,
-                  modified: false
-                };
-              }),
-              threeScaleServiceRule: {
-                serviceName: prevState.threeScaleServiceRule.serviceName,
-                serviceNamespace: prevState.threeScaleServiceRule.serviceNamespace,
-                threeScaleHandlerName:
-                  prevState.threeScaleServiceRule.threeScaleHandlerName === handlerName
-                    ? ''
-                    : prevState.threeScaleServiceRule.threeScaleHandlerName
-              }
-            };
-          },
-          () => this.props.onChange(this.state.threeScaleHandlers.length > 0, this.state.threeScaleServiceRule)
-        );
-      })
-      .catch(error => {
-        AlertUtils.addError('Could not delete ThreeScaleHandlers.', error);
-      });
-  };
-
   isValid = () => {
     let isModified = true;
     this.state.threeScaleHandlers.forEach(handlers => {
@@ -191,87 +116,6 @@ class ThreeScaleIntegration extends React.Component<Props, State> {
       this.state.newThreeScaleHandler.systemUrl !== '' ||
       this.state.newThreeScaleHandler.accessToken !== '';
     return !(isModified || isNewModified);
-  };
-
-  onChangeHandler = (selectedId: number, field: string, value: string) => {
-    this.setState(prevState => {
-      const newThreeScaleHandler = prevState.newThreeScaleHandler;
-      if (selectedId === -1) {
-        switch (field) {
-          case 'name':
-            newThreeScaleHandler.name = value.trim();
-            break;
-          case 'serviceId':
-            newThreeScaleHandler.serviceId = value.trim();
-            break;
-          case 'accessToken':
-            newThreeScaleHandler.accessToken = value.trim();
-            break;
-          case 'systemUrl':
-            newThreeScaleHandler.systemUrl = value.trim();
-            break;
-          default:
-        }
-      }
-      return {
-        threeScaleServiceRule: prevState.threeScaleServiceRule,
-        threeScaleHandlers: prevState.threeScaleHandlers.map((handler, id) => {
-          if (selectedId === id) {
-            handler.modified = true;
-            switch (field) {
-              case 'serviceId':
-                handler.serviceId = value.trim();
-                break;
-              case 'accessToken':
-                handler.accessToken = value.trim();
-                break;
-              case 'systemUrl':
-                handler.systemUrl = value.trim();
-                break;
-              default:
-            }
-          }
-          return handler;
-        }),
-        newThreeScaleHandler: newThreeScaleHandler
-      };
-    });
-  };
-
-  onCreateHandler = () => {
-    API.createThreeScaleHandler(JSON.stringify(this.state.newThreeScaleHandler))
-      .then(results => {
-        this.setState(
-          prevState => {
-            return {
-              threeScaleHandlers: results.data.map(h => {
-                return {
-                  name: h.name,
-                  serviceId: h.serviceId,
-                  accessToken: h.accessToken,
-                  systemUrl: h.systemUrl,
-                  modified: false
-                };
-              }),
-              threeScaleServiceRule: {
-                serviceName: prevState.threeScaleServiceRule.serviceName,
-                serviceNamespace: prevState.threeScaleServiceRule.serviceNamespace,
-                threeScaleHandlerName: this.state.newThreeScaleHandler.name
-              },
-              newThreeScaleHandler: {
-                name: '',
-                serviceId: '',
-                systemUrl: '',
-                accessToken: ''
-              }
-            };
-          },
-          () => this.props.onChange(true, this.state.threeScaleServiceRule)
-        );
-      })
-      .catch(error => {
-        AlertUtils.addError('Could not create ThreeScaleHandlers.', error);
-      });
   };
 
   onSelectHandler = (handlerName: string) => {
@@ -368,17 +212,6 @@ class ThreeScaleIntegration extends React.Component<Props, State> {
                       Select
                     </Button>
                   )}
-                  <Dropdown
-                    isPlain
-                    position={DropdownPosition.right}
-                    isOpen={this.state.actionsToggle.includes('handler' + id)}
-                    onSelect={() => {
-                      this.onActionsToggle('handler' + id);
-                      this.onDeleteHandler(handler.name);
-                    }}
-                    toggle={<KebabToggle onToggle={() => this.onActionsToggle('handler' + id)} />}
-                    dropdownItems={[<DropdownItem key="link">Remove</DropdownItem>]}
-                  />
                 </DataListAction>
               </DataListItemRow>
               <DataListContent
@@ -393,12 +226,7 @@ class ThreeScaleIntegration extends React.Component<Props, State> {
                     isValid={handler.serviceId !== ''}
                     helperTextInvalid="Service Id cannot be empty"
                   >
-                    <TextInput
-                      id="serviceId"
-                      value={handler.serviceId}
-                      placeholder="3scale ID for API calls"
-                      onChange={value => this.onChangeHandler(id, 'serviceId', value)}
-                    />
+                    {handler.serviceId}
                   </FormGroup>
                   <FormGroup
                     fieldId="systemUrl"
@@ -406,12 +234,7 @@ class ThreeScaleIntegration extends React.Component<Props, State> {
                     isValid={handler.systemUrl !== ''}
                     helperTextInvalid="System Url cannot be empty"
                   >
-                    <TextInput
-                      id="systemUrl"
-                      value={handler.systemUrl}
-                      placeholder="3scale System Url for API"
-                      onChange={value => this.onChangeHandler(id, 'systemUrl', value)}
-                    />
+                    {handler.systemUrl}
                   </FormGroup>
                   <FormGroup
                     fieldId="accessToken"
@@ -419,33 +242,8 @@ class ThreeScaleIntegration extends React.Component<Props, State> {
                     isValid={handler.accessToken !== ''}
                     helperTextInvalid="Access Token cannot be empty"
                   >
-                    <TextInput
-                      id="accessToken"
-                      value={handler.accessToken}
-                      placeholder="3scale access token"
-                      onChange={value => this.onChangeHandler(id, 'accessToken', value)}
-                    />
+                    {handler.accessToken}
                   </FormGroup>
-                  <ActionGroup>
-                    <Button
-                      key="create_handler"
-                      variant="secondary"
-                      onClick={() => this.onUpdateHandler(id)}
-                      isDisabled={
-                        handler.serviceId === '' ||
-                        handler.systemUrl === '' ||
-                        handler.accessToken === '' ||
-                        !handler.modified
-                      }
-                    >
-                      Update Handler
-                    </Button>
-                  </ActionGroup>
-                  <>
-                    Notes:
-                    <br />
-                    Changes in a 3scale handler will affect to all linked services.
-                  </>
                 </Form>
               </DataListContent>
             </DataListItem>
@@ -460,114 +258,12 @@ class ThreeScaleIntegration extends React.Component<Props, State> {
     );
   };
 
-  isValidCreateHandler = () => {
-    return (
-      this.isValidK8SName(this.state.newThreeScaleHandler.name) &&
-      this.state.newThreeScaleHandler.serviceId !== '' &&
-      this.state.newThreeScaleHandler.systemUrl !== '' &&
-      this.state.newThreeScaleHandler.accessToken !== ''
-    );
-  };
-
-  isValidK8SName = (name: string) => {
-    return name === '' ? false : name.search(k8sRegExpName) === 0;
-  };
-
-  renderCreateHandler = () => {
-    const isValidName = this.isValidK8SName(this.state.newThreeScaleHandler.name);
-    return (
-      <Form isHorizontal={true}>
-        <FormGroup
-          fieldId="handlerName"
-          label="Handler Name:"
-          isValid={isValidName}
-          helperTextInvalid="Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character."
-        >
-          <TextInput
-            id="handlerName"
-            value={this.state.newThreeScaleHandler.name}
-            onChange={value => this.onChangeHandler(-1, 'name', value)}
-          />
-        </FormGroup>
-        <FormGroup
-          fieldId="serviceId"
-          label="Service Id:"
-          isValid={this.state.newThreeScaleHandler.serviceId !== ''}
-          helperTextInvalid="Service Id cannot be empty"
-        >
-          <TextInput
-            id="serviceId"
-            value={this.state.newThreeScaleHandler.serviceId}
-            placeholder="3scale ID for API calls"
-            onChange={value => this.onChangeHandler(-1, 'serviceId', value)}
-          />
-        </FormGroup>
-        <FormGroup
-          fieldId="systemUrl"
-          label="System Url:"
-          isValid={this.state.newThreeScaleHandler.systemUrl !== ''}
-          helperTextInvalid="System Url cannot be empty"
-        >
-          <TextInput
-            id="systemUrl"
-            value={this.state.newThreeScaleHandler.systemUrl}
-            placeholder="3scale System Url for API"
-            onChange={value => this.onChangeHandler(-1, 'systemUrl', value)}
-          />
-        </FormGroup>
-        <FormGroup
-          fieldId="accessToken"
-          label="Access Token:"
-          isValid={this.state.newThreeScaleHandler.accessToken !== ''}
-          helperTextInvalid="Access Token cannot be empty"
-        >
-          <TextInput
-            id="accessToken"
-            value={this.state.newThreeScaleHandler.accessToken}
-            placeholder="3scale access token"
-            onChange={value => this.onChangeHandler(-1, 'accessToken', value)}
-          />
-        </FormGroup>
-        <ActionGroup>
-          <Button
-            key="create_handler"
-            variant="secondary"
-            onClick={this.onCreateHandler}
-            isDisabled={!this.isValidCreateHandler()}
-          >
-            Create Handler
-          </Button>
-        </ActionGroup>
-        <>
-          Notes:
-          <br />A 3scale handler defines the 3scale parameters (Service Id, System Url and Access Token) to link a
-          Service with a 3scale API. A 3scale handler can be used link one to many Services with a 3scale API.
-        </>
-      </Form>
-    );
-  };
-
   render() {
-    const isExpanded =
-      this.state.threeScaleHandlers.length === 0 ||
-      this.state.newThreeScaleHandler.name !== '' ||
-      this.state.showCreateHandler;
     return (
       <>
         Select a 3scale handler:
         {this.renderHandlers()}
         <br />
-        <Expandable
-          isExpanded={isExpanded}
-          toggleText={(isExpanded ? 'Hide' : 'Show') + ' Create Handler'}
-          onToggle={() => {
-            this.setState({
-              showCreateHandler: !this.state.showCreateHandler
-            });
-          }}
-        >
-          {isExpanded && this.renderCreateHandler()}
-        </Expandable>
       </>
     );
   }

--- a/src/components/IstioWizards/ThreeScaleIntegration.tsx
+++ b/src/components/IstioWizards/ThreeScaleIntegration.tsx
@@ -20,6 +20,7 @@ import { style } from 'typestyle';
 import * as API from '../../services/Api';
 import * as AlertUtils from '../../utils/AlertUtils';
 import { PfColors } from '../Pf/PfColors';
+import { Link } from 'react-router-dom';
 
 type Props = {
   serviceName: string;
@@ -264,6 +265,15 @@ class ThreeScaleIntegration extends React.Component<Props, State> {
         Select a 3scale handler:
         {this.renderHandlers()}
         <br />
+        {this.state.threeScaleHandlers.length !== 0 ? (
+          <Link to={`/extensions/threescale`} key={'ThreeScaleHandlersLink'}>
+            View 3scale Handlers
+          </Link>
+        ) : (
+          <Link to={`/extensions/threescale/new`} key={'ThreeScaleHandlersNewLink'}>
+            Create New 3scale Handler
+          </Link>
+        )}
       </>
     );
   }

--- a/src/components/Nav/RenderPage.tsx
+++ b/src/components/Nav/RenderPage.tsx
@@ -26,7 +26,7 @@ class RenderPage extends React.Component<{ isGraph: boolean }> {
     const allPathRoutes = pathRoutes.concat(
       extensionsRoutes.filter(route => {
         // Extensions are conditionally rendered
-        if (route.path === '/extensions/threescale' && serverConfig.extensions!.threescale.enabled) {
+        if (route.path.startsWith('/extensions/threescale') && serverConfig.extensions!.threescale.enabled) {
           return true;
         }
         return false;

--- a/src/components/Nav/RenderPage.tsx
+++ b/src/components/Nav/RenderPage.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { Redirect, Route } from 'react-router-dom';
 import SwitchErrorBoundary from '../SwitchErrorBoundary/SwitchErrorBoundary';
-import { pathRoutes, defaultRoute, secondaryMastheadRoutes } from '../../routes';
+import { pathRoutes, defaultRoute, secondaryMastheadRoutes, extensionsRoutes } from '../../routes';
 import { Path } from '../../types/Routes';
 import { style } from 'typestyle';
 import { PfColors } from '../Pf/PfColors';
+import { serverConfig } from '../../config';
 
 const containerStyle = style({ marginLeft: 0, marginRight: 0 });
 const containerPadding = style({ padding: '0 20px 0 20px' });
@@ -22,7 +23,16 @@ class RenderPage extends React.Component<{ isGraph: boolean }> {
   }
 
   renderPathRoutes() {
-    return this.renderPaths(pathRoutes);
+    const allPathRoutes = pathRoutes.concat(
+      extensionsRoutes.filter(route => {
+        // Extensions are conditionally rendered
+        if (route.path === '/extensions/threescale' && serverConfig.extensions!.threescale.enabled) {
+          return true;
+        }
+        return false;
+      })
+    );
+    return this.renderPaths(allPathRoutes);
   }
 
   render() {

--- a/src/pages/extensions/threescale/ThreeScaleHandlerDetails/ThreeScaleHandlerDetailsPage.tsx
+++ b/src/pages/extensions/threescale/ThreeScaleHandlerDetails/ThreeScaleHandlerDetailsPage.tsx
@@ -1,0 +1,358 @@
+import * as React from 'react';
+import { RouteComponentProps } from 'react-router-dom';
+import {
+  ActionGroup,
+  Button,
+  ButtonVariant,
+  Dropdown,
+  DropdownItem,
+  DropdownPosition,
+  DropdownToggle,
+  Form,
+  FormGroup,
+  TextInput,
+  Title,
+  Toolbar,
+  ToolbarSection
+} from '@patternfly/react-core';
+import { style } from 'typestyle';
+import { PfColors } from '../../../../components/Pf/PfColors';
+import * as API from '../../../../services/Api';
+import * as AlertUtils from '../../../../utils/AlertUtils';
+import { ThreeScaleHandler, ThreeScaleInfo } from '../../../../types/ThreeScale';
+import { RenderContent } from '../../../../components/Nav/Page';
+import history from '../../../../app/History';
+import RefreshButtonContainer from '../../../../components/Refresh/RefreshButton';
+
+interface Props {
+  handlerName: string;
+}
+interface State {
+  isNew: boolean;
+  isModified: boolean;
+  threeScaleInfo: ThreeScaleInfo;
+  handler: ThreeScaleHandler;
+  dropdownOpen: boolean;
+}
+
+const containerPadding = style({ padding: '20px 20px 20px 20px' });
+const containerWhite = style({ backgroundColor: PfColors.White });
+const rightToolbar = style({ marginLeft: 'auto' });
+
+const k8sRegExpName = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[-a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
+
+const isValidK8SName = (name: string) => {
+  return name === '' ? false : name.search(k8sRegExpName) === 0;
+};
+
+// Used only when there is no namespace selector, otherwise use the SecondaryMasthead component
+
+const actionsToolbar = (
+  dropdownOpen: boolean,
+  onSelect: () => void,
+  onToggle: (toggle: boolean) => void,
+  onClick: () => void
+) => {
+  return (
+    <Dropdown
+      id="actions"
+      title="Actions"
+      toggle={<DropdownToggle onToggle={onToggle}>Actions</DropdownToggle>}
+      onSelect={onSelect}
+      position={DropdownPosition.right}
+      isOpen={dropdownOpen}
+      dropdownItems={[
+        <DropdownItem key="createIstioConfig" onClick={onClick}>
+          Create New 3scale Handler
+        </DropdownItem>
+      ]}
+    />
+  );
+};
+
+class ThreeScaleHandlerDetailsPage extends React.Component<RouteComponentProps<Props>, State> {
+  constructor(props: RouteComponentProps<Props>) {
+    super(props);
+    this.state = {
+      isNew: true,
+      isModified: false,
+      threeScaleInfo: {
+        enabled: false,
+        permissions: {
+          create: false,
+          update: false,
+          delete: false
+        }
+      },
+      handler: {
+        name: '',
+        serviceId: '',
+        systemUrl: '',
+        accessToken: ''
+      },
+      dropdownOpen: false
+    };
+  }
+
+  // This is a simplified toolbar only using a refresh button, other pages build a Filter/Sorting toolbar
+  toolbar = (
+    onRefresh: () => void,
+    dropdownOpen: boolean,
+    onSelect: () => void,
+    onToggle: (toggle: boolean) => void,
+    onClick: () => void
+  ) => {
+    return (
+      <Toolbar className="pf-l-toolbar pf-u-justify-content-space-between pf-u-mx-xl pf-u-my-md">
+        <ToolbarSection aria-label="ToolbarSection">
+          <Toolbar className={rightToolbar}>
+            <RefreshButtonContainer key={'Refresh'} handleRefresh={onRefresh} />
+            {this.canDelete() && actionsToolbar(dropdownOpen, onSelect, onToggle, onClick)}
+          </Toolbar>
+        </ToolbarSection>
+      </Toolbar>
+    );
+  };
+
+  pageTitle = (title: string) => (
+    <div className={`${containerPadding} ${containerWhite}`}>
+      <Title headingLevel="h1" size="4xl" style={{ margin: '20px 0 0' }}>
+        {title}
+      </Title>
+      {!this.state.isNew &&
+        this.toolbar(
+          () => {
+            this.fetchInfoHandler(this.props.match.params.handlerName);
+          },
+          this.state.dropdownOpen,
+          () => {
+            this.setState({
+              dropdownOpen: !this.state.dropdownOpen
+            });
+          },
+          toggle => {
+            this.setState({
+              dropdownOpen: toggle
+            });
+          },
+          () => {
+            this.onDeleteHandler();
+          }
+        )}
+    </div>
+  );
+
+  fetchInfoHandler = (handlerName: string | undefined) => {
+    API.getThreeScaleInfo()
+      .then(result => {
+        const threeScaleInfo = result.data;
+        if (handlerName) {
+          API.getThreeScaleHandlers()
+            .then(results => {
+              let handler: ThreeScaleHandler | undefined = undefined;
+              for (let i = 0; results.data.length; i++) {
+                if (results.data[i].name === handlerName) {
+                  handler = results.data[i];
+                  break;
+                }
+              }
+              if (handler) {
+                this.setState({
+                  isNew: false,
+                  threeScaleInfo: threeScaleInfo,
+                  handler: handler
+                });
+              } else {
+                AlertUtils.addError('Could not fetch ThreeScaleHandler ' + handlerName + '.');
+              }
+            })
+            .catch(error => {
+              AlertUtils.addError('Could not fetch ThreeScaleHandlers.', error);
+            });
+        } else {
+          this.setState({
+            threeScaleInfo: threeScaleInfo
+          });
+        }
+      })
+      .catch(error => {
+        AlertUtils.addError('Could not fetch ThreeScaleInfo.', error);
+      });
+  };
+
+  componentDidMount() {
+    this.fetchInfoHandler(this.props.match.params.handlerName);
+  }
+
+  canCreate = (): boolean => {
+    return this.state.threeScaleInfo.enabled && this.state.threeScaleInfo.permissions.create;
+  };
+
+  canUpdate = (): boolean => {
+    return this.state.threeScaleInfo.enabled && this.state.threeScaleInfo.permissions.update;
+  };
+
+  canDelete = (): boolean => {
+    return this.state.threeScaleInfo.enabled && this.state.threeScaleInfo.permissions.delete;
+  };
+
+  goHandlersPage = () => {
+    // Invoke the history object to update and URL and start a routing
+    history.push('/extensions/threescale');
+  };
+
+  isValid = () => {
+    return (
+      this.state.handler.name !== '' &&
+      this.state.handler.serviceId !== '' &&
+      this.state.handler.systemUrl !== '' &&
+      this.state.handler.accessToken !== ''
+    );
+  };
+
+  onChangeHandler = (field: string, value: string) => {
+    this.setState(prevState => {
+      const newThreeScaleHandler = prevState.handler;
+      switch (field) {
+        case 'handlerName':
+          newThreeScaleHandler.name = value.trim();
+          break;
+        case 'serviceId':
+          newThreeScaleHandler.serviceId = value.trim();
+          break;
+        case 'accessToken':
+          newThreeScaleHandler.accessToken = value.trim();
+          break;
+        case 'systemUrl':
+          newThreeScaleHandler.systemUrl = value.trim();
+          break;
+        default:
+      }
+      return {
+        isNew: prevState.isNew,
+        isModified: true,
+        handler: newThreeScaleHandler
+      };
+    });
+  };
+
+  onUpdateHandler = () => {
+    if (this.state.isNew) {
+      API.createThreeScaleHandler(JSON.stringify(this.state.handler))
+        .then(_ => this.goHandlersPage())
+        .catch(error => AlertUtils.addError('Could not create ThreeScaleHandlers.', error));
+    } else {
+      API.updateThreeScaleHandler(this.state.handler.name, JSON.stringify(this.state.handler))
+        .then(_ => this.goHandlersPage())
+        .catch(error => AlertUtils.addError('Could not update ThreeScaleHandlers.', error));
+    }
+  };
+
+  onDeleteHandler = () => {
+    API.deleteThreeScaleHandler(this.state.handler.name)
+      .then(_ => this.goHandlersPage())
+      .catch(error => AlertUtils.addError('Could not delete ThreeScaleHandlers.', error));
+  };
+
+  render() {
+    const title = this.props.match.params.handlerName
+      ? '3scale Handler ' + this.props.match.params.handlerName
+      : 'Create New 3scale Handler';
+    return (
+      <>
+        {this.pageTitle(title)}
+        <RenderContent>
+          <div className={containerPadding}>
+            <Form isHorizontal={true}>
+              <FormGroup
+                fieldId="handlerName"
+                label="Handler Name:"
+                isValid={isValidK8SName(this.state.handler.name)}
+                helperTextInvalid="Name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character."
+              >
+                <TextInput
+                  id="handlerName"
+                  value={this.state.handler.name}
+                  placeholder="3scale Handler Name"
+                  onChange={value => this.onChangeHandler('handlerName', value)}
+                  isDisabled={!this.state.isNew}
+                />
+              </FormGroup>
+              <FormGroup
+                fieldId="serviceId"
+                label="Service Id:"
+                isValid={this.state.handler.serviceId !== ''}
+                helperTextInvalid="Service Id cannot be empty"
+              >
+                <TextInput
+                  id="serviceId"
+                  value={this.state.handler.serviceId}
+                  placeholder="3scale ID for API calls"
+                  onChange={value => this.onChangeHandler('serviceId', value)}
+                />
+              </FormGroup>
+              <FormGroup
+                fieldId="systemUrl"
+                label="System Url:"
+                isValid={this.state.handler.systemUrl !== ''}
+                helperTextInvalid="System Url cannot be empty"
+              >
+                <TextInput
+                  id="systemUrl"
+                  value={this.state.handler.systemUrl}
+                  placeholder="3scale System Url for API"
+                  onChange={value => this.onChangeHandler('systemUrl', value)}
+                />
+              </FormGroup>
+              <FormGroup
+                fieldId="accessToken"
+                label="Access Token:"
+                isValid={this.state.handler.accessToken !== ''}
+                helperTextInvalid="Access Token cannot be empty"
+              >
+                <TextInput
+                  id="accessToken"
+                  value={this.state.handler.accessToken}
+                  placeholder="3scale access token"
+                  onChange={value => this.onChangeHandler('accessToken', value)}
+                />
+              </FormGroup>
+              <ActionGroup>
+                <span style={{ float: 'left', paddingTop: '10px', paddingBottom: '10px' }}>
+                  {this.canUpdate() && (
+                    <span style={{ paddingRight: '5px' }}>
+                      <Button
+                        variant={ButtonVariant.primary}
+                        isDisabled={!this.isValid()}
+                        onClick={this.onUpdateHandler}
+                      >
+                        {this.state.isNew ? 'Create' : 'Save'}
+                      </Button>
+                    </span>
+                  )}
+                  <span style={{ paddingRight: '5px' }}>
+                    <Button
+                      variant={ButtonVariant.secondary}
+                      onClick={() => {
+                        this.goHandlersPage();
+                      }}
+                    >
+                      Cancel
+                    </Button>
+                  </span>
+                </span>
+              </ActionGroup>
+              <>
+                Notes:
+                <br />
+                Changes in a 3scale handler will affect to all linked services.
+              </>
+            </Form>
+          </div>
+        </RenderContent>
+      </>
+    );
+  }
+}
+
+export default ThreeScaleHandlerDetailsPage;

--- a/src/pages/extensions/threescale/ThreeScaleHandlerDetails/ThreeScaleHandlerDetailsPage.tsx
+++ b/src/pages/extensions/threescale/ThreeScaleHandlerDetails/ThreeScaleHandlerDetailsPage.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
-import { RouteComponentProps } from 'react-router-dom';
+import { Link, RouteComponentProps } from 'react-router-dom';
 import {
   ActionGroup,
+  Breadcrumb,
+  BreadcrumbItem,
   Button,
   ButtonVariant,
   Dropdown,
@@ -10,8 +12,10 @@ import {
   DropdownToggle,
   Form,
   FormGroup,
+  Modal,
+  Text,
   TextInput,
-  Title,
+  TextVariants,
   Toolbar,
   ToolbarSection
 } from '@patternfly/react-core';
@@ -24,50 +28,35 @@ import { RenderContent } from '../../../../components/Nav/Page';
 import history from '../../../../app/History';
 import RefreshButtonContainer from '../../../../components/Refresh/RefreshButton';
 
+// Properties handled by the component/page
+// Note that ThreeScaleHandlerDetailsPage uses a RouteComponentProps<Props> used to capture the parameters in the route
+// As this page can work for create a new handler or edit an existing handler, when handlerName is undefined the page
+// take the scenario that is a "new handler" case.
 interface Props {
   handlerName: string;
 }
+
+// State of the the component/page.
+// It stores the visual state of the controllers and the handler edited/created.
 interface State {
   isNew: boolean;
   isModified: boolean;
   threeScaleInfo: ThreeScaleInfo;
   handler: ThreeScaleHandler;
   dropdownOpen: boolean;
+  deleteModalOpen: boolean;
 }
 
+// Style constants
 const containerPadding = style({ padding: '20px 20px 20px 20px' });
 const containerWhite = style({ backgroundColor: PfColors.White });
+const paddingLeft = style({ paddingLeft: '20px' });
 const rightToolbar = style({ marginLeft: 'auto' });
 
+// Kubernetes ID validation helper, used to allow mark a warning in the form edition
 const k8sRegExpName = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[-a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
-
 const isValidK8SName = (name: string) => {
   return name === '' ? false : name.search(k8sRegExpName) === 0;
-};
-
-// Used only when there is no namespace selector, otherwise use the SecondaryMasthead component
-
-const actionsToolbar = (
-  dropdownOpen: boolean,
-  onSelect: () => void,
-  onToggle: (toggle: boolean) => void,
-  onClick: () => void
-) => {
-  return (
-    <Dropdown
-      id="actions"
-      title="Actions"
-      toggle={<DropdownToggle onToggle={onToggle}>Actions</DropdownToggle>}
-      onSelect={onSelect}
-      position={DropdownPosition.right}
-      isOpen={dropdownOpen}
-      dropdownItems={[
-        <DropdownItem key="createIstioConfig" onClick={onClick}>
-          Create New 3scale Handler
-        </DropdownItem>
-      ]}
-    />
-  );
 };
 
 class ThreeScaleHandlerDetailsPage extends React.Component<RouteComponentProps<Props>, State> {
@@ -90,89 +79,48 @@ class ThreeScaleHandlerDetailsPage extends React.Component<RouteComponentProps<P
         systemUrl: '',
         accessToken: ''
       },
-      dropdownOpen: false
+      dropdownOpen: false,
+      deleteModalOpen: false
     };
   }
 
-  // This is a simplified toolbar only using a refresh button, other pages build a Filter/Sorting toolbar
-  toolbar = (
-    onRefresh: () => void,
-    dropdownOpen: boolean,
-    onSelect: () => void,
-    onToggle: (toggle: boolean) => void,
-    onClick: () => void
-  ) => {
-    return (
-      <Toolbar className="pf-l-toolbar pf-u-justify-content-space-between pf-u-mx-xl pf-u-my-md">
-        <ToolbarSection aria-label="ToolbarSection">
-          <Toolbar className={rightToolbar}>
-            <RefreshButtonContainer key={'Refresh'} handleRefresh={onRefresh} />
-            {this.canDelete() && actionsToolbar(dropdownOpen, onSelect, onToggle, onClick)}
-          </Toolbar>
-        </ToolbarSection>
-      </Toolbar>
-    );
-  };
-
-  pageTitle = (title: string) => (
-    <div className={`${containerPadding} ${containerWhite}`}>
-      <Title headingLevel="h1" size="4xl" style={{ margin: '20px 0 0' }}>
-        {title}
-      </Title>
-      {!this.state.isNew &&
-        this.toolbar(
-          () => {
-            this.fetchInfoHandler(this.props.match.params.handlerName);
-          },
-          this.state.dropdownOpen,
-          () => {
-            this.setState({
-              dropdownOpen: !this.state.dropdownOpen
-            });
-          },
-          toggle => {
-            this.setState({
-              dropdownOpen: toggle
-            });
-          },
-          () => {
-            this.onDeleteHandler();
-          }
-        )}
-    </div>
-  );
-
-  fetchInfoHandler = (handlerName: string | undefined) => {
+  // It fetches the information about Threescale adapter (adapter detected at runtime, permissions).
+  // It fetches the specific handler to edit. It ignores handler when creating a new Threescale handler.
+  fetchHandler = (handlerName: string | undefined) => {
     API.getThreeScaleInfo()
       .then(result => {
         const threeScaleInfo = result.data;
-        if (handlerName) {
-          API.getThreeScaleHandlers()
-            .then(results => {
-              let handler: ThreeScaleHandler | undefined = undefined;
-              for (let i = 0; results.data.length; i++) {
-                if (results.data[i].name === handlerName) {
-                  handler = results.data[i];
-                  break;
+        if (threeScaleInfo.enabled) {
+          if (handlerName) {
+            API.getThreeScaleHandlers()
+              .then(results => {
+                let handler: ThreeScaleHandler | undefined = undefined;
+                for (let i = 0; results.data.length; i++) {
+                  if (results.data[i].name === handlerName) {
+                    handler = results.data[i];
+                    break;
+                  }
                 }
-              }
-              if (handler) {
-                this.setState({
-                  isNew: false,
-                  threeScaleInfo: threeScaleInfo,
-                  handler: handler
-                });
-              } else {
-                AlertUtils.addError('Could not fetch ThreeScaleHandler ' + handlerName + '.');
-              }
-            })
-            .catch(error => {
-              AlertUtils.addError('Could not fetch ThreeScaleHandlers.', error);
+                if (handler) {
+                  this.setState({
+                    isNew: false,
+                    threeScaleInfo: threeScaleInfo,
+                    handler: handler
+                  });
+                } else {
+                  AlertUtils.addError('Could not fetch ThreeScaleHandler ' + handlerName + '.');
+                }
+              })
+              .catch(error => {
+                AlertUtils.addError('Could not fetch ThreeScaleHandlers.', error);
+              });
+          } else {
+            this.setState({
+              threeScaleInfo: threeScaleInfo
             });
+          }
         } else {
-          this.setState({
-            threeScaleInfo: threeScaleInfo
-          });
+          AlertUtils.addError('Kiali has 3scale extension enabled but 3scale adapter is not detected in the cluster');
         }
       })
       .catch(error => {
@@ -180,27 +128,111 @@ class ThreeScaleHandlerDetailsPage extends React.Component<RouteComponentProps<P
       });
   };
 
+  // It invokes backend when component is mounted
   componentDidMount() {
-    this.fetchInfoHandler(this.props.match.params.handlerName);
+    this.fetchHandler(this.props.match.params.handlerName);
   }
 
-  canCreate = (): boolean => {
-    return this.state.threeScaleInfo.enabled && this.state.threeScaleInfo.permissions.create;
+  // This is a simplified actions toolbar.
+  // It contains a delete action and invokes a confirmation modal.
+  actionsToolbar = () => {
+    return (
+      <>
+        <Dropdown
+          id="actions"
+          title="Actions"
+          toggle={
+            <DropdownToggle onToggle={(toggle: boolean) => this.setState({ dropdownOpen: toggle })}>
+              Actions
+            </DropdownToggle>
+          }
+          onSelect={() => this.setState({ dropdownOpen: !this.state.dropdownOpen })}
+          position={DropdownPosition.right}
+          isOpen={this.state.dropdownOpen}
+          dropdownItems={[
+            <DropdownItem key="createIstioConfig" onClick={() => this.setState({ deleteModalOpen: true })}>
+              Delete
+            </DropdownItem>
+          ]}
+        />
+        <Modal
+          title="Confirm Delete"
+          isSmall={true}
+          isOpen={this.state.deleteModalOpen}
+          onClose={() => this.setState({ deleteModalOpen: false })}
+          actions={[
+            <Button key="cancel" variant="secondary" onClick={() => this.setState({ deleteModalOpen: false })}>
+              Cancel
+            </Button>,
+            <Button key="confirm" variant="danger" onClick={() => this.deleteHandler()}>
+              Delete
+            </Button>
+          ]}
+        >
+          <Text component={TextVariants.p}>
+            Are you sure you want to delete the 3scale Handler '{this.props.match.params.handlerName}'? It cannot be
+            undone. Make sure this is something you really want to do!
+          </Text>
+        </Modal>
+      </>
+    );
   };
 
-  canUpdate = (): boolean => {
-    return this.state.threeScaleInfo.enabled && this.state.threeScaleInfo.permissions.update;
-  };
-
+  // Check if user has permission to write Threescale objects (under the hood it checks if user can write on control plane namespace)
   canDelete = (): boolean => {
     return this.state.threeScaleInfo.enabled && this.state.threeScaleInfo.permissions.delete;
   };
 
+  canUpdate = (): boolean => {
+    return (
+      this.state.threeScaleInfo.enabled &&
+      this.state.threeScaleInfo.permissions.create &&
+      this.state.threeScaleInfo.permissions.update
+    );
+  };
+
+  // This is a simplified toolbar for refresh and actions.
+  // Kiali has a shared component toolbar for more complex scenarios like filtering
+  // It renders actions only if user has permissions
+  toolbar = () => {
+    return (
+      <Toolbar className="pf-l-toolbar pf-u-justify-content-space-between pf-u-mx-xl pf-u-my-md">
+        <ToolbarSection aria-label="ToolbarSection">
+          <Toolbar className={rightToolbar}>
+            <RefreshButtonContainer
+              key={'Refresh'}
+              handleRefresh={() => this.fetchHandler(this.props.match.params.handlerName)}
+            />
+            {this.canDelete() && this.actionsToolbar()}
+          </Toolbar>
+        </ToolbarSection>
+      </Toolbar>
+    );
+  };
+
+  // Page title on 3scale extension doesn't have a namespace
+  // 3scale entities are always located under the control plane namespace, but that's implicit in the domain
+  pageTitle = (title: string) => (
+    <>
+      <div className={`breadcrumb ${containerWhite} ${paddingLeft}`}>
+        <Breadcrumb>
+          <BreadcrumbItem>
+            <Link to={'/extensions/threescale'}>3scale Handlers</Link>
+          </BreadcrumbItem>
+          <BreadcrumbItem isActive={true}>{title}</BreadcrumbItem>
+        </Breadcrumb>
+        <Text component={TextVariants.h1}>{title}</Text>
+        {!this.state.isNew && this.toolbar()}
+      </div>
+    </>
+  );
+
+  // Invoke the history object to update and URL and start a routing
   goHandlersPage = () => {
-    // Invoke the history object to update and URL and start a routing
     history.push('/extensions/threescale');
   };
 
+  // Basic form validation for new and updates
   isValid = () => {
     return (
       this.state.handler.name !== '' &&
@@ -210,7 +242,8 @@ class ThreeScaleHandlerDetailsPage extends React.Component<RouteComponentProps<P
     );
   };
 
-  onChangeHandler = (field: string, value: string) => {
+  // Updates state with modifications of the new/editing handler
+  changeHandler = (field: string, value: string) => {
     this.setState(prevState => {
       const newThreeScaleHandler = prevState.handler;
       switch (field) {
@@ -236,7 +269,8 @@ class ThreeScaleHandlerDetailsPage extends React.Component<RouteComponentProps<P
     });
   };
 
-  onUpdateHandler = () => {
+  // It invokes backend to create/update a 3scale handler
+  updateHandler = () => {
     if (this.state.isNew) {
       API.createThreeScaleHandler(JSON.stringify(this.state.handler))
         .then(_ => this.goHandlersPage())
@@ -248,7 +282,8 @@ class ThreeScaleHandlerDetailsPage extends React.Component<RouteComponentProps<P
     }
   };
 
-  onDeleteHandler = () => {
+  // It invokes backend to delete a 3scale handler
+  deleteHandler = () => {
     API.deleteThreeScaleHandler(this.state.handler.name)
       .then(_ => this.goHandlersPage())
       .catch(error => AlertUtils.addError('Could not delete ThreeScaleHandlers.', error));
@@ -256,7 +291,7 @@ class ThreeScaleHandlerDetailsPage extends React.Component<RouteComponentProps<P
 
   render() {
     const title = this.props.match.params.handlerName
-      ? '3scale Handler ' + this.props.match.params.handlerName
+      ? this.props.match.params.handlerName
       : 'Create New 3scale Handler';
     return (
       <>
@@ -274,7 +309,7 @@ class ThreeScaleHandlerDetailsPage extends React.Component<RouteComponentProps<P
                   id="handlerName"
                   value={this.state.handler.name}
                   placeholder="3scale Handler Name"
-                  onChange={value => this.onChangeHandler('handlerName', value)}
+                  onChange={value => this.changeHandler('handlerName', value)}
                   isDisabled={!this.state.isNew}
                 />
               </FormGroup>
@@ -288,7 +323,7 @@ class ThreeScaleHandlerDetailsPage extends React.Component<RouteComponentProps<P
                   id="serviceId"
                   value={this.state.handler.serviceId}
                   placeholder="3scale ID for API calls"
-                  onChange={value => this.onChangeHandler('serviceId', value)}
+                  onChange={value => this.changeHandler('serviceId', value)}
                 />
               </FormGroup>
               <FormGroup
@@ -301,7 +336,7 @@ class ThreeScaleHandlerDetailsPage extends React.Component<RouteComponentProps<P
                   id="systemUrl"
                   value={this.state.handler.systemUrl}
                   placeholder="3scale System Url for API"
-                  onChange={value => this.onChangeHandler('systemUrl', value)}
+                  onChange={value => this.changeHandler('systemUrl', value)}
                 />
               </FormGroup>
               <FormGroup
@@ -314,22 +349,20 @@ class ThreeScaleHandlerDetailsPage extends React.Component<RouteComponentProps<P
                   id="accessToken"
                   value={this.state.handler.accessToken}
                   placeholder="3scale access token"
-                  onChange={value => this.onChangeHandler('accessToken', value)}
+                  onChange={value => this.changeHandler('accessToken', value)}
                 />
               </FormGroup>
               <ActionGroup>
                 <span style={{ float: 'left', paddingTop: '10px', paddingBottom: '10px' }}>
-                  {this.canUpdate() && (
-                    <span style={{ paddingRight: '5px' }}>
-                      <Button
-                        variant={ButtonVariant.primary}
-                        isDisabled={!this.isValid()}
-                        onClick={this.onUpdateHandler}
-                      >
-                        {this.state.isNew ? 'Create' : 'Save'}
-                      </Button>
-                    </span>
-                  )}
+                  <span style={{ paddingRight: '5px' }}>
+                    <Button
+                      variant={ButtonVariant.primary}
+                      isDisabled={!this.canUpdate() || !this.isValid()}
+                      onClick={this.updateHandler}
+                    >
+                      {this.state.isNew ? 'Create' : 'Save'}
+                    </Button>
+                  </span>
                   <span style={{ paddingRight: '5px' }}>
                     <Button
                       variant={ButtonVariant.secondary}

--- a/src/pages/extensions/threescale/ThreeScaleHandlerList/ThreeScaleHandlerListPage.tsx
+++ b/src/pages/extensions/threescale/ThreeScaleHandlerList/ThreeScaleHandlerListPage.tsx
@@ -18,15 +18,17 @@ import { sortable, SortByDirection, Table, TableBody, TableHeader, ISortBy, IRow
 import RefreshButtonContainer from '../../../../components/Refresh/RefreshButton';
 import * as API from '../../../../services/Api';
 import * as AlertUtils from '../../../../utils/AlertUtils';
-import { ThreeScaleHandler } from '../../../../types/ThreeScale';
+import { ThreeScaleHandler, ThreeScaleInfo } from '../../../../types/ThreeScale';
 import { Link } from 'react-router-dom';
 import history from '../../../../app/History';
 
+// Style constants
 const containerPadding = style({ padding: '20px 20px 20px 20px' });
 const containerWhite = style({ backgroundColor: PfColors.White });
 const rightToolbar = style({ marginLeft: 'auto' });
 
-// Used only when there is no namespace selector, otherwise use the SecondaryMasthead component
+// Page title on 3scale extension doesn't have a namespace
+// 3scale entities are always located under the control plane namespace, but that's implicit in the domain
 const pageTitle = (
   <div className={`${containerPadding} ${containerWhite}`}>
     <Title headingLevel="h1" size="4xl" style={{ margin: '20px 0 0' }}>
@@ -35,56 +37,20 @@ const pageTitle = (
   </div>
 );
 
-const actionsToolbar = (
-  dropdownOpen: boolean,
-  onSelect: () => void,
-  onToggle: (toggle: boolean) => void,
-  onClick: () => void
-) => {
-  return (
-    <Dropdown
-      id="actions"
-      title="Actions"
-      toggle={<DropdownToggle onToggle={onToggle}>Actions</DropdownToggle>}
-      onSelect={onSelect}
-      position={DropdownPosition.right}
-      isOpen={dropdownOpen}
-      dropdownItems={[
-        <DropdownItem key="createIstioConfig" onClick={onClick}>
-          Create New 3scale Handler
-        </DropdownItem>
-      ]}
-    />
-  );
-};
-
-// This is a simplified toolbar only using a refresh button, other pages build a Filter/Sorting toolbar
-const toolbar = (
-  onRefresh: () => void,
-  dropdownOpen: boolean,
-  onSelect: () => void,
-  onToggle: (toggle: boolean) => void,
-  onClick: () => void
-) => {
-  return (
-    <Toolbar className="pf-l-toolbar pf-u-justify-content-space-between pf-u-mx-xl pf-u-my-md">
-      <ToolbarSection aria-label="ToolbarSection">
-        <Toolbar className={rightToolbar}>
-          <RefreshButtonContainer key={'Refresh'} handleRefresh={onRefresh} />
-          {actionsToolbar(dropdownOpen, onSelect, onToggle, onClick)}
-        </Toolbar>
-      </ToolbarSection>
-    </Toolbar>
-  );
-};
-
+// Empty properties, but using a type just for code consistency
 interface Props {}
+
+// State of the component/page
+// It stores the visual state of the components and the handlers fetched from the backend.
 interface State {
+  threeScaleInfo: ThreeScaleInfo;
   handlers: ThreeScaleHandler[];
   sortBy: ISortBy;
   dropdownOpen: boolean;
 }
 
+// Column headers used for the handlers table.
+// It addes the sortable capability.
 const columns = [
   {
     title: 'Handler Name',
@@ -104,12 +70,100 @@ class ThreeScaleHandlerListPage extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {
+      threeScaleInfo: {
+        enabled: false,
+        permissions: {
+          create: false,
+          update: false,
+          delete: false
+        }
+      },
       handlers: [],
       sortBy: {},
       dropdownOpen: false
     };
   }
 
+  // It fetches the information about Threescale adapter (adapter detected at runtime, permissions).
+  // It fetches the list of 3scale handlers.
+  fetchHandlers = () => {
+    API.getThreeScaleInfo()
+      .then(result => {
+        const threeScaleInfo = result.data;
+        if (threeScaleInfo.enabled) {
+          API.getThreeScaleHandlers()
+            .then(results => {
+              this.setState(prevState => {
+                return {
+                  threeScaleInfo: threeScaleInfo,
+                  handlers: results.data,
+                  sortBy: prevState.sortBy
+                };
+              });
+            })
+            .catch(error => {
+              AlertUtils.addError('Could not fetch ThreeScaleHandlers.', error);
+            });
+        } else {
+          AlertUtils.addError('Kiali has 3scale extension enabled but 3scale adapter is not detected in the cluster');
+        }
+      })
+      .catch(error => {
+        AlertUtils.addError('Could not fetch ThreeScaleInfo.', error);
+      });
+  };
+
+  // It invokes backend when component is mounted
+  componentDidMount() {
+    this.fetchHandlers();
+  }
+
+  // Invoke the history object to update and URL and start a routing
+  goNewHandlerPage = () => {
+    history.push('/extensions/threescale/new');
+  };
+
+  // This is a simplified actions toolbar.
+  // It contains a create new handler action.
+  actionsToolbar = () => {
+    return (
+      <Dropdown
+        id="actions"
+        title="Actions"
+        toggle={<DropdownToggle onToggle={toggle => this.setState({ dropdownOpen: toggle })}>Actions</DropdownToggle>}
+        onSelect={() => this.setState({ dropdownOpen: !this.state.dropdownOpen })}
+        position={DropdownPosition.right}
+        isOpen={this.state.dropdownOpen}
+        dropdownItems={[
+          <DropdownItem
+            key="createIstioConfig"
+            isDisabled={!(this.state.threeScaleInfo.enabled && this.state.threeScaleInfo.permissions.create)}
+            onClick={() => this.goNewHandlerPage()}
+          >
+            Create New 3scale Handler
+          </DropdownItem>
+        ]}
+      />
+    );
+  };
+
+  // This is a simplified toolbar for refresh and actions.
+  // Kiali has a shared component toolbar for more complex scenarios like filtering
+  // It renders actions only if user has permissions
+  toolbar = () => {
+    return (
+      <Toolbar className="pf-l-toolbar pf-u-justify-content-space-between pf-u-mx-xl pf-u-my-md">
+        <ToolbarSection aria-label="ToolbarSection">
+          <Toolbar className={rightToolbar}>
+            <RefreshButtonContainer key={'Refresh'} handleRefresh={() => this.fetchHandlers()} />
+            {this.actionsToolbar()}
+          </Toolbar>
+        </ToolbarSection>
+      </Toolbar>
+    );
+  };
+
+  // Helper used for Table to sort handlers based on index column == field
   onSort = (_event, index, direction) => {
     const sortedHandlers = this.state.handlers.sort((a, b) => {
       switch (index) {
@@ -131,25 +185,8 @@ class ThreeScaleHandlerListPage extends React.Component<Props, State> {
     });
   };
 
-  updateListItems = () => {
-    API.getThreeScaleHandlers()
-      .then(results => {
-        this.setState(prevState => {
-          return {
-            handlers: results.data,
-            sortBy: prevState.sortBy
-          };
-        });
-      })
-      .catch(error => {
-        AlertUtils.addError('Could not fetch ThreeScaleHandlers.', error);
-      });
-  };
-
-  componentDidMount() {
-    this.updateListItems();
-  }
-
+  // Helper used to build the table content.
+  // Note that maps the handlers to the internal types required for PF4 Table component.
   rows = (): IRow[] => {
     return this.state.handlers.map(h => {
       return {
@@ -197,24 +234,7 @@ class ThreeScaleHandlerListPage extends React.Component<Props, State> {
         {pageTitle}
         <RenderContent>
           <div className={containerPadding}>
-            {toolbar(
-              this.updateListItems,
-              this.state.dropdownOpen,
-              () => {
-                this.setState({
-                  dropdownOpen: !this.state.dropdownOpen
-                });
-              },
-              toggle => {
-                this.setState({
-                  dropdownOpen: toggle
-                });
-              },
-              () => {
-                // Invoke the history object to update and URL and start a routing
-                history.push('/extensions/threescale/new');
-              }
-            )}
+            {this.toolbar()}
             <Table
               aria-label="Sortable Table"
               sortBy={this.state.sortBy}

--- a/src/pages/extensions/threescale/ThreeScaleHandlerList/ThreeScaleHandlerListPage.tsx
+++ b/src/pages/extensions/threescale/ThreeScaleHandlerList/ThreeScaleHandlerListPage.tsx
@@ -1,0 +1,140 @@
+import * as React from 'react';
+import { RenderContent } from '../../../../components/Nav/Page';
+import { Title, Toolbar, ToolbarSection } from '@patternfly/react-core';
+import { style } from 'typestyle';
+import { PfColors } from '../../../../components/Pf/PfColors';
+import { sortable, SortByDirection, Table, TableBody, TableHeader, ISortBy, IRow } from '@patternfly/react-table';
+import RefreshButtonContainer from '../../../../components/Refresh/RefreshButton';
+import * as API from '../../../../services/Api';
+import * as AlertUtils from '../../../../utils/AlertUtils';
+import { ThreeScaleHandler } from '../../../../types/ThreeScale';
+
+const containerPadding = style({ padding: '20px 20px 20px 20px' });
+const containerWhite = style({ backgroundColor: PfColors.White });
+const rightToolbar = style({ marginLeft: 'auto' });
+
+// Used only when there is no namespace selector, otherwise use the SecondaryMasthead component
+const pageTitle = (
+  <div className={`${containerPadding} ${containerWhite}`}>
+    <Title headingLevel="h1" size="4xl" style={{ margin: '20px 0 0' }}>
+      3scale Handlers
+    </Title>
+  </div>
+);
+
+// This is a simplified toolbar only using a refresh button, other pages build a Filter/Sorting toolbar
+const refreshToolbar = (refresh: () => void) => {
+  return (
+    <Toolbar className="pf-l-toolbar pf-u-justify-content-space-between pf-u-mx-xl pf-u-my-md">
+      <ToolbarSection aria-label="ToolbarSection">
+        <Toolbar className={rightToolbar}>
+          <RefreshButtonContainer key={'Refresh'} handleRefresh={refresh} />
+        </Toolbar>
+      </ToolbarSection>
+    </Toolbar>
+  );
+};
+
+interface Props {}
+interface State {
+  handlers: ThreeScaleHandler[];
+  sortBy: ISortBy;
+}
+
+const columns = [
+  {
+    title: 'Handler Name',
+    transforms: [sortable]
+  },
+  {
+    title: 'Service Id',
+    transforms: [sortable]
+  },
+  {
+    title: 'System Url',
+    transforms: [sortable]
+  }
+];
+
+class ThreeScaleHandlerListPage extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      handlers: [],
+      sortBy: {}
+    };
+  }
+
+  onSort = (_event, index, direction) => {
+    const sortedHandlers = this.state.handlers.sort((a, b) => {
+      switch (index) {
+        case 0:
+          return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
+        case 1:
+          return a.serviceId < b.serviceId ? -1 : a.serviceId > b.serviceId ? 1 : 0;
+        case 2:
+          return a.systemUrl < b.systemUrl ? -1 : a.systemUrl > b.systemUrl ? 1 : 0;
+      }
+      return 0;
+    });
+    this.setState({
+      handlers: direction === SortByDirection.asc ? sortedHandlers : sortedHandlers.reverse(),
+      sortBy: {
+        index,
+        direction
+      }
+    });
+  };
+
+  updateListItems = () => {
+    API.getThreeScaleHandlers()
+      .then(results => {
+        this.setState(prevState => {
+          return {
+            handlers: results.data,
+            sortBy: prevState.sortBy
+          };
+        });
+      })
+      .catch(error => {
+        AlertUtils.addError('Could not fetch ThreeScaleHandlers.', error);
+      });
+  };
+
+  componentDidMount() {
+    this.updateListItems();
+  }
+
+  rows = (): IRow[] => {
+    return this.state.handlers.map(h => {
+      return {
+        cells: [<div>{h.name}</div>, <div>{h.serviceId}</div>, <div>{h.systemUrl}</div>]
+      };
+    });
+  };
+
+  render() {
+    return (
+      <>
+        {pageTitle}
+        <RenderContent>
+          <div className={containerPadding}>
+            {refreshToolbar(this.updateListItems)}
+            <Table
+              aria-label="Sortable Table"
+              sortBy={this.state.sortBy}
+              onSort={this.onSort}
+              cells={columns}
+              rows={this.rows()}
+            >
+              <TableHeader />
+              <TableBody />
+            </Table>
+          </div>
+        </RenderContent>
+      </>
+    );
+  }
+}
+
+export default ThreeScaleHandlerListPage;

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -13,6 +13,7 @@ import ServiceDetailsPageContainer from './pages/ServiceDetails/ServiceDetailsPa
 import DefaultSecondaryMasthead from './components/DefaultSecondaryMasthead/DefaultSecondaryMasthead';
 import IstioConfigNewPageContainer from './pages/IstioConfigNew/IstioConfigNewPage';
 import ThreeScaleHandlerListPage from './pages/extensions/threescale/ThreeScaleHandlerList/ThreeScaleHandlerListPage';
+import ThreeScaleHandlerDetailsPage from './pages/extensions/threescale/ThreeScaleHandlerDetails/ThreeScaleHandlerDetailsPage';
 
 /**
  * Return array of objects that describe vertical menu
@@ -173,6 +174,15 @@ const secondaryMastheadRoutes: Path[] = [
 ];
 
 const extensionsRoutes: Path[] = [
+  // Keep routes ordered with the more specific URLs first
+  {
+    path: '/extensions/threescale/new',
+    component: ThreeScaleHandlerDetailsPage
+  },
+  {
+    path: '/extensions/threescale/:handlerName',
+    component: ThreeScaleHandlerDetailsPage
+  },
   {
     path: '/extensions/threescale',
     component: ThreeScaleHandlerListPage

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -12,6 +12,7 @@ import { icons, Paths } from './config';
 import ServiceDetailsPageContainer from './pages/ServiceDetails/ServiceDetailsPage';
 import DefaultSecondaryMasthead from './components/DefaultSecondaryMasthead/DefaultSecondaryMasthead';
 import IstioConfigNewPageContainer from './pages/IstioConfigNew/IstioConfigNewPage';
+import ThreeScaleHandlerListPage from './pages/extensions/threescale/ThreeScaleHandlerList/ThreeScaleHandlerListPage';
 
 /**
  * Return array of objects that describe vertical menu
@@ -58,6 +59,15 @@ const navItems: MenuItem[] = [
     iconClass: icons.menu.distributedTracing,
     title: 'Distributed Tracing',
     to: '/jaeger'
+  }
+];
+
+const extensionsItems: MenuItem[] = [
+  {
+    iconClass: '',
+    title: '3scale Config',
+    to: '/extensions/threescale',
+    pathsActive: [/^\/extensions\/threescale/]
   }
 ];
 
@@ -162,4 +172,11 @@ const secondaryMastheadRoutes: Path[] = [
   }
 ];
 
-export { defaultRoute, navItems, pathRoutes, secondaryMastheadRoutes };
+const extensionsRoutes: Path[] = [
+  {
+    path: '/extensions/threescale',
+    component: ThreeScaleHandlerListPage
+  }
+];
+
+export { defaultRoute, navItems, extensionsItems, pathRoutes, secondaryMastheadRoutes, extensionsRoutes };

--- a/src/types/ServerConfig.ts
+++ b/src/types/ServerConfig.ts
@@ -2,7 +2,18 @@ import { DurationInSeconds } from './Common';
 
 export type IstioLabelKey = 'appLabelName' | 'versionLabelName';
 
+// 3scale public config, typically to check if addon/extension is enabled
+interface ThreeScaleConfig {
+  enabled: boolean;
+}
+
+// Kiali addons/extensions specific
+interface Extensions {
+  threescale: ThreeScaleConfig;
+}
+
 export interface ServerConfig {
+  extensions?: Extensions;
   installationTag?: string;
   istioIdentityDomain: string;
   istioNamespace: string;


### PR DESCRIPTION
UI changes to refactor 3scale feature to move it like a structured add-on/extension.

In the previous 3scale extension implementation, the 3scale handler management was included inside the 3scale wizard.

This PR moves the handlers to a separate 3scale section enabled/disabled from the backend config as an extension:

![image](https://user-images.githubusercontent.com/1662329/74026707-032f0280-49a7-11ea-9181-ca1a01ee0fe5.png)

It implements a pretty basic list/details model with a basic form to create/edit a 3scale handler (an entity with 4 fields):

![image](https://user-images.githubusercontent.com/1662329/74026762-2063d100-49a7-11ea-9a70-88354dce8008.png)

Note that 3scale handlers have no notion of namespace, user manages 3scale entities that Kiali maps internally on Istio Rules/Adapter/Handlers typically co-located into the control plane.

But from 3scale extension perspective, it doesn't belong to any namespace as it is not a formal entity.

In practice, the implementation of these handlers are regular Istio Config objects that can be seen under the Istio Config section:

![image](https://user-images.githubusercontent.com/1662329/74026898-6faa0180-49a7-11ea-9b39-4f0f2fb63281.png)

Previous feature/behaviour remains intact, as user would be able to add/update/remove a 3scale rule from the Service Details Wizard section:
![image](https://user-images.githubusercontent.com/1662329/74026976-8d776680-49a7-11ea-8c20-40dc2598ba9b.png)

Main change of this refactoring is in the 3scale Wizard Advanced section that now is gone and it has been moved as a main entity:

![image](https://user-images.githubusercontent.com/1662329/74027071-ba2b7e00-49a7-11ea-9249-94069beb2b04.png)

Requires https://github.com/kiali/kiali/pull/2159
Related to https://github.com/kiali/kiali/issues/2146