### PR TITLE
Support Weigthed Routing Wizard when workloads are added/removed

### DIFF
--- a/src/components/IstioWizards/IstioWizardActions.ts
+++ b/src/components/IstioWizards/IstioWizardActions.ts
@@ -450,13 +450,30 @@ const getWorkloadsByVersion = (workloads: WorkloadOverview[]): { [key: string]: 
   return wkdVersionName;
 };
 
+export const getDefaultWeights = (workloads: WorkloadOverview[]): WorkloadWeight[] => {
+  const wkTraffic = workloads.length < 100 ? Math.floor(100 / workloads.length) : 0;
+  const remainTraffic = workloads.length < 100 ? 100 % workloads.length : 0;
+  const wkWeights: WorkloadWeight[] = workloads.map(workload => ({
+    name: workload.name,
+    weight: wkTraffic,
+    locked: false,
+    maxWeight: 100
+  }));
+  if (remainTraffic > 0) {
+    wkWeights[wkWeights.length - 1].weight = wkWeights[wkWeights.length - 1].weight + remainTraffic;
+  }
+  return wkWeights;
+};
+
 export const getInitWeights = (workloads: WorkloadOverview[], virtualServices: VirtualServices): WorkloadWeight[] => {
   const wkdVersionName = getWorkloadsByVersion(workloads);
   const wkdWeights: WorkloadWeight[] = [];
   if (virtualServices.items.length === 1 && virtualServices.items[0].spec.http!.length === 1) {
     // Populate WorkloadWeights from a VirtualService
     virtualServices.items[0].spec.http![0].route!.forEach(route => {
-      if (route.destination.subset) {
+      // A wkdVersionName[route.destination.subset] === undefined may indicate that a VS contains a removed workload
+      // Checking before to add it to the Init Weights
+      if (route.destination.subset && wkdVersionName[route.destination.subset]) {
         wkdWeights.push({
           name: wkdVersionName[route.destination.subset],
           weight: route.weight || 0,
@@ -465,6 +482,28 @@ export const getInitWeights = (workloads: WorkloadOverview[], virtualServices: V
         });
       }
     });
+  }
+  // Add new workloads with 0 weight if there is missing workloads
+  if (wkdWeights.length > 0 && workloads.length !== wkdWeights.length) {
+    for (let i = 0; i < workloads.length; i++) {
+      const wkd = workloads[i];
+      let newWkd = true;
+      for (let j = 0; j < wkdWeights.length; j++) {
+        const wkdWeight = wkdWeights[j];
+        if (wkd.name === wkdWeight.name) {
+          newWkd = false;
+          break;
+        }
+      }
+      if (newWkd) {
+        wkdWeights.push({
+          name: wkd.name,
+          weight: 0,
+          locked: false,
+          maxWeight: 100
+        });
+      }
+    }
   }
   return wkdWeights;
 };

--- a/src/components/IstioWizards/WeightedRouting.tsx
+++ b/src/components/IstioWizards/WeightedRouting.tsx
@@ -6,6 +6,7 @@ import { style } from 'typestyle';
 import { PfColors } from '../Pf/PfColors';
 import { Badge, Button, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { EqualizerIcon } from '@patternfly/react-icons';
+import { getDefaultWeights } from './IstioWizardActions';
 
 type Props = {
   serviceName: string;
@@ -48,21 +49,6 @@ class WeightedRouting extends React.Component<Props, State> {
     this.resetState();
   }
 
-  getDefaultWeights = (workloads: WorkloadOverview[]): WorkloadWeight[] => {
-    const wkTraffic = workloads.length < 100 ? Math.floor(100 / workloads.length) : 0;
-    const remainTraffic = workloads.length < 100 ? 100 % workloads.length : 0;
-    const wkWeights: WorkloadWeight[] = workloads.map(workload => ({
-      name: workload.name,
-      weight: wkTraffic,
-      locked: false,
-      maxWeight: 100
-    }));
-    if (remainTraffic > 0) {
-      wkWeights[wkWeights.length - 1].weight = wkWeights[wkWeights.length - 1].weight + remainTraffic;
-    }
-    return wkWeights;
-  };
-
   resetState = () => {
     if (this.props.workloads.length === 0) {
       return;
@@ -73,7 +59,7 @@ class WeightedRouting extends React.Component<Props, State> {
           workloads:
             prevState.workloads.length === 0 && this.props.initWeights.length > 0
               ? this.props.initWeights
-              : this.getDefaultWeights(this.props.workloads)
+              : getDefaultWeights(this.props.workloads)
         };
       },
       () => this.props.onChange(this.checkTotalWeight(), this.state.workloads, true)


### PR DESCRIPTION
Fixes kiali/kiali#2205
This PR address the use cases we have discussed.

I'm going to review 2205 in the context of the other wizards and see here what is missing.

But probably the Weigthed Routing Wizard can be tested. @hhovsepy 