### PR TITLE
Fix service link into Istio Object details page

### DIFF
--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Link, Prompt, RouteComponentProps } from 'react-router-dom';
+import { Prompt, RouteComponentProps } from 'react-router-dom';
 import {
   aceOptions,
   compareResourceVersion,
@@ -21,7 +21,7 @@ import { default as IstioActionButtonsContainer } from '../../components/IstioAc
 import VirtualServiceDetail from './IstioObjectDetails/VirtualServiceDetail';
 import DestinationRuleDetail from './IstioObjectDetails/DestinationRuleDetail';
 import history from '../../app/History';
-import { Paths, serverConfig } from '../../config';
+import { Paths } from '../../config';
 import { MessageType } from '../../types/MessageCenter';
 import { getIstioObject, mergeJsonPatch } from '../../utils/IstioConfigUtils';
 import { style } from 'typestyle';
@@ -49,7 +49,6 @@ import { dicIstioType } from '../../types/IstioConfigList';
 import { showInMessageCenter } from '../../utils/IstioValidationUtils';
 import { PfColors } from '../../components/Pf/PfColors';
 import IstioObjectLink from '../../components/Link/IstioObjectLink';
-import { ServiceIcon } from '@patternfly/react-icons';
 
 const rightToolbarStyle = style({
   position: 'absolute',
@@ -78,33 +77,6 @@ const tabName = 'list';
 const paramToTab: { [key: string]: number } = {
   overview: 0,
   yaml: 1
-};
-
-export const serviceLink = (namespace: string, host: string, isValid: boolean): any => {
-  if (!host) {
-    return '-';
-  }
-  const isFqdn = host.endsWith('.' + serverConfig.istioIdentityDomain);
-  const isShortName = host.split('.').length === 2;
-  const showLink = isValid && (isFqdn || isShortName);
-  if (showLink) {
-    let linkNamespace = namespace;
-    let linkService = host;
-    if (isFqdn) {
-      // FQDN format: service.namespace.svc.cluster.local
-      const splitFqdn = host.split('.');
-      linkService = splitFqdn[0];
-      linkNamespace = splitFqdn[1];
-    }
-    return (
-      <Link to={'/namespaces/' + linkNamespace + '/services/' + linkService}>
-        {host + ' '}
-        <ServiceIcon />
-      </Link>
-    );
-  } else {
-    return host;
-  }
 };
 
 class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioConfigId>, IstioConfigDetailsState> {

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/DestinationRuleDetail.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/DestinationRuleDetail.tsx
@@ -18,7 +18,7 @@ import GlobalValidation from '../../../components/Validations/GlobalValidation';
 import { checkForPath } from '../../../types/ServiceInfo';
 import ValidationList from '../../../components/Validations/ValidationList';
 import Labels from '../../../components/Label/Labels';
-import { serviceLink } from '../IstioConfigDetailsPage';
+import ServiceLink from './ServiceLink';
 
 interface DestinationRuleProps {
   namespace: string;
@@ -127,7 +127,11 @@ class DestinationRuleDetail extends React.Component<DestinationRuleProps> {
                 {destinationRule.spec.host && (
                   <>
                     <Text component={TextVariants.h3}>Host</Text>
-                    {serviceLink(destinationRule.metadata.namespace || '', destinationRule.spec.host, isValid)}
+                    <ServiceLink
+                      namespace={destinationRule.metadata.namespace || ''}
+                      host={destinationRule.spec.host}
+                      isValid={isValid}
+                    />
                   </>
                 )}
               </StackItem>

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/ServiceLink.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/ServiceLink.tsx
@@ -27,8 +27,16 @@ class ServiceLink extends React.PureComponent<Props> {
     return this.props.host.split('.').length === 1;
   };
 
+  isWildCardScoped = (): boolean => {
+    return this.props.host.startsWith('*');
+  };
+
   showLink = (): boolean => {
-    return this.props.isValid && (this.isFQDN() || this.isTwoPartsService() || this.isShortName());
+    return (
+      this.props.isValid &&
+      !this.isWildCardScoped() &&
+      (this.isFQDN() || this.isTwoPartsService() || this.isShortName())
+    );
   };
 
   hostParts = (): string[] => {

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/ServiceLink.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/ServiceLink.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import { serverConfig } from '../../../config';
+import { ServiceIcon } from '@patternfly/react-icons';
+import { Link } from 'react-router-dom';
+
+interface Props {
+  namespace: string;
+  host: string;
+  isValid: boolean;
+}
+
+export const serviceLink = (namespace: string, host: string, isValid: boolean): any => {
+  if (!host) {
+    return '-';
+  }
+  const isFqdn = host.endsWith('.' + serverConfig.istioIdentityDomain);
+  const isShortName = host.split('.').length === 2;
+  const showLink = isValid && (isFqdn || isShortName);
+  if (showLink) {
+    let linkNamespace = namespace;
+    let linkService = host;
+    if (isFqdn) {
+      // FQDN format: service.namespace.svc.cluster.local
+      const splitFqdn = host.split('.');
+      linkService = splitFqdn[0];
+      linkNamespace = splitFqdn[1];
+    }
+    return (
+      <Link to={'/namespaces/' + linkNamespace + '/services/' + linkService}>
+        {host + ' '}
+        <ServiceIcon />
+      </Link>
+    );
+  } else {
+    return host;
+  }
+};
+
+class ServiceLink extends React.PureComponent<Props> {
+  render() {
+    return serviceLink(this.props.namespace, this.props.host, this.props.isValid);
+  }
+}
+
+export default ServiceLink;

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceRoute.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceRoute.tsx
@@ -6,7 +6,7 @@ import { Table, TableBody, TableHeader, TableVariant } from '@patternfly/react-t
 import { Grid, GridItem, Text, TextVariants } from '@patternfly/react-core';
 import { ChartBullet } from '@patternfly/react-charts/dist/js/components/ChartBullet';
 import ValidationList from '../../../components/Validations/ValidationList';
-import { serviceLink } from '../IstioConfigDetailsPage';
+import ServiceLink from './ServiceLink';
 
 interface VirtualServiceRouteProps {
   name: string;
@@ -67,7 +67,7 @@ class VirtualServiceRoute extends React.Component<VirtualServiceRouteProps> {
           const destination = routeItem.destination;
           cells = [
             { title: validation },
-            { title: serviceLink(this.props.namespace, destination.host, isValid) },
+            { title: <ServiceLink namespace={this.props.namespace} host={destination.host} isValid={isValid} /> },
             { title: destination.subset || '-' },
             { title: destination.port ? destination.port.number || '-' : '-' },
             { title: routeItem.weight ? routeItem.weight : '-' }

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/__tests__/ServiceLink.test.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/__tests__/ServiceLink.test.tsx
@@ -43,6 +43,11 @@ describe('SerivceLink component', () => {
       const wrapper = serviceLink('bookinfo', 'reviews.bookinfo.svc.cluster.local', false);
       testPlain(wrapper, 'reviews.bookinfo.svc.cluster.local');
     });
+
+    it('and has wildcard, it should render a link', () => {
+      let wrapper = serviceLink('bookinfo', '*.bookinfo.svc.cluster.local', true);
+      testPlain(wrapper, '*.bookinfo.svc.cluster.local');
+    });
   });
 
   describe('when is shortname', () => {
@@ -99,6 +104,13 @@ describe('SerivceLink component', () => {
     it('when invalid, should render a hyphen, not linked', () => {
       let wrapper = serviceLink('bookinfo', 'kiali.io', false);
       testPlain(wrapper, 'kiali.io');
+    });
+  });
+
+  describe('when is *.local', () => {
+    it("shouldn't render link", () => {
+      let wrapper = serviceLink('bookinfo', '*.local', true);
+      testPlain(wrapper, '*.local');
     });
   });
 });

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/__tests__/ServiceLink.test.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/__tests__/ServiceLink.test.tsx
@@ -1,0 +1,104 @@
+import * as React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+import ServiceLink from '../ServiceLink';
+import { ServiceIcon } from '@patternfly/react-icons';
+import { Link } from 'react-router-dom';
+
+const serviceLink = (ns: string, host: string, isValid: boolean) => {
+  return shallow(<ServiceLink namespace={ns} host={host} isValid={isValid} />);
+};
+
+const testLink = (wrapper: any, url: string, host: string) => {
+  // Get the link component
+  const link = wrapper.find(Link).first();
+
+  // There is a link
+  expect(link).toBeDefined();
+
+  // Inspect the link
+  const linkProps = link.props();
+  expect(linkProps.to).toBe(url);
+
+  // Inspect host and icon presence
+  expect(link.find(ServiceIcon)).toBeDefined();
+  expect(link.contains(host));
+};
+
+const testPlain = (wrapper: ShallowWrapper, host: string) => {
+  expect(wrapper.text()).toBe(host);
+};
+
+describe('SerivceLink component', () => {
+  describe('when is FQDN', () => {
+    it('should render link', () => {
+      let wrapper = serviceLink('bookinfo', 'reviews.bookinfo.svc.cluster.local', true);
+      testLink(wrapper, '/namespaces/bookinfo/services/reviews', 'reviews.bookinfo.svc.cluster.local');
+
+      // It keeps FQDN namespace
+      wrapper = serviceLink('bookinfo', 'reviews.default.svc.cluster.local', true);
+      testLink(wrapper, '/namespaces/default/services/reviews', 'reviews.default.svc.cluster.local');
+    });
+
+    it('if is not valid, should render plain text', () => {
+      const wrapper = serviceLink('bookinfo', 'reviews.bookinfo.svc.cluster.local', false);
+      testPlain(wrapper, 'reviews.bookinfo.svc.cluster.local');
+    });
+  });
+
+  describe('when is shortname', () => {
+    it('should render link', () => {
+      const wrapper = serviceLink('bookinfo', 'reviews', true);
+      testLink(wrapper, '/namespaces/bookinfo/services/reviews', 'reviews');
+    });
+
+    it('if is not valid, should render plain text', () => {
+      const wrapper = serviceLink('bookinfo', 'reviews', false);
+      testPlain(wrapper, 'reviews');
+    });
+  });
+
+  describe('when is svc.namespace format', () => {
+    it('should render link', () => {
+      let wrapper = serviceLink('bookinfo', 'reviews.bookinfo', true);
+      testLink(wrapper, '/namespaces/bookinfo/services/reviews', 'reviews');
+
+      wrapper = serviceLink('bookinfo', 'reviews.default', true);
+      testPlain(wrapper, 'reviews.default');
+    });
+
+    it('if is not valid, should render plain text', () => {
+      const wrapper = serviceLink('bookinfo', 'reviews.bookinfo', false);
+      testPlain(wrapper, 'reviews.bookinfo');
+    });
+  });
+
+  describe('when host is empty', () => {
+    it('should render a hyphen, not linked', () => {
+      const wrapper = serviceLink('bookinfo', '', true);
+      testPlain(wrapper, '-');
+    });
+
+    it('when invalid, should render a hyphen, not linked', () => {
+      const wrapper = serviceLink('bookinfo', '', true);
+      testPlain(wrapper, '-');
+    });
+  });
+
+  describe('when host is a service entry', () => {
+    it('should render a the service in plain', () => {
+      let wrapper = serviceLink('bookinfo', 'kiali.io', true);
+      testPlain(wrapper, 'kiali.io');
+
+      wrapper = serviceLink('bookinfo', 'books.bookinfo.hello.com', true);
+      testPlain(wrapper, 'books.bookinfo.hello.com');
+
+      wrapper = serviceLink('bookinfo', '*.hello.com', true);
+      testPlain(wrapper, '*.hello.com');
+    });
+
+    it('when invalid, should render a hyphen, not linked', () => {
+      let wrapper = serviceLink('bookinfo', 'kiali.io', false);
+      testPlain(wrapper, 'kiali.io');
+    });
+  });
+});


### PR DESCRIPTION
** Describe the change **

Service link from both DestinationRule and VirtualService details page is fixed.
Supported links:
- reviews
- reviews.default (not cross-namespace, may clash with service entries)
- reviews.default.svc.cluster.local (cross-namespace supported)

Not linked:
- service entries
- *.local
- *.bookinfo.svc.cluster.local

** Issue reference **

https://github.com/kiali/kiali/issues/2533

** Screenshot **

![Screenshot of Kiali Console (47)](https://user-images.githubusercontent.com/613814/77093153-e4db0e80-6a0a-11ea-843e-9a70f5a08409.png)

![Screenshot of Kiali Console (48)](https://user-images.githubusercontent.com/613814/77093263-0b994500-6a0b-11ea-9745-40dcd3f9fb9b.png)

Fixes https://github.com/kiali/kiali/issues/2533

