### PR TITLE
Namespaces overview should differentiate idle from failure apps

### DIFF
--- a/src/components/Health/__tests__/HealthIndicator.test.tsx
+++ b/src/components/Health/__tests__/HealthIndicator.test.tsx
@@ -4,7 +4,7 @@ import { shallowToJson } from 'enzyme-to-json';
 
 import { HealthIndicator, DisplayMode } from '../HealthIndicator';
 import { AppHealth } from '../../../types/Health';
-import { PFAlertColor } from 'components/Pf/PfColors';
+import { PFAlertColor, PfColors } from 'components/Pf/PfColors';
 
 describe('HealthIndicator', () => {
   it('renders when empty', () => {
@@ -96,12 +96,12 @@ describe('HealthIndicator', () => {
     // SMALL
     let wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.SMALL} />);
     let html = wrapper.html();
-    expect(html).toContain(PFAlertColor.Danger);
+    expect(html).toContain(PfColors.Gray);
 
     // LARGE
     wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} />);
     html = wrapper.html();
-    expect(html).toContain(PFAlertColor.Danger);
+    expect(html).toContain(PfColors.Gray);
   });
 
   it('renders error rate failure', () => {

--- a/src/components/Health/__tests__/HealthIndicator.test.tsx
+++ b/src/components/Health/__tests__/HealthIndicator.test.tsx
@@ -4,7 +4,7 @@ import { shallowToJson } from 'enzyme-to-json';
 
 import { HealthIndicator, DisplayMode } from '../HealthIndicator';
 import { AppHealth } from '../../../types/Health';
-import { PFAlertColor, PfColors } from 'components/Pf/PfColors';
+import { PFAlertColor } from 'components/Pf/PfColors';
 
 describe('HealthIndicator', () => {
   it('renders when empty', () => {
@@ -39,7 +39,7 @@ describe('HealthIndicator', () => {
     expect(html).toContain(PFAlertColor.Success);
   });
 
-  it('renders workloads undesired', () => {
+  it('renders workloads defraded', () => {
     const health = new AppHealth(
       [
         { name: 'A', availableReplicas: 1, currentReplicas: 1, desiredReplicas: 10 },
@@ -52,12 +52,12 @@ describe('HealthIndicator', () => {
     // SMALL
     let wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.SMALL} />);
     let html = wrapper.html();
-    expect(html).toContain(PFAlertColor.InfoBackground);
+    expect(html).toContain(PFAlertColor.Warning);
 
     // LARGE
     wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} />);
     html = wrapper.html();
-    expect(html).toContain(PFAlertColor.InfoBackground);
+    expect(html).toContain(PFAlertColor.Warning);
     expect(html).toContain('1 / 10');
   });
 
@@ -74,12 +74,12 @@ describe('HealthIndicator', () => {
     // SMALL
     let wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.SMALL} />);
     let html = wrapper.html();
-    expect(html).toContain(PFAlertColor.Success);
+    expect(html).toContain(PFAlertColor.InfoBackground);
 
     // LARGE
     wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} />);
     html = wrapper.html();
-    expect(html).toContain(PFAlertColor.Success);
+    expect(html).toContain(PFAlertColor.InfoBackground);
     expect(html).toContain('0 / 0');
   });
 
@@ -96,12 +96,12 @@ describe('HealthIndicator', () => {
     // SMALL
     let wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.SMALL} />);
     let html = wrapper.html();
-    expect(html).toContain(PfColors.Gray);
+    expect(html).toContain(PFAlertColor.InfoBackground);
 
     // LARGE
     wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} />);
     html = wrapper.html();
-    expect(html).toContain(PfColors.Gray);
+    expect(html).toContain(PFAlertColor.InfoBackground);
   });
 
   it('renders error rate failure', () => {

--- a/src/components/Health/__tests__/HealthIndicator.test.tsx
+++ b/src/components/Health/__tests__/HealthIndicator.test.tsx
@@ -39,7 +39,7 @@ describe('HealthIndicator', () => {
     expect(html).toContain(PFAlertColor.Success);
   });
 
-  it('renders workloads defraded', () => {
+  it('renders workloads degraded', () => {
     const health = new AppHealth(
       [
         { name: 'A', availableReplicas: 1, currentReplicas: 1, desiredReplicas: 10 },

--- a/src/components/Health/__tests__/HealthIndicator.test.tsx
+++ b/src/components/Health/__tests__/HealthIndicator.test.tsx
@@ -39,7 +39,7 @@ describe('HealthIndicator', () => {
     expect(html).toContain(PFAlertColor.Success);
   });
 
-  it('renders workloads degraded', () => {
+  it('renders workloads undesired', () => {
     const health = new AppHealth(
       [
         { name: 'A', availableReplicas: 1, currentReplicas: 1, desiredReplicas: 10 },
@@ -52,12 +52,12 @@ describe('HealthIndicator', () => {
     // SMALL
     let wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.SMALL} />);
     let html = wrapper.html();
-    expect(html).toContain(PFAlertColor.Warning);
+    expect(html).toContain(PFAlertColor.InfoBackground);
 
     // LARGE
     wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} />);
     html = wrapper.html();
-    expect(html).toContain(PFAlertColor.Warning);
+    expect(html).toContain(PFAlertColor.InfoBackground);
     expect(html).toContain('1 / 10');
   });
 

--- a/src/pages/Overview/NamespaceInfo.ts
+++ b/src/pages/Overview/NamespaceInfo.ts
@@ -12,7 +12,7 @@ export type NamespaceInfo = {
 };
 
 export type NamespaceStatus = {
-  inUndesiredReplica: string[];
+  inIdle: string[];
   inError: string[];
   inWarning: string[];
   inSuccess: string[];

--- a/src/pages/Overview/NamespaceInfo.ts
+++ b/src/pages/Overview/NamespaceInfo.ts
@@ -12,6 +12,7 @@ export type NamespaceInfo = {
 };
 
 export type NamespaceStatus = {
+  inUndesiredReplica: string[];
   inError: string[];
   inWarning: string[];
   inSuccess: string[];

--- a/src/pages/Overview/OverviewCardBars.tsx
+++ b/src/pages/Overview/OverviewCardBars.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Chart, ChartBar, ChartStack, ChartAxis } from '@patternfly/react-charts';
 
 import { NamespaceStatus } from './NamespaceInfo';
-import { FAILURE, DEGRADED, HEALTHY } from '../../types/Health';
+import { FAILURE, DEGRADED, HEALTHY, UNDESIRED } from '../../types/Health';
 
 type Props = {
   status: NamespaceStatus;
@@ -46,7 +46,8 @@ class OverviewCardBars extends React.Component<Props, State> {
     return (
       <div ref={this.containerRef}>
         <Chart height={50} width={this.state.width} padding={{ top: 20, left: 5, right: 5, bottom: 0 }}>
-          <ChartStack colorScale={[FAILURE.color, DEGRADED.color, HEALTHY.color]} xOffset={10}>
+          <ChartStack colorScale={[UNDESIRED.color, FAILURE.color, DEGRADED.color, HEALTHY.color]} xOffset={10}>
+            <ChartBar horizontal={true} barWidth={16} data={[{ y: this.props.status.inUndesiredReplica.length }]} />
             <ChartBar horizontal={true} barWidth={16} data={[{ y: this.props.status.inError.length }]} />
             <ChartBar horizontal={true} barWidth={16} data={[{ y: this.props.status.inWarning.length }]} />
             <ChartBar horizontal={true} barWidth={16} data={[{ y: this.props.status.inSuccess.length }]} />

--- a/src/pages/Overview/OverviewCardBars.tsx
+++ b/src/pages/Overview/OverviewCardBars.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Chart, ChartBar, ChartStack, ChartAxis } from '@patternfly/react-charts';
 
 import { NamespaceStatus } from './NamespaceInfo';
-import { FAILURE, DEGRADED, HEALTHY, UNDESIRED } from '../../types/Health';
+import { FAILURE, DEGRADED, HEALTHY, IDLE } from '../../types/Health';
 
 type Props = {
   status: NamespaceStatus;
@@ -46,8 +46,8 @@ class OverviewCardBars extends React.Component<Props, State> {
     return (
       <div ref={this.containerRef}>
         <Chart height={50} width={this.state.width} padding={{ top: 20, left: 5, right: 5, bottom: 0 }}>
-          <ChartStack colorScale={[UNDESIRED.color, FAILURE.color, DEGRADED.color, HEALTHY.color]} xOffset={10}>
-            <ChartBar horizontal={true} barWidth={16} data={[{ y: this.props.status.inUndesiredReplica.length }]} />
+          <ChartStack colorScale={[IDLE.color, FAILURE.color, DEGRADED.color, HEALTHY.color]} xOffset={10}>
+            <ChartBar horizontal={true} barWidth={16} data={[{ y: this.props.status.inIdle.length }]} />
             <ChartBar horizontal={true} barWidth={16} data={[{ y: this.props.status.inError.length }]} />
             <ChartBar horizontal={true} barWidth={16} data={[{ y: this.props.status.inWarning.length }]} />
             <ChartBar horizontal={true} barWidth={16} data={[{ y: this.props.status.inSuccess.length }]} />

--- a/src/pages/Overview/OverviewCardContentExpanded.tsx
+++ b/src/pages/Overview/OverviewCardContentExpanded.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { Text, TextVariants } from '@patternfly/react-core';
 
-import { DEGRADED, FAILURE, HEALTHY, UNDESIRED } from '../../types/Health';
+import { DEGRADED, FAILURE, HEALTHY, IDLE } from '../../types/Health';
 import OverviewStatus from './OverviewStatus';
 import { OverviewType } from './OverviewToolbar';
 import { NamespaceStatus } from './NamespaceInfo';
@@ -51,7 +51,7 @@ class OverviewCardContentExpanded extends React.Component<Props> {
       status.inWarning.length +
       status.inSuccess.length +
       status.notAvailable.length +
-      status.inUndesiredReplica.length;
+      status.inIdle.length;
     let text: string;
     if (nbItems === 1) {
       text = switchType(this.props.type, '1 Application', '1 Service', '1 Workload');
@@ -73,12 +73,12 @@ class OverviewCardContentExpanded extends React.Component<Props> {
         <OverviewCardBars status={this.props.status} />
         <div style={{ marginTop: -20, position: 'relative' }}>
           <Text component={TextVariants.h2} style={{ marginTop: 0 }}>
-            {status.inUndesiredReplica.length > 0 && (
+            {status.inIdle.length > 0 && (
               <OverviewStatus
                 id={name + '-undesired'}
                 namespace={name}
-                status={UNDESIRED}
-                items={status.inUndesiredReplica}
+                status={IDLE}
+                items={status.inIdle}
                 targetPage={targetPage}
               />
             )}

--- a/src/pages/Overview/OverviewCardContentExpanded.tsx
+++ b/src/pages/Overview/OverviewCardContentExpanded.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { Text, TextVariants } from '@patternfly/react-core';
 
-import { DEGRADED, FAILURE, HEALTHY } from '../../types/Health';
+import { DEGRADED, FAILURE, HEALTHY, UNDESIRED } from '../../types/Health';
 import OverviewStatus from './OverviewStatus';
 import { OverviewType } from './OverviewToolbar';
 import { NamespaceStatus } from './NamespaceInfo';
@@ -47,7 +47,11 @@ class OverviewCardContentExpanded extends React.Component<Props> {
     const name = this.props.name;
     const status = this.props.status;
     const nbItems =
-      status.inError.length + status.inWarning.length + status.inSuccess.length + status.notAvailable.length;
+      status.inError.length +
+      status.inWarning.length +
+      status.inSuccess.length +
+      status.notAvailable.length +
+      status.inUndesiredReplica.length;
     let text: string;
     if (nbItems === 1) {
       text = switchType(this.props.type, '1 Application', '1 Service', '1 Workload');
@@ -69,6 +73,15 @@ class OverviewCardContentExpanded extends React.Component<Props> {
         <OverviewCardBars status={this.props.status} />
         <div style={{ marginTop: -20, position: 'relative' }}>
           <Text component={TextVariants.h2} style={{ marginTop: 0 }}>
+            {status.inUndesiredReplica.length > 0 && (
+              <OverviewStatus
+                id={name + '-undesired'}
+                namespace={name}
+                status={UNDESIRED}
+                items={status.inUndesiredReplica}
+                targetPage={targetPage}
+              />
+            )}
             {status.inError.length > 0 && (
               <OverviewStatus
                 id={name + '-failure'}

--- a/src/pages/Overview/OverviewCardContentExpanded.tsx
+++ b/src/pages/Overview/OverviewCardContentExpanded.tsx
@@ -75,7 +75,7 @@ class OverviewCardContentExpanded extends React.Component<Props> {
           <Text component={TextVariants.h2} style={{ marginTop: 0 }}>
             {status.inIdle.length > 0 && (
               <OverviewStatus
-                id={name + '-undesired'}
+                id={name + '-iddle'}
                 namespace={name}
                 status={IDLE}
                 items={status.inIdle}

--- a/src/pages/Overview/OverviewPage.tsx
+++ b/src/pages/Overview/OverviewPage.tsx
@@ -25,7 +25,7 @@ import {
   FAILURE,
   Health,
   HEALTHY,
-  UNDESIRED,
+  IDLE,
   NamespaceAppHealth,
   NamespaceServiceHealth,
   NamespaceWorkloadHealth
@@ -216,7 +216,7 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
       .then(results => {
         results.forEach(result => {
           const nsStatus: NamespaceStatus = {
-            inUndesiredReplica: [],
+            inIdle: [],
             inError: [],
             inWarning: [],
             inSuccess: [],
@@ -231,8 +231,8 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
               nsStatus.inWarning.push(item);
             } else if (status === HEALTHY) {
               nsStatus.inSuccess.push(item);
-            } else if (status === UNDESIRED) {
-              nsStatus.inUndesiredReplica.push(item);
+            } else if (status === IDLE) {
+              nsStatus.inIdle.push(item);
             } else {
               nsStatus.notAvailable.push(item);
             }

--- a/src/pages/Overview/OverviewPage.tsx
+++ b/src/pages/Overview/OverviewPage.tsx
@@ -25,6 +25,7 @@ import {
   FAILURE,
   Health,
   HEALTHY,
+  UNDESIRED,
   NamespaceAppHealth,
   NamespaceServiceHealth,
   NamespaceWorkloadHealth
@@ -215,6 +216,7 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
       .then(results => {
         results.forEach(result => {
           const nsStatus: NamespaceStatus = {
+            inUndesiredReplica: [],
             inError: [],
             inWarning: [],
             inSuccess: [],
@@ -229,6 +231,8 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
               nsStatus.inWarning.push(item);
             } else if (status === HEALTHY) {
               nsStatus.inSuccess.push(item);
+            } else if (status === UNDESIRED) {
+              nsStatus.inUndesiredReplica.push(item);
             } else {
               nsStatus.notAvailable.push(item);
             }

--- a/src/types/Health.ts
+++ b/src/types/Health.ts
@@ -104,7 +104,7 @@ export const ratioCheck = (availableReplicas: number, currentReplicas: number, d
   /*
     IDLE STATE
  */
-  // User performed the action
+  // User has scaled down a workload, then desired replicas will be 0 and it's not an error condition
   if (desiredReplicas === 0) {
     return IDLE;
   }
@@ -112,6 +112,7 @@ export const ratioCheck = (availableReplicas: number, currentReplicas: number, d
   /*
    DEGRADED STATE
   */
+  // When a workload has available pods but less than desired defined by user it should be marked as degraded
   if (
     desiredReplicas > 0 &&
     currentReplicas > 0 &&
@@ -124,30 +125,13 @@ export const ratioCheck = (availableReplicas: number, currentReplicas: number, d
   /*
      FAILURE STATE
   */
-  if (desiredReplicas > 0 && (currentReplicas === 0 || availableReplicas === 0)) {
-    return FAILURE;
-  }
-
-  // Some pods are up but not ready
-  if (desiredReplicas > 0 && currentReplicas > 0 && availableReplicas === 0) {
-    return FAILURE;
-  }
-
-  if (desiredReplicas > 0 && currentReplicas < desiredReplicas) {
-    return FAILURE;
-  }
-
-  if (desiredReplicas === currentReplicas && availableReplicas > currentReplicas) {
+  // When availableReplicas is 0 but user has marked a desired > 0, that's an error condition
+  if (desiredReplicas > 0 && availableReplicas === 0) {
     return FAILURE;
   }
 
   // Pending Pods means problems
   if (desiredReplicas === availableReplicas && availableReplicas !== currentReplicas) {
-    return FAILURE;
-  }
-
-  // No available Pods when there are desired and current means a Failure
-  if (desiredReplicas > 0 && currentReplicas > 0 && availableReplicas === 0) {
     return FAILURE;
   }
 

--- a/src/types/Health.ts
+++ b/src/types/Health.ts
@@ -101,7 +101,7 @@ interface ThresholdStatus {
 const RATIO_NA = -1;
 
 export const ratioCheck = (availableReplicas: number, currentReplicas: number, desiredReplicas: number): Status => {
-  // No Pods returns No Health Info
+  // No Pods returns No Health
   if (desiredReplicas === 0 && currentReplicas === 0) {
     return NA;
   }
@@ -222,12 +222,8 @@ export class AppHealth extends Health {
     const items: HealthItem[] = [];
     {
       // Pods
-      let countInactive = 0;
       const children: HealthSubItem[] = workloadStatuses.map(d => {
         const status = ratioCheck(d.availableReplicas, d.currentReplicas, d.desiredReplicas);
-        if (status === NA) {
-          countInactive++;
-        }
         return {
           text: d.name + ': ' + d.availableReplicas + ' / ' + d.desiredReplicas,
           status: status
@@ -239,10 +235,6 @@ export class AppHealth extends Health {
         status: podsStatus,
         children: children
       };
-      if (countInactive > 0 && countInactive === workloadStatuses.length) {
-        // No active deployment => special case for failure
-        item.status = FAILURE;
-      }
       items.push(item);
     }
     // Request errors

--- a/src/types/Health.ts
+++ b/src/types/Health.ts
@@ -1,4 +1,10 @@
-import { CheckCircleIcon, ExclamationCircleIcon, ExclamationTriangleIcon, UnknownIcon } from '@patternfly/react-icons';
+import {
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+  ExclamationTriangleIcon,
+  MinusCircleIcon,
+  UnknownIcon
+} from '@patternfly/react-icons';
 import { IconType } from '@patternfly/react-icons/dist/js/createIcon';
 import { getName } from '../utils/RateIntervals';
 import { PFAlertColor, PfColors } from 'components/Pf/PfColors';
@@ -35,6 +41,14 @@ export interface Status {
   icon: IconType;
   class: string;
 }
+
+export const UNDESIRED: Status = {
+  name: 'Undesired Replica',
+  color: PFAlertColor.InfoBackground,
+  priority: 3,
+  icon: MinusCircleIcon,
+  class: 'icon-degraded'
+};
 
 export const FAILURE: Status = {
   name: 'Failure',
@@ -98,6 +112,10 @@ export const ratioCheck = (availableReplicas: number, currentReplicas: number, d
   // Pending Pods means problems
   if (desiredReplicas === availableReplicas && availableReplicas !== currentReplicas) {
     return FAILURE;
+  }
+  // Undesired Replica
+  if (currentReplicas < desiredReplicas) {
+    return UNDESIRED;
   }
   // Health condition
   if (desiredReplicas === currentReplicas && currentReplicas === availableReplicas) {

--- a/src/types/__tests__/Health.test.ts
+++ b/src/types/__tests__/Health.test.ts
@@ -11,7 +11,7 @@ describe('Health', () => {
     expect(H.ratioCheck(3, 3, 3)).toEqual(H.HEALTHY);
   });
   it('should check ratio with no item', () => {
-    expect(H.ratioCheck(0, 0, 0)).toEqual(H.NA);
+    expect(H.ratioCheck(0, 0, 0)).toEqual(H.IDLE);
   });
   it('should check ratio pending Pods', () => {
     // 3 Pods with problems
@@ -79,7 +79,7 @@ describe('Health', () => {
     );
     expect(health.getGlobalStatus()).toEqual(H.HEALTHY);
   });
-  it('should aggregate undesired workload', () => {
+  it('should aggregate idle workload', () => {
     const health = new H.AppHealth(
       [
         { availableReplicas: 1, currentReplicas: 1, desiredReplicas: 1, name: 'a' },
@@ -88,7 +88,7 @@ describe('Health', () => {
       { errorRatio: 0, inboundErrorRatio: 0, outboundErrorRatio: 0 },
       { rateInterval: 60, hasSidecar: true }
     );
-    expect(health.getGlobalStatus()).toEqual(H.UNDESIRED);
+    expect(health.getGlobalStatus()).toEqual(H.DEGRADED);
   });
   it('should aggregate failing requests', () => {
     const health = new H.AppHealth(

--- a/src/types/__tests__/Health.test.ts
+++ b/src/types/__tests__/Health.test.ts
@@ -79,7 +79,7 @@ describe('Health', () => {
     );
     expect(health.getGlobalStatus()).toEqual(H.HEALTHY);
   });
-  it('should aggregate degraded workload', () => {
+  it('should aggregate undesired workload', () => {
     const health = new H.AppHealth(
       [
         { availableReplicas: 1, currentReplicas: 1, desiredReplicas: 1, name: 'a' },
@@ -88,7 +88,7 @@ describe('Health', () => {
       { errorRatio: 0, inboundErrorRatio: 0, outboundErrorRatio: 0 },
       { rateInterval: 60, hasSidecar: true }
     );
-    expect(health.getGlobalStatus()).toEqual(H.DEGRADED);
+    expect(health.getGlobalStatus()).toEqual(H.UNDESIRED);
   });
   it('should aggregate failing requests', () => {
     const health = new H.AppHealth(


### PR DESCRIPTION
Fix https://github.com/kiali/kiali/issues/2049

The idea is show resources undesired replica
![Screenshot from 2020-04-07 14-40-39](https://user-images.githubusercontent.com/3019213/78670452-0f1f3e00-78de-11ea-9995-108e629b0e15.png)
