### PR TITLE
Better font sizing and positioning in Overview page

### DIFF
--- a/src/pages/Overview/OverviewCardContentExpanded.tsx
+++ b/src/pages/Overview/OverviewCardContentExpanded.tsx
@@ -59,7 +59,7 @@ class OverviewCardContentExpanded extends React.Component<Props> {
       return (
         <>
           {mainLink}
-          <Text component={TextVariants.h2}>N/A</Text>
+          <Text style={{ marginTop: '20px' }}>N/A</Text>
         </>
       );
     }

--- a/src/pages/Overview/OverviewCardSparkline.tsx
+++ b/src/pages/Overview/OverviewCardSparkline.tsx
@@ -35,7 +35,7 @@ class OverviewCardSparkline extends React.Component<Props, {}> {
         </>
       );
     }
-    return <div style={{ marginTop: 20 }}>No traffic</div>;
+    return <div style={{ marginTop: '40px' }}>No traffic</div>;
   }
 }
 


### PR DESCRIPTION
* Change the size of "N/A" indicator to match "No traffic" size (expanded/list views)
* Position "N/A" and "No traffic" in the middle of the card (expanded/list views)

Fixes kiali/kiali#2331

**Expanded view / BEFORE**
![image](https://user-images.githubusercontent.com/23639005/79147495-a296ba00-7d89-11ea-9f69-10992d444393.png)

**Expanded view / AFTER**
![image](https://user-images.githubusercontent.com/23639005/79147450-901c8080-7d89-11ea-819c-40ee9c765fe4.png)

**List view / BEFORE**
![image](https://user-images.githubusercontent.com/23639005/79147537-b510f380-7d89-11ea-9d06-c5e9bc0b9425.png)

**List view / AFTER**
![image](https://user-images.githubusercontent.com/23639005/79147560-be9a5b80-7d89-11ea-9088-8ac467e4794f.png)
