### PR TITLE
Make traffic animation proportional to volumetry

### DIFF
--- a/src/components/CytoscapeGraph/TrafficAnimation/AnimationTimerConfig.ts
+++ b/src/components/CytoscapeGraph/TrafficAnimation/AnimationTimerConfig.ts
@@ -1,22 +1,44 @@
 import { clamp } from 'utils/MathUtils';
 
+// Some information about the mathematical problem here:
+// We try to project a set of RATE values from an upper-unbounded interval ]0, +Inf[ to a set of TIMER DELAY values in
+//    a bounded interval [40ms, 5000ms] (arbitrary bounds).
+// TIMER DELAY is the delay for dots generation in the animation. The lower it is, the more dots there are.
+//
+// The constraints are:
+// - We'd like the relation to be inversely proportional: if RATE 1 is twice as big as RATE 2, DELAY 1 must be half of DELAY 2.
+// - The animations should be quite representative of volumetry both _relatively_ and _absolutely_: _relatively_ is the
+//    previous constraint (edges compared to each other); but _absolutely_ is another thing: regardless edges compared to
+//    each other, we should have a notion of low and high traffic.
+//
+// To better understand the issue, we can imagine two rates R1 = 0.001 rps and R2 = 0.1 rps. R2 should have 100 times more
+//    dots than R1. So it's likely to be "crowded", and looks like a high volumetry if we only consider the relative
+//    relationships. But thinking in absolute, 0.1 rps is small, it shouldn't be crowded.
+
 const initialThreshold = 50;
 
-class AnimationTimerConfig {
-  threshold: number;
+export class AnimationTimerConfig {
+  private threshold: number;
+  private scaleFactor: number;
 
-  // baseDelay: for a rate of 1 rps/bps, there will be one dot every `baseDelay` second.
-  constructor(public baseDelay: number) {
+  // baseDelay: for a rate of 1 rps/bps, there will be one dot every `baseDelay` seconds.
+  constructor(private baseDelay: number) {
     this.threshold = initialThreshold;
+    this.scaleFactor = 1;
   }
 
   resetCalibration() {
     this.threshold = initialThreshold;
+    this.scaleFactor = 1;
   }
 
   calibrate(rate: number) {
+    // We make this.threshold grow with max rate
+    // (there's some "magic numbers" here, not really explained, perhaps this formula can be changed, but keep threshold following max rate)
+    // The scale factor for this graph is updated with the changed threshold.
     if (rate > this.threshold / 1.5) {
       this.threshold = 3 * rate;
+      this.scaleFactor = this.computeScaleFactor();
     }
   }
 
@@ -24,12 +46,15 @@ class AnimationTimerConfig {
     if (isNaN(rate) || rate === 0) {
       return undefined;
     }
-    const scaleFactor = this.scaleFactor();
-    const d = (1000 * this.baseDelay * scaleFactor) / rate;
+    // TIMER DELAY is inversely proportional to RATE. Scale factor is used to keep as much as possible TIMER DELAY in bounds
+    const d = (1000 * this.baseDelay * this.scaleFactor) / rate;
+    // In case it's out of bounds, clamp to bounds. Only case where proportionality is broken. Should only happen for very low values.
     return clamp(d, 40, 5000);
   }
 
-  private scaleFactor() {
+  private computeScaleFactor() {
+    // Scale factor is how much values are upscaled compared to the initial threshold that is used with low rates
+    // Some arbitrary thresholds are used to amplify high volumetry
     if (this.threshold > 100000) {
       return Math.pow(this.threshold / initialThreshold, 0.9);
     }
@@ -40,5 +65,7 @@ class AnimationTimerConfig {
   }
 }
 
+// HTTP config: 1 RPS => 1 dot every second
 export const timerConfig = new AnimationTimerConfig(1);
+// TCP config: 4 bps => 1 dot every second
 export const tcpTimerConfig = new AnimationTimerConfig(4);

--- a/src/components/CytoscapeGraph/TrafficAnimation/AnimationTimerConfig.ts
+++ b/src/components/CytoscapeGraph/TrafficAnimation/AnimationTimerConfig.ts
@@ -1,0 +1,44 @@
+import { clamp } from 'utils/MathUtils';
+
+const initialThreshold = 50;
+
+class AnimationTimerConfig {
+  threshold: number;
+
+  // baseDelay: for a rate of 1 rps/bps, there will be one dot every `baseDelay` second.
+  constructor(public baseDelay: number) {
+    this.threshold = initialThreshold;
+  }
+
+  resetCalibration() {
+    this.threshold = initialThreshold;
+  }
+
+  calibrate(rate: number) {
+    if (rate > this.threshold / 1.5) {
+      this.threshold = 3 * rate;
+    }
+  }
+
+  computeDelay(rate: number) {
+    if (isNaN(rate) || rate === 0) {
+      return undefined;
+    }
+    const scaleFactor = this.scaleFactor();
+    const d = (1000 * this.baseDelay * scaleFactor) / rate;
+    return clamp(d, 40, 5000);
+  }
+
+  private scaleFactor() {
+    if (this.threshold > 100000) {
+      return Math.pow(this.threshold / initialThreshold, 0.9);
+    }
+    if (this.threshold > 1000) {
+      return Math.pow(this.threshold / initialThreshold, 0.95);
+    }
+    return this.threshold / initialThreshold;
+  }
+}
+
+export const timerConfig = new AnimationTimerConfig(1);
+export const tcpTimerConfig = new AnimationTimerConfig(4);

--- a/src/components/CytoscapeGraph/TrafficAnimation/AnimationTimerConfig.ts
+++ b/src/components/CytoscapeGraph/TrafficAnimation/AnimationTimerConfig.ts
@@ -34,10 +34,9 @@ export class AnimationTimerConfig {
 
   calibrate(rate: number) {
     // We make this.threshold grow with max rate
-    // (there's some "magic numbers" here, not really explained, perhaps this formula can be changed, but keep threshold following max rate)
     // The scale factor for this graph is updated with the changed threshold.
-    if (rate > this.threshold / 1.5) {
-      this.threshold = 3 * rate;
+    if (rate > this.threshold) {
+      this.threshold = 2 * rate;
       this.scaleFactor = this.computeScaleFactor();
     }
   }
@@ -67,5 +66,5 @@ export class AnimationTimerConfig {
 
 // HTTP config: 1 RPS => 1 dot every second
 export const timerConfig = new AnimationTimerConfig(1);
-// TCP config: 4 bps => 1 dot every second
-export const tcpTimerConfig = new AnimationTimerConfig(4);
+// TCP config: 20 bps => 1 dot every second
+export const tcpTimerConfig = new AnimationTimerConfig(20);

--- a/src/components/CytoscapeGraph/TrafficAnimation/__tests__/AnimationTimerConfig.test.ts
+++ b/src/components/CytoscapeGraph/TrafficAnimation/__tests__/AnimationTimerConfig.test.ts
@@ -1,0 +1,56 @@
+import { AnimationTimerConfig } from '../AnimationTimerConfig';
+
+describe('AnimationTimeConfig', () => {
+  it('should produce baseDelay*1000 with rate 1', () => {
+    let baseDelay = 1;
+    let timerConfig = new AnimationTimerConfig(baseDelay);
+    timerConfig.resetCalibration();
+    timerConfig.calibrate(1);
+    let delay = timerConfig.computeDelay(1);
+    expect(delay).toEqual(1000 * baseDelay);
+
+    baseDelay = 4;
+    timerConfig = new AnimationTimerConfig(baseDelay);
+    timerConfig.resetCalibration();
+    timerConfig.calibrate(1);
+    delay = timerConfig.computeDelay(1);
+    expect(delay).toEqual(1000 * baseDelay);
+  });
+
+  it('should scale inversely proportional', () => {
+    const timerConfig = new AnimationTimerConfig(4);
+    const rates = [10, 20, 30];
+    timerConfig.resetCalibration();
+    rates.forEach(r => timerConfig.calibrate(r));
+    const [d1, d2, d3] = rates.map(r => timerConfig.computeDelay(r));
+    expect(d1).toEqual(2 * d2);
+    expect(d1).toEqual(3 * d3);
+  });
+
+  it('should clamp low rates', () => {
+    const timerConfig = new AnimationTimerConfig(4);
+    const rates = [0.001, 0.01, 0.1, 1];
+    timerConfig.resetCalibration();
+    rates.forEach(r => timerConfig.calibrate(r));
+    const [d1, d2, d3, d4] = rates.map(r => timerConfig.computeDelay(r));
+    // Unit: 1 => baseDelay * 1000
+    expect(d4).toEqual(4000);
+    // Others reach max 5000 => clamped
+    expect(d1).toEqual(5000);
+    expect(d2).toEqual(5000);
+    expect(d3).toEqual(5000);
+  });
+
+  it('should be kept in bounds with high rates', () => {
+    const timerConfig = new AnimationTimerConfig(4);
+    const rates = [1, 100, 1000, 2000];
+    timerConfig.resetCalibration();
+    rates.forEach(r => timerConfig.calibrate(r));
+    const [d1, d2, d3, d4] = rates.map(r => timerConfig.computeDelay(r));
+    // Due to upscaling, unit 1 is now out of bounds, so clamped to 5000
+    expect(d1).toEqual(5000);
+    // Others are within bounds, so still proportional to each other
+    expect(d3).toEqual(d2 / 10);
+    expect(d4).toEqual(d2 / 20);
+  });
+});


### PR DESCRIPTION
- Needs to calibrate amplitude as first step
- Use linear relation between rate and dots generator
- Use consistent code between http & tcp rates

Fixes https://github.com/kiali/kiali/issues/2469

![Capture d’écran de 2020-03-17 09-52-25](https://user-images.githubusercontent.com/2153442/76839574-059e3b00-6836-11ea-895c-2e1f1249ddd4.png)

