### PR TITLE
Add support for OpenId strategy for authentication

### DIFF
--- a/src/actions/LoginThunkActions.ts
+++ b/src/actions/LoginThunkActions.ts
@@ -22,7 +22,10 @@ const loginSuccess = async (dispatch: KialiDispatch, session: LoginSession) => {
 // different kinds of data (such as e-mail/password, tokens).
 const performLogin = (dispatch: KialiDispatch, state: KialiAppState, data?: any) => {
   const bail = (loginResult: Login.LoginResult) => {
-    if (authenticationConfig.strategy === AuthStrategy.openshift) {
+    if (
+      authenticationConfig.strategy === AuthStrategy.openshift ||
+      authenticationConfig.strategy === AuthStrategy.openid
+    ) {
       dispatch(LoginActions.loginFailure(loginResult.error));
     } else {
       data ? dispatch(LoginActions.loginFailure(loginResult.error)) : dispatch(LoginActions.logoutSuccess());

--- a/src/actions/LoginThunkActions.ts
+++ b/src/actions/LoginThunkActions.ts
@@ -35,8 +35,8 @@ const performLogin = (dispatch: KialiDispatch, state: KialiAppState, data?: any)
   Dispatcher.prepare().then((result: AuthResult) => {
     if (result === AuthResult.CONTINUE) {
       Dispatcher.perform({ dispatch, state, data }).then(
-        loginResult => loginSuccess(dispatch, loginResult.session!),
-        error => bail(error)
+        (loginResult) => loginSuccess(dispatch, loginResult.session!),
+        (error) => bail(error)
       );
     } else {
       bail({ status: AuthResult.FAILURE, error: 'Preparation for login failed, try again.' });
@@ -81,7 +81,7 @@ const LoginThunkActions = {
         AlertUtils.addError('Logout failed', err);
       }
     };
-  }
+  },
 };
 
 export default LoginThunkActions;

--- a/src/actions/LoginThunkActions.ts
+++ b/src/actions/LoginThunkActions.ts
@@ -53,19 +53,14 @@ const LoginThunkActions = {
   },
   checkCredentials: () => {
     return (dispatch: KialiDispatch, getState: () => KialiAppState) => {
-      // If Openshift login strategy is enabled, or anonymous mode is enabled,
-      // perform the login cycle. Else, it doesn't make sense to login with
-      // blank credentials.
-      if (authenticationConfig.strategy !== AuthStrategy.login) {
-        const state: KialiAppState = getState();
+      const state: KialiAppState = getState();
 
-        dispatch(LoginActions.loginRequest());
+      dispatch(LoginActions.loginRequest());
 
-        if (shouldRelogin(state.authentication)) {
-          performLogin(dispatch, state);
-        } else {
-          loginSuccess(dispatch, state.authentication!.session!);
-        }
+      if (shouldRelogin(state.authentication)) {
+        performLogin(dispatch, state);
+      } else {
+        loginSuccess(dispatch, state.authentication!.session!);
       }
     };
   },

--- a/src/actions/LoginThunkActions.ts
+++ b/src/actions/LoginThunkActions.ts
@@ -3,9 +3,9 @@ import { KialiAppState, LoginSession, LoginState } from '../store/Store';
 import { LoginActions } from './LoginActions';
 import * as API from '../services/Api';
 import * as Login from '../services/Login';
-import { AuthResult, AuthStrategy } from '../types/Auth';
+import { AuthResult } from '../types/Auth';
 import { KialiDispatch } from '../types/Redux';
-import authenticationConfig from '../config/AuthenticationConfig';
+import { isAuthStrategyOAuth } from '../config/AuthenticationConfig';
 import * as AlertUtils from '../utils/AlertUtils';
 
 const Dispatcher = new Login.LoginDispatcher();
@@ -22,10 +22,7 @@ const loginSuccess = async (dispatch: KialiDispatch, session: LoginSession) => {
 // different kinds of data (such as e-mail/password, tokens).
 const performLogin = (dispatch: KialiDispatch, state: KialiAppState, data?: any) => {
   const bail = (loginResult: Login.LoginResult) => {
-    if (
-      authenticationConfig.strategy === AuthStrategy.openshift ||
-      authenticationConfig.strategy === AuthStrategy.openid
-    ) {
+    if (isAuthStrategyOAuth()) {
       dispatch(LoginActions.loginFailure(loginResult.error));
     } else {
       data ? dispatch(LoginActions.loginFailure(loginResult.error)) : dispatch(LoginActions.logoutSuccess());

--- a/src/actions/LoginThunkActions.ts
+++ b/src/actions/LoginThunkActions.ts
@@ -32,8 +32,8 @@ const performLogin = (dispatch: KialiDispatch, state: KialiAppState, data?: any)
   Dispatcher.prepare().then((result: AuthResult) => {
     if (result === AuthResult.CONTINUE) {
       Dispatcher.perform({ dispatch, state, data }).then(
-        (loginResult) => loginSuccess(dispatch, loginResult.session!),
-        (error) => bail(error)
+        loginResult => loginSuccess(dispatch, loginResult.session!),
+        error => bail(error)
       );
     } else {
       bail({ status: AuthResult.FAILURE, error: 'Preparation for login failed, try again.' });
@@ -78,7 +78,7 @@ const LoginThunkActions = {
         AlertUtils.addError('Logout failed', err);
       }
     };
-  },
+  }
 };
 
 export default LoginThunkActions;

--- a/src/app/AuthenticationController.tsx
+++ b/src/app/AuthenticationController.tsx
@@ -38,7 +38,7 @@ enum LoginStage {
   LOGIN,
   POST_LOGIN,
   LOGGED_IN,
-  LOGGED_IN_AT_LOAD,
+  LOGGED_IN_AT_LOAD
 }
 
 interface AuthenticationControllerState {
@@ -55,7 +55,7 @@ class AuthenticationController extends React.Component<AuthenticationControllerP
     super(props);
     this.state = {
       stage: this.props.authenticated ? LoginStage.LOGGED_IN_AT_LOAD : LoginStage.LOGIN,
-      isPostLoginError: false,
+      isPostLoginError: false
     };
   }
 
@@ -86,7 +86,7 @@ class AuthenticationController extends React.Component<AuthenticationControllerP
         // This state shows the initializing screen while doing the login cycle. This
         // prevents from briefly showing the login form while the trip to the back-end completes.
         this.setState({
-          stage: LoginStage.LOGGED_IN_AT_LOAD,
+          stage: LoginStage.LOGGED_IN_AT_LOAD
         });
       }
     }
@@ -139,13 +139,13 @@ class AuthenticationController extends React.Component<AuthenticationControllerP
   private doPostLoginActions = async () => {
     try {
       const getStatusPromise = API.getStatus()
-        .then((response) => this.props.setServerStatus(response.data))
-        .catch((error) => {
+        .then(response => this.props.setServerStatus(response.data))
+        .catch(error => {
           AlertUtils.addError('Error fetching server status.', error, 'default', MessageType.WARNING);
         });
       const getJaegerInfoPromise = API.getJaegerInfo()
-        .then((response) => this.props.setJaegerInfo(response.data))
-        .catch((error) => {
+        .then(response => this.props.setJaegerInfo(response.data))
+        .catch(error => {
           this.props.setJaegerInfo(null);
           AlertUtils.addError(
             'Could not fetch Jaeger info. Turning off Jaeger integration.',
@@ -177,21 +177,21 @@ const processServerStatus = (dispatch: KialiDispatch, serverStatus: ServerStatus
     HelpDropdownActions.statusRefresh(serverStatus.status, serverStatus.externalServices, serverStatus.warningMessages)
   );
 
-  serverStatus.warningMessages.forEach((wMsg) => {
+  serverStatus.warningMessages.forEach(wMsg => {
     dispatch(MessageCenterActions.addMessage(wMsg, '', 'systemErrors', MessageType.WARNING));
   });
 };
 
 const mapStateToProps = (state: KialiAppState) => ({
   authenticated: state.authentication.status === LoginStatus.loggedIn,
-  isLoginError: state.authentication.status === LoginStatus.error,
+  isLoginError: state.authentication.status === LoginStatus.error
 });
 
 const mapDispatchToProps = (dispatch: KialiDispatch) => ({
   setJaegerInfo: bindActionCreators(JaegerActions.setInfo, dispatch),
   setServerStatus: (serverStatus: ServerStatus) => processServerStatus(dispatch, serverStatus),
   setMeshTlsStatus: bindActionCreators(MeshTlsActions.setinfo, dispatch),
-  checkCredentials: () => dispatch(LoginThunkActions.checkCredentials()),
+  checkCredentials: () => dispatch(LoginThunkActions.checkCredentials())
 });
 
 const AuthenticationControllerContainer = connect(mapStateToProps, mapDispatchToProps)(AuthenticationController);

--- a/src/app/AuthenticationController.tsx
+++ b/src/app/AuthenticationController.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import authenticationConfig from '../config/AuthenticationConfig';
 import { KialiAppState, LoginStatus } from '../store/Store';
 import * as API from '../services/Api';
 import { HelpDropdownActions } from '../actions/HelpDropdownActions';
 import { JaegerActions } from '../actions/JaegerActions';
+import LoginThunkActions from '../actions/LoginThunkActions';
 import { MessageCenterActions } from '../actions/MessageCenterActions';
 import { MessageType } from '../types/MessageCenter';
 import { KialiDispatch } from '../types/Redux';
@@ -15,10 +17,12 @@ import * as AlertUtils from '../utils/AlertUtils';
 import { setServerConfig } from '../config/ServerConfig';
 import { TLSStatus } from '../types/TLSStatus';
 import { MeshTlsActions } from '../actions/MeshTlsActions';
+import { AuthStrategy } from '../types/Auth';
 import { JaegerInfo } from '../types/JaegerInfo';
 
 interface AuthenticationControllerReduxProps {
   authenticated: boolean;
+  checkCredentials: () => void;
   setJaegerInfo: (jaegerInfo: JaegerInfo | null) => void;
   setServerStatus: (serverStatus: ServerStatus) => void;
   setMeshTlsStatus: (meshStatus: TLSStatus) => void;
@@ -57,6 +61,36 @@ class AuthenticationController extends React.Component<AuthenticationControllerP
   componentDidMount(): void {
     if (this.state.stage === LoginStage.LOGGED_IN_AT_LOAD) {
       this.doPostLoginActions();
+    } else {
+      let dispatchLoginCycleOnLoad = false;
+
+      // If login strategy is "anonymous", dispatch login cycle
+      // because there is no need to ask for any credentials
+      if (authenticationConfig.strategy === AuthStrategy.anonymous) {
+        dispatchLoginCycleOnLoad = true;
+      }
+
+      // If login strategy is Openshift, OpenId, check if there is an
+      // "access_token" or "id_token" hash parameter in the URL. If there is,
+      // this means the IdP is calling back. Dispatch the login cycle to finish
+      // the authentication.
+      if (
+        authenticationConfig.strategy === AuthStrategy.openshift ||
+        authenticationConfig.strategy === AuthStrategy.openid
+      ) {
+        const pattern = /[#&](access_token|id_token)=/;
+        dispatchLoginCycleOnLoad = pattern.test(window.location.hash);
+      }
+
+      if (dispatchLoginCycleOnLoad) {
+        this.props.checkCredentials();
+
+        // This state shows the initializing screen while doing the login cycle. This
+        // prevents from briefly showing the login form while the trip to the back-end completes.
+        this.setState({
+          stage: LoginStage.LOGGED_IN_AT_LOAD
+        });
+      }
     }
 
     this.setDocLayout();
@@ -86,6 +120,16 @@ class AuthenticationController extends React.Component<AuthenticationControllerP
         <InitializingScreen errorMsg={AuthenticationController.PostLoginErrorMsg} />
       );
     } else if (this.state.stage === LoginStage.POST_LOGIN) {
+      // For OAuth/OpenID auth strategies, show/keep the initializing screen unless there
+      // is an error.
+      if (
+        !this.state.isPostLoginError &&
+        (authenticationConfig.strategy === AuthStrategy.openshift ||
+          authenticationConfig.strategy === AuthStrategy.openid)
+      ) {
+        return <InitializingScreen />;
+      }
+
       return !this.state.isPostLoginError
         ? this.props.publicAreaComponent(true)
         : this.props.publicAreaComponent(false, AuthenticationController.PostLoginErrorMsg);
@@ -144,13 +188,12 @@ const mapStateToProps = (state: KialiAppState) => ({
   authenticated: state.authentication.status === LoginStatus.loggedIn
 });
 
-const mapDispatchToProps = (dispatch: KialiDispatch) => {
-  return {
-    setJaegerInfo: bindActionCreators(JaegerActions.setInfo, dispatch),
-    setServerStatus: (serverStatus: ServerStatus) => processServerStatus(dispatch, serverStatus),
-    setMeshTlsStatus: bindActionCreators(MeshTlsActions.setinfo, dispatch)
-  };
-};
+const mapDispatchToProps = (dispatch: KialiDispatch) => ({
+  setJaegerInfo: bindActionCreators(JaegerActions.setInfo, dispatch),
+  setServerStatus: (serverStatus: ServerStatus) => processServerStatus(dispatch, serverStatus),
+  setMeshTlsStatus: bindActionCreators(MeshTlsActions.setinfo, dispatch),
+  checkCredentials: () => dispatch(LoginThunkActions.checkCredentials())
+});
 
 const AuthenticationControllerContainer = connect(mapStateToProps, mapDispatchToProps)(AuthenticationController);
 export default AuthenticationControllerContainer;

--- a/src/app/AuthenticationController.tsx
+++ b/src/app/AuthenticationController.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import authenticationConfig from '../config/AuthenticationConfig';
+import authenticationConfig, { isAuthStrategyOAuth } from '../config/AuthenticationConfig';
 import { KialiAppState, LoginStatus } from '../store/Store';
 import * as API from '../services/Api';
 import { HelpDropdownActions } from '../actions/HelpDropdownActions';
@@ -75,10 +75,7 @@ class AuthenticationController extends React.Component<AuthenticationControllerP
       // "access_token" or "id_token" hash parameter in the URL. If there is,
       // this means the IdP is calling back. Dispatch the login cycle to finish
       // the authentication.
-      if (
-        authenticationConfig.strategy === AuthStrategy.openshift ||
-        authenticationConfig.strategy === AuthStrategy.openid
-      ) {
+      if (isAuthStrategyOAuth()) {
         const pattern = /[#&](access_token|id_token)=/;
         dispatchLoginCycleOnLoad = pattern.test(window.location.hash);
       }
@@ -127,11 +124,7 @@ class AuthenticationController extends React.Component<AuthenticationControllerP
     } else if (this.state.stage === LoginStage.POST_LOGIN) {
       // For OAuth/OpenID auth strategies, show/keep the initializing screen unless there
       // is an error.
-      if (
-        !this.state.isPostLoginError &&
-        (authenticationConfig.strategy === AuthStrategy.openshift ||
-          authenticationConfig.strategy === AuthStrategy.openid)
-      ) {
+      if (!this.state.isPostLoginError && isAuthStrategyOAuth()) {
         return <InitializingScreen />;
       }
 

--- a/src/app/AuthenticationController.tsx
+++ b/src/app/AuthenticationController.tsx
@@ -38,7 +38,7 @@ enum LoginStage {
   LOGIN,
   POST_LOGIN,
   LOGGED_IN,
-  LOGGED_IN_AT_LOAD
+  LOGGED_IN_AT_LOAD,
 }
 
 interface AuthenticationControllerState {
@@ -55,7 +55,7 @@ class AuthenticationController extends React.Component<AuthenticationControllerP
     super(props);
     this.state = {
       stage: this.props.authenticated ? LoginStage.LOGGED_IN_AT_LOAD : LoginStage.LOGIN,
-      isPostLoginError: false
+      isPostLoginError: false,
     };
   }
 
@@ -89,7 +89,7 @@ class AuthenticationController extends React.Component<AuthenticationControllerP
         // This state shows the initializing screen while doing the login cycle. This
         // prevents from briefly showing the login form while the trip to the back-end completes.
         this.setState({
-          stage: LoginStage.LOGGED_IN_AT_LOAD
+          stage: LoginStage.LOGGED_IN_AT_LOAD,
         });
       }
     }
@@ -146,13 +146,13 @@ class AuthenticationController extends React.Component<AuthenticationControllerP
   private doPostLoginActions = async () => {
     try {
       const getStatusPromise = API.getStatus()
-        .then(response => this.props.setServerStatus(response.data))
-        .catch(error => {
+        .then((response) => this.props.setServerStatus(response.data))
+        .catch((error) => {
           AlertUtils.addError('Error fetching server status.', error, 'default', MessageType.WARNING);
         });
       const getJaegerInfoPromise = API.getJaegerInfo()
-        .then(response => this.props.setJaegerInfo(response.data))
-        .catch(error => {
+        .then((response) => this.props.setJaegerInfo(response.data))
+        .catch((error) => {
           this.props.setJaegerInfo(null);
           AlertUtils.addError(
             'Could not fetch Jaeger info. Turning off Jaeger integration.',
@@ -184,21 +184,21 @@ const processServerStatus = (dispatch: KialiDispatch, serverStatus: ServerStatus
     HelpDropdownActions.statusRefresh(serverStatus.status, serverStatus.externalServices, serverStatus.warningMessages)
   );
 
-  serverStatus.warningMessages.forEach(wMsg => {
+  serverStatus.warningMessages.forEach((wMsg) => {
     dispatch(MessageCenterActions.addMessage(wMsg, '', 'systemErrors', MessageType.WARNING));
   });
 };
 
 const mapStateToProps = (state: KialiAppState) => ({
   authenticated: state.authentication.status === LoginStatus.loggedIn,
-  isLoginError: state.authentication.status === LoginStatus.error
+  isLoginError: state.authentication.status === LoginStatus.error,
 });
 
 const mapDispatchToProps = (dispatch: KialiDispatch) => ({
   setJaegerInfo: bindActionCreators(JaegerActions.setInfo, dispatch),
   setServerStatus: (serverStatus: ServerStatus) => processServerStatus(dispatch, serverStatus),
   setMeshTlsStatus: bindActionCreators(MeshTlsActions.setinfo, dispatch),
-  checkCredentials: () => dispatch(LoginThunkActions.checkCredentials())
+  checkCredentials: () => dispatch(LoginThunkActions.checkCredentials()),
 });
 
 const AuthenticationControllerContainer = connect(mapStateToProps, mapDispatchToProps)(AuthenticationController);

--- a/src/app/AuthenticationController.tsx
+++ b/src/app/AuthenticationController.tsx
@@ -23,6 +23,7 @@ import { JaegerInfo } from '../types/JaegerInfo';
 interface AuthenticationControllerReduxProps {
   authenticated: boolean;
   checkCredentials: () => void;
+  isLoginError: boolean;
   setJaegerInfo: (jaegerInfo: JaegerInfo | null) => void;
   setServerStatus: (serverStatus: ServerStatus) => void;
   setMeshTlsStatus: (meshStatus: TLSStatus) => void;
@@ -107,6 +108,10 @@ class AuthenticationController extends React.Component<AuthenticationControllerP
       this.setState({ stage: LoginStage.LOGIN });
     }
 
+    if (!prevProps.isLoginError && this.props.isLoginError) {
+      this.setState({ stage: LoginStage.LOGIN });
+    }
+
     this.setDocLayout();
   }
 
@@ -185,7 +190,8 @@ const processServerStatus = (dispatch: KialiDispatch, serverStatus: ServerStatus
 };
 
 const mapStateToProps = (state: KialiAppState) => ({
-  authenticated: state.authentication.status === LoginStatus.loggedIn
+  authenticated: state.authentication.status === LoginStatus.loggedIn,
+  isLoginError: state.authentication.status === LoginStatus.error
 });
 
 const mapDispatchToProps = (dispatch: KialiDispatch) => ({

--- a/src/components/Nav/Masthead/UserDropdown.tsx
+++ b/src/components/Nav/Masthead/UserDropdown.tsx
@@ -156,8 +156,7 @@ const mapStateToProps = (state: KialiAppState) => ({
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<KialiAppState, void, KialiAppAction>) => ({
   logout: () => dispatch(LoginThunkActions.logout()),
-  extendSession: (session: LoginSession) => dispatch(LoginThunkActions.extendSession(session)),
-  checkCredentials: () => dispatch(LoginThunkActions.checkCredentials())
+  extendSession: (session: LoginSession) => dispatch(LoginThunkActions.extendSession(session))
 });
 
 const UserDropdown = connect(mapStateToProps, mapDispatchToProps)(UserDropdownConnected);

--- a/src/components/Nav/Masthead/UserDropdown.tsx
+++ b/src/components/Nav/Masthead/UserDropdown.tsx
@@ -36,7 +36,7 @@ class UserDropdownConnected extends React.Component<UserProps, UserState> {
       showSessionTimeOut: false,
       timeCountDownSeconds: this.timeLeft() / MILLISECONDS,
       isSessionTimeoutDismissed: false,
-      isDropdownOpen: false
+      isDropdownOpen: false,
     };
   }
   componentDidMount() {
@@ -49,7 +49,7 @@ class UserDropdownConnected extends React.Component<UserProps, UserState> {
 
     this.setState({
       checkSessionTimerId: checkSessionTimerId,
-      timeLeftTimerId: timeLeftTimerId
+      timeLeftTimerId: timeLeftTimerId,
     });
   }
 
@@ -92,15 +92,15 @@ class UserDropdownConnected extends React.Component<UserProps, UserState> {
     this.setState({ showSessionTimeOut: false });
   };
 
-  onDropdownToggle = isDropdownOpen => {
+  onDropdownToggle = (isDropdownOpen) => {
     this.setState({
-      isDropdownOpen
+      isDropdownOpen,
     });
   };
 
-  onDropdownSelect = _event => {
+  onDropdownSelect = (_event) => {
     this.setState({
-      isDropdownOpen: !this.state.isDropdownOpen
+      isDropdownOpen: !this.state.isDropdownOpen,
     });
   };
 
@@ -151,12 +151,12 @@ class UserDropdownConnected extends React.Component<UserProps, UserState> {
 }
 
 const mapStateToProps = (state: KialiAppState) => ({
-  session: state.authentication.session
+  session: state.authentication.session,
 });
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<KialiAppState, void, KialiAppAction>) => ({
   logout: () => dispatch(LoginThunkActions.logout()),
-  extendSession: (session: LoginSession) => dispatch(LoginThunkActions.extendSession(session))
+  extendSession: (session: LoginSession) => dispatch(LoginThunkActions.extendSession(session)),
 });
 
 const UserDropdown = connect(mapStateToProps, mapDispatchToProps)(UserDropdownConnected);

--- a/src/components/Nav/Masthead/UserDropdown.tsx
+++ b/src/components/Nav/Masthead/UserDropdown.tsx
@@ -36,7 +36,7 @@ class UserDropdownConnected extends React.Component<UserProps, UserState> {
       showSessionTimeOut: false,
       timeCountDownSeconds: this.timeLeft() / MILLISECONDS,
       isSessionTimeoutDismissed: false,
-      isDropdownOpen: false,
+      isDropdownOpen: false
     };
   }
   componentDidMount() {
@@ -49,7 +49,7 @@ class UserDropdownConnected extends React.Component<UserProps, UserState> {
 
     this.setState({
       checkSessionTimerId: checkSessionTimerId,
-      timeLeftTimerId: timeLeftTimerId,
+      timeLeftTimerId: timeLeftTimerId
     });
   }
 
@@ -92,15 +92,15 @@ class UserDropdownConnected extends React.Component<UserProps, UserState> {
     this.setState({ showSessionTimeOut: false });
   };
 
-  onDropdownToggle = (isDropdownOpen) => {
+  onDropdownToggle = isDropdownOpen => {
     this.setState({
-      isDropdownOpen,
+      isDropdownOpen
     });
   };
 
-  onDropdownSelect = (_event) => {
+  onDropdownSelect = _event => {
     this.setState({
-      isDropdownOpen: !this.state.isDropdownOpen,
+      isDropdownOpen: !this.state.isDropdownOpen
     });
   };
 
@@ -151,12 +151,12 @@ class UserDropdownConnected extends React.Component<UserProps, UserState> {
 }
 
 const mapStateToProps = (state: KialiAppState) => ({
-  session: state.authentication.session,
+  session: state.authentication.session
 });
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<KialiAppState, void, KialiAppAction>) => ({
   logout: () => dispatch(LoginThunkActions.logout()),
-  extendSession: (session: LoginSession) => dispatch(LoginThunkActions.extendSession(session)),
+  extendSession: (session: LoginSession) => dispatch(LoginThunkActions.extendSession(session))
 });
 
 const UserDropdown = connect(mapStateToProps, mapDispatchToProps)(UserDropdownConnected);

--- a/src/config/AuthenticationConfig.ts
+++ b/src/config/AuthenticationConfig.ts
@@ -2,7 +2,7 @@ import { AuthConfig, AuthStrategy } from '../types/Auth';
 
 const authenticationConfig: AuthConfig = {
   strategy: AuthStrategy.login,
-  secretMissing: false,
+  secretMissing: false
 };
 
 // Returns true if authentication strategy is either 'openshift' or 'openid'

--- a/src/config/AuthenticationConfig.ts
+++ b/src/config/AuthenticationConfig.ts
@@ -2,7 +2,11 @@ import { AuthConfig, AuthStrategy } from '../types/Auth';
 
 const authenticationConfig: AuthConfig = {
   strategy: AuthStrategy.login,
-  secretMissing: false
+  secretMissing: false,
 };
+
+// Returns true if authentication strategy is either 'openshift' or 'openid'
+export const isAuthStrategyOAuth = () =>
+  authenticationConfig.strategy === AuthStrategy.openshift || authenticationConfig.strategy === AuthStrategy.openid;
 
 export default authenticationConfig;

--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -83,8 +83,11 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
   handleSubmit = (e: any) => {
     e.preventDefault();
 
-    if (authenticationConfig.strategy === AuthStrategy.openshift) {
-      // If we are using OpenShift OAuth, take the user back to the OpenShift OAuth login
+    if (
+      authenticationConfig.strategy === AuthStrategy.openshift ||
+      authenticationConfig.strategy === AuthStrategy.openid
+    ) {
+      // If we are using OpenShift or OpenId strategy, take the user back to the authorization endpoint
       window.location.href = authenticationConfig.authorizationEndpoint!;
     } else if (authenticationConfig.strategy === AuthStrategy.token) {
       if (this.state.password.trim().length !== 0 && this.props.authenticate) {
@@ -184,6 +187,8 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
     let loginLabel = 'Log In';
     if (authenticationConfig.strategy === AuthStrategy.openshift) {
       loginLabel = 'Log In With OpenShift';
+    } else if (authenticationConfig.strategy === AuthStrategy.openid) {
+      loginLabel = 'Log In With OpenID';
     }
 
     const messages = this.getHelperMessage();

--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -27,7 +27,6 @@ type LoginProps = {
   message?: string;
   error?: any;
   authenticate: (username: string, password: string) => void;
-  checkCredentials: () => void;
   isPostLoginPerforming: boolean;
   postLoginErrorMsg?: string;
 };
@@ -63,9 +62,6 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
   }
 
   componentDidMount() {
-    // handle initial path from the browser
-    this.props.checkCredentials();
-
     const loginInput = document.getElementById('pf-login-username-id');
     if (loginInput) {
       loginInput.focus();
@@ -284,8 +280,7 @@ const mapStateToProps = (state: KialiAppState) => ({
 });
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<KialiAppState, void, KialiAppAction>) => ({
-  authenticate: (username: string, password: string) => dispatch(LoginThunkActions.authenticate(username, password)),
-  checkCredentials: () => dispatch(LoginThunkActions.checkCredentials())
+  authenticate: (username: string, password: string) => dispatch(LoginThunkActions.authenticate(username, password))
 });
 
 const LoginPageContainer = connect(mapStateToProps, mapDispatchToProps)(LoginPage);

--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -12,7 +12,7 @@ import {
   LoginFooterItem,
   LoginForm,
   LoginPage as LoginNext,
-  TextInput
+  TextInput,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { KialiAppState, LoginSession, LoginStatus } from '../../store/Store';
@@ -44,7 +44,7 @@ type LoginState = {
 
 export class LoginPage extends React.Component<LoginProps, LoginState> {
   static contextTypes = {
-    store: () => null
+    store: () => null,
   };
   constructor(props: LoginProps) {
     super(props);
@@ -57,7 +57,7 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
       isValidToken: true,
       filledInputs: false,
       showHelperText: false,
-      errorInput: ''
+      errorInput: '',
     };
   }
 
@@ -68,11 +68,11 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
     }
   }
 
-  handleUsernameChange = value => {
+  handleUsernameChange = (value) => {
     this.setState({ username: value });
   };
 
-  handlePasswordChange = passwordValue => {
+  handlePasswordChange = (passwordValue) => {
     this.setState({ password: passwordValue });
   };
 
@@ -92,7 +92,7 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
           showHelperText: false,
           errorInput: '',
           isValidToken: true,
-          filledInputs: true
+          filledInputs: true,
         });
       } else {
         const message = 'Please, provide a Service Account token.';
@@ -101,14 +101,14 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
           showHelperText: true,
           errorInput: message,
           isValidToken: false,
-          filledInputs: false
+          filledInputs: false,
         });
       }
     } else {
       this.setState({
         isValidUsername: !!this.state.username,
         isValidPassword: !!this.state.password,
-        filledInputs: !!this.state.username && !!this.state.password
+        filledInputs: !!this.state.username && !!this.state.password,
       });
 
       if (!!this.state.username && !!this.state.password && this.props.authenticate) {
@@ -127,7 +127,7 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
           showHelperText: true,
           errorInput: message,
           isValidUsername: false,
-          isValidPassword: false
+          isValidPassword: false,
         });
       }
     }
@@ -286,11 +286,11 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
 
 const mapStateToProps = (state: KialiAppState) => ({
   status: state.authentication.status,
-  message: state.authentication.message
+  message: state.authentication.message,
 });
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<KialiAppState, void, KialiAppAction>) => ({
-  authenticate: (username: string, password: string) => dispatch(LoginThunkActions.authenticate(username, password))
+  authenticate: (username: string, password: string) => dispatch(LoginThunkActions.authenticate(username, password)),
 });
 
 const LoginPageContainer = connect(mapStateToProps, mapDispatchToProps)(LoginPage);

--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -12,7 +12,7 @@ import {
   LoginFooterItem,
   LoginForm,
   LoginPage as LoginNext,
-  TextInput,
+  TextInput
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { KialiAppState, LoginSession, LoginStatus } from '../../store/Store';
@@ -45,7 +45,7 @@ type LoginState = {
 
 export class LoginPage extends React.Component<LoginProps, LoginState> {
   static contextTypes = {
-    store: () => null,
+    store: () => null
   };
   constructor(props: LoginProps) {
     super(props);
@@ -58,7 +58,7 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
       isValidToken: true,
       filledInputs: false,
       showHelperText: false,
-      errorInput: '',
+      errorInput: ''
     };
   }
 
@@ -69,11 +69,11 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
     }
   }
 
-  handleUsernameChange = (value) => {
+  handleUsernameChange = value => {
     this.setState({ username: value });
   };
 
-  handlePasswordChange = (passwordValue) => {
+  handlePasswordChange = passwordValue => {
     this.setState({ password: passwordValue });
   };
 
@@ -90,7 +90,7 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
           showHelperText: false,
           errorInput: '',
           isValidToken: true,
-          filledInputs: true,
+          filledInputs: true
         });
       } else {
         const message = 'Please, provide a Service Account token.';
@@ -99,14 +99,14 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
           showHelperText: true,
           errorInput: message,
           isValidToken: false,
-          filledInputs: false,
+          filledInputs: false
         });
       }
     } else {
       this.setState({
         isValidUsername: !!this.state.username,
         isValidPassword: !!this.state.password,
-        filledInputs: !!this.state.username && !!this.state.password,
+        filledInputs: !!this.state.username && !!this.state.password
       });
 
       if (!!this.state.username && !!this.state.password && this.props.authenticate) {
@@ -125,7 +125,7 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
           showHelperText: true,
           errorInput: message,
           isValidUsername: false,
-          isValidPassword: false,
+          isValidPassword: false
         });
       }
     }
@@ -284,11 +284,11 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
 
 const mapStateToProps = (state: KialiAppState) => ({
   status: state.authentication.status,
-  message: state.authentication.message,
+  message: state.authentication.message
 });
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<KialiAppState, void, KialiAppAction>) => ({
-  authenticate: (username: string, password: string) => dispatch(LoginThunkActions.authenticate(username, password)),
+  authenticate: (username: string, password: string) => dispatch(LoginThunkActions.authenticate(username, password))
 });
 
 const LoginPageContainer = connect(mapStateToProps, mapDispatchToProps)(LoginPage);

--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -253,9 +253,19 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
       );
     } else {
       loginPane = (
-        <Button onClick={this.handleSubmit} style={{ width: '100%' }} variant="primary">
-          {loginLabel}
-        </Button>
+        <Form>
+          <FormHelperText
+            isError={this.props.status === LoginStatus.error}
+            isHidden={this.props.status !== LoginStatus.error && this.props.message === '' && messages.length === 0}
+          >
+            {messages}
+          </FormHelperText>
+          <ActionGroup>
+            <Button type="submit" onClick={this.handleSubmit} style={{ width: '100%' }} variant="primary">
+              {loginLabel}
+            </Button>
+          </ActionGroup>
+        </Form>
       );
     }
 

--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -20,6 +20,7 @@ import { AuthStrategy } from '../../types/Auth';
 import { authenticationConfig, kialiLogo } from '../../config';
 import { KialiAppAction } from '../../actions/KialiAppAction';
 import LoginThunkActions from '../../actions/LoginThunkActions';
+import { isAuthStrategyOAuth } from '../../config/AuthenticationConfig';
 
 type LoginProps = {
   status: LoginStatus;
@@ -79,10 +80,7 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
   handleSubmit = (e: any) => {
     e.preventDefault();
 
-    if (
-      authenticationConfig.strategy === AuthStrategy.openshift ||
-      authenticationConfig.strategy === AuthStrategy.openid
-    ) {
+    if (isAuthStrategyOAuth()) {
       // If we are using OpenShift or OpenId strategy, take the user back to the authorization endpoint
       window.location.href = authenticationConfig.authorizationEndpoint!;
     } else if (authenticationConfig.strategy === AuthStrategy.token) {

--- a/src/services/Login.ts
+++ b/src/services/Login.ts
@@ -60,7 +60,7 @@ class WebLogin implements LoginStrategy<WebLoginData> {
 
     return {
       status: AuthResult.SUCCESS,
-      session: session
+      session: session,
     };
   }
 }
@@ -75,7 +75,7 @@ class TokenLogin implements LoginStrategy<WebLoginData> {
 
     return {
       status: AuthResult.SUCCESS,
-      session: session
+      session: session,
     };
   }
 }
@@ -90,7 +90,7 @@ class LdapLogin implements LoginStrategy<WebLoginData> {
 
     return {
       status: AuthResult.SUCCESS,
-      session: session
+      session: session,
     };
   }
 }
@@ -118,7 +118,7 @@ class OAuthLogin implements LoginStrategy<unknown> {
 
     return {
       status: AuthResult.SUCCESS,
-      session: session
+      session: session,
     };
   }
 }
@@ -144,7 +144,7 @@ export class LoginDispatcher {
 
     try {
       const delay = async (ms: TimeInMilliseconds = 3000) => {
-        return new Promise(resolve => setTimeout(resolve, ms));
+        return new Promise((resolve) => setTimeout(resolve, ms));
       };
 
       const result = await strategy.prepare(info);
@@ -160,7 +160,7 @@ export class LoginDispatcher {
 
         return Promise.reject({
           status: AuthResult.FAILURE,
-          error: 'Failed to redirect user to authentication page.'
+          error: 'Failed to redirect user to authentication page.',
         });
       } else {
         return result;

--- a/src/services/Login.ts
+++ b/src/services/Login.ts
@@ -135,6 +135,7 @@ export class LoginDispatcher {
     this.strategyMapping.set(AuthStrategy.openshift, new OpenshiftLogin());
     this.strategyMapping.set(AuthStrategy.ldap, new LdapLogin());
     this.strategyMapping.set(AuthStrategy.token, new TokenLogin());
+    this.strategyMapping.set(AuthStrategy.openid, new OpenshiftLogin());
   }
 
   public async prepare(): Promise<AuthResult> {

--- a/src/services/Login.ts
+++ b/src/services/Login.ts
@@ -95,7 +95,7 @@ class LdapLogin implements LoginStrategy<WebLoginData> {
   }
 }
 
-class OpenshiftLogin implements LoginStrategy<unknown> {
+class OAuthLogin implements LoginStrategy<unknown> {
   public async prepare(info: AuthConfig) {
     if (!info.authorizationEndpoint) {
       return AuthResult.FAILURE;
@@ -132,10 +132,10 @@ export class LoginDispatcher {
 
     this.strategyMapping.set(AuthStrategy.anonymous, new AnonymousLogin());
     this.strategyMapping.set(AuthStrategy.login, new WebLogin());
-    this.strategyMapping.set(AuthStrategy.openshift, new OpenshiftLogin());
+    this.strategyMapping.set(AuthStrategy.openshift, new OAuthLogin());
     this.strategyMapping.set(AuthStrategy.ldap, new LdapLogin());
     this.strategyMapping.set(AuthStrategy.token, new TokenLogin());
-    this.strategyMapping.set(AuthStrategy.openid, new OpenshiftLogin());
+    this.strategyMapping.set(AuthStrategy.openid, new OAuthLogin());
   }
 
   public async prepare(): Promise<AuthResult> {

--- a/src/services/Login.ts
+++ b/src/services/Login.ts
@@ -60,7 +60,7 @@ class WebLogin implements LoginStrategy<WebLoginData> {
 
     return {
       status: AuthResult.SUCCESS,
-      session: session,
+      session: session
     };
   }
 }
@@ -75,7 +75,7 @@ class TokenLogin implements LoginStrategy<WebLoginData> {
 
     return {
       status: AuthResult.SUCCESS,
-      session: session,
+      session: session
     };
   }
 }
@@ -90,7 +90,7 @@ class LdapLogin implements LoginStrategy<WebLoginData> {
 
     return {
       status: AuthResult.SUCCESS,
-      session: session,
+      session: session
     };
   }
 }
@@ -118,7 +118,7 @@ class OAuthLogin implements LoginStrategy<unknown> {
 
     return {
       status: AuthResult.SUCCESS,
-      session: session,
+      session: session
     };
   }
 }
@@ -144,7 +144,7 @@ export class LoginDispatcher {
 
     try {
       const delay = async (ms: TimeInMilliseconds = 3000) => {
-        return new Promise((resolve) => setTimeout(resolve, ms));
+        return new Promise(resolve => setTimeout(resolve, ms));
       };
 
       const result = await strategy.prepare(info);
@@ -160,7 +160,7 @@ export class LoginDispatcher {
 
         return Promise.reject({
           status: AuthResult.FAILURE,
-          error: 'Failed to redirect user to authentication page.',
+          error: 'Failed to redirect user to authentication page.'
         });
       } else {
         return result;

--- a/src/types/Auth.ts
+++ b/src/types/Auth.ts
@@ -15,7 +15,8 @@ export enum AuthStrategy {
   anonymous = 'anonymous',
   openshift = 'openshift',
   ldap = 'ldap',
-  token = 'token'
+  token = 'token',
+  openid = 'openid'
 }
 
 // Stores the result of a computation:

--- a/src/types/Auth.ts
+++ b/src/types/Auth.ts
@@ -16,7 +16,7 @@ export enum AuthStrategy {
   openshift = 'openshift',
   ldap = 'ldap',
   token = 'token',
-  openid = 'openid',
+  openid = 'openid'
 }
 
 // Stores the result of a computation:
@@ -28,7 +28,7 @@ export enum AuthResult {
   HOLD = 'hold',
   CONTINUE = 'continue',
   SUCCESS = 'success',
-  FAILURE = 'failure',
+  FAILURE = 'failure'
 }
 
 export interface SessionInfo {

--- a/src/types/Auth.ts
+++ b/src/types/Auth.ts
@@ -16,7 +16,7 @@ export enum AuthStrategy {
   openshift = 'openshift',
   ldap = 'ldap',
   token = 'token',
-  openid = 'openid'
+  openid = 'openid',
 }
 
 // Stores the result of a computation:
@@ -28,7 +28,7 @@ export enum AuthResult {
   HOLD = 'hold',
   CONTINUE = 'continue',
   SUCCESS = 'success',
-  FAILURE = 'failure'
+  FAILURE = 'failure',
 }
 
 export interface SessionInfo {


### PR DESCRIPTION
* Add support for OpenId strategy for authentication.
  * It was just a matter of adding openid to some conditionals.
  * Renamed OpenshiftLogin class as OAuthLogin for code clarity
  * (see commits cdd8ffac07ca1a8de459e0768c4e434f40cb8fc3 and c6415eafa8c741c304f9b5869036566fd1aab048)
* Move the checkCredentials to AuthenticationController.tsx
  * This was mainly for a more centralized authentication flow.
  * Also, to prevent showing the login form for OpenShift/OpenID while the login cycle is finalizing.
  * (see commit 3defea26de510bb7ae34c39126d4f5861e8a55c1)

Part of kiali/kiali#2056