### PR TITLE
Move "Show on graph" link down to the mini-graph card

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -20,7 +20,6 @@ import {
   CytoscapeMouseOutEvent,
   DecoratedGraphElements,
   EdgeLabelMode,
-  GraphType,
   Layout,
   NodeParamsType,
   NodeType,
@@ -41,7 +40,6 @@ import { EdgeSingular } from 'cytoscape';
 import { Core } from 'cytoscape';
 
 type CytoscapeGraphProps = {
-  activeNamespaces: Namespace[];
   containerClassName?: string;
   contextMenuEdgeComponent?: EdgeContextMenuType;
   contextMenuGroupComponent?: NodeContextMenuType;
@@ -50,7 +48,6 @@ type CytoscapeGraphProps = {
   displayUnusedNodes: () => void;
   edgeLabelMode: EdgeLabelMode;
   focusSelector?: string;
-  graphType: GraphType;
   isMiniGraph: boolean;
   isMTLSEnabled: boolean;
   layout: Layout;
@@ -245,7 +242,7 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps,
           isLoading={this.state.isLoading}
           isError={this.state.isError}
           isMiniGraph={this.props.isMiniGraph}
-          namespaces={this.props.activeNamespaces}
+          namespaces={this.props.dataSource.fetchParameters.namespaces}
         >
           <CytoscapeContextMenuWrapper
             ref={this.contextMenuRef}
@@ -587,9 +584,9 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps,
     }
 
     const globalScratchData: CytoscapeGlobalScratchData = {
-      activeNamespaces: this.props.activeNamespaces,
+      activeNamespaces: this.props.dataSource.fetchParameters.namespaces,
       edgeLabelMode: this.props.edgeLabelMode,
-      graphType: this.props.graphType,
+      graphType: this.props.dataSource.fetchParameters.graphType,
       mtlsEnabled: this.props.isMTLSEnabled,
       showCircuitBreakers: this.props.showCircuitBreakers,
       showMissingSidecars: this.props.showMissingSidecars,
@@ -772,11 +769,11 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps,
     }
 
     const urlParams: GraphUrlParams = {
-      activeNamespaces: this.props.activeNamespaces,
+      activeNamespaces: this.props.dataSource.fetchParameters.namespaces,
       duration: this.props.dataSource.fetchParameters.duration,
       edgeLabelMode: this.props.edgeLabelMode,
       graphLayout: this.props.layout,
-      graphType: this.props.graphType,
+      graphType: this.props.dataSource.fetchParameters.graphType,
       node: targetNode,
       refreshInterval: this.props.refreshInterval,
       showServiceNodes: this.props.showServiceNodes,

--- a/src/components/CytoscapeGraph/MiniGraphCard.tsx
+++ b/src/components/CytoscapeGraph/MiniGraphCard.tsx
@@ -37,7 +37,7 @@ export default class MiniGraphCard extends React.Component<MiniGraphCardProps, M
   render() {
     const graphCardActions = [
       <DropdownItem key="viewGraph" onClick={this.onViewGraph}>
-        View full graph
+        Show full graph
       </DropdownItem>
     ];
 
@@ -75,7 +75,7 @@ export default class MiniGraphCard extends React.Component<MiniGraphCardProps, M
               showNodeLabels={true}
               showSecurity={false}
               showServiceNodes={true}
-              showTrafficAnimation={true}
+              showTrafficAnimation={false}
               showUnusedNodes={false}
               showVirtualServices={true}
             />

--- a/src/components/CytoscapeGraph/MiniGraphCard.tsx
+++ b/src/components/CytoscapeGraph/MiniGraphCard.tsx
@@ -1,0 +1,124 @@
+import * as React from 'react';
+import { style } from 'typestyle';
+import {
+  Card,
+  CardActions,
+  CardBody,
+  CardHead,
+  CardHeader,
+  Dropdown,
+  DropdownItem,
+  KebabToggle,
+  Title
+} from '@patternfly/react-core';
+import history from '../../app/History';
+import GraphDataSource from '../../services/GraphDataSource';
+import { EdgeLabelMode, GraphType, NodeType } from '../../types/Graph';
+import CytoscapeGraph from './CytoscapeGraph';
+import { CytoscapeGraphSelectorBuilder } from './CytoscapeGraphSelector';
+import { DagreGraph } from './graphs/DagreGraph';
+
+const miniGraphContainerStyle = style({ height: '300px' });
+
+type MiniGraphCardProps = {
+  dataSource: GraphDataSource;
+};
+
+type MiniGraphCardState = {
+  isKebabOpen: boolean;
+};
+
+export default class MiniGraphCard extends React.Component<MiniGraphCardProps, MiniGraphCardState> {
+  constructor(props) {
+    super(props);
+    this.state = { isKebabOpen: false };
+  }
+
+  render() {
+    const graphCardActions = [
+      <DropdownItem key="viewGraph" onClick={this.onViewGraph}>
+        View full graph
+      </DropdownItem>
+    ];
+
+    return (
+      <Card style={{ height: '100%' }}>
+        <CardHead>
+          <CardActions>
+            <Dropdown
+              toggle={<KebabToggle onToggle={this.onGraphActionsToggle} />}
+              dropdownItems={graphCardActions}
+              isPlain
+              isOpen={this.state.isKebabOpen}
+              position={'right'}
+            />
+          </CardActions>
+          <CardHeader>
+            <Title style={{ float: 'left' }} headingLevel="h3" size="2xl">
+              Graph Overview
+            </Title>
+          </CardHeader>
+        </CardHead>
+        <CardBody>
+          <div style={{ height: '100%' }}>
+            <CytoscapeGraph
+              containerClassName={miniGraphContainerStyle}
+              dataSource={this.props.dataSource}
+              displayUnusedNodes={() => undefined}
+              edgeLabelMode={EdgeLabelMode.NONE}
+              isMTLSEnabled={false}
+              isMiniGraph={true}
+              layout={DagreGraph.getLayout()}
+              refreshInterval={0}
+              showCircuitBreakers={false}
+              showMissingSidecars={true}
+              showNodeLabels={true}
+              showSecurity={false}
+              showServiceNodes={true}
+              showTrafficAnimation={true}
+              showUnusedNodes={false}
+              showVirtualServices={true}
+            />
+          </div>
+        </CardBody>
+      </Card>
+    );
+  }
+
+  private onGraphActionsToggle = (isOpen: boolean) => {
+    this.setState({
+      isKebabOpen: isOpen
+    });
+  };
+
+  private onViewGraph = () => {
+    const namespace = this.props.dataSource.fetchParameters.namespaces[0].name;
+    let cytoscapeGraph = new CytoscapeGraphSelectorBuilder().namespace(namespace);
+    let graphType: GraphType = GraphType.APP;
+
+    switch (this.props.dataSource.fetchParameters.node!.nodeType) {
+      case NodeType.WORKLOAD:
+        graphType = GraphType.WORKLOAD;
+        cytoscapeGraph = cytoscapeGraph.workload(this.props.dataSource.fetchParameters.node!.workload);
+        break;
+
+      case NodeType.APP:
+        cytoscapeGraph = cytoscapeGraph
+          .app(this.props.dataSource.fetchParameters.node!.app)
+          .nodeType(NodeType.APP)
+          .isGroup(null);
+        break;
+
+      case NodeType.SERVICE:
+        graphType = GraphType.SERVICE;
+        cytoscapeGraph = cytoscapeGraph.service(this.props.dataSource.fetchParameters.node!.service);
+        break;
+    }
+
+    const graphUrl = `/graph/namespaces?graphType=${graphType}&injectServiceNodes=true&namespaces=${namespace}&unusedNodes=true&focusSelector=${encodeURI(
+      cytoscapeGraph.build()
+    )}`;
+
+    history.push(graphUrl);
+  };
+}

--- a/src/components/CytoscapeGraph/__tests__/CytoscapeGraph.test.tsx
+++ b/src/components/CytoscapeGraph/__tests__/CytoscapeGraph.test.tsx
@@ -43,7 +43,6 @@ describe('CytoscapeGraph component test', () => {
 
     const wrapper = shallow(
       <CytoscapeGraph
-        activeNamespaces={[{ name: testNamespace }]}
         edgeLabelMode={myEdgeLabelMode}
         layout={myLayout}
         updateGraph={testClickHandler}
@@ -62,7 +61,6 @@ describe('CytoscapeGraph component test', () => {
         showTrafficAnimation={false}
         showUnusedNodes={false}
         showVirtualServices={true}
-        graphType={GraphType.VERSIONED_APP}
         dataSource={dataSource}
         displayUnusedNodes={() => undefined}
       />

--- a/src/components/Pf/PfTitle.tsx
+++ b/src/components/Pf/PfTitle.tsx
@@ -1,10 +1,7 @@
 import * as React from 'react';
 import MissingSidecar from '../../components/MissingSidecar/MissingSidecar';
-import { Link } from 'react-router-dom';
 import { ServiceIcon, BundleIcon, ApplicationsIcon } from '@patternfly/react-icons';
-import { CytoscapeGraphSelectorBuilder } from '../CytoscapeGraph/CytoscapeGraphSelector';
 import { style } from 'typestyle';
-import { NodeType } from '../../types/Graph';
 
 const PfTitleStyle = style({
   fontSize: '19px',
@@ -57,24 +54,17 @@ class PfTitle extends React.Component<PfTitleProps, PfTitleState> {
       type = match[2];
       name = match[3];
     }
-    let cytoscapeGraph = new CytoscapeGraphSelectorBuilder().namespace(ns);
     switch (type) {
       case 'services':
         graphType = 'service';
-        cytoscapeGraph = cytoscapeGraph.service(name);
         icon = <ServiceIcon />;
         break;
       case 'workloads':
         graphType = 'workload';
-        cytoscapeGraph = cytoscapeGraph.workload(name);
         icon = <BundleIcon />;
         break;
       case 'applications':
         graphType = 'app';
-        cytoscapeGraph = cytoscapeGraph
-          .app(name)
-          .nodeType(NodeType.APP)
-          .isGroup(null);
         icon = <ApplicationsIcon />;
         break;
       default:
@@ -84,8 +74,7 @@ class PfTitle extends React.Component<PfTitleProps, PfTitleState> {
       type: type,
       name: name,
       graphType: graphType,
-      icon: icon,
-      cytoscapeGraph: cytoscapeGraph.build()
+      icon: icon
     });
   }
 
@@ -105,12 +94,6 @@ class PfTitle extends React.Component<PfTitleProps, PfTitleState> {
     }
   }
 
-  showOnGraphLink() {
-    return `/graph/namespaces?graphType=${this.state.graphType}&injectServiceNodes=true&namespaces=${
-      this.state.namespace
-    }&unusedNodes=true&focusSelector=${encodeURI(this.state.cytoscapeGraph)}`;
-  }
-
   render() {
     return (
       <h2 className={PfTitleStyle}>
@@ -119,11 +102,6 @@ class PfTitle extends React.Component<PfTitleProps, PfTitleState> {
           <span style={{ marginLeft: '10px' }}>
             <MissingSidecar namespace={this.state.namespace} />
           </span>
-        )}
-        {this.state.name && (
-          <>
-            {'  '}(<Link to={this.showOnGraphLink()}>Show on graph</Link>)
-          </>
         )}
       </h2>
     );

--- a/src/pages/AppDetails/AppInfo/AppDescription.tsx
+++ b/src/pages/AppDetails/AppInfo/AppDescription.tsx
@@ -34,16 +34,7 @@ type AppDescriptionProps = {
   miniGraphDataSource: GraphDataSource;
 };
 
-type AppDescriptionState = {
-  isGraphActionsOpen: boolean;
-};
-
-class AppDescription extends React.Component<AppDescriptionProps, AppDescriptionState> {
-  constructor(props: AppDescriptionProps) {
-    super(props);
-    this.state = { isGraphActionsOpen: false };
-  }
-
+class AppDescription extends React.Component<AppDescriptionProps> {
   istioSidecar() {
     let istioSidecar = true; // true until proven otherwise (workload with missing sidecar exists)
     this.props.app.workloads.forEach(wkd => {

--- a/src/pages/AppDetails/AppInfo/AppDescription.tsx
+++ b/src/pages/AppDetails/AppInfo/AppDescription.tsx
@@ -7,20 +7,15 @@ import { Link } from 'react-router-dom';
 import {
   Badge,
   Card,
-  CardActions,
   CardBody,
-  CardHead,
   CardHeader,
   DataList,
   DataListCell,
   DataListItem,
   DataListItemCells,
   DataListItemRow,
-  Dropdown,
-  DropdownItem,
   Grid,
   GridItem,
-  KebabToggle,
   List,
   ListItem,
   PopoverPosition,
@@ -30,13 +25,8 @@ import {
   TextVariants,
   Title
 } from '@patternfly/react-core';
-import { style } from 'typestyle';
-import history from '../../../app/History';
-import { EdgeLabelMode, GraphType, NodeType } from '../../../types/Graph';
-import CytoscapeGraph from '../../../components/CytoscapeGraph/CytoscapeGraph';
-import { CytoscapeGraphSelectorBuilder } from '../../../components/CytoscapeGraph/CytoscapeGraphSelector';
-import { DagreGraph } from '../../../components/CytoscapeGraph/graphs/DagreGraph';
 import GraphDataSource from '../../../services/GraphDataSource';
+import MiniGraphCard from '../../../components/CytoscapeGraph/MiniGraphCard';
 
 type AppDescriptionProps = {
   app: App;
@@ -47,8 +37,6 @@ type AppDescriptionProps = {
 type AppDescriptionState = {
   isGraphActionsOpen: boolean;
 };
-
-const cytoscapeGraphContainerStyle = style({ height: '300px' });
 
 class AppDescription extends React.Component<AppDescriptionProps, AppDescriptionState> {
   constructor(props: AppDescriptionProps) {
@@ -134,12 +122,6 @@ class AppDescription extends React.Component<AppDescriptionProps, AppDescription
 
   render() {
     const app = this.props.app;
-    const graphCardActions = [
-      <DropdownItem key="viewGraph" onClick={this.onViewGraph}>
-        View full graph
-      </DropdownItem>
-    ];
-
     return app ? (
       <Grid gutter="md">
         <GridItem span={4}>
@@ -166,48 +148,7 @@ class AppDescription extends React.Component<AppDescriptionProps, AppDescription
           </Card>
         </GridItem>
         <GridItem span={4}>
-          <Card style={{ height: '100%' }}>
-            <CardHead>
-              <CardActions>
-                <Dropdown
-                  toggle={<KebabToggle onToggle={this.onGraphActionsToggle} />}
-                  dropdownItems={graphCardActions}
-                  isPlain
-                  isOpen={this.state.isGraphActionsOpen}
-                  position={'right'}
-                />
-              </CardActions>
-              <CardHeader>
-                <Title style={{ float: 'left' }} headingLevel="h3" size="2xl">
-                  Graph Overview
-                </Title>
-              </CardHeader>
-            </CardHead>
-            <CardBody>
-              <div style={{ height: '100%' }}>
-                <CytoscapeGraph
-                  activeNamespaces={[this.props.app.namespace]}
-                  containerClassName={cytoscapeGraphContainerStyle}
-                  dataSource={this.props.miniGraphDataSource}
-                  displayUnusedNodes={() => undefined}
-                  edgeLabelMode={EdgeLabelMode.NONE}
-                  graphType={GraphType.WORKLOAD}
-                  isMTLSEnabled={false}
-                  isMiniGraph={true}
-                  layout={DagreGraph.getLayout()}
-                  refreshInterval={0}
-                  showCircuitBreakers={false}
-                  showMissingSidecars={true}
-                  showNodeLabels={true}
-                  showSecurity={false}
-                  showServiceNodes={true}
-                  showTrafficAnimation={true}
-                  showUnusedNodes={false}
-                  showVirtualServices={true}
-                />
-              </div>
-            </CardBody>
-          </Card>
+          <MiniGraphCard dataSource={this.props.miniGraphDataSource} />
         </GridItem>
         <GridItem span={4}>
           <Card style={{ height: '100%' }}>
@@ -235,26 +176,6 @@ class AppDescription extends React.Component<AppDescriptionProps, AppDescription
       'Loading'
     );
   }
-
-  private onGraphActionsToggle = (isOpen: boolean) => {
-    this.setState({
-      isGraphActionsOpen: isOpen
-    });
-  };
-
-  private onViewGraph = () => {
-    let cytoscapeGraph = new CytoscapeGraphSelectorBuilder()
-      .namespace(this.props.app.namespace.name)
-      .app(this.props.app.name)
-      .nodeType(NodeType.APP)
-      .isGroup(null);
-
-    const graphUrl = `/graph/namespaces?graphType=${GraphType.APP}&injectServiceNodes=true&namespaces=${
-      this.props.app.namespace.name
-    }&unusedNodes=true&focusSelector=${encodeURI(cytoscapeGraph.build())}`;
-
-    history.push(graphUrl);
-  };
 }
 
 export default AppDescription;

--- a/src/pages/Graph/GraphToolbar/GraphFind.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphFind.tsx
@@ -263,7 +263,6 @@ export class GraphFind extends React.PureComponent<GraphFindProps, GraphFindStat
     layoutChanged: boolean
   ) => {
     if (!this.props.cyData) {
-      console.debug('Skip Hide: cy not set.');
       return;
     }
 
@@ -333,7 +332,6 @@ export class GraphFind extends React.PureComponent<GraphFindProps, GraphFindStat
 
   private handleFind = () => {
     if (!this.props.cyData) {
-      console.debug('Skip Find: cy not set.');
       return;
     }
 

--- a/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
@@ -168,11 +168,7 @@ export class GraphToolbar extends React.PureComponent<GraphToolbarProps> {
         <Toolbar className={toolbarStyle}>
           <div style={{ display: 'flex' }}>
             {this.props.node ? (
-              <Tooltip
-                key={'graph-tour-help-ot'}
-                position={TooltipPosition.right}
-                content={`Back to full ${GraphToolbar.GRAPH_TYPES[graphTypeKey]}`}
-              >
+              <Tooltip key={'graph-tour-help-ot'} position={TooltipPosition.right} content={'Back to full graph'}>
                 <Button variant={ButtonVariant.link} onClick={this.handleNamespaceReturn}>
                   <KialiIcon.Back className={defaultIconStyle} />
                 </Button>

--- a/src/pages/Graph/GraphToolbar/__tests__/GraphFind.test.tsx
+++ b/src/pages/Graph/GraphToolbar/__tests__/GraphFind.test.tsx
@@ -3,13 +3,8 @@ import { shallow } from 'enzyme';
 import { GraphFind } from '../GraphFind';
 import { EdgeLabelMode } from 'types/Graph';
 
-const testHandler = () => {
-  console.log('handled');
-};
-
-const testSetter = _val => {
-  console.log('set');
-};
+const testHandler = () => undefined;
+const testSetter = _val => undefined;
 
 // TODO Find out why typescript is unhappy and get rid of all of these ts-ignores
 describe('Parse find value test', () => {

--- a/src/pages/Overview/OverviewCardLinks.tsx
+++ b/src/pages/Overview/OverviewCardLinks.tsx
@@ -24,7 +24,7 @@ class OverviewCardLinks extends React.Component<Props> {
 
     // Link to the graph page
     links.push(
-      <Tooltip key="ot_graph" content={<>Go to graph</>} {...tooltipProps}>
+      <Tooltip key="ot_graph" content={<>Show graph</>} {...tooltipProps}>
         <Link
           to={`/graph/namespaces?namespaces=${this.props.name}&graphType=${this.toGraphType(this.props.overviewType)}`}
           className={iconStyle}
@@ -37,7 +37,7 @@ class OverviewCardLinks extends React.Component<Props> {
     // Link to the apps list
     if (this.props.overviewType !== 'app') {
       links.push(
-        <Tooltip key="ot_apps" content={<>Go to applications</>} {...tooltipProps}>
+        <Tooltip key="ot_apps" content={<>Show applications</>} {...tooltipProps}>
           <Link to={`/${Paths.APPLICATIONS}?namespaces=` + this.props.name} className={iconStyle}>
             <ApplicationsIcon />
           </Link>
@@ -48,7 +48,7 @@ class OverviewCardLinks extends React.Component<Props> {
     // Link to the workloads list
     if (this.props.overviewType !== 'workload') {
       links.push(
-        <Tooltip key="ot_workloads" content={<>Go to workloads</>} {...tooltipProps}>
+        <Tooltip key="ot_workloads" content={<>Show workloads</>} {...tooltipProps}>
           <Link to={`/${Paths.WORKLOADS}?namespaces=` + this.props.name} className={iconStyle}>
             <BundleIcon />
           </Link>
@@ -59,7 +59,7 @@ class OverviewCardLinks extends React.Component<Props> {
     // Link to the services list
     if (this.props.overviewType !== 'service') {
       links.push(
-        <Tooltip key="ot_services" content={<>Go to services</>} {...tooltipProps}>
+        <Tooltip key="ot_services" content={<>Show services</>} {...tooltipProps}>
           <Link to={`/${Paths.SERVICES}?namespaces=` + this.props.name} className={iconStyle}>
             <ServiceIcon />
           </Link>
@@ -69,7 +69,7 @@ class OverviewCardLinks extends React.Component<Props> {
 
     // Link to the Istio Config list
     links.push(
-      <Tooltip key="ot_istio" content={<>Go to Istio config</>} {...tooltipProps}>
+      <Tooltip key="ot_istio" content={<>Show Istio config</>} {...tooltipProps}>
         <Link to={`/${Paths.ISTIO}?namespaces=` + this.props.name} className={iconStyle}>
           <PficonTemplateIcon />
         </Link>

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
@@ -49,10 +49,6 @@ interface ServiceInfoDescriptionProps {
   miniGraphDatasource: GraphDataSource;
 }
 
-interface ServiceInfoDescriptionState {
-  isGraphActionsOpen: boolean;
-}
-
 const listStyle = style({
   listStyleType: 'none',
   padding: 0
@@ -60,11 +56,7 @@ const listStyle = style({
 
 const ExternalNameType = 'ExternalName';
 
-class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps, ServiceInfoDescriptionState> {
-  constructor(props: ServiceInfoDescriptionProps) {
-    super(props);
-    this.state = { isGraphActionsOpen: false };
-  }
+class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps> {
   getPortOver(portId: number) {
     return <ValidationList checks={this.getPortChecks(portId)} />;
   }

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoDescription.tsx
@@ -1,15 +1,9 @@
 import * as React from 'react';
 import {
   Card,
-  CardActions,
   CardBody,
-  CardHead,
-  CardHeader,
-  Dropdown,
-  DropdownItem,
   Grid,
   GridItem,
-  KebabToggle,
   Stack,
   StackItem,
   Text,
@@ -19,25 +13,21 @@ import {
 } from '@patternfly/react-core';
 import { EyeIcon } from '@patternfly/react-icons';
 import { style } from 'typestyle';
-import CytoscapeGraph from '../../../components/CytoscapeGraph/CytoscapeGraph';
-import { DagreGraph } from '../../../components/CytoscapeGraph/graphs/DagreGraph';
 import LocalTime from '../../../components/Time/LocalTime';
 import { DisplayMode, HealthIndicator } from '../../../components/Health/HealthIndicator';
 import GraphDataSource from '../../../services/GraphDataSource';
 import { ServiceHealth } from '../../../types/Health';
 import { Endpoints } from '../../../types/ServiceInfo';
 import { ObjectCheck, ObjectValidation, Port } from '../../../types/IstioObjects';
-import { EdgeLabelMode, GraphType } from '../../../types/Graph';
-import { CytoscapeGraphSelectorBuilder } from '../../../components/CytoscapeGraph/CytoscapeGraphSelector';
 import { ValidationObjectSummary } from '../../../components/Validations/ValidationObjectSummary';
 import ValidationList from '../../../components/Validations/ValidationList';
-import history from '../../../app/History';
 import Labels from '../../../components/Label/Labels';
 import { ThreeScaleServiceRule } from '../../../types/ThreeScale';
 import { AdditionalItem } from 'types/Workload';
 import { TextOrLink } from 'components/TextOrLink';
 import { renderAPILogo } from 'components/Logo/Logos';
 import './ServiceInfoDescription.css';
+import MiniGraphCard from '../../../components/CytoscapeGraph/MiniGraphCard';
 
 interface ServiceInfoDescriptionProps {
   name: string;
@@ -70,8 +60,6 @@ const listStyle = style({
 
 const ExternalNameType = 'ExternalName';
 
-const cytoscapeGraphContainerStyle = style({ height: '300px' });
-
 class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps, ServiceInfoDescriptionState> {
   constructor(props: ServiceInfoDescriptionProps) {
     super(props);
@@ -92,12 +80,6 @@ class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps
   }
 
   render() {
-    const graphCardActions = [
-      <DropdownItem key="viewGraph" onClick={this.onViewGraph}>
-        View full graph
-      </DropdownItem>
-    ];
-
     return (
       <Grid gutter="md">
         <GridItem span={4}>
@@ -144,48 +126,7 @@ class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps
           </Card>
         </GridItem>
         <GridItem span={4}>
-          <Card style={{ height: '100%' }}>
-            <CardHead>
-              <CardActions>
-                <Dropdown
-                  toggle={<KebabToggle onToggle={this.onGraphActionsToggle} />}
-                  dropdownItems={graphCardActions}
-                  isPlain
-                  isOpen={this.state.isGraphActionsOpen}
-                  position={'right'}
-                />
-              </CardActions>
-              <CardHeader>
-                <Title headingLevel="h3" size="2xl">
-                  Graph Overview
-                </Title>
-              </CardHeader>
-            </CardHead>
-            <CardBody>
-              <div style={{ height: '100%' }}>
-                <CytoscapeGraph
-                  activeNamespaces={[{ name: this.props.namespace }]}
-                  containerClassName={cytoscapeGraphContainerStyle}
-                  dataSource={this.props.miniGraphDatasource}
-                  displayUnusedNodes={() => undefined}
-                  edgeLabelMode={EdgeLabelMode.NONE}
-                  graphType={GraphType.APP}
-                  isMTLSEnabled={false}
-                  isMiniGraph={true}
-                  layout={DagreGraph.getLayout()}
-                  refreshInterval={0}
-                  showCircuitBreakers={false}
-                  showMissingSidecars={true}
-                  showNodeLabels={true}
-                  showSecurity={false}
-                  showServiceNodes={true}
-                  showTrafficAnimation={true}
-                  showUnusedNodes={false}
-                  showVirtualServices={true}
-                />
-              </div>
-            </CardBody>
-          </Card>
+          <MiniGraphCard dataSource={this.props.miniGraphDatasource} />
         </GridItem>
         <GridItem span={4}>
           <Card style={{ height: '100%' }}>
@@ -265,22 +206,6 @@ class ServiceInfoDescription extends React.Component<ServiceInfoDescriptionProps
       </Grid>
     );
   }
-
-  private onGraphActionsToggle = (isOpen: boolean) => {
-    this.setState({
-      isGraphActionsOpen: isOpen
-    });
-  };
-
-  private onViewGraph = () => {
-    let cytoscapeGraph = new CytoscapeGraphSelectorBuilder().namespace(this.props.namespace).service(this.props.name);
-
-    const graphUrl = `/graph/namespaces?graphType=${GraphType.SERVICE}&injectServiceNodes=true&namespaces=${
-      this.props.namespace
-    }&unusedNodes=true&focusSelector=${encodeURI(cytoscapeGraph.build())}`;
-
-    history.push(graphUrl);
-  };
 }
 
 export default ServiceInfoDescription;

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
@@ -81,100 +81,44 @@ exports[`#ServiceInfoDescription render correctly with data should render servic
   <GridItem
     span={4}
   >
-    <Card
-      style={
-        Object {
-          "height": "100%",
+    <MiniGraphCard
+      dataSource={
+        GraphDataSource {
+          "_errorMessage": null,
+          "_fetchParams": Object {
+            "duration": 0,
+            "edgeLabelMode": "noEdgeLabels",
+            "graphType": "versionedApp",
+            "injectServiceNodes": true,
+            "namespaces": Array [],
+            "showSecurity": false,
+            "showUnusedNodes": false,
+          },
+          "_isError": false,
+          "_isLoading": false,
+          "decoratedData": [Function],
+          "emit": [Function],
+          "eventEmitter": EventEmitter {
+            "_events": Object {},
+            "_eventsCount": 0,
+          },
+          "fetchDataForNamespaces": [Function],
+          "fetchDataForNode": [Function],
+          "fetchGraphData": [Function],
+          "graphDuration": 0,
+          "graphElements": Object {
+            "edges": Array [],
+            "nodes": Array [],
+          },
+          "graphTimestamp": 0,
+          "on": [Function],
+          "promiseRegistry": PromisesRegistry {
+            "promises": Map {},
+          },
+          "removeListener": [Function],
         }
       }
-    >
-      <CardBody>
-        <Title
-          headingLevel="h3"
-          size="2xl"
-        >
-           
-          Graph Overview
-           
-        </Title>
-        <div
-          style={
-            Object {
-              "height": "100%",
-            }
-          }
-        >
-          <CytoscapeGraph
-            activeNamespaces={
-              Array [
-                Object {
-                  "name": "my-namespace",
-                },
-              ]
-            }
-            containerClassName="f1niyge3"
-            dataSource={
-              GraphDataSource {
-                "_errorMessage": null,
-                "_fetchParams": Object {
-                  "duration": 0,
-                  "edgeLabelMode": "noEdgeLabels",
-                  "graphType": "versionedApp",
-                  "injectServiceNodes": true,
-                  "namespaces": Array [],
-                  "showSecurity": false,
-                  "showUnusedNodes": false,
-                },
-                "_isError": false,
-                "_isLoading": false,
-                "decoratedData": [Function],
-                "emit": [Function],
-                "eventEmitter": EventEmitter {
-                  "_events": Object {},
-                  "_eventsCount": 0,
-                },
-                "fetchDataForNamespaces": [Function],
-                "fetchDataForNode": [Function],
-                "fetchGraphData": [Function],
-                "graphDuration": 0,
-                "graphElements": Object {
-                  "edges": Array [],
-                  "nodes": Array [],
-                },
-                "graphTimestamp": 0,
-                "on": [Function],
-                "promiseRegistry": PromisesRegistry {
-                  "promises": Map {},
-                },
-                "removeListener": [Function],
-              }
-            }
-            displayUnusedNodes={[Function]}
-            edgeLabelMode="noEdgeLabels"
-            graphType="app"
-            isMTLSEnabled={false}
-            isMiniGraph={true}
-            layout={
-              Object {
-                "fit": false,
-                "name": "dagre",
-                "nodeDimensionsIncludeLabels": true,
-                "rankDir": "LR",
-              }
-            }
-            refreshInterval={0}
-            showCircuitBreakers={false}
-            showMissingSidecars={true}
-            showNodeLabels={true}
-            showSecurity={false}
-            showServiceNodes={true}
-            showTrafficAnimation={true}
-            showUnusedNodes={false}
-            showVirtualServices={true}
-          />
-        </div>
-      </CardBody>
-    </Card>
+    />
   </GridItem>
   <GridItem
     span={4}

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadDescription.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadDescription.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { style } from 'typestyle';
 import { Workload } from '../../../types/Workload';
 import LocalTime from '../../../components/Time/LocalTime';
 import { DisplayMode, HealthIndicator } from '../../../components/Health/HealthIndicator';
@@ -7,15 +6,9 @@ import { WorkloadHealth } from '../../../types/Health';
 import Labels from '../../../components/Label/Labels';
 import {
   Card,
-  CardActions,
   CardBody,
-  CardHead,
-  CardHeader,
-  Dropdown,
-  DropdownItem,
   Grid,
   GridItem,
-  KebabToggle,
   PopoverPosition,
   Stack,
   StackItem,
@@ -25,14 +18,8 @@ import {
 } from '@patternfly/react-core';
 import { TextOrLink } from 'components/TextOrLink';
 import { renderRuntimeLogo, renderAPILogo } from 'components/Logo/Logos';
-import history from '../../../app/History';
-import CytoscapeGraph from '../../../components/CytoscapeGraph/CytoscapeGraph';
-import { CytoscapeGraphSelectorBuilder } from '../../../components/CytoscapeGraph/CytoscapeGraphSelector';
-import { DagreGraph } from '../../../components/CytoscapeGraph/graphs/DagreGraph';
-import { EdgeLabelMode, GraphType } from '../../../types/Graph';
 import GraphDataSource from '../../../services/GraphDataSource';
-
-const cytoscapeGraphContainerStyle = style({ height: '300px' });
+import MiniGraphCard from '../../../components/CytoscapeGraph/MiniGraphCard';
 
 type WorkloadDescriptionProps = {
   workload: Workload;
@@ -42,27 +29,13 @@ type WorkloadDescriptionProps = {
   miniGraphDataSource: GraphDataSource;
 };
 
-type WorkloadDescriptionState = {
-  isGraphActionsOpen: boolean;
-};
-
-class WorkloadDescription extends React.Component<WorkloadDescriptionProps, WorkloadDescriptionState> {
-  constructor(props: WorkloadDescriptionProps) {
-    super(props);
-    this.state = { isGraphActionsOpen: false };
-  }
-
+class WorkloadDescription extends React.Component<WorkloadDescriptionProps> {
   render() {
     const workload = this.props.workload;
     const isTemplateLabels =
       workload &&
       ['Deployment', 'ReplicaSet', 'ReplicationController', 'DeploymentConfig', 'StatefulSet'].indexOf(workload.type) >=
         0;
-    const graphCardActions = [
-      <DropdownItem key="viewGraph" onClick={this.onViewGraph}>
-        View full graph
-      </DropdownItem>
-    ];
     const runtimes = workload.runtimes.map(r => r.name).filter(name => name !== '');
     return workload ? (
       <Grid gutter="md">
@@ -116,48 +89,7 @@ class WorkloadDescription extends React.Component<WorkloadDescriptionProps, Work
           </Card>
         </GridItem>
         <GridItem span={4}>
-          <Card style={{ height: '100%' }}>
-            <CardHead>
-              <CardActions>
-                <Dropdown
-                  toggle={<KebabToggle onToggle={this.onGraphActionsToggle} />}
-                  dropdownItems={graphCardActions}
-                  isPlain
-                  isOpen={this.state.isGraphActionsOpen}
-                  position={'right'}
-                />
-              </CardActions>
-              <CardHeader>
-                <Title headingLevel="h3" size="2xl">
-                  Graph Overview{' '}
-                </Title>
-              </CardHeader>
-            </CardHead>
-            <CardBody>
-              <div style={{ height: '300px' }}>
-                <CytoscapeGraph
-                  activeNamespaces={[{ name: this.props.namespace }]}
-                  containerClassName={cytoscapeGraphContainerStyle}
-                  dataSource={this.props.miniGraphDataSource}
-                  displayUnusedNodes={() => undefined}
-                  edgeLabelMode={EdgeLabelMode.NONE}
-                  graphType={GraphType.APP}
-                  isMTLSEnabled={false}
-                  isMiniGraph={true}
-                  layout={DagreGraph.getLayout()}
-                  refreshInterval={0}
-                  showCircuitBreakers={false}
-                  showMissingSidecars={true}
-                  showNodeLabels={true}
-                  showSecurity={false}
-                  showServiceNodes={true}
-                  showTrafficAnimation={true}
-                  showUnusedNodes={false}
-                  showVirtualServices={true}
-                />
-              </div>
-            </CardBody>
-          </Card>
+          <MiniGraphCard dataSource={this.props.miniGraphDataSource} />
         </GridItem>
         <GridItem span={4}>
           <Card style={{ height: '100%' }}>
@@ -185,24 +117,6 @@ class WorkloadDescription extends React.Component<WorkloadDescriptionProps, Work
       'Loading'
     );
   }
-
-  private onGraphActionsToggle = (isOpen: boolean) => {
-    this.setState({
-      isGraphActionsOpen: isOpen
-    });
-  };
-
-  private onViewGraph = () => {
-    let cytoscapeGraph = new CytoscapeGraphSelectorBuilder()
-      .namespace(this.props.namespace)
-      .workload(this.props.workload.name);
-
-    const graphUrl = `/graph/namespaces?graphType=${GraphType.WORKLOAD}&injectServiceNodes=true&namespaces=${
-      this.props.namespace
-    }&unusedNodes=true&focusSelector=${encodeURI(cytoscapeGraph.build())}`;
-
-    history.push(graphUrl);
-  };
 }
 
 export default WorkloadDescription;

--- a/src/pages/WorkloadDetails/WorkloadInfo/__tests__/__snapshots__/WorkloadDescription.test.tsx.snap
+++ b/src/pages/WorkloadDetails/WorkloadInfo/__tests__/__snapshots__/WorkloadDescription.test.tsx.snap
@@ -101,100 +101,44 @@ exports[`WorkloadDescription should render with runtimes 1`] = `
   <GridItem
     span={4}
   >
-    <Card
-      style={
-        Object {
-          "height": "100%",
+    <MiniGraphCard
+      dataSource={
+        GraphDataSource {
+          "_errorMessage": null,
+          "_fetchParams": Object {
+            "duration": 0,
+            "edgeLabelMode": "noEdgeLabels",
+            "graphType": "versionedApp",
+            "injectServiceNodes": true,
+            "namespaces": Array [],
+            "showSecurity": false,
+            "showUnusedNodes": false,
+          },
+          "_isError": false,
+          "_isLoading": false,
+          "decoratedData": [Function],
+          "emit": [Function],
+          "eventEmitter": EventEmitter {
+            "_events": Object {},
+            "_eventsCount": 0,
+          },
+          "fetchDataForNamespaces": [Function],
+          "fetchDataForNode": [Function],
+          "fetchGraphData": [Function],
+          "graphDuration": 0,
+          "graphElements": Object {
+            "edges": Array [],
+            "nodes": Array [],
+          },
+          "graphTimestamp": 0,
+          "on": [Function],
+          "promiseRegistry": PromisesRegistry {
+            "promises": Map {},
+          },
+          "removeListener": [Function],
         }
       }
-    >
-      <CardBody>
-        <Title
-          headingLevel="h3"
-          size="2xl"
-        >
-           
-          Graph Overview
-           
-        </Title>
-        <div
-          style={
-            Object {
-              "height": "300px",
-            }
-          }
-        >
-          <CytoscapeGraph
-            activeNamespaces={
-              Array [
-                Object {
-                  "name": "my-namespace",
-                },
-              ]
-            }
-            containerClassName="f1niyge3"
-            dataSource={
-              GraphDataSource {
-                "_errorMessage": null,
-                "_fetchParams": Object {
-                  "duration": 0,
-                  "edgeLabelMode": "noEdgeLabels",
-                  "graphType": "versionedApp",
-                  "injectServiceNodes": true,
-                  "namespaces": Array [],
-                  "showSecurity": false,
-                  "showUnusedNodes": false,
-                },
-                "_isError": false,
-                "_isLoading": false,
-                "decoratedData": [Function],
-                "emit": [Function],
-                "eventEmitter": EventEmitter {
-                  "_events": Object {},
-                  "_eventsCount": 0,
-                },
-                "fetchDataForNamespaces": [Function],
-                "fetchDataForNode": [Function],
-                "fetchGraphData": [Function],
-                "graphDuration": 0,
-                "graphElements": Object {
-                  "edges": Array [],
-                  "nodes": Array [],
-                },
-                "graphTimestamp": 0,
-                "on": [Function],
-                "promiseRegistry": PromisesRegistry {
-                  "promises": Map {},
-                },
-                "removeListener": [Function],
-              }
-            }
-            displayUnusedNodes={[Function]}
-            edgeLabelMode="noEdgeLabels"
-            graphType="app"
-            isMTLSEnabled={false}
-            isMiniGraph={true}
-            layout={
-              Object {
-                "fit": false,
-                "name": "dagre",
-                "nodeDimensionsIncludeLabels": true,
-                "rankDir": "LR",
-              }
-            }
-            refreshInterval={0}
-            showCircuitBreakers={false}
-            showMissingSidecars={true}
-            showNodeLabels={true}
-            showSecurity={false}
-            showServiceNodes={true}
-            showTrafficAnimation={true}
-            showUnusedNodes={false}
-            showVirtualServices={true}
-          />
-        </div>
-      </CardBody>
-    </Card>
+    />
   </GridItem>
   <GridItem
     span={4}


### PR DESCRIPTION
Follow up of the mini-graph feature. This is addressing the following points (commented in https://github.com/kiali/kiali-ui/pull/1670#issuecomment-590141647):

* the graph shouldn't have any actions, other than pan enabled
* add a View graph link on the card title
  * The "Show on graph" link of the title of the page was moved under a kebab menu on the mini-graph card.
* mini-graph shouldn't manipulate the URL

**BEFORE:**
![image](https://user-images.githubusercontent.com/23639005/75493979-cab88e00-5980-11ea-9d3a-d2d3aa3eeabd.png)

**AFTER:**
![image](https://user-images.githubusercontent.com/23639005/76032063-aae41580-5efe-11ea-8a03-0f08bfd156e9.png)

---

This is creating a MiniGraphCard component to reduce code duplication.
Additionally, because of UX feedback, this is also:
* Turning off traffic animation for mini-graph
* Shorten to "Back to full graph" on the back button of the drilled-down graph
![image](https://user-images.githubusercontent.com/23639005/76032165-e7177600-5efe-11ea-8a4b-85ea5fb8b38e.png)

* Use "Show" instead of "Go to" in the tooltips of the cards on the overview page
![image](https://user-images.githubusercontent.com/23639005/76032182-f1397480-5efe-11ea-8d53-e21edee686f3.png)

---
Fixes kiali/kiali#1960.