### PR TITLE
Double-click focus node to navigate to detail

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -673,6 +673,27 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
     this.graphHighlighter!.onClick(event);
   };
 
+  // This allows us to navigate to the service details page when zoomed in on nodes
+  private handleDoubleTapSameNode = (targetNode: NodeParamsType) => {
+    const makeAppDetailsPageUrl = (namespace: string, nodeType: string, name?: string): string => {
+      return `/namespaces/${namespace}/${nodeType}/${name}`;
+    };
+    const nodeType = targetNode.nodeType;
+    let urlNodeType = targetNode.nodeType + 's';
+    let name = targetNode.app;
+    if (nodeType === 'service') {
+      name = targetNode.service;
+    } else if (nodeType === 'workload') {
+      name = targetNode.workload;
+    } else {
+      urlNodeType = 'applications';
+    }
+    const detailsPageUrl = makeAppDetailsPageUrl(targetNode.namespace.name, urlNodeType, name);
+    console.warn(detailsPageUrl);
+    history.push(detailsPageUrl);
+    return;
+  };
+
   private handleDoubleTap = (event: CytoscapeClickEvent) => {
     const target = event.summaryTarget;
     const targetType = event.summaryType;
@@ -740,7 +761,9 @@ export class CytoscapeGraph extends React.Component<CytoscapeGraphProps, Cytosca
           sameNode = true; // don't navigate to unsupported node type
       }
     }
+
     if (sameNode) {
+      this.handleDoubleTapSameNode(targetNode);
       return;
     }
 


### PR DESCRIPTION
** Describe the change **
Today in the graph, a single click selects a node and a double-click drills down into the node focus graph (aka node graph, node detail graph). On the node focus graph a double-click on the focus node has no effect because we are already drilled down. A natural progression would be to have that double-click navigate to the relevant detail page.

** Issue reference **
fixes https://github.com/kiali/kiali/issues/2046

** Screenshot **

![dbl-click](https://user-images.githubusercontent.com/1312165/74879455-04085280-531e-11ea-9010-d8244dba19a4.gif)

