### PR TITLE
For non-istio apps make correct the namespace/validation spacing

### DIFF
--- a/src/pages/Graph/SummaryPanelGraph.tsx
+++ b/src/pages/Graph/SummaryPanelGraph.tsx
@@ -275,7 +275,7 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
               NS
             </Badge>
           </Tooltip>
-          {ns}
+          {ns}{' '}
           {!!validation && (
             <ValidationSummary
               id={'ns-val-' + ns}


### PR DESCRIPTION
** Describe the change **
For regular k8s apps, meaning non-istio (without sidecars) apps, correct the namespace spacing and validations to look proper.

fixes #https://github.com/kiali/kiali/issues/2217

** Screenshot **

Before:
![Kiali_Console_-_Firefox_Developer_Edition](https://user-images.githubusercontent.com/1312165/73993593-7b45eb80-4907-11ea-9d1f-9466a819ae18.png)


After:
![Kiali_Console](https://user-images.githubusercontent.com/1312165/73993385-e4792f00-4906-11ea-9a1a-77707938d26e.png)

