### PR TITLE
Adjust alignment of tabs and body with header in all pages

### DIFF
--- a/src/components/IstioActions/IstioActionsButtons.tsx
+++ b/src/components/IstioActions/IstioActionsButtons.tsx
@@ -35,7 +35,7 @@ class IstioActionButtons extends React.Component<Props, State> {
   render() {
     return (
       <>
-        <span style={{ float: 'left', paddingTop: '10px', paddingBottom: '10px' }}>
+        <span style={{ float: 'left', padding: '10px' }}>
           {!this.props.readOnly && (
             <span style={{ paddingRight: '5px' }}>
               <Button variant={ButtonVariant.primary} isDisabled={!this.props.canUpdate} onClick={this.props.onUpdate}>

--- a/src/components/Metrics/IstioMetrics.tsx
+++ b/src/components/Metrics/IstioMetrics.tsx
@@ -200,7 +200,7 @@ class IstioMetrics extends React.Component<Props, MetricsState> {
 
     return (
       <RenderComponentScroll>
-        <Grid style={{ padding: '20px' }}>
+        <Grid style={{ padding: '10px' }}>
           <GridItem span={12}>
             <Card>
               <CardBody>

--- a/src/components/Metrics/TrafficDetails.tsx
+++ b/src/components/Metrics/TrafficDetails.tsx
@@ -75,7 +75,7 @@ class TrafficDetails extends React.Component<TrafficDetailsProps, TrafficDetails
 
     return (
       <RenderComponentScroll>
-        <Grid style={{ padding: '20px' }}>
+        <Grid style={{ padding: '10px' }}>
           <GridItem span={12}>
             <Card>
               <CardBody>

--- a/src/pages/AppDetails/AppInfo.tsx
+++ b/src/pages/AppDetails/AppInfo.tsx
@@ -27,7 +27,7 @@ class AppInfo extends React.Component<AppInfoProps, AppInfoState> {
 
     return (
       <RenderComponentScroll>
-        <Grid style={{ margin: '30px' }} gutter={'md'}>
+        <Grid style={{ margin: '10px' }} gutter={'md'}>
           <GridItem span={12}>
             <AppDescription app={app} health={this.props.health} miniGraphDataSource={this.props.miniGraphDataSource} />
           </GridItem>

--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -374,8 +374,8 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
     }
 
     return (
-      <div className="container-fluid container-cards-pf">
-        <Grid gutter={'md'}>
+      <>
+        <Grid style={{ margin: '10px' }} gutter={'md'}>
           <GridItem span={editorSpan}>
             {this.state.istioObjectDetails ? (
               <AceEditor
@@ -425,7 +425,7 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
           )}
         </Grid>
         {this.renderActionButtons()}
-      </div>
+      </>
     );
   };
 

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/DestinationRuleDetail.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/DestinationRuleDetail.tsx
@@ -175,13 +175,11 @@ class DestinationRuleDetail extends React.Component<DestinationRuleProps> {
 
   render() {
     return (
-      <div className="container-fluid container-cards-pf">
-        <Grid gutter={'md'}>
-          {this.rawConfig()}
-          {this.trafficPolicy()}
-          {this.generateSubsets()}
-        </Grid>
-      </div>
+      <Grid style={{ margin: '10px' }} gutter={'md'}>
+        {this.rawConfig()}
+        {this.trafficPolicy()}
+        {this.generateSubsets()}
+      </Grid>
     );
   }
 }

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceDetail.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceDetail.tsx
@@ -173,12 +173,10 @@ class VirtualServiceDetail extends React.Component<VirtualServiceProps> {
 
   render() {
     return (
-      <div className="container-fluid container-cards-pf">
-        <Grid gutter={'md'}>
-          {this.rawConfig()}
-          {this.weights()}
-        </Grid>
-      </div>
+      <Grid style={{ margin: '10px' }} gutter={'md'}>
+        {this.rawConfig()}
+        {this.weights()}
+      </Grid>
     );
   }
 }

--- a/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -157,7 +157,7 @@ class ServiceInfo extends React.Component<ServiceDetails, ServiceInfoState> {
 
     return (
       <RenderComponentScroll>
-        <Grid style={{ margin: '30px' }} gutter={'md'}>
+        <Grid style={{ margin: '10px' }} gutter={'md'}>
           <GridItem span={12}>
             <ServiceInfoDescription
               name={this.props.serviceDetails.service.name}

--- a/src/pages/ServiceDetails/ServiceTraces.tsx
+++ b/src/pages/ServiceDetails/ServiceTraces.tsx
@@ -254,7 +254,7 @@ class ServiceTracesC extends React.Component<ServiceTracesProps, ServiceTracesSt
   render() {
     return (
       <RenderComponentScroll>
-        <Grid style={{ padding: '20px' }}>
+        <Grid style={{ padding: '10px' }}>
           <GridItem span={12}>
             <Card>
               <CardBody>

--- a/src/pages/ServiceDetails/__tests__/__snapshots__/ServiceInfo.test.tsx.snap
+++ b/src/pages/ServiceDetails/__tests__/__snapshots__/ServiceInfo.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`#ServiceInfo render correctly with data should render serviceInfo with 
     gutter="md"
     style={
       Object {
-        "margin": "30px",
+        "margin": "10px",
       }
     }
   >

--- a/src/pages/WorkloadDetails/WorkloadInfo.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo.tsx
@@ -116,7 +116,7 @@ class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInfoState>
 
     return (
       <RenderComponentScroll>
-        <Grid style={{ margin: '30px' }} gutter={'md'}>
+        <Grid style={{ margin: '10px' }} gutter={'md'}>
           <GridItem span={12}>
             <WorkloadDescription
               workload={workload}

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
@@ -193,7 +193,7 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
     return (
       <RenderComponentScroll>
         {this.state.containerInfo && (
-          <Grid style={{ padding: '20px', height: '100%' }}>
+          <Grid style={{ padding: '10px', height: '100%' }}>
             <GridItem span={12}>
               <Card style={{ height: '100%' }}>
                 <CardBody>

--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -37,7 +37,7 @@ body,
 }
 
 #basic-tabs .pf-c-tabs__list {
-  margin-left: 30px;
+  margin-left: 20px;
 }
 
 #basic-tabs .pf-c-tab-content {


### PR DESCRIPTION
This is a minor CSS adjustment, but necessary to align all header components with tabs and body cards in the details pages:

![image](https://user-images.githubusercontent.com/1662329/81838103-f857b100-9545-11ea-9bfb-8ff5114ad6fd.png)

Fixes https://github.com/kiali/kiali/issues/2744

Note the bottom padding is a little bit more complex as it requires more checking to adjust correctly the scrolling in "all" components.