### PR TITLE
Graph toolbar use custom secondary masthead

### DIFF
--- a/src/components/Nav/SecondaryMasthead.tsx
+++ b/src/components/Nav/SecondaryMasthead.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { style } from 'typestyle';
 
-const paddingStyle = style({
+const marginStyle = style({
   margin: '10px 20px 0 0'
 });
 const secondaryMastheadStyle = style({
@@ -22,7 +22,7 @@ export default class SecondaryMasthead extends React.Component<{ title: boolean 
         id="global-namespace-selector"
         className={`container-fluid ${secondaryMastheadStyle} ${secondaryMastheadStyleHeight}`}
       >
-        <div className={paddingStyle}>{this.props.children}</div>
+        <div className={marginStyle}>{this.props.children}</div>
       </div>
     );
   }

--- a/src/pages/Graph/GraphHelpFind.tsx
+++ b/src/pages/Graph/GraphHelpFind.tsx
@@ -10,6 +10,12 @@ export interface GraphHelpFindProps {
   className?: string;
 }
 
+const tabFont: React.CSSProperties = {
+  fontSize: '14px'
+};
+
+const contentWidth = '540px';
+
 export default class GraphHelpFind extends React.Component<GraphHelpFindProps> {
   private onResize = () => {
     this.forceUpdate();
@@ -30,10 +36,11 @@ export default class GraphHelpFind extends React.Component<GraphHelpFindProps> {
       fontSize: '12px',
       color: '#fff',
       backgroundColor: '#003145',
-      width: '540px',
+      width: contentWidth,
       height: '71px',
       padding: '5px',
-      resize: 'none'
+      resize: 'none',
+      overflowY: 'hidden'
     });
     const preface =
       'You can use the Find and Hide fields to highlight or hide graph edges and nodes. Each field accepts ' +
@@ -62,10 +69,10 @@ export default class GraphHelpFind extends React.Component<GraphHelpFindProps> {
             </div>
           }
           bodyContent={
-            <div>
+            <>
               <textarea className={`${prefaceStyle}`} readOnly={true} value={preface} />
-              <SimpleTabs id="graph_find_help_tabs" defaultTab={0}>
-                <Tab eventKey={0} title="Usage Notes">
+              <SimpleTabs id="graph_find_help_tabs" defaultTab={0} style={{ width: contentWidth }}>
+                <Tab style={tabFont} eventKey={0} title="Usage Notes">
                   <Table
                     header={<></>}
                     variant={TableVariant.compact}
@@ -76,7 +83,7 @@ export default class GraphHelpFind extends React.Component<GraphHelpFindProps> {
                     <TableBody />
                   </Table>
                 </Tab>
-                <Tab eventKey={1} title="Operators">
+                <Tab style={tabFont} eventKey={1} title="Operators">
                   <Table
                     header={<></>}
                     variant={TableVariant.compact}
@@ -87,7 +94,7 @@ export default class GraphHelpFind extends React.Component<GraphHelpFindProps> {
                     <TableBody />
                   </Table>
                 </Tab>
-                <Tab eventKey={2} title="Nodes">
+                <Tab style={tabFont} eventKey={2} title="Nodes">
                   <Table
                     header={<></>}
                     variant={TableVariant.compact}
@@ -98,7 +105,7 @@ export default class GraphHelpFind extends React.Component<GraphHelpFindProps> {
                     <TableBody />
                   </Table>
                 </Tab>
-                <Tab eventKey={3} title="Edges">
+                <Tab style={tabFont} eventKey={3} title="Edges">
                   <Table
                     header={<></>}
                     variant={TableVariant.compact}
@@ -109,7 +116,7 @@ export default class GraphHelpFind extends React.Component<GraphHelpFindProps> {
                     <TableBody />
                   </Table>
                 </Tab>
-                <Tab eventKey={4} title="Examples">
+                <Tab style={tabFont} eventKey={4} title="Examples">
                   <Table
                     header={<></>}
                     variant={TableVariant.compact}
@@ -121,7 +128,7 @@ export default class GraphHelpFind extends React.Component<GraphHelpFindProps> {
                   </Table>
                 </Tab>
               </SimpleTabs>
-            </div>
+            </>
           }
         >
           <>{this.props.children}</>

--- a/src/pages/Graph/GraphToolbar/GraphFind.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphFind.tsx
@@ -165,13 +165,13 @@ export class GraphFind extends React.PureComponent<GraphFindProps, GraphFindStat
             {this.props.showFindHelp ? (
               <GraphHelpFind onClose={this.toggleFindHelp}>
                 <Button variant={ButtonVariant.link} style={{ paddingLeft: '6px' }} onClick={this.toggleFindHelp}>
-                  <KialiIcon.Help className={defaultIconStyle} />
+                  <KialiIcon.Info className={defaultIconStyle} />
                 </Button>
               </GraphHelpFind>
             ) : (
               <Tooltip key={'ot_graph_find_help'} position="top" content="Find/Hide Help...">
                 <Button variant={ButtonVariant.link} style={{ paddingLeft: '6px' }} onClick={this.toggleFindHelp}>
-                  <KialiIcon.Help className={defaultIconStyle} />
+                  <KialiIcon.Info className={defaultIconStyle} />
                 </Button>
               </Tooltip>
             )}

--- a/src/pages/Graph/GraphToolbar/GraphSecondaryMasthead.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphSecondaryMasthead.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { Tooltip, TooltipPosition, Button } from '@patternfly/react-core';
+import { KialiIcon, defaultIconStyle } from 'config/KialiIcon';
+import SecondaryMasthead from 'components/Nav/SecondaryMasthead';
+import NamespaceDropdownContainer from 'components/NamespaceDropdown';
+import { style } from 'typestyle';
+import TourStopContainer from 'components/Tour/TourStop';
+import { GraphTourStops } from '../GraphHelpTour';
+import ToolbarDropdown from 'components/ToolbarDropdown/ToolbarDropdown';
+import { GraphType } from 'types/Graph';
+import * as _ from 'lodash';
+
+type GraphSecondaryMastheadProps = {
+  disabled: boolean;
+  graphType: GraphType;
+
+  onToggleHelp: () => void;
+  onGraphTypeChange: (graphType: GraphType) => void;
+};
+
+const mastheadStyle = style({
+  marginLeft: '-20px',
+  marginRight: '-40px'
+});
+
+const leftSpacerStyle = style({
+  marginLeft: '10px'
+});
+
+const rightToolbarStyle = style({
+  float: 'right'
+});
+
+/**
+ *  Key-value pair object representation of GraphType enum.  Values are human-readable versions of enum keys.
+ *
+ *  Example:  GraphType => {'APP': 'App', 'VERSIONED_APP': 'VersionedApp'}
+ */
+const GRAPH_TYPES = _.mapValues(GraphType, val => `${_.capitalize(_.startCase(val))} graph`);
+
+export default class GraphSecondaryMasthead extends React.PureComponent<GraphSecondaryMastheadProps> {
+  render() {
+    const graphTypeKey: string = _.findKey(GraphType, val => val === this.props.graphType)!;
+
+    return (
+      <SecondaryMasthead title={false}>
+        <div className={mastheadStyle}>
+          <NamespaceDropdownContainer disabled={false} />
+          <TourStopContainer info={GraphTourStops.GraphType}>
+            <span className={leftSpacerStyle}>
+              <ToolbarDropdown
+                id={'graph_filter_view_type'}
+                disabled={this.props.disabled}
+                handleSelect={this.setGraphType}
+                value={graphTypeKey}
+                label={GRAPH_TYPES[graphTypeKey]}
+                options={GRAPH_TYPES}
+              />
+            </span>
+          </TourStopContainer>
+          <Tooltip key={'graph-tour-help-ot'} position={TooltipPosition.right} content="Graph help tour...">
+            <Button
+              className={rightToolbarStyle}
+              variant="link"
+              style={{ paddingLeft: '6px', paddingRight: '0px' }}
+              onClick={this.props.onToggleHelp}
+            >
+              <KialiIcon.Help className={defaultIconStyle} />
+              {' Graph tour'}
+            </Button>
+          </Tooltip>
+        </div>
+      </SecondaryMasthead>
+    );
+  }
+
+  private setGraphType = (type: string) => {
+    const graphType: GraphType = GraphType[type] as GraphType;
+    if (this.props.graphType !== graphType) {
+      this.props.onGraphTypeChange(graphType);
+    }
+  };
+}

--- a/src/pages/Graph/GraphToolbar/GraphSecondaryMasthead.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphSecondaryMasthead.tsx
@@ -27,6 +27,13 @@ const leftSpacerStyle = style({
   marginLeft: '10px'
 });
 
+const vrStyle = style({
+  border: '1px inset',
+  height: '20px',
+  margin: '4px 0 0 10px',
+  width: '1px'
+});
+
 const rightToolbarStyle = style({
   float: 'right'
 });
@@ -46,6 +53,7 @@ export default class GraphSecondaryMasthead extends React.PureComponent<GraphSec
       <SecondaryMasthead title={false}>
         <div className={mastheadStyle}>
           <NamespaceDropdownContainer disabled={false} />
+          <span className={vrStyle} />
           <TourStopContainer info={GraphTourStops.GraphType}>
             <span className={leftSpacerStyle}>
               <ToolbarDropdown

--- a/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
@@ -18,7 +18,6 @@ import { GraphType, NodeParamsType, EdgeLabelMode } from '../../../types/Graph';
 import GraphFindContainer from './GraphFind';
 import GraphSettingsContainer from './GraphSettings';
 import history, { HistoryManager, URLParam } from '../../../app/History';
-import { ToolbarDropdown } from '../../../components/ToolbarDropdown/ToolbarDropdown';
 import Namespace, { namespacesFromString, namespacesToString } from '../../../types/Namespace';
 import { NamespaceActions } from '../../../actions/NamespaceAction';
 import { GraphActions } from '../../../actions/GraphActions';
@@ -29,6 +28,7 @@ import TimeControlsContainer from 'components/Time/TimeControls';
 import { KialiIcon, defaultIconStyle } from 'config/KialiIcon';
 import ReplayContainer from 'components/Time/Replay';
 import { UserSettingsActions } from 'actions/UserSettingsActions';
+import GraphSecondaryMasthead from './GraphSecondaryMasthead';
 
 type ReduxProps = {
   activeNamespaces: Namespace[];
@@ -48,8 +48,8 @@ type ReduxProps = {
 
 type GraphToolbarProps = ReduxProps & {
   disabled: boolean;
-  onRefresh?: () => void;
   onToggleHelp: () => void;
+  onRefresh?: () => void;
 };
 
 const toolbarStyle = style({
@@ -61,18 +61,7 @@ const rightToolbarStyle = style({
   marginLeft: 'auto'
 });
 
-const leftSpacerStyle = style({
-  marginLeft: '10px'
-});
-
 export class GraphToolbar extends React.PureComponent<GraphToolbarProps> {
-  /**
-   *  Key-value pair object representation of GraphType enum.  Values are human-readable versions of enum keys.
-   *
-   *  Example:  GraphType => {'APP': 'App', 'VERSIONED_APP': 'VersionedApp'}
-   */
-  static readonly GRAPH_TYPES = _.mapValues(GraphType, val => `${_.capitalize(_.startCase(val))} graph`);
-
   /**
    *  Key-value pair object representation of EdgeLabelMode
    *
@@ -159,48 +148,27 @@ export class GraphToolbar extends React.PureComponent<GraphToolbarProps> {
     history.push('/graph/namespaces');
   };
 
-  // TODO [jshaughn] Is there a better typescript way than the style attribute with the spread syntax (here and other places)
   render() {
-    const graphTypeKey: string = _.findKey(GraphType, val => val === this.props.graphType)!;
-
     return (
       <>
+        <GraphSecondaryMasthead
+          disabled={this.props.disabled}
+          graphType={this.props.graphType}
+          onToggleHelp={this.props.onToggleHelp}
+          onGraphTypeChange={this.props.setGraphType}
+        />
         <Toolbar className={toolbarStyle}>
           <div style={{ display: 'flex' }}>
-            {this.props.node ? (
+            {this.props.node && (
               <Tooltip key={'graph-tour-help-ot'} position={TooltipPosition.right} content={'Back to full graph'}>
                 <Button variant={ButtonVariant.link} onClick={this.handleNamespaceReturn}>
                   <KialiIcon.Back className={defaultIconStyle} />
                 </Button>
               </Tooltip>
-            ) : (
-              <>
-                <TourStopContainer info={GraphTourStops.GraphType}>
-                  <ToolbarDropdown
-                    id={'graph_filter_view_type'}
-                    disabled={this.props.disabled}
-                    handleSelect={this.setGraphType}
-                    value={graphTypeKey}
-                    label={GraphToolbar.GRAPH_TYPES[graphTypeKey]}
-                    options={GraphToolbar.GRAPH_TYPES}
-                  />
-                </TourStopContainer>
-                <Tooltip key={'graph-tour-help-ot'} position={TooltipPosition.right} content="Graph help tour...">
-                  <Button
-                    variant="link"
-                    style={{ paddingLeft: '6px', paddingRight: '0px' }}
-                    onClick={this.props.onToggleHelp}
-                  >
-                    <KialiIcon.Help className={defaultIconStyle} />
-                  </Button>
-                </Tooltip>
-              </>
             )}
-            <div className={leftSpacerStyle}>
-              <TourStopContainer info={GraphTourStops.Display}>
-                <GraphSettingsContainer graphType={this.props.graphType} />
-              </TourStopContainer>
-            </div>
+            <TourStopContainer info={GraphTourStops.Display}>
+              <GraphSettingsContainer graphType={this.props.graphType} />
+            </TourStopContainer>
           </div>
           <GraphFindContainer />
           <ToolbarGroup className={rightToolbarStyle} aria-label="graph_refresh_toolbar">
@@ -218,13 +186,6 @@ export class GraphToolbar extends React.PureComponent<GraphToolbarProps> {
       </>
     );
   }
-
-  private setGraphType = (type: string) => {
-    const graphType: GraphType = GraphType[type] as GraphType;
-    if (this.props.graphType !== graphType) {
-      this.props.setGraphType(graphType);
-    }
-  };
 }
 
 const mapStateToProps = (state: KialiAppState) => ({

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -148,10 +148,6 @@ const pathRoutes: Path[] = [
 
 const secondaryMastheadRoutes: Path[] = [
   {
-    path: '/graph/namespaces',
-    component: DefaultSecondaryMasthead
-  },
-  {
     path: '/' + Paths.APPLICATIONS,
     component: DefaultSecondaryMasthead
   },


### PR DESCRIPTION
A custom secondary masthead allows us to move some things around for a more balanced use of space and less overall width required.

Also includes:
- change to info icon for graph find help
- a couple of small tweaks to the find help popover to remove scrollbar in preface and arrow on tabs

Fixes https://github.com/kiali/kiali/issues/2620