### PR TITLE
Focus animation changes

### DIFF
--- a/src/app/History.ts
+++ b/src/app/History.ts
@@ -13,6 +13,7 @@ export enum URLParam {
   BY_LABELS = 'bylbl',
   DIRECTION = 'direction',
   DURATION = 'duration',
+  FOCUS_SELECTOR = 'focusSelector',
   FROM = 'from',
   GRAPH_EDGES = 'edges',
   GRAPH_LAYOUT = 'layout',

--- a/src/pages/Graph/GraphPage.tsx
+++ b/src/pages/Graph/GraphPage.tsx
@@ -40,7 +40,7 @@ import { PfColors, PFKialiColor } from 'components/Pf/PfColors';
 import { TourActions } from 'actions/TourActions';
 import TourStopContainer, { TourInfo, getNextTourStop } from 'components/Tour/TourStop';
 import { arrayEquals } from 'utils/Common';
-import { isKioskMode, getFocusSelector } from 'utils/SearchParamUtils';
+import { isKioskMode, getFocusSelector, unsetFocusSelector } from 'utils/SearchParamUtils';
 import GraphTour, { GraphTourStops } from './GraphHelpTour';
 import { getErrorString } from 'services/Api';
 import { Chip, Badge } from '@patternfly/react-core';
@@ -158,6 +158,7 @@ export class GraphPage extends React.Component<GraphPageProps> {
   private loadPromise?: CancelablePromise<any>;
   private readonly errorBoundaryRef: any;
   private cytoscapeGraphRef: any;
+  private focusSelector?: string;
 
   static getNodeParamsFromProps(props: RouteComponentProps<Partial<GraphURLPathProps>>): NodeParamsType | undefined {
     const app = props.match.params.app;
@@ -221,7 +222,7 @@ export class GraphPage extends React.Component<GraphPageProps> {
     super(props);
     this.errorBoundaryRef = React.createRef();
     this.cytoscapeGraphRef = React.createRef();
-
+    this.focusSelector = getFocusSelector();
     // Let URL override current redux state at construction time
     // Note that state updates will not be posted until until after the first render
     const urlNode = GraphPage.getNodeParamsFromProps(props);
@@ -272,6 +273,11 @@ export class GraphPage extends React.Component<GraphPageProps> {
       this.loadGraphDataFromBackend();
     }
 
+    if (!!this.focusSelector) {
+      this.focusSelector = undefined;
+      unsetFocusSelector();
+    }
+
     if (prev.layout.name !== curr.layout.name || prev.graphData !== curr.graphData || activeNamespacesChanged) {
       this.errorBoundaryRef.current.cleanError();
     }
@@ -292,7 +298,6 @@ export class GraphPage extends React.Component<GraphPageProps> {
     if (isKioskMode()) {
       conStyle = kioskContainerStyle;
     }
-    const focusSelector = getFocusSelector();
     const isReady =
       this.props.graphData.nodes && Object.keys(this.props.graphData.nodes).length > 0 && !this.props.isError;
     const isReplayReady = this.props.replayActive && !!this.props.replayQueryTime;
@@ -340,7 +345,7 @@ export class GraphPage extends React.Component<GraphPageProps> {
                       containerClassName={cytoscapeGraphContainerStyle}
                       ref={refInstance => this.setCytoscapeGraph(refInstance)}
                       isMTLSEnabled={this.props.mtlsEnabled}
-                      focusSelector={focusSelector}
+                      focusSelector={this.focusSelector}
                       contextMenuNodeComponent={NodeContextMenuContainer}
                       contextMenuGroupComponent={NodeContextMenuContainer}
                     />

--- a/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
@@ -28,6 +28,7 @@ import TourStopContainer from 'components/Tour/TourStop';
 import TimeControlsContainer from 'components/Time/TimeControls';
 import { KialiIcon, defaultIconStyle } from 'config/KialiIcon';
 import ReplayContainer from 'components/Time/Replay';
+import { UserSettingsActions } from 'actions/UserSettingsActions';
 
 type ReduxProps = {
   activeNamespaces: Namespace[];
@@ -42,6 +43,7 @@ type ReduxProps = {
   setGraphType: (graphType: GraphType) => void;
   setNode: (node?: NodeParamsType) => void;
   setShowUnusedNodes: (unusedNodes: boolean) => void;
+  toggleReplayActive: () => void;
 };
 
 type GraphToolbarProps = ReduxProps & {
@@ -137,6 +139,13 @@ export class GraphToolbar extends React.PureComponent<GraphToolbarProps> {
     HistoryManager.setParam(URLParam.GRAPH_EDGES, String(this.props.edgeLabelMode));
     HistoryManager.setParam(URLParam.GRAPH_TYPE, String(this.props.graphType));
     HistoryManager.setParam(URLParam.UNUSED_NODES, String(this.props.showUnusedNodes));
+  }
+
+  componentWillUnmount() {
+    // If replay was left active then turn it off
+    if (this.props.replayActive) {
+      this.props.toggleReplayActive();
+    }
   }
 
   handleRefresh = () => {
@@ -254,7 +263,8 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<KialiAppState, void, KialiAp
     setEdgeLabelMode: bindActionCreators(GraphToolbarActions.setEdgelLabelMode, dispatch),
     setGraphType: bindActionCreators(GraphToolbarActions.setGraphType, dispatch),
     setNode: bindActionCreators(GraphActions.setNode, dispatch),
-    setShowUnusedNodes: bindActionCreators(GraphToolbarActions.setShowUnusedNodes, dispatch)
+    setShowUnusedNodes: bindActionCreators(GraphToolbarActions.setShowUnusedNodes, dispatch),
+    toggleReplayActive: bindActionCreators(UserSettingsActions.toggleReplayActive, dispatch)
   };
 };
 

--- a/src/utils/SearchParamUtils.ts
+++ b/src/utils/SearchParamUtils.ts
@@ -1,8 +1,14 @@
+import { HistoryManager, URLParam } from '../app/History';
+
 export const isKioskMode = () => {
   const urlParams = new URLSearchParams(window.location.search);
   return urlParams.get('kiosk') === 'true';
 };
 
 export const getFocusSelector = () => {
-  return new URLSearchParams(window.location.search).get('focusSelector') || undefined;
+  return new URLSearchParams(window.location.search).get(URLParam.FOCUS_SELECTOR) || undefined;
+};
+
+export const unsetFocusSelector = () => {
+  HistoryManager.deleteParam(URLParam.FOCUS_SELECTOR, true);
 };


### PR DESCRIPTION
ensure that the focusSelector is processed only one time
  - clean the URL param and prop after initial render

bonus fix: another dirty state issue, ensure graph replay is stopped when navigating away from the graph.

Fixes https://github.com/kiali/kiali/issues/2228

Test1:
1) Nav to workloads
2) Select a workload
3) Click "Show on Graph"
    - note the animation
4) Click Replay
5) Click Start
    pre-fix: note focus animation repeats
    post-fix: no second animation and url is clean of the focusSelector param

Test2:
1) Nav to graph
2) Click Replay
3) Nav to workloads (left menu)
4) Nav back to graph (left menu)
    pre-fix: replay is still open
    post-fix: replay is not open, standard graph for current time
