### PR TITLE
Log tailing capability (and horizontal scrolling)

### DIFF
--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
@@ -63,7 +63,8 @@ const logsTextarea = style({
   backgroundColor: '#003145',
   fontFamily: 'monospace',
   fontSize: '11pt',
-  padding: '10px'
+  padding: '10px',
+  whiteSpace: 'pre'
 });
 
 const toolbarRight = style({

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
@@ -6,11 +6,11 @@ import { getPodLogs, Response } from '../../../services/Api';
 import { CancelablePromise, makeCancelablePromise } from '../../../utils/CancelablePromises';
 import { ToolbarDropdown } from '../../../components/ToolbarDropdown/ToolbarDropdown';
 import { DurationInSeconds, TimeRange } from '../../../types/Common';
-import RefreshButtonContainer from '../../../components/Refresh/RefreshButton';
 import { RenderComponentScroll } from '../../../components/Nav/Page';
 import { retrieveDuration } from 'components/Time/TimeRangeHelper';
 import TimeRangeComponent from 'components/Time/TimeRangeComponent';
 import Splitter from 'm-react-splitters';
+import RefreshContainer from '../../../components/Refresh/Refresh';
 
 export interface WorkloadPodLogsProps {
   namespace: string;
@@ -86,8 +86,8 @@ const tailToolbarMargin = style({
 export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, WorkloadPodLogsState> {
   private loadPodLogsPromise?: CancelablePromise<Response<PodLogs>[]>;
   private loadContainerLogsPromise?: CancelablePromise<Response<PodLogs>[]>;
-  private podLogsRef: any;
-  private proxyLogsRef: any;
+  private readonly podLogsRef: any;
+  private readonly proxyLogsRef: any;
   private podOptions: object = {};
 
   constructor(props: WorkloadPodLogsProps) {
@@ -201,7 +201,12 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
                         />
                       </ToolbarItem>
                       <ToolbarItem>
-                        <RefreshButtonContainer disabled={!this.state.podLogs} handleRefresh={this.handleRefresh} />
+                        <RefreshContainer
+                          id="workload_logging_refresh"
+                          hideLabel={true}
+                          disabled={!this.state.podLogs}
+                          handleRefresh={this.handleRefresh}
+                        />
                       </ToolbarItem>
                     </ToolbarGroup>
                   </Toolbar>

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
@@ -86,11 +86,15 @@ const tailToolbarMargin = style({
 export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, WorkloadPodLogsState> {
   private loadPodLogsPromise?: CancelablePromise<Response<PodLogs>[]>;
   private loadContainerLogsPromise?: CancelablePromise<Response<PodLogs>[]>;
+  private podLogsRef: any;
+  private proxyLogsRef: any;
   private podOptions: object = {};
 
   constructor(props: WorkloadPodLogsProps) {
     super(props);
 
+    this.podLogsRef = React.createRef();
+    this.proxyLogsRef = React.createRef();
     if (this.props.pods.length < 1) {
       this.state = {
         duration: retrieveDuration() || 600,
@@ -147,6 +151,8 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
       const pod = this.props.pods[this.state.podValue!];
       this.fetchLogs(this.props.namespace, pod.name, newContainer!, this.state.tailLines, this.state.duration);
     }
+    this.proxyLogsRef.current.scrollTop = this.proxyLogsRef.current.scrollHeight;
+    this.podLogsRef.current.scrollTop = this.podLogsRef.current.scrollHeight;
   }
 
   renderItem = object => {
@@ -213,6 +219,7 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
                       </Title>
                       <textarea
                         className={logsTextarea}
+                        ref={this.podLogsRef}
                         readOnly={true}
                         value={this.state.podLogs ? this.state.podLogs.logs : 'Loading logs...'}
                         aria-label="Pod logs text"
@@ -224,6 +231,7 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
                       </Title>
                       <textarea
                         className={logsTextarea}
+                        ref={this.proxyLogsRef}
                         readOnly={true}
                         value={this.state.containerLogs ? this.state.containerLogs.logs : 'Loading container logs...'}
                         aria-label="Container logs text"
@@ -314,6 +322,7 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
           loadingPodLogs: false,
           podLogs: podLogs.logs ? podLogs : { logs: 'No logs found for the time period.' }
         });
+        this.podLogsRef.current.scrollTop = this.podLogsRef.current.scrollHeight;
         return;
       })
       .catch(error => {
@@ -336,6 +345,7 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
           loadingContainerLogs: false,
           containerLogs: containerLogs.logs ? containerLogs : { logs: 'No container logs found for the time period.' }
         });
+        this.podLogsRef.current.scrollTop = this.podLogsRef.current.scrollHeight;
         return;
       })
       .catch(error => {


### PR DESCRIPTION
** Describe the change **
This PR adds:
- [x] Log Tailing at various intervals
- [x] In true Tailing manner, shows the bottom of the logs updating (instead of showing the top and having to scroll down to the bottom manually)
- [x] Eliminates line wrapping making it easier to read the logs
- [x] Add horizontal scrolling to see the details


** Issue reference **
fixes: https://github.com/kiali/kiali/issues/2667

** Screenshot **

**Before**
![Kiali_Console](https://user-images.githubusercontent.com/1312165/80769865-668e8380-8b03-11ea-8e2f-39ccd98815a1.png)

**After**
![Kiali_Console](https://user-images.githubusercontent.com/1312165/80842603-df9ae300-8bb6-11ea-8cdb-2d5d9771c017.png)

