### PR TITLE
Sync Health tooltip style with rest of Kiali

### DIFF
--- a/src/components/Health/Health.scss
+++ b/src/components/Health/Health.scss
@@ -5,19 +5,24 @@ svg:not(:root).icon-na {
   overflow: visible;
 }
 .tippy-popper[x-placement^='left'] .pf-tooltip-theme .tippy-arrow {
-  background-color: #fff;
-  border-color: black;
-  border-width: 1px;
-  border-style: solid;
+  // This is the old style of health tooltip with white background
+  // I will keep it here instead to remove completely the style in case we need tweaks in the future
+  // background-color: #fff;
+  // border-color: black;
+  // border-width: 1px;
+  // border-style: solid;
 }
 .health_indicator .pf-c-tooltip__content {
-  background-color: #fff;
-  border-style: solid;
-  border-color: black;
+  // This is the old style of health tooltip with white background
+  // I will keep it here instead to remove completely the style in case we need tweaks in the future
+  // background-color: #fff;
+  // border-style: solid;
+  // border-color: black;
   border-width: 1px;
   text-align: left;
 }
 .health_indicator .pf-c-content ul {
   margin-bottom: var(--pf-c-content--ul--MarginTop);
   margin-top: 0;
+  color: #fff;
 }

--- a/src/components/Health/HealthIndicator.tsx
+++ b/src/components/Health/HealthIndicator.tsx
@@ -4,6 +4,7 @@ import { HealthDetails } from './HealthDetails';
 import * as H from '../../types/Health';
 import { createIcon } from './Helper';
 import './Health.css';
+import { PfColors } from '../Pf/PfColors';
 
 export enum DisplayMode {
   LARGE,
@@ -68,7 +69,7 @@ export class HealthIndicator extends React.PureComponent<Props, HealthState> {
   }
   renderHealthTooltip(health: H.Health) {
     return (
-      <TextContent>
+      <TextContent style={{ color: PfColors.White }}>
         <Text component={TextVariants.h2}>{this.state.globalStatus.name}</Text>
         <HealthDetails health={health} />
       </TextContent>

--- a/src/components/Health/__tests__/__snapshots__/HealthIndicator.test.tsx.snap
+++ b/src/components/Health/__tests__/__snapshots__/HealthIndicator.test.tsx.snap
@@ -8,7 +8,13 @@ exports[`HealthIndicator renders healthy 1`] = `
   boundary="window"
   className="health_indicator"
   content={
-    <TextContent>
+    <TextContent
+      style={
+        Object {
+          "color": "#fff",
+        }
+      }
+    >
       <Text
         component="h2"
       >


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/2706

Now health is consistent with other tooltips used in Kiali:
![image](https://user-images.githubusercontent.com/1662329/80735684-5d0c1800-8b11-11ea-9023-0b4d95aaeff5.png)

This out-of-sync is more visible in the same row that other tooltips are used:
![image](https://user-images.githubusercontent.com/1662329/80735767-790fb980-8b11-11ea-8354-96332c05dac1.png)

![image](https://user-images.githubusercontent.com/1662329/80735798-82992180-8b11-11ea-9315-5fe97ab46bc5.png)

Note, that this is consistent with other complex tooltips with similar structure (list of status with icons):

![image](https://user-images.githubusercontent.com/1662329/80735947-bd9b5500-8b11-11ea-8f13-4cb1bbfebc2b.png)
