### PR TITLE
Summary panel actions: allow open in new window

### DIFF
--- a/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
+++ b/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
@@ -6,6 +6,7 @@ import { KialiAppState } from '../../../store/Store';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { NodeType, DecoratedGraphNodeData } from 'types/Graph';
+import history from 'app/History';
 
 type ReduxProps = {
   jaegerIntegration: boolean;
@@ -130,6 +131,14 @@ export type ContextMenuOption = {
   url: string;
   external?: boolean;
   target?: string;
+};
+
+export const clickHandler = (o: ContextMenuOption) => {
+  if (o.external) {
+    window.open(o.url, o.target);
+  } else {
+    history.push(o.url);
+  }
 };
 
 export const getOptions = (

--- a/src/pages/Graph/SummaryPanelGroup.tsx
+++ b/src/pages/Graph/SummaryPanelGroup.tsx
@@ -23,8 +23,7 @@ import { CancelablePromise, makeCancelablePromise } from '../../utils/Cancelable
 import { KialiIcon } from 'config/KialiIcon';
 import { decoratedNodeData, CyNode } from 'components/CytoscapeGraph/CytoscapeGraphUtils';
 import { Dropdown, DropdownPosition, DropdownItem, KebabToggle } from '@patternfly/react-core';
-import { getOptions } from 'components/CytoscapeGraph/ContextMenu/NodeContextMenu';
-import history from 'app/History';
+import { getOptions, clickHandler } from 'components/CytoscapeGraph/ContextMenu/NodeContextMenu';
 
 type SummaryPanelGroupMetricsState = {
   requestCountIn: Datapoint[];
@@ -116,12 +115,7 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
 
     const actions = getOptions(nodeData, true, false, '').map(o => {
       return (
-        <DropdownItem
-          key={o.text}
-          onClick={() => {
-            this.onClickAction(o.url);
-          }}
-        >
+        <DropdownItem key={o.text} onClick={() => clickHandler(o)}>
           {o.text}
         </DropdownItem>
       );
@@ -172,10 +166,6 @@ export default class SummaryPanelGroup extends React.Component<SummaryPanelPropT
       </div>
     );
   }
-
-  private onClickAction = path => {
-    history.push(path);
-  };
 
   private onToggleActions = isExpanded => {
     this.setState({ isOpen: isExpanded });

--- a/src/pages/Graph/SummaryPanelNode.tsx
+++ b/src/pages/Graph/SummaryPanelNode.tsx
@@ -36,9 +36,8 @@ import { Response } from '../../services/Api';
 import { Reporter } from '../../types/MetricsOptions';
 import { CyNode, decoratedNodeData } from '../../components/CytoscapeGraph/CytoscapeGraphUtils';
 import { KialiIcon } from 'config/KialiIcon';
-import { getOptions } from 'components/CytoscapeGraph/ContextMenu/NodeContextMenu';
+import { getOptions, clickHandler } from 'components/CytoscapeGraph/ContextMenu/NodeContextMenu';
 import { Dropdown, DropdownItem, DropdownPosition, KebabToggle } from '@patternfly/react-core';
-import history from 'app/History';
 import { KialiAppState } from 'store/Store';
 import { connect } from 'react-redux';
 
@@ -321,12 +320,7 @@ export class SummaryPanelNode extends React.Component<SummaryPanelNodeProps, Sum
       this.props.jaegerURL
     ).map(o => {
       return (
-        <DropdownItem
-          key={o.text}
-          onClick={() => {
-            this.onClickAction(o.url);
-          }}
-        >
+        <DropdownItem key={o.text} onClick={() => clickHandler(o)}>
           {o.text}
         </DropdownItem>
       );
@@ -378,10 +372,6 @@ export class SummaryPanelNode extends React.Component<SummaryPanelNodeProps, Sum
       </div>
     );
   }
-
-  private onClickAction = path => {
-    history.push(path);
-  };
 
   private onToggleActions = isOpen => {
     this.setState({ isOpen: isOpen });


### PR DESCRIPTION
It happens when jaeger is not configured in cluster: external link is used in this case. It must be dealt with something like window.open

Fixes https://github.com/kiali/kiali/issues/2202

@jshaughn I've put the click handler in a common function for wherever it's used. I could have opted for a dedicated component as well... but did the quickest way, if it's ok with you.