### PR TITLE
Show broken locks into edges without mtls in mesh-wide mtls scanarios

### DIFF
--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -367,7 +367,7 @@ export class GraphStyles {
       }
 
       const mtlsPercentage = edgeData.isMTLS;
-      if (cyGlobal.showSecurity && mtlsPercentage && mtlsPercentage >= 0) {
+      if (cyGlobal.showSecurity) {
         if (mtlsPercentage > 0 && !cyGlobal.mtlsEnabled) {
           content = `${EdgeIconMTLS} ${content}`;
         } else if (mtlsPercentage < 100 && cyGlobal.mtlsEnabled) {

--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -367,11 +367,15 @@ export class GraphStyles {
       }
 
       const mtlsPercentage = edgeData.isMTLS;
-      if (cyGlobal.showSecurity) {
-        if (mtlsPercentage > 0 && !cyGlobal.mtlsEnabled) {
-          content = `${EdgeIconMTLS} ${content}`;
-        } else if (mtlsPercentage < 100 && cyGlobal.mtlsEnabled) {
-          content = `${EdgeIconDisabledMTLS} ${content}`;
+      if (cyGlobal.showSecurity && edgeData.hasTraffic) {
+        if (cyGlobal.mtlsEnabled) {
+          if (!mtlsPercentage || mtlsPercentage < 100) {
+            content = `${EdgeIconDisabledMTLS} ${content}`;
+          }
+        } else {
+          if (mtlsPercentage && mtlsPercentage > 0) {
+            content = `${EdgeIconMTLS} ${content}`;
+          }
         }
       }
 


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/2787

I've seen that when there has never been mtls traffic, isMTLS has a -1. It made the not getting in the if condition and therefore, not printing any badge.

My question is, should I protect the usage of `mtlsPercentage` or the system guarantees that there will be always a number?

![Screenshot of Kiali Console (66)](https://user-images.githubusercontent.com/613814/81931451-71a8df80-95ea-11ea-90cb-118e6e3605ed.png)

Steps to test this PR in bookinfo: https://github.com/xeviknal/istio-lab/tree/master/meshwide-mtls/details-disabled