### PR TITLE
In-chart time navigation with brush container

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "snyk-protect": "snyk protect"
   },
   "dependencies": {
-    "@kiali/k-charted-pf4": "0.4.4",
+    "@kiali/k-charted-pf4": "0.5.0-rc7",
     "@patternfly/patternfly": "2.44.2",
     "@patternfly/react-charts": "5.2.2",
     "@patternfly/react-core": "3.124.1",

--- a/src/app/__tests__/App.test.tsx
+++ b/src/app/__tests__/App.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import App from '../App';
-import 'jest-canvas-mock';
 
 // Mock getComputedStyle: Cytoscape relies on the result of this to have a valid paddingXXX
 // Current implementation returns '' which is parsed to float as NAN, breaking cytoscape.

--- a/src/components/Time/TimeRangeComponent.tsx
+++ b/src/components/Time/TimeRangeComponent.tsx
@@ -14,6 +14,7 @@ import { retrieveTimeRange, retrieveDuration, storeBounds, storeDuration } from 
 import { DateTimePicker } from './DateTimePicker';
 
 type Props = {
+  range?: TimeRange;
   allowCustom: boolean;
   tooltip: string;
   onChanged: (range: TimeRange) => void;
@@ -24,7 +25,17 @@ export default class TimeRangeComponent extends React.Component<Props> {
 
   constructor(props: Props) {
     super(props);
-    this.range = (this.props.allowCustom ? retrieveTimeRange() : retrieveDuration()) || defaultMetricsDuration;
+    if (props.range) {
+      this.range = props.range;
+    } else {
+      this.range = (this.props.allowCustom ? retrieveTimeRange() : retrieveDuration()) || defaultMetricsDuration;
+    }
+  }
+
+  componentDidUpdate(prev: Props) {
+    if (this.props.range && prev.range !== this.props.range) {
+      this.range = this.props.range;
+    }
   }
 
   onDurationChanged = (key: string) => {
@@ -72,6 +83,7 @@ export default class TimeRangeComponent extends React.Component<Props> {
         id={'metrics_filter_interval_duration'}
         handleSelect={this.onDurationChanged}
         initialValue={d || 'custom'}
+        value={d || 'custom'}
         initialLabel={d ? serverConfig.durations[d] : 'Custom'}
         options={options}
         tooltip={this.props.tooltip}

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,5 +1,6 @@
 import * as Enzyme from 'enzyme';
 require('jest-localstorage-mock');
+require('jest-canvas-mock');
 const Adapter = require('enzyme-adapter-react-16');
 
 var JSDOM = require('jsdom').JSDOM;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1118,10 +1118,10 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@kiali/k-charted-pf4@0.4.4":
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/@kiali/k-charted-pf4/-/k-charted-pf4-0.4.4.tgz#8cc6f056f1bbaa1a695d06c441191dcce7a2e225"
-  integrity sha512-U6OPE4OYF/nzM06mXp5geuhz/5O+dVfqUNtrGW9OOgnTOKZ6j5bGkwGsLNZHOCOUy4izh4QlKnRBtBaraP2yzQ==
+"@kiali/k-charted-pf4@0.5.0-rc7":
+  version "0.5.0-rc7"
+  resolved "https://registry.yarnpkg.com/@kiali/k-charted-pf4/-/k-charted-pf4-0.5.0-rc7.tgz#587f0ded72caa8f9cd4075dda19765ab86d7e9ad"
+  integrity sha512-aVKoMbECnfF5KQyr6jrigMc0W/iucyHKwZithMAVtAULrcq/2SOPQrqN7Y1ySgvR4SROvPvdDu3n7PIYH1QKfg==
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"


### PR DESCRIPTION
It allows to zoom-in charts by selecting a region (works for Istio metrics & Custom metrics)

Fixes https://github.com/kiali/kiali/issues/1860

It needs k-charted update /  https://github.com/kiali/k-charted/pull/78