### PR TITLE
Fix distributed tracing link displayed with no url

### DIFF
--- a/src/components/Nav/Menu.tsx
+++ b/src/components/Nav/Menu.tsx
@@ -60,10 +60,10 @@ class Menu extends React.Component<MenuProps, MenuState> {
       })
       .map(item => {
         if (item.title === 'Distributed Tracing') {
-          return this.props.jaegerUrl !== '' ? (
-            <ExternalLink key={item.to} href={this.props.jaegerUrl} name="Distributed Tracing" />
-          ) : (
-            ''
+          return (
+            this.props.jaegerUrl && (
+              <ExternalLink key={item.to} href={this.props.jaegerUrl} name="Distributed Tracing" />
+            )
           );
         }
 


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/2479

@aljesusg I think i introduced this regression in a previous change. In Menu props, now `jaegerUrl` is `string?` instead of `string`.