### PR TITLE
Add AuthorizationPolicy form

### DIFF
--- a/src/components/IstioWizards/IstioWizardActions.ts
+++ b/src/components/IstioWizards/IstioWizardActions.ts
@@ -4,6 +4,8 @@ import { WorkloadWeight } from './WeightedRouting';
 import { Rule } from './MatchingRouting/Rules';
 import { SuspendedRoute } from './SuspendTraffic';
 import {
+  AuthorizationPolicy,
+  AuthorizationPolicyRule,
   DestinationRule,
   DestinationRules,
   DestinationWeight,
@@ -11,10 +13,13 @@ import {
   HTTPMatchRequest,
   HTTPRoute,
   LoadBalancerSettings,
+  Operation,
   Sidecar,
+  Source,
   StringMatch,
   VirtualService,
-  VirtualServices
+  VirtualServices,
+  WorkloadSelector
 } from '../../types/IstioObjects';
 import { serverConfig } from '../../config';
 import { ThreeScaleServiceRule } from '../../types/ThreeScale';
@@ -22,6 +27,7 @@ import { GatewaySelectorState } from './GatewaySelector';
 import { ConsistentHashType, MUTUAL, TrafficPolicyState } from './TrafficPolicy';
 import { GatewayState } from '../../pages/IstioConfigNew/GatewayForm';
 import { SidecarState } from '../../pages/IstioConfigNew/SidecarForm';
+import { AuthorizationPolicyState } from '../../pages/IstioConfigNew/AuthorizationPolicyForm';
 
 export const WIZARD_WEIGHTED_ROUTING = 'weighted_routing';
 export const WIZARD_MATCHING_ROUTING = 'matching_routing';
@@ -635,6 +641,91 @@ export const getInitGateway = (virtualServices: VirtualServices): [string, boole
     return [selectedGateway, meshPresent];
   }
   return ['', false];
+};
+
+export const buildAuthorizationPolicy = (
+  name: string,
+  namespace: string,
+  state: AuthorizationPolicyState
+): AuthorizationPolicy => {
+  const ap: AuthorizationPolicy = {
+    metadata: {
+      name: name,
+      namespace: namespace,
+      labels: {
+        [KIALI_WIZARD_LABEL]: 'AuthorizationPolicy'
+      }
+    },
+    spec: {}
+  };
+
+  console.log('TODELETE state');
+  console.log(state);
+
+  // DENY_ALL and ALLOW_ALL are two specific cases
+  if (state.policy === 'DENY_ALL') {
+    return ap;
+  }
+
+  if (state.policy === 'ALLOW_ALL') {
+    ap.spec.rules = [{}];
+    console.log('TODELETE ap');
+    console.log(ap);
+    return ap;
+  }
+
+  // RULES use case
+  if (state.workloadSelector.length > 0) {
+    const workloadSelector: WorkloadSelector = {
+      labels: {}
+    };
+    state.workloadSelector.split(',').forEach(label => {
+      label = label.trim();
+      const labelDetails = label.split('=');
+      if (labelDetails.length === 2) {
+        workloadSelector.labels[labelDetails[0]] = labelDetails[1];
+      }
+    });
+    ap.spec.selector = workloadSelector;
+  }
+
+  if (state.rules.length > 0) {
+    ap.spec.rules = [];
+    state.rules.forEach(rule => {
+      const apRule: AuthorizationPolicyRule = {
+        from: rule.from.map(fromItem => {
+          const source: Source = {};
+          Object.keys(fromItem).forEach(key => {
+            source[key] = fromItem[key];
+          });
+          return {
+            source: source
+          };
+        }),
+        to: rule.to.map(toItem => {
+          const operation: Operation = {};
+          Object.keys(toItem).forEach(key => {
+            operation[key] = operation[key];
+          });
+          return {
+            operation: operation
+          };
+        }),
+        when: rule.when.map(condition => {
+          return {
+            key: condition.key,
+            values: condition.values,
+            notValues: condition.notValues
+          };
+        })
+      };
+      ap.spec.rules!.push(apRule);
+    });
+  }
+  if (state.action.length > 0) {
+    ap.spec.action = state.action;
+  }
+  return ap;
 };
 
 export const buildGateway = (name: string, namespace: string, state: GatewayState): Gateway => {

--- a/src/components/IstioWizards/IstioWizardActions.ts
+++ b/src/components/IstioWizards/IstioWizardActions.ts
@@ -660,9 +660,6 @@ export const buildAuthorizationPolicy = (
     spec: {}
   };
 
-  console.log('TODELETE state');
-  console.log(state);
-
   // DENY_ALL and ALLOW_ALL are two specific cases
   if (state.policy === 'DENY_ALL') {
     return ap;
@@ -738,10 +735,6 @@ export const buildAuthorizationPolicy = (
   if (state.action.length > 0) {
     ap.spec.action = state.action;
   }
-
-  console.log('TODELETE ap');
-  console.log(ap);
-
   return ap;
 };
 

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm.tsx
@@ -61,9 +61,12 @@ class AuthorizationPolicyForm extends React.Component<Props, State> {
   }
 
   onRulesFormChange = (value, _) => {
-    this.setState({
-      rulesForm: value
-    });
+    this.setState(
+      {
+        rulesForm: value
+      },
+      () => this.onAuthorizationChange()
+    );
   };
 
   addWorkloadLabels = (value: string, _) => {
@@ -94,34 +97,56 @@ class AuthorizationPolicyForm extends React.Component<Props, State> {
         break;
       }
     }
-    this.setState({
-      workloadSelectorValid: isValid,
-      workloadSelectorLabels: value
-    });
+    this.setState(
+      {
+        workloadSelectorValid: isValid,
+        workloadSelectorLabels: value
+      },
+      () => this.onAuthorizationChange()
+    );
   };
 
   onActionChange = (value, _) => {
-    this.setState({
-      action: value
-    });
+    this.setState(
+      {
+        action: value
+      },
+      () => this.onAuthorizationChange()
+    );
   };
 
   onAddRule = (rule: Rule) => {
-    this.setState(prevState => {
-      prevState.rules.push(rule);
-      return {
-        rules: prevState.rules
-      };
-    });
+    this.setState(
+      prevState => {
+        prevState.rules.push(rule);
+        return {
+          rules: prevState.rules
+        };
+      },
+      () => this.onAuthorizationChange()
+    );
   };
 
   onRemoveRule = (index: number) => {
-    this.setState(prevState => {
-      prevState.rules.splice(index, 1);
-      return {
-        rules: prevState.rules
-      };
-    });
+    this.setState(
+      prevState => {
+        prevState.rules.splice(index, 1);
+        return {
+          rules: prevState.rules
+        };
+      },
+      () => this.onAuthorizationChange()
+    );
+  };
+
+  onAuthorizationChange = () => {
+    const authorizationPolicy: AuthorizationPolicyState = {
+      policy: this.state.rulesForm,
+      workloadSelector: this.state.workloadSelectorLabels,
+      action: this.state.action,
+      rules: this.state.rules
+    };
+    this.props.onChange(authorizationPolicy);
   };
 
   render() {

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+
+type Props = {};
+
+type State = {};
+
+class AuthorizationPolicyForm extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+  }
+
+  render() {
+    return <>Here we will create the AuthorizationPolicy form</>;
+  }
+}
+
+export default AuthorizationPolicyForm;

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm.tsx
@@ -1,16 +1,148 @@
 import * as React from 'react';
+import { FormGroup, FormSelect, FormSelectOption, Switch, TextInput } from '@patternfly/react-core';
+import RuleBuilder from './AuthorizationPolicyForm/RuleBuilder';
+import RuleList from './AuthorizationPolicyForm/RuleList';
 
 type Props = {};
 
-type State = {};
+type State = {
+  // Used to identify DENY_ALL, ALLOW_ALL or RULES
+  rulesForm: string;
+  addWorkloadSelector: boolean;
+  workloadSelectorValid: boolean;
+  workloadSelectorLabels: string;
+  action: string;
+};
+
+const DENY_ALL = 'DENY_ALL';
+const ALLOW_ALL = 'ALLOW_ALL';
+const RULES = 'RULES';
+const ALLOW = 'ALLOW';
+const DENY = 'DENY';
+
+const HELPER_TEXT = {
+  DENY_ALL: 'Denies all requests to workloads in given namespace(s)',
+  ALLOW_ALL: 'Allows all requests to workloads in given namespace(s)',
+  RULES: 'Builds an Authorization Policy based on Rules'
+};
+
+const rulesFormValues = [DENY_ALL, ALLOW_ALL, RULES];
+const actions = [ALLOW, DENY];
 
 class AuthorizationPolicyForm extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
+    this.state = {
+      rulesForm: DENY_ALL,
+      addWorkloadSelector: false,
+      workloadSelectorValid: false,
+      workloadSelectorLabels: '',
+      action: ALLOW
+    };
   }
 
+  onRulesFormChange = (value, _) => {
+    this.setState({
+      rulesForm: value
+    });
+  };
+
+  addWorkloadLabels = (value: string, _) => {
+    if (value.length === 0) {
+      this.setState({
+        workloadSelectorValid: false,
+        workloadSelectorLabels: ''
+      });
+      return;
+    }
+    value = value.trim();
+    const labels: string[] = value.split(',');
+    let isValid = true;
+    // Some smoke validation rules for the labels
+    for (let i = 0; i < labels.length; i++) {
+      const label = labels[i];
+      if (label.indexOf('=') < 0) {
+        isValid = false;
+        break;
+      }
+      const splitLabel: string[] = label.split('=');
+      if (splitLabel.length !== 2) {
+        isValid = false;
+        break;
+      }
+      if (splitLabel[0].trim().length === 0 || splitLabel[1].trim().length === 0) {
+        isValid = false;
+        break;
+      }
+    }
+    this.setState({
+      workloadSelectorValid: isValid,
+      workloadSelectorLabels: value
+    });
+  };
+
+  onActionChange = (value, _) => {
+    this.setState({
+      action: value
+    });
+  };
+
   render() {
-    return <>Here we will create the AuthorizationPolicy form</>;
+    return (
+      <>
+        <FormGroup label="Policy" fieldId="rules-form" helperText={HELPER_TEXT[this.state.rulesForm]}>
+          <FormSelect value={this.state.rulesForm} onChange={this.onRulesFormChange} id="rules-form" name="rules-form">
+            {rulesFormValues.map((option, index) => (
+              <FormSelectOption key={index} value={option} label={option} />
+            ))}
+          </FormSelect>
+        </FormGroup>
+        {this.state.rulesForm === RULES && (
+          <FormGroup label="Add Workload Selector" fieldId="workloadSelectorSwitch">
+            <Switch
+              id="workloadSelectorSwitch"
+              label={' '}
+              labelOff={' '}
+              isChecked={this.state.addWorkloadSelector}
+              onChange={() => {
+                this.setState(prevState => ({
+                  addWorkloadSelector: !prevState.addWorkloadSelector
+                }));
+              }}
+            />
+          </FormGroup>
+        )}
+        {this.state.addWorkloadSelector && (
+          <FormGroup
+            fieldId="workloadLabels"
+            label="Labels"
+            helperText="One or more labels to select a workload where AuthorizationPolicy is applied. Enter a label in the format <label>=<value>. Enter one or multiple labels separated by comma."
+            helperTextInvalid="Invalid labels format: One or more labels to select a workload where AuthorizationPolicy is applied. Enter a label in the format <label>=<value>. Enter one or multiple labels separated by comma."
+            isValid={this.state.workloadSelectorValid}
+          >
+            <TextInput
+              id="gwHosts"
+              name="gwHosts"
+              isDisabled={!this.state.addWorkloadSelector}
+              value={this.state.workloadSelectorLabels}
+              onChange={this.addWorkloadLabels}
+              isValid={this.state.workloadSelectorValid}
+            />
+          </FormGroup>
+        )}
+        {this.state.rulesForm === RULES && (
+          <FormGroup label="Action" fieldId="action-form">
+            <FormSelect value={this.state.action} onChange={this.onActionChange} id="action-form" name="action-form">
+              {actions.map((option, index) => (
+                <FormSelectOption key={index} value={option} label={option} />
+              ))}
+            </FormSelect>
+          </FormGroup>
+        )}
+        {this.state.rulesForm === RULES && <RuleBuilder />}
+        {this.state.rulesForm === RULES && <RuleList />}
+      </>
+    );
   }
 }
 

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm.tsx
@@ -1,9 +1,19 @@
 import * as React from 'react';
 import { FormGroup, FormSelect, FormSelectOption, Switch, TextInput } from '@patternfly/react-core';
-import RuleBuilder from './AuthorizationPolicyForm/RuleBuilder';
+import RuleBuilder, { Rule } from './AuthorizationPolicyForm/RuleBuilder';
 import RuleList from './AuthorizationPolicyForm/RuleList';
 
-type Props = {};
+type Props = {
+  authorizationPolicy: AuthorizationPolicyState;
+  onChange: (authorizationPolicy: AuthorizationPolicyState) => void;
+};
+
+export type AuthorizationPolicyState = {
+  policy: string;
+  workloadSelector: string;
+  action: string;
+  rules: Rule[];
+};
 
 type State = {
   // Used to identify DENY_ALL, ALLOW_ALL or RULES
@@ -12,6 +22,7 @@ type State = {
   workloadSelectorValid: boolean;
   workloadSelectorLabels: string;
   action: string;
+  rules: Rule[];
 };
 
 const DENY_ALL = 'DENY_ALL';
@@ -29,15 +40,23 @@ const HELPER_TEXT = {
 const rulesFormValues = [DENY_ALL, ALLOW_ALL, RULES];
 const actions = [ALLOW, DENY];
 
+export const INIT_AUTHORIZATION_POLICY: AuthorizationPolicyState = {
+  policy: DENY_ALL,
+  workloadSelector: '',
+  action: ALLOW,
+  rules: []
+};
+
 class AuthorizationPolicyForm extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {
-      rulesForm: DENY_ALL,
+      rulesForm: this.props.authorizationPolicy.policy,
       addWorkloadSelector: false,
       workloadSelectorValid: false,
-      workloadSelectorLabels: '',
-      action: ALLOW
+      workloadSelectorLabels: this.props.authorizationPolicy.workloadSelector,
+      action: this.props.authorizationPolicy.action,
+      rules: []
     };
   }
 
@@ -84,6 +103,24 @@ class AuthorizationPolicyForm extends React.Component<Props, State> {
   onActionChange = (value, _) => {
     this.setState({
       action: value
+    });
+  };
+
+  onAddRule = (rule: Rule) => {
+    this.setState(prevState => {
+      prevState.rules.push(rule);
+      return {
+        rules: prevState.rules
+      };
+    });
+  };
+
+  onRemoveRule = (index: number) => {
+    this.setState(prevState => {
+      prevState.rules.splice(index, 1);
+      return {
+        rules: prevState.rules
+      };
     });
   };
 
@@ -139,8 +176,8 @@ class AuthorizationPolicyForm extends React.Component<Props, State> {
             </FormSelect>
           </FormGroup>
         )}
-        {this.state.rulesForm === RULES && <RuleBuilder />}
-        {this.state.rulesForm === RULES && <RuleList />}
+        {this.state.rulesForm === RULES && <RuleBuilder onAddRule={this.onAddRule} />}
+        {this.state.rulesForm === RULES && <RuleList ruleList={this.state.rules} onRemoveRule={this.onRemoveRule} />}
       </>
     );
   }

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FormGroup, FormSelect, FormSelectOption, Switch, TextInput } from '@patternfly/react-core';
+import { FormGroup, FormSelect, FormSelectOption, Switch, TextInputBase as TextInput } from '@patternfly/react-core';
 import RuleBuilder, { Rule } from './AuthorizationPolicyForm/RuleBuilder';
 import RuleList from './AuthorizationPolicyForm/RuleList';
 

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm.tsx
@@ -40,12 +40,12 @@ const HELPER_TEXT = {
 const rulesFormValues = [DENY_ALL, ALLOW_ALL, RULES];
 const actions = [ALLOW, DENY];
 
-export const INIT_AUTHORIZATION_POLICY: AuthorizationPolicyState = {
+export const INIT_AUTHORIZATION_POLICY = (): AuthorizationPolicyState => ({
   policy: DENY_ALL,
   workloadSelector: '',
   action: ALLOW,
   rules: []
-};
+});
 
 class AuthorizationPolicyForm extends React.Component<Props, State> {
   constructor(props: Props) {
@@ -58,6 +58,17 @@ class AuthorizationPolicyForm extends React.Component<Props, State> {
       action: this.props.authorizationPolicy.action,
       rules: []
     };
+  }
+
+  componentDidMount() {
+    this.setState({
+      rulesForm: this.props.authorizationPolicy.policy,
+      addWorkloadSelector: false,
+      workloadSelectorValid: false,
+      workloadSelectorLabels: this.props.authorizationPolicy.workloadSelector,
+      action: this.props.authorizationPolicy.action,
+      rules: []
+    });
   }
 
   onRulesFormChange = (value, _) => {

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/From/SourceBuilder.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/From/SourceBuilder.tsx
@@ -1,0 +1,199 @@
+import * as React from 'react';
+import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
+import { Button, FormSelect, FormSelectOption, TextInput } from '@patternfly/react-core';
+import { PlusCircleIcon } from '@patternfly/react-icons';
+
+type Props = {
+  onAddFrom: (source: { [key: string]: string[] }) => void;
+};
+
+type State = {
+  sourceFields: string[];
+  source: {
+    [key: string]: string[];
+  };
+  newSourceField: string;
+  newValues: string;
+};
+
+const INIT_SOURCE_FIELDS = [
+  'principals',
+  'notPrincipals',
+  'requestPrincipals',
+  'notRequestPrincipals',
+  'namespaces',
+  'notNamespaces',
+  'ipBlocks',
+  'notIpBlocks'
+].sort();
+
+const headerCells: ICell[] = [
+  {
+    title: 'Source Field',
+    transforms: [cellWidth(20) as any],
+    props: {}
+  },
+  {
+    title: 'Values',
+    transforms: [cellWidth(80) as any],
+    props: {}
+  },
+  {
+    title: '',
+    props: {}
+  }
+];
+
+class SourceBuilder extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      sourceFields: Object.assign([], INIT_SOURCE_FIELDS),
+      source: {},
+      newSourceField: INIT_SOURCE_FIELDS[0],
+      newValues: ''
+    };
+  }
+
+  onAddNewSourceField = (value: string, _) => {
+    this.setState({
+      newSourceField: value
+    });
+  };
+
+  onAddNewValues = (value: string, _) => {
+    this.setState({
+      newValues: value
+    });
+  };
+
+  onAddSource = () => {
+    this.setState(prevState => {
+      const i = prevState.sourceFields.indexOf(prevState.newSourceField);
+      if (i > -1) {
+        prevState.sourceFields.splice(i, 1);
+      }
+      prevState.source[prevState.newSourceField] = prevState.newValues.split(',');
+      return {
+        sourceFields: prevState.sourceFields,
+        source: prevState.source,
+        newSourceField: prevState.sourceFields[0],
+        newValues: ''
+      };
+    });
+  };
+
+  onAddSourceFromList = () => {
+    const fromItem = this.state.source;
+    this.setState(
+      {
+        sourceFields: Object.assign([], INIT_SOURCE_FIELDS),
+        source: {},
+        newSourceField: INIT_SOURCE_FIELDS[0],
+        newValues: ''
+      },
+      () => {
+        this.props.onAddFrom(fromItem);
+      }
+    );
+  };
+
+  // @ts-ignore
+  actionResolver = (rowData, { rowIndex }) => {
+    const removeAction = {
+      title: 'Remove Field',
+      // @ts-ignore
+      onClick: (event, rowIndex, rowData, extraData) => {
+        // Fetch sourceField from rowData, it's a fixed string on children
+        const removeSourceField = rowData.cells[0].props.children.toString();
+        this.setState(prevState => {
+          prevState.sourceFields.push(removeSourceField);
+          delete prevState.source[removeSourceField];
+          const newSourceFields = prevState.sourceFields.sort();
+          return {
+            sourceFields: newSourceFields,
+            source: prevState.source,
+            newSourceField: newSourceFields[0],
+            newValues: ''
+          };
+        });
+      }
+    };
+    if (rowIndex < Object.keys(this.state.source).length) {
+      return [removeAction];
+    }
+    return [];
+  };
+
+  rows = () => {
+    return Object.keys(this.state.source)
+      .map((sourceField, i) => {
+        return {
+          key: 'sourceKey' + i,
+          cells: [<>{sourceField}</>, <>{this.state.source[sourceField].join(',')}</>, <></>]
+        };
+      })
+      .concat([
+        {
+          key: 'sourceKeyNew',
+          cells: [
+            <>
+              <FormSelect
+                value={this.state.newSourceField}
+                id="addNewSourceField"
+                name="addNewSourceField"
+                onChange={this.onAddNewSourceField}
+              >
+                {this.state.sourceFields.map((option, index) => (
+                  <FormSelectOption isDisabled={false} key={'source' + index} value={option} label={option} />
+                ))}
+              </FormSelect>
+            </>,
+            <>
+              <TextInput
+                value={this.state.newValues}
+                type="text"
+                id="addNewValues"
+                key="addNewValues"
+                aria-describedby="add new source values"
+                name="addNewValues"
+                onChange={this.onAddNewValues}
+              />
+            </>,
+            <>
+              {this.state.sourceFields.length > 0 && (
+                <Button variant="link" icon={<PlusCircleIcon />} onClick={this.onAddSource} />
+              )}
+            </>
+          ]
+        }
+      ]);
+  };
+
+  render() {
+    return (
+      <>
+        <Table
+          aria-label="Source Builder"
+          cells={headerCells}
+          rows={this.rows()}
+          // @ts-ignore
+          actionResolver={this.actionResolver}
+        >
+          <TableHeader />
+          <TableBody />
+        </Table>
+        <Button
+          variant="link"
+          icon={<PlusCircleIcon />}
+          isDisabled={Object.keys(this.state.source).length === 0}
+          onClick={this.onAddSourceFromList}
+        >
+          Add Source to From List
+        </Button>
+      </>
+    );
+  }
+}
+
+export default SourceBuilder;

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/From/SourceBuilder.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/From/SourceBuilder.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
-import { Button, FormSelect, FormSelectOption, TextInput } from '@patternfly/react-core';
+// Use TextInputBase like workaround while PF4 team work in https://github.com/patternfly/patternfly-react/issues/4072
+import { Button, FormSelect, FormSelectOption, TextInputBase as TextInput } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 
 type Props = {

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/From/SourceList.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/From/SourceList.tsx
@@ -6,8 +6,6 @@ type Props = {
   onRemoveFrom: (index: number) => void;
 };
 
-type State = {};
-
 const headerCells: ICell[] = [
   {
     title: 'Source Matches of a Request',
@@ -20,11 +18,7 @@ const headerCells: ICell[] = [
   }
 ];
 
-class SourceList extends React.Component<Props, State> {
-  constructor(props: Props) {
-    super(props);
-  }
-
+class SourceList extends React.Component<Props> {
   rows = () => {
     return this.props.fromList.map((source, i) => {
       return {

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/From/SourceList.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/From/SourceList.tsx
@@ -10,7 +10,7 @@ type State = {};
 
 const headerCells: ICell[] = [
   {
-    title: 'Source Matches',
+    title: 'Source Matches of a Request',
     transforms: [cellWidth(100) as any],
     props: {}
   },
@@ -33,7 +33,7 @@ class SourceList extends React.Component<Props, State> {
           <>
             {Object.keys(source).map((field, j) => {
               return (
-                <div key={'sourceField' + j}>
+                <div key={'sourceField_' + field + '_' + i + '_' + j}>
                   <b>{field}</b>: [{source[field].join(',')}]<br />
                 </div>
               );

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/From/SourceList.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/From/SourceList.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
+import { style } from 'typestyle';
+import { PfColors } from '../../../../components/Pf/PfColors';
 
 type Props = {
   fromList: { [key: string]: string[] }[];
@@ -18,6 +20,13 @@ const headerCells: ICell[] = [
   }
 ];
 
+const noSourceStyle = style({
+  marginTop: 10,
+  color: PfColors.Red100,
+  textAlign: 'center',
+  width: '100%'
+});
+
 class SourceList extends React.Component<Props> {
   rows = () => {
     return this.props.fromList.map((source, i) => {
@@ -25,6 +34,7 @@ class SourceList extends React.Component<Props> {
         key: 'fromSource' + i,
         cells: [
           <>
+            Rules
             {Object.keys(source).map((field, j) => {
               return (
                 <div key={'sourceField_' + field + '_' + i + '_' + j}>
@@ -64,6 +74,7 @@ class SourceList extends React.Component<Props> {
           <TableHeader />
           <TableBody />
         </Table>
+        {this.props.fromList.length === 0 && <div className={noSourceStyle}>No Source Matches Defined</div>}
       </>
     );
   }

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/From/SourceList.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/From/SourceList.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react';
+import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
+
+type Props = {
+  fromList: { [key: string]: string[] }[];
+  onRemoveFrom: (index: number) => void;
+};
+
+type State = {};
+
+const headerCells: ICell[] = [
+  {
+    title: 'Source Matches',
+    transforms: [cellWidth(100) as any],
+    props: {}
+  },
+  {
+    title: '',
+    props: {}
+  }
+];
+
+class SourceList extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+  }
+
+  rows = () => {
+    return this.props.fromList.map((source, i) => {
+      return {
+        key: 'fromSource' + i,
+        cells: [
+          <>
+            {Object.keys(source).map(field => {
+              return (
+                <>
+                  <b>{field}</b>: [{source[field].join(',')}]<br />
+                </>
+              );
+            })}
+          </>,
+          <></>
+        ]
+      };
+    });
+  };
+
+  // @ts-ignore
+  actionResolver = (rowData, { rowIndex }) => {
+    const removeAction = {
+      title: 'Remove From',
+      // @ts-ignore
+      onClick: (event, rowIndex, rowData, extraData) => {
+        this.props.onRemoveFrom(rowIndex);
+      }
+    };
+    return [removeAction];
+  };
+
+  render() {
+    return (
+      <>
+        <Table
+          aria-label="Source Builder"
+          cells={headerCells}
+          rows={this.rows()}
+          // @ts-ignore
+          actionResolver={this.actionResolver}
+        >
+          <TableHeader />
+          <TableBody />
+        </Table>
+      </>
+    );
+  }
+}
+
+export default SourceList;

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/From/SourceList.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/From/SourceList.tsx
@@ -31,11 +31,11 @@ class SourceList extends React.Component<Props, State> {
         key: 'fromSource' + i,
         cells: [
           <>
-            {Object.keys(source).map(field => {
+            {Object.keys(source).map((field, j) => {
               return (
-                <>
+                <div key={'sourceField' + j}>
                   <b>{field}</b>: [{source[field].join(',')}]<br />
-                </>
+                </div>
               );
             })}
           </>,

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/RuleBuilder.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/RuleBuilder.tsx
@@ -1,0 +1,120 @@
+import * as React from 'react';
+import { ActionGroup, Button, FormGroup, Switch } from '@patternfly/react-core';
+import SourceBuilder from './From/SourceBuilder';
+import SourceList from './From/SourceList';
+import OperationBuilder from './To/OperationBuilder';
+import OperationList from './To/OperationList';
+import ConditionBuilder from './When/ConditionBuilder';
+import ConditionList from './When/ConditionList';
+
+type Props = {};
+
+type State = {
+  addFromSwitch: boolean;
+  addToSwitch: boolean;
+  addWhenSwitch: boolean;
+  fromList: { [key: string]: string[] }[];
+};
+
+class RuleBuilder extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      addFromSwitch: false,
+      addToSwitch: false,
+      addWhenSwitch: false,
+      fromList: []
+    };
+  }
+
+  onAddFrom = (source: { [key: string]: string[] }): void => {
+    this.setState(prevState => {
+      prevState.fromList.push(source);
+      return {
+        fromList: prevState.fromList
+      };
+    });
+  };
+
+  onRemoveFrom = (index: number): void => {
+    this.setState(prevState => {
+      prevState.fromList.splice(index, 1);
+      return {
+        fromList: prevState.fromList
+      };
+    });
+  };
+
+  render() {
+    return (
+      <>
+        <FormGroup label="Add From" fieldId="addFromSwitch">
+          <Switch
+            id="addFromSwitch"
+            label={' '}
+            labelOff={' '}
+            isChecked={this.state.addFromSwitch}
+            onChange={() => {
+              this.setState(prevState => ({
+                addFromSwitch: !prevState.addFromSwitch
+              }));
+            }}
+          />
+        </FormGroup>
+        {this.state.addFromSwitch && (
+          <>
+            <FormGroup label="Source Builder" fieldId="sourceBuilder">
+              <SourceBuilder onAddFrom={this.onAddFrom} />
+            </FormGroup>
+            <FormGroup label="From List" fieldId="sourceList">
+              <SourceList fromList={this.state.fromList} onRemoveFrom={this.onRemoveFrom} />
+            </FormGroup>
+          </>
+        )}
+        <FormGroup label="Add To" fieldId="addToSwitch">
+          <Switch
+            id="addToSwitch"
+            label={' '}
+            labelOff={' '}
+            isChecked={this.state.addToSwitch}
+            onChange={() => {
+              this.setState(prevState => ({
+                addToSwitch: !prevState.addToSwitch
+              }));
+            }}
+          />
+        </FormGroup>
+        {this.state.addToSwitch && (
+          <FormGroup fieldId="operationBuilder">
+            <OperationBuilder />
+            <OperationList />
+          </FormGroup>
+        )}
+        <FormGroup label="Add When" fieldId="addWhenSwitch">
+          <Switch
+            id="addWhenSwitch"
+            label={' '}
+            labelOff={' '}
+            isChecked={this.state.addWhenSwitch}
+            onChange={() => {
+              this.setState(prevState => ({
+                addWhenSwitch: !prevState.addWhenSwitch
+              }));
+            }}
+          />
+        </FormGroup>
+        {this.state.addWhenSwitch && (
+          <FormGroup fieldId="conditionBuilder">
+            <ConditionBuilder />
+            <ConditionList />
+          </FormGroup>
+        )}
+        <ActionGroup>
+          <Button variant="primary">Add Rule</Button>
+        </ActionGroup>
+      </>
+    );
+  }
+}
+
+export default RuleBuilder;

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/RuleBuilder.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/RuleBuilder.tsx
@@ -93,6 +93,29 @@ class RuleBuilder extends React.Component<Props, State> {
     });
   };
 
+  onAddRule = (): void => {
+    const newRule: Rule = {
+      from: Object.assign([], this.state.fromList),
+      to: Object.assign([], this.state.toList),
+      when: Object.assign([], this.state.conditionList)
+    };
+    this.setState(
+      {
+        addFromSwitch: false,
+        addToSwitch: false,
+        addWhenSwitch: false,
+        fromList: [],
+        toList: [],
+        conditionList: []
+      },
+      () => this.props.onAddRule(newRule)
+    );
+  };
+
+  canAddRule = (): boolean => {
+    return this.state.fromList.length > 0 || this.state.toList.length > 0 || this.state.conditionList.length > 0;
+  };
+
   render() {
     return (
       <>
@@ -166,7 +189,9 @@ class RuleBuilder extends React.Component<Props, State> {
           </>
         )}
         <FormGroup fieldId="addRule">
-          <Button variant="secondary">Add Rule</Button>
+          <Button variant="secondary" onClick={this.onAddRule} isDisabled={!this.canAddRule()}>
+            Add Rule
+          </Button>
         </FormGroup>
       </>
     );

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/RuleBuilder.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/RuleBuilder.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ActionGroup, Button, FormGroup, Switch } from '@patternfly/react-core';
+import { Button, FormGroup, Switch } from '@patternfly/react-core';
 import SourceBuilder from './From/SourceBuilder';
 import SourceList from './From/SourceList';
 import OperationBuilder from './To/OperationBuilder';
@@ -7,7 +7,15 @@ import OperationList from './To/OperationList';
 import ConditionBuilder, { Condition } from './When/ConditionBuilder';
 import ConditionList from './When/ConditionList';
 
-type Props = {};
+type Props = {
+  onAddRule: (rule: Rule) => void;
+};
+
+export type Rule = {
+  from: { [key: string]: string[] }[];
+  to: { [key: string]: string[] }[];
+  when: Condition[];
+};
 
 type State = {
   addFromSwitch: boolean;
@@ -152,14 +160,14 @@ class RuleBuilder extends React.Component<Props, State> {
             <FormGroup label="Condition Builder" fieldId="conditionBuilder">
               <ConditionBuilder onAddCondition={this.onAddCondition} />
             </FormGroup>
-            <FormGroup label="Condition List" fieldId="conditionList">
+            <FormGroup label="When List" fieldId="conditionList">
               <ConditionList conditionList={this.state.conditionList} onRemoveCondition={this.onRemoveCondition} />
             </FormGroup>
           </>
         )}
-        <ActionGroup>
-          <Button variant="primary">Add Rule</Button>
-        </ActionGroup>
+        <FormGroup fieldId="addRule">
+          <Button variant="secondary">Add Rule</Button>
+        </FormGroup>
       </>
     );
   }

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/RuleBuilder.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/RuleBuilder.tsx
@@ -6,6 +6,8 @@ import OperationBuilder from './To/OperationBuilder';
 import OperationList from './To/OperationList';
 import ConditionBuilder, { Condition } from './When/ConditionBuilder';
 import ConditionList from './When/ConditionList';
+import { style } from 'typestyle';
+import { PfColors } from '../../../components/Pf/PfColors';
 
 type Props = {
   onAddRule: (rule: Rule) => void;
@@ -25,6 +27,12 @@ type State = {
   toList: { [key: string]: string[] }[];
   conditionList: Condition[];
 };
+
+const warningStyle = style({
+  marginLeft: 25,
+  color: PfColors.Red100,
+  textAlign: 'center'
+});
 
 class RuleBuilder extends React.Component<Props, State> {
   constructor(props: Props) {
@@ -192,6 +200,11 @@ class RuleBuilder extends React.Component<Props, State> {
           <Button variant="secondary" onClick={this.onAddRule} isDisabled={!this.canAddRule()}>
             Add Rule
           </Button>
+          {!this.canAddRule() && (
+            <span className={warningStyle}>
+              A Rule needs at least an item in "Add From", "Add To" or "Add When" sections
+            </span>
+          )}
         </FormGroup>
       </>
     );

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/RuleBuilder.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/RuleBuilder.tsx
@@ -4,7 +4,7 @@ import SourceBuilder from './From/SourceBuilder';
 import SourceList from './From/SourceList';
 import OperationBuilder from './To/OperationBuilder';
 import OperationList from './To/OperationList';
-import ConditionBuilder from './When/ConditionBuilder';
+import ConditionBuilder, { Condition } from './When/ConditionBuilder';
 import ConditionList from './When/ConditionList';
 
 type Props = {};
@@ -14,6 +14,8 @@ type State = {
   addToSwitch: boolean;
   addWhenSwitch: boolean;
   fromList: { [key: string]: string[] }[];
+  toList: { [key: string]: string[] }[];
+  conditionList: Condition[];
 };
 
 class RuleBuilder extends React.Component<Props, State> {
@@ -23,7 +25,9 @@ class RuleBuilder extends React.Component<Props, State> {
       addFromSwitch: false,
       addToSwitch: false,
       addWhenSwitch: false,
-      fromList: []
+      fromList: [],
+      toList: [],
+      conditionList: []
     };
   }
 
@@ -41,6 +45,42 @@ class RuleBuilder extends React.Component<Props, State> {
       prevState.fromList.splice(index, 1);
       return {
         fromList: prevState.fromList
+      };
+    });
+  };
+
+  onAddTo = (operation: { [key: string]: string[] }): void => {
+    this.setState(prevState => {
+      prevState.toList.push(operation);
+      return {
+        toList: prevState.toList
+      };
+    });
+  };
+
+  onRemoveTo = (index: number): void => {
+    this.setState(prevState => {
+      prevState.toList.splice(index, 1);
+      return {
+        toList: prevState.toList
+      };
+    });
+  };
+
+  onAddCondition = (condition: Condition): void => {
+    this.setState(prevState => {
+      prevState.conditionList.push(condition);
+      return {
+        conditionList: prevState.conditionList
+      };
+    });
+  };
+
+  onRemoveCondition = (index: number): void => {
+    this.setState(prevState => {
+      prevState.conditionList.splice(index, 1);
+      return {
+        conditionList: prevState.conditionList
       };
     });
   };
@@ -85,10 +125,14 @@ class RuleBuilder extends React.Component<Props, State> {
           />
         </FormGroup>
         {this.state.addToSwitch && (
-          <FormGroup fieldId="operationBuilder">
-            <OperationBuilder />
-            <OperationList />
-          </FormGroup>
+          <>
+            <FormGroup label="Operation Builder" fieldId="operationBuilder">
+              <OperationBuilder onAddTo={this.onAddTo} />
+            </FormGroup>
+            <FormGroup label="To List" fieldId="operationList">
+              <OperationList toList={this.state.toList} onRemoveTo={this.onRemoveTo} />
+            </FormGroup>
+          </>
         )}
         <FormGroup label="Add When" fieldId="addWhenSwitch">
           <Switch
@@ -104,10 +148,14 @@ class RuleBuilder extends React.Component<Props, State> {
           />
         </FormGroup>
         {this.state.addWhenSwitch && (
-          <FormGroup fieldId="conditionBuilder">
-            <ConditionBuilder />
-            <ConditionList />
-          </FormGroup>
+          <>
+            <FormGroup label="Condition Builder" fieldId="conditionBuilder">
+              <ConditionBuilder onAddCondition={this.onAddCondition} />
+            </FormGroup>
+            <FormGroup label="Condition List" fieldId="conditionList">
+              <ConditionList conditionList={this.state.conditionList} onRemoveCondition={this.onRemoveCondition} />
+            </FormGroup>
+          </>
         )}
         <ActionGroup>
           <Button variant="primary">Add Rule</Button>

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/RuleList.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/RuleList.tsx
@@ -8,8 +8,6 @@ type Props = {
   onRemoveRule: (index: number) => void;
 };
 
-type State = {};
-
 const headerCells: ICell[] = [
   {
     title: 'Rules to match the request',
@@ -26,11 +24,7 @@ const rulesPadding = style({
   paddingLeft: 10
 });
 
-class RuleList extends React.Component<Props, State> {
-  constructor(props: Props) {
-    super(props);
-  }
-
+class RuleList extends React.Component<Props> {
   rows = () => {
     return this.props.ruleList.map((rule, i) => {
       return {

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/RuleList.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/RuleList.tsx
@@ -1,22 +1,66 @@
 import * as React from 'react';
+import { Rule } from './RuleBuilder';
+import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
 
-type Props = {};
+type Props = {
+  ruleList: Rule[];
+  onRemoveRule: (index: number) => void;
+};
 
 type State = {};
 
-class RuleList extends React.Component<Props, State> {
+const headerCells: ICell[] = [
+  {
+    title: 'Rules to match the request',
+    transforms: [cellWidth(100) as any],
+    props: {}
+  },
+  {
+    title: '',
+    props: {}
+  }
+];
+
+export class RuleList extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
   }
 
+  rows = () => {
+    return this.props.ruleList.map((_rule, i) => {
+      return {
+        key: 'rule' + i,
+        cells: [<>Here to print the rule</>, <></>]
+      };
+    });
+  };
+
+  // @ts-ignore
+  actionResolver = (rowData, { rowIndex }) => {
+    const removeAction = {
+      title: 'Remove Rule',
+      // @ts-ignore
+      onClick: (event, rowIndex, rowData, extraData) => {
+        this.props.onRemoveRule(rowIndex);
+      }
+    };
+    return [removeAction];
+  };
+
   render() {
     return (
       <>
-        Rules defined:
-        <br />
+        <Table
+          aria-label="Source Builder"
+          cells={headerCells}
+          rows={this.rows()}
+          // @ts-ignore
+          actionResolver={this.actionResolver}
+        >
+          <TableHeader />
+          <TableBody />
+        </Table>
       </>
     );
   }
 }
-
-export default RuleList;

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/RuleList.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/RuleList.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+
+type Props = {};
+
+type State = {};
+
+class RuleList extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <>
+        Rules defined:
+        <br />
+      </>
+    );
+  }
+}
+
+export default RuleList;

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/RuleList.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/RuleList.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Rule } from './RuleBuilder';
 import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
 import { style } from 'typestyle';
+import { PfColors } from '../../../components/Pf/PfColors';
 
 type Props = {
   ruleList: Rule[];
@@ -22,6 +23,12 @@ const headerCells: ICell[] = [
 
 const rulesPadding = style({
   paddingLeft: 10
+});
+
+const noRulesStyle = style({
+  color: PfColors.Red100,
+  textAlign: 'center',
+  width: '100%'
 });
 
 class RuleList extends React.Component<Props> {
@@ -125,6 +132,7 @@ class RuleList extends React.Component<Props> {
           <TableHeader />
           <TableBody />
         </Table>
+        {this.props.ruleList.length === 0 && <div className={noRulesStyle}>No Rules Defined</div>}
       </>
     );
   }

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/RuleList.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/RuleList.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Rule } from './RuleBuilder';
 import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
+import { style } from 'typestyle';
 
 type Props = {
   ruleList: Rule[];
@@ -21,16 +22,86 @@ const headerCells: ICell[] = [
   }
 ];
 
-export class RuleList extends React.Component<Props, State> {
+const rulesPadding = style({
+  paddingLeft: 10
+});
+
+class RuleList extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
   }
 
   rows = () => {
-    return this.props.ruleList.map((_rule, i) => {
+    return this.props.ruleList.map((rule, i) => {
       return {
         key: 'rule' + i,
-        cells: [<>Here to print the rule</>, <></>]
+        cells: [
+          <>
+            {rule.from.length > 0 && (
+              <>
+                <b>From:</b>
+                <>
+                  {rule.from.map((fromItem, i) => {
+                    const keys = Object.keys(fromItem);
+                    return (
+                      <div id={'from' + i} className={rulesPadding}>
+                        <span style={{ marginRight: 20 }}>source:</span>
+                        {keys.map((k, j) => {
+                          return (
+                            <span id={'fromField' + i + '_' + j}>
+                              <b>{k}</b>: [{fromItem[k].join(',')}]{j < keys.length - 1 ? ' and ' : ''}
+                            </span>
+                          );
+                        })}
+                      </div>
+                    );
+                  })}
+                </>
+              </>
+            )}
+            {rule.to.length > 0 && (
+              <>
+                <b>To:</b>
+                {rule.to.map((toItem, i) => {
+                  const keys = Object.keys(toItem);
+                  return (
+                    <div id={'to' + i} className={rulesPadding}>
+                      <span style={{ marginRight: 20 }}>operation:</span>
+                      {keys.map((k, j) => {
+                        return (
+                          <span id={'toItem' + i + '_' + j}>
+                            <b>{k}</b>: [{toItem[k].join(',')}]{j < keys.length - 1 ? ' and ' : ''}
+                          </span>
+                        );
+                      })}
+                    </div>
+                  );
+                })}
+              </>
+            )}
+            {rule.when.length > 0 && (
+              <>
+                <b>When:</b>
+                {rule.when.map((whenItem, i) => {
+                  return (
+                    <div id={'when' + i} className={rulesPadding}>
+                      <span>
+                        <b>key</b>: [{whenItem.key}]
+                      </span>
+                      <span style={{ marginLeft: 5 }}>
+                        <b>values:</b> [{whenItem.values}]
+                      </span>
+                      <span style={{ marginLeft: 5 }}>
+                        <b>notValues:</b> [{whenItem.notValues}]
+                      </span>
+                    </div>
+                  );
+                })}
+              </>
+            )}
+          </>,
+          <></>
+        ]
       };
     });
   };
@@ -64,3 +135,5 @@ export class RuleList extends React.Component<Props, State> {
     );
   }
 }
+
+export default RuleList;

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/To/OperationBuilder.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/To/OperationBuilder.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+
+type Props = {};
+
+type State = {};
+
+class OperationBuilder extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <>
+        Operation Builder
+        <br />
+      </>
+    );
+  }
+}
+
+export default OperationBuilder;

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/To/OperationBuilder.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/To/OperationBuilder.tsx
@@ -1,19 +1,196 @@
 import * as React from 'react';
+import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
+import { Button, FormSelect, FormSelectOption, TextInput } from '@patternfly/react-core';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 
-type Props = {};
+type Props = {
+  onAddTo: (operation: { [key: string]: string[] }) => void;
+};
 
-type State = {};
+type State = {
+  operationFields: string[];
+  operation: {
+    [key: string]: string[];
+  };
+  newOperationField: string;
+  newValues: string;
+};
+
+const INIT_OPERATION_FIELDS = [
+  'hosts',
+  'notHosts',
+  'ports',
+  'notPorts',
+  'methods',
+  'notMethods',
+  'paths',
+  'notPaths'
+].sort();
+
+const headerCells: ICell[] = [
+  {
+    title: 'Operation Field',
+    transforms: [cellWidth(20) as any],
+    props: {}
+  },
+  {
+    title: 'Values',
+    transforms: [cellWidth(80) as any],
+    props: {}
+  },
+  {
+    title: '',
+    props: {}
+  }
+];
 
 class OperationBuilder extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
+    this.state = {
+      operationFields: Object.assign([], INIT_OPERATION_FIELDS),
+      operation: {},
+      newOperationField: INIT_OPERATION_FIELDS[0],
+      newValues: ''
+    };
   }
+
+  onAddNewOperationField = (value: string, _) => {
+    this.setState({
+      newOperationField: value
+    });
+  };
+
+  onAddNewValues = (value: string, _) => {
+    this.setState({
+      newValues: value
+    });
+  };
+
+  onAddOperation = () => {
+    this.setState(prevState => {
+      const i = prevState.operationFields.indexOf(prevState.newOperationField);
+      if (i > -1) {
+        prevState.operationFields.splice(i, 1);
+      }
+      prevState.operation[prevState.newOperationField] = prevState.newValues.split(',');
+      return {
+        operationFields: prevState.operationFields,
+        operation: prevState.operation,
+        newOperationField: prevState.operationFields[0],
+        newValues: ''
+      };
+    });
+  };
+
+  onAddOperationToList = () => {
+    const toItem = this.state.operation;
+    this.setState(
+      {
+        operationFields: Object.assign([], INIT_OPERATION_FIELDS),
+        operation: {},
+        newOperationField: INIT_OPERATION_FIELDS[0],
+        newValues: ''
+      },
+      () => {
+        this.props.onAddTo(toItem);
+      }
+    );
+  };
+
+  // @ts-ignore
+  actionResolver = (rowData, { rowIndex }) => {
+    const removeAction = {
+      title: 'Remove Field',
+      // @ts-ignore
+      onClick: (event, rowIndex, rowData, extraData) => {
+        // Fetch sourceField from rowData, it's a fixed string on children
+        const removeOperationField = rowData.cells[0].props.children.toString();
+        this.setState(prevState => {
+          prevState.operationFields.push(removeOperationField);
+          delete prevState.operation[removeOperationField];
+          const newOperationFields = prevState.operationFields.sort();
+          return {
+            operationFields: newOperationFields,
+            operation: prevState.operation,
+            newOperationField: newOperationFields[0],
+            newValues: ''
+          };
+        });
+      }
+    };
+    if (rowIndex < Object.keys(this.state.operation).length) {
+      return [removeAction];
+    }
+    return [];
+  };
+
+  rows = () => {
+    return Object.keys(this.state.operation)
+      .map((operationField, i) => {
+        return {
+          key: 'operationKey' + i,
+          cells: [<>{operationField}</>, <>{this.state.operation[operationField].join(',')}</>, <></>]
+        };
+      })
+      .concat([
+        {
+          key: 'operationKeyNew',
+          cells: [
+            <>
+              <FormSelect
+                value={this.state.newOperationField}
+                id="addNewOperationField"
+                name="addNewOperationField"
+                onChange={this.onAddNewOperationField}
+              >
+                {this.state.operationFields.map((option, index) => (
+                  <FormSelectOption isDisabled={false} key={'operation' + index} value={option} label={option} />
+                ))}
+              </FormSelect>
+            </>,
+            <>
+              <TextInput
+                value={this.state.newValues}
+                type="text"
+                id="addNewValues"
+                key="addNewValues"
+                aria-describedby="add new operation values"
+                name="addNewValues"
+                onChange={this.onAddNewValues}
+              />
+            </>,
+            <>
+              {this.state.operationFields.length > 0 && (
+                <Button variant="link" icon={<PlusCircleIcon />} onClick={this.onAddOperation} />
+              )}
+            </>
+          ]
+        }
+      ]);
+  };
 
   render() {
     return (
       <>
-        Operation Builder
-        <br />
+        <Table
+          aria-label="Operation Builder"
+          cells={headerCells}
+          rows={this.rows()}
+          // @ts-ignore
+          actionResolver={this.actionResolver}
+        >
+          <TableHeader />
+          <TableBody />
+        </Table>
+        <Button
+          variant="link"
+          icon={<PlusCircleIcon />}
+          isDisabled={Object.keys(this.state.operation).length === 0}
+          onClick={this.onAddOperationToList}
+        >
+          Add Operation to To List
+        </Button>
       </>
     );
   }

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/To/OperationBuilder.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/To/OperationBuilder.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
-import { Button, FormSelect, FormSelectOption, TextInput } from '@patternfly/react-core';
+// Use TextInputBase like workaround while PF4 team work in https://github.com/patternfly/patternfly-react/issues/4072
+import { Button, FormSelect, FormSelectOption, TextInputBase as TextInput } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 
 type Props = {

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/To/OperationList.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/To/OperationList.tsx
@@ -1,19 +1,75 @@
 import * as React from 'react';
+import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
 
-type Props = {};
+type Props = {
+  toList: { [key: string]: string[] }[];
+  onRemoveTo: (index: number) => void;
+};
 
 type State = {};
+
+const headerCells: ICell[] = [
+  {
+    title: 'Operations of a Request',
+    transforms: [cellWidth(100) as any],
+    props: {}
+  },
+  {
+    title: '',
+    props: {}
+  }
+];
 
 class OperationList extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
   }
 
+  rows = () => {
+    return this.props.toList.map((operation, i) => {
+      return {
+        key: 'toOperation' + i,
+        cells: [
+          <>
+            {Object.keys(operation).map((field, j) => {
+              return (
+                <div key={'operationField' + j}>
+                  <b>{field}</b>: [{operation[field].join(',')}]<br />
+                </div>
+              );
+            })}
+          </>,
+          <></>
+        ]
+      };
+    });
+  };
+
+  // @ts-ignore
+  actionResolver = (rowData, { rowIndex }) => {
+    const removeAction = {
+      title: 'Remove To',
+      // @ts-ignore
+      onClick: (event, rowIndex, rowData, extraData) => {
+        this.props.onRemoveTo(rowIndex);
+      }
+    };
+    return [removeAction];
+  };
+
   render() {
     return (
       <>
-        Operation List
-        <br />
+        <Table
+          aria-label="Source Builder"
+          cells={headerCells}
+          rows={this.rows()}
+          // @ts-ignore
+          actionResolver={this.actionResolver}
+        >
+          <TableHeader />
+          <TableBody />
+        </Table>
       </>
     );
   }

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/To/OperationList.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/To/OperationList.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+
+type Props = {};
+
+type State = {};
+
+class OperationList extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <>
+        Operation List
+        <br />
+      </>
+    );
+  }
+}
+
+export default OperationList;

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/To/OperationList.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/To/OperationList.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
+import { style } from 'typestyle';
+import { PfColors } from '../../../../components/Pf/PfColors';
 
 type Props = {
   toList: { [key: string]: string[] }[];
@@ -17,6 +19,13 @@ const headerCells: ICell[] = [
     props: {}
   }
 ];
+
+const noOperationsStyle = style({
+  marginTop: 10,
+  color: PfColors.Red100,
+  textAlign: 'center',
+  width: '100%'
+});
 
 class OperationList extends React.Component<Props> {
   rows = () => {
@@ -64,6 +73,7 @@ class OperationList extends React.Component<Props> {
           <TableHeader />
           <TableBody />
         </Table>
+        {this.props.toList.length === 0 && <div className={noOperationsStyle}>No Operations Defined</div>}
       </>
     );
   }

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/To/OperationList.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/To/OperationList.tsx
@@ -33,7 +33,7 @@ class OperationList extends React.Component<Props, State> {
           <>
             {Object.keys(operation).map((field, j) => {
               return (
-                <div key={'operationField' + j}>
+                <div key={'operationField_' + i + '_' + j}>
                   <b>{field}</b>: [{operation[field].join(',')}]<br />
                 </div>
               );

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/To/OperationList.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/To/OperationList.tsx
@@ -6,8 +6,6 @@ type Props = {
   onRemoveTo: (index: number) => void;
 };
 
-type State = {};
-
 const headerCells: ICell[] = [
   {
     title: 'Operations of a Request',
@@ -20,11 +18,7 @@ const headerCells: ICell[] = [
   }
 ];
 
-class OperationList extends React.Component<Props, State> {
-  constructor(props: Props) {
-    super(props);
-  }
-
+class OperationList extends React.Component<Props> {
   rows = () => {
     return this.props.toList.map((operation, i) => {
       return {

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/When/ConditionBuilder.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/When/ConditionBuilder.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
-import { Button, TextInput } from '@patternfly/react-core';
+// Use TextInputBase like workaround while PF4 team work in https://github.com/patternfly/patternfly-react/issues/4072
+import { Button, TextInputBase as TextInput } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 
 export type Condition = {

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/When/ConditionBuilder.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/When/ConditionBuilder.tsx
@@ -1,19 +1,149 @@
 import * as React from 'react';
+import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
+import { Button, TextInput } from '@patternfly/react-core';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 
-type Props = {};
+export type Condition = {
+  key: string;
+  values?: string[];
+  notValues?: string[];
+};
 
-type State = {};
+type Props = {
+  onAddCondition: (condition: Condition) => void;
+};
+
+type State = {
+  condition: Condition;
+};
+
+const headerCells: ICell[] = [
+  {
+    title: 'Condition Key',
+    transforms: [cellWidth(30) as any],
+    props: {}
+  },
+  {
+    title: 'Values',
+    transforms: [cellWidth(30) as any],
+    props: {}
+  },
+  {
+    title: 'Not Values',
+    transforms: [cellWidth(30) as any],
+    props: {}
+  }
+];
 
 class ConditionBuilder extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
+    this.state = {
+      condition: {
+        key: ''
+      }
+    };
   }
+
+  onAddNewConditionKey = (key: string, _) => {
+    this.setState(prevState => {
+      prevState.condition.key = key;
+      return {
+        condition: prevState.condition
+      };
+    });
+  };
+
+  onAddNewValues = (value: string, _) => {
+    this.setState(prevState => {
+      prevState.condition.values = value.split(',');
+      return {
+        condition: prevState.condition
+      };
+    });
+  };
+
+  onAddNewNotValues = (notValues: string, _) => {
+    this.setState(prevState => {
+      prevState.condition.notValues = notValues.split(',');
+      return {
+        condition: prevState.condition
+      };
+    });
+  };
+
+  onAddConditionToList = () => {
+    const conditionItem = this.state.condition;
+    this.setState(
+      {
+        condition: {
+          key: ''
+        }
+      },
+      () => {
+        this.props.onAddCondition(conditionItem);
+      }
+    );
+  };
+
+  rows = () => {
+    return [
+      {
+        key: 'conditionKeyNew',
+        cells: [
+          <>
+            <TextInput
+              value={this.state.condition.key}
+              type="text"
+              id="addNewConditionKey"
+              key="addNewConditionKey"
+              aria-describedby="add new condition key"
+              name="addNewConditionKey"
+              onChange={this.onAddNewConditionKey}
+            />
+          </>,
+          <>
+            <TextInput
+              value={this.state.condition.values ? this.state.condition.values.join(',') : ''}
+              type="text"
+              id="addNewValues"
+              key="addNewValues"
+              aria-describedby="add new condition values"
+              name="addNewConditionValues"
+              onChange={this.onAddNewValues}
+            />
+          </>,
+          <>
+            <TextInput
+              value={this.state.condition.notValues ? this.state.condition.notValues.join(',') : ''}
+              type="text"
+              id="addNewNotValues"
+              key="addNewNotValues"
+              aria-describedby="add new condition not values"
+              name="addNewNotValues"
+              onChange={this.onAddNewNotValues}
+            />
+          </>
+        ]
+      }
+    ];
+  };
 
   render() {
     return (
       <>
-        Condition Builder
-        <br />
+        <Table aria-label="Condition Builder" cells={headerCells} rows={this.rows()}>
+          <TableHeader />
+          <TableBody />
+        </Table>
+        <Button
+          variant="link"
+          icon={<PlusCircleIcon />}
+          isDisabled={this.state.condition.key.length === 0}
+          onClick={this.onAddConditionToList}
+        >
+          Add Condition to Condition List
+        </Button>
       </>
     );
   }

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/When/ConditionBuilder.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/When/ConditionBuilder.tsx
@@ -142,7 +142,7 @@ class ConditionBuilder extends React.Component<Props, State> {
           isDisabled={this.state.condition.key.length === 0}
           onClick={this.onAddConditionToList}
         >
-          Add Condition to Condition List
+          Add Condition to When List
         </Button>
       </>
     );

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/When/ConditionBuilder.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/When/ConditionBuilder.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+
+type Props = {};
+
+type State = {};
+
+class ConditionBuilder extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <>
+        Condition Builder
+        <br />
+      </>
+    );
+  }
+}
+
+export default ConditionBuilder;

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/When/ConditionList.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/When/ConditionList.tsx
@@ -1,19 +1,80 @@
 import * as React from 'react';
+import { Condition } from './ConditionBuilder';
+import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
 
-type Props = {};
+type Props = {
+  conditionList: Condition[];
+  onRemoveCondition: (index: number) => void;
+};
 
 type State = {};
+
+const headerCells: ICell[] = [
+  {
+    title: 'Additional Conditions of a Request',
+    transforms: [cellWidth(100) as any],
+    props: {}
+  },
+  {
+    title: '',
+    props: {}
+  }
+];
 
 class ConditionList extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
   }
 
+  rows = () => {
+    return this.props.conditionList.map((condition, i) => {
+      return {
+        key: 'condition' + i,
+        cells: [
+          <>
+            <b>key: </b> [{condition.key}]<br />
+            {condition.values && (
+              <>
+                <b>values: </b> [{condition.values}]<br />
+              </>
+            )}
+            {condition.notValues && (
+              <>
+                <b>notValues: </b> [{condition.notValues}]<br />
+              </>
+            )}
+          </>,
+          <></>
+        ]
+      };
+    });
+  };
+
+  // @ts-ignore
+  actionResolver = (rowData, { rowIndex }) => {
+    const removeAction = {
+      title: 'Remove Condition',
+      // @ts-ignore
+      onClick: (event, rowIndex, rowData, extraData) => {
+        this.props.onRemoveCondition(rowIndex);
+      }
+    };
+    return [removeAction];
+  };
+
   render() {
     return (
       <>
-        Condition List
-        <br />
+        <Table
+          aria-label="Condition Builder"
+          cells={headerCells}
+          rows={this.rows()}
+          // @ts-ignore
+          actionResolver={this.actionResolver}
+        >
+          <TableHeader />
+          <TableBody />
+        </Table>
       </>
     );
   }

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/When/ConditionList.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/When/ConditionList.tsx
@@ -32,7 +32,6 @@ class ConditionList extends React.Component<Props> {
                 <b>values: </b> [{condition.values}]<br />
               </>
             )}
-            , State
             {condition.notValues && (
               <>
                 <b>notValues: </b> [{condition.notValues}]<br />

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/When/ConditionList.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/When/ConditionList.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+
+type Props = {};
+
+type State = {};
+
+class ConditionList extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <>
+        Condition List
+        <br />
+      </>
+    );
+  }
+}
+
+export default ConditionList;

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/When/ConditionList.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/When/ConditionList.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { Condition } from './ConditionBuilder';
 import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
+import { style } from 'typestyle';
+import { PfColors } from '../../../../components/Pf/PfColors';
 
 type Props = {
   conditionList: Condition[];
@@ -18,6 +20,13 @@ const headerCells: ICell[] = [
     props: {}
   }
 ];
+
+const noConditionsStyle = style({
+  marginTop: 10,
+  color: PfColors.Red100,
+  textAlign: 'center',
+  width: '100%'
+});
 
 class ConditionList extends React.Component<Props> {
   rows = () => {
@@ -69,6 +78,7 @@ class ConditionList extends React.Component<Props> {
           <TableHeader />
           <TableBody />
         </Table>
+        {this.props.conditionList.length === 0 && <div className={noConditionsStyle}>No Conditions Defined</div>}
       </>
     );
   }

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/When/ConditionList.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/When/ConditionList.tsx
@@ -7,8 +7,6 @@ type Props = {
   onRemoveCondition: (index: number) => void;
 };
 
-type State = {};
-
 const headerCells: ICell[] = [
   {
     title: 'Additional Conditions of a Request',
@@ -21,11 +19,7 @@ const headerCells: ICell[] = [
   }
 ];
 
-class ConditionList extends React.Component<Props, State> {
-  constructor(props: Props) {
-    super(props);
-  }
-
+class ConditionList extends React.Component<Props> {
   rows = () => {
     return this.props.conditionList.map((condition, i) => {
       return {
@@ -38,6 +32,7 @@ class ConditionList extends React.Component<Props, State> {
                 <b>values: </b> [{condition.values}]<br />
               </>
             )}
+            , State
             {condition.notValues && (
               <>
                 <b>notValues: </b> [{condition.notValues}]<br />

--- a/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
+++ b/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
@@ -55,11 +55,11 @@ const istioResourceOptions = [
   { value: SIDECAR, label: SIDECAR, disabled: false }
 ];
 
-const INIT_STATE: State = {
+const INIT_STATE = (): State => ({
   istioResource: istioResourceOptions[0].value,
   name: '',
   istioPermissions: {},
-  authorizationPolicy: INIT_AUTHORIZATION_POLICY,
+  authorizationPolicy: INIT_AUTHORIZATION_POLICY(),
   gateway: {
     gatewayServers: []
   },
@@ -74,14 +74,14 @@ const INIT_STATE: State = {
     workloadSelectorValid: false,
     workloadSelectorLabels: ''
   }
-};
+});
 
 class IstioConfigNewPage extends React.Component<Props, State> {
   private promises = new PromisesRegistry();
 
   constructor(props: Props) {
     super(props);
-    this.state = INIT_STATE;
+    this.state = INIT_STATE();
   }
 
   componentWillUnmount() {
@@ -90,7 +90,7 @@ class IstioConfigNewPage extends React.Component<Props, State> {
 
   componentDidMount() {
     // Init component state
-    this.setState(INIT_STATE);
+    this.setState(Object.assign({}, INIT_STATE));
     this.fetchPermissions();
   }
 
@@ -220,8 +220,10 @@ class IstioConfigNewPage extends React.Component<Props, State> {
   };
 
   backToList = () => {
-    // Back to list page
-    history.push(`/${Paths.ISTIO}?namespaces=${this.props.activeNamespaces.join(',')}`);
+    this.setState(INIT_STATE(), () => {
+      // Back to list page
+      history.push(`/${Paths.ISTIO}?namespaces=${this.props.activeNamespaces.join(',')}`);
+    });
   };
 
   isAuthorizationPolicyValid = (): boolean => {
@@ -403,9 +405,11 @@ class IstioConfigNewPage extends React.Component<Props, State> {
   }
 }
 
-const mapStateToProps = (state: KialiAppState) => ({
-  activeNamespaces: activeNamespacesSelector(state)
-});
+const mapStateToProps = (state: KialiAppState) => {
+  return {
+    activeNamespaces: activeNamespacesSelector(state)
+  };
+};
 
 const IstioConfigNewPageContainer = connect(
   mapStateToProps,

--- a/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
+++ b/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
@@ -147,6 +147,10 @@ class IstioConfigNewPage extends React.Component<Props, State> {
   onIstioResourceCreate = () => {
     switch (this.state.istioResource) {
       case AUTHORIZACION_POLICY:
+        console.log('TODELETE');
+        console.log(
+          JSON.stringify(buildAuthorizationPolicy(this.state.name, 'default', this.state.authorizationPolicy))
+        );
         this.promises
           .registerAll(
             'Create AuthorizationPolicies',

--- a/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
+++ b/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
@@ -55,31 +55,33 @@ const istioResourceOptions = [
   { value: SIDECAR, label: SIDECAR, disabled: false }
 ];
 
+const INIT_STATE: State = {
+  istioResource: istioResourceOptions[0].value,
+  name: '',
+  istioPermissions: {},
+  authorizationPolicy: INIT_AUTHORIZATION_POLICY,
+  gateway: {
+    gatewayServers: []
+  },
+  sidecar: {
+    egressHosts: [
+      // Init with the istio-system/* for sidecar
+      {
+        host: serverConfig.istioNamespace + '/*'
+      }
+    ],
+    addWorkloadSelector: false,
+    workloadSelectorValid: false,
+    workloadSelectorLabels: ''
+  }
+};
+
 class IstioConfigNewPage extends React.Component<Props, State> {
   private promises = new PromisesRegistry();
 
   constructor(props: Props) {
     super(props);
-    this.state = {
-      istioResource: istioResourceOptions[0].value,
-      name: '',
-      istioPermissions: {},
-      authorizationPolicy: INIT_AUTHORIZATION_POLICY,
-      gateway: {
-        gatewayServers: []
-      },
-      sidecar: {
-        egressHosts: [
-          // Init with the istio-system/* for sidecar
-          {
-            host: serverConfig.istioNamespace + '/*'
-          }
-        ],
-        addWorkloadSelector: false,
-        workloadSelectorValid: false,
-        workloadSelectorLabels: ''
-      }
-    };
+    this.state = INIT_STATE;
   }
 
   componentWillUnmount() {
@@ -87,6 +89,8 @@ class IstioConfigNewPage extends React.Component<Props, State> {
   }
 
   componentDidMount() {
+    // Init component state
+    this.setState(INIT_STATE);
     this.fetchPermissions();
   }
 

--- a/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
+++ b/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
@@ -16,6 +16,7 @@ import * as AlertUtils from '../../utils/AlertUtils';
 import history from '../../app/History';
 import { buildGateway, buildSidecar } from '../../components/IstioWizards/IstioWizardActions';
 import { MessageType } from '../../types/MessageCenter';
+import AuthorizationPolicyForm from './AuthorizationPolicyForm';
 
 type Props = {
   activeNamespaces: Namespace[];
@@ -31,17 +32,21 @@ type State = {
 
 const formPadding = style({ padding: '30px 20px 30px 20px' });
 
+const AUTHORIZACION_POLICY = 'AuthorizationPolicy';
+const AUTHORIZATION_POLICIES = 'authorizationpolicies';
 const GATEWAY = 'Gateway';
 const GATEWAYS = 'gateways';
 const SIDECAR = 'Sidecar';
 const SIDECARS = 'sidecars';
 
 const DIC = {
+  AuthorizationPolicy: AUTHORIZATION_POLICIES,
   Gateway: GATEWAYS,
   Sidecar: SIDECARS
 };
 
 const istioResourceOptions = [
+  { value: AUTHORIZACION_POLICY, label: AUTHORIZACION_POLICY, disabled: false },
   { value: GATEWAY, label: GATEWAY, disabled: false },
   { value: SIDECAR, label: SIDECAR, disabled: false }
 ];
@@ -136,6 +141,9 @@ class IstioConfigNewPage extends React.Component<Props, State> {
 
   onIstioResourceCreate = () => {
     switch (this.state.istioResource) {
+      case AUTHORIZACION_POLICY:
+        console.log('TODELETE Invoke backend to create an AuthorizationPolicy object');
+        break;
       case GATEWAY:
         this.promises
           .registerAll(
@@ -188,6 +196,10 @@ class IstioConfigNewPage extends React.Component<Props, State> {
     history.push(`/${Paths.ISTIO}?namespaces=${this.props.activeNamespaces.join(',')}`);
   };
 
+  isAuthorizationPolicyValid = (): boolean => {
+    return this.state.istioResource === AUTHORIZACION_POLICY;
+  };
+
   isGatewayValid = (): boolean => {
     return this.state.istioResource === GATEWAY && this.state.gateway.gatewayServers.length > 0;
   };
@@ -204,7 +216,10 @@ class IstioConfigNewPage extends React.Component<Props, State> {
   render() {
     const isNameValid = this.state.name.length > 0;
     const isNamespacesValid = this.props.activeNamespaces.length > 0;
-    const isFormValid = isNameValid && isNamespacesValid && (this.isGatewayValid() || this.isSidecarValid());
+    const isFormValid =
+      isNameValid &&
+      isNamespacesValid &&
+      (this.isGatewayValid() || this.isSidecarValid() || this.isAuthorizationPolicyValid());
     return (
       <RenderContent>
         <Form className={formPadding} isHorizontal={true}>
@@ -258,6 +273,7 @@ class IstioConfigNewPage extends React.Component<Props, State> {
               isValid={isNamespacesValid}
             />
           </FormGroup>
+          {this.state.istioResource === AUTHORIZACION_POLICY && <AuthorizationPolicyForm />}
           {this.state.istioResource === GATEWAY && (
             <GatewayForm
               gatewayServers={this.state.gateway.gatewayServers}

--- a/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
+++ b/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
@@ -16,7 +16,10 @@ import * as AlertUtils from '../../utils/AlertUtils';
 import history from '../../app/History';
 import { buildGateway, buildSidecar } from '../../components/IstioWizards/IstioWizardActions';
 import { MessageType } from '../../types/MessageCenter';
-import AuthorizationPolicyForm from './AuthorizationPolicyForm';
+import AuthorizationPolicyForm, {
+  AuthorizationPolicyState,
+  INIT_AUTHORIZATION_POLICY
+} from './AuthorizationPolicyForm';
 
 type Props = {
   activeNamespaces: Namespace[];
@@ -26,6 +29,7 @@ type State = {
   istioResource: string;
   name: string;
   istioPermissions: IstioPermissions;
+  authorizationPolicy: AuthorizationPolicyState;
   gateway: GatewayState;
   sidecar: SidecarState;
 };
@@ -60,6 +64,7 @@ class IstioConfigNewPage extends React.Component<Props, State> {
       istioResource: istioResourceOptions[0].value,
       name: '',
       istioPermissions: {},
+      authorizationPolicy: INIT_AUTHORIZATION_POLICY,
       gateway: {
         gatewayServers: []
       },
@@ -213,6 +218,18 @@ class IstioConfigNewPage extends React.Component<Props, State> {
     );
   };
 
+  onChangeAuthorizationPolicy = (authorizationPolicy: AuthorizationPolicyState) => {
+    this.setState(prevState => {
+      prevState.authorizationPolicy.workloadSelector = authorizationPolicy.workloadSelector;
+      prevState.authorizationPolicy.action = authorizationPolicy.action;
+      prevState.authorizationPolicy.policy = authorizationPolicy.policy;
+      prevState.authorizationPolicy.rules = authorizationPolicy.rules;
+      return {
+        authorizationPolicy: prevState.authorizationPolicy
+      };
+    });
+  };
+
   render() {
     const isNameValid = this.state.name.length > 0;
     const isNamespacesValid = this.props.activeNamespaces.length > 0;
@@ -273,7 +290,12 @@ class IstioConfigNewPage extends React.Component<Props, State> {
               isValid={isNamespacesValid}
             />
           </FormGroup>
-          {this.state.istioResource === AUTHORIZACION_POLICY && <AuthorizationPolicyForm />}
+          {this.state.istioResource === AUTHORIZACION_POLICY && (
+            <AuthorizationPolicyForm
+              authorizationPolicy={this.state.authorizationPolicy}
+              onChange={this.onChangeAuthorizationPolicy}
+            />
+          )}
           {this.state.istioResource === GATEWAY && (
             <GatewayForm
               gatewayServers={this.state.gateway.gatewayServers}

--- a/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
+++ b/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
@@ -151,10 +151,6 @@ class IstioConfigNewPage extends React.Component<Props, State> {
   onIstioResourceCreate = () => {
     switch (this.state.istioResource) {
       case AUTHORIZACION_POLICY:
-        console.log('TODELETE');
-        console.log(
-          JSON.stringify(buildAuthorizationPolicy(this.state.name, 'default', this.state.authorizationPolicy))
-        );
         this.promises
           .registerAll(
             'Create AuthorizationPolicies',

--- a/src/types/IstioObjects.ts
+++ b/src/types/IstioObjects.ts
@@ -615,8 +615,12 @@ export interface AuthorizationPolicy extends IstioObject {
   spec: AuthorizationPolicySpec;
 }
 
+export interface AuthorizationPolicyWorkloadSelector {
+  matchLabels: { [key: string]: string };
+}
+
 export interface AuthorizationPolicySpec {
-  selector?: WorkloadSelector;
+  selector?: AuthorizationPolicyWorkloadSelector;
   rules?: AuthorizationPolicyRule[];
   action?: string;
 }

--- a/src/types/IstioObjects.ts
+++ b/src/types/IstioObjects.ts
@@ -618,6 +618,7 @@ export interface AuthorizationPolicy extends IstioObject {
 export interface AuthorizationPolicySpec {
   selector?: WorkloadSelector;
   rules?: AuthorizationPolicyRule[];
+  action?: string;
 }
 
 export interface AuthorizationPolicyRule {
@@ -632,9 +633,13 @@ export interface RuleFrom {
 
 export interface Source {
   principals?: string[];
+  notPrincipals?: string[];
   requestPrincipals?: string[];
+  notRequestPrincipals?: string[];
   namespaces?: string[];
+  notNamespaces?: string[];
   ipBlocks?: string[];
+  notIpBlocks?: string[];
 }
 
 export interface RuleTo {
@@ -643,14 +648,19 @@ export interface RuleTo {
 
 export interface Operation {
   hosts?: string[];
+  notHosts?: string[];
   ports?: string[];
+  notPorts?: string[];
   methods?: string[];
+  notMethods?: string[];
   paths?: string[];
+  notPaths?: string[];
 }
 
 export interface Condition {
   key: string;
-  values: string[];
+  values?: string[];
+  notValues?: string[];
 }
 
 export interface ServiceRole extends IstioObject {


### PR DESCRIPTION
This PRs provides a new form to create AuthorizationPolicy objects.

Note:
- IstioConfig new form only support the creation of the object, updates are done via yaml editor.
- AuthorizationPolicy is a complex object with multiple edges and corner cases, hard to focus just on some, so, the form supports all cases (in other objects as Gateways/Sidecars forms only support a subset of most direct scenarios).
- User requires to catch up with the terminology used by AuthorizationPolicy entity.

How to test:
- Best strategy would be to follow the Istio tasks tutorial https://istio.io/docs/tasks/security/authorization/ and check that all scenarios can be done via the form, checking that resulting yaml is valid and well formed.

Fixes https://github.com/kiali/kiali/issues/2041

It requires backend PR https://github.com/kiali/kiali/pull/2680