### PR TITLE
Split the workload logging tab  into pod logs and container logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "json-beautify": "1.0.1",
     "lodash": "4.17.15",
     "logfmt": "1.2.1",
+    "m-react-splitters": "1.2.0",
     "moment": "2.24.0",
     "react": "16.9.0",
     "react-ace": "6.4.0",

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
@@ -46,13 +46,17 @@ const TailLinesOptions = {
   '5000': 'Last 5000 lines'
 };
 
-const logsDiv = style({
+const appLogsDiv = style({
+  height: 'calc(100% + 30px)'
+});
+
+const proxyLogsDiv = style({
   height: '100%'
 });
 
 const logsTextarea = style({
   width: '100%',
-  height: 'calc(100% - 80px)',
+  height: 'calc(100% - 70px)',
   overflow: 'auto',
   resize: 'none',
   color: '#fff',
@@ -203,7 +207,7 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
                     dispatchResize={true}
                     postPoned={true}
                   >
-                    <div className={logsDiv}>
+                    <div className={appLogsDiv}>
                       <Title size="lg" headingLevel="h5">
                         {this.formatAppLogLabel(this.props.pods[this.state.podValue!])} Logs
                       </Title>
@@ -214,7 +218,7 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
                         aria-label="Pod logs text"
                       />
                     </div>
-                    <div className={logsDiv}>
+                    <div className={proxyLogsDiv}>
                       <Title size="lg" headingLevel="h5">
                         Proxy Logs
                       </Title>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7964,6 +7964,14 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+m-react-splitters@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/m-react-splitters/-/m-react-splitters-1.2.0.tgz#75babeac9093ca63dd83c58bf5bdccfb88e6af5e"
+  integrity sha512-w6zftbSImtRH5NcbbZFNBnziTJC5iG3hDo5oF1GYRAnbYCsDCEMLCHeJZG3X/6Bhy6fz1RJ+sZcvMSmY5pZkqQ==
+  dependencies:
+    react "^16.4.2"
+    react-dom "^16.4.2"
+
 macos-release@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.3.0.tgz#eb1930b036c0800adebccd5f17bc4c12de8bb71f"
@@ -10555,6 +10563,16 @@ react-dom@16.9.0:
     prop-types "^15.6.2"
     scheduler "^0.15.0"
 
+react-dom@^16.4.2:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
+  integrity sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.19.1"
+
 react-dropzone@9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-9.0.0.tgz#4f5223cdcb4d3bd8a66e3298c4041eb0c75c4634"
@@ -10789,6 +10807,15 @@ react@16.9.0:
   version "16.9.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.9.0.tgz#40ba2f9af13bc1a38d75dbf2f4359a5185c4f7aa"
   integrity sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+
+react@^16.4.2:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
+  integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -11437,6 +11464,14 @@ scheduler@^0.18.0:
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.18.0.tgz#5901ad6659bc1d8f3fdaf36eb7a67b0d6746b1c4"
   integrity sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
+scheduler@^0.19.1:
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
+  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
Split the workload tab into pod logs and container logs sections. This eliminated the container selection dropdown as well.

Before:

![Kiali_Console](https://user-images.githubusercontent.com/1312165/79398765-458c3700-7f36-11ea-8b01-601f7642410e.png)

After:

![splitter](https://user-images.githubusercontent.com/1312165/79515025-67e88800-7ffc-11ea-8d0d-faa1fd21299c.gif)


** Issue reference **
closes https://github.com/kiali/kiali/issues/2203
