### PR TITLE
Labels tooltip on overview displayed shifted for top right projects

### DIFF
--- a/src/pages/Overview/OverviewPage.tsx
+++ b/src/pages/Overview/OverviewPage.tsx
@@ -446,8 +446,9 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
     return ns.labels ? (
       <Tooltip
         aria-label={'Labels list'}
-        position={TooltipPosition.auto}
+        position={TooltipPosition.bottom}
         enableFlip={true}
+        distance={5}
         content={
           <ul>
             {Object.entries(ns.labels || []).map(([key, value]) => (


### PR DESCRIPTION
Fix https://github.com/kiali/kiali/issues/2693

Now the tooltip is at bottom of the "labels trigger" and I set the distance to 5 (iis the distance of the tooltip to its target, defaults to 15)