### PR TITLE
Fix undefined value not caught on jaeger rendering

### DIFF
--- a/src/components/Nav/Menu.tsx
+++ b/src/components/Nav/Menu.tsx
@@ -50,7 +50,7 @@ class Menu extends React.Component<MenuProps, MenuState> {
     });
     return navItems.map(item => {
       if (item.title === 'Distributed Tracing') {
-        return this.props.jaegerUrl !== '' ? (
+        return this.props.jaegerUrl && this.props.jaegerUrl !== '' ? (
           <ExternalLink key={item.to} href={this.props.jaegerUrl} name="Distributed Tracing" />
         ) : (
           ''

--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -463,7 +463,7 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
     const tabsArray: any[] = [overviewTab, trafficTab, inboundMetricsTab];
 
     // Conditional Traces tab
-    if (this.props.jaegerIntegration || this.props.jaegerUrl !== '') {
+    if (this.props.jaegerIntegration || (this.props.jaegerUrl && this.props.jaegerUrl !== '')) {
       let jaegerTag: any = undefined;
       if (this.props.jaegerIntegration) {
         const jaegerTitle =


### PR DESCRIPTION
When `this.props.jaegerUrl` is `undefined` then `this.props.jaegerUrl !== ''` returns a true which triggers to render the Distributed Tracing menu and the Traces tab.

I've tested disabling the the tracing service in config.yaml.

There is also an error of the backend when fetching service details (but I'm using a non-master branch, so I'll let @aljesusg address that).
