### PR TITLE
Graph: Merge edge options into display dropdown to limit toolbar wrap

### DIFF
--- a/src/components/Health/__tests__/__snapshots__/HealthDetails.test.tsx.snap
+++ b/src/components/Health/__tests__/__snapshots__/HealthDetails.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`HealthDetails renders deployments failure 1`] = `
     >
       <UnknownIcon
         className="icon-na"
-        color="#72767b"
+        color="#6a6e73"
         noVerticalAlign={false}
         size="sm"
         title={null}
@@ -52,7 +52,7 @@ exports[`HealthDetails renders healthy 1`] = `
     >
       <UnknownIcon
         className="icon-na"
-        color="#72767b"
+        color="#6a6e73"
         noVerticalAlign={false}
         size="sm"
         title={null}

--- a/src/components/Health/__tests__/__snapshots__/HealthIndicator.test.tsx.snap
+++ b/src/components/Health/__tests__/__snapshots__/HealthIndicator.test.tsx.snap
@@ -55,7 +55,7 @@ exports[`HealthIndicator renders healthy 1`] = `
                   Object {
                     "status": Object {
                       "class": "icon-na",
-                      "color": "#72767b",
+                      "color": "#6a6e73",
                       "icon": [Function],
                       "name": "No health information",
                       "priority": 0,
@@ -65,7 +65,7 @@ exports[`HealthIndicator renders healthy 1`] = `
                   Object {
                     "status": Object {
                       "class": "icon-na",
-                      "color": "#72767b",
+                      "color": "#6a6e73",
                       "icon": [Function],
                       "name": "No health information",
                       "priority": 0,
@@ -75,7 +75,7 @@ exports[`HealthIndicator renders healthy 1`] = `
                 ],
                 "status": Object {
                   "class": "icon-na",
-                  "color": "#72767b",
+                  "color": "#6a6e73",
                   "icon": [Function],
                   "name": "No health information",
                   "priority": 0,

--- a/src/components/Pf/PfColors.tsx
+++ b/src/components/Pf/PfColors.tsx
@@ -1,11 +1,11 @@
 export enum PfColors {
   Black100 = '#fafafa',
   Black150 = '#f5f5f5',
-  Black200 = '#ededed',
+  Black200 = '#f0f0f0',
   Black300 = '#d1d1d1',
   Black400 = '#bbb',
   Black500 = '#8b8d8f',
-  Black600 = '#72767b',
+  Black600 = '#6a6e73',
   Black700 = '#4d5258',
   Black800 = '#393f44',
   Black900 = '#292e34',

--- a/src/pages/Graph/GraphHelpTour.ts
+++ b/src/pages/Graph/GraphHelpTour.ts
@@ -4,12 +4,8 @@ import { TourStopInfo, TourInfo } from 'components/Tour/TourStop';
 export const GraphTourStops: { [name: string]: TourStopInfo } = {
   Display: {
     name: 'Display',
-    description: 'Toggle various display options such as badging traffic animation, and service nodes.'
-  },
-  EdgeLabels: {
-    name: 'Edge Labels',
     description:
-      'Select the information to show on the edges between nodes. Response times reflect the 95th percentile.'
+      'Set edge labeling, node badging, and various display options. Response-time edge labeling, security badging, and traffic animation may affect performance. Response-times reflect the 95th percentile.'
   },
   Find: {
     name: 'Find and Hide',
@@ -64,7 +60,6 @@ const GraphTour: TourInfo = {
   stops: [
     GraphTourStops.Namespaces,
     GraphTourStops.GraphType,
-    GraphTourStops.EdgeLabels,
     GraphTourStops.Display,
     GraphTourStops.Find,
     GraphTourStops.TimeRange,

--- a/src/pages/Graph/GraphToolbar/GraphSettings.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphSettings.tsx
@@ -15,6 +15,7 @@ import {
   PropertyType
 } from 'components/BoundingClientAwareComponent/BoundingClientAwareComponent';
 import { style } from 'typestyle';
+import { PfColors } from 'components/Pf/PfColors';
 
 type ReduxProps = Omit<GraphToolbarState, 'findValue' | 'hideValue' | 'showLegend' | 'showFindHelp'> & {
   setEdgeLabelMode: (edgeLabelMode: EdgeLabelMode) => void;
@@ -47,22 +48,24 @@ const containerStyle = style({
   overflow: 'auto'
 });
 
+// this emulates Select component .pf-c-select__menu
 const menuStyle = style({
   fontSize: '14px'
 });
 
-const firstTitleStyle = style({
-  margin: '0.5em 0.25em 0.5em 0.25em',
-  fontWeight: 'bold'
-});
-
+// this emulates Select component .pf-c-select__menu-group-title but with less bottom padding to conserve space
 const titleStyle = style({
-  margin: '1em 0.25em 0.5em 0.25em',
-  fontWeight: 'bold'
+  padding: '8px 16px 2px 16px',
+  fontWeight: 700,
+  color: PfColors.Black600
 });
 
-const checkboxStyle = style({
-  margin: '0.25em 0.5em 0.25em 0.5em'
+// this emulates Select component .pf-c-select__menu-item but with less vertical padding to conserve space
+const itemStyle = style({
+  alignItems: 'center',
+  whiteSpace: 'nowrap',
+  margin: 0,
+  padding: '6px 16px'
 });
 
 class GraphSettings extends React.PureComponent<GraphSettingsProps, GraphSettingsState> {
@@ -141,25 +144,25 @@ class GraphSettings extends React.PureComponent<GraphSettingsProps, GraphSetting
     const edgeLabelOptions: DisplayOptionType[] = [
       {
         id: EdgeLabelMode.NONE,
-        labelText: _.capitalize(_.startCase(EdgeLabelMode.NONE)),
+        labelText: _.upperFirst(_.startCase(EdgeLabelMode.NONE)),
         value: edgeLabelMode === EdgeLabelMode.NONE,
         onChange: this.setEdgeLabelModeNone
       },
       {
         id: EdgeLabelMode.REQUESTS_PER_SECOND,
-        labelText: _.capitalize(_.startCase(EdgeLabelMode.REQUESTS_PER_SECOND)),
+        labelText: _.upperFirst(_.startCase(EdgeLabelMode.REQUESTS_PER_SECOND)),
         value: edgeLabelMode === EdgeLabelMode.REQUESTS_PER_SECOND,
         onChange: this.setEdgeLabelModeRPS
       },
       {
         id: EdgeLabelMode.REQUESTS_PERCENTAGE,
-        labelText: _.capitalize(_.startCase(EdgeLabelMode.REQUESTS_PERCENTAGE)),
+        labelText: _.upperFirst(_.startCase(EdgeLabelMode.REQUESTS_PERCENTAGE)),
         value: edgeLabelMode === EdgeLabelMode.REQUESTS_PERCENTAGE,
         onChange: this.setEdgeLabelModePCT
       },
       {
         id: EdgeLabelMode.RESPONSE_TIME_95TH_PERCENTILE,
-        labelText: _.capitalize(_.startCase(EdgeLabelMode.RESPONSE_TIME_95TH_PERCENTILE)),
+        labelText: _.upperFirst(_.startCase(EdgeLabelMode.RESPONSE_TIME_95TH_PERCENTILE)),
         value: edgeLabelMode === EdgeLabelMode.RESPONSE_TIME_95TH_PERCENTILE,
         onChange: this.setEdgeLabelModeRT
       }
@@ -232,11 +235,10 @@ class GraphSettings extends React.PureComponent<GraphSettingsProps, GraphSetting
         maxHeight={{ type: PropertyType.VIEWPORT_HEIGHT_MINUS_TOP, margin: marginBottom }}
       >
         <div className={menuStyle}>
-          <div className={firstTitleStyle}>Edge Labels</div>
+          <div className={titleStyle}>Show Edge Labels</div>
           {edgeLabelOptions.map((item: DisplayOptionType) => (
-            <label className="pf-c-select__menu-item">
+            <label className={itemStyle}>
               <Radio
-                className={checkboxStyle}
                 id={item.id}
                 name="edgeLabels"
                 isChecked={item.value}
@@ -248,9 +250,8 @@ class GraphSettings extends React.PureComponent<GraphSettingsProps, GraphSetting
           ))}
           <div className={titleStyle}>Show</div>
           {visibilityOptions.map((item: DisplayOptionType) => (
-            <label className="pf-c-select__menu-item">
+            <label className={itemStyle}>
               <Checkbox
-                className={checkboxStyle}
                 id={item.id}
                 isChecked={item.value}
                 key={item.id}
@@ -261,9 +262,8 @@ class GraphSettings extends React.PureComponent<GraphSettingsProps, GraphSetting
           ))}
           <div className={titleStyle}>Show Badges</div>
           {badgeOptions.map((item: DisplayOptionType) => (
-            <label className="pf-c-select__menu-item">
+            <label className={itemStyle}>
               <Checkbox
-                className={checkboxStyle}
                 id={item.id}
                 isChecked={item.value}
                 key={item.id}

--- a/src/pages/Graph/GraphToolbar/GraphSettings.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphSettings.tsx
@@ -113,7 +113,7 @@ class GraphSettings extends React.PureComponent<GraphSettingsProps, GraphSetting
     );
   }
 
-  getPopoverContent() {
+  private getPopoverContent() {
     // map our attributes from redux
     const {
       compressOnHide,
@@ -234,15 +234,14 @@ class GraphSettings extends React.PureComponent<GraphSettingsProps, GraphSetting
         className={containerStyle}
         maxHeight={{ type: PropertyType.VIEWPORT_HEIGHT_MINUS_TOP, margin: marginBottom }}
       >
-        <div className={menuStyle}>
+        <div id="graph-display-menu" className={menuStyle}>
           <div className={titleStyle}>Show Edge Labels</div>
           {edgeLabelOptions.map((item: DisplayOptionType) => (
-            <label className={itemStyle}>
+            <label key={item.id} className={itemStyle}>
               <Radio
                 id={item.id}
                 name="edgeLabels"
                 isChecked={item.value}
-                key={item.id}
                 label={item.labelText}
                 onChange={item.onChange}
               />
@@ -250,26 +249,14 @@ class GraphSettings extends React.PureComponent<GraphSettingsProps, GraphSetting
           ))}
           <div className={titleStyle}>Show</div>
           {visibilityOptions.map((item: DisplayOptionType) => (
-            <label className={itemStyle}>
-              <Checkbox
-                id={item.id}
-                isChecked={item.value}
-                key={item.id}
-                label={item.labelText}
-                onChange={item.onChange}
-              />
+            <label key={item.id} className={itemStyle}>
+              <Checkbox id={item.id} isChecked={item.value} label={item.labelText} onChange={item.onChange} />
             </label>
           ))}
           <div className={titleStyle}>Show Badges</div>
           {badgeOptions.map((item: DisplayOptionType) => (
-            <label className={itemStyle}>
-              <Checkbox
-                id={item.id}
-                isChecked={item.value}
-                key={item.id}
-                label={item.labelText}
-                onChange={item.onChange}
-              />
+            <label key={item.id} className={itemStyle}>
+              <Checkbox id={item.id} isChecked={item.value} label={item.labelText} onChange={item.onChange} />
             </label>
           ))}
         </div>

--- a/src/pages/Graph/GraphToolbar/GraphSettings.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphSettings.tsx
@@ -144,25 +144,25 @@ class GraphSettings extends React.PureComponent<GraphSettingsProps, GraphSetting
     const edgeLabelOptions: DisplayOptionType[] = [
       {
         id: EdgeLabelMode.NONE,
-        labelText: _.upperFirst(_.startCase(EdgeLabelMode.NONE)),
+        labelText: _.startCase(EdgeLabelMode.NONE),
         value: edgeLabelMode === EdgeLabelMode.NONE,
         onChange: this.setEdgeLabelModeNone
       },
       {
         id: EdgeLabelMode.REQUESTS_PER_SECOND,
-        labelText: _.upperFirst(_.startCase(EdgeLabelMode.REQUESTS_PER_SECOND)),
+        labelText: _.startCase(EdgeLabelMode.REQUESTS_PER_SECOND),
         value: edgeLabelMode === EdgeLabelMode.REQUESTS_PER_SECOND,
         onChange: this.setEdgeLabelModeRPS
       },
       {
         id: EdgeLabelMode.REQUESTS_PERCENTAGE,
-        labelText: _.upperFirst(_.startCase(EdgeLabelMode.REQUESTS_PERCENTAGE)),
+        labelText: _.startCase(EdgeLabelMode.REQUESTS_PERCENTAGE),
         value: edgeLabelMode === EdgeLabelMode.REQUESTS_PERCENTAGE,
         onChange: this.setEdgeLabelModePCT
       },
       {
         id: EdgeLabelMode.RESPONSE_TIME_95TH_PERCENTILE,
-        labelText: _.upperFirst(_.startCase(EdgeLabelMode.RESPONSE_TIME_95TH_PERCENTILE)),
+        labelText: _.startCase(EdgeLabelMode.RESPONSE_TIME_95TH_PERCENTILE),
         value: edgeLabelMode === EdgeLabelMode.RESPONSE_TIME_95TH_PERCENTILE,
         onChange: this.setEdgeLabelModeRT
       }

--- a/src/pages/Graph/GraphToolbar/GraphSettings.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphSettings.tsx
@@ -1,4 +1,4 @@
-import { Select, SelectGroup, SelectOption, SelectVariant, Radio } from '@patternfly/react-core';
+import { Radio, Dropdown, DropdownToggle, Checkbox } from '@patternfly/react-core';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { ThunkDispatch } from 'redux-thunk';
@@ -10,6 +10,11 @@ import { GraphType, EdgeLabelMode } from '../../../types/Graph';
 import { KialiAppAction } from 'actions/KialiAppAction';
 import * as _ from 'lodash';
 import { edgeLabelModeSelector } from 'store/Selectors';
+import {
+  BoundingClientAwareComponent,
+  PropertyType
+} from 'components/BoundingClientAwareComponent/BoundingClientAwareComponent';
+import { style } from 'typestyle';
 
 type ReduxProps = Omit<GraphToolbarState, 'findValue' | 'hideValue' | 'showLegend' | 'showFindHelp'> & {
   setEdgeLabelMode: (edgeLabelMode: EdgeLabelMode) => void;
@@ -35,6 +40,30 @@ interface DisplayOptionType {
   value: boolean;
   onChange: () => void;
 }
+
+const marginBottom = 20;
+
+const containerStyle = style({
+  overflow: 'auto'
+});
+
+const menuStyle = style({
+  fontSize: '14px'
+});
+
+const firstTitleStyle = style({
+  margin: '0.5em 0.25em 0.5em 0.25em',
+  fontWeight: 'bold'
+});
+
+const titleStyle = style({
+  margin: '1em 0.25em 0.5em 0.25em',
+  fontWeight: 'bold'
+});
+
+const checkboxStyle = style({
+  margin: '0.25em 0.5em 0.25em 0.5em'
+});
 
 class GraphSettings extends React.PureComponent<GraphSettingsProps, GraphSettingsState> {
   constructor(props: GraphSettingsProps) {
@@ -66,6 +95,22 @@ class GraphSettings extends React.PureComponent<GraphSettingsProps, GraphSetting
   }
 
   render() {
+    const { isOpen } = this.state;
+    return (
+      <Dropdown
+        toggle={
+          <DropdownToggle id={'display-settings'} onToggle={this.onToggle}>
+            Display
+          </DropdownToggle>
+        }
+        isOpen={isOpen}
+      >
+        {this.getPopoverContent()}
+      </Dropdown>
+    );
+  }
+
+  getPopoverContent() {
     // map our attributes from redux
     const {
       compressOnHide,
@@ -181,30 +226,17 @@ class GraphSettings extends React.PureComponent<GraphSettingsProps, GraphSetting
       }
     ];
 
-    const { isOpen } = this.state;
-
-    const selections = edgeLabelOptions
-      .filter((item: DisplayOptionType) => item.value)
-      .concat(visibilityOptions.filter((item: DisplayOptionType) => item.value))
-      .concat(badgeOptions.filter((item: DisplayOptionType) => item.value))
-      .map((item: DisplayOptionType) => item.labelText);
-
     return (
-      <Select
-        style={{ overflow: 'hidden', overflowY: 'auto' }}
-        maxHeight={650}
-        placeholderText="Display"
-        onToggle={this.onToggle}
-        onSelect={() => undefined}
-        isExpanded={isOpen}
-        variant={SelectVariant.checkbox}
-        isGrouped={true}
-        selections={selections}
+      <BoundingClientAwareComponent
+        className={containerStyle}
+        maxHeight={{ type: PropertyType.VIEWPORT_HEIGHT_MINUS_TOP, margin: marginBottom }}
       >
-        <SelectGroup label="Show Edge Labels" key="edges">
+        <div className={menuStyle}>
+          <div className={firstTitleStyle}>Edge Labels</div>
           {edgeLabelOptions.map((item: DisplayOptionType) => (
             <label className="pf-c-select__menu-item">
               <Radio
+                className={checkboxStyle}
                 id={item.id}
                 name="edgeLabels"
                 isChecked={item.value}
@@ -214,24 +246,34 @@ class GraphSettings extends React.PureComponent<GraphSettingsProps, GraphSetting
               />
             </label>
           ))}
-        </SelectGroup>
-        <SelectGroup label="Show" key="visibilityLayers">
+          <div className={titleStyle}>Show</div>
           {visibilityOptions.map((item: DisplayOptionType) => (
-            <SelectOption
-              isChecked={item.value}
-              isDisabled={item.disabled}
-              key={item.id}
-              value={item.labelText}
-              onClick={item.onChange}
-            />
+            <label className="pf-c-select__menu-item">
+              <Checkbox
+                className={checkboxStyle}
+                id={item.id}
+                isChecked={item.value}
+                key={item.id}
+                label={item.labelText}
+                onChange={item.onChange}
+              />
+            </label>
           ))}
-        </SelectGroup>
-        <SelectGroup label="Show Badges" key="badges">
+          <div className={titleStyle}>Show Badges</div>
           {badgeOptions.map((item: DisplayOptionType) => (
-            <SelectOption isChecked={item.value} key={item.id} value={item.labelText} onClick={item.onChange} />
+            <label className="pf-c-select__menu-item">
+              <Checkbox
+                className={checkboxStyle}
+                id={item.id}
+                isChecked={item.value}
+                key={item.id}
+                label={item.labelText}
+                onChange={item.onChange}
+              />
+            </label>
           ))}
-        </SelectGroup>
-      </Select>
+        </div>
+      </BoundingClientAwareComponent>
     );
   }
 

--- a/src/pages/Graph/GraphToolbar/GraphSettings.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphSettings.tsx
@@ -38,8 +38,8 @@ interface DisplayOptionType {
   id: string;
   disabled?: boolean;
   labelText: string;
-  value: boolean;
-  onChange: () => void;
+  isChecked: boolean;
+  onChange?: () => void;
 }
 
 const marginBottom = 20;
@@ -145,26 +145,22 @@ class GraphSettings extends React.PureComponent<GraphSettingsProps, GraphSetting
       {
         id: EdgeLabelMode.NONE,
         labelText: _.startCase(EdgeLabelMode.NONE),
-        value: edgeLabelMode === EdgeLabelMode.NONE,
-        onChange: this.setEdgeLabelModeNone
+        isChecked: edgeLabelMode === EdgeLabelMode.NONE
       },
       {
         id: EdgeLabelMode.REQUESTS_PER_SECOND,
         labelText: _.startCase(EdgeLabelMode.REQUESTS_PER_SECOND),
-        value: edgeLabelMode === EdgeLabelMode.REQUESTS_PER_SECOND,
-        onChange: this.setEdgeLabelModeRPS
+        isChecked: edgeLabelMode === EdgeLabelMode.REQUESTS_PER_SECOND
       },
       {
         id: EdgeLabelMode.REQUESTS_PERCENTAGE,
         labelText: _.startCase(EdgeLabelMode.REQUESTS_PERCENTAGE),
-        value: edgeLabelMode === EdgeLabelMode.REQUESTS_PERCENTAGE,
-        onChange: this.setEdgeLabelModePCT
+        isChecked: edgeLabelMode === EdgeLabelMode.REQUESTS_PERCENTAGE
       },
       {
         id: EdgeLabelMode.RESPONSE_TIME_95TH_PERCENTILE,
         labelText: _.startCase(EdgeLabelMode.RESPONSE_TIME_95TH_PERCENTILE),
-        value: edgeLabelMode === EdgeLabelMode.RESPONSE_TIME_95TH_PERCENTILE,
-        onChange: this.setEdgeLabelModeRT
+        isChecked: edgeLabelMode === EdgeLabelMode.RESPONSE_TIME_95TH_PERCENTILE
       }
     ];
 
@@ -172,32 +168,32 @@ class GraphSettings extends React.PureComponent<GraphSettingsProps, GraphSetting
       {
         id: 'filterHide',
         labelText: 'Compress Hidden',
-        value: compressOnHide,
+        isChecked: compressOnHide,
         onChange: toggleCompressOnHide
       },
       {
         id: 'filterNodes',
         labelText: 'Node Names',
-        value: showNodeLabels,
+        isChecked: showNodeLabels,
         onChange: toggleGraphNodeLabels
       },
       {
         id: 'filterServiceNodes',
         disabled: this.props.graphType === GraphType.SERVICE,
         labelText: 'Service Nodes',
-        value: showServiceNodes,
+        isChecked: showServiceNodes,
         onChange: toggleServiceNodes
       },
       {
         id: 'filterTrafficAnimation',
         labelText: 'Traffic Animation',
-        value: showTrafficAnimation,
+        isChecked: showTrafficAnimation,
         onChange: toggleTrafficAnimation
       },
       {
         id: 'filterUnusedNodes',
         labelText: 'Unused Nodes',
-        value: showUnusedNodes,
+        isChecked: showUnusedNodes,
         onChange: toggleUnusedNodes
       }
     ];
@@ -206,25 +202,25 @@ class GraphSettings extends React.PureComponent<GraphSettingsProps, GraphSetting
       {
         id: 'filterCB',
         labelText: 'Circuit Breakers',
-        value: showCircuitBreakers,
+        isChecked: showCircuitBreakers,
         onChange: toggleGraphCircuitBreakers
       },
       {
         id: 'filterSidecars',
         labelText: 'Missing Sidecars',
-        value: showMissingSidecars,
+        isChecked: showMissingSidecars,
         onChange: toggleGraphMissingSidecars
       },
       {
         id: 'filterVS',
         labelText: 'Virtual Services',
-        value: showVirtualServices,
+        isChecked: showVirtualServices,
         onChange: toggleGraphVirtualServices
       },
       {
         id: 'filterSecurity',
         labelText: 'Security',
-        value: showSecurity,
+        isChecked: showSecurity,
         onChange: toggleGraphSecurity
       }
     ];
@@ -241,22 +237,23 @@ class GraphSettings extends React.PureComponent<GraphSettingsProps, GraphSetting
               <Radio
                 id={item.id}
                 name="edgeLabels"
-                isChecked={item.value}
+                isChecked={item.isChecked}
                 label={item.labelText}
-                onChange={item.onChange}
+                onChange={this.setEdgeLabelMode}
+                value={item.id}
               />
             </label>
           ))}
           <div className={titleStyle}>Show</div>
           {visibilityOptions.map((item: DisplayOptionType) => (
             <label key={item.id} className={itemStyle}>
-              <Checkbox id={item.id} isChecked={item.value} label={item.labelText} onChange={item.onChange} />
+              <Checkbox id={item.id} isChecked={item.isChecked} label={item.labelText} onChange={item.onChange} />
             </label>
           ))}
           <div className={titleStyle}>Show Badges</div>
           {badgeOptions.map((item: DisplayOptionType) => (
             <label key={item.id} className={itemStyle}>
-              <Checkbox id={item.id} isChecked={item.value} label={item.labelText} onChange={item.onChange} />
+              <Checkbox id={item.id} isChecked={item.isChecked} label={item.labelText} onChange={item.onChange} />
             </label>
           ))}
         </div>
@@ -264,23 +261,8 @@ class GraphSettings extends React.PureComponent<GraphSettingsProps, GraphSetting
     );
   }
 
-  private setEdgeLabelModeNone = () => {
-    this.setEdgeLabelMode(EdgeLabelMode.NONE);
-  };
-
-  private setEdgeLabelModeRPS = () => {
-    this.setEdgeLabelMode(EdgeLabelMode.REQUESTS_PER_SECOND);
-  };
-
-  private setEdgeLabelModePCT = () => {
-    this.setEdgeLabelMode(EdgeLabelMode.REQUESTS_PERCENTAGE);
-  };
-
-  private setEdgeLabelModeRT = () => {
-    this.setEdgeLabelMode(EdgeLabelMode.RESPONSE_TIME_95TH_PERCENTILE);
-  };
-
-  private setEdgeLabelMode = (mode: EdgeLabelMode) => {
+  private setEdgeLabelMode = (_, event) => {
+    const mode = event.target.value as EdgeLabelMode;
     if (this.props.edgeLabelMode !== mode) {
       this.props.setEdgeLabelMode(mode);
     }

--- a/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
@@ -61,10 +61,6 @@ const rightToolbarStyle = style({
   marginLeft: 'auto'
 });
 
-const marginLeftRight = style({
-  margin: '0 10px 0 10px'
-});
-
 export class GraphToolbar extends React.PureComponent<GraphToolbarProps> {
   /**
    *  Key-value pair object representation of GraphType enum.  Values are human-readable versions of enum keys.
@@ -162,7 +158,7 @@ export class GraphToolbar extends React.PureComponent<GraphToolbarProps> {
   // TODO [jshaughn] Is there a better typescript way than the style attribute with the spread syntax (here and other places)
   render() {
     const graphTypeKey: string = _.findKey(GraphType, val => val === this.props.graphType)!;
-    const edgeLabelModeKey: string = _.findKey(EdgeLabelMode, val => val === this.props.edgeLabelMode)!;
+
     return (
       <>
         <Toolbar className={toolbarStyle}>
@@ -196,20 +192,10 @@ export class GraphToolbar extends React.PureComponent<GraphToolbarProps> {
                 </Tooltip>
               </>
             )}
-            <div className={marginLeftRight}>
-              <TourStopContainer info={GraphTourStops.EdgeLabels}>
-                <ToolbarDropdown
-                  id={'graph_filter_edge_labels'}
-                  disabled={false}
-                  handleSelect={this.setEdgeLabelMode}
-                  value={edgeLabelModeKey}
-                  label={GraphToolbar.EDGE_LABEL_MODES[edgeLabelModeKey]}
-                  options={GraphToolbar.EDGE_LABEL_MODES}
-                />
-              </TourStopContainer>
-            </div>
             <TourStopContainer info={GraphTourStops.Display}>
-              <GraphSettingsContainer edgeLabelMode={this.props.edgeLabelMode} graphType={this.props.graphType} />
+              <TourStopContainer info={GraphTourStops.EdgeLabels}>
+                <GraphSettingsContainer graphType={this.props.graphType} />
+              </TourStopContainer>
             </TourStopContainer>
           </div>
           <GraphFindContainer />
@@ -233,13 +219,6 @@ export class GraphToolbar extends React.PureComponent<GraphToolbarProps> {
     const graphType: GraphType = GraphType[type] as GraphType;
     if (this.props.graphType !== graphType) {
       this.props.setGraphType(graphType);
-    }
-  };
-
-  private setEdgeLabelMode = (edgeMode: string) => {
-    const mode: EdgeLabelMode = EdgeLabelMode[edgeMode] as EdgeLabelMode;
-    if (this.props.edgeLabelMode !== mode) {
-      this.props.setEdgeLabelMode(mode);
     }
   };
 }

--- a/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
@@ -61,6 +61,10 @@ const rightToolbarStyle = style({
   marginLeft: 'auto'
 });
 
+const leftSpacerStyle = style({
+  marginLeft: '10px'
+});
+
 export class GraphToolbar extends React.PureComponent<GraphToolbarProps> {
   /**
    *  Key-value pair object representation of GraphType enum.  Values are human-readable versions of enum keys.
@@ -192,11 +196,11 @@ export class GraphToolbar extends React.PureComponent<GraphToolbarProps> {
                 </Tooltip>
               </>
             )}
-            <TourStopContainer info={GraphTourStops.Display}>
-              <TourStopContainer info={GraphTourStops.EdgeLabels}>
+            <div className={leftSpacerStyle}>
+              <TourStopContainer info={GraphTourStops.Display}>
                 <GraphSettingsContainer graphType={this.props.graphType} />
               </TourStopContainer>
-            </TourStopContainer>
+            </div>
           </div>
           <GraphFindContainer />
           <ToolbarGroup className={rightToolbarStyle} aria-label="graph_refresh_toolbar">

--- a/src/pages/Graph/_Graph.scss
+++ b/src/pages/Graph/_Graph.scss
@@ -51,3 +51,11 @@
   border-top-left-radius: 0;
   border-top-right-radius: 0;
 }
+
+#graph-display-menu .pf-c-radio__input {
+  margin: 0;
+}
+
+#graph-display-menu .pf-c-check__input {
+  margin: 0;
+}


### PR DESCRIPTION
The graph toolbar wraps even on relatively wide browser windows.  Merging it into the Display dropdown conserves quite a bit of space and helps limit wrapping.  It also consolidates display options since edge labeling is an option.

@lwrigh, @israel-hdez  The good news is that I was able to get the mixture of radio buttons and checkboxes into a single dropdown.  The bad news is that I had to toss out the use of the PF4 Select component.  The dropdown is now signifigantly long and the Select component did not handle scrolling well, and so for shorter windows the bottom options were clipped.  Note that this was true in the past as well, but the lesser number of options made it unlikely to happen.  As an alternative I reworked things in the model of what we do in the namespaces dropdown.   The fallout is the the look of the dropdown is no longer that of Select.  But we can likely tweak it if needed.

Before:
![image](https://user-images.githubusercontent.com/2104052/78183969-bdd30280-7436-11ea-8519-95b8463fa592.png)

After:
![image](https://user-images.githubusercontent.com/2104052/78184009-d3482c80-7436-11ea-9248-e199becb0e37.png)

With Scroll:
![image](https://user-images.githubusercontent.com/2104052/78183893-a136ca80-7436-11ea-84bd-11c9a70577eb.png)
