### PR TITLE
Allow pre-set query params in Grafana URL

### DIFF
--- a/src/components/Metrics/GrafanaLinks.tsx
+++ b/src/components/Metrics/GrafanaLinks.tsx
@@ -14,28 +14,29 @@ type Props = {
 };
 
 export class GrafanaLinks extends React.PureComponent<Props, {}> {
-  private buildGrafanaLinks(): [string, string][] {
+  static buildGrafanaLinks(props: Props): [string, string][] {
     const links: [string, string][] = [];
-    this.props.links.forEach(d => {
-      const nsvar = d.variables.namespace ? `&${d.variables.namespace}=${this.props.namespace}` : '';
-      const vervar = d.variables.version && this.props.version ? `&${d.variables.version}=${this.props.version}` : '';
-      switch (this.props.objectType) {
+    props.links.forEach(d => {
+      const first = d.url.includes('?') ? '&' : '?';
+      const nsvar = d.variables.namespace ? `&${d.variables.namespace}=${props.namespace}` : '';
+      const vervar = d.variables.version && props.version ? `&${d.variables.version}=${props.version}` : '';
+      switch (props.objectType) {
         case MetricsObjectTypes.SERVICE:
-          const fullServiceName = `${this.props.object}.${this.props.namespace}.svc.cluster.local`;
+          const fullServiceName = `${props.object}.${props.namespace}.svc.cluster.local`;
           if (d.variables.service) {
-            const url = `${d.url}?${d.variables.service}=${fullServiceName}${nsvar}${vervar}`;
+            const url = `${d.url}${first}${d.variables.service}=${fullServiceName}${nsvar}${vervar}`;
             links.push([d.name, url]);
           }
           break;
         case MetricsObjectTypes.WORKLOAD:
           if (d.variables.workload) {
-            const url = `${d.url}?${d.variables.workload}=${this.props.object}${nsvar}${vervar}`;
+            const url = `${d.url}${first}${d.variables.workload}=${props.object}${nsvar}${vervar}`;
             links.push([d.name, url]);
           }
           break;
         case MetricsObjectTypes.APP:
           if (d.variables.app) {
-            const url = `${d.url}?${d.variables.app}=${this.props.object}${nsvar}${vervar}`;
+            const url = `${d.url}${first}${d.variables.app}=${props.object}${nsvar}${vervar}`;
             links.push([d.name, url]);
           }
           break;
@@ -47,7 +48,7 @@ export class GrafanaLinks extends React.PureComponent<Props, {}> {
   }
 
   render() {
-    const links = this.buildGrafanaLinks();
+    const links = GrafanaLinks.buildGrafanaLinks(this.props);
     return (
       <>
         {links.length === 1 && (

--- a/src/components/Metrics/__tests__/GrafanaLinks.test.ts
+++ b/src/components/Metrics/__tests__/GrafanaLinks.test.ts
@@ -1,0 +1,84 @@
+import { GrafanaLinks } from '../GrafanaLinks';
+import { MetricsObjectTypes } from 'types/Metrics';
+
+describe('Grafana links', () => {
+  it('build service links', () => {
+    const links = GrafanaLinks.buildGrafanaLinks({
+      links: [
+        {
+          name: 'View in Grafana',
+          url: 'http://grafana:3000',
+          variables: { namespace: 'var-namespace', service: 'var-service' }
+        },
+        {
+          name: 'View in Grafana 2',
+          url: 'http://grafana:3000?orgId=1',
+          variables: { namespace: 'var-namespace', service: 'var-service' }
+        }
+      ],
+      namespace: 'my-namespace',
+      object: 'my-service',
+      objectType: MetricsObjectTypes.SERVICE
+    });
+    expect(links).toHaveLength(2);
+    expect(links[0][0]).toEqual('View in Grafana');
+    expect(links[0][1]).toEqual(
+      'http://grafana:3000?var-service=my-service.my-namespace.svc.cluster.local&var-namespace=my-namespace'
+    );
+    expect(links[1][0]).toEqual('View in Grafana 2');
+    expect(links[1][1]).toEqual(
+      'http://grafana:3000?orgId=1&var-service=my-service.my-namespace.svc.cluster.local&var-namespace=my-namespace'
+    );
+  });
+
+  it('build workload links', () => {
+    const links = GrafanaLinks.buildGrafanaLinks({
+      links: [
+        {
+          name: 'View in Grafana',
+          url: 'http://grafana:3000',
+          variables: { namespace: 'var-namespace', workload: 'var-workload' }
+        },
+        {
+          name: 'View in Grafana 2',
+          url: 'http://grafana:3000?orgId=1',
+          variables: { namespace: 'var-namespace', workload: 'var-workload' }
+        }
+      ],
+      namespace: 'my-namespace',
+      object: 'my-workload',
+      objectType: MetricsObjectTypes.WORKLOAD
+    });
+    expect(links).toHaveLength(2);
+    expect(links[0][0]).toEqual('View in Grafana');
+    expect(links[0][1]).toEqual('http://grafana:3000?var-workload=my-workload&var-namespace=my-namespace');
+    expect(links[1][0]).toEqual('View in Grafana 2');
+    expect(links[1][1]).toEqual('http://grafana:3000?orgId=1&var-workload=my-workload&var-namespace=my-namespace');
+  });
+
+  it('build app links', () => {
+    const links = GrafanaLinks.buildGrafanaLinks({
+      links: [
+        {
+          name: 'View in Grafana',
+          url: 'http://grafana:3000',
+          variables: { namespace: 'var-namespace', app: 'var-app', version: 'var-version' }
+        },
+        {
+          name: 'View in Grafana 2',
+          url: 'http://grafana:3000?orgId=1',
+          variables: { namespace: 'var-namespace', app: 'var-app' }
+        }
+      ],
+      namespace: 'my-namespace',
+      object: 'my-app',
+      objectType: MetricsObjectTypes.APP,
+      version: 'v1'
+    });
+    expect(links).toHaveLength(2);
+    expect(links[0][0]).toEqual('View in Grafana');
+    expect(links[0][1]).toEqual('http://grafana:3000?var-app=my-app&var-namespace=my-namespace&var-version=v1');
+    expect(links[1][0]).toEqual('View in Grafana 2');
+    expect(links[1][1]).toEqual('http://grafana:3000?orgId=1&var-app=my-app&var-namespace=my-namespace');
+  });
+});


### PR DESCRIPTION
Example: Configured Grafana URL 'http://grafana:3000?orgId=1' to not screw up link generation

Fixes https://github.com/kiali/kiali/issues/2623

Backend PR: https://github.com/kiali/kiali/pull/2687