### PR TITLE
Labels filtering: "all of" / "any of" switch

### DIFF
--- a/src/components/BreadcrumbView/BreadcrumbView.tsx
+++ b/src/components/BreadcrumbView/BreadcrumbView.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Paths } from '../../config';
 import { Link } from 'react-router-dom';
 import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
-import { ActiveFilter } from '../../types/Filters';
+import { ActiveFiltersInfo, DEFAULT_LABEL_OPERATION } from '../../types/Filters';
 import { FilterSelected } from '../Filters/StatefulFilters';
 import { dicIstioType } from '../../types/IstioConfigList';
 
@@ -76,14 +76,14 @@ export class BreadcrumbView extends React.Component<BreadCumbViewProps, BreadCum
   }
 
   cleanFilters = () => {
-    FilterSelected.setSelected([]);
+    FilterSelected.setSelected({ filters: [], op: DEFAULT_LABEL_OPERATION });
   };
 
   updateTypeFilter = () => {
     this.cleanFilters();
     // When updateTypeFilter is called, selected filters are already updated with namespace. Just push additional type obj
-    const activeFilters: ActiveFilter[] = FilterSelected.getSelected();
-    activeFilters.push({
+    const activeFilters: ActiveFiltersInfo = FilterSelected.getSelected();
+    activeFilters.filters.push({
       category: 'Istio Type',
       value: dicIstioType[this.state.istioType || '']
     });

--- a/src/components/FilterList/FilterHelper.ts
+++ b/src/components/FilterList/FilterHelper.ts
@@ -32,6 +32,7 @@ export const setFiltersToURL = (filterTypes: FilterType[], filters: ActiveFilter
     urlParams.delete(type.id);
   });
   const cleanFilters: ActiveFilter[] = [];
+
   filters.forEach(activeFilter => {
     const filterType = filterTypes.find(filter => filter.title === activeFilter.category);
     if (!filterType) {

--- a/src/components/FilterList/FilterHelper.ts
+++ b/src/components/FilterList/FilterHelper.ts
@@ -1,6 +1,13 @@
 import history, { URLParam, HistoryManager } from '../../app/History';
 import { config } from '../../config';
-import { ActiveFilter, FilterType } from '../../types/Filters';
+import {
+  ActiveFilter,
+  ActiveFiltersInfo,
+  DEFAULT_LABEL_OPERATION,
+  FilterType,
+  ID_LABEL_OPERATION,
+  LabelOperation
+} from '../../types/Filters';
 import { SortField } from '../../types/SortFilters';
 import * as AlertUtils from '../../utils/AlertUtils';
 
@@ -12,7 +19,7 @@ export const handleError = (error: string) => {
   AlertUtils.add(error);
 };
 
-export const getFiltersFromURL = (filterTypes: FilterType[]): ActiveFilter[] => {
+export const getFiltersFromURL = (filterTypes: FilterType[]): ActiveFiltersInfo => {
   const urlParams = new URLSearchParams(history.location.search);
   const activeFilters: ActiveFilter[] = [];
   filterTypes.forEach(filter => {
@@ -23,17 +30,22 @@ export const getFiltersFromURL = (filterTypes: FilterType[]): ActiveFilter[] => 
       });
     });
   });
-  return activeFilters;
+
+  return {
+    filters: activeFilters,
+    op: (urlParams.get(ID_LABEL_OPERATION) as LabelOperation) || DEFAULT_LABEL_OPERATION
+  };
 };
 
-export const setFiltersToURL = (filterTypes: FilterType[], filters: ActiveFilter[]): ActiveFilter[] => {
+export const setFiltersToURL = (filterTypes: FilterType[], filters: ActiveFiltersInfo): ActiveFiltersInfo => {
   const urlParams = new URLSearchParams(history.location.search);
   filterTypes.forEach(type => {
     urlParams.delete(type.id);
   });
+  urlParams.delete(ID_LABEL_OPERATION);
   const cleanFilters: ActiveFilter[] = [];
 
-  filters.forEach(activeFilter => {
+  filters.filters.forEach(activeFilter => {
     const filterType = filterTypes.find(filter => filter.title === activeFilter.category);
     if (!filterType) {
       return;
@@ -41,15 +53,16 @@ export const setFiltersToURL = (filterTypes: FilterType[], filters: ActiveFilter
     cleanFilters.push(activeFilter);
     urlParams.append(filterType.id, activeFilter.value);
   });
+  urlParams.append(ID_LABEL_OPERATION, filters.op);
   // Resetting pagination when filters change
   history.push(history.location.pathname + '?' + urlParams.toString());
-  return cleanFilters;
+  return { filters: cleanFilters, op: filters.op || DEFAULT_LABEL_OPERATION };
 };
 
-export const filtersMatchURL = (filterTypes: FilterType[], filters: ActiveFilter[]): boolean => {
+export const filtersMatchURL = (filterTypes: FilterType[], filters: ActiveFiltersInfo): boolean => {
   // This can probably be improved and/or simplified?
   const fromFilters: Map<string, string[]> = new Map<string, string[]>();
-  filters.forEach(activeFilter => {
+  filters.filters.forEach(activeFilter => {
     const existingValue = fromFilters.get(activeFilter.category) || [];
     fromFilters.set(activeFilter.category, existingValue.concat(activeFilter.value));
   });

--- a/src/components/FilterList/__tests__/ListPagesHelper.test.ts
+++ b/src/components/FilterList/__tests__/ListPagesHelper.test.ts
@@ -1,6 +1,6 @@
 import history from '../../../app/History';
 import * as FilterHelper from '../FilterHelper';
-import { FilterType } from '../../../types/Filters';
+import { DEFAULT_LABEL_OPERATION, FilterType } from '../../../types/Filters';
 
 const managedFilterTypes = [
   {
@@ -21,143 +21,191 @@ describe('List page', () => {
   it('sets selected filters from URL', () => {
     history.push('?a=1&b=2&c=3&c=4');
     const filters = FilterHelper.getFiltersFromURL(managedFilterTypes);
-    expect(filters).toEqual([
-      {
-        category: 'A',
-        value: '1'
-      },
-      {
-        category: 'C',
-        value: '3'
-      },
-      {
-        category: 'C',
-        value: '4'
-      }
-    ]);
+    expect(filters).toEqual({
+      filters: [
+        {
+          category: 'A',
+          value: '1'
+        },
+        {
+          category: 'C',
+          value: '3'
+        },
+        {
+          category: 'C',
+          value: '4'
+        }
+      ],
+      op: 'or'
+    });
   });
 
   it('sets selected filters to URL', () => {
     history.push('?a=10&b=20&c=30&c=40');
-    const cleanFilters = FilterHelper.setFiltersToURL(managedFilterTypes, [
-      {
-        category: 'A',
-        value: '1'
-      },
-      {
-        category: 'C',
-        value: '3'
-      },
-      {
-        category: 'C',
-        value: '4'
-      }
-    ]);
-    expect(history.location.search).toEqual('?b=20&a=1&c=3&c=4');
-    expect(cleanFilters).toHaveLength(3);
+    const cleanFilters = FilterHelper.setFiltersToURL(managedFilterTypes, {
+      filters: [
+        {
+          category: 'A',
+          value: '1'
+        },
+        {
+          category: 'C',
+          value: '3'
+        },
+        {
+          category: 'C',
+          value: '4'
+        }
+      ],
+      op: DEFAULT_LABEL_OPERATION
+    });
+    expect(history.location.search).toEqual('?b=20&a=1&c=3&c=4&opLabel=or');
+    expect(cleanFilters.filters).toHaveLength(3);
+  });
+
+  it('sets selected filters to URL with OpLabel to and', () => {
+    history.push('?a=10&b=20&c=30&c=40');
+    const cleanFilters = FilterHelper.setFiltersToURL(managedFilterTypes, {
+      filters: [
+        {
+          category: 'A',
+          value: '1'
+        },
+        {
+          category: 'C',
+          value: '3'
+        },
+        {
+          category: 'C',
+          value: '4'
+        }
+      ],
+      op: 'and'
+    });
+    expect(history.location.search).toEqual('?b=20&a=1&c=3&c=4&opLabel=and');
+    expect(cleanFilters.filters).toHaveLength(3);
+    expect(cleanFilters.op).toEqual('and');
   });
 
   it('filters should match URL, ignoring order and non-managed query params', () => {
     history.push('?a=1&b=2&c=3&c=4');
     // Make sure order is ignored
-    const match = FilterHelper.filtersMatchURL(managedFilterTypes, [
-      {
-        category: 'C',
-        value: '3'
-      },
-      {
-        category: 'A',
-        value: '1'
-      },
-      {
-        category: 'C',
-        value: '4'
-      }
-    ]);
+    const match = FilterHelper.filtersMatchURL(managedFilterTypes, {
+      filters: [
+        {
+          category: 'C',
+          value: '3'
+        },
+        {
+          category: 'A',
+          value: '1'
+        },
+        {
+          category: 'C',
+          value: '4'
+        }
+      ],
+      op: DEFAULT_LABEL_OPERATION
+    });
     expect(match).toBe(true);
   });
 
   it('filters should not match URL', () => {
     history.push('?a=1&b=2&c=3&c=4');
     // Incorrect value
-    let match = FilterHelper.filtersMatchURL(managedFilterTypes, [
-      {
-        category: 'A',
-        value: '1'
-      },
-      {
-        category: 'C',
-        value: '3'
-      },
-      {
-        category: 'C',
-        value: '5'
-      }
-    ]);
+    let match = FilterHelper.filtersMatchURL(managedFilterTypes, {
+      filters: [
+        {
+          category: 'A',
+          value: '1'
+        },
+        {
+          category: 'C',
+          value: '3'
+        },
+        {
+          category: 'C',
+          value: '5'
+        }
+      ],
+      op: DEFAULT_LABEL_OPERATION
+    });
     expect(match).toBe(false);
 
     // Missing value from selection
-    match = FilterHelper.filtersMatchURL(managedFilterTypes, [
-      {
-        category: 'A',
-        value: '1'
-      },
-      {
-        category: 'C',
-        value: '3'
-      }
-    ]);
+    match = FilterHelper.filtersMatchURL(managedFilterTypes, {
+      filters: [
+        {
+          category: 'A',
+          value: '1'
+        },
+        {
+          category: 'C',
+          value: '3'
+        }
+      ],
+      op: DEFAULT_LABEL_OPERATION
+    });
     expect(match).toBe(false);
 
     // Missing value from URL
-    match = FilterHelper.filtersMatchURL(managedFilterTypes, [
-      {
-        category: 'A',
-        value: '1'
-      },
-      {
-        category: 'C',
-        value: '3'
-      },
-      {
-        category: 'C',
-        value: '4'
-      },
-      {
-        category: 'C',
-        value: '5'
-      }
-    ]);
+    match = FilterHelper.filtersMatchURL(managedFilterTypes, {
+      filters: [
+        {
+          category: 'A',
+          value: '1'
+        },
+        {
+          category: 'C',
+          value: '3'
+        },
+        {
+          category: 'C',
+          value: '4'
+        },
+        {
+          category: 'C',
+          value: '5'
+        }
+      ],
+      op: DEFAULT_LABEL_OPERATION
+    });
     expect(match).toBe(false);
 
     // Missing key from selection
-    match = FilterHelper.filtersMatchURL(managedFilterTypes, [
-      {
-        category: 'A',
-        value: '1'
-      }
-    ]);
+    match = FilterHelper.filtersMatchURL(managedFilterTypes, {
+      filters: [
+        {
+          category: 'A',
+          value: '1'
+        }
+      ],
+      op: DEFAULT_LABEL_OPERATION
+    });
     expect(match).toBe(false);
 
     // Missing key from URL
-    match = FilterHelper.filtersMatchURL(managedFilterTypes, [
-      {
-        category: 'A',
-        value: '1'
-      },
-      {
-        category: 'C',
-        value: '3'
-      },
-      {
-        category: 'C',
-        value: '4'
-      },
-      {
-        category: 'D',
-        value: '5'
-      }
-    ]);
+    match = FilterHelper.filtersMatchURL(managedFilterTypes, {
+      filters: [
+        {
+          category: 'A',
+          value: '1'
+        },
+        {
+          category: 'C',
+          value: '3'
+        },
+        {
+          category: 'C',
+          value: '4'
+        },
+        {
+          category: 'D',
+          value: '5'
+        }
+      ],
+      op: DEFAULT_LABEL_OPERATION
+    });
     expect(match).toBe(false);
   });
 });

--- a/src/components/Filters/CommonFilters.ts
+++ b/src/components/Filters/CommonFilters.ts
@@ -3,7 +3,7 @@ import {
   FilterType,
   FILTER_ACTION_UPDATE,
   FilterValue,
-  ActiveFilter,
+  ActiveFiltersInfo,
   FilterTypes
 } from '../../types/Filters';
 import { HEALTHY, DEGRADED, FAILURE, NA, Health } from '../../types/Health';
@@ -55,15 +55,15 @@ export const healthFilter: FilterType = {
   ]
 };
 
-export const getFilterSelectedValues = (filter: FilterType, activeFilters: ActiveFilter[]): string[] => {
-  const selected: string[] = activeFilters
+export const getFilterSelectedValues = (filter: FilterType, activeFilters: ActiveFiltersInfo): string[] => {
+  const selected: string[] = activeFilters.filters
     .filter(activeFilter => activeFilter.category === filter.title)
     .map(activeFilter => activeFilter.value);
   return removeDuplicatesArray(selected);
 };
 
-export const getPresenceFilterValue = (filter: FilterType, activeFilters: ActiveFilter[]): boolean | undefined => {
-  const presenceFilters = activeFilters.filter(activeFilter => activeFilter.category === filter.title);
+export const getPresenceFilterValue = (filter: FilterType, activeFilters: ActiveFiltersInfo): boolean | undefined => {
+  const presenceFilters = activeFilters.filters.filter(activeFilter => activeFilter.category === filter.title);
   if (presenceFilters.length > 0) {
     return presenceFilters[0].value === 'Present';
   }

--- a/src/components/Filters/LabelFilter.tsx
+++ b/src/components/Filters/LabelFilter.tsx
@@ -9,7 +9,12 @@ interface LabelFiltersProps {
   duplicatesFilter: (value: string) => boolean;
 }
 
-export class LabelFilters extends React.Component<LabelFiltersProps> {
+export class LabelFilters extends React.Component<LabelFiltersProps, { sortOperation: string }> {
+  constructor(props) {
+    super(props);
+    this.state = { sortOperation: 'or' };
+  }
+
   onkeyPress = (e: any) => {
     if (e.key === 'Enter') {
       if (this.props.value && this.props.value.length > 0) {

--- a/src/components/Filters/StatefulFilters.tsx
+++ b/src/components/Filters/StatefulFilters.tsx
@@ -226,7 +226,7 @@ export class StatefulFilters extends React.Component<StatefulFiltersProps, State
   renderInput() {
     const { currentFilterType, currentValue } = this.state;
 
-    if (!currentFilterType || currentFilterType.filterType === FilterTypes.opLabel) {
+    if (!currentFilterType) {
       return null;
     }
     if (currentFilterType.filterType === FilterTypes.typeAhead) {

--- a/src/components/Filters/StatefulFilters.tsx
+++ b/src/components/Filters/StatefulFilters.tsx
@@ -155,11 +155,6 @@ export class StatefulFilters extends React.Component<StatefulFiltersProps, State
     this.updateActiveFilters(activeFilters);
   };
 
-  updateOpSortLabel = (value: LabelOperation) => {
-    this.setState({ activeFilters: { filters: this.state.activeFilters.filters, op: value } });
-    this.updateActiveFilters({ filters: this.state.activeFilters.filters, op: value });
-  };
-
   selectFilterType = (value: string) => {
     const { currentFilterType } = this.state;
     const filterType = this.state.filterTypes.filter(filter => filter.id === value)[0];
@@ -367,7 +362,9 @@ export class StatefulFilters extends React.Component<StatefulFiltersProps, State
                 <span className={classNames(paddingStyle)}>Label Operation</span>
                 <FormSelect
                   value={activeFilters.op}
-                  onChange={value => this.updateOpSortLabel(value as LabelOperation)}
+                  onChange={value =>
+                    this.updateActiveFilters({ filters: this.state.activeFilters.filters, op: value as LabelOperation })
+                  }
                   aria-label="filter_select_value"
                   style={{ width: 'auto' }}
                 >

--- a/src/components/VirtualList/Renderers.tsx
+++ b/src/components/VirtualList/Renderers.tsx
@@ -232,7 +232,7 @@ export const labels: Renderer<SortResource | NamespaceInfo> = (item: SortResourc
           <Badge
             key={`labelbadge_${key}_${value}_${item.name}`}
             isRead={true}
-            style={{ backgroundColor: labelActivate(filters, key, value) ? PfColors.Blue200 : undefined }}
+            style={{ backgroundColor: labelActivate(filters.filters, key, value) ? PfColors.Blue200 : undefined }}
           >
             {key}: {value}
           </Badge>

--- a/src/helpers/LabelFilterHelper.ts
+++ b/src/helpers/LabelFilterHelper.ts
@@ -36,7 +36,9 @@ const filterLabelByOp = (labels: { [key: string]: string }, filters: string[], o
             .split(',')
             .some(labelValue => labelValue.trim().startsWith(v.trim()));
         }
+        return undefined;
       });
+      return undefined;
     });
     return filterOkForLabel;
   }
@@ -50,6 +52,7 @@ const filterLabelByOp = (labels: { [key: string]: string }, filters: string[], o
     if (!labelKeys.includes(k) && filterOkForLabel) {
       filterOkForLabel = false;
     }
+    return undefined;
   });
 
   // If label presence is validated we continue checking with key,value
@@ -63,12 +66,14 @@ const filterLabelByOp = (labels: { [key: string]: string }, filters: string[], o
           if (!labels[key].split(',').some(labelVal => labelVal.trim().startsWith(val.trim()))) {
             filterOkForLabel = false;
           }
+          return undefined;
         });
       } else {
         // The key is not in the labels so not match AND operation
 
         filterOkForLabel = false;
       }
+      return undefined;
     });
   }
 
@@ -83,6 +88,7 @@ export const filterByLabel = (items: itemsType[], filter: string[], op: string =
         if (filterLabelByOp(item.labels, filter, op)) {
           result = result.concat(item);
         }
+        return undefined;
       });
   return result;
 };

--- a/src/helpers/LabelFilterHelper.ts
+++ b/src/helpers/LabelFilterHelper.ts
@@ -4,36 +4,85 @@ import { ServiceListItem } from '../types/ServiceList';
 
 type itemsType = AppListItem | ServiceListItem | WorkloadListItem;
 
-export const filterByLabel = (items: itemsType[], filter: string[]): itemsType[] => {
-  let result: itemsType[] = [];
-  filter.map(filter => {
-    if (filter.includes(':')) {
-      const values = filter.split(':');
-      // Check Values
-      values[1]
-        .split(',')
-        .map(
-          val =>
-            (result = result.concat(
-              items.filter(
-                item =>
-                  values[0] in item.labels &&
-                  item.labels[values[0].trim()]
-                    .split(',')
-                    .some(appVal => appVal.trim().startsWith(val.trim()) && !result.includes(item))
-              )
-            ))
-        );
-    } else {
-      // Check if has Label
-      result = result.concat(
-        items.filter(item =>
-          Object.keys(item.labels).some(key => key.startsWith(filter.trim()) && !result.includes(item))
-        )
-      );
+const filterLabelByOp = (labels: { [key: string]: string }, filters: string[], op: string = 'or'): boolean => {
+  let filterOkForLabel: boolean = false;
+  // keys => List of filters with only Label Presence
+  // keyValues => List of filters with Label and value
+  /*
+    TS Error but this works...
+  */
+  // const [keys, keyValues] = filters.reduce(([p, f], e) => (!e.includes(':') ? [[...p, e], f] : [p, [...f, e]]), [[], []]);
+  const keys = filters.filter(f => !f.includes(':'));
+  const keyValues = filters.filter(f => f.includes(':'));
+
+  // Get all keys of labels
+  const labelKeys = Object.keys(labels);
+  // Case OR operation
+  if (op === 'or') {
+    // Check presence label
+    filterOkForLabel = labelKeys.filter(label => keys.map(key => label.startsWith(key))).length > 0;
+    if (filterOkForLabel) {
+      return true;
     }
-    return null;
+    // Check key and value
+    keyValues.map(filter => {
+      const [key, value] = filter.split(':');
+      // Check if multiple values
+      value.split(',').map(v => {
+        if (key in labels && !filterOkForLabel) {
+          // Split label values for serviceList Case where we can have multiple values for a label
+          filterOkForLabel = labels[key]
+            .trim()
+            .split(',')
+            .some(labelValue => labelValue.trim().startsWith(v.trim()));
+        }
+      });
+    });
+    return filterOkForLabel;
+  }
+
+  // Case AND operation
+
+  // We expect this label is ok for the filters with And Operation
+  filterOkForLabel = true;
+  // Start check label presence
+  keys.map(k => {
+    if (!labelKeys.includes(k) && filterOkForLabel) {
+      filterOkForLabel = false;
+    }
   });
 
-  return filter.length > 0 ? result : items;
+  // If label presence is validated we continue checking with key,value
+  if (filterOkForLabel) {
+    keyValues.map(filter => {
+      const [key, value] = filter.split(':');
+      if (key in labels && filterOkForLabel) {
+        // We need to check if some value of filter match
+        value.split(',').map(val => {
+          // Split label values for serviceList Case where we can have multiple values for a label
+          if (!labels[key].split(',').some(labelVal => labelVal.trim().startsWith(val.trim()))) {
+            filterOkForLabel = false;
+          }
+        });
+      } else {
+        // The key is not in the labels so not match AND operation
+
+        filterOkForLabel = false;
+      }
+    });
+  }
+
+  return filterOkForLabel;
+};
+
+export const filterByLabel = (items: itemsType[], filter: string[], op: string = 'or'): itemsType[] => {
+  let result: itemsType[] = [];
+  filter.length === 0
+    ? (result = items)
+    : items.map(item => {
+        if (filterLabelByOp(item.labels, filter, op)) {
+          result = result.concat(item);
+        }
+      });
+  return result;
 };

--- a/src/helpers/LabelFilterHelper.ts
+++ b/src/helpers/LabelFilterHelper.ts
@@ -14,7 +14,8 @@ const orLabelOperation = (labels: { [key: string]: string }, filters: string[]):
   const labelKeys = Object.keys(labels);
 
   // Check presence label
-  let filterOkForLabel = labelKeys.filter(label => keys.map(key => label.startsWith(key))).length > 0;
+  let filterOkForLabel = labelKeys.filter(label => keys.some(key => label.startsWith(key))).length > 0;
+
   if (filterOkForLabel) {
     return true;
   }
@@ -29,6 +30,7 @@ const orLabelOperation = (labels: { [key: string]: string }, filters: string[]):
           .trim()
           .split(',')
           .some(labelValue => labelValue.trim().startsWith(v.trim()));
+        console.log();
       }
       return undefined;
     });

--- a/src/helpers/__tests__/LabelFilterHelper.test.ts
+++ b/src/helpers/__tests__/LabelFilterHelper.test.ts
@@ -1,0 +1,226 @@
+import { filterByLabel } from '../LabelFilterHelper';
+import { AppListItem } from '../../types/AppList';
+import { WorkloadListItem } from '../../types/Workload';
+import { ServiceListItem } from '../../types/ServiceList';
+
+const appList: AppListItem[] = [
+  {
+    namespace: 'bookinfo',
+    healthPromise: new Promise(() => {}),
+    name: 'ratings',
+    istioSidecar: false,
+    labels: { app: 'ratings', service: 'ratings', version: 'v1' }
+  },
+  {
+    namespace: 'bookinfo',
+    healthPromise: new Promise(() => {}),
+    name: 'productpage',
+    istioSidecar: false,
+    labels: { app: 'productpage', service: 'productpage', version: 'v1' }
+  },
+  {
+    namespace: 'bookinfo',
+    healthPromise: new Promise(() => {}),
+    name: 'details',
+    istioSidecar: false,
+    labels: { app: 'details', service: 'details', version: 'v1' }
+  },
+  {
+    namespace: 'bookinfo',
+    healthPromise: new Promise(() => {}),
+    name: 'reviews',
+    istioSidecar: false,
+    labels: { app: 'reviews', service: 'reviews', version: 'v1,v2,v3' }
+  }
+];
+
+const workloadList: WorkloadListItem[] = [
+  {
+    namespace: 'bookinfo',
+    healthPromise: new Promise(() => {}),
+    name: 'details-v1',
+    type: 'Deployment',
+    istioSidecar: false,
+    labels: { app: 'details', version: 'v1' },
+    appLabel: true,
+    versionLabel: true
+  },
+  {
+    namespace: 'bookinfo',
+    healthPromise: new Promise(() => {}),
+    name: 'productpage-v1',
+    type: 'Deployment',
+    istioSidecar: false,
+    labels: { app: 'productpage', version: 'v1' },
+    appLabel: true,
+    versionLabel: true
+  },
+  {
+    namespace: 'bookinfo',
+    healthPromise: new Promise(() => {}),
+    name: 'ratings-v1',
+    type: 'Deployment',
+    istioSidecar: false,
+    labels: { app: 'ratings', version: 'v1' },
+    appLabel: true,
+    versionLabel: true
+  },
+  {
+    namespace: 'bookinfo',
+    healthPromise: new Promise(() => {}),
+    name: 'reviews-v1',
+    type: 'Deployment',
+    istioSidecar: false,
+    labels: { app: 'reviews', version: 'v1' },
+    appLabel: true,
+    versionLabel: true
+  },
+  {
+    namespace: 'bookinfo',
+    healthPromise: new Promise(() => {}),
+    name: 'reviews-v2',
+    type: 'Deployment',
+    istioSidecar: false,
+    labels: { app: 'reviews', version: 'v2' },
+    appLabel: true,
+    versionLabel: true
+  },
+  {
+    namespace: 'bookinfo',
+    healthPromise: new Promise(() => {}),
+    name: 'reviews-v3',
+    type: 'Deployment',
+    istioSidecar: false,
+    labels: { app: 'reviews', version: 'v3' },
+    appLabel: true,
+    versionLabel: true
+  }
+];
+
+const serviceList: ServiceListItem[] = [
+  {
+    namespace: 'bookinfo',
+    healthPromise: new Promise(() => {}),
+    name: 'details',
+    istioSidecar: false,
+    labels: { app: 'details', service: 'details' },
+    validation: { name: 'details', objectType: 'service', valid: true, checks: [] }
+  },
+  {
+    namespace: 'bookinfo',
+    healthPromise: new Promise(() => {}),
+    name: 'reviews',
+    istioSidecar: false,
+    labels: { app: 'reviews', service: 'reviews' },
+    validation: { name: 'reviews', objectType: 'service', valid: true, checks: [] }
+  },
+  {
+    namespace: 'bookinfo',
+    healthPromise: new Promise(() => {}),
+    name: 'ratings',
+    istioSidecar: false,
+    labels: { app: 'ratings', service: 'ratings' },
+    validation: { name: 'ratings', objectType: 'service', valid: true, checks: [] }
+  },
+  {
+    namespace: 'bookinfo',
+    healthPromise: new Promise(() => {}),
+    name: 'productpage',
+    istioSidecar: false,
+    labels: { app: 'productpage', service: 'productpage' },
+    validation: { name: 'productpage', objectType: 'service', valid: true, checks: [] }
+  }
+];
+
+describe('LabelFilter', () => {
+  it('check Label Filter with AppList and OR Operation', () => {
+    const result = filterByLabel(appList, ['app', 'service:details']);
+    expect(result).toEqual(appList);
+  });
+
+  it('check Label Filter with AppList and AND Operation', () => {
+    const result = filterByLabel(appList, ['app', 'service:details'], 'and');
+    expect(result).toEqual([
+      {
+        namespace: 'bookinfo',
+        healthPromise: new Promise(() => {}),
+        name: 'details',
+        istioSidecar: false,
+        labels: { app: 'details', service: 'details', version: 'v1' }
+      }
+    ]);
+  });
+
+  it('check Label Filter with AppList and AND Operation with multiple values', () => {
+    const result = filterByLabel(appList, ['app', 'version:v2'], 'and');
+    expect(result).toEqual([
+      {
+        namespace: 'bookinfo',
+        healthPromise: new Promise(() => {}),
+        name: 'reviews',
+        istioSidecar: false,
+        labels: { app: 'reviews', service: 'reviews', version: 'v1,v2,v3' }
+      }
+    ]);
+  });
+
+  it('check Label Filter with WorkloadList and OR Operation', () => {
+    const result = filterByLabel(workloadList, ['app', 'version:v1']);
+    expect(result).toEqual(workloadList);
+  });
+
+  it('check Label Filter with WorkloadList and AND Operation', () => {
+    const result = filterByLabel(workloadList, ['app:reviews', 'version'], 'and');
+    expect(result).toEqual([
+      {
+        namespace: 'bookinfo',
+        healthPromise: new Promise(() => {}),
+        name: 'reviews-v1',
+        type: 'Deployment',
+        istioSidecar: false,
+        labels: { app: 'reviews', version: 'v1' },
+        appLabel: true,
+        versionLabel: true
+      },
+      {
+        namespace: 'bookinfo',
+        healthPromise: new Promise(() => {}),
+        name: 'reviews-v2',
+        type: 'Deployment',
+        istioSidecar: false,
+        labels: { app: 'reviews', version: 'v2' },
+        appLabel: true,
+        versionLabel: true
+      },
+      {
+        namespace: 'bookinfo',
+        healthPromise: new Promise(() => {}),
+        name: 'reviews-v3',
+        type: 'Deployment',
+        istioSidecar: false,
+        labels: { app: 'reviews', version: 'v3' },
+        appLabel: true,
+        versionLabel: true
+      }
+    ]);
+  });
+
+  it('check Label Filter with ServiceList and OR Operation', () => {
+    const result = filterByLabel(serviceList, ['app', 'service:details']);
+    expect(result).toEqual(serviceList);
+  });
+
+  it('check Label Filter with ServiceList and AND Operation', () => {
+    const result = filterByLabel(serviceList, ['app', 'service:de'], 'and');
+    expect(result).toEqual([
+      {
+        namespace: 'bookinfo',
+        healthPromise: new Promise(() => {}),
+        name: 'details',
+        istioSidecar: false,
+        labels: { app: 'details', service: 'details' },
+        validation: { name: 'details', objectType: 'service', valid: true, checks: [] }
+      }
+    ]);
+  });
+});

--- a/src/pages/AppList/AppListComponent.tsx
+++ b/src/pages/AppList/AppListComponent.tsx
@@ -6,7 +6,7 @@ import { AppListItem } from '../../types/AppList';
 import * as AppListFilters from './FiltersAndSorts';
 import * as AppListClass from './AppListClass';
 import { FilterSelected, StatefulFilters } from '../../components/Filters/StatefulFilters';
-import { ActiveFilter } from '../../types/Filters';
+import { ActiveFiltersInfo } from '../../types/Filters';
 import { PromisesRegistry } from '../../utils/CancelablePromises';
 import { SortField } from '../../types/SortFilters';
 import * as FilterComponent from '../../components/FilterList/FilterComponent';
@@ -78,7 +78,7 @@ class AppListComponent extends FilterComponent.Component<AppListComponentProps, 
   updateListItems() {
     this.promises.cancelAll();
 
-    const activeFilters: ActiveFilter[] = FilterSelected.getSelected();
+    const activeFilters: ActiveFiltersInfo = FilterSelected.getSelected();
     const namespacesSelected = this.props.activeNamespaces.map(item => item.name);
 
     if (namespacesSelected.length === 0) {
@@ -98,7 +98,7 @@ class AppListComponent extends FilterComponent.Component<AppListComponentProps, 
     }
   }
 
-  fetchApps(namespaces: string[], filters: ActiveFilter[], rateInterval: number) {
+  fetchApps(namespaces: string[], filters: ActiveFiltersInfo, rateInterval: number) {
     const appsPromises = namespaces.map(namespace => API.getApps(namespace));
     this.promises
       .registerAll('apps', appsPromises)

--- a/src/pages/AppList/FiltersAndSorts.ts
+++ b/src/pages/AppList/FiltersAndSorts.ts
@@ -1,4 +1,4 @@
-import { ActiveFilter, FILTER_ACTION_APPEND, FilterType, LabelFilter, OpLabelFilter } from '../../types/Filters';
+import { ActiveFiltersInfo, FILTER_ACTION_APPEND, FilterType, LabelFilter } from '../../types/Filters';
 import { AppListItem } from '../../types/AppList';
 import { SortField } from '../../types/SortFilters';
 import { getRequestErrorsStatus, WithAppHealth, hasHealth } from '../../types/Health';
@@ -84,13 +84,7 @@ const appNameFilter: FilterType = {
   filterValues: []
 };
 
-export const availableFilters: FilterType[] = [
-  appNameFilter,
-  istioSidecarFilter,
-  healthFilter,
-  LabelFilter,
-  OpLabelFilter
-];
+export const availableFilters: FilterType[] = [appNameFilter, istioSidecarFilter, healthFilter, LabelFilter];
 
 /** Filter Method */
 
@@ -114,7 +108,10 @@ const filterByIstioSidecar = (items: AppListItem[], istioSidecar: boolean): AppL
   return items.filter(item => item.istioSidecar === istioSidecar);
 };
 
-export const filterBy = (appsList: AppListItem[], filters: ActiveFilter[]): Promise<AppListItem[]> | AppListItem[] => {
+export const filterBy = (
+  appsList: AppListItem[],
+  filters: ActiveFiltersInfo
+): Promise<AppListItem[]> | AppListItem[] => {
   let ret = appsList;
   const istioSidecar = getPresenceFilterValue(istioSidecarFilter, filters);
   if (istioSidecar !== undefined) {
@@ -128,7 +125,7 @@ export const filterBy = (appsList: AppListItem[], filters: ActiveFilter[]): Prom
 
   const appLabelsSelected = getFilterSelectedValues(LabelFilter, filters);
   if (appLabelsSelected.length > 0) {
-    ret = filterByLabel(ret, appLabelsSelected) as AppListItem[];
+    ret = filterByLabel(ret, appLabelsSelected, filters.op) as AppListItem[];
   }
 
   // We may have to perform a second round of filtering, using data fetched asynchronously (health)

--- a/src/pages/AppList/FiltersAndSorts.ts
+++ b/src/pages/AppList/FiltersAndSorts.ts
@@ -1,4 +1,4 @@
-import { ActiveFilter, FILTER_ACTION_APPEND, FilterType, LabelFilter } from '../../types/Filters';
+import { ActiveFilter, FILTER_ACTION_APPEND, FilterType, LabelFilter, OpLabelFilter } from '../../types/Filters';
 import { AppListItem } from '../../types/AppList';
 import { SortField } from '../../types/SortFilters';
 import { getRequestErrorsStatus, WithAppHealth, hasHealth } from '../../types/Health';
@@ -84,7 +84,13 @@ const appNameFilter: FilterType = {
   filterValues: []
 };
 
-export const availableFilters: FilterType[] = [appNameFilter, istioSidecarFilter, healthFilter, LabelFilter];
+export const availableFilters: FilterType[] = [
+  appNameFilter,
+  istioSidecarFilter,
+  healthFilter,
+  LabelFilter,
+  OpLabelFilter
+];
 
 /** Filter Method */
 

--- a/src/pages/IstioConfigList/IstioConfigListComponent.tsx
+++ b/src/pages/IstioConfigList/IstioConfigListComponent.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { FilterSelected, StatefulFilters } from '../../components/Filters/StatefulFilters';
-import { ActiveFilter } from '../../types/Filters';
+import { ActiveFiltersInfo } from '../../types/Filters';
 import * as API from '../../services/Api';
 import Namespace from '../../types/Namespace';
 import {
@@ -87,7 +87,7 @@ class IstioConfigListComponent extends FilterComponent.Component<
   updateListItems() {
     this.promises.cancelAll();
 
-    const activeFilters: ActiveFilter[] = FilterSelected.getSelected();
+    const activeFilters: ActiveFiltersInfo = FilterSelected.getSelected();
     const namespacesSelected = this.props.activeNamespaces!.map(item => item.name);
     const istioTypeFilters = getFilterSelectedValues(IstioConfigListFilters.istioTypeFilter, activeFilters).map(
       value => dicIstioType[value]

--- a/src/pages/Overview/OverviewPage.tsx
+++ b/src/pages/Overview/OverviewPage.tsx
@@ -136,7 +136,7 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
     this.promises
       .register('namespaces', API.getNamespaces())
       .then(namespacesResponse => {
-        const nameFilters = FilterSelected.getSelected().filter(f => f.category === Filters.nameFilter.title);
+        const nameFilters = FilterSelected.getSelected().filters.filter(f => f.category === Filters.nameFilter.title);
         const allNamespaces: NamespaceInfo[] = namespacesResponse.data
           .filter(ns => {
             return nameFilters.length === 0 || nameFilters.some(f => ns.name.includes(f.value));

--- a/src/pages/Overview/OverviewStatus.tsx
+++ b/src/pages/Overview/OverviewStatus.tsx
@@ -3,7 +3,7 @@ import { Text, TextVariants, Tooltip, TooltipPosition } from '@patternfly/react-
 import { Link } from 'react-router-dom';
 import { Status } from '../../types/Health';
 import { Paths } from '../../config';
-import { ActiveFilter } from '../../types/Filters';
+import { ActiveFilter, DEFAULT_LABEL_OPERATION } from '../../types/Filters';
 import { healthFilter } from '../../components/Filters/CommonFilters';
 import { FilterSelected } from '../../components/Filters/StatefulFilters';
 import { createIcon } from '../../components/Health/Helper';
@@ -27,7 +27,7 @@ class OverviewStatus extends React.Component<Props, {}> {
         value: this.props.status.name
       }
     ];
-    FilterSelected.setSelected(filters);
+    FilterSelected.setSelected({ filters: filters, op: DEFAULT_LABEL_OPERATION });
   };
 
   render() {

--- a/src/pages/Overview/__tests__/OverviewPage.test.tsx
+++ b/src/pages/Overview/__tests__/OverviewPage.test.tsx
@@ -11,6 +11,7 @@ import * as API from '../../../services/Api';
 import { AppHealth, NamespaceAppHealth, HEALTHY, FAILURE, DEGRADED } from '../../../types/Health';
 import { store } from '../../../store/ConfigStore';
 import { MTLSStatuses } from '../../../types/TLSStatus';
+import { DEFAULT_LABEL_OPERATION } from '../../../types/Filters';
 
 const mockAPIToPromise = (func: keyof typeof API, obj: any, encapsData: boolean): Promise<void> => {
   return new Promise((resolve, reject) => {
@@ -76,7 +77,7 @@ describe('Overview page', () => {
   });
 
   it('renders all without filters', done => {
-    FilterSelected.setSelected([]);
+    FilterSelected.setSelected({ filters: [], op: DEFAULT_LABEL_OPERATION });
     Promise.all([
       mockNamespaces(['a', 'b', 'c']),
       mockNamespaceHealth({
@@ -97,12 +98,15 @@ describe('Overview page', () => {
   });
 
   it('filters failures match', done => {
-    FilterSelected.setSelected([
-      {
-        category: 'Health',
-        value: 'Failure'
-      }
-    ]);
+    FilterSelected.setSelected({
+      filters: [
+        {
+          category: 'Health',
+          value: 'Failure'
+        }
+      ],
+      op: DEFAULT_LABEL_OPERATION
+    });
     Promise.all([
       mockNamespaces(['a']),
       mockNamespaceHealth({
@@ -125,12 +129,15 @@ describe('Overview page', () => {
   });
 
   it('filters failures no match', done => {
-    FilterSelected.setSelected([
-      {
-        category: 'Health',
-        value: 'Failure'
-      }
-    ]);
+    FilterSelected.setSelected({
+      filters: [
+        {
+          category: 'Health',
+          value: 'Failure'
+        }
+      ],
+      op: DEFAULT_LABEL_OPERATION
+    });
     Promise.all([
       mockNamespaces(['a']),
       mockNamespaceHealth({
@@ -153,16 +160,19 @@ describe('Overview page', () => {
   });
 
   it('multi-filters health match', done => {
-    FilterSelected.setSelected([
-      {
-        category: 'Health',
-        value: 'Failure'
-      },
-      {
-        category: 'Health',
-        value: 'Degraded'
-      }
-    ]);
+    FilterSelected.setSelected({
+      filters: [
+        {
+          category: 'Health',
+          value: 'Failure'
+        },
+        {
+          category: 'Health',
+          value: 'Degraded'
+        }
+      ],
+      op: DEFAULT_LABEL_OPERATION
+    });
     Promise.all([
       mockNamespaces(['a']),
       mockNamespaceHealth({
@@ -182,16 +192,19 @@ describe('Overview page', () => {
   });
 
   it('multi-filters health no match', done => {
-    FilterSelected.setSelected([
-      {
-        category: 'Health',
-        value: 'Failure'
-      },
-      {
-        category: 'Health',
-        value: 'Degraded'
-      }
-    ]);
+    FilterSelected.setSelected({
+      filters: [
+        {
+          category: 'Health',
+          value: 'Failure'
+        },
+        {
+          category: 'Health',
+          value: 'Degraded'
+        }
+      ],
+      op: DEFAULT_LABEL_OPERATION
+    });
     Promise.all([
       mockNamespaces(['a']),
       mockNamespaceHealth({
@@ -211,12 +224,15 @@ describe('Overview page', () => {
   });
 
   it('filters namespaces info name match', done => {
-    FilterSelected.setSelected([
-      {
-        category: 'Namespace',
-        value: 'bc'
-      }
-    ]);
+    FilterSelected.setSelected({
+      filters: [
+        {
+          category: 'Namespace',
+          value: 'bc'
+        }
+      ],
+      op: DEFAULT_LABEL_OPERATION
+    });
     Promise.all([
       mockNamespaces(['abc', 'bce', 'ced']),
       mockNamespaceHealth({
@@ -233,12 +249,15 @@ describe('Overview page', () => {
   });
 
   it('filters namespaces info name no match', done => {
-    FilterSelected.setSelected([
-      {
-        category: 'Namespace',
-        value: 'yz'
-      }
-    ]);
+    FilterSelected.setSelected({
+      filters: [
+        {
+          category: 'Namespace',
+          value: 'yz'
+        }
+      ],
+      op: DEFAULT_LABEL_OPERATION
+    });
     mockNamespaces(['abc', 'bce', 'ced']).then(() => {
       mounted!.update();
       expect(mounted!.find('Card')).toHaveLength(0);
@@ -248,16 +267,19 @@ describe('Overview page', () => {
   });
 
   it('filters namespaces info name and health match', done => {
-    FilterSelected.setSelected([
-      {
-        category: 'Namespace',
-        value: 'bc'
-      },
-      {
-        category: 'Health',
-        value: 'Healthy'
-      }
-    ]);
+    FilterSelected.setSelected({
+      filters: [
+        {
+          category: 'Namespace',
+          value: 'bc'
+        },
+        {
+          category: 'Health',
+          value: 'Healthy'
+        }
+      ],
+      op: DEFAULT_LABEL_OPERATION
+    });
     Promise.all([
       mockNamespaces(['abc', 'bce', 'ced']),
       mockNamespaceHealth({
@@ -274,16 +296,19 @@ describe('Overview page', () => {
   });
 
   it('filters namespaces info name and health no match', done => {
-    FilterSelected.setSelected([
-      {
-        category: 'Name',
-        value: 'bc'
-      },
-      {
-        category: 'Health',
-        value: 'Healthy'
-      }
-    ]);
+    FilterSelected.setSelected({
+      filters: [
+        {
+          category: 'Name',
+          value: 'bc'
+        },
+        {
+          category: 'Health',
+          value: 'Healthy'
+        }
+      ],
+      op: DEFAULT_LABEL_OPERATION
+    });
     Promise.all([
       mockNamespaces(['abc', 'bce', 'ced']),
       mockNamespaceHealth({

--- a/src/pages/ServiceList/FiltersAndSorts.ts
+++ b/src/pages/ServiceList/FiltersAndSorts.ts
@@ -1,4 +1,4 @@
-import { ActiveFilter, FilterType, FILTER_ACTION_APPEND, LabelFilter } from '../../types/Filters';
+import { ActiveFilter, FilterType, FILTER_ACTION_APPEND, LabelFilter, OpLabelFilter } from '../../types/Filters';
 import { getRequestErrorsStatus, WithServiceHealth, hasHealth } from '../../types/Health';
 import { ServiceListItem } from '../../types/ServiceList';
 import { SortField } from '../../types/SortFilters';
@@ -126,7 +126,13 @@ const serviceNameFilter: FilterType = {
   filterValues: []
 };
 
-export const availableFilters: FilterType[] = [serviceNameFilter, istioSidecarFilter, healthFilter, LabelFilter];
+export const availableFilters: FilterType[] = [
+  serviceNameFilter,
+  istioSidecarFilter,
+  healthFilter,
+  LabelFilter,
+  OpLabelFilter
+];
 
 const filterByIstioSidecar = (items: ServiceListItem[], istioSidecar: boolean): ServiceListItem[] => {
   return items.filter(item => item.istioSidecar === istioSidecar);

--- a/src/pages/ServiceList/FiltersAndSorts.ts
+++ b/src/pages/ServiceList/FiltersAndSorts.ts
@@ -1,4 +1,4 @@
-import { ActiveFilter, FilterType, FILTER_ACTION_APPEND, LabelFilter, OpLabelFilter } from '../../types/Filters';
+import { ActiveFiltersInfo, FilterType, FILTER_ACTION_APPEND, LabelFilter } from '../../types/Filters';
 import { getRequestErrorsStatus, WithServiceHealth, hasHealth } from '../../types/Health';
 import { ServiceListItem } from '../../types/ServiceList';
 import { SortField } from '../../types/SortFilters';
@@ -126,13 +126,7 @@ const serviceNameFilter: FilterType = {
   filterValues: []
 };
 
-export const availableFilters: FilterType[] = [
-  serviceNameFilter,
-  istioSidecarFilter,
-  healthFilter,
-  LabelFilter,
-  OpLabelFilter
-];
+export const availableFilters: FilterType[] = [serviceNameFilter, istioSidecarFilter, healthFilter, LabelFilter];
 
 const filterByIstioSidecar = (items: ServiceListItem[], istioSidecar: boolean): ServiceListItem[] => {
   return items.filter(item => item.istioSidecar === istioSidecar);
@@ -156,7 +150,7 @@ const filterByName = (items: ServiceListItem[], names: string[]): ServiceListIte
 
 export const filterBy = (
   items: ServiceListItem[],
-  filters: ActiveFilter[]
+  filters: ActiveFiltersInfo
 ): Promise<ServiceListItem[]> | ServiceListItem[] => {
   let ret = items;
   const istioSidecar = getPresenceFilterValue(istioSidecarFilter, filters);
@@ -171,7 +165,7 @@ export const filterBy = (
 
   const serviceFilterSelected = getFilterSelectedValues(LabelFilter, filters);
   if (serviceFilterSelected.length > 0) {
-    ret = filterByLabel(ret, serviceFilterSelected) as ServiceListItem[];
+    ret = filterByLabel(ret, serviceFilterSelected, filters.op) as ServiceListItem[];
   }
   // We may have to perform a second round of filtering, using data fetched asynchronously (health)
   // If not, exit fast

--- a/src/pages/ServiceList/ServiceListComponent.tsx
+++ b/src/pages/ServiceList/ServiceListComponent.tsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { FilterSelected, StatefulFilters } from '../../components/Filters/StatefulFilters';
 import * as API from '../../services/Api';
 import Namespace from '../../types/Namespace';
-import { ActiveFilter } from '../../types/Filters';
+import { ActiveFiltersInfo } from '../../types/Filters';
 import { ServiceList, ServiceListItem } from '../../types/ServiceList';
 import { PromisesRegistry } from '../../utils/CancelablePromises';
 import * as ServiceListFilters from './FiltersAndSorts';
@@ -85,7 +85,7 @@ class ServiceListComponent extends FilterComponent.Component<
   updateListItems() {
     this.promises.cancelAll();
 
-    const activeFilters: ActiveFilter[] = FilterSelected.getSelected();
+    const activeFilters: ActiveFiltersInfo = FilterSelected.getSelected();
     const namespacesSelected = this.props.activeNamespaces.map(item => item.name);
 
     if (namespacesSelected.length === 0) {
@@ -120,7 +120,7 @@ class ServiceListComponent extends FilterComponent.Component<
     return [];
   }
 
-  fetchServices(namespaces: string[], filters: ActiveFilter[], rateInterval: number) {
+  fetchServices(namespaces: string[], filters: ActiveFiltersInfo, rateInterval: number) {
     const servicesPromises = namespaces.map(ns => API.getServices(ns));
 
     this.promises

--- a/src/pages/WorkloadList/FiltersAndSorts.ts
+++ b/src/pages/WorkloadList/FiltersAndSorts.ts
@@ -1,11 +1,10 @@
 import {
-  ActiveFilter,
+  ActiveFiltersInfo,
   FILTER_ACTION_APPEND,
   FILTER_ACTION_UPDATE,
   FilterType,
   FilterTypes,
-  LabelFilter,
-  OpLabelFilter
+  LabelFilter
 } from '../../types/Filters';
 import { WorkloadListItem, WorkloadType } from '../../types/Workload';
 import { SortField } from '../../types/SortFilters';
@@ -252,8 +251,7 @@ export const availableFilters: FilterType[] = [
   healthFilter,
   appLabelFilter,
   versionLabelFilter,
-  LabelFilter,
-  OpLabelFilter
+  LabelFilter
 ];
 
 /** Filter Method */
@@ -301,7 +299,7 @@ const filterByName = (items: WorkloadListItem[], names: string[]): WorkloadListI
 
 export const filterBy = (
   items: WorkloadListItem[],
-  filters: ActiveFilter[]
+  filters: ActiveFiltersInfo
 ): Promise<WorkloadListItem[]> | WorkloadListItem[] => {
   const workloadTypeFilters = getFilterSelectedValues(workloadTypeFilter, filters);
   const workloadNamesSelected = getFilterSelectedValues(workloadNameFilter, filters);
@@ -309,13 +307,12 @@ export const filterBy = (
   const appLabel = getPresenceFilterValue(appLabelFilter, filters);
   const versionLabel = getPresenceFilterValue(versionLabelFilter, filters);
   const labelFilters = getFilterSelectedValues(LabelFilter, filters);
-  const opLabelFilter = getFilterSelectedValues(OpLabelFilter, filters);
 
   let ret = items;
   ret = filterByType(ret, workloadTypeFilters);
   ret = filterByName(ret, workloadNamesSelected);
   ret = filterByLabelPresence(ret, istioSidecar, appLabel, versionLabel);
-  ret = filterByLabel(ret, labelFilters, opLabelFilter[0]) as WorkloadListItem[];
+  ret = filterByLabel(ret, labelFilters, filters.op) as WorkloadListItem[];
 
   // We may have to perform a second round of filtering, using data fetched asynchronously (health)
   // If not, exit fast

--- a/src/pages/WorkloadList/FiltersAndSorts.ts
+++ b/src/pages/WorkloadList/FiltersAndSorts.ts
@@ -4,7 +4,8 @@ import {
   FILTER_ACTION_UPDATE,
   FilterType,
   FilterTypes,
-  LabelFilter
+  LabelFilter,
+  OpLabelFilter
 } from '../../types/Filters';
 import { WorkloadListItem, WorkloadType } from '../../types/Workload';
 import { SortField } from '../../types/SortFilters';
@@ -251,7 +252,8 @@ export const availableFilters: FilterType[] = [
   healthFilter,
   appLabelFilter,
   versionLabelFilter,
-  LabelFilter
+  LabelFilter,
+  OpLabelFilter
 ];
 
 /** Filter Method */
@@ -307,12 +309,13 @@ export const filterBy = (
   const appLabel = getPresenceFilterValue(appLabelFilter, filters);
   const versionLabel = getPresenceFilterValue(versionLabelFilter, filters);
   const labelFilters = getFilterSelectedValues(LabelFilter, filters);
+  const opLabelFilter = getFilterSelectedValues(OpLabelFilter, filters);
 
   let ret = items;
   ret = filterByType(ret, workloadTypeFilters);
   ret = filterByName(ret, workloadNamesSelected);
   ret = filterByLabelPresence(ret, istioSidecar, appLabel, versionLabel);
-  ret = filterByLabel(ret, labelFilters) as WorkloadListItem[];
+  ret = filterByLabel(ret, labelFilters, opLabelFilter[0]) as WorkloadListItem[];
 
   // We may have to perform a second round of filtering, using data fetched asynchronously (health)
   // If not, exit fast

--- a/src/pages/WorkloadList/WorkloadListComponent.tsx
+++ b/src/pages/WorkloadList/WorkloadListComponent.tsx
@@ -5,7 +5,7 @@ import Namespace from '../../types/Namespace';
 import { WorkloadListItem, WorkloadNamespaceResponse } from '../../types/Workload';
 import * as WorkloadListFilters from './FiltersAndSorts';
 import { FilterSelected, StatefulFilters } from '../../components/Filters/StatefulFilters';
-import { ActiveFilter } from '../../types/Filters';
+import { ActiveFiltersInfo } from '../../types/Filters';
 import { PromisesRegistry } from '../../utils/CancelablePromises';
 import { SortField } from '../../types/SortFilters';
 import * as FilterComponent from '../../components/FilterList/FilterComponent';
@@ -82,7 +82,7 @@ class WorkloadListComponent extends FilterComponent.Component<
   updateListItems() {
     this.promises.cancelAll();
 
-    const activeFilters: ActiveFilter[] = FilterSelected.getSelected();
+    const activeFilters: ActiveFiltersInfo = FilterSelected.getSelected();
     const namespacesSelected = this.props.activeNamespaces.map(item => item.name);
 
     if (namespacesSelected.length === 0) {
@@ -124,7 +124,7 @@ class WorkloadListComponent extends FilterComponent.Component<
     return [];
   };
 
-  fetchWorkloads(namespaces: string[], filters: ActiveFilter[]) {
+  fetchWorkloads(namespaces: string[], filters: ActiveFiltersInfo) {
     const workloadsConfigPromises = namespaces.map(namespace => API.getWorkloads(namespace));
     this.promises
       .registerAll('workloads', workloadsConfigPromises)

--- a/src/pages/extensions/iter8/Iter8ExperimentList/FiltersAndSorts.ts
+++ b/src/pages/extensions/iter8/Iter8ExperimentList/FiltersAndSorts.ts
@@ -1,4 +1,4 @@
-import { ActiveFilter, FILTER_ACTION_APPEND, FilterType, FilterTypes } from '../../../../types/Filters';
+import { ActiveFiltersInfo, FILTER_ACTION_APPEND, FilterType, FilterTypes } from '../../../../types/Filters';
 import { SortField } from '../../../../types/SortFilters';
 import { Iter8Experiment } from '../../../../types/Iter8';
 import { TextInputTypes } from '@patternfly/react-core';
@@ -112,7 +112,7 @@ const filterByPhase = (items: Iter8Experiment[], names: string[]): Iter8Experime
   });
 };
 
-export const filterBy = (iter8Experiment: Iter8Experiment[], filters: ActiveFilter[]): Iter8Experiment[] => {
+export const filterBy = (iter8Experiment: Iter8Experiment[], filters: ActiveFiltersInfo): Iter8Experiment[] => {
   let ret = iter8Experiment;
 
   const targetServiceSelected = getFilterSelectedValues(targetServiceFilter, filters);

--- a/src/types/Filters.ts
+++ b/src/types/Filters.ts
@@ -35,7 +35,7 @@ export interface FilterType {
 }
 
 export interface FilterTypeWithFilter<T> extends FilterType {
-  filter: (items: T[], filters: ActiveFilter[]) => T[];
+  filter: (items: T[], filters: ActiveFiltersInfo) => T[];
 }
 
 export const FILTER_ACTION_APPEND = 'append';
@@ -44,6 +44,15 @@ export const FILTER_ACTION_UPDATE = 'update';
 export interface ActiveFilter {
   category: string;
   value: string;
+}
+
+export type LabelOperation = 'and' | 'or';
+export const ID_LABEL_OPERATION = 'opLabel';
+export const DEFAULT_LABEL_OPERATION: LabelOperation = 'or';
+
+export interface ActiveFiltersInfo {
+  filters: ActiveFilter[];
+  op: LabelOperation;
 }
 
 // labelFilter common to lists
@@ -56,14 +65,4 @@ export const LabelFilter: FilterType = {
   customComponent: LabelFilters,
   action: FILTER_ACTION_APPEND,
   filterValues: []
-};
-
-export const OpLabelFilter: FilterType = {
-  id: 'opLabel',
-  title: 'Operation Label',
-  placeholder: 'Sort op',
-  filterType: FilterTypes.opLabel,
-  customComponent: undefined,
-  action: FILTER_ACTION_UPDATE,
-  filterValues: [{ id: 'or', title: 'or' }, { id: 'and', title: 'and' }]
 };

--- a/src/types/Filters.ts
+++ b/src/types/Filters.ts
@@ -11,7 +11,8 @@ enum NonInputTypes {
   typeAhead = 'typeahead',
   select = 'select',
   label = 'label',
-  nsLabel = 'nsLabel'
+  nsLabel = 'nsLabel',
+  opLabel = 'oplabel'
 }
 
 export const FilterTypes = {
@@ -55,4 +56,14 @@ export const LabelFilter: FilterType = {
   customComponent: LabelFilters,
   action: FILTER_ACTION_APPEND,
   filterValues: []
+};
+
+export const OpLabelFilter: FilterType = {
+  id: 'opLabel',
+  title: 'Operation Label',
+  placeholder: 'Sort op',
+  filterType: FilterTypes.opLabel,
+  customComponent: undefined,
+  action: FILTER_ACTION_UPDATE,
+  filterValues: [{ id: 'or', title: 'or' }, { id: 'and', title: 'and' }]
 };

--- a/src/types/Filters.ts
+++ b/src/types/Filters.ts
@@ -11,8 +11,7 @@ enum NonInputTypes {
   typeAhead = 'typeahead',
   select = 'select',
   label = 'label',
-  nsLabel = 'nsLabel',
-  opLabel = 'oplabel'
+  nsLabel = 'nsLabel'
 }
 
 export const FilterTypes = {


### PR DESCRIPTION
Fix https://github.com/kiali/kiali/issues/2734

# Demo

- I had to add this like a new Filter to be able to move this param to other lists
- LabelOperation Dropdown is displayed when user go to Label filter selection or we have a Label filter applied
- LabelOperation not add a "chip" in filters because by default we'll apply "OR" operation and it make not sense to add it for me.
- Applied in Workload, Services and Apps.
- It make sense to have this in overview too when we are filtering by labels related with the namespace and not by the objects of the namespace?

## Or Operation (the results are the same that master)
![Or](https://user-images.githubusercontent.com/3019213/81385915-70704200-9114-11ea-8ae2-e83e3c26d560.png)

## This show results that match all label filters.
![AND](https://user-images.githubusercontent.com/3019213/81385909-6fd7ab80-9114-11ea-84a7-614c2b5b7181.png)




## Other notes

The line https://github.com/aljesusg/kiali-ui/blob/fix_2734/src/helpers/LabelFilterHelper.ts#L14 throw TS error

```bash
TypeScript error in /home/aljesusg/Projects/kiali/kiali-ui/src/helpers/LabelFilterHelper.ts(14,59):
No overload matches this call.
  Overload 1 of 3, '(callbackfn: (previousValue: string, currentValue: string, currentIndex: number, array: string[]) => string, initialValue: string): string', gave the following error.
    Type '[string[], never[]] | [never[], string[]]' is not assignable to type 'string'.
      Type '[string[], never[]]' is not assignable to type 'string'.
  Overload 2 of 3, '(callbackfn: (previousValue: [never[], never[]], currentValue: string, currentIndex: number, array: string[]) => [never[], never[]], initialValue: [never[], never[]]): [never[], never[]]', gave the following error.
    Type '[string[], never[]] | [never[], string[]]' is not assignable to type '[never[], never[]]'.
      Type '[string[], never[]]' is not assignable to type '[never[], never[]]'.
        Type 'string[]' is not assignable to type 'never[]'.
          Type 'string' is not assignable to type 'never'.  TS2769

    12 |     TS Error but this works...
    13 |   */
  > 14 |   const [keys, keyValues] = filters.reduce(([p, f], e) => (!e.includes(':') ? [[...p, e], f] : [p, [...f, e]]), [[], []]);

```
In my opinion 

This is take more time
```ts
  //const keys = filters.filter(f => !f.includes(':'));
  //const keyValues = filters.filter(f => f.includes(':'));
```
than
```ts
const [keys, keyValues] = filters.reduce(([p, f], e) => (!e.includes(':') ? [[...p, e], f] : [p, [...f, e]]), [[], []]);
```
to separate the results.

cc @jotak @lucasponce 
