### PR TITLE
Graph side-panel UX review

### DIFF
--- a/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
+++ b/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
@@ -106,7 +106,7 @@ export class NodeContextMenu extends React.PureComponent<Props> {
         <div className={graphContextMenuTitleStyle}>
           <strong>{name}</strong>
         </div>
-        {options.map(o => this.createMenuItem(o.url, o.display, o.target, o.external))}
+        {options.map(o => this.createMenuItem(o.url, o.text, o.target, o.external))}
       </div>
     );
   }
@@ -126,7 +126,7 @@ const getJaegerURL = (namespace: string, namespaceSelector: boolean, jaegerURL: 
 };
 
 export type ContextMenuOption = {
-  display: string;
+  text: string;
   url: string;
   external?: boolean;
   target?: string;
@@ -142,24 +142,24 @@ export const getOptions = (
   const detailsPageUrl = makeDetailsPageUrl(namespace, type, name);
   const options: ContextMenuOption[] = [];
 
-  options.push({ display: 'Show Details', url: detailsPageUrl });
+  options.push({ text: 'Show Details', url: detailsPageUrl });
   if (type !== Paths.SERVICEENTRIES) {
-    options.push({ display: 'Show Traffic', url: `${detailsPageUrl}?tab=traffic` });
+    options.push({ text: 'Show Traffic', url: `${detailsPageUrl}?tab=traffic` });
     if (type === Paths.WORKLOADS) {
-      options.push({ display: 'Show Logs', url: `${detailsPageUrl}?tab=logs` });
+      options.push({ text: 'Show Logs', url: `${detailsPageUrl}?tab=logs` });
     }
     options.push({
-      display: 'Show Inbound Metrics',
+      text: 'Show Inbound Metrics',
       url: `${detailsPageUrl}?tab=${type === Paths.SERVICES ? 'metrics' : 'in_metrics'}`
     });
     if (type !== Paths.SERVICES) {
-      options.push({ display: 'Show Outbound Metrics', url: `${detailsPageUrl}?tab=out_metrics` });
+      options.push({ text: 'Show Outbound Metrics', url: `${detailsPageUrl}?tab=out_metrics` });
     }
     if (type === Paths.SERVICES) {
       jaegerIntegration
-        ? options.push({ display: 'Show Traces', url: `${detailsPageUrl}?tab=traces` })
+        ? options.push({ text: 'Show Traces', url: `${detailsPageUrl}?tab=traces` })
         : options.push({
-            display: 'Show Traces',
+            text: 'Show Traces',
             url: getJaegerURL(namespace, namespaceSelector, jaegerUrl!, name),
             external: true,
             target: '_blank'

--- a/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
+++ b/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
@@ -5,7 +5,7 @@ import { style } from 'typestyle';
 import { KialiAppState } from '../../../store/Store';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
-import { NodeType } from 'types/Graph';
+import { NodeType, DecoratedGraphNodeData } from 'types/Graph';
 
 type ReduxProps = {
   jaegerIntegration: boolean;
@@ -42,43 +42,33 @@ const graphContextMenuItemLinkStyle = style({
 type Props = NodeContextMenuProps & ReduxProps;
 
 export class NodeContextMenu extends React.PureComponent<Props> {
-  private static derivedValuesFromProps(props: Props) {
+  static derivedValuesFromProps(node: DecoratedGraphNodeData) {
+    const namespace: string = node.namespace;
     let name: string | undefined = '';
     let type = '';
-    switch (props.nodeType) {
+    switch (node.nodeType) {
       case 'app':
         // Prefer workload type for nodes backed by a workload
-        if (props.workload && props.parent) {
-          name = props.workload;
+        if (node.workload && node.parent) {
+          name = node.workload;
           type = Paths.WORKLOADS;
         } else {
           type = Paths.APPLICATIONS;
-          name = props.app;
+          name = node.app;
         }
         break;
       case 'service':
-        type = props.isServiceEntry ? Paths.SERVICEENTRIES : Paths.SERVICES;
-        name = props.service;
+        type = node.isServiceEntry ? Paths.SERVICEENTRIES : Paths.SERVICES;
+        name = node.service;
         break;
       case 'workload':
-        name = props.workload;
+        name = node.workload;
         type = Paths.WORKLOADS;
         break;
       default:
     }
 
-    return { type, name };
-  }
-
-  // @todo: We need take care of this at global app level
-  makeDetailsPageUrl(type: string, name?: string) {
-    return `/namespaces/${this.props.namespace}/${type}/${name}`;
-  }
-
-  getJaegerURL(name?: string) {
-    return `${this.props.jaegerURL}/search?service=${name}${
-      this.props.namespaceSelector ? `.${this.props.namespace}` : ''
-    }`;
+    return { namespace, type, name };
   }
 
   createMenuItem(href: string, title: string, target: string = '_self', external: boolean = false) {
@@ -103,30 +93,20 @@ export class NodeContextMenu extends React.PureComponent<Props> {
       return null;
     }
 
-    const { type, name } = NodeContextMenu.derivedValuesFromProps(this.props);
-    const detailsPageUrl = this.makeDetailsPageUrl(type, name);
+    const { name } = NodeContextMenu.derivedValuesFromProps(this.props);
+    const options: ContextMenuOption[] = getOptions(
+      this.props,
+      this.props.namespaceSelector,
+      this.props.jaegerIntegration,
+      this.props.jaegerURL
+    );
 
     return (
       <div className={graphContextMenuContainerStyle}>
         <div className={graphContextMenuTitleStyle}>
           <strong>{name}</strong>
         </div>
-        {this.createMenuItem(detailsPageUrl, 'Show Details')}
-        {type !== Paths.SERVICEENTRIES && (
-          <>
-            {this.createMenuItem(`${detailsPageUrl}?tab=traffic`, 'Show Traffic')}
-            {type === Paths.WORKLOADS && this.createMenuItem(`${detailsPageUrl}?tab=logs`, 'Show Logs')}
-            {this.createMenuItem(
-              `${detailsPageUrl}?tab=${type === Paths.SERVICES ? 'metrics' : 'in_metrics'}`,
-              'Show Inbound Metrics'
-            )}
-            {type !== Paths.SERVICES &&
-              this.createMenuItem(`${detailsPageUrl}?tab=out_metrics`, 'Show Outbound Metrics')}
-            {type === Paths.SERVICES && this.props.jaegerIntegration
-              ? this.createMenuItem(`${detailsPageUrl}?tab=traces`, 'Show Traces')
-              : this.props.jaegerURL && this.createMenuItem(this.getJaegerURL(name), 'Show Traces', '_blank', true)}
-          </>
-        )}
+        {options.map(o => this.createMenuItem(o.url, o.display, o.target, o.external))}
       </div>
     );
   }
@@ -135,6 +115,60 @@ export class NodeContextMenu extends React.PureComponent<Props> {
     this.props.contextMenu.hide(0);
   };
 }
+
+// @todo: We need take care of this at global app level
+const makeDetailsPageUrl = (namespace: string, type: string, name?: string): string => {
+  return `/namespaces/${namespace}/${type}/${name}`;
+};
+
+const getJaegerURL = (namespace: string, namespaceSelector: boolean, jaegerURL: string, name?: string): string => {
+  return `${jaegerURL}/search?service=${name}${namespaceSelector ? `.${namespace}` : ''}`;
+};
+
+export type ContextMenuOption = {
+  display: string;
+  url: string;
+  external?: boolean;
+  target?: string;
+};
+
+export const getOptions = (
+  node: DecoratedGraphNodeData,
+  namespaceSelector: boolean,
+  jaegerIntegration?: boolean,
+  jaegerUrl?: string
+): ContextMenuOption[] => {
+  const { namespace, type, name } = NodeContextMenu.derivedValuesFromProps(node);
+  const detailsPageUrl = makeDetailsPageUrl(namespace, type, name);
+  const options: ContextMenuOption[] = [];
+
+  options.push({ display: 'Show Details', url: detailsPageUrl });
+  if (type !== Paths.SERVICEENTRIES) {
+    options.push({ display: 'Show Traffic', url: `${detailsPageUrl}?tab=traffic` });
+    if (type === Paths.WORKLOADS) {
+      options.push({ display: 'Show Logs', url: `${detailsPageUrl}?tab=logs` });
+    }
+    options.push({
+      display: 'Show Inbound Metrics',
+      url: `${detailsPageUrl}?tab=${type === Paths.SERVICES ? 'metrics' : 'in_metrics'}`
+    });
+    if (type !== Paths.SERVICES) {
+      options.push({ display: 'Show Outbound Metrics', url: `${detailsPageUrl}?tab=out_metrics` });
+    }
+    if (type === Paths.SERVICES) {
+      jaegerIntegration
+        ? options.push({ display: 'Show Traces', url: `${detailsPageUrl}?tab=traces` })
+        : options.push({
+            display: 'Show Traces',
+            url: getJaegerURL(namespace, namespaceSelector, jaegerUrl!, name),
+            external: true,
+            target: '_blank'
+          });
+    }
+  }
+
+  return options;
+};
 
 const mapStateToProps = (state: KialiAppState) => ({
   jaegerIntegration: state.jaegerState ? state.jaegerState.integration : false,

--- a/src/components/SummaryPanel/InOutRateTable.tsx
+++ b/src/components/SummaryPanel/InOutRateTable.tsx
@@ -93,9 +93,9 @@ export class InOutRateTableHttp extends React.Component<InOutRateTableHttpPropTy
     return (
       <div>
         <strong>{this.props.title}</strong>
-        <table className="table">
+        <table className="table" style={{ marginBottom: '10px' }}>
           <thead>
-            <tr>
+            <tr style={{ backgroundColor: 'white' }}>
               <th />
               <th>Total</th>
               <th>%Success</th>

--- a/src/components/SummaryPanel/RateChart.tsx
+++ b/src/components/SummaryPanel/RateChart.tsx
@@ -8,8 +8,8 @@ import * as Legend from 'components/Charts/LegendHelper';
 import { CustomFlyout } from 'components/Charts/CustomFlyout';
 import { VCLines } from 'utils/Graphing';
 
-export const legendHeight = 30;
-export const legendTopMargin = 25;
+export const legendHeight = 25;
+export const legendTopMargin = 20;
 
 type Props = {
   baseName: string;
@@ -58,7 +58,7 @@ export class RateChart extends React.Component<Props, State> {
     });
     const fontSize = getComputedStyle(document.body).getPropertyValue('--graph-side-panel--font-size');
     const fontSizePx = getComputedStyle(document.body).getPropertyValue('--graph-side-panel--font-size-px');
-    const horizontalAxisStyle = { tickLabels: { fontSize: fontSize } };
+    const horizontalAxisStyle = { tickLabels: { fontSize: fontSize, padding: 3 } };
     const verticalAxisStyle = singleBar
       ? { tickLabels: { fill: 'none', fontSize: fontSize } }
       : { tickLabels: { padding: 2, fontSize: fontSize } };
@@ -89,7 +89,7 @@ export class RateChart extends React.Component<Props, State> {
                     label: `${dp.name}: ${dp.y.toFixed(2)} %`
                   };
                 })}
-                barWidth={30}
+                barWidth={10}
                 labelComponent={<ChartTooltip constrainToVisibleArea={true} flyoutComponent={<CustomFlyout />} />}
               />
             );
@@ -196,7 +196,7 @@ export const renderInOutRateChartHttp = (
       }
     };
   });
-  return <RateChart baseName={'in-out-rate-http'} height={132} xLabelsWidth={25} series={vcLines} />;
+  return <RateChart baseName={'in-out-rate-http'} height={80} xLabelsWidth={25} series={vcLines} />;
 };
 
 export const renderInOutRateChartGrpc = (

--- a/src/components/SummaryPanel/RateChart.tsx
+++ b/src/components/SummaryPanel/RateChart.tsx
@@ -56,7 +56,12 @@ export class RateChart extends React.Component<Props, State> {
         };
       }
     });
-    const verticalAxisStyle = singleBar ? { tickLabels: { fill: 'none' } } : { tickLabels: { padding: 2 } };
+    const fontSize = getComputedStyle(document.body).getPropertyValue('--graph-side-panel--font-size');
+    const fontSizePx = getComputedStyle(document.body).getPropertyValue('--graph-side-panel--font-size-px');
+    const horizontalAxisStyle = { tickLabels: { fontSize: fontSize } };
+    const verticalAxisStyle = singleBar
+      ? { tickLabels: { fill: 'none', fontSize: fontSize } }
+      : { tickLabels: { padding: 2, fontSize: fontSize } };
     return (
       <Chart
         height={height}
@@ -91,8 +96,15 @@ export class RateChart extends React.Component<Props, State> {
           })}
         </ChartStack>
         <ChartAxis style={verticalAxisStyle} />
-        <ChartAxis dependentAxis={true} showGrid={true} crossAxis={false} tickValues={[0, 25, 50, 75, 100]} />
+        <ChartAxis
+          style={horizontalAxisStyle}
+          dependentAxis={true}
+          showGrid={true}
+          crossAxis={false}
+          tickValues={[0, 25, 50, 75, 100]}
+        />
         <VictoryLegend
+          style={{ labels: { fontSize: Number(fontSizePx) } }}
           name={this.props.baseName + '-legend'}
           data={this.props.series.map((s, idx) => {
             if (this.state.hiddenSeries.has(idx)) {

--- a/src/components/SummaryPanel/RateTable.tsx
+++ b/src/components/SummaryPanel/RateTable.tsx
@@ -64,9 +64,9 @@ export class RateTableHttp extends React.Component<RateTableHttpPropType, {}> {
     return (
       <div>
         <strong>{this.props.title}</strong>
-        <table className="table">
+        <table className="table" style={{ marginBottom: '10px' }}>
           <thead>
-            <tr>
+            <tr style={{ backgroundColor: 'white' }}>
               <th>Total</th>
               <th>%Success</th>
               <th>%Error</th>

--- a/src/components/Tab/SimpleTabs.tsx
+++ b/src/components/Tab/SimpleTabs.tsx
@@ -7,6 +7,7 @@ import { Tabs } from '@patternfly/react-core';
 type SimpleTabsProps = {
   defaultTab: number;
   id: string;
+  isFilled?: boolean;
   mountOnEnter?: boolean;
   style?: React.CSSProperties;
   unmountOnExit?: boolean;
@@ -30,6 +31,7 @@ export default class SimpleTabs extends React.Component<SimpleTabsProps, SimpleT
       <Tabs
         id={this.props.id}
         style={this.props.style ? this.props.style : {}}
+        isFilled={this.props.isFilled ? this.props.isFilled : true}
         activeKey={this.state.activeTab}
         onSelect={this.handleTabSelect}
         mountOnEnter={this.props.mountOnEnter === undefined ? true : this.props.mountOnEnter}

--- a/src/pages/Graph/SummaryLink.tsx
+++ b/src/pages/Graph/SummaryLink.tsx
@@ -121,12 +121,17 @@ export const renderBadgedHost = (host: string) => {
   );
 };
 
-export const renderBadgedLink = (nodeData: GraphNodeData, nodeType?: NodeType) => {
+export const renderBadgedLink = (nodeData: GraphNodeData, nodeType?: NodeType, label?: string) => {
   const link = getLink(nodeData, nodeType);
 
   return (
     <>
       <span style={{ marginRight: '1em', marginBottom: '3px', display: 'inline-block' }}>
+        {label && (
+          <span style={{ whiteSpace: 'pre' }}>
+            <b>{label}</b>
+          </span>
+        )}
         {getBadge(nodeData, nodeType)}
         {link}
       </span>

--- a/src/pages/Graph/SummaryLink.tsx
+++ b/src/pages/Graph/SummaryLink.tsx
@@ -110,25 +110,37 @@ export const RenderLink = (props: RenderLinkProps) => {
   );
 };
 
-export const renderTitle = (nodeData: DecoratedGraphNodeData, health?: Health) => {
+export const renderTitle = (nodeData: DecoratedGraphNodeData) => {
   const link = getLink(nodeData);
 
   return (
-    <span>
+    <>
       <span style={{ paddingRight: '0.5em' }}>
         {getTitle(nodeData)}
         {link}
       </span>
       {nodeData.isInaccessible && <KialiIcon.MtlsLock />}
+    </>
+  );
+};
+
+export const renderHealth = (health?: Health) => {
+  return (
+    <>
       {health && (
-        <HealthIndicator
-          id="graph-health-indicator"
-          mode={DisplayMode.SMALL}
-          health={health}
-          tooltipPlacement={PopoverPosition.left}
-        />
+        <Badge style={{ fontWeight: 'normal', marginTop: '4px', marginBottom: '4px' }} isRead={true}>
+          <span style={{ margin: '3px 0 1px 0' }}>
+            <HealthIndicator
+              id="graph-health-indicator"
+              mode={DisplayMode.SMALL}
+              health={health}
+              tooltipPlacement={PopoverPosition.left}
+            />
+          </span>
+          <span style={{ marginLeft: '4px' }}>health</span>
+        </Badge>
       )}
-    </span>
+    </>
   );
 };
 

--- a/src/pages/Graph/SummaryLink.tsx
+++ b/src/pages/Graph/SummaryLink.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { NodeType, DecoratedGraphNodeData, GraphNodeData } from '../../types/Graph';
+import { NodeType, GraphNodeData } from '../../types/Graph';
 import { CyNode, decoratedNodeData } from '../../components/CytoscapeGraph/CytoscapeGraphUtils';
 import { KialiIcon } from 'config/KialiIcon';
 import { Tooltip, Badge, PopoverPosition } from '@patternfly/react-core';
 import { Health } from 'types/Health';
 import { HealthIndicator, DisplayMode } from 'components/Health/HealthIndicator';
 
-const getTitle = (nodeData: DecoratedGraphNodeData) => {
-  switch (nodeData.nodeType) {
+const getTitle = (nodeData: GraphNodeData, nodeType?: NodeType) => {
+  switch (nodeType || nodeData.nodeType) {
     case NodeType.APP:
       return (
         <Tooltip content={<>Application</>}>
@@ -110,13 +110,13 @@ export const RenderLink = (props: RenderLinkProps) => {
   );
 };
 
-export const renderTitle = (nodeData: DecoratedGraphNodeData) => {
-  const link = getLink(nodeData);
+export const renderTitle = (nodeData: GraphNodeData, nodeType?: NodeType) => {
+  const link = getLink(nodeData, nodeType);
 
   return (
     <>
       <span style={{ paddingRight: '0.5em' }}>
-        {getTitle(nodeData)}
+        {getTitle(nodeData, nodeType)}
         {link}
       </span>
       {nodeData.isInaccessible && <KialiIcon.MtlsLock />}
@@ -153,7 +153,7 @@ export const renderDestServicesLinks = (node: any) => {
     return links;
   }
 
-  destServices.forEach((ds, index) => {
+  destServices.forEach(ds => {
     const serviceNodeData: GraphNodeData = {
       id: nodeData.id,
       app: '',
@@ -167,13 +167,14 @@ export const renderDestServicesLinks = (node: any) => {
       version: '',
       workload: ''
     };
-    links.push(<RenderLink key={`service-${index}`} nodeData={serviceNodeData} nodeType={NodeType.SERVICE} />);
-    links.push(<span key={`comma-after-${ds.name}`}>, </span>);
+    // links.push(<RenderLink key={`service-${index}`} nodeData={serviceNodeData} nodeType={NodeType.SERVICE} />);
+    // links.push(<span key={`comma-after-${ds.name}`}>, </span>);
+    links.push(renderTitle(serviceNodeData));
   });
 
-  if (links.length > 0) {
-    links.pop();
-  }
+  // if (links.length > 0) {
+  //  links.pop();
+  // }
 
   return links;
 };

--- a/src/pages/Graph/SummaryLink.tsx
+++ b/src/pages/Graph/SummaryLink.tsx
@@ -7,7 +7,7 @@ import { Tooltip, Badge, PopoverPosition } from '@patternfly/react-core';
 import { Health } from 'types/Health';
 import { HealthIndicator, DisplayMode } from 'components/Health/HealthIndicator';
 
-const getTitle = (nodeData: GraphNodeData, nodeType?: NodeType) => {
+const getBadge = (nodeData: GraphNodeData, nodeType?: NodeType) => {
   switch (nodeType || nodeData.nodeType) {
     case NodeType.APP:
       return (
@@ -110,13 +110,24 @@ export const RenderLink = (props: RenderLinkProps) => {
   );
 };
 
-export const renderTitle = (nodeData: GraphNodeData, nodeType?: NodeType) => {
+export const renderBadgedHost = (host: string) => {
+  return (
+    <span>
+      <Tooltip content={<>Host</>}>
+        <Badge className="virtualitem_badge_definition">H</Badge>
+      </Tooltip>
+      {host}
+    </span>
+  );
+};
+
+export const renderBadgedLink = (nodeData: GraphNodeData, nodeType?: NodeType) => {
   const link = getLink(nodeData, nodeType);
 
   return (
     <>
-      <span style={{ paddingRight: '0.5em' }}>
-        {getTitle(nodeData, nodeType)}
+      <span style={{ marginRight: '1em', marginBottom: '3px', display: 'inline-block' }}>
+        {getBadge(nodeData, nodeType)}
         {link}
       </span>
       {nodeData.isInaccessible && <KialiIcon.MtlsLock />}
@@ -127,19 +138,21 @@ export const renderTitle = (nodeData: GraphNodeData, nodeType?: NodeType) => {
 export const renderHealth = (health?: Health) => {
   return (
     <>
-      {health && (
-        <Badge style={{ fontWeight: 'normal', marginTop: '4px', marginBottom: '4px' }} isRead={true}>
-          <span style={{ margin: '3px 0 1px 0' }}>
+      <Badge style={{ fontWeight: 'normal', marginTop: '4px', marginBottom: '4px' }} isRead={true}>
+        <span style={{ margin: '3px 0 1px 0' }}>
+          {health ? (
             <HealthIndicator
               id="graph-health-indicator"
               mode={DisplayMode.SMALL}
               health={health}
               tooltipPlacement={PopoverPosition.left}
             />
-          </span>
-          <span style={{ marginLeft: '4px' }}>health</span>
-        </Badge>
-      )}
+          ) : (
+            'n/a'
+          )}
+        </span>
+        <span style={{ marginLeft: '4px' }}>health</span>
+      </Badge>
     </>
   );
 };
@@ -167,14 +180,8 @@ export const renderDestServicesLinks = (node: any) => {
       version: '',
       workload: ''
     };
-    // links.push(<RenderLink key={`service-${index}`} nodeData={serviceNodeData} nodeType={NodeType.SERVICE} />);
-    // links.push(<span key={`comma-after-${ds.name}`}>, </span>);
-    links.push(renderTitle(serviceNodeData));
+    links.push(renderBadgedLink(serviceNodeData));
   });
-
-  // if (links.length > 0) {
-  //  links.pop();
-  // }
 
   return links;
 };

--- a/src/pages/Graph/SummaryPanel.tsx
+++ b/src/pages/Graph/SummaryPanel.tsx
@@ -16,13 +16,13 @@ type MainSummaryPanelPropType = SummaryPanelPropType & {
 };
 
 const expandedStyle = style({
-  fontSize: '74%', // TODO: Remove
+  fontSize: 'var(--graph-side-panel--font-size)',
   padding: '0',
   position: 'relative'
 });
 
 const collapsedStyle = style({
-  fontSize: '74%', // TODO: Remove
+  fontSize: 'var(--graph-side-panel--font-size)',
   padding: '0',
   position: 'relative',
   $nest: {
@@ -65,7 +65,7 @@ export default class SummaryPanel extends React.Component<MainSummaryPanelPropTy
       return null;
     }
     return (
-      <div className={this.state.isVisible ? expandedStyle : collapsedStyle}>
+      <div id="graph-side-panel" className={this.state.isVisible ? expandedStyle : collapsedStyle}>
         <div className={toggleSidePanelStyle} onClick={this.togglePanel}>
           {this.state.isVisible ? (
             <>

--- a/src/pages/Graph/SummaryPanel.tsx
+++ b/src/pages/Graph/SummaryPanel.tsx
@@ -4,8 +4,8 @@ import { SummaryPanelPropType } from '../../types/Graph';
 import SummaryPanelEdge from './SummaryPanelEdge';
 import SummaryPanelGraph from './SummaryPanelGraph';
 import SummaryPanelGroup from './SummaryPanelGroup';
-import SummaryPanelNode from './SummaryPanelNode';
 import { KialiIcon } from 'config/KialiIcon';
+import SummaryPanelNodeContainer from './SummaryPanelNode';
 
 type SummaryPanelState = {
   isVisible: boolean;
@@ -103,7 +103,7 @@ export default class SummaryPanel extends React.Component<MainSummaryPanelPropTy
           />
         ) : null}
         {this.props.data.summaryType === 'node' ? (
-          <SummaryPanelNode
+          <SummaryPanelNodeContainer
             data={this.props.data}
             queryTime={this.props.queryTime}
             namespaces={this.props.namespaces}

--- a/src/pages/Graph/SummaryPanelCommon.tsx
+++ b/src/pages/Graph/SummaryPanelCommon.tsx
@@ -7,9 +7,7 @@ import * as API from '../../services/Api';
 import * as M from '../../types/Metrics';
 import { Metric } from '../../types/Metrics';
 import { Response } from '../../services/Api';
-import { serverConfig } from '../../config/ServerConfig';
 import { decoratedNodeData } from 'components/CytoscapeGraph/CytoscapeGraphUtils';
-import { Badge } from '@patternfly/react-core';
 import { PfColors } from 'components/Pf/PfColors';
 import { KialiIcon } from 'config/KialiIcon';
 
@@ -51,7 +49,7 @@ type HealthState = {
 export const updateHealth = (summaryTarget: any, stateSetter: (hs: HealthState) => void) => {
   const healthPromise = summaryTarget.data('healthPromise');
   if (healthPromise) {
-    stateSetter({ health: undefined, healthLoading: true });
+    stateSetter({ healthLoading: true });
     healthPromise
       .then(h => stateSetter({ health: h, healthLoading: false }))
       .catch(_err => stateSetter({ health: healthNotAvailable(), healthLoading: false }));
@@ -149,27 +147,6 @@ export const getDatapoints = (
     }
   }
   return [];
-};
-
-export const renderNodeInfo = (nodeData: DecoratedGraphNodeData) => {
-  const hasNamespace =
-    nodeData.nodeType !== NodeType.UNKNOWN && !(nodeData.nodeType === NodeType.SERVICE && nodeData.isServiceEntry);
-  const hasVersion = hasNamespace && nodeData.version;
-  return (
-    <>
-      <div className={`label-collection ${summaryLabels}`}>
-        {hasNamespace && <Badge>Namespace: {nodeData.namespace}</Badge>}
-        {hasVersion && (
-          <>
-            <br />
-            <Badge style={{ marginTop: '2px' }}>
-              {serverConfig.istioLabels.versionLabelName}: {nodeData.version!}
-            </Badge>
-          </>
-        )}
-      </div>
-    </>
-  );
 };
 
 export const renderNoTraffic = (protocol?: string) => {

--- a/src/pages/Graph/SummaryPanelCommon.tsx
+++ b/src/pages/Graph/SummaryPanelCommon.tsx
@@ -38,6 +38,10 @@ export const summaryPanel = style({
   width: '25em'
 });
 
+export const summaryFont: React.CSSProperties = {
+  fontSize: 'var(--graph-side-panel--font-size)'
+};
+
 export const hr = () => {
   return <hr style={{ margin: '10px 0' }} />;
 };

--- a/src/pages/Graph/SummaryPanelCommon.tsx
+++ b/src/pages/Graph/SummaryPanelCommon.tsx
@@ -17,6 +17,10 @@ export enum NodeMetricType {
   SERVICE = 3
 }
 
+export const summaryBodyTabs = style({
+  padding: '10px 15px 0 15px'
+});
+
 export const summaryHeader: React.CSSProperties = {
   backgroundColor: PfColors.White
 };
@@ -26,9 +30,17 @@ export const summaryLabels = style({
   marginBottom: '5px'
 });
 
-export const summaryBodyTabs = style({
-  padding: '10px 15px 0 15px'
+export const summaryPanel = style({
+  height: '100%',
+  margin: 0,
+  minWidth: '25em',
+  overflowY: 'scroll',
+  width: '25em'
 });
+
+export const hr = () => {
+  return <hr style={{ margin: '10px 0' }} />;
+};
 
 export const shouldRefreshData = (prevProps: SummaryPanelPropType, nextProps: SummaryPanelPropType) => {
   return (

--- a/src/pages/Graph/SummaryPanelEdge.tsx
+++ b/src/pages/Graph/SummaryPanelEdge.tsx
@@ -16,10 +16,13 @@ import {
   getDatapoints,
   getNodeMetrics,
   getNodeMetricType,
+  hr,
   renderNoTraffic,
   NodeMetricType,
   summaryHeader,
-  summaryBodyTabs
+  summaryBodyTabs,
+  summaryPanel,
+  summaryFont
 } from './SummaryPanelCommon';
 import { MetricGroup, Metric, Metrics, Datapoint } from '../../types/Metrics';
 import { Response } from '../../services/Api';
@@ -69,14 +72,6 @@ const defaultState: SummaryPanelEdgeState = {
 };
 
 export default class SummaryPanelEdge extends React.Component<SummaryPanelPropType, SummaryPanelEdgeState> {
-  static readonly panelStyle = {
-    height: '100%',
-    margin: 0,
-    minWidth: '25em',
-    overflowY: 'auto' as 'auto',
-    width: '25em'
-  };
-
   private metricsPromise?: CancelablePromise<Response<Metrics>>;
   private readonly mainDivRef: React.RefObject<HTMLDivElement>;
 
@@ -117,89 +112,96 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
   }
 
   render() {
-    const edge = this.props.data.summaryTarget;
-    const source = edge.source();
-    const dest = edge.target();
-    const edgeData = decoratedEdgeData(edge);
-    const mTLSPercentage = edgeData.isMTLS;
+    const target = this.props.data.summaryTarget;
+    const source = decoratedNodeData(target.source());
+    const dest = decoratedNodeData(target.target());
+    const edge = decoratedEdgeData(target);
+    const mTLSPercentage = edge.isMTLS;
     const isMtls = mTLSPercentage && mTLSPercentage > 0;
-    const protocol = edgeData.protocol;
+    const protocol = edge.protocol;
     const isGrpc = protocol === Protocol.GRPC;
     const isHttp = protocol === Protocol.HTTP;
     const isTcp = protocol === Protocol.TCP;
 
-    const HeadingBlock = ({ prefix, node }) => {
-      const nodeData = decoratedNodeData(node);
+    const MTLSBlock = () => {
       return (
-        <div className="panel-heading label-collection" style={summaryHeader}>
-          <strong>{prefix}</strong> {renderBadgedLink(nodeData)}
+        <div className="panel-heading" style={summaryHeader}>
+          {this.renderBadgeSummary(mTLSPercentage)}
         </div>
       );
     };
 
-    const MTLSBlock = () => {
-      return <div className="panel-heading label-collection">{this.renderBadgeSummary(mTLSPercentage)}</div>;
-    };
-
     return (
-      <div ref={this.mainDivRef} className="panel panel-default" style={SummaryPanelEdge.panelStyle}>
-        <HeadingBlock prefix="" node={source} />
-        <HeadingBlock prefix="" node={dest} />
+      <div ref={this.mainDivRef} className={`panel panel-default ${summaryPanel}`}>
+        <div className="panel-heading" style={summaryHeader}>
+          {renderBadgedLink(source, undefined, 'From:  ')}
+          {renderBadgedLink(dest, undefined, 'To:        ')}
+        </div>
         {isMtls && <MTLSBlock />}
         {(isGrpc || isHttp) && (
           <div className={summaryBodyTabs}>
             <SimpleTabs id="edge_summary_rate_tabs" defaultTab={0} style={{ paddingBottom: '10px' }}>
-              <Tab title="Traffic" eventKey={0}>
-                {isGrpc && (
-                  <>
-                    <RateTableGrpc
-                      title="GRPC requests per second:"
-                      rate={this.safeRate(edgeData.grpc)}
-                      rateErr={this.safeRate(edgeData.grpcPercentErr)}
-                    />
-                  </>
-                )}
-                {isHttp && (
-                  <>
-                    <RateTableHttp
-                      title="HTTP requests per second:"
-                      rate={this.safeRate(edgeData.http)}
-                      rate3xx={this.safeRate(edgeData.http3xx)}
-                      rate4xx={this.safeRate(edgeData.http4xx)}
-                      rate5xx={this.safeRate(edgeData.http5xx)}
-                    />
-                  </>
-                )}
+              <Tab style={summaryFont} title="Traffic" eventKey={0}>
+                <div style={summaryFont}>
+                  {isGrpc && (
+                    <>
+                      <RateTableGrpc
+                        title="GRPC requests per second:"
+                        rate={this.safeRate(edge.grpc)}
+                        rateErr={this.safeRate(edge.grpcPercentErr)}
+                      />
+                    </>
+                  )}
+                  {isHttp && (
+                    <>
+                      <RateTableHttp
+                        title="HTTP requests per second:"
+                        rate={this.safeRate(edge.http)}
+                        rate3xx={this.safeRate(edge.http3xx)}
+                        rate4xx={this.safeRate(edge.http4xx)}
+                        rate5xx={this.safeRate(edge.http5xx)}
+                      />
+                    </>
+                  )}
+                </div>
               </Tab>
-              <Tab title="Flags" eventKey={1}>
-                <ResponseFlagsTable
-                  title={'Response flags by ' + (isGrpc ? 'GRPC code:' : 'HTTP code:')}
-                  responses={edgeData.responses}
-                />
+              <Tab style={summaryFont} title="Flags" eventKey={1}>
+                <div style={summaryFont}>
+                  <ResponseFlagsTable
+                    title={'Response flags by ' + (isGrpc ? 'GRPC code:' : 'HTTP code:')}
+                    responses={edge.responses}
+                  />
+                </div>
               </Tab>
-              <Tab title="Hosts" eventKey={2}>
-                <ResponseHostsTable
-                  title={'Hosts by ' + (isGrpc ? 'GRPC code:' : 'HTTP code:')}
-                  responses={edgeData.responses}
-                />
+              <Tab style={summaryFont} title="Hosts" eventKey={2}>
+                <div style={summaryFont}>
+                  <ResponseHostsTable
+                    title={'Hosts by ' + (isGrpc ? 'GRPC code:' : 'HTTP code:')}
+                    responses={edge.responses}
+                  />
+                </div>
               </Tab>
             </SimpleTabs>
-            <hr />
-            {this.renderCharts(edge, isGrpc, isHttp, isTcp)}
+            {hr()}
+            {this.renderCharts(target, isGrpc, isHttp, isTcp)}
           </div>
         )}
         {isTcp && (
           <div className={summaryBodyTabs}>
             <SimpleTabs id="edge_summary_flag_hosts_tabs" defaultTab={0} style={{ paddingBottom: '10px' }}>
-              <Tab eventKey={0} title="Flags">
-                <ResponseFlagsTable title="Response flags by code:" responses={edgeData.responses} />
+              <Tab style={summaryFont} eventKey={0} title="Flags">
+                <div style={summaryFont}>
+                  <ResponseFlagsTable title="Response flags by code:" responses={edge.responses} />
+                </div>
               </Tab>
-              <Tab eventKey={1} title="Hosts">
-                <ResponseHostsTable title="Hosts by code:" responses={edgeData.responses} />
+              <Tab style={summaryFont} eventKey={1} title="Hosts">
+                <div style={summaryFont}>
+                  <ResponseHostsTable title="Hosts by code:" responses={edge.responses} />
+                </div>
               </Tab>
             </SimpleTabs>
-            <hr />
-            {this.renderCharts(edge, isGrpc, isHttp, isTcp)}
+            {hr()}
+            {this.renderCharts(target, isGrpc, isHttp, isTcp)}
           </div>
         )}
         {!isGrpc && !isHttp && !isTcp && <div className="panel-body">{renderNoTraffic()}</div>}
@@ -456,7 +458,7 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
       rpsChart = (
         <>
           <RpsChart label={labelRps} dataRps={this.state.reqRates!} dataErrors={this.state.errRates} />
-          <hr />
+          {hr()}
           <ResponseTimeChart
             label={labelRt}
             rtAvg={this.state.rtAvg}
@@ -465,7 +467,6 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
             rt99={this.state.rt99}
             unit={this.state.unit}
           />
-          <hr />
         </>
       );
     } else if (isTcp) {

--- a/src/pages/Graph/SummaryPanelEdge.tsx
+++ b/src/pages/Graph/SummaryPanelEdge.tsx
@@ -10,7 +10,7 @@ import {
   DecoratedGraphNodeData,
   UNKNOWN
 } from '../../types/Graph';
-import { renderTitle } from './SummaryLink';
+import { renderBadgedLink } from './SummaryLink';
 import {
   shouldRefreshData,
   getDatapoints,
@@ -132,7 +132,7 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
       const nodeData = decoratedNodeData(node);
       return (
         <div className="panel-heading label-collection" style={summaryHeader}>
-          <strong>{prefix}</strong> {renderTitle(nodeData)}
+          <strong>{prefix}</strong> {renderBadgedLink(nodeData)}
         </div>
       );
     };

--- a/src/pages/Graph/SummaryPanelEdge.tsx
+++ b/src/pages/Graph/SummaryPanelEdge.tsx
@@ -18,7 +18,6 @@ import {
   getNodeMetricType,
   renderNoTraffic,
   NodeMetricType,
-  renderNodeInfo,
   summaryHeader,
   summaryBodyTabs
 } from './SummaryPanelCommon';
@@ -134,7 +133,6 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
       return (
         <div className="panel-heading label-collection" style={summaryHeader}>
           <strong>{prefix}</strong> {renderTitle(nodeData)}
-          {renderNodeInfo(nodeData)}
         </div>
       );
     };

--- a/src/pages/Graph/SummaryPanelGraph.tsx
+++ b/src/pages/Graph/SummaryPanelGraph.tsx
@@ -89,7 +89,7 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
     // if the summaryTarget (i.e. graph) has changed, then init the state and set to loading. The loading
     // will actually be kicked off after the render (in componentDidMount/Update).
     return props.data.summaryTarget !== state.graph
-      ? { node: props.data.summaryTarget, loading: true, ...defaultMetricsState }
+      ? { graph: props.data.summaryTarget, loading: true, ...defaultMetricsState }
       : null;
   }
 

--- a/src/pages/Graph/SummaryPanelGraph.tsx
+++ b/src/pages/Graph/SummaryPanelGraph.tsx
@@ -1,14 +1,5 @@
 import * as React from 'react';
-import {
-  Tab,
-  Tooltip,
-  TooltipPosition,
-  Badge,
-  DropdownItem,
-  Dropdown,
-  DropdownPosition,
-  DropdownToggle
-} from '@patternfly/react-core';
+import { Tab, Tooltip, TooltipPosition, Badge } from '@patternfly/react-core';
 import { style } from 'typestyle';
 import _ from 'lodash';
 import { RateTableGrpc, RateTableHttp } from '../../components/SummaryPanel/RateTable';
@@ -29,7 +20,6 @@ import { Response } from '../../services/Api';
 import { Metrics, Datapoint } from '../../types/Metrics';
 import { IstioMetricsOptions } from '../../types/MetricsOptions';
 import { CancelablePromise, makeCancelablePromise, PromisesRegistry } from '../../utils/CancelablePromises';
-import { Paths } from '../../config';
 import { CyNode } from '../../components/CytoscapeGraph/CytoscapeGraphUtils';
 import { KialiIcon } from 'config/KialiIcon';
 import SimpleTabs from 'components/Tab/SimpleTabs';
@@ -272,58 +262,7 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
   };
 
   private renderNamespacesSummary = () => {
-    const options = [
-      {
-        text: 'Show applications for namespaces',
-        url: `/${Paths.APPLICATIONS}?namespaces=${this.props.namespaces.map(ns => ns.name).join(',')}`
-      },
-      {
-        text: 'Show service for namespaces',
-        url: `/${Paths.SERVICES}?namespaces=${this.props.namespaces.map(ns => ns.name).join(',')}`
-      },
-      {
-        text: 'Show workloads for namespaces',
-        url: `/${Paths.WORKLOADS}?namespaces=${this.props.namespaces.map(ns => ns.name).join(',')}`
-      },
-      {
-        text: 'Show Istio configs for namespaces',
-        url: `/${Paths.ISTIO}?namespaces=${this.props.namespaces.map(ns => ns.name).join(',')}`
-      }
-    ];
-    const items = options.map(o => {
-      return (
-        <DropdownItem
-          key={o.text}
-          onClick={() => {
-            this.onClickAction(o.url);
-          }}
-        >
-          {o.text}
-        </DropdownItem>
-      );
-    });
-    return (
-      <>
-        {this.props.namespaces.map(namespace => this.renderNamespace(namespace.name))}
-        <Dropdown
-          id="summary-graph-actions"
-          style={{ float: 'right' }}
-          dropdownItems={items}
-          isOpen={this.state.isOpen}
-          position={DropdownPosition.right}
-          toggle={<DropdownToggle onToggle={this.onToggleActions}>Actions</DropdownToggle>}
-        />
-      </>
-    );
-  };
-
-  private onClickAction = url => {
-    console.log(`Action=${url}`);
-    this.onToggleActions(false);
-  };
-
-  private onToggleActions = isOpen => {
-    this.setState({ isOpen: isOpen });
+    return <>{this.props.namespaces.map(namespace => this.renderNamespace(namespace.name))}</>;
   };
 
   private renderNamespace = (ns: string) => {

--- a/src/pages/Graph/SummaryPanelGroup.tsx
+++ b/src/pages/Graph/SummaryPanelGroup.tsx
@@ -11,7 +11,9 @@ import {
   getNodeMetrics,
   getNodeMetricType,
   renderNoTraffic,
-  summaryHeader
+  summaryHeader,
+  hr,
+  summaryPanel
 } from './SummaryPanelCommon';
 import { Health } from '../../types/Health';
 import { Response } from '../../services/Api';
@@ -64,14 +66,6 @@ const defaultState: SummaryPanelGroupState = {
 };
 
 export default class SummaryPanelGroup extends React.Component<SummaryPanelPropType, SummaryPanelGroupState> {
-  static readonly panelStyle = {
-    height: '100%',
-    margin: 0,
-    minWidth: '25em',
-    overflowY: 'auto' as 'auto',
-    width: '25em'
-  };
-
   private metricsPromise?: CancelablePromise<Response<Metrics>[]>;
   private readonly mainDivRef: React.RefObject<HTMLDivElement>;
 
@@ -133,7 +127,7 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
     });
 
     return (
-      <div ref={this.mainDivRef} className="panel panel-default" style={SummaryPanelGroup.panelStyle}>
+      <div ref={this.mainDivRef} className={`panel panel-default ${summaryPanel}`}>
         <div className="panel-heading" style={summaryHeader}>
           <div>{renderBadgedLink(nodeData)}</div>
           <div>
@@ -154,10 +148,24 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
           </div>
         </div>
         <div className="panel-body">
-          {(serviceList.length > 0 || workloadList.length > 0) && <hr />}
-          {this.hasGrpcTraffic(group) ? this.renderGrpcRates(group) : renderNoTraffic('GRPC')}
-          {this.hasHttpTraffic(group) ? this.renderHttpRates(group) : renderNoTraffic('HTTP')}
-          <div>{this.renderSparklines(group)}</div>
+          {this.hasGrpcTraffic(group) && (
+            <>
+              {this.renderGrpcRates(group)}
+              {hr()}
+            </>
+          )}
+          {this.hasHttpTraffic(group) && (
+            <>
+              {this.renderHttpRates(group)}
+              {hr()}
+            </>
+          )}
+          <div>
+            {this.renderSparklines(group)}
+            {hr()}
+          </div>
+          {!this.hasGrpcTraffic(group) && renderNoTraffic('GRPC')}
+          {!this.hasHttpTraffic(group) && renderNoTraffic('HTTP')}
         </div>
       </div>
     );
@@ -270,7 +278,6 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
           outRate={outgoing.rate}
           outRateErr={outgoing.rateErr}
         />
-        <hr />
       </>
     );
   };
@@ -293,7 +300,6 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
           outRate4xx={outgoing.rate4xx}
           outRate5xx={outgoing.rate5xx}
         />
-        <hr />
       </>
     );
   };
@@ -326,7 +332,6 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
             dataRps={this.state.requestCountOut}
             dataErrors={this.state.errorCountOut}
           />
-          <hr />
         </>
       );
     }
@@ -346,7 +351,6 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
             receivedRates={this.state.tcpReceivedOut}
             sentRates={this.state.tcpSentOut}
           />
-          <hr />
         </>
       );
     }

--- a/src/pages/Graph/SummaryPanelGroup.tsx
+++ b/src/pages/Graph/SummaryPanelGroup.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
-import { Badge } from '@patternfly/react-core';
 import { InOutRateTableGrpc, InOutRateTableHttp } from '../../components/SummaryPanel/InOutRateTable';
 import { RpsChart, TcpChart } from '../../components/SummaryPanel/RpsChart';
 import { NodeType, SummaryPanelPropType } from '../../types/Graph';
 import { getAccumulatedTrafficRateGrpc, getAccumulatedTrafficRateHttp } from '../../utils/TrafficRate';
-import { RenderLink, renderTitle } from './SummaryLink';
+import { RenderLink, renderTitle, renderHealth } from './SummaryLink';
 import {
   shouldRefreshData,
   updateHealth,
@@ -12,17 +11,15 @@ import {
   getNodeMetrics,
   getNodeMetricType,
   renderNoTraffic,
-  summaryHeader,
-  summaryLabels
+  summaryHeader
 } from './SummaryPanelCommon';
 import { Health } from '../../types/Health';
 import { Response } from '../../services/Api';
 import { Metrics, Datapoint } from '../../types/Metrics';
 import { Reporter } from '../../types/MetricsOptions';
 import { CancelablePromise, makeCancelablePromise } from '../../utils/CancelablePromises';
-import { serverConfig } from '../../config/ServerConfig';
-import { CyNode, decoratedNodeData } from '../../components/CytoscapeGraph/CytoscapeGraphUtils';
 import { KialiIcon } from 'config/KialiIcon';
+import { decoratedNodeData, CyNode } from 'components/CytoscapeGraph/CytoscapeGraphUtils';
 
 type SummaryPanelGroupMetricsState = {
   requestCountIn: Datapoint[];
@@ -115,18 +112,14 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
   render() {
     const group = this.props.data.summaryTarget;
     const nodeData = decoratedNodeData(group);
-    const { namespace } = nodeData;
     const serviceList = this.renderServiceList(group);
     const workloadList = this.renderWorkloadList(group);
 
     return (
       <div ref={this.mainDivRef} className="panel panel-default" style={SummaryPanelGroup.panelStyle}>
         <div className={`panel-heading ${summaryHeader}`}>
-          {renderTitle(nodeData, this.state.health)}
-          <div className={`label-collection ${summaryLabels}`}>
-            <Badge>namespace: {namespace}</Badge>
-            {this.renderVersionBadges()}
-          </div>
+          {renderTitle(nodeData)}
+          {renderHealth(this.state.health)}
           {this.renderBadgeSummary(group)}
         </div>
         <div className="panel-body">
@@ -211,20 +204,6 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
       });
 
     this.setState({ loading: true, metricsLoadError: null });
-  };
-
-  private renderVersionBadges = () => {
-    const versions = this.props.data.summaryTarget.children(`node[${CyNode.version}]`).toArray();
-    return (
-      <>
-        {versions.length > 0 && <br />}
-        {versions.map((c, _i) => (
-          <Badge style={{ marginTop: '2px', marginRight: '1px' }}>
-            {serverConfig.istioLabels.versionLabelName}: value={c.data(CyNode.version)}
-          </Badge>
-        ))}
-      </>
-    );
   };
 
   private renderBadgeSummary = group => {

--- a/src/pages/Graph/SummaryPanelGroup.tsx
+++ b/src/pages/Graph/SummaryPanelGroup.tsx
@@ -173,6 +173,7 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
 
   private onClickAction = url => {
     console.log(`Action=${url}`);
+    this.onToggleActions(false);
   };
 
   private onToggleActions = isExpanded => {

--- a/src/pages/Graph/SummaryPanelGroup.tsx
+++ b/src/pages/Graph/SummaryPanelGroup.tsx
@@ -22,7 +22,7 @@ import { Reporter } from '../../types/MetricsOptions';
 import { CancelablePromise, makeCancelablePromise } from '../../utils/CancelablePromises';
 import { KialiIcon } from 'config/KialiIcon';
 import { decoratedNodeData, CyNode } from 'components/CytoscapeGraph/CytoscapeGraphUtils';
-import { Dropdown, DropdownPosition, DropdownToggle, DropdownItem } from '@patternfly/react-core';
+import { Dropdown, DropdownPosition, DropdownItem, KebabToggle } from '@patternfly/react-core';
 import { getOptions } from 'components/CytoscapeGraph/ContextMenu/NodeContextMenu';
 
 type SummaryPanelGroupMetricsState = {
@@ -129,18 +129,19 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
     return (
       <div ref={this.mainDivRef} className={`panel panel-default ${summaryPanel}`}>
         <div className="panel-heading" style={summaryHeader}>
-          <div>{renderBadgedLink(nodeData)}</div>
           <div>
-            {renderHealth(this.state.health)}
+            {renderBadgedLink(nodeData)}
             <Dropdown
               id="summary-group-actions"
+              isPlain={true}
               style={{ float: 'right' }}
               dropdownItems={actions}
               isOpen={this.state.isOpen}
               position={DropdownPosition.right}
-              toggle={<DropdownToggle onToggle={this.onToggleActions}>Actions</DropdownToggle>}
+              toggle={<KebabToggle id="summary-group-kebab" onToggle={this.onToggleActions} />}
             />
           </div>
+          <div>{renderHealth(this.state.health)}</div>
           <div>
             {this.renderBadgeSummary(group)}
             {serviceList.length > 0 && <div>{serviceList}</div>}

--- a/src/pages/Graph/SummaryPanelGroup.tsx
+++ b/src/pages/Graph/SummaryPanelGroup.tsx
@@ -117,10 +117,12 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
 
     return (
       <div ref={this.mainDivRef} className="panel panel-default" style={SummaryPanelGroup.panelStyle}>
-        <div className={`panel-heading ${summaryHeader}`}>
-          {renderTitle(nodeData)}
-          {renderHealth(this.state.health)}
-          {this.renderBadgeSummary(group)}
+        <div className="panel-heading" style={summaryHeader}>
+          <div>{renderTitle(nodeData)}</div>
+          <div>
+            {renderHealth(this.state.health)}
+            {this.renderBadgeSummary(group)}
+          </div>
         </div>
         <div className="panel-body">
           {serviceList.length > 0 && (
@@ -219,7 +221,7 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
       });
 
     return (
-      <>
+      <div style={{ marginTop: '10px' }}>
         {hasCB && (
           <div>
             <KialiIcon.CircuitBreaker />
@@ -232,7 +234,7 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
             <span style={{ paddingLeft: '4px' }}>Has Virtual Service</span>
           </div>
         )}
-      </>
+      </div>
     );
   };
 

--- a/src/pages/Graph/SummaryPanelGroup.tsx
+++ b/src/pages/Graph/SummaryPanelGroup.tsx
@@ -24,6 +24,7 @@ import { KialiIcon } from 'config/KialiIcon';
 import { decoratedNodeData, CyNode } from 'components/CytoscapeGraph/CytoscapeGraphUtils';
 import { Dropdown, DropdownPosition, DropdownItem, KebabToggle } from '@patternfly/react-core';
 import { getOptions } from 'components/CytoscapeGraph/ContextMenu/NodeContextMenu';
+import history from 'app/History';
 
 type SummaryPanelGroupMetricsState = {
   requestCountIn: Datapoint[];
@@ -116,7 +117,7 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
     const actions = getOptions(nodeData, true, false, '').map(o => {
       return (
         <DropdownItem
-          key={o.url}
+          key={o.text}
           onClick={() => {
             this.onClickAction(o.url);
           }}
@@ -172,9 +173,8 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
     );
   }
 
-  private onClickAction = url => {
-    console.log(`Action=${url}`);
-    this.onToggleActions(false);
+  private onClickAction = path => {
+    history.push(path);
   };
 
   private onToggleActions = isExpanded => {

--- a/src/pages/Graph/SummaryPanelNode.tsx
+++ b/src/pages/Graph/SummaryPanelNode.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { renderDestServicesLinks, renderTitle, renderHealth } from './SummaryLink';
+import { renderDestServicesLinks, renderBadgedLink, renderHealth, renderBadgedHost } from './SummaryLink';
 import {
   getAccumulatedTrafficRateGrpc,
   getAccumulatedTrafficRateHttp,
@@ -323,45 +323,44 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
     });
 
     return (
-      <div ref={this.mainDivRef} className="panel panel-default" style={SummaryPanelNode.panelStyle}>
+      <div ref={this.mainDivRef} className={`panel panel-default ${SummaryPanelNode.panelStyle}`}>
         <div className="panel-heading" style={summaryHeader}>
+          <div>{renderBadgedLink(nodeData)}</div>
           <div>
-            <div>
-              {renderTitle(nodeData)}
-              <Dropdown
-                style={{ float: 'right', fontSize: '0.5rem' }}
-                id="summary-node-actions"
-                dropdownItems={actions}
-                isOpen={this.state.isOpen}
-                position={DropdownPosition.right}
-                toggle={<DropdownToggle onToggle={this.onToggleActions}>Actions</DropdownToggle>}
-              />
-            </div>
             {renderHealth(this.state.health)}
+            <Dropdown
+              id="summary-node-actions"
+              style={{ float: 'right' }}
+              dropdownItems={actions}
+              isOpen={this.state.isOpen}
+              position={DropdownPosition.right}
+              toggle={<DropdownToggle onToggle={this.onToggleActions}>Actions</DropdownToggle>}
+            />
+          </div>
+          <div>
             {this.renderBadgeSummary(nodeData.hasCB, nodeData.hasVS, nodeData.hasMissingSC, nodeData.isDead)}
-            {shouldRenderDestsList && (
-              <div>
-                <strong>Destinations: </strong>
-                {destsList}
-              </div>
-            )}
+            {shouldRenderDestsList && <div>{destsList}</div>}
             {shouldRenderSvcList && <div>{servicesList}</div>}
-            {shouldRenderWorkload && <div>{renderTitle(nodeData, NodeType.WORKLOAD)}</div>}
+            {shouldRenderWorkload && <div>{renderBadgedLink(nodeData, NodeType.WORKLOAD)}</div>}
           </div>
         </div>
         <div className="panel-body">
-          {(shouldRenderDestsList || shouldRenderSvcList || shouldRenderWorkload) && <hr />}
-          {/* TODO: link to App or Workload Details charts when available
-          {nodeType !== NodeType.UNKNOWN && (
-            <p style={{ textAlign: 'right' }}>
-              <Link to={`/namespaces/${namespace}/services/${app}?tab=metrics&groupings=local+version%2Cresponse+code`}>
-                View detailed charts <KialiIcon.AngleDoubleRight />
-              </Link>
-            </p>
-          )} */}
-          {this.hasGrpcTraffic(nodeData) && this.renderGrpcRates(node)}
-          {this.hasHttpTraffic(nodeData) && this.renderHttpRates(node)}
-          <div>{this.renderCharts(node)}</div>
+          {this.hasGrpcTraffic(nodeData) && (
+            <>
+              {this.renderGrpcRates(node)}
+              <hr style={{ margin: '10px 0' }} />
+            </>
+          )}
+          {this.hasHttpTraffic(nodeData) && (
+            <>
+              {this.renderHttpRates(node)}
+              <hr style={{ margin: '10px 0' }} />
+            </>
+          )}
+          <div>
+            {this.renderCharts(node)}
+            <hr style={{ margin: '10px 0' }} />
+          </div>
           {!this.hasGrpcTraffic(nodeData) && renderNoTraffic('GRPC')}
           {!this.hasHttpTraffic(nodeData) && renderNoTraffic('HTTP')}
         </div>
@@ -390,7 +389,6 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
           outRate={outgoing.rate}
           outRateErr={outgoing.rateErr}
         />
-        <hr />
       </>
     );
   };
@@ -412,7 +410,6 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
           outRate4xx={outgoing.rate4xx}
           outRate5xx={outgoing.rate5xx}
         />
-        <hr />
       </>
     );
   };
@@ -425,7 +422,6 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
         <>
           <div>
             <KialiIcon.Info /> Sparkline charts not supported for unknown node. Use edge for details.
-            <hr />
           </div>
         </>
       );
@@ -434,7 +430,6 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
         <>
           <div>
             <KialiIcon.Info /> Sparkline charts cannot be shown because the selected node is inaccessible.
-            <hr />
           </div>
         </>
       );
@@ -443,7 +438,6 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
         <>
           <div>
             <KialiIcon.Info /> Sparkline charts cannot be shown because the selected node is a serviceEntry.
-            <hr />
           </div>
         </>
       );
@@ -502,7 +496,6 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
               </div>
             </>
           )}
-          <hr />
         </>
       );
     }
@@ -535,7 +528,6 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
               </div>
             </>
           )}
-          <hr />
         </>
       );
     }
@@ -554,7 +546,6 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
             sentRates={this.state.tcpSentOut}
             hide={isServiceNode}
           />
-          <hr />
         </>
       );
     }
@@ -571,7 +562,7 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
   // TODO:(see https://github.com/kiali/kiali-design/issues/63) If we want to show an icon for SE uncomment below
   private renderBadgeSummary = (hasCB?: boolean, hasVS?: boolean, hasMissingSC?: boolean, isDead?: boolean) => {
     return (
-      <div style={{ marginTop: '10px' }}>
+      <div style={{ marginTop: '10px', marginBottom: '10px' }}>
         {hasCB && (
           <div>
             <KialiIcon.CircuitBreaker />
@@ -612,15 +603,9 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
 
     destServices.forEach(ds => {
       const service = ds.name;
-      const key = `${ds.namespace}.svc.${service}`;
       const displayName = service;
-      entries.push(<span key={key}>{displayName}</span>);
-      entries.push(<span key={`comma-after-${ds.name}`}>, </span>);
+      entries.push(renderBadgedHost(displayName));
     });
-
-    if (entries.length > 0) {
-      entries.pop();
-    }
 
     return entries;
   };

--- a/src/pages/Graph/SummaryPanelNode.tsx
+++ b/src/pages/Graph/SummaryPanelNode.tsx
@@ -37,7 +37,7 @@ import { Reporter } from '../../types/MetricsOptions';
 import { CyNode, decoratedNodeData } from '../../components/CytoscapeGraph/CytoscapeGraphUtils';
 import { KialiIcon } from 'config/KialiIcon';
 import { getOptions } from 'components/CytoscapeGraph/ContextMenu/NodeContextMenu';
-import { Dropdown, DropdownToggle, DropdownItem, DropdownPosition } from '@patternfly/react-core';
+import { Dropdown, DropdownItem, DropdownPosition, KebabToggle } from '@patternfly/react-core';
 
 type SummaryPanelNodeMetricsState = {
   grpcRequestCountIn: Datapoint[];
@@ -319,18 +319,19 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
     return (
       <div ref={this.mainDivRef} className={`panel panel-default ${summaryPanel}`}>
         <div className="panel-heading" style={summaryHeader}>
-          <div>{renderBadgedLink(nodeData)}</div>
           <div>
-            {renderHealth(this.state.health)}
+            {renderBadgedLink(nodeData)}
             <Dropdown
               id="summary-node-actions"
               style={{ float: 'right' }}
+              isPlain={true}
               dropdownItems={actions}
               isOpen={this.state.isOpen}
               position={DropdownPosition.right}
-              toggle={<DropdownToggle onToggle={this.onToggleActions}>Actions</DropdownToggle>}
+              toggle={<KebabToggle id="summary-node-kebab" onToggle={this.onToggleActions} />}
             />
           </div>
+          <div>{renderHealth(this.state.health)}</div>
           <div>
             {this.renderBadgeSummary(nodeData.hasCB, nodeData.hasVS, nodeData.hasMissingSC, nodeData.isDead)}
             {shouldRenderDestsList && <div>{destsList}</div>}

--- a/src/pages/Graph/SummaryPanelNode.tsx
+++ b/src/pages/Graph/SummaryPanelNode.tsx
@@ -546,7 +546,7 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
   // TODO:(see https://github.com/kiali/kiali-design/issues/63) If we want to show an icon for SE uncomment below
   private renderBadgeSummary = (hasCB?: boolean, hasVS?: boolean, hasMissingSC?: boolean, isDead?: boolean) => {
     return (
-      <>
+      <div style={{ marginTop: '10px' }}>
         {hasCB && (
           <div>
             <KialiIcon.CircuitBreaker />
@@ -573,7 +573,7 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
             <span style={{ paddingLeft: '4px' }}>Has No Running Pods</span>
           </div>
         )}
-      </>
+      </div>
     );
   };
 

--- a/src/pages/Graph/SummaryPanelNode.tsx
+++ b/src/pages/Graph/SummaryPanelNode.tsx
@@ -26,7 +26,9 @@ import {
   getNodeMetricType,
   renderNoTraffic,
   mergeMetricsResponses,
-  summaryHeader
+  summaryHeader,
+  hr,
+  summaryPanel
 } from './SummaryPanelCommon';
 import { Health } from '../../types/Health';
 import { CancelablePromise, makeCancelablePromise } from '../../utils/CancelablePromises';
@@ -86,14 +88,6 @@ const defaultState: SummaryPanelNodeState = {
 };
 
 export default class SummaryPanelNode extends React.Component<SummaryPanelPropType, SummaryPanelNodeState> {
-  static readonly panelStyle = {
-    height: '100%',
-    margin: 0,
-    minWidth: '25em',
-    overflowY: 'scroll' as 'scroll',
-    width: '25em'
-  };
-
   private metricsPromise?: CancelablePromise<Response<Metrics>[]>;
   private readonly mainDivRef: React.RefObject<HTMLDivElement>;
 
@@ -323,7 +317,7 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
     });
 
     return (
-      <div ref={this.mainDivRef} className={`panel panel-default ${SummaryPanelNode.panelStyle}`}>
+      <div ref={this.mainDivRef} className={`panel panel-default ${summaryPanel}`}>
         <div className="panel-heading" style={summaryHeader}>
           <div>{renderBadgedLink(nodeData)}</div>
           <div>
@@ -348,18 +342,18 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
           {this.hasGrpcTraffic(nodeData) && (
             <>
               {this.renderGrpcRates(node)}
-              <hr style={{ margin: '10px 0' }} />
+              {hr()}
             </>
           )}
           {this.hasHttpTraffic(nodeData) && (
             <>
               {this.renderHttpRates(node)}
-              <hr style={{ margin: '10px 0' }} />
+              {hr()}
             </>
           )}
           <div>
             {this.renderCharts(node)}
-            <hr style={{ margin: '10px 0' }} />
+            {hr()}
           </div>
           {!this.hasGrpcTraffic(nodeData) && renderNoTraffic('GRPC')}
           {!this.hasHttpTraffic(nodeData) && renderNoTraffic('HTTP')}

--- a/src/pages/Graph/SummaryPanelNode.tsx
+++ b/src/pages/Graph/SummaryPanelNode.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { renderDestServicesLinks, RenderLink, renderTitle } from './SummaryLink';
+import { renderDestServicesLinks, RenderLink, renderTitle, renderHealth } from './SummaryLink';
 import {
   getAccumulatedTrafficRateGrpc,
   getAccumulatedTrafficRateHttp,
@@ -24,7 +24,6 @@ import {
   getDatapoints,
   getNodeMetrics,
   getNodeMetricType,
-  renderNodeInfo,
   renderNoTraffic,
   mergeMetricsResponses,
   summaryHeader
@@ -309,9 +308,11 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
     return (
       <div ref={this.mainDivRef} className="panel panel-default" style={SummaryPanelNode.panelStyle}>
         <div className="panel-heading" style={summaryHeader}>
-          {renderTitle(nodeData, this.state.health)}
-          {renderNodeInfo(nodeData)}
-          {this.renderBadgeSummary(nodeData.hasCB, nodeData.hasVS, nodeData.hasMissingSC, nodeData.isDead)}
+          <div>{renderTitle(nodeData)}</div>
+          <div>
+            {renderHealth(this.state.health)}
+            {this.renderBadgeSummary(nodeData.hasCB, nodeData.hasVS, nodeData.hasMissingSC, nodeData.isDead)}
+          </div>
         </div>
         <div className="panel-body">
           {shouldRenderDestsList && (

--- a/src/pages/Graph/SummaryPanelNode.tsx
+++ b/src/pages/Graph/SummaryPanelNode.tsx
@@ -306,7 +306,7 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
     const actions = getOptions(nodeData, true, false, '').map(o => {
       return (
         <DropdownItem
-          key={o.url}
+          key={o.text}
           onClick={() => {
             this.onClickAction(o.url);
           }}
@@ -364,10 +364,11 @@ export default class SummaryPanelNode extends React.Component<SummaryPanelPropTy
 
   private onClickAction = url => {
     console.log(`Action=${url}`);
+    this.onToggleActions(false);
   };
 
-  private onToggleActions = isExpanded => {
-    this.setState({ isOpen: isExpanded });
+  private onToggleActions = isOpen => {
+    this.setState({ isOpen: isOpen });
   };
 
   private renderGrpcRates = node => {

--- a/src/pages/Graph/_Graph.scss
+++ b/src/pages/Graph/_Graph.scss
@@ -1,0 +1,18 @@
+:root {
+  --graph-side-panel--font-size: 12px;
+  --graph-side-panel--font-size-px: 12;
+}
+
+#summary-group-actions .pf-c-dropdown__toggle {
+  font-size: var(--graph-side-panel--font-size);
+}
+#summary-group-actions .pf-c-dropdown__menu-item {
+  font-size: var(--graph-side-panel--font-size);
+}
+
+#summary-node-actions .pf-c-dropdown__toggle {
+  font-size: var(--graph-side-panel--font-size);
+}
+#summary-node-actions .pf-c-dropdown__menu-item {
+  font-size: var(--graph-side-panel--font-size);
+}

--- a/src/pages/Graph/_Graph.scss
+++ b/src/pages/Graph/_Graph.scss
@@ -3,6 +3,13 @@
   --graph-side-panel--font-size-px: 12;
 }
 
+#summary-graph-actions .pf-c-dropdown__toggle {
+  font-size: var(--graph-side-panel--font-size);
+}
+#summary-graph-actions .pf-c-dropdown__menu-item {
+  font-size: var(--graph-side-panel--font-size);
+}
+
 #summary-group-actions .pf-c-dropdown__toggle {
   font-size: var(--graph-side-panel--font-size);
 }

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -45,3 +45,4 @@ body {
 @import '../components/VirtualList/_VirtualList';
 @import '../components/JaegerIntegration/JaegerResults/_SpanTable';
 @import '../components/Time/_Time';
+@import '../pages/Graph/_Graph';


### PR DESCRIPTION
Apply design feedback for graph side panels:
- prefer badged resources
  - remove "node badges" (confusing as not equivalent to labels)
- make health a distinct badge
- introduce kebab action menu equiv to context menu options
- consistent font
- thin charts and reduce whitespace
- thin chart bars
- use white background for table headers
- remove links in graph summary as they duplicate the main accordian menu options
- extend tabs to 100%
- add fixed scroll bar to avoid "resize flashing" on refresh

Design issue
closes https://github.com/kiali/kiali-design/issues/149

Kiali issue
closes https://github.com/kiali/kiali/issues/1417

@mattmahoneyrh, @pbajjuri20  For testing I suggest setting up a before/after approach and compare old side panel with new side panel.  Also, verify kebab options match context menu options and that links work.

@mceledonia Here is an example of updates after the design meeting.  I think I was able to apply all desired changes.

Graph Summary (removed action dropdown, extended tabs to fill width, thinned chart bars):

![image](https://user-images.githubusercontent.com/2104052/73492558-e7ac7200-437e-11ea-9d55-f7443917c6ab.png)

Node Summary (shows kebab and in/out chart with thinned bars):

![image](https://user-images.githubusercontent.com/2104052/73492161-27268e80-437e-11ea-99c0-cab14eda670a.png)
