### PR TITLE
Fix issue zoom/pan/fit and graph-hide

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -536,12 +536,9 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps>
 
     cy.endBatch();
 
+    // Run layout and fit outside of the batch operation for it to take effect on the new nodes
     if (updateLayout) {
       CytoscapeGraphUtils.runLayout(cy, this.props.layout);
-    }
-
-    // We need to fit outside of the batch operation for it to take effect on the new nodes
-    if (updateLayout) {
       this.safeFit(cy);
     }
 

--- a/src/components/CytoscapeGraph/CytoscapeGraphUtils.ts
+++ b/src/components/CytoscapeGraph/CytoscapeGraphUtils.ts
@@ -67,14 +67,15 @@ export const CyNode = {
 };
 
 export const ZoomOptions = {
-  fitPadding: 25
+  fitPadding: 25,
+  maxZoom: 2.5
 };
 
 export const safeFit = (cy: Cy.Core, centerElements?: Cy.Collection) => {
   cy.fit(centerElements, ZoomOptions.fitPadding);
-  if (cy.zoom() > 2.5) {
-    cy.zoom(2.5);
-    cy.center(centerElements);
+  if (cy.zoom() > ZoomOptions.maxZoom) {
+    cy.zoom(ZoomOptions.maxZoom);
+    !!centerElements && !!centerElements.length ? cy.center(centerElements) : cy.center();
   }
 };
 


### PR DESCRIPTION
This fixes an issue with zoom/fit/pan and graph hide.  We only want to re-establish the zoom/pan settings if we believe the graph is unchanged (basically the same removed elements are in play as when we previously executed the hide logic).  The determination is not perfect but should work fairly well.
- also made a couple of minor tweaks to "safeFit()" on the off-chance it could help in general.

Fix related to https://github.com/kiali/kiali/issues/2514

In the _before_ video note that after applying the hide expression and toggling `Show Services` that we need to also click `Fit` in the cytoscape toolbar.  In the _after_ video we can see that the clicking `Fit `has no effect, the graph is already layed out correctly.

Before:
![kiali#2514-before](https://user-images.githubusercontent.com/2104052/80146993-c2e02900-8580-11ea-8b6d-a5b2d3e4113b.gif)

After:
![kiali#2514-after](https://user-images.githubusercontent.com/2104052/80147006-cd022780-8580-11ea-8b7c-443c1d3913a4.gif)

After 2: this second _after_ video shows that we maintain the proper zoom/pan on a standard refresh (this is to prove no regression, the original code also works in this case):
![kiali#2514-after-2](https://user-images.githubusercontent.com/2104052/80147233-33874580-8581-11ea-970a-cb532b02a4e7.gif)


