### PR TITLE
Show Istio Config status only when objects present. Show # objects counted

### DIFF
--- a/src/components/Validations/ValidationSummary.tsx
+++ b/src/components/Validations/ValidationSummary.tsx
@@ -9,6 +9,7 @@ interface Props {
   id: string;
   errors: number;
   warnings: number;
+  objectCount?: number;
   style?: CSSProperties;
 }
 
@@ -53,14 +54,27 @@ export class ValidationSummary extends React.PureComponent<Props> {
     return severity;
   }
 
-  tooltipContent() {
+  tooltipSubtitle() {
     const validation = severityToValidation[this.severity()];
+    let subtitle = validation.name;
+
+    if (this.props.objectCount) {
+      const plural = this.props.objectCount > 1 ? 's' : '';
+      subtitle = this.props.objectCount + ' object' + plural + ' analyzed';
+    }
+
+    return subtitle;
+  }
+
+  tooltipContent() {
     return (
       <>
         <Text style={{ textAlign: 'left', textEmphasis: 'strong' }} component={TextVariants.h4}>
           Istio Config Validation
         </Text>
-        <Text style={{ textAlign: 'left', textEmphasis: 'strong', paddingLeft: '1em' }}>{validation.name}</Text>
+        <Text style={{ textAlign: 'left', textEmphasis: 'strong', paddingLeft: '1em' }} component={TextVariants.h5}>
+          {this.tooltipSubtitle()}
+        </Text>
         <div className={tooltipListStyle}>
           {this.severitySummary().map(cat => (
             <div key={cat}>{cat}</div>

--- a/src/components/Validations/ValidationSummary.tsx
+++ b/src/components/Validations/ValidationSummary.tsx
@@ -74,7 +74,7 @@ export class ValidationSummary extends React.PureComponent<Props> {
   }
 
   tooltipNA() {
-    return <Text className={tooltipSentenceStyle}>No Istio Objects found in this namespace</Text>;
+    return <Text className={tooltipSentenceStyle}>No Istio configuration objects found in this namespace</Text>;
   }
 
   tooltipNoValidationAvailable() {

--- a/src/components/Validations/ValidationSummary.tsx
+++ b/src/components/Validations/ValidationSummary.tsx
@@ -20,6 +20,13 @@ const tooltipListStyle = style({
   margin: '0 0 0 0'
 });
 
+const tooltipSentenceStyle = style({
+  textAlign: 'center',
+  border: 0,
+  padding: '0 0 0 0',
+  margin: '0 0 0 0'
+});
+
 export class ValidationSummary extends React.PureComponent<Props> {
   getTypeMessage = (count: number, type: ValidationTypes): string => {
     return count > 1 ? `${count} ${type}s found` : `${count} ${type} found`;
@@ -66,7 +73,15 @@ export class ValidationSummary extends React.PureComponent<Props> {
     return subtitle;
   }
 
-  tooltipContent() {
+  tooltipNA() {
+    return <Text className={tooltipSentenceStyle}>No Istio Objects found in this namespace</Text>;
+  }
+
+  tooltipNoValidationAvailable() {
+    return <Text className={tooltipListStyle}>No validation available for this type</Text>;
+  }
+
+  tooltipSummary() {
     return (
       <>
         <Text style={{ textAlign: 'left', textEmphasis: 'strong' }} component={TextVariants.h4}>
@@ -84,6 +99,26 @@ export class ValidationSummary extends React.PureComponent<Props> {
     );
   }
 
+  tooltipContent() {
+    if (typeof this.props.objectCount !== undefined) {
+      if (this.props.objectCount === 0) {
+        return this.tooltipNA();
+      } else {
+        return this.tooltipSummary();
+      }
+    } else {
+      return this.tooltipNoValidationAvailable();
+    }
+  }
+
+  tooltipBase() {
+    return typeof this.props.objectCount === 'undefined' || this.props.objectCount > 1 ? (
+      <Validation iconStyle={this.props.style} severity={this.severity()} />
+    ) : (
+      <small>N/A</small>
+    );
+  }
+
   render() {
     return (
       <Tooltip
@@ -92,7 +127,7 @@ export class ValidationSummary extends React.PureComponent<Props> {
         enableFlip={true}
         content={this.tooltipContent()}
       >
-        <Validation iconStyle={this.props.style} severity={this.severity()} />
+        {this.tooltipBase()}
       </Tooltip>
     );
   }

--- a/src/pages/Graph/SummaryPanelGraph.tsx
+++ b/src/pages/Graph/SummaryPanelGraph.tsx
@@ -314,6 +314,7 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
               id={'ns-val-' + ns}
               errors={validation.errors}
               warnings={validation.warnings}
+              objectCount={validation.objectCount}
               style={{ marginLeft: '5px' }}
             />
           )}

--- a/src/pages/Overview/OverviewPage.tsx
+++ b/src/pages/Overview/OverviewPage.tsx
@@ -431,13 +431,14 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
 
   renderIstioConfigStatus(ns: NamespaceInfo): JSX.Element {
     let status: any = 'N/A';
-    if (ns.validations && !this.isNamespaceEmpty(ns)) {
+    if (ns.validations && ns.validations.objectCount > 0) {
       status = (
         <Link to={`/${Paths.ISTIO}?namespaces=${ns.name}`}>
           <ValidationSummary
             id={'ns-val-' + ns.name}
             errors={ns.validations.errors}
             warnings={ns.validations.warnings}
+            objectCount={ns.validations.objectCount}
             style={{ marginLeft: '5px' }}
           />
         </Link>

--- a/src/pages/Overview/OverviewPage.tsx
+++ b/src/pages/Overview/OverviewPage.tsx
@@ -431,7 +431,7 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
 
   renderIstioConfigStatus(ns: NamespaceInfo): JSX.Element {
     let status: any = 'N/A';
-    if (ns.validations && ns.validations.objectCount > 0) {
+    if (ns.validations) {
       status = (
         <Link to={`/${Paths.ISTIO}?namespaces=${ns.name}`}>
           <ValidationSummary

--- a/src/types/IstioObjects.ts
+++ b/src/types/IstioObjects.ts
@@ -79,7 +79,7 @@ export interface Reference {
 
 export interface ValidationStatus {
   errors: number;
-  objectCount: number;
+  objectCount?: number;
   warnings: number;
 }
 

--- a/src/types/IstioObjects.ts
+++ b/src/types/IstioObjects.ts
@@ -79,6 +79,7 @@ export interface Reference {
 
 export interface ValidationStatus {
   errors: number;
+  objectCount: number;
   warnings: number;
 }
 


### PR DESCRIPTION
Needs backend PR: https://github.com/kiali/kiali/pull/2193

Kiali doesn't compute the validity of a namespace, Kiali analyzes Istio objects living in a namespace. Because of that, the behavior in the Overview page and Graph regarding Istio Objects is changed in this PR.

The new behavior is:
- Kiali shows 'N/A' with a tooltip saying: "No Istio Objects found in this namespace" **when** there aren't istio Objects for that namespace.
- Kiali shows an Icon (Validation higher severity) with a tooltip saying: "N objects analyzed - Error - 4 warnings, 2 errors found", **when** there is one or more Istio Objects.

In the picture below we have:
1. default ns - bookinfo example running on the mesh and we have istio objects (in warning).
2. desert ns - no applications running, no istio objects. It shows N/A.
3. empty ns - it has applications running but no istio objects. It shows N/A.
4. only-objects ns - it hasn't contain any running app but it has istio objects. As a result, Kiali shows the highest severity of objects analyzed.

![Screenshot of Kiali Console](https://user-images.githubusercontent.com/613814/73649653-8c30fb80-4680-11ea-90a9-37a392b1dda7.png)

![Screenshot of Kiali Console - 2020-01-31T175139 067](https://user-images.githubusercontent.com/613814/73557916-6c1bf500-4452-11ea-96cc-8ed2364939c2.jpg)

The list of objects is left unchanged:
![Screenshot of Kiali Console - 2020-01-31T175421 226](https://user-images.githubusercontent.com/613814/73558091-c321ca00-4452-11ea-996a-b13562464eaf.jpg)

Whilst the Graph has been updated with same tooltip wording:
![Screenshot of Kiali Console - 2020-01-31T175359 787](https://user-images.githubusercontent.com/613814/73558092-c321ca00-4452-11ea-84e4-f3a3dd6f01dd.jpg)


Fixes https://github.com/kiali/kiali/issues/2113
Fixes https://github.com/kiali/kiali/issues/1930