### PR TITLE
Add Iter8 feature

### DIFF
--- a/src/components/Nav/Menu.tsx
+++ b/src/components/Nav/Menu.tsx
@@ -54,7 +54,9 @@ class Menu extends React.Component<MenuProps, MenuState> {
       .filter(item => {
         // Extensions are conditionally rendered
         if (item.title === '3scale Config') {
-          return serverConfig.extensions!.threescale.enabled;
+          return serverConfig.extensions!.threescale!.enabled;
+        } else if (item.title === 'Iter8 Experiment') {
+          return serverConfig.extensions!.iter8!.enabled;
         }
         return true;
       })

--- a/src/components/Nav/RenderPage.tsx
+++ b/src/components/Nav/RenderPage.tsx
@@ -28,6 +28,8 @@ class RenderPage extends React.Component<{ isGraph: boolean }> {
         // Extensions are conditionally rendered
         if (route.path.startsWith('/extensions/threescale') && serverConfig.extensions!.threescale.enabled) {
           return true;
+        } else if (route.path.startsWith('/extensions/iter8') && serverConfig.extensions!.iter8.enabled) {
+          return true;
         }
         return false;
       })

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -111,6 +111,11 @@ const conf = {
         `api/namespaces/${namespace}/istio/${objectType}/${object}`,
       istioConfigDetailSubtype: (namespace: string, objectType: string, objectSubtype: string, object: string) =>
         `api/namespaces/${namespace}/istio/${objectType}/${objectSubtype}/${object}`,
+      iter8: `api/iter8`,
+      iter8Experiments: `api/iter8/experiments`,
+      iter8ExperimentsByNamespace: (namespace: string) => `api/iter8/experiments/${namespace}`,
+      iter8Experiment: (namespace: string, name: string) => `api/iter8/experiment/namespace/${namespace}/name/${name}`,
+      iter8ExperimentOp: 'api/iter8/experiment',
       istioPermissions: 'api/istio/permissions',
       jaeger: 'api/jaeger',
       jaegerTraces: (namespace: string, service: string) => `api/namespaces/${namespace}/services/${service}/traces`,

--- a/src/pages/extensions/iter8/ExperimentCreatePage.tsx
+++ b/src/pages/extensions/iter8/ExperimentCreatePage.tsx
@@ -174,11 +174,9 @@ class ExperimentCreatePage extends React.Component<RouteComponentProps<Props>, S
         case 'knative':
           newExperiment.apiversion = 'serving.knative.dev/v1alpha1';
           break;
-        case 'algorithm':
-          newExperiment.trafficControl.algorithm = value.trim();
-          break;
         case 'metricName':
           newExperiment.criterias[0].metric = value.trim();
+          break;
         case 'toleranceType':
           newExperiment.criterias[0].toleranceType = value.trim();
           break;

--- a/src/pages/extensions/iter8/ExperimentCreatePage.tsx
+++ b/src/pages/extensions/iter8/ExperimentCreatePage.tsx
@@ -1,0 +1,514 @@
+import * as React from 'react';
+import { Iter8Info } from '../../../types/Iter8';
+import { style } from 'typestyle';
+import { PfColors } from '../../../components/Pf/PfColors';
+import { Link, RouteComponentProps } from 'react-router-dom';
+import * as API from '../../../services/Api';
+import * as AlertUtils from '../../../utils/AlertUtils';
+import {
+  ActionGroup,
+  Breadcrumb,
+  BreadcrumbItem,
+  Button,
+  ButtonVariant,
+  Form,
+  FormGroup,
+  FormSelect,
+  FormSelectOption,
+  Grid,
+  GridItem,
+  Text,
+  TextInput,
+  TextVariants
+} from '@patternfly/react-core';
+import history from '../../../app/History';
+import { RenderContent } from '../../../components/Nav/Page';
+import Namespace from '../../../types/Namespace';
+import ExperimentCriteriaForm from './ExperimentCriteriaForm';
+import { PromisesRegistry } from '../../../utils/CancelablePromises';
+
+interface Props {
+  experimentName: string;
+}
+
+interface State {
+  isNew: boolean;
+  isModified: boolean;
+  iter8Info: Iter8Info;
+  experiment: ExperimentSpec;
+  namespaces: string[];
+}
+
+interface ExperimentSpec {
+  name: string;
+  namespace: string;
+  service: string;
+  apiversion: string;
+  baseline: string;
+  candidate: string;
+  // canaryVersion: string;
+  trafficControl: TrafficControl;
+  criterias: Criteria[];
+}
+
+interface TrafficControl {
+  algorithm: string;
+  interval: string;
+  maxIteration: number;
+  maxTrafficPercentage: number;
+  trafficStepSize: number;
+}
+
+export interface Criteria {
+  metric: string;
+  toleranceType: string;
+  tolerance: number;
+  sampleSize: number;
+  stopOnFailure: boolean;
+}
+
+// Style constants
+const containerPadding = style({ padding: '20px 20px 20px 20px' });
+const containerWhite = style({ backgroundColor: PfColors.White });
+const paddingLeft = style({ paddingLeft: '20px' });
+
+const algorithms = [
+  'check_and_increment',
+  'epsilon_greedy',
+  'increment_without_check',
+  ' posterior_bayesian_routing',
+  'optimistic_bayesian_routing'
+];
+
+class ExperimentCreatePage extends React.Component<RouteComponentProps<Props>, State> {
+  private promises = new PromisesRegistry();
+
+  constructor(props: RouteComponentProps<Props>) {
+    super(props);
+
+    this.state = {
+      isNew: true,
+      isModified: false,
+      iter8Info: {
+        enabled: false,
+        permissions: {
+          create: true,
+          update: true,
+          delete: true
+        }
+      },
+
+      experiment: {
+        name: '',
+        namespace: 'default',
+        apiversion: 'v1',
+        service: '',
+        baseline: '',
+        candidate: '',
+        trafficControl: {
+          algorithm: 'check_and_increment',
+          interval: '30s',
+          maxIteration: 100,
+          maxTrafficPercentage: 50,
+          trafficStepSize: 2
+        },
+
+        criterias: []
+      },
+      namespaces: []
+    };
+  }
+
+  // Get available namespaces first
+  componentDidMount() {
+    this.updateNamespaces();
+  }
+
+  // Page title for creating new experiment, no namespace dropdown
+  // as it is selected inside the form
+  pageTitle = (title: string) => (
+    <>
+      <div className={`breadcrumb ${containerWhite} ${paddingLeft}`}>
+        <Breadcrumb>
+          <BreadcrumbItem>
+            <Link to={'/extensions/iter8/list'}>Iter8 Experiments</Link>
+          </BreadcrumbItem>
+          <BreadcrumbItem isActive={true}>{title}</BreadcrumbItem>
+        </Breadcrumb>
+        <Text component={TextVariants.h1}>{title}</Text>
+      </div>
+    </>
+  );
+
+  // Invoke the history object to update and URL and start a routing
+  goExperimentsPage = () => {
+    history.push('/extensions/iter8/list');
+  };
+
+  // Updates state with modifications of the new/editing handler
+  changeExperiment = (field: string, value: string) => {
+    this.setState(prevState => {
+      const newExperiment = prevState.experiment;
+      switch (field) {
+        case 'name':
+          newExperiment.name = value.trim();
+          break;
+        case 'namespace':
+          newExperiment.namespace = value.trim();
+          break;
+        case 'service':
+          newExperiment.service = value.trim();
+          break;
+        case 'algorithm':
+          newExperiment.trafficControl.algorithm = value.trim();
+          break;
+        case 'baseline':
+          newExperiment.baseline = value.trim();
+          break;
+        case 'candidate':
+          newExperiment.candidate = value.trim();
+          break;
+        case 'kubernets':
+          newExperiment.apiversion = 'v1';
+          break;
+        case 'knative':
+          newExperiment.apiversion = 'serving.knative.dev/v1alpha1';
+          break;
+        case 'algorithm':
+          newExperiment.trafficControl.algorithm = value.trim();
+          break;
+        case 'metricName':
+          newExperiment.criterias[0].metric = value.trim();
+        case 'toleranceType':
+          newExperiment.criterias[0].toleranceType = value.trim();
+          break;
+        case 'interval':
+          newExperiment.trafficControl.interval = value.trim();
+          break;
+        default:
+      }
+      return {
+        isNew: prevState.isNew,
+        isModified: true,
+        experiment: newExperiment
+      };
+    });
+  };
+
+  // Updates state with modifications of the new/editing handler
+  changeExperimentNumber = (field: string, value: number) => {
+    this.setState(prevState => {
+      const newExperiment = prevState.experiment;
+      switch (field) {
+        case 'maxIteration':
+          newExperiment.trafficControl.maxIteration = value;
+          break;
+        case 'maxTrafficPercentage':
+          newExperiment.trafficControl.maxTrafficPercentage = value;
+          break;
+        case 'trafficStepSize':
+          newExperiment.trafficControl.trafficStepSize = value;
+          break;
+        case 'sampleSize':
+          newExperiment.criterias[0].sampleSize = value;
+          break;
+        case 'tolerance':
+          newExperiment.criterias[0].tolerance = value;
+          break;
+        default:
+      }
+      return {
+        isNew: prevState.isNew,
+        isModified: true,
+        experiment: newExperiment
+      };
+    });
+  };
+
+  // It invokes backend to create  a new experiment
+  createExperiment = () => {
+    if (this.state.isNew) {
+      API.createExperiment(JSON.stringify(this.state.experiment))
+        .then(_ => this.goExperimentsPage())
+        .catch(error => AlertUtils.addError('Could not create Experiment.', error));
+    } else {
+      API.updateExperiment(
+        this.state.experiment.namespace,
+        this.state.experiment.name,
+        JSON.stringify(this.state.experiment)
+      )
+        .then(_ => this.goExperimentsPage())
+        .catch(error => AlertUtils.addError('Could not update Experiment', error));
+    }
+  };
+
+  updateNamespaces() {
+    this.promises.cancelAll();
+    let arr: string[];
+    this.promises
+      .register('namespaces', API.getNamespaces())
+      .then(namespacesResponse => {
+        const namespacesdata: Namespace[] = namespacesResponse.data;
+        arr = [];
+        for (let ns of namespacesdata.map(namespace => namespace.name)) {
+          arr.push(ns);
+        }
+        this.setState({
+          namespaces: arr
+        });
+      })
+      .catch(namespacesError => {
+        if (!namespacesError.isCanceled) {
+          AlertUtils.addError('Could not fetch namespaces', namespacesError);
+        }
+      });
+  }
+
+  render() {
+    const title = 'Create New Experiment';
+
+    // @ts-ignore
+    return (
+      <>
+        {this.pageTitle(title)}
+        <RenderContent>
+          <div className={containerPadding}>
+            <Form isHorizontal={true}>
+              <FormGroup
+                fieldId="name"
+                label="Experiment Name :"
+                isValid={this.state.experiment.name !== ''}
+                helperTextInvalid="Name cannot be empty"
+              >
+                <TextInput
+                  id="name"
+                  value={this.state.experiment.name}
+                  placeholder="Exteriment Name"
+                  onChange={value => this.changeExperiment('name', value)}
+                />
+              </FormGroup>
+
+              <Grid gutter="md">
+                <GridItem span={6}>
+                  <FormGroup
+                    fieldId="service"
+                    label="Target Service :"
+                    isValid={this.state.experiment.service !== ''}
+                    helperTextInvalid="Target Service cannot be empty"
+                  >
+                    <TextInput
+                      id="service"
+                      value={this.state.experiment.service}
+                      placeholder="Target Service"
+                      onChange={value => this.changeExperiment('service', value)}
+                    />
+                  </FormGroup>
+                </GridItem>
+                <GridItem span={6}>
+                  <FormGroup
+                    fieldId="namespace"
+                    label="Namespace :"
+                    isValid={this.state.experiment.namespace !== ''}
+                    helperText="Namespace of the service"
+                  >
+                    <FormSelect
+                      value={this.state.experiment.namespace}
+                      id="namespace"
+                      name="Namespace"
+                      onChange={value => this.changeExperiment('namespace', value)}
+                    >
+                      {this.state.namespaces.map((option, index) => (
+                        <FormSelectOption isDisabled={false} key={'p' + index} value={option} label={option} />
+                      ))}
+                    </FormSelect>
+                  </FormGroup>
+                </GridItem>
+              </Grid>
+              <Grid gutter="md">
+                <GridItem span={6}>
+                  <FormGroup
+                    fieldId="baseline"
+                    label="Baseline :"
+                    isValid={this.state.experiment.baseline !== ''}
+                    helperTextInvalid="Baseline cannot be empty"
+                  >
+                    <TextInput
+                      id="baseline"
+                      value={this.state.experiment.baseline}
+                      placeholder="Service Name"
+                      onChange={value => this.changeExperiment('baseline', value)}
+                    />
+                  </FormGroup>
+                </GridItem>
+                <GridItem span={6}>
+                  <FormGroup
+                    fieldId="candidate"
+                    label="Candidate :"
+                    isValid={this.state.experiment.candidate !== ''}
+                    helperTextInvalid="Candidate cannot be empty"
+                  >
+                    <TextInput
+                      id="candidate"
+                      value={this.state.experiment.candidate}
+                      placeholder="Service Name"
+                      onChange={value => this.changeExperiment('candidate', value)}
+                    />
+                  </FormGroup>
+                </GridItem>
+              </Grid>
+              <hr />
+              <h1 className="pf-c-title pf-m-xl">Traffic Control</h1>
+              <Grid gutter="md">
+                <GridItem span={6}>
+                  <FormGroup
+                    fieldId="interval"
+                    label="Interval :"
+                    isValid={this.state.experiment.trafficControl.interval !== ''}
+                    helperText="frequency with which the controller calls the analytics service"
+                  >
+                    <TextInput
+                      id="interval"
+                      value={this.state.experiment.trafficControl.interval}
+                      placeholder="Service Name"
+                      onChange={value => this.changeExperimentNumber('interval', Number(value))}
+                    />
+                  </FormGroup>
+                </GridItem>
+                <GridItem span={6}>
+                  <FormGroup
+                    fieldId="maxIteration"
+                    label="Maximum Iteration :"
+                    isValid={isNaN(this.state.experiment.trafficControl.maxIteration)}
+                    helperText="Default is 100"
+                  >
+                    <TextInput
+                      id="maxIteration"
+                      value={this.state.experiment.trafficControl.maxIteration}
+                      placeholder="Maximum Iteration "
+                      onChange={value => this.changeExperimentNumber('maxIteration', Number(value))}
+                    />
+                  </FormGroup>
+                </GridItem>
+              </Grid>
+              <Grid gutter="md">
+                <GridItem span={6}>
+                  <FormGroup
+                    fieldId="maxTrafficPercentage"
+                    label="Maximum Traffic Percentage :"
+                    isValid={isNaN(this.state.experiment.trafficControl.maxTrafficPercentage)}
+                    helperText="Default is 50"
+                  >
+                    <TextInput
+                      id="maxTrafficPercentage"
+                      value={this.state.experiment.trafficControl.maxTrafficPercentage}
+                      placeholder="Service Name"
+                      onChange={value => this.changeExperimentNumber('maxTrafficPercentage', parseFloat(value))}
+                    />
+                  </FormGroup>
+                </GridItem>
+                <GridItem span={6}>
+                  <FormGroup
+                    fieldId="maxTrafficPercentage"
+                    label="Maximum Traffic Percentage :"
+                    isValid={isNaN(this.state.experiment.trafficControl.trafficStepSize)}
+                    helperText="Default is 2"
+                  >
+                    <TextInput
+                      id="maxTrafficPercentage"
+                      value={this.state.experiment.trafficControl.trafficStepSize}
+                      placeholder="Service Name"
+                      onChange={value => this.changeExperimentNumber('trafficStepSize', parseFloat(value))}
+                    />
+                  </FormGroup>
+                </GridItem>
+              </Grid>
+              <FormGroup
+                fieldId="algorithm"
+                label="Algorithm :"
+                isValid={this.state.experiment.trafficControl.algorithm !== ''}
+                helperText="Default to check_and_increment"
+              >
+                <FormSelect
+                  value={this.state.experiment.trafficControl.algorithm}
+                  id="algorithm"
+                  name="Algorithm"
+                  onChange={value => this.changeExperiment('algorithm', value)}
+                >
+                  {algorithms.map((option, index) => (
+                    <FormSelectOption isDisabled={false} key={'p' + index} value={option} label={option} />
+                  ))}
+                </FormSelect>
+              </FormGroup>
+              <hr />
+              <h1 className="pf-c-title pf-m-xl">Success Criteria</h1>
+              <ExperimentCriteriaForm
+                criterias={this.state.experiment.criterias}
+                onAdd={newCriteria => {
+                  this.setState(prevState => {
+                    prevState.experiment.criterias.push(newCriteria);
+                    return {
+                      isNew: prevState.isNew,
+                      isModified: prevState.isModified,
+                      iter8Info: prevState.iter8Info,
+                      experiment: {
+                        name: prevState.experiment.name,
+                        namespace: prevState.experiment.namespace,
+                        service: prevState.experiment.service,
+                        apiversion: prevState.experiment.apiversion,
+                        baseline: prevState.experiment.baseline,
+                        candidate: prevState.experiment.candidate,
+                        trafficControl: prevState.experiment.trafficControl,
+                        criterias: prevState.experiment.criterias
+                      }
+                    };
+                  });
+                }}
+                onRemove={index => {
+                  this.setState(prevState => {
+                    prevState.experiment.criterias.splice(index, 1);
+                    return {
+                      isNew: prevState.isNew,
+                      isModified: prevState.isModified,
+                      iter8Info: prevState.iter8Info,
+                      experiment: {
+                        name: prevState.experiment.name,
+                        namespace: prevState.experiment.namespace,
+                        service: prevState.experiment.service,
+                        apiversion: prevState.experiment.apiversion,
+                        baseline: prevState.experiment.baseline,
+                        candidate: prevState.experiment.candidate,
+                        trafficControl: prevState.experiment.trafficControl,
+                        criterias: prevState.experiment.criterias
+                      }
+                    };
+                  });
+                }}
+              />
+              <ActionGroup>
+                <span style={{ float: 'left', paddingTop: '10px', paddingBottom: '10px' }}>
+                  <span style={{ paddingRight: '5px' }}>
+                    <Button variant={ButtonVariant.primary} onClick={this.createExperiment}>
+                      Create
+                    </Button>
+                  </span>
+                  <span style={{ paddingRight: '5px' }}>
+                    <Button
+                      variant={ButtonVariant.secondary}
+                      onClick={() => {
+                        this.goExperimentsPage();
+                      }}
+                    >
+                      Cancel
+                    </Button>
+                  </span>
+                </span>
+              </ActionGroup>
+            </Form>
+          </div>
+        </RenderContent>
+      </>
+    );
+  }
+}
+
+export default ExperimentCreatePage;

--- a/src/pages/extensions/iter8/ExperimentCriteriaForm.tsx
+++ b/src/pages/extensions/iter8/ExperimentCriteriaForm.tsx
@@ -1,0 +1,276 @@
+import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
+import { Criteria } from './ExperimentCreatePage';
+import * as React from 'react';
+import { Button, FormSelect, FormSelectOption, TextInput, Radio } from '@patternfly/react-core';
+import { style } from 'typestyle';
+import { PfColors } from '../../../components/Pf/PfColors';
+const headerCells: ICell[] = [
+  {
+    title: 'Matric Name',
+    transforms: [cellWidth(30) as any],
+    props: {}
+  },
+  {
+    title: 'Sample Size',
+    transforms: [cellWidth(10) as any],
+    props: {}
+  },
+  {
+    title: 'Tolerance',
+    transforms: [cellWidth(10) as any],
+    props: {}
+  },
+  {
+    title: 'Tolerance Type',
+    transforms: [cellWidth(10) as any],
+    props: {}
+  },
+  {
+    title: 'Stop on Failure',
+    props: {}
+  },
+  {
+    title: '',
+    props: {}
+  }
+];
+
+const metrics = ['', 'iter8_latency', 'iter8_error_count', 'iter8_error_rate'];
+const toleranceType = ['threshold', 'delta'];
+
+const noCriteriaStyle = style({
+  marginTop: 15,
+  color: PfColors.Red100
+});
+
+type Props = {
+  criterias: Criteria[];
+  onAdd: (server: Criteria) => void;
+  onRemove: (index: number) => void;
+};
+
+export type CriteriaState = {
+  criterias: Criteria[];
+};
+
+type State = {
+  addCriteria: Criteria;
+  validName: boolean;
+};
+
+// Create Success Criteria, can be multiple with same metric, but different sampleSize, etc...
+class ExperimentCriteriaForm extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      addCriteria: {
+        metric: '',
+        sampleSize: 100,
+        tolerance: 0.2,
+        toleranceType: 'threshold',
+        stopOnFailure: false
+      },
+      validName: false
+    };
+  }
+
+  // @ts-ignore
+  actionResolver = (rowData, { rowIndex }) => {
+    const removeAction = {
+      title: 'Remove Criteria',
+      // @ts-ignore
+      onClick: (event, rowIndex, rowData, extraData) => {
+        this.props.onRemove(rowIndex);
+      }
+    };
+    if (rowIndex < this.props.criterias.length) {
+      return [removeAction];
+    }
+    return [];
+  };
+
+  onAddMetricName = (value: string, _) => {
+    this.setState(prevState => ({
+      addCriteria: {
+        metric: value.trim(),
+        sampleSize: prevState.addCriteria.sampleSize,
+        tolerance: prevState.addCriteria.tolerance,
+        toleranceType: prevState.addCriteria.toleranceType,
+        stopOnFailure: prevState.addCriteria.stopOnFailure
+      },
+      validName: true
+    }));
+  };
+
+  onAddSampleSize = (value: string, _) => {
+    this.setState(prevState => ({
+      addCriteria: {
+        metric: prevState.addCriteria.metric,
+        sampleSize: Number(value.trim()),
+        tolerance: prevState.addCriteria.tolerance,
+        toleranceType: prevState.addCriteria.toleranceType,
+        stopOnFailure: prevState.addCriteria.stopOnFailure
+      },
+      validName: true
+    }));
+  };
+
+  onAddTolerance = (value: string, _) => {
+    this.setState(prevState => ({
+      addCriteria: {
+        metric: prevState.addCriteria.metric,
+        sampleSize: prevState.addCriteria.sampleSize,
+        tolerance: parseFloat(value.trim()),
+        toleranceType: prevState.addCriteria.toleranceType,
+        stopOnFailure: prevState.addCriteria.stopOnFailure
+      },
+      validName: true
+    }));
+  };
+  onAddToleranceType = (value: string, _) => {
+    this.setState(prevState => ({
+      addCriteria: {
+        metric: prevState.addCriteria.metric,
+        sampleSize: prevState.addCriteria.sampleSize,
+        tolerance: prevState.addCriteria.tolerance,
+        toleranceType: value.trim(),
+        stopOnFailure: prevState.addCriteria.stopOnFailure
+      },
+      validName: true
+    }));
+  };
+
+  onAddStopOnFailure = (value: boolean, _) => {
+    this.setState(prevState => ({
+      addCriteria: {
+        metric: prevState.addCriteria.metric,
+        sampleSize: prevState.addCriteria.sampleSize,
+        tolerance: prevState.addCriteria.tolerance,
+        toleranceType: prevState.addCriteria.toleranceType,
+        stopOnFailure: value
+      },
+      validName: true
+    }));
+  };
+
+  onAddCriteria = () => {
+    this.props.onAdd(this.state.addCriteria);
+    this.setState({
+      addCriteria: {
+        metric: '',
+        sampleSize: 100,
+        tolerance: 0.2,
+        toleranceType: 'threshold',
+        stopOnFailure: false
+      }
+    });
+  };
+
+  rows() {
+    return this.props.criterias
+      .map((gw, i) => ({
+        key: 'criteria' + i,
+        cells: [
+          <>{gw.metric}</>,
+          <>{gw.sampleSize}</>,
+          <>{gw.tolerance}</>,
+          <>{gw.toleranceType}</>,
+          <>{gw.stopOnFailure}</>
+        ]
+      }))
+      .concat([
+        {
+          key: 'gwNew',
+          cells: [
+            <>
+              <FormSelect
+                value={this.state.addCriteria.metric}
+                id="addMetricName"
+                name="addMetricName"
+                onChange={this.onAddMetricName}
+              >
+                {metrics.map((option, index) => (
+                  <FormSelectOption isDisabled={false} key={'p' + index} value={option} label={option} />
+                ))}
+              </FormSelect>
+            </>,
+            <>
+              <TextInput
+                value={this.state.addCriteria.sampleSize}
+                type="number"
+                id="addSampleSize"
+                aria-describedby="Sample Size"
+                name="addSampleSize"
+                onChange={this.onAddSampleSize}
+                isValid={!isNaN(this.state.addCriteria.sampleSize)}
+              />
+            </>,
+            <>
+              <TextInput
+                value={this.state.addCriteria.tolerance}
+                type="number"
+                id="addTolerance"
+                aria-describedby="Tolerance"
+                name="addTolerance"
+                onChange={this.onAddTolerance}
+                isValid={!isNaN(this.state.addCriteria.sampleSize)}
+              />
+            </>,
+            <>
+              <FormSelect
+                value={this.state.addCriteria.toleranceType}
+                id="addPortProtocol"
+                name="addPortProtocol"
+                onChange={this.onAddToleranceType}
+              >
+                {toleranceType.map((option, index) => (
+                  <FormSelectOption isDisabled={false} key={'p' + index} value={option} label={option} />
+                ))}
+              </FormSelect>
+            </>,
+            <>
+              <Radio
+                isChecked={this.state.addCriteria.stopOnFailure}
+                name="stopOnFailure"
+                onChange={this.onAddStopOnFailure}
+                label="Stop On Failure"
+                id="stopOnFailure"
+                value={this.state.addCriteria.stopOnFailure ? 'Yes' : 'No'}
+              />
+            </>,
+            <>
+              <Button
+                id="addServerBtn"
+                variant="secondary"
+                isDisabled={this.state.addCriteria.metric.length === 0}
+                onClick={this.onAddCriteria}
+              >
+                Add this Criteria
+              </Button>
+            </>
+          ]
+        }
+      ]);
+  }
+  render() {
+    return (
+      <>
+        <Table
+          aria-label="Success Criterias"
+          cells={headerCells}
+          rows={this.rows()}
+          // @ts-ignore
+          actionResolver={this.actionResolver}
+        >
+          <TableHeader />
+          <TableBody />
+        </Table>
+        {this.props.criterias.length === 0 && (
+          <div className={noCriteriaStyle}>Experiment has no Success Criteria Defined</div>
+        )}
+      </>
+    );
+  }
+}
+
+export default ExperimentCriteriaForm;

--- a/src/pages/extensions/iter8/ExperimentListContainer.tsx
+++ b/src/pages/extensions/iter8/ExperimentListContainer.tsx
@@ -1,0 +1,280 @@
+import * as React from 'react';
+import { RenderContent } from '../../../components/Nav/Page';
+import {
+  Dropdown,
+  DropdownItem,
+  DropdownPosition,
+  DropdownToggle,
+  Title,
+  Toolbar,
+  ToolbarSection
+} from '@patternfly/react-core';
+import { style } from 'typestyle';
+import { PfColors } from '../../../components/Pf/PfColors';
+import { sortable, Table, TableBody, TableHeader, ISortBy, IRow } from '@patternfly/react-table';
+import * as API from '../../../services/Api';
+import * as AlertUtils from '../../../utils/AlertUtils';
+import history from '../../../app/History';
+import { Iter8Info, Iter8Experiment } from '../../../types/Iter8';
+import { Link } from 'react-router-dom';
+import * as FilterComponent from '../../../components/FilterList/FilterComponent';
+
+import RefreshButtonContainer from '../../../components/Refresh/RefreshButton';
+import { KialiAppState } from '../../../store/Store';
+import { activeNamespacesSelector } from '../../../store/Selectors';
+import { connect } from 'react-redux';
+import { IstioConfigItem } from '../../../types/IstioConfigList';
+import { SortField } from '../../../types/SortFilters';
+import Namespace from '../../../types/Namespace';
+import { PromisesRegistry } from '../../../utils/CancelablePromises';
+
+// Style constants
+const containerPadding = style({ padding: '20px 20px 20px 20px' });
+const containerWhite = style({ backgroundColor: PfColors.White });
+const rightToolbar = style({ marginLeft: 'auto' });
+
+// Page title
+const pageTitle = (
+  <div className={`${containerPadding} ${containerWhite}`}>
+    <Title headingLevel="h1" size="4xl" style={{ margin: '20px 0 0' }}>
+      Experiments
+    </Title>
+  </div>
+);
+
+interface Props extends FilterComponent.State<Iter8Experiment> {
+  activeNamespaces: Namespace[];
+}
+
+// State of the component/page
+// It stores the visual state of the components and the experiments fetched from the backend.
+interface State extends FilterComponent.State<Iter8Experiment> {
+  iter8Info: Iter8Info;
+  experimentLists: Iter8Experiment[];
+  sortBy: ISortBy; // ?? not used yet
+  dropdownOpen: boolean;
+}
+
+const columns = [
+  {
+    title: 'Name',
+    transforms: [sortable]
+  },
+  {
+    title: 'Phase',
+    transforms: [sortable]
+  },
+  {
+    title: 'Status',
+    transforms: [sortable]
+  },
+  {
+    title: 'Baseline',
+    transforms: [sortable]
+  },
+  {
+    title: 'Candidate',
+    transforms: [sortable]
+  },
+  {
+    title: 'Namespace',
+    transforms: [sortable]
+  }
+];
+
+class ExperimentListPage extends FilterComponent.Component<Props, State, Iter8Experiment> {
+  private promises = new PromisesRegistry();
+
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      iter8Info: {
+        enabled: false,
+        permissions: {
+          create: false,
+          update: false,
+          delete: false
+        }
+      },
+      experimentLists: [],
+      sortBy: {},
+      dropdownOpen: false,
+      listItems: [],
+      currentSortField: this.props.currentSortField,
+      isSortAscending: this.props.isSortAscending
+    };
+  }
+
+  fetchExperiments = (namespaces: string[]) => {
+    API.getIter8Info()
+      .then(result => {
+        const iter8Info = result.data;
+        if (iter8Info.enabled) {
+          API.getExperiments(namespaces)
+            .then(result => {
+              this.setState(prevState => {
+                return {
+                  iter8Info: iter8Info,
+                  experimentLists: result.data,
+                  sortBy: prevState.sortBy
+                };
+              });
+            })
+            .catch(error => {
+              AlertUtils.addError('Could not fetch Iter8 Experiments.', error);
+            });
+        } else {
+        }
+      })
+      .catch(error => {
+        AlertUtils.addError('Could not fetch Iter8INfo.', error);
+      });
+  };
+
+  // It invokes backend when component is mounted
+  componentDidMount() {
+    // this.fetchExperiments([]);
+    this.updateListItems();
+  }
+
+  componentDidUpdate() {
+    // this.fetchExperiments([]);
+    this.updateListItems();
+  }
+
+  // place holder, need to decide what is sortable field
+  sortItemList(apps: Iter8Experiment[], sortField: SortField<IstioConfigItem>, isAscending: boolean) {
+    return this.sortExperimentItems(apps, sortField, isAscending);
+  }
+
+  sortExperimentItems = (unsorted: Iter8Experiment[], sortField: SortField<Iter8Experiment>, isAscending: boolean) => {
+    const sortPromise: Promise<Iter8Experiment[]> = new Promise(resolve => {
+      resolve(unsorted.sort(isAscending ? sortField.compare : (a, b) => sortField.compare(b, a)));
+    });
+
+    return sortPromise;
+  };
+
+  updateListItems() {
+    this.promises.cancelAll();
+
+    const namespacesSelected = this.props.activeNamespaces.map(item => item.name);
+
+    if (namespacesSelected.length === 0) {
+      this.promises
+        .register('namespaces', API.getNamespaces())
+        .then(namespacesResponse => {
+          const namespaces: Namespace[] = namespacesResponse.data;
+          this.fetchExperiments(namespaces.map(namespace => namespace.name));
+        })
+        .catch(namespacesError => {
+          if (!namespacesError.isCanceled) {
+            this.handleAxiosError('Could not fetch namespace list', namespacesError);
+          }
+        });
+    } else {
+      this.fetchExperiments(namespacesSelected);
+    }
+  }
+
+  // Invoke the history object to update and URL and start a routing
+  goNewExperimentPage = () => {
+    history.push('/extensions/iter8/new');
+  };
+
+  // This is a simplified actions toolbar.
+  // It contains a create new handler action.
+  actionsToolbar = () => {
+    return (
+      <Dropdown
+        id="actions"
+        title="Actions"
+        toggle={<DropdownToggle onToggle={toggle => this.setState({ dropdownOpen: toggle })}>Actions</DropdownToggle>}
+        onSelect={() => this.setState({ dropdownOpen: !this.state.dropdownOpen })}
+        position={DropdownPosition.right}
+        isOpen={this.state.dropdownOpen}
+        dropdownItems={[
+          <DropdownItem
+            key="createExperiment"
+            isDisabled={!this.state.iter8Info.enabled}
+            onClick={() => this.goNewExperimentPage()}
+          >
+            Create New Experiment
+          </DropdownItem>
+        ]}
+      />
+    );
+  };
+
+  // This is a simplified toolbar for refresh and actions.
+  // Kiali has a shared component toolbar for more complex scenarios like filtering
+  // It renders actions only if user has permissions
+  toolbar = () => {
+    return (
+      <Toolbar className="pf-l-toolbar pf-u-justify-content-space-between pf-u-mx-xl pf-u-my-md">
+        <ToolbarSection aria-label="ToolbarSection">
+          <Toolbar className={rightToolbar}>
+            <RefreshButtonContainer key={'Refresh'} handleRefresh={() => this.updateListItems()} />
+            {this.actionsToolbar()}
+          </Toolbar>
+        </ToolbarSection>
+      </Toolbar>
+    );
+  };
+
+  // Helper used to build the table content.
+  rows = (): IRow[] => {
+    return this.state.experimentLists.map(h => {
+      return {
+        cells: [
+          <>
+            <Link
+              to={`/extensions/iter8/namespaces/${h.namespace}/name/${h.name}`}
+              key={'Experiment_' + h.namespace + '_' + h.namespace}
+            >
+              {h.name}
+            </Link>
+          </>,
+          <>{h.phase}</>,
+          <>{h.status}</>,
+          <>
+            {h.baseline} <br /> {h.baselinePercentage}%
+          </>,
+          <>
+            {h.candidate}
+            <br /> {h.candidatePercentage}%
+          </>,
+          <>{h.namespace}</>
+        ]
+      };
+    });
+  };
+
+  render() {
+    return (
+      <>
+        {pageTitle}
+        <RenderContent>
+          <div className={containerPadding}>
+            {this.toolbar()}
+            <Table aria-label="Sortable Table" sortBy={this.state.sortBy} cells={columns} rows={this.rows()}>
+              <TableHeader />
+              <TableBody />
+            </Table>
+          </div>
+        </RenderContent>
+      </>
+    );
+  }
+}
+
+const mapStateToProps = (state: KialiAppState) => ({
+  activeNamespaces: activeNamespacesSelector(state)
+});
+
+const ExperimentListPageContainer = connect(
+  mapStateToProps,
+  null
+)(ExperimentListPage);
+
+export default ExperimentListPageContainer;

--- a/src/pages/extensions/iter8/ExperimentListPage.tsx
+++ b/src/pages/extensions/iter8/ExperimentListPage.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import * as FilterHelper from '../../../components/FilterList/FilterHelper';
+import { RenderContent } from '../../../components/Nav/Page';
+import ExperimentListContainer from './ExperimentListContainer';
+import * as ExpListFilters from './FiltersAndSorts';
+
+const ExperimentListPage: React.SFC<{}> = () => {
+  return (
+    <RenderContent>
+      <ExperimentListContainer
+        currentSortField={FilterHelper.currentSortField(ExpListFilters.sortFields)}
+        isSortAscending={FilterHelper.isCurrentSortAscending()}
+        listItems={[]}
+      />
+    </RenderContent>
+  );
+};
+
+export default ExperimentListPage;

--- a/src/pages/extensions/iter8/FiltersAndSorts.ts
+++ b/src/pages/extensions/iter8/FiltersAndSorts.ts
@@ -1,0 +1,72 @@
+import { FILTER_ACTION_APPEND, FilterType } from '../../../types/Filters';
+import { GenericSortField } from '../../../types/SortFilters';
+import { Iter8Experiment } from '../../../types/Iter8';
+import { TextInputTypes } from '@patternfly/react-core';
+
+// Place Holder, not quite finished yet. Or if filter is needed, and how to use the common filters?
+
+export const sortFields: GenericSortField<Iter8Experiment>[] = [
+  {
+    id: 'namespace',
+    title: 'Namespace',
+    isNumeric: false,
+    param: 'ns',
+    compare: (a, b) => {
+      let sortValue = a.namespace.localeCompare(b.namespace);
+      if (sortValue === 0) {
+        sortValue = a.name.localeCompare(b.name);
+      }
+      return sortValue;
+    }
+  },
+  {
+    id: 'name',
+    title: 'Name',
+    isNumeric: false,
+    param: 'wn',
+    compare: (a, b) => a.name.localeCompare(b.name)
+  },
+  {
+    id: 'phase',
+    title: 'Phase',
+    isNumeric: false,
+    param: 'is',
+    compare: (a, b) => a.name.localeCompare(b.name)
+  },
+  {
+    id: 'baseline',
+    title: 'Baseline',
+    isNumeric: false,
+    param: 'is',
+    compare: (a, b) => a.name.localeCompare(b.name)
+  },
+  {
+    id: 'candidate',
+    title: 'Candidate',
+    isNumeric: false,
+    param: 'is',
+    compare: (a, b) => a.name.localeCompare(b.name)
+  }
+];
+
+const appNameFilter: FilterType = {
+  id: 'name',
+  title: 'Name',
+  placeholder: 'Filter by Experiment Name',
+  filterType: TextInputTypes.text,
+  action: FILTER_ACTION_APPEND,
+  filterValues: []
+};
+
+export const availableFilters: FilterType[] = [appNameFilter];
+
+/** Sort Method */
+
+export const sortAppsItems = (
+  unsorted: Iter8Experiment[],
+  sortField: GenericSortField<Iter8Experiment>,
+  isAscending: boolean
+): Promise<Iter8Experiment[]> => {
+  const sorted = unsorted.sort(isAscending ? sortField.compare : (a, b) => sortField.compare(b, a));
+  return Promise.resolve(sorted);
+};

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -14,6 +14,8 @@ import DefaultSecondaryMasthead from './components/DefaultSecondaryMasthead/Defa
 import IstioConfigNewPageContainer from './pages/IstioConfigNew/IstioConfigNewPage';
 import ThreeScaleHandlerListPage from './pages/extensions/threescale/ThreeScaleHandlerList/ThreeScaleHandlerListPage';
 import ThreeScaleHandlerDetailsPage from './pages/extensions/threescale/ThreeScaleHandlerDetails/ThreeScaleHandlerDetailsPage';
+import ExperimentListPage from './pages/extensions/iter8/ExperimentListPage';
+import ExperimentCreatePage from './pages/extensions/iter8/ExperimentCreatePage';
 
 /**
  * Return array of objects that describe vertical menu
@@ -69,6 +71,12 @@ const extensionsItems: MenuItem[] = [
     title: '3scale Config',
     to: '/extensions/threescale',
     pathsActive: [/^\/extensions\/threescale/]
+  },
+  {
+    iconClass: '',
+    title: 'Iter8 Experiment',
+    to: '/extensions/iter8/list',
+    pathsActive: [/^\/extensions\/iter8\/list/]
   }
 ];
 
@@ -170,6 +178,10 @@ const secondaryMastheadRoutes: Path[] = [
   {
     path: '/' + Paths.JAEGER,
     component: DefaultSecondaryMasthead
+  },
+  {
+    path: '/extensions/iter8/list',
+    component: DefaultSecondaryMasthead
   }
 ];
 
@@ -186,6 +198,14 @@ const extensionsRoutes: Path[] = [
   {
     path: '/extensions/threescale',
     component: ThreeScaleHandlerListPage
+  },
+  {
+    path: '/extensions/iter8/new',
+    component: ExperimentCreatePage
+  },
+  {
+    path: '/extensions/iter8/list',
+    component: ExperimentListPage
   }
 ];
 

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -32,7 +32,7 @@ import { Pod, PodLogs, ValidationStatus } from '../types/IstioObjects';
 import { ThreeScaleHandler, ThreeScaleInfo, ThreeScaleServiceRule } from '../types/ThreeScale';
 import { GrafanaInfo } from '../types/GrafanaInfo';
 import { Span, TracingQuery } from 'types/Tracing';
-
+import { Iter8Info, Iter8Experiment, Iter8ExpDetailsInfo } from '../types/Iter8';
 export const ANONYMOUS_USER = 'anonymous';
 
 export interface Response<T> {
@@ -531,4 +531,32 @@ export const getServiceSpans = (namespace: string, service: string, params: Trac
 
 export const getIstioPermissions = (namespaces: string[]) => {
   return newRequest<IstioPermissions>(HTTP_VERBS.GET, urls.istioPermissions, { namespaces: namespaces.join(',') }, {});
+};
+
+export const getIter8Info = () => {
+  return newRequest<Iter8Info>(HTTP_VERBS.GET, urls.iter8, {}, {});
+};
+
+export const getExperiments = (namespaces: string[]) => {
+  return newRequest<Iter8Experiment[]>(HTTP_VERBS.GET, urls.iter8Experiments, { namespaces: namespaces.join(',') }, {});
+};
+
+export const getExperimentsByNamespace = (namespace: string) => {
+  return newRequest<Iter8Experiment>(HTTP_VERBS.GET, urls.iter8ExperimentsByNamespace(namespace), {}, {});
+};
+
+export const getExperiment = (namespace: string, name: string) => {
+  return newRequest<Iter8ExpDetailsInfo>(HTTP_VERBS.GET, urls.iter8Experiment(namespace, name), {}, {});
+};
+
+export const deleteExperiment = (namespace: string, name: string) => {
+  return newRequest<Iter8Experiment>(HTTP_VERBS.DELETE, urls.iter8Experiment(namespace, name), {}, {});
+};
+
+export const createExperiment = (specBody: string) => {
+  return newRequest<Iter8Experiment>(HTTP_VERBS.POST, urls.iter8ExperimentOp, {}, specBody);
+};
+
+export const updateExperiment = (namespace: string, name: string, specBody: string) => {
+  return newRequest<Iter8Experiment>(HTTP_VERBS.POST, urls.iter8Experiment(namespace, name), {}, specBody);
 };

--- a/src/types/Iter8.ts
+++ b/src/types/Iter8.ts
@@ -1,0 +1,59 @@
+import { ResourcePermissions } from './Permissions';
+
+export interface Iter8Info {
+  enabled: boolean;
+  permissions: ResourcePermissions;
+}
+
+export interface Iter8Experiment {
+  name: string;
+  phase: string;
+  status: string;
+  baseline: string;
+  baselinePercentage: number;
+  candidate: string;
+  candidatePercentage: number;
+  namespace: string;
+}
+
+export interface ExpId {
+  namespace: string;
+  name: string;
+}
+
+export interface Iter8ExpDetailsInfo {
+  experimentItem: ExperimentItem;
+  criterias: SuccessCriteria[];
+}
+
+export interface ExperimentItem {
+  name: string;
+  phase: string;
+  status: string;
+  labels?: { [key: string]: string };
+  createdAt: string;
+  resourceVersion: string;
+  baseline: string;
+  baselinePercentage: number;
+  candidate: string;
+  candidatePercentage: number;
+  namespace: string;
+}
+export interface SuccessCriteria {
+  name: string;
+  criteria: Criteria;
+  metric: Metric;
+}
+export interface Metric {
+  absent_value: string;
+  is_count: boolean;
+  query_template: string;
+  sample_size_template: string;
+}
+export interface Criteria {
+  metric: string;
+  tolerance: number;
+  toleranceType: string;
+  sampleSize: number;
+  stopOnFailure: boolean;
+}

--- a/src/types/ServerConfig.ts
+++ b/src/types/ServerConfig.ts
@@ -6,10 +6,13 @@ export type IstioLabelKey = 'appLabelName' | 'versionLabelName';
 interface ThreeScaleConfig {
   enabled: boolean;
 }
-
+interface iter8Config {
+  enabled: boolean;
+}
 // Kiali addons/extensions specific
 interface Extensions {
   threescale: ThreeScaleConfig;
+  iter8: iter8Config;
 }
 
 export interface ServerConfig {


### PR DESCRIPTION
Listing Experiment List page - (issue#2453)

** Describe the change **

Implement kiali iter8 extension
For Iter8, please reference https://iter8.tools

** Issue reference **
[#2453](https://github.com/kiali/kiali/issues/2453)

** Screenshot **

![Screen Shot 2020-02-28 at 1 04 53 PM](https://user-images.githubusercontent.com/4615187/75591222-2a7c6b00-5a4d-11ea-93b2-26ba03b4149b.png)

** Documentation **

To install Iter8, please follow [install Iter8](https://github.com/iter8-tools/docs/blob/master/doc_files/iter8_install.md). 
(For minikube - it has been tested with with kubernetes version 1.14.2  
```minikube start --memory=32768 --cpus=4 --kubernetes-version=v1.14.2```)
To use Iter8 - please follow the [tutorial](https://github.com/iter8-tools/docs/blob/master/doc_files/iter8_bookinfo_istio.md)

** Known Issues **
1. No filters on the Experiment Listing page - have not decide it we need it or not.
2. Use secondaryMastheadRoutes for the listing page, Namespaces dropdown is enabled. But no Title page, Title page is build inside the ListingComponent.
3. No tooltips 