### PR TITLE
Trivial: Make version strategy consistent with other package versioning 

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "react-ace": "6.4.0",
     "react-bootstrap": "0.32.4",
     "react-copy-to-clipboard": "5.0.1",
-    "react-datepicker": "^2.10.1",
+    "react-datepicker": "2.10.1",
     "react-dom": "16.9.0",
     "react-flexview": "4.0.3",
     "react-floater": "0.6.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11599,7 +11599,7 @@ react-copy-to-clipboard@5.0.1:
     copy-to-clipboard "^3"
     prop-types "^15.5.8"
 
-react-datepicker@^2.10.1:
+react-datepicker@2.10.1:
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/react-datepicker/-/react-datepicker-2.10.1.tgz#5db917a8e10af8b311715f4bdae8b8dfe64f9357"
   integrity sha512-b9UjPy5/uZpzqBoGJdR9Mwnv/0ecHyUQUJf499hm2m2Luo3u9HZwAERSExYC4CvAecVUz88AsfowrjVAf7Kulg==


### PR DESCRIPTION
Make version strategy consistent with other package versioning with 'pinned' static versions.

** Describe the change **

Using the pinned versions will prevent building something that may not have been tested. So if QE tests a particular version built a couple of weeks ago and then a newer version of that library comes out -- it gets pulled in unknowingly.
