### PR TITLE
Add Container selection back into Workload logs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "jest-canvas-mock": "2.2.0",
     "jest-localstorage-mock": "2.4.2",
     "node-sass": "4.12.0",
-    "prettier": "1.16.4",
+    "prettier": "2.0.5",
     "pretty-quick": "2.0.1",
     "react-scripts": "3.4.1",
     "redux-mock-store": "1.5.3",

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
@@ -210,6 +210,17 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
                           options={this.podOptions!}
                         />
                       </ToolbarItem>
+                      <ToolbarItem className={displayFlex}>
+                        <ToolbarDropdown
+                          id={'wpl_containers'}
+                          nameDropdown="&nbsp;&nbsp;&nbsp;Container"
+                          tooltip="Display logs for the selected pod container"
+                          handleSelect={key => this.setContainer(key)}
+                          value={this.state.containerInfo.container}
+                          label={this.state.containerInfo.container}
+                          options={this.state.containerInfo.containerOptions!}
+                        />
+                      </ToolbarItem>
                     </ToolbarGroup>
                     <ToolbarGroup>
                       <ToolbarItem>
@@ -299,6 +310,12 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
     this.setState({ containerInfo: containerInfo, podValue: Number(podValue) });
   };
 
+  private setContainer = (container: string) => {
+    this.setState({
+      containerInfo: { container: container, containerOptions: this.state.containerInfo!.containerOptions }
+    });
+  };
+
   private setTimeRange = (range: TimeRange) => {
     this.setState({ duration: range as DurationInSeconds });
   };
@@ -328,7 +345,10 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
     const containerNames: string[] = containers.map(c => c.name);
     const options: any[] = [];
     containerNames.forEach(c => {
-      options[c] = c;
+      // ignore the proxy
+      if (c !== 'istio-proxy') {
+        options[c] = c;
+      }
     });
     return { container: containerNames[0], containerOptions: options };
   };

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
@@ -355,7 +355,11 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
     containerNames.forEach((c) => {
       // ignore the proxy
       if (c !== 'istio-proxy') {
-        options[c] = c;
+        if (pod.appLabel && pod.labels) {
+          options[c] = c + '-' + pod.labels['version'];
+        } else {
+          options[c] = c;
+        }
       }
     });
     return { container: containerNames[0], containerOptions: options };

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
@@ -89,7 +89,7 @@ const logTextAreaBackground = (enabled = true) => ({ backgroundColor: enabled ? 
 const logsTextarea = (enabled = true) =>
   style(logTextAreaBackground(enabled), {
     width: 'calc(100% - 15px)',
-    height: 'calc(100% - 75px)',
+    height: 'calc(100% - 85px)',
     overflow: 'auto',
     resize: 'none',
     color: '#fff',

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
@@ -8,7 +8,7 @@ import {
   Title,
   Toolbar,
   ToolbarGroup,
-  ToolbarItem
+  ToolbarItem,
 } from '@patternfly/react-core';
 import { style } from 'typestyle';
 import { Pod, PodLogs } from '../../../types/IstioObjects';
@@ -29,7 +29,7 @@ export interface WorkloadPodLogsProps {
 
 interface ContainerInfo {
   container: string;
-  containerOptions: any[];
+  containerOptions: string[];
 }
 
 interface WorkloadPodLogsState {
@@ -49,7 +49,8 @@ interface WorkloadPodLogsState {
 }
 
 const NoAppLogsFoundMessage = 'No logs found for the time period.';
-const NoProxyLogsFoundMessage = 'Failed to fetch container logs: container istio-proxy is not valid for pod two-containers';
+const NoProxyLogsFoundMessage =
+  'Failed to fetch container logs: container istio-proxy is not valid for pod two-containers';
 
 const TailLinesDefault = 500;
 const TailLinesOptions = {
@@ -60,33 +61,32 @@ const TailLinesOptions = {
   '300': 'Last 300 lines',
   '500': 'Last 500 lines',
   '1000': 'Last 1000 lines',
-  '5000': 'Last 5000 lines'
+  '5000': 'Last 5000 lines',
 };
 
 const appLogsDivVertical = style({
-  height: 'calc(100% + 30px)'
+  height: 'calc(100% + 30px)',
 });
 const appLogsDivHorizontal = style({
-  height: '100%'
+  height: '100%',
 });
 
 const proxyLogsDiv = style({
-  height: '100%'
+  height: '100%',
 });
 
 const logsTitle = style({
-  marginLeft: '10px'
+  marginLeft: '10px',
 });
 
 const containerDropdown = style({
-  marginLeft: '10px'
+  marginLeft: '10px',
 });
 
 const logTextAreaBackground = (enabled = true) => ({ backgroundColor: enabled ? '#003145' : 'gray' });
 
-const logsTextarea = (enabled = true) => style(
-  logTextAreaBackground(enabled),
-  {
+const logsTextarea = (enabled = true) =>
+  style(logTextAreaBackground(enabled), {
     width: 'calc(100% - 15px)',
     height: 'calc(100% - 70px)',
     overflow: 'auto',
@@ -96,24 +96,24 @@ const logsTextarea = (enabled = true) => style(
     fontSize: '11pt',
     padding: '10px',
     whiteSpace: 'pre',
-    margin: '0 10px 0 10px'
+    margin: '0 10px 0 10px',
   });
 
 const toolbarRight = style({
   right: '50px',
-  position: 'absolute'
+  position: 'absolute',
 });
 
 const displayFlex = style({
-  display: 'flex'
+  display: 'flex',
 });
 
 const toolbarMargin = style({
-  margin: '10px'
+  margin: '10px',
 });
 
 const tailToolbarMargin = style({
-  marginTop: '2px'
+  marginTop: '2px',
 });
 
 export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, WorkloadPodLogsState> {
@@ -121,13 +121,13 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
   private loadContainerLogsPromise?: CancelablePromise<Response<PodLogs>[]>;
   private readonly appLogsRef: any;
   private readonly proxyLogsRef: any;
-  private podOptions: any[] = [];
+  private podOptions: string[] = [];
 
   constructor(props: WorkloadPodLogsProps) {
     super(props);
-
     this.appLogsRef = React.createRef();
     this.proxyLogsRef = React.createRef();
+
     if (this.props.pods.length < 1) {
       this.state = {
         duration: retrieveDuration() || 600,
@@ -138,7 +138,7 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
         tailLines: TailLinesDefault,
         isLogWindowSelectExpanded: false,
         logWindowSelections: [],
-        sideBySideOrientation: false
+        sideBySideOrientation: false,
       };
       return;
     }
@@ -162,7 +162,7 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
       tailLines: TailLinesDefault,
       isLogWindowSelectExpanded: false,
       logWindowSelections: [],
-      sideBySideOrientation: false
+      sideBySideOrientation: false,
     };
   }
 
@@ -194,7 +194,7 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
     this.appLogsRef.current.scrollTop = this.appLogsRef.current.scrollHeight;
   }
 
-  renderItem = object => {
+  renderItem = (object) => {
     return <ToolbarItem className={displayFlex}>{object}</ToolbarItem>;
   };
 
@@ -214,7 +214,7 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
                           id={'wpl_pods'}
                           nameDropdown="Pod"
                           tooltip="Display logs for the selected pod"
-                          handleSelect={key => this.setPod(key)}
+                          handleSelect={(key) => this.setPod(key)}
                           value={this.state.podValue}
                           label={this.props.pods[this.state.podValue!].name}
                           options={this.podOptions!}
@@ -235,7 +235,7 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
                       <ToolbarItem className={displayFlex}>
                         <ToolbarDropdown
                           id={'wpl_tailLines'}
-                          handleSelect={key => this.setTailLines(Number(key))}
+                          handleSelect={(key) => this.setTailLines(Number(key))}
                           value={this.state.tailLines}
                           label={TailLinesOptions[this.state.tailLines]}
                           options={TailLinesOptions}
@@ -261,7 +261,7 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
                     </ToolbarGroup>
                   </Toolbar>
                   <Splitter
-                    position={!this.state.sideBySideOrientation ? 'horizontal' : 'vertical'}
+                    position={!sideBySideOrientation ? 'horizontal' : 'vertical'}
                     primaryPaneMaxHeight="100%"
                     primaryPaneMinHeight={0}
                     primaryPaneHeight="50%"
@@ -273,13 +273,15 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
                         id={'wpl_containers'}
                         tooltip="Choose container for selected pod"
                         classNameSelect={containerDropdown}
-                        handleSelect={key => this.setContainer(key)}
+                        handleSelect={(key) => this.setContainer(key)}
                         value={this.state.containerInfo.container}
                         label={this.state.containerInfo.container}
                         options={this.state.containerInfo.containerOptions!}
                       />
                       <textarea
-                        className={logsTextarea(!this.state.loadingAppLogs && this.state.appLogs?.logs !== NoAppLogsFoundMessage)}
+                        className={logsTextarea(
+                          !this.state.loadingAppLogs && this.state.appLogs?.logs !== NoAppLogsFoundMessage
+                        )}
                         ref={this.appLogsRef}
                         readOnly={true}
                         value={this.state.appLogs ? this.state.appLogs.logs : 'Loading logs...'}
@@ -287,7 +289,7 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
                       />
                     </div>
                     <div className={proxyLogsDiv}>
-                      <Title size="lg" headingLevel="h5" className={logsTitle}>
+                      <Title size="sm" headingLevel="h5" className={logsTitle}>
                         Istio proxy (sidecar)
                       </Title>
                       <textarea
@@ -317,7 +319,7 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
 
   private setContainer = (container: string) => {
     this.setState({
-      containerInfo: { container: container, containerOptions: this.state.containerInfo!.containerOptions }
+      containerInfo: { container: container, containerOptions: this.state.containerInfo!.containerOptions },
     });
   };
 
@@ -347,10 +349,10 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
   private getContainerInfo = (pod: Pod): ContainerInfo => {
     const containers = pod.containers ? pod.containers : [];
     containers.push(...(pod.istioContainers ? pod.istioContainers : []));
-    const containerNames: string[] = containers.map(c => c.name);
-    const options: any[] = [];
+    const containerNames: string[] = containers.map((c) => c.name);
+    const options: string[] = [];
 
-    containerNames.forEach(c => {
+    containerNames.forEach((c) => {
       // ignore the proxy
       if (c !== 'istio-proxy') {
         options[c] = c;
@@ -379,16 +381,16 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
     this.loadPodLogsPromise = makeCancelablePromise(Promise.all([promise]));
 
     this.loadPodLogsPromise.promise
-      .then(response => {
+      .then((response) => {
         const podLogs = response[0].data;
         this.setState({
           loadingAppLogs: false,
-          appLogs: podLogs.logs ? podLogs : { logs: NoAppLogsFoundMessage }
+          appLogs: podLogs.logs ? podLogs : { logs: NoAppLogsFoundMessage },
         });
         this.appLogsRef.current.scrollTop = this.appLogsRef.current.scrollHeight;
         return;
       })
-      .catch(error => {
+      .catch((error) => {
         if (error.isCanceled) {
           console.debug('PodLogs: Ignore fetch error (canceled).');
           this.setState({ loadingAppLogs: false });
@@ -397,21 +399,21 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
         const errorMsg = error.response && error.response.data.error ? error.response.data.error : error.message;
         this.setState({
           loadingAppLogs: false,
-          appLogs: { logs: `Failed to fetch pod logs: ${errorMsg}` }
+          appLogs: { logs: `Failed to fetch pod logs: ${errorMsg}` },
         });
       });
 
     this.loadContainerLogsPromise.promise
-      .then(response => {
+      .then((response) => {
         const containerLogs = response[0].data;
         this.setState({
           loadingProxyLogs: false,
-          proxyLogs: containerLogs.logs ? containerLogs : { logs: NoProxyLogsFoundMessage }
+          proxyLogs: containerLogs.logs ? containerLogs : { logs: NoProxyLogsFoundMessage },
         });
         this.appLogsRef.current.scrollTop = this.appLogsRef.current.scrollHeight;
         return;
       })
-      .catch(error => {
+      .catch((error) => {
         if (error.isCanceled) {
           console.debug('ContainerLogs: Ignore fetch error (canceled).');
           this.setState({ loadingProxyLogs: false });
@@ -420,7 +422,7 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
         const errorMsg = error.response && error.response.data.error ? error.response.data.error : error.message;
         this.setState({
           loadingProxyLogs: false,
-          proxyLogs: { logs: `Failed to fetch container logs: ${errorMsg}` }
+          proxyLogs: { logs: `Failed to fetch container logs: ${errorMsg}` },
         });
       });
 
@@ -428,7 +430,7 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
       loadingAppLogs: true,
       loadingProxyLogs: true,
       appLogs: undefined,
-      proxyLogs: undefined
+      proxyLogs: undefined,
     });
   };
 }

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
@@ -69,6 +69,7 @@ const appLogsDivVertical = style({
 });
 const appLogsDivHorizontal = style({
   height: '100%',
+  marginRight: '5px',
 });
 
 const proxyLogsDiv = style({
@@ -76,7 +77,7 @@ const proxyLogsDiv = style({
 });
 
 const logsTitle = style({
-  marginLeft: '10px',
+  margin: '12px 0 0 10px',
 });
 
 const containerDropdown = style({
@@ -297,7 +298,7 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
                         ref={this.proxyLogsRef}
                         readOnly={true}
                         value={this.state.proxyLogs ? this.state.proxyLogs.logs : 'Loading container logs...'}
-                        aria-label="Container logs text"
+                        aria-label="Proxy logs text"
                       />
                     </div>
                   </Splitter>

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
@@ -77,11 +77,11 @@ const proxyLogsDiv = style({
 });
 
 const logsTitle = style({
-  margin: '12px 0 0 10px',
+  margin: '15px 0 0 10px',
 });
 
 const containerDropdown = style({
-  marginLeft: '10px',
+  margin: '0 0 3px 10px',
 });
 
 const logTextAreaBackground = (enabled = true) => ({ backgroundColor: enabled ? '#003145' : 'gray' });
@@ -89,7 +89,7 @@ const logTextAreaBackground = (enabled = true) => ({ backgroundColor: enabled ? 
 const logsTextarea = (enabled = true) =>
   style(logTextAreaBackground(enabled), {
     width: 'calc(100% - 15px)',
-    height: 'calc(100% - 70px)',
+    height: 'calc(100% - 75px)',
     overflow: 'auto',
     resize: 'none',
     color: '#fff',

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
@@ -46,6 +46,7 @@ interface WorkloadPodLogsState {
   isLogWindowSelectExpanded: boolean;
   logWindowSelections: any[];
   sideBySideOrientation: boolean;
+  splitPercent: string;
 }
 
 const NoAppLogsFoundMessage = 'No logs found for the time period.';
@@ -140,6 +141,7 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
         isLogWindowSelectExpanded: false,
         logWindowSelections: [],
         sideBySideOrientation: false,
+        splitPercent: '50%',
       };
       return;
     }
@@ -164,6 +166,7 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
       isLogWindowSelectExpanded: false,
       logWindowSelections: [],
       sideBySideOrientation: false,
+      splitPercent: '50%',
     };
   }
 
@@ -264,10 +267,10 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
                   <Splitter
                     position={!sideBySideOrientation ? 'horizontal' : 'vertical'}
                     primaryPaneMaxHeight="100%"
-                    primaryPaneMinHeight={0}
-                    primaryPaneHeight="50%"
+                    primaryPaneMinHeight={30}
+                    primaryPaneHeight={this.state.splitPercent}
                     dispatchResize={true}
-                    postPoned={true}
+                    postPoned={false}
                   >
                     <div className={sideBySideOrientation ? appLogsDivHorizontal : appLogsDivVertical}>
                       <ToolbarDropdown
@@ -333,7 +336,7 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
   };
 
   private handleOrientationChange = (isChecked: boolean) => {
-    this.setState({ sideBySideOrientation: isChecked });
+    this.setState({ sideBySideOrientation: isChecked, splitPercent: '50%' });
   };
 
   private handleRefresh = () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11286,10 +11286,10 @@ prepend-http@^1.0.0, prepend-http@^1.0.1:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
 
-prettier@1.16.4:
-  version "1.16.4"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.4.tgz#73e37e73e018ad2db9c76742e2647e21790c9717"
-  integrity sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==
+prettier@2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
+  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
 
 pretty-bytes@^5.1.0:
   version "5.3.0"


### PR DESCRIPTION
** Describe the change **
Add the ability to select a container in the pod.


** Issue reference **
fixes: https://github.com/kiali/kiali/issues/2765


** Screenshot **
![Kiali_Console](https://user-images.githubusercontent.com/1312165/82259344-41c24a80-9910-11ea-8f64-85a8ca0a5509.png)

![two-containers](https://user-images.githubusercontent.com/1312165/82262177-49d0b900-9915-11ea-8cfe-537015c33656.gif)

