### PR TITLE
Use new patternfly spinner

### DIFF
--- a/src/components/Nav/Masthead/Masthead.tsx
+++ b/src/components/Nav/Masthead/Masthead.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-
+import { style } from 'typestyle';
 import { Toolbar as ToolbarNext, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
+
 import { default as MeshMTLSStatus } from '../../../components/MTls/MeshMTLSStatus';
 import { default as IstioStatus } from '../../IstioStatus/IstioStatus';
 import PfSpinner from '../../PfSpinner';
@@ -8,11 +9,17 @@ import UserDropdown from './UserDropdown';
 import HelpDropdown from './HelpDropdown';
 import MessageCenterTriggerContainer from '../../../components/MessageCenter/MessageCenterTrigger';
 
+const leftGroup = style({
+  position: 'absolute',
+  left: 210,
+  top: 28
+});
+
 class Masthead extends React.Component {
   render() {
     return (
       <ToolbarNext>
-        <ToolbarGroup>
+        <ToolbarGroup className={leftGroup}>
           <PfSpinner />
         </ToolbarGroup>
         <ToolbarGroup>

--- a/src/components/PfSpinner.tsx
+++ b/src/components/PfSpinner.tsx
@@ -1,19 +1,11 @@
 import React from 'react';
-import { KialiAppState } from '../store/Store';
+import { Spinner } from '@patternfly/react-core';
 import { connect } from 'react-redux';
-import { style } from 'typestyle';
-import { SpinnerIcon } from '@patternfly/react-icons';
+import { KialiAppState } from '../store/Store';
 
 type PfSpinnerProps = {
   isLoading?: boolean;
 };
-
-const spinnerStyle = style({
-  position: 'absolute',
-  left: 210,
-  top: 35,
-  animation: 'rotation 1000ms infinite linear'
-});
 
 const mapStateToProps = (state: KialiAppState) => ({
   isLoading: state.globalState.loadingCounter > 0
@@ -22,8 +14,7 @@ const mapStateToProps = (state: KialiAppState) => ({
 export const PfSpinner: React.SFC<PfSpinnerProps> = props => {
   const { isLoading } = props;
   // It is more than likely it won't have any children; but it could.
-  // @todo: Patternfly Spinner is not working here
-  return isLoading ? <SpinnerIcon id="loading_kiali_spinner" className={spinnerStyle} /> : <></>;
+  return isLoading ? <Spinner id="loading_kiali_spinner" size={'lg'} /> : <></>;
 };
 
 // hook up to Redux for our State to be mapped to props


### PR DESCRIPTION
This is using the new spinner. Note that it's said to be experimental.
Fixes https://github.com/kiali/kiali/issues/2679

![Capture d’écran de 2020-05-18 11-35-56](https://user-images.githubusercontent.com/2153442/82198059-0f0e5700-98fc-11ea-8746-0c74f4d7c8f9.png)

(See also https://www.patternfly.org/v4/documentation/core/components/spinner )

A couple of notes:

- Previously the spinner was positioned to the left via absolute position. For some reason, this style wasn't applied on the new spinner, so I just removed it. Our spinner is in the "masterhead" icons/controls, so it makes more sense IMO to display it to the right ... if it's not what we want, then we should reorganize the whole masthead I think. Let me know if it's not ok to have it to the right.

- The PF component is said to be experimental. While testing I've seen that sometimes it displays very short arcs (almost dots) instead of the long ones, I'm not sure if it's intentional or if it's related to it being  experimental.

- I haven't seen any big problem beside that.