### PR TITLE
Ellipsis on cards of overview page when namespace name is too large

### DIFF
--- a/src/pages/Overview/OverviewPage.tsx
+++ b/src/pages/Overview/OverviewPage.tsx
@@ -65,6 +65,15 @@ const emptyStateStyle = style({
   marginTop: 10
 });
 
+const cardNamespaceNameStyle = style({
+  display: 'inline-block',
+  maxWidth: 'calc(100% - 45px)',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  verticalAlign: 'middle',
+  whiteSpace: 'nowrap'
+});
+
 type State = {
   namespaces: NamespaceInfo[];
   type: OverviewType;
@@ -381,7 +390,9 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
                   <Card isCompact={true} className={cardGridStyle}>
                     <CardHeader>
                       {ns.tlsStatus ? <NamespaceMTLSStatusContainer status={ns.tlsStatus.status} /> : undefined}
-                      {ns.name}
+                      <span className={cardNamespaceNameStyle} title={ns.name}>
+                        {ns.name}
+                      </span>
                       {this.renderIstioConfigStatus(ns)}
                     </CardHeader>
                     <CardBody>


### PR DESCRIPTION
- Adding some styles to truncate the namespace name if it is too large to fit the card in one line
- Add a tooltip to be able to read the full name of the namespace

Fixes kiali/kiali#2330.

**BEFORE**

![image](https://user-images.githubusercontent.com/23639005/78180889-adb02880-7420-11ea-8891-115e2195408f.png)

**AFTER CHANGES**

**Expanded view** (notice tooltip)

![image](https://user-images.githubusercontent.com/23639005/78180864-a12bd000-7420-11ea-8a7e-fe6283581802.png)

**Compact view** (tooltip available, but not shown)

![image](https://user-images.githubusercontent.com/23639005/78180787-83f70180-7420-11ea-987e-cbaa5c7f4a25.png)
