### PR TITLE
Typo: Sidercars. IstioConfig details error

### DIFF
--- a/src/components/VirtualList/Config.ts
+++ b/src/components/VirtualList/Config.ts
@@ -132,7 +132,7 @@ export const IstioTypes = {
   rbacconfig: { name: 'RbacConfig', url: 'rbacconfigs', icon: 'RC' },
   authorizationpolicy: { name: 'AuthorizationPolicy', url: 'authorizationpolicy', icon: 'AP' },
   servicemeshrbacconfig: { name: 'ServiceMeshRbacConfig', url: 'servicemeshrbacconfigs', icon: 'SRC' },
-  sidecar: { name: 'Sidecar', url: 'sidercars', icon: 'S' },
+  sidecar: { name: 'Sidecar', url: 'sidecars', icon: 'S' },
   servicerole: { name: 'ServiceRole', url: 'serviceroles', icon: 'SR' },
   servicerolebinding: { name: 'ServiceRoleBinding', url: 'servicerolebindings', icon: 'SRB' }
 };


### PR DESCRIPTION
** Describe the change **
Typo that makes sidecar yaml editor page blow up.

** Issue reference **

https://github.com/kiali/kiali/pull/2468