### PR TITLE
Fix race condition when sorting by Health

### DIFF
--- a/src/pages/ServiceList/FiltersAndSorts.ts
+++ b/src/pages/ServiceList/FiltersAndSorts.ts
@@ -1,7 +1,7 @@
 import { ActiveFilter, FilterType, FILTER_ACTION_APPEND } from '../../types/Filters';
-import { getRequestErrorsStatus, WithServiceHealth } from '../../types/Health';
+import { getRequestErrorsStatus, WithServiceHealth, hasHealth } from '../../types/Health';
 import { ServiceListItem } from '../../types/ServiceList';
-import { GenericSortField, HealthSortField } from '../../types/SortFilters';
+import { SortField } from '../../types/SortFilters';
 import {
   istioSidecarFilter,
   healthFilter,
@@ -12,7 +12,7 @@ import {
 import { hasMissingSidecar } from '../../components/VirtualList/Config';
 import { TextInputTypes } from '@patternfly/react-core';
 
-export const sortFields: GenericSortField<ServiceListItem>[] = [
+export const sortFields: SortField<ServiceListItem>[] = [
   {
     id: 'namespace',
     title: 'Namespace',
@@ -59,20 +59,24 @@ export const sortFields: GenericSortField<ServiceListItem>[] = [
     title: 'Health',
     isNumeric: false,
     param: 'he',
-    compare: (a: WithServiceHealth<ServiceListItem>, b: WithServiceHealth<ServiceListItem>) => {
-      const statusForA = a.health.getGlobalStatus();
-      const statusForB = b.health.getGlobalStatus();
+    compare: (a, b) => {
+      if (hasHealth(a) && hasHealth(b)) {
+        const statusForA = a.health.getGlobalStatus();
+        const statusForB = b.health.getGlobalStatus();
 
-      if (statusForA.priority === statusForB.priority) {
-        // If both services have same health status, use error rate to determine order.
-        const ratioA = getRequestErrorsStatus(a.health.requests.errorRatio).value;
-        const ratioB = getRequestErrorsStatus(b.health.requests.errorRatio).value;
-        return ratioA === ratioB ? a.name.localeCompare(b.name) : ratioB - ratioA;
+        if (statusForA.priority === statusForB.priority) {
+          // If both services have same health status, use error rate to determine order.
+          const ratioA = getRequestErrorsStatus(a.health.requests.errorRatio).value;
+          const ratioB = getRequestErrorsStatus(b.health.requests.errorRatio).value;
+          return ratioA === ratioB ? a.name.localeCompare(b.name) : ratioB - ratioA;
+        }
+
+        return statusForB.priority - statusForA.priority;
+      } else {
+        return 0;
       }
-
-      return statusForB.priority - statusForA.priority;
     }
-  } as HealthSortField<ServiceListItem>,
+  },
   {
     id: 'configvalidation',
     title: 'Config',
@@ -161,7 +165,7 @@ export const filterBy = (
 // Exported for test
 export const sortServices = (
   services: ServiceListItem[],
-  sortField: GenericSortField<ServiceListItem>,
+  sortField: SortField<ServiceListItem>,
   isAscending: boolean
 ): Promise<ServiceListItem[]> => {
   if (sortField.title === 'Health') {

--- a/src/pages/WorkloadList/FiltersAndSorts.ts
+++ b/src/pages/WorkloadList/FiltersAndSorts.ts
@@ -1,7 +1,7 @@
 import { ActiveFilter, FILTER_ACTION_APPEND, FILTER_ACTION_UPDATE, FilterType, FilterTypes } from '../../types/Filters';
 import { WorkloadListItem, WorkloadType } from '../../types/Workload';
-import { GenericSortField, HealthSortField } from '../../types/SortFilters';
-import { getRequestErrorsStatus, WithWorkloadHealth } from '../../types/Health';
+import { SortField } from '../../types/SortFilters';
+import { getRequestErrorsStatus, WithWorkloadHealth, hasHealth } from '../../types/Health';
 import {
   presenceValues,
   istioSidecarFilter,
@@ -13,7 +13,7 @@ import {
 import { hasMissingSidecar } from '../../components/VirtualList/Config';
 import { TextInputTypes } from '@patternfly/react-core';
 
-export const sortFields: GenericSortField<WorkloadListItem>[] = [
+export const sortFields: SortField<WorkloadListItem>[] = [
   {
     id: 'namespace',
     title: 'Namespace',
@@ -119,20 +119,24 @@ export const sortFields: GenericSortField<WorkloadListItem>[] = [
     title: 'Health',
     isNumeric: false,
     param: 'he',
-    compare: (a: WithWorkloadHealth<WorkloadListItem>, b: WithWorkloadHealth<WorkloadListItem>) => {
-      const statusForA = a.health.getGlobalStatus();
-      const statusForB = b.health.getGlobalStatus();
+    compare: (a, b) => {
+      if (hasHealth(a) && hasHealth(b)) {
+        const statusForA = a.health.getGlobalStatus();
+        const statusForB = b.health.getGlobalStatus();
 
-      if (statusForA.priority === statusForB.priority) {
-        // If both workloads have same health status, use error rate to determine order.
-        const ratioA = getRequestErrorsStatus(a.health.requests.errorRatio).value;
-        const ratioB = getRequestErrorsStatus(b.health.requests.errorRatio).value;
-        return ratioA === ratioB ? a.name.localeCompare(b.name) : ratioB - ratioA;
+        if (statusForA.priority === statusForB.priority) {
+          // If both workloads have same health status, use error rate to determine order.
+          const ratioA = getRequestErrorsStatus(a.health.requests.errorRatio).value;
+          const ratioB = getRequestErrorsStatus(b.health.requests.errorRatio).value;
+          return ratioA === ratioB ? a.name.localeCompare(b.name) : ratioB - ratioA;
+        }
+
+        return statusForB.priority - statusForA.priority;
+      } else {
+        return 0;
       }
-
-      return statusForB.priority - statusForA.priority;
     }
-  } as HealthSortField<WorkloadListItem>
+  }
 ];
 
 const workloadNameFilter: FilterType = {
@@ -288,7 +292,7 @@ export const filterBy = (
 
 export const sortWorkloadsItems = (
   unsorted: WorkloadListItem[],
-  sortField: GenericSortField<WorkloadListItem>,
+  sortField: SortField<WorkloadListItem>,
   isAscending: boolean
 ): Promise<WorkloadListItem[]> => {
   if (sortField.title === 'Health') {

--- a/src/types/Health.ts
+++ b/src/types/Health.ts
@@ -332,11 +332,8 @@ export type NamespaceServiceHealth = { [service: string]: ServiceHealth };
 export type NamespaceWorkloadHealth = { [workload: string]: WorkloadHealth };
 
 export type WithAppHealth<T> = T & { health: AppHealth };
-
-export const hasHealth = <T>(val: T): val is WithAppHealth<T> => {
-  return !!val['health']['requests'];
-};
-
 export type WithServiceHealth<T> = T & { health: ServiceHealth };
 export type WithWorkloadHealth<T> = T & { health: WorkloadHealth };
+
 export type WithHealth<T> = WithAppHealth<T> | WithServiceHealth<T> | WithWorkloadHealth<T>;
+export const hasHealth = <T>(val: T): val is WithHealth<T> => !!val['health'];

--- a/src/types/Health.ts
+++ b/src/types/Health.ts
@@ -332,5 +332,11 @@ export type NamespaceServiceHealth = { [service: string]: ServiceHealth };
 export type NamespaceWorkloadHealth = { [workload: string]: WorkloadHealth };
 
 export type WithAppHealth<T> = T & { health: AppHealth };
+
+export const hasHealth = <T>(val: T): val is WithAppHealth<T> => {
+  return !!val['health']['requests'];
+};
+
 export type WithServiceHealth<T> = T & { health: ServiceHealth };
 export type WithWorkloadHealth<T> = T & { health: WorkloadHealth };
+export type WithHealth<T> = WithAppHealth<T> | WithServiceHealth<T> | WithWorkloadHealth<T>;

--- a/src/types/SortFilters.ts
+++ b/src/types/SortFilters.ts
@@ -5,8 +5,6 @@ export interface SortField<T> {
   title: string;
   isNumeric: boolean;
   param: string;
-  compare: <A extends T>(a: A, b: A) => number;
+  compare: (a: T | WithHealth<T>, b: T | WithHealth<T>) => number;
 }
-
-export type HealthSortField<T> = SortField<T & { health: typeof Health }>;
-export type GenericSortField<T> = SortField<T> | HealthSortField<T>;
+type WithHealth<T> = T & { health: Health };


### PR DESCRIPTION
Closes https://github.com/kiali/kiali/issues/1935.

This, combined with https://github.com/kiali/kiali-ui/pull/1561 fixes all the problems with the health tooltips and sorting.

The main problem this tackles is that, when doing the sort, the health for the services/apps/workloads might not be available yet, so it fails. It is ittermitent but it does not happen anymore after the change.