### PR TITLE
Improve edge side-panel Hosts tab

### DIFF
--- a/src/components/SummaryPanel/ResponseHostsTable.tsx
+++ b/src/components/SummaryPanel/ResponseHostsTable.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import _ from 'lodash';
 import { style } from 'typestyle';
 import { Responses } from '../../types/Graph';
+import { Tooltip } from '@patternfly/react-core';
 
 type ResponseHostsTableProps = {
   responses: Responses;
@@ -16,7 +17,9 @@ interface Row {
 }
 
 const hostStyle = style({
-  wordWrap: 'break-word'
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap'
 });
 
 export class ResponseHostsTable extends React.PureComponent<ResponseHostsTableProps> {
@@ -40,7 +43,9 @@ export class ResponseHostsTable extends React.PureComponent<ResponseHostsTablePr
                 {rows.map(row => (
                   <tr key={row.key}>
                     <td>{row.code}</td>
-                    <td className={hostStyle}>{row.host}</td>
+                    <Tooltip distance={3} maxWidth="25rem" content={row.host}>
+                      <td className={hostStyle}>{row.host}</td>
+                    </Tooltip>
                     <td>{row.val}</td>
                   </tr>
                 ))}


### PR DESCRIPTION
Improve edge side-panel Hosts tab by presenting host value as ellipsed with tooltip, when necessary.

Fixes https://github.com/kiali/kiali/issues/2499

After:

![image](https://user-images.githubusercontent.com/2104052/76626565-bdb6a580-650f-11ea-8207-4abcfd653639.png)
