### PR TITLE
Link from traces to workload logs can be wrong

### DIFF
--- a/src/components/JaegerIntegration/JaegerResults/SpanTable.tsx
+++ b/src/components/JaegerIntegration/JaegerResults/SpanTable.tsx
@@ -72,8 +72,8 @@ export class SpanTableC extends React.Component<SpanDetailProps, SpanDetailState
       node = sp.tags.filter(tag => tag.key === 'node_id')[0].value;
     }
     const srv = sp.process.serviceName.split('.')[0];
-    const regex = new RegExp(`${srv}-v[0-9]*`);
-    const result = node !== '' ? regex.exec(node) : null;
+    const regex = new RegExp(`([a-z0-9-\\.]+)-[a-z0-9]+-[a-z0-9]+\\.[a-z0-9-]+`);
+    const result = node !== '' ? regex.exec(node.split('~')[2]) : null;
     if (result) {
       return (
         <Tooltip content={<>View logs of workload {result[0]}</>}>

--- a/src/components/JaegerIntegration/JaegerResults/SpanTable.tsx
+++ b/src/components/JaegerIntegration/JaegerResults/SpanTable.tsx
@@ -74,12 +74,13 @@ export class SpanTableC extends React.Component<SpanDetailProps, SpanDetailState
     const srv = sp.process.serviceName.split('.')[0];
     const regex = new RegExp(`([a-z0-9-\\.]+)-[a-z0-9]+-[a-z0-9]+\\.[a-z0-9-]+`);
     const result = node !== '' ? regex.exec(node.split('~')[2]) : null;
-    if (result) {
+    const workload = result ? result[1] : undefined;
+    if (workload) {
       return (
-        <Tooltip content={<>View logs of workload {result[0]}</>}>
+        <Tooltip content={<>View logs of workload {workload}</>}>
           <Link
-            to={this.goLogsWorkloads(result[0], sp.operationName)}
-            onClick={() => history.push(this.goLogsWorkloads(result[0], sp.operationName))}
+            to={this.goLogsWorkloads(workload, sp.operationName)}
+            onClick={() => history.push(this.goLogsWorkloads(workload, sp.operationName))}
           >
             View logs
           </Link>


### PR DESCRIPTION
Fix https://github.com/kiali/kiali/issues/2712

The proposal is /^([a-z0-9-\.]+)-[a-z0-9]+-[a-z0-9]+\.[a-z0-9-]+$/

We had ${srv}-v[0-9]*

I can't test if works because I have problems with me maistra cluster

Sample node to parse => sidecar~172.17.0.22~ai-visitors-779956ddf8-s78gr.default~default.svc.cluster.local

We need ai-visitors-779956ddf8-s78gr.default

In normal cases reviews-v2(.bookinfo)