### PR TITLE
Use "auto" tooltip positioning for graph side panel

### DIFF
--- a/src/pages/Graph/SummaryLink.tsx
+++ b/src/pages/Graph/SummaryLink.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { NodeType, GraphNodeData } from '../../types/Graph';
 import { CyNode, decoratedNodeData } from '../../components/CytoscapeGraph/CytoscapeGraphUtils';
 import { KialiIcon } from 'config/KialiIcon';
-import { Tooltip, Badge, PopoverPosition } from '@patternfly/react-core';
+import { Tooltip, Badge, PopoverPosition, TooltipPosition } from '@patternfly/react-core';
 import { Health } from 'types/Health';
 import { HealthIndicator, DisplayMode } from 'components/Health/HealthIndicator';
 
@@ -11,13 +11,14 @@ const getBadge = (nodeData: GraphNodeData, nodeType?: NodeType) => {
   switch (nodeType || nodeData.nodeType) {
     case NodeType.APP:
       return (
-        <Tooltip content={<>Application</>}>
+        <Tooltip position={TooltipPosition.auto} content={<>Application</>}>
           <Badge className="virtualitem_badge_definition">A</Badge>
         </Tooltip>
       );
     case NodeType.SERVICE:
       return !!nodeData.isServiceEntry ? (
         <Tooltip
+          position={TooltipPosition.auto}
           content={
             <>{nodeData.isServiceEntry === 'MESH_EXTERNAL' ? 'External Service Entry' : 'Internal Service Entry'}</>
           }
@@ -25,19 +26,19 @@ const getBadge = (nodeData: GraphNodeData, nodeType?: NodeType) => {
           <Badge className="virtualitem_badge_definition">SE</Badge>
         </Tooltip>
       ) : (
-        <Tooltip content={<>Service</>}>
+        <Tooltip position={TooltipPosition.auto} content={<>Service</>}>
           <Badge className="virtualitem_badge_definition">S</Badge>
         </Tooltip>
       );
     case NodeType.WORKLOAD:
       return (
-        <Tooltip content={<>Workload</>}>
+        <Tooltip position={TooltipPosition.auto} content={<>Workload</>}>
           <Badge className="virtualitem_badge_definition">W</Badge>
         </Tooltip>
       );
     default:
       return (
-        <Tooltip content={<>Unknown</>}>
+        <Tooltip position={TooltipPosition.auto} content={<>Unknown</>}>
           <Badge className="virtualitem_badge_definition">U</Badge>
         </Tooltip>
       );

--- a/src/pages/Graph/SummaryPanelGraph.tsx
+++ b/src/pages/Graph/SummaryPanelGraph.tsx
@@ -270,7 +270,7 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
     return (
       <>
         <span>
-          <Tooltip position={TooltipPosition.top} content={<>Namespace</>}>
+          <Tooltip position={TooltipPosition.auto} content={<>Namespace</>}>
             <Badge className="virtualitem_badge_definition" style={{ marginBottom: '2px' }}>
               NS
             </Badge>


### PR DESCRIPTION
Use "auto" tooltip positioning for the graph side panel badges to reduce tooltip covering.

Fixes https://github.com/kiali/kiali/issues/2196

![image](https://user-images.githubusercontent.com/2104052/74843418-ddd0bb80-52f9-11ea-8cd7-6c3acfda96e2.png)

@abonas A couple of comments.  First, as seen in the screenshot the tooltip pointer does not have a black background when positioned to the left.  That seems to be a feature of Tooltip, perhaps a minor bug.  I am going to show UX and create a PF bug if necessary.   Second, I have very occasionally seen the second part of this issue, the "transparent" tooltip.   I can't reproduce it reliably, or sometime at all.  This looks like a PF issue for sure.  The Tooltip looks like it's stuck in a "fade" animation.  We could try to workaround this by explicitly setting animation="none" but I think it 's probably better to generate a PF issue.  Again, I'll pass it by UX.  I think this issue should just focus on the positioning.