### PR TITLE
[v1.12] Fix missing Gateway initialization on Wizard state

### DIFF
--- a/src/components/IstioWizards/IstioWizard.tsx
+++ b/src/components/IstioWizards/IstioWizard.tsx
@@ -125,6 +125,22 @@ class IstioWizard extends React.Component<WizardProps, WizardState> {
               simple: ROUND_ROBIN
             }
       };
+      const gateway: GatewaySelectorState = {
+        addGateway: false,
+        gwHosts: '',
+        gwHostsValid: false,
+        newGateway: false,
+        selectedGateway: '',
+        addMesh: false,
+        port: 80
+      };
+      if (hasGateway(this.props.virtualServices)) {
+        const [gatewaySelected, isMesh] = getInitGateway(this.props.virtualServices);
+        gateway.addGateway = true;
+        gateway.selectedGateway = gatewaySelected;
+        gateway.addMesh = isMesh;
+      }
+
       this.setState({
         showWizard: this.props.show,
         workloads: [],
@@ -140,7 +156,8 @@ class IstioWizard extends React.Component<WizardProps, WizardState> {
           initVsHosts.length > 1 || (initVsHosts.length === 1 && initVsHosts[0].length > 0)
             ? initVsHosts
             : [fqdnServiceName(this.props.serviceName, this.props.namespace)],
-        trafficPolicy: trafficPolicy
+        trafficPolicy: trafficPolicy,
+        gateway: gateway
       });
     }
   }


### PR DESCRIPTION
When Kiali Wizard is updated, Gateway is populated from properties but without initializing state.
This creates a bug when updating a Wizard when Gateway are wrongly deleted.

Related to https://github.com/kiali/kiali/issues/2726

How to reproduce error:
1.- Go to service reviews
2.- Create configuration using wizard, i.e. Weighted Routing.
3.- Add/Select a Gateway.
4.- Save configuration.
5.- Confirm Gateway is in generated VirtualService.
6.- Open the Wizard for Updates.
7.- Modify some weights but don't touch the Gateway.
8.- Save configuration.
9.- Gateway is removed. This is a bug.

How to test:
- Validate repeating previous steps, on step 9, an existing Gateway prevails in the update.

It requires a PR in master branch.