### PR TITLE
Expand log area

### DIFF
--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
@@ -48,7 +48,7 @@ const logsTextarea = style({
   // 75px is the height of the toolbar inside "Logs" tab
   height: 'calc(100% - 75px)',
   overflow: 'auto',
-  resize: 'vertical',
+  resize: 'none',
   color: '#fff',
   backgroundColor: '#003145',
   fontFamily: 'monospace',

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
@@ -52,7 +52,8 @@ const logsTextarea = style({
   color: '#fff',
   backgroundColor: '#003145',
   fontFamily: 'monospace',
-  fontSize: '11pt'
+  fontSize: '11pt',
+  padding: '10px'
 });
 
 const toolbarRight = style({

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
@@ -46,8 +46,7 @@ const TailLinesOptions = {
 const logsTextarea = style({
   width: '100%',
   // 75px is the height of the toolbar inside "Logs" tab
-  // 200px is the height added by RenderComponentScroll
-  height: 'calc(var(--kiali-details-pages-tab-content-height) - 275px)',
+  height: 'calc(100% - 75px)',
   overflow: 'auto',
   resize: 'vertical',
   color: '#fff',
@@ -140,9 +139,9 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
     return (
       <RenderComponentScroll>
         {this.state.containerInfo && (
-          <Grid style={{ padding: '20px' }}>
+          <Grid style={{ padding: '20px', height: '100%' }}>
             <GridItem span={12}>
-              <Card>
+              <Card style={{ height: '100%' }}>
                 <CardBody>
                   <Toolbar className={toolbarMargin}>
                     <ToolbarGroup>


### PR DESCRIPTION
** Describe the change **

This improves the styling of the logs-textarea on a workloads detail page.
* the textarea is now filling the entire available height
* resizing is disabled, as that doesn't provide any benefit anymore with the above improvement
* there is some padding around the text so the logs are not hugging the border of the textarea anymore

** Issue reference **

fixes: https://github.com/kiali/kiali/issues/2189

** Backwards compatible? **

[ ] Is your pull-request introducing changes in behaviour? No



** Screenshot **

<img width="1508"  src="https://user-images.githubusercontent.com/9500791/74071055-0ce65380-4a03-11ea-9637-e443e4153bbf.png">

Before:

![logs-before](https://user-images.githubusercontent.com/1312165/74073574-abe95c00-49bf-11ea-9ff0-485d4e94800b.gif)

After:

![logs-after](https://user-images.githubusercontent.com/1312165/74073588-bd326880-49bf-11ea-8e32-0b4d9ee36b4f.gif)

