### PR TITLE
KIALI-2215: Enable wrapping on the ACE editor

### DIFF
--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -361,6 +361,7 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
                 width={'100%'}
                 height={'var(--kiali-yaml-editor-height)'}
                 className={'istio-ace-editor'}
+                wrapEnabled={true}
                 readOnly={!this.canUpdate()}
                 setOptions={aceOptions}
                 value={this.state.istioObjectDetails ? yamlSource : undefined}


### PR DESCRIPTION
** Describe the change **

This enables line wrapping on the YAML editor of Istio resources.

** Issue reference **

https://issues.redhat.com/browse/KIALI-2215
https://github.com/kiali/kiali/issues/1406

** Backwards compatible? **

[] Is your pull-request introducing changes in behaviour?

Not really changes in behaviour - this is solely a visual change.

** Screenshot **

![image](https://user-images.githubusercontent.com/9500791/74067186-ec190080-49f8-11ea-9885-d6419a2c394e.png)
