### PR TITLE
Add {Peer,Request}Authentication objects to Create Istio Config

### DIFF
--- a/src/components/IstioWizards/IstioWizardActions.ts
+++ b/src/components/IstioWizards/IstioWizardActions.ts
@@ -25,7 +25,7 @@ import {
   StringMatch,
   VirtualService,
   VirtualServices,
-  WorkloadEntrySelector
+  WorkloadEntrySelector,
 } from '../../types/IstioObjects';
 import { serverConfig } from '../../config';
 import { ThreeScaleServiceRule } from '../../types/ThreeScale';
@@ -48,14 +48,14 @@ export const WIZARD_TITLES = {
   [WIZARD_WEIGHTED_ROUTING]: 'Create Weighted Routing',
   [WIZARD_MATCHING_ROUTING]: 'Create Matching Routing',
   [WIZARD_SUSPEND_TRAFFIC]: 'Suspend Traffic',
-  [WIZARD_THREESCALE_INTEGRATION]: 'Add 3scale API Management Rule'
+  [WIZARD_THREESCALE_INTEGRATION]: 'Add 3scale API Management Rule',
 };
 
 export const WIZARD_UPDATE_TITLES = {
   [WIZARD_WEIGHTED_ROUTING]: 'Update Weighted Routing',
   [WIZARD_MATCHING_ROUTING]: 'Update Matching Routing',
   [WIZARD_SUSPEND_TRAFFIC]: 'Update Suspended Traffic',
-  [WIZARD_THREESCALE_INTEGRATION]: 'Update 3scale API Management Rule'
+  [WIZARD_THREESCALE_INTEGRATION]: 'Update 3scale API Management Rule',
 };
 
 export type WizardProps = {
@@ -108,8 +108,8 @@ const buildHTTPMatchRequest = (matches: string[]): HTTPMatchRequest[] => {
   const matchHeaders: HTTPMatchRequest = { headers: {} };
   // Headers are grouped
   matches
-    .filter(match => match.startsWith('headers'))
-    .forEach(match => {
+    .filter((match) => match.startsWith('headers'))
+    .forEach((match) => {
       // match follows format:  headers [<header-name>] <op> <value>
       const i0 = match.indexOf('[');
       const j0 = match.indexOf(']');
@@ -125,8 +125,8 @@ const buildHTTPMatchRequest = (matches: string[]): HTTPMatchRequest[] => {
   }
   // Rest of matches
   matches
-    .filter(match => !match.startsWith('headers'))
-    .forEach(match => {
+    .filter((match) => !match.startsWith('headers'))
+    .forEach((match) => {
       // match follows format: <name> <op> <value>
       const i = match.indexOf(' ');
       const j = match.indexOf(' ', i + 1);
@@ -135,8 +135,8 @@ const buildHTTPMatchRequest = (matches: string[]): HTTPMatchRequest[] => {
       const value = match.substring(j + 1).trim();
       matchRequests.push({
         [name]: {
-          [op]: value
-        }
+          [op]: value,
+        },
       });
     });
   return matchRequests;
@@ -159,7 +159,7 @@ const parseHttpMatchRequest = (httpMatchRequest: HTTPMatchRequest): string[] => 
   const matches: string[] = [];
   // Headers
   if (httpMatchRequest.headers) {
-    Object.keys(httpMatchRequest.headers).forEach(headerName => {
+    Object.keys(httpMatchRequest.headers).forEach((headerName) => {
       const value = httpMatchRequest.headers![headerName];
       matches.push('headers [' + headerName + '] ' + parseStringMatch(value));
     });
@@ -214,12 +214,12 @@ export const buildIstioConfig = (
       namespace: wProps.namespace,
       name: wProps.serviceName,
       labels: {
-        [KIALI_WIZARD_LABEL]: wProps.type
-      }
+        [KIALI_WIZARD_LABEL]: wProps.type,
+      },
     },
     spec: {
       host: fqdnServiceName(wProps.serviceName, wProps.namespace),
-      subsets: wProps.workloads.map(workload => {
+      subsets: wProps.workloads.map((workload) => {
         // Using version
         const versionLabelName = serverConfig.istioLabels.versionLabelName;
         const versionValue = workload.labels![versionLabelName];
@@ -229,10 +229,10 @@ export const buildIstioConfig = (
         wkdNameVersion[workload.name] = versionValue;
         return {
           name: versionValue,
-          labels: labels
+          labels: labels,
         };
-      })
-    }
+      }),
+    },
   };
 
   const wizardVS: VirtualService = {
@@ -240,10 +240,10 @@ export const buildIstioConfig = (
       namespace: wProps.namespace,
       name: wProps.serviceName,
       labels: {
-        [KIALI_WIZARD_LABEL]: wProps.type
-      }
+        [KIALI_WIZARD_LABEL]: wProps.type,
+      },
     },
-    spec: {}
+    spec: {},
   };
 
   // Wizard is optional, only when user has explicitly selected "Create a Gateway"
@@ -255,24 +255,24 @@ export const buildIstioConfig = (
             namespace: wProps.namespace,
             name: fullNewGatewayName.substr(wProps.namespace.length + 1),
             labels: {
-              [KIALI_WIZARD_LABEL]: wProps.type
-            }
+              [KIALI_WIZARD_LABEL]: wProps.type,
+            },
           },
           spec: {
             selector: {
-              istio: 'ingressgateway'
+              istio: 'ingressgateway',
             },
             servers: [
               {
                 port: {
                   number: wState.gateway.port,
                   name: 'http',
-                  protocol: 'HTTP'
+                  protocol: 'HTTP',
                 },
-                hosts: wState.gateway.gwHosts.split(',')
-              }
-            ]
-          }
+                hosts: wState.gateway.gwHosts.split(','),
+              },
+            ],
+          },
         }
       : undefined;
 
@@ -282,32 +282,32 @@ export const buildIstioConfig = (
       wizardVS.spec = {
         http: [
           {
-            route: wState.workloads.map(workload => {
+            route: wState.workloads.map((workload) => {
               return {
                 destination: {
                   host: fqdnServiceName(wProps.serviceName, wProps.namespace),
-                  subset: wkdNameVersion[workload.name]
+                  subset: wkdNameVersion[workload.name],
                 },
-                weight: workload.weight
+                weight: workload.weight,
               };
-            })
-          }
-        ]
+            }),
+          },
+        ],
       };
       break;
     }
     case WIZARD_MATCHING_ROUTING: {
       // VirtualService from the routes
       wizardVS.spec = {
-        http: wState.rules.map(rule => {
+        http: wState.rules.map((rule) => {
           const httpRoute: HTTPRoute = {};
           httpRoute.route = [];
           for (let iRoute = 0; iRoute < rule.routes.length; iRoute++) {
             const destW: HTTPRouteDestination = {
               destination: {
                 host: fqdnServiceName(wProps.serviceName, wProps.namespace),
-                subset: wkdNameVersion[rule.routes[iRoute]]
-              }
+                subset: wkdNameVersion[rule.routes[iRoute]],
+              },
             };
             destW.weight = Math.floor(100 / rule.routes.length);
             if (iRoute === 0) {
@@ -320,18 +320,18 @@ export const buildIstioConfig = (
             httpRoute.match = buildHTTPMatchRequest(rule.matches);
           }
           return httpRoute;
-        })
+        }),
       };
       break;
     }
     case WIZARD_SUSPEND_TRAFFIC: {
       // VirtualService from the suspendedRoutes
       const httpRoute: HTTPRoute = {
-        route: []
+        route: [],
       };
       // Let's use the # os suspended notes to create weights
       const totalRoutes = wState.suspendedRoutes.length;
-      const closeRoutes = wState.suspendedRoutes.filter(s => s.suspended).length;
+      const closeRoutes = wState.suspendedRoutes.filter((s) => s.suspended).length;
       const openRoutes = totalRoutes - closeRoutes;
       let firstValue = true;
       // If we have some suspended routes, we need to use weights
@@ -341,8 +341,8 @@ export const buildIstioConfig = (
           const destW: HTTPRouteDestination = {
             destination: {
               host: fqdnServiceName(wProps.serviceName, wProps.namespace),
-              subset: wkdNameVersion[suspendedRoute.workload]
-            }
+              subset: wkdNameVersion[suspendedRoute.workload],
+            },
           };
           if (suspendedRoute.suspended) {
             // A suspended route has a 0 weight
@@ -362,21 +362,21 @@ export const buildIstioConfig = (
         httpRoute.route = [
           {
             destination: {
-              host: fqdnServiceName(wProps.serviceName, wProps.namespace)
-            }
-          }
+              host: fqdnServiceName(wProps.serviceName, wProps.namespace),
+            },
+          },
         ];
         httpRoute.fault = {
           abort: {
             httpStatus: SERVICE_UNAVAILABLE,
             percentage: {
-              value: 100
-            }
-          }
+              value: 100,
+            },
+          },
         };
       }
       wizardVS.spec = {
-        http: [httpRoute]
+        http: [httpRoute],
       };
       break;
     }
@@ -392,14 +392,14 @@ export const buildIstioConfig = (
   if (wState.trafficPolicy.tlsModified || wState.trafficPolicy.addLoadBalancer) {
     wizardDR.spec.trafficPolicy = {
       tls: null,
-      loadBalancer: null
+      loadBalancer: null,
     };
     if (wState.trafficPolicy.tlsModified) {
       wizardDR.spec.trafficPolicy.tls = {
         mode: wState.trafficPolicy.mtlsMode,
         clientCertificate: null,
         privateKey: null,
-        caCertificates: null
+        caCertificates: null,
       };
       if (wState.trafficPolicy.mtlsMode === MUTUAL) {
         wizardDR.spec.trafficPolicy.tls.clientCertificate = wState.trafficPolicy.clientCertificate;
@@ -412,17 +412,17 @@ export const buildIstioConfig = (
         // Remember to put a null fields that need to be deleted on a JSON merge patch
         wizardDR.spec.trafficPolicy.loadBalancer = {
           simple: wState.trafficPolicy.loadBalancer.simple,
-          consistentHash: null
+          consistentHash: null,
         };
       } else {
         wizardDR.spec.trafficPolicy.loadBalancer = {
           simple: null,
-          consistentHash: {}
+          consistentHash: {},
         };
         wizardDR.spec.trafficPolicy.loadBalancer.consistentHash = {
           httpHeaderName: null,
           httpCookie: null,
-          useSourceIp: null
+          useSourceIp: null,
         };
         if (wState.trafficPolicy.loadBalancer.consistentHash) {
           const consistentHash = wState.trafficPolicy.loadBalancer.consistentHash;
@@ -460,18 +460,18 @@ export const buildIstioConfig = (
 const getWorkloadsByVersion = (workloads: WorkloadOverview[]): { [key: string]: string } => {
   const versionLabelName = serverConfig.istioLabels.versionLabelName;
   const wkdVersionName: { [key: string]: string } = {};
-  workloads.forEach(workload => (wkdVersionName[workload.labels![versionLabelName]] = workload.name));
+  workloads.forEach((workload) => (wkdVersionName[workload.labels![versionLabelName]] = workload.name));
   return wkdVersionName;
 };
 
 export const getDefaultWeights = (workloads: WorkloadOverview[]): WorkloadWeight[] => {
   const wkTraffic = workloads.length < 100 ? Math.floor(100 / workloads.length) : 0;
   const remainTraffic = workloads.length < 100 ? 100 % workloads.length : 0;
-  const wkWeights: WorkloadWeight[] = workloads.map(workload => ({
+  const wkWeights: WorkloadWeight[] = workloads.map((workload) => ({
     name: workload.name,
     weight: wkTraffic,
     locked: false,
-    maxWeight: 100
+    maxWeight: 100,
   }));
   if (remainTraffic > 0) {
     wkWeights[wkWeights.length - 1].weight = wkWeights[wkWeights.length - 1].weight + remainTraffic;
@@ -484,7 +484,7 @@ export const getInitWeights = (workloads: WorkloadOverview[], virtualServices: V
   const wkdWeights: WorkloadWeight[] = [];
   if (virtualServices.items.length === 1 && virtualServices.items[0].spec.http!.length === 1) {
     // Populate WorkloadWeights from a VirtualService
-    virtualServices.items[0].spec.http![0].route!.forEach(route => {
+    virtualServices.items[0].spec.http![0].route!.forEach((route) => {
       // A wkdVersionName[route.destination.subset] === undefined may indicate that a VS contains a removed workload
       // Checking before to add it to the Init Weights
       if (route.destination.subset && wkdVersionName[route.destination.subset]) {
@@ -492,7 +492,7 @@ export const getInitWeights = (workloads: WorkloadOverview[], virtualServices: V
           name: wkdVersionName[route.destination.subset],
           weight: route.weight || 0,
           locked: false,
-          maxWeight: 100
+          maxWeight: 100,
         });
       }
     });
@@ -514,7 +514,7 @@ export const getInitWeights = (workloads: WorkloadOverview[], virtualServices: V
           name: wkd.name,
           weight: 0,
           locked: false,
-          maxWeight: 100
+          maxWeight: 100,
         });
       }
     }
@@ -526,16 +526,16 @@ export const getInitRules = (workloads: WorkloadOverview[], virtualServices: Vir
   const wkdVersionName = getWorkloadsByVersion(workloads);
   const rules: Rule[] = [];
   if (virtualServices.items.length === 1) {
-    virtualServices.items[0].spec.http!.forEach(httpRoute => {
+    virtualServices.items[0].spec.http!.forEach((httpRoute) => {
       const rule: Rule = {
         matches: [],
-        routes: []
+        routes: [],
       };
       if (httpRoute.match) {
-        httpRoute.match.forEach(m => (rule.matches = rule.matches.concat(parseHttpMatchRequest(m))));
+        httpRoute.match.forEach((m) => (rule.matches = rule.matches.concat(parseHttpMatchRequest(m))));
       }
       if (httpRoute.route) {
-        httpRoute.route.forEach(r => {
+        httpRoute.route.forEach((r) => {
           const subset = r.destination.subset;
           const workload = wkdVersionName[subset || ''];
           // Not adding a route if a workload is not found with a destination subset
@@ -559,10 +559,10 @@ export const getInitSuspendedRoutes = (
   virtualServices: VirtualServices
 ): SuspendedRoute[] => {
   const wkdVersionName = getWorkloadsByVersion(workloads);
-  const routes: SuspendedRoute[] = workloads.map(wk => ({
+  const routes: SuspendedRoute[] = workloads.map((wk) => ({
     workload: wk.name,
     suspended: true,
-    httpStatus: SERVICE_UNAVAILABLE
+    httpStatus: SERVICE_UNAVAILABLE,
   }));
   if (virtualServices.items.length === 1 && virtualServices.items[0].spec.http!.length === 1) {
     // All routes are suspended default value is correct
@@ -570,10 +570,10 @@ export const getInitSuspendedRoutes = (
       return routes;
     }
     // Iterate on route weights to identify the suspended routes
-    virtualServices.items[0].spec.http![0].route!.forEach(route => {
+    virtualServices.items[0].spec.http![0].route!.forEach((route) => {
       if (route.weight && route.weight > 0) {
         const workloadName = wkdVersionName[route.destination.subset || ''];
-        routes.filter(w => w.workload === workloadName).forEach(w => (w.suspended = false));
+        routes.filter((w) => w.workload === workloadName).forEach((w) => (w.suspended = false));
       }
     });
   }
@@ -590,7 +590,7 @@ export const getInitTlsMode = (destinationRules: DestinationRules): [string, str
       destinationRules.items[0].spec.trafficPolicy.tls.mode || '',
       destinationRules.items[0].spec.trafficPolicy.tls.clientCertificate || '',
       destinationRules.items[0].spec.trafficPolicy.tls.privateKey || '',
-      destinationRules.items[0].spec.trafficPolicy.tls.caCertificates || ''
+      destinationRules.items[0].spec.trafficPolicy.tls.caCertificates || '',
     ];
   }
   return ['', '', '', ''];
@@ -661,10 +661,10 @@ export const buildAuthorizationPolicy = (
       name: name,
       namespace: namespace,
       labels: {
-        [KIALI_WIZARD_LABEL]: 'AuthorizationPolicy'
-      }
+        [KIALI_WIZARD_LABEL]: 'AuthorizationPolicy',
+      },
     },
-    spec: {}
+    spec: {},
   };
 
   // DENY_ALL and ALLOW_ALL are two specific cases
@@ -680,9 +680,9 @@ export const buildAuthorizationPolicy = (
   // RULES use case
   if (state.workloadSelector.length > 0) {
     const workloadSelector: AuthorizationPolicyWorkloadSelector = {
-      matchLabels: {}
+      matchLabels: {},
     };
-    state.workloadSelector.split(',').forEach(label => {
+    state.workloadSelector.split(',').forEach((label) => {
       label = label.trim();
       const labelDetails = label.split('=');
       if (labelDetails.length === 2) {
@@ -694,38 +694,38 @@ export const buildAuthorizationPolicy = (
 
   if (state.rules.length > 0) {
     ap.spec.rules = [];
-    state.rules.forEach(rule => {
+    state.rules.forEach((rule) => {
       const appRule: AuthorizationPolicyRule = {
         from: undefined,
         to: undefined,
-        when: undefined
+        when: undefined,
       };
       if (rule.from.length > 0) {
-        appRule.from = rule.from.map(fromItem => {
+        appRule.from = rule.from.map((fromItem) => {
           const source: Source = {};
-          Object.keys(fromItem).forEach(key => {
+          Object.keys(fromItem).forEach((key) => {
             source[key] = fromItem[key];
           });
           return {
-            source: source
+            source: source,
           };
         });
       }
       if (rule.to.length > 0) {
-        appRule.to = rule.to.map(toItem => {
+        appRule.to = rule.to.map((toItem) => {
           const operation: Operation = {};
-          Object.keys(toItem).forEach(key => {
+          Object.keys(toItem).forEach((key) => {
             operation[key] = toItem[key];
           });
           return {
-            operation: operation
+            operation: operation,
           };
         });
       }
       if (rule.when.length > 0) {
-        appRule.when = rule.when.map(condition => {
+        appRule.when = rule.when.map((condition) => {
           const cond: Condition = {
-            key: condition.key
+            key: condition.key,
           };
           if (condition.values && condition.values.length > 0) {
             cond.values = condition.values;
@@ -751,23 +751,23 @@ export const buildGateway = (name: string, namespace: string, state: GatewayStat
       name: name,
       namespace: namespace,
       labels: {
-        [KIALI_WIZARD_LABEL]: 'Gateway'
-      }
+        [KIALI_WIZARD_LABEL]: 'Gateway',
+      },
     },
     spec: {
       // Default for istio scenarios, user may change it editing YAML
       selector: {
-        istio: 'ingressgateway'
+        istio: 'ingressgateway',
       },
-      servers: state.gatewayServers.map(s => ({
+      servers: state.gatewayServers.map((s) => ({
         port: {
           number: +s.portNumber,
           protocol: s.portProtocol,
-          name: s.portName
+          name: s.portName,
         },
-        hosts: s.hosts
-      }))
-    }
+        hosts: s.hosts,
+      })),
+    },
   };
   return gw;
 };
@@ -782,17 +782,17 @@ export const buildPeerAuthentication = (
       name: name,
       namespace: namespace,
       labels: {
-        [KIALI_WIZARD_LABEL]: 'PeerAuthentication'
-      }
+        [KIALI_WIZARD_LABEL]: 'PeerAuthentication',
+      },
     },
-    spec: {}
+    spec: {},
   };
 
   if (state.workloadSelector.length > 0) {
     const workloadSelector: PeerAuthenticationWorkloadSelector = {
-      matchLabels: {}
+      matchLabels: {},
     };
-    state.workloadSelector.split(',').forEach(label => {
+    state.workloadSelector.split(',').forEach((label) => {
       label = label.trim();
       const labelDetails = label.split('=');
       if (labelDetails.length === 2) {
@@ -804,15 +804,15 @@ export const buildPeerAuthentication = (
 
   // Kiali is always adding this field
   pa.spec.mtls = {
-    mode: PeerAuthenticationMutualTLSMode[state.mtls]
+    mode: PeerAuthenticationMutualTLSMode[state.mtls],
   };
 
   if (state.portLevelMtls.length > 0) {
     pa.spec.portLevelMtls = {};
-    state.portLevelMtls.forEach(p => {
+    state.portLevelMtls.forEach((p) => {
       if (pa.spec.portLevelMtls) {
         pa.spec.portLevelMtls[Number(p.port)] = {
-          mode: PeerAuthenticationMutualTLSMode[p.mtls]
+          mode: PeerAuthenticationMutualTLSMode[p.mtls],
         };
       }
     });
@@ -831,19 +831,19 @@ export const buildRequestAuthentication = (
       name: name,
       namespace: namespace,
       labels: {
-        [KIALI_WIZARD_LABEL]: 'RequestAuthentication'
-      }
+        [KIALI_WIZARD_LABEL]: 'RequestAuthentication',
+      },
     },
     spec: {
-      jwtRules: []
-    }
+      jwtRules: [],
+    },
   };
 
   if (state.workloadSelector.length > 0) {
     const workloadSelector: WorkloadEntrySelector = {
-      matchLabels: {}
+      matchLabels: {},
     };
-    state.workloadSelector.split(',').forEach(label => {
+    state.workloadSelector.split(',').forEach((label) => {
       label = label.trim();
       const labelDetails = label.split('=');
       if (labelDetails.length === 2) {
@@ -865,25 +865,25 @@ export const buildSidecar = (name: string, namespace: string, state: SidecarStat
       name: name,
       namespace: namespace,
       labels: {
-        [KIALI_WIZARD_LABEL]: 'Sidecar'
-      }
+        [KIALI_WIZARD_LABEL]: 'Sidecar',
+      },
     },
     spec: {
       egress: [
         {
-          hosts: state.egressHosts.map(eh => eh.host)
-        }
-      ]
-    }
+          hosts: state.egressHosts.map((eh) => eh.host),
+        },
+      ],
+    },
   };
   if (state.addWorkloadSelector && state.workloadSelectorValid) {
     sc.spec.workloadSelector = {
-      labels: {}
+      labels: {},
     };
     state.workloadSelectorLabels
       .trim()
       .split(',')
-      .forEach(split => {
+      .forEach((split) => {
         const labels = split.trim().split('=');
         // It should be already validated with workloadSelectorValid, but just to add extra safe check
         if (sc.spec.workloadSelector && labels.length === 2) {

--- a/src/components/MessageCenter/AlertDrawerMessage.tsx
+++ b/src/components/MessageCenter/AlertDrawerMessage.tsx
@@ -57,7 +57,7 @@ class AlertDrawerMessage extends React.PureComponent<AlertDrawerMessageProps> {
               onToggle={() => this.props.toggleMessageDetail(this.props.message)}
               isExpanded={this.props.message.showDetail}
             >
-              <pre>{this.props.message.detail}</pre>
+              <pre style={{ whiteSpace: 'pre-wrap' }}>{this.props.message.detail}</pre>
             </Expandable>
           )}
           {this.props.message.count > 1 && (

--- a/src/components/MessageCenter/AlertDrawerMessage.tsx
+++ b/src/components/MessageCenter/AlertDrawerMessage.tsx
@@ -36,13 +36,13 @@ type AlertDrawerMessageProps = ReduxProps & {
 
 class AlertDrawerMessage extends React.PureComponent<AlertDrawerMessageProps> {
   static readonly body = style({
-    paddingTop: 0
+    paddingTop: 0,
   });
   static readonly left = style({
-    float: 'left'
+    float: 'left',
   });
   static readonly right = style({
-    float: 'right'
+    float: 'right',
   });
 
   render() {
@@ -77,13 +77,10 @@ class AlertDrawerMessage extends React.PureComponent<AlertDrawerMessageProps> {
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<KialiAppState, void, KialiAppAction>) => {
   return {
-    markAsRead: message => dispatch(MessageCenterActions.markAsRead(message.id)),
-    toggleMessageDetail: message => dispatch(MessageCenterActions.toggleMessageDetail(message.id))
+    markAsRead: (message) => dispatch(MessageCenterActions.markAsRead(message.id)),
+    toggleMessageDetail: (message) => dispatch(MessageCenterActions.toggleMessageDetail(message.id)),
   };
 };
 
-const AlertDrawerMessageContainer = connect(
-  null,
-  mapDispatchToProps
-)(AlertDrawerMessage);
+const AlertDrawerMessageContainer = connect(null, mapDispatchToProps)(AlertDrawerMessage);
 export default AlertDrawerMessageContainer;

--- a/src/helpers/ValidationHelpers.ts
+++ b/src/helpers/ValidationHelpers.ts
@@ -1,0 +1,10 @@
+// Kubernetes ID validation helper, used to allow mark a warning in the form edition
+const k8sRegExpName = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[-a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
+export const isValidK8SName = (name: string) => {
+  return name === '' ? false : name.search(k8sRegExpName) === 0;
+};
+
+const regExpRequestHeaders = /^request\.headers\[.*\]$/;
+export const isValidRequestHeaderName = (name: string) => {
+  return name === '' ? false : name.search(regExpRequestHeaders) === 0;
+};

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm.tsx
@@ -30,7 +30,7 @@ export const DENY = 'DENY';
 const HELPER_TEXT = {
   DENY_ALL: 'Denies all requests to workloads in given namespace(s)',
   ALLOW_ALL: 'Allows all requests to workloads in given namespace(s)',
-  RULES: 'Builds an Authorization Policy based on Rules'
+  RULES: 'Builds an Authorization Policy based on Rules',
 };
 
 const rulesFormValues = [DENY_ALL, ALLOW_ALL, RULES];
@@ -43,7 +43,7 @@ export const initAuthorizationPolicy = (): AuthorizationPolicyState => ({
   rules: [],
   rulesForm: DENY_ALL,
   addWorkloadSelector: false,
-  workloadSelectorValid: false
+  workloadSelectorValid: false,
 });
 
 export const isAuthorizationPolicyStateValid = (ap: AuthorizationPolicyState): boolean => {
@@ -67,14 +67,14 @@ class AuthorizationPolicyForm extends React.Component<Props, AuthorizationPolicy
       rules: [],
       rulesForm: this.props.authorizationPolicy.rulesForm,
       addWorkloadSelector: this.props.authorizationPolicy.addWorkloadSelector,
-      workloadSelectorValid: this.props.authorizationPolicy.workloadSelectorValid
+      workloadSelectorValid: this.props.authorizationPolicy.workloadSelectorValid,
     });
   }
 
   onRulesFormChange = (value, _) => {
     this.setState(
       {
-        rulesForm: value
+        rulesForm: value,
       },
       () => this.onAuthorizationChange()
     );
@@ -82,9 +82,9 @@ class AuthorizationPolicyForm extends React.Component<Props, AuthorizationPolicy
 
   onChangeWorkloadSelector = () => {
     this.setState(
-      prevState => {
+      (prevState) => {
         return {
-          addWorkloadSelector: !prevState.addWorkloadSelector
+          addWorkloadSelector: !prevState.addWorkloadSelector,
         };
       },
       () => this.onAuthorizationChange()
@@ -96,7 +96,7 @@ class AuthorizationPolicyForm extends React.Component<Props, AuthorizationPolicy
       this.setState(
         {
           workloadSelectorValid: false,
-          workloadSelector: ''
+          workloadSelector: '',
         },
         () => this.onAuthorizationChange()
       );
@@ -125,7 +125,7 @@ class AuthorizationPolicyForm extends React.Component<Props, AuthorizationPolicy
     this.setState(
       {
         workloadSelectorValid: isValid,
-        workloadSelector: value
+        workloadSelector: value,
       },
       () => this.onAuthorizationChange()
     );
@@ -134,7 +134,7 @@ class AuthorizationPolicyForm extends React.Component<Props, AuthorizationPolicy
   onActionChange = (value, _) => {
     this.setState(
       {
-        action: value
+        action: value,
       },
       () => this.onAuthorizationChange()
     );
@@ -142,10 +142,10 @@ class AuthorizationPolicyForm extends React.Component<Props, AuthorizationPolicy
 
   onAddRule = (rule: Rule) => {
     this.setState(
-      prevState => {
+      (prevState) => {
         prevState.rules.push(rule);
         return {
-          rules: prevState.rules
+          rules: prevState.rules,
         };
       },
       () => this.onAuthorizationChange()
@@ -154,10 +154,10 @@ class AuthorizationPolicyForm extends React.Component<Props, AuthorizationPolicy
 
   onRemoveRule = (index: number) => {
     this.setState(
-      prevState => {
+      (prevState) => {
         prevState.rules.splice(index, 1);
         return {
-          rules: prevState.rules
+          rules: prevState.rules,
         };
       },
       () => this.onAuthorizationChange()

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm.tsx
@@ -13,23 +13,19 @@ export type AuthorizationPolicyState = {
   workloadSelector: string;
   action: string;
   rules: Rule[];
-};
-
-type State = {
   // Used to identify DENY_ALL, ALLOW_ALL or RULES
   rulesForm: string;
   addWorkloadSelector: boolean;
   workloadSelectorValid: boolean;
-  workloadSelectorLabels: string;
-  action: string;
-  rules: Rule[];
 };
 
-const DENY_ALL = 'DENY_ALL';
-const ALLOW_ALL = 'ALLOW_ALL';
-const RULES = 'RULES';
-const ALLOW = 'ALLOW';
-const DENY = 'DENY';
+export const AUTHORIZACION_POLICY = 'AuthorizationPolicy';
+export const AUTHORIZATION_POLICIES = 'authorizationpolicies';
+export const DENY_ALL = 'DENY_ALL';
+export const ALLOW_ALL = 'ALLOW_ALL';
+export const RULES = 'RULES';
+export const ALLOW = 'ALLOW';
+export const DENY = 'DENY';
 
 const HELPER_TEXT = {
   DENY_ALL: 'Denies all requests to workloads in given namespace(s)',
@@ -40,34 +36,38 @@ const HELPER_TEXT = {
 const rulesFormValues = [DENY_ALL, ALLOW_ALL, RULES];
 const actions = [ALLOW, DENY];
 
-export const INIT_AUTHORIZATION_POLICY = (): AuthorizationPolicyState => ({
-  policy: DENY_ALL,
+export const initAuthorizationPolicy = (): AuthorizationPolicyState => ({
+  policy: DENY,
   workloadSelector: '',
   action: ALLOW,
-  rules: []
+  rules: [],
+  rulesForm: DENY_ALL,
+  addWorkloadSelector: false,
+  workloadSelectorValid: false
 });
 
-class AuthorizationPolicyForm extends React.Component<Props, State> {
+export const isAuthorizationPolicyStateValid = (ap: AuthorizationPolicyState): boolean => {
+  const workloadSelectorRule = ap.addWorkloadSelector ? ap.workloadSelectorValid : true;
+  const denyRule = ap.action === DENY ? ap.rules.length > 0 : true;
+
+  return workloadSelectorRule && denyRule;
+};
+
+class AuthorizationPolicyForm extends React.Component<Props, AuthorizationPolicyState> {
   constructor(props: Props) {
     super(props);
-    this.state = {
-      rulesForm: this.props.authorizationPolicy.policy,
-      addWorkloadSelector: false,
-      workloadSelectorValid: false,
-      workloadSelectorLabels: this.props.authorizationPolicy.workloadSelector,
-      action: this.props.authorizationPolicy.action,
-      rules: []
-    };
+    this.state = initAuthorizationPolicy();
   }
 
   componentDidMount() {
     this.setState({
-      rulesForm: this.props.authorizationPolicy.policy,
-      addWorkloadSelector: false,
-      workloadSelectorValid: false,
-      workloadSelectorLabels: this.props.authorizationPolicy.workloadSelector,
+      policy: this.props.authorizationPolicy.policy,
+      workloadSelector: this.props.authorizationPolicy.workloadSelector,
       action: this.props.authorizationPolicy.action,
-      rules: []
+      rules: [],
+      rulesForm: this.props.authorizationPolicy.rulesForm,
+      addWorkloadSelector: this.props.authorizationPolicy.addWorkloadSelector,
+      workloadSelectorValid: this.props.authorizationPolicy.workloadSelectorValid
     });
   }
 
@@ -80,12 +80,26 @@ class AuthorizationPolicyForm extends React.Component<Props, State> {
     );
   };
 
+  onChangeWorkloadSelector = () => {
+    this.setState(
+      prevState => {
+        return {
+          addWorkloadSelector: !prevState.addWorkloadSelector
+        };
+      },
+      () => this.onAuthorizationChange()
+    );
+  };
+
   addWorkloadLabels = (value: string, _) => {
     if (value.length === 0) {
-      this.setState({
-        workloadSelectorValid: false,
-        workloadSelectorLabels: ''
-      });
+      this.setState(
+        {
+          workloadSelectorValid: false,
+          workloadSelector: ''
+        },
+        () => this.onAuthorizationChange()
+      );
       return;
     }
     value = value.trim();
@@ -111,7 +125,7 @@ class AuthorizationPolicyForm extends React.Component<Props, State> {
     this.setState(
       {
         workloadSelectorValid: isValid,
-        workloadSelectorLabels: value
+        workloadSelector: value
       },
       () => this.onAuthorizationChange()
     );
@@ -151,13 +165,7 @@ class AuthorizationPolicyForm extends React.Component<Props, State> {
   };
 
   onAuthorizationChange = () => {
-    const authorizationPolicy: AuthorizationPolicyState = {
-      policy: this.state.rulesForm,
-      workloadSelector: this.state.workloadSelectorLabels,
-      action: this.state.action,
-      rules: this.state.rules
-    };
-    this.props.onChange(authorizationPolicy);
+    this.props.onChange(this.state);
   };
 
   render() {
@@ -177,11 +185,7 @@ class AuthorizationPolicyForm extends React.Component<Props, State> {
               label={' '}
               labelOff={' '}
               isChecked={this.state.addWorkloadSelector}
-              onChange={() => {
-                this.setState(prevState => ({
-                  addWorkloadSelector: !prevState.addWorkloadSelector
-                }));
-              }}
+              onChange={this.onChangeWorkloadSelector}
             />
           </FormGroup>
         )}
@@ -197,7 +201,7 @@ class AuthorizationPolicyForm extends React.Component<Props, State> {
               id="gwHosts"
               name="gwHosts"
               isDisabled={!this.state.addWorkloadSelector}
-              value={this.state.workloadSelectorLabels}
+              value={this.state.workloadSelector}
               onChange={this.addWorkloadLabels}
               isValid={this.state.workloadSelectorValid}
             />
@@ -213,7 +217,9 @@ class AuthorizationPolicyForm extends React.Component<Props, State> {
           </FormGroup>
         )}
         {this.state.rulesForm === RULES && <RuleBuilder onAddRule={this.onAddRule} />}
-        {this.state.rulesForm === RULES && <RuleList ruleList={this.state.rules} onRemoveRule={this.onRemoveRule} />}
+        {this.state.rulesForm === RULES && (
+          <RuleList action={this.state.action} ruleList={this.state.rules} onRemoveRule={this.onRemoveRule} />
+        )}
       </>
     );
   }

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/From/SourceBuilder.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/From/SourceBuilder.tsx
@@ -109,12 +109,13 @@ class SourceBuilder extends React.Component<Props, State> {
   // Helper to identify when some values are valid
   isValidSource = (): [boolean, string] => {
     if (this.state.newSourceField === 'ipBlocks' || this.state.newSourceField === 'notIpBlocks') {
-      const validIp = isValidIp(this.state.newValues);
+      const validIp = this.state.newValues.split(',').every((ip) => isValidIp(ip));
       if (!validIp) {
         return [false, 'Not valid IP'];
       }
     }
-    if (this.state.newValues.length === 0) {
+    const emptyValues = this.state.newValues.split(',').every((v) => v.length === 0);
+    if (emptyValues) {
       return [false, 'Empty value'];
     }
     return [true, ''];
@@ -149,14 +150,15 @@ class SourceBuilder extends React.Component<Props, State> {
 
   rows = () => {
     const [isValidSource, invalidText] = this.isValidSource();
-    return Object.keys(this.state.source)
-      .map((sourceField, i) => {
-        return {
-          key: 'sourceKey' + i,
-          cells: [<>{sourceField}</>, <>{this.state.source[sourceField].join(',')}</>, <></>],
-        };
-      })
-      .concat([
+
+    const sourceRows = Object.keys(this.state.source).map((sourceField, i) => {
+      return {
+        key: 'sourceKey' + i,
+        cells: [<>{sourceField}</>, <>{this.state.source[sourceField].join(',')}</>, <></>],
+      };
+    });
+    if (this.state.sourceFields.length > 0) {
+      return sourceRows.concat([
         {
           key: 'sourceKeyNew',
           cells: [
@@ -202,6 +204,8 @@ class SourceBuilder extends React.Component<Props, State> {
           ],
         },
       ]);
+    }
+    return sourceRows;
   };
 
   render() {

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/From/SourceBuilder.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/From/SourceBuilder.tsx
@@ -28,28 +28,28 @@ const INIT_SOURCE_FIELDS = [
   'namespaces',
   'notNamespaces',
   'ipBlocks',
-  'notIpBlocks'
+  'notIpBlocks',
 ].sort();
 
 const noSourceStyle = style({
-  color: PfColors.Red100
+  color: PfColors.Red100,
 });
 
 const headerCells: ICell[] = [
   {
     title: 'Source Field',
     transforms: [cellWidth(20) as any],
-    props: {}
+    props: {},
   },
   {
     title: 'Values',
     transforms: [cellWidth(80) as any],
-    props: {}
+    props: {},
   },
   {
     title: '',
-    props: {}
-  }
+    props: {},
+  },
 ];
 
 class SourceBuilder extends React.Component<Props, State> {
@@ -59,24 +59,24 @@ class SourceBuilder extends React.Component<Props, State> {
       sourceFields: Object.assign([], INIT_SOURCE_FIELDS),
       source: {},
       newSourceField: INIT_SOURCE_FIELDS[0],
-      newValues: ''
+      newValues: '',
     };
   }
 
   onAddNewSourceField = (value: string, _) => {
     this.setState({
-      newSourceField: value
+      newSourceField: value,
     });
   };
 
   onAddNewValues = (value: string, _) => {
     this.setState({
-      newValues: value
+      newValues: value,
     });
   };
 
   onAddSource = () => {
-    this.setState(prevState => {
+    this.setState((prevState) => {
       const i = prevState.sourceFields.indexOf(prevState.newSourceField);
       if (i > -1) {
         prevState.sourceFields.splice(i, 1);
@@ -86,7 +86,7 @@ class SourceBuilder extends React.Component<Props, State> {
         sourceFields: prevState.sourceFields,
         source: prevState.source,
         newSourceField: prevState.sourceFields[0],
-        newValues: ''
+        newValues: '',
       };
     });
   };
@@ -98,7 +98,7 @@ class SourceBuilder extends React.Component<Props, State> {
         sourceFields: Object.assign([], INIT_SOURCE_FIELDS),
         source: {},
         newSourceField: INIT_SOURCE_FIELDS[0],
-        newValues: ''
+        newValues: '',
       },
       () => {
         this.props.onAddFrom(fromItem);
@@ -128,7 +128,7 @@ class SourceBuilder extends React.Component<Props, State> {
       onClick: (event, rowIndex, rowData, extraData) => {
         // Fetch sourceField from rowData, it's a fixed string on children
         const removeSourceField = rowData.cells[0].props.children.toString();
-        this.setState(prevState => {
+        this.setState((prevState) => {
           prevState.sourceFields.push(removeSourceField);
           delete prevState.source[removeSourceField];
           const newSourceFields = prevState.sourceFields.sort();
@@ -136,10 +136,10 @@ class SourceBuilder extends React.Component<Props, State> {
             sourceFields: newSourceFields,
             source: prevState.source,
             newSourceField: newSourceFields[0],
-            newValues: ''
+            newValues: '',
           };
         });
-      }
+      },
     };
     if (rowIndex < Object.keys(this.state.source).length) {
       return [removeAction];
@@ -153,7 +153,7 @@ class SourceBuilder extends React.Component<Props, State> {
       .map((sourceField, i) => {
         return {
           key: 'sourceKey' + i,
-          cells: [<>{sourceField}</>, <>{this.state.source[sourceField].join(',')}</>, <></>]
+          cells: [<>{sourceField}</>, <>{this.state.source[sourceField].join(',')}</>, <></>],
         };
       })
       .concat([
@@ -198,9 +198,9 @@ class SourceBuilder extends React.Component<Props, State> {
                   isDisabled={!isValidSource}
                 />
               )}
-            </>
-          ]
-        }
+            </>,
+          ],
+        },
       ]);
   };
 

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/RuleList.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/RuleList.tsx
@@ -5,6 +5,7 @@ import { style } from 'typestyle';
 import { PfColors } from '../../../components/Pf/PfColors';
 
 type Props = {
+  action: string;
   ruleList: Rule[];
   onRemoveRule: (index: number) => void;
 };
@@ -120,6 +121,8 @@ class RuleList extends React.Component<Props> {
   };
 
   render() {
+    const noRulesMessage =
+      this.props.action === 'DENY' ? ' DENY action requires at least one Rule' : 'No Rules Defined.';
     return (
       <>
         <Table
@@ -132,7 +135,7 @@ class RuleList extends React.Component<Props> {
           <TableHeader />
           <TableBody />
         </Table>
-        {this.props.ruleList.length === 0 && <div className={noRulesStyle}>No Rules Defined</div>}
+        {this.props.ruleList.length === 0 && <div className={noRulesStyle}>{noRulesMessage}</div>}
       </>
     );
   }

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/RuleList.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/RuleList.tsx
@@ -14,22 +14,22 @@ const headerCells: ICell[] = [
   {
     title: 'Rules to match the request',
     transforms: [cellWidth(100) as any],
-    props: {}
+    props: {},
   },
   {
     title: '',
-    props: {}
-  }
+    props: {},
+  },
 ];
 
 const rulesPadding = style({
-  paddingLeft: 10
+  paddingLeft: 10,
 });
 
 const noRulesStyle = style({
   color: PfColors.Red100,
   textAlign: 'center',
-  width: '100%'
+  width: '100%',
 });
 
 class RuleList extends React.Component<Props> {
@@ -102,8 +102,8 @@ class RuleList extends React.Component<Props> {
               </>
             )}
           </>,
-          <></>
-        ]
+          <></>,
+        ],
       };
     });
   };
@@ -115,7 +115,7 @@ class RuleList extends React.Component<Props> {
       // @ts-ignore
       onClick: (event, rowIndex, rowData, extraData) => {
         this.props.onRemoveRule(rowIndex);
-      }
+      },
     };
     return [removeAction];
   };

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/To/OperationBuilder.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/To/OperationBuilder.tsx
@@ -25,24 +25,24 @@ const INIT_OPERATION_FIELDS = [
   'methods',
   'notMethods',
   'paths',
-  'notPaths'
+  'notPaths',
 ].sort();
 
 const headerCells: ICell[] = [
   {
     title: 'Operation Field',
     transforms: [cellWidth(20) as any],
-    props: {}
+    props: {},
   },
   {
     title: 'Values',
     transforms: [cellWidth(80) as any],
-    props: {}
+    props: {},
   },
   {
     title: '',
-    props: {}
-  }
+    props: {},
+  },
 ];
 
 class OperationBuilder extends React.Component<Props, State> {
@@ -52,24 +52,24 @@ class OperationBuilder extends React.Component<Props, State> {
       operationFields: Object.assign([], INIT_OPERATION_FIELDS),
       operation: {},
       newOperationField: INIT_OPERATION_FIELDS[0],
-      newValues: ''
+      newValues: '',
     };
   }
 
   onAddNewOperationField = (value: string, _) => {
     this.setState({
-      newOperationField: value
+      newOperationField: value,
     });
   };
 
   onAddNewValues = (value: string, _) => {
     this.setState({
-      newValues: value
+      newValues: value,
     });
   };
 
   onAddOperation = () => {
-    this.setState(prevState => {
+    this.setState((prevState) => {
       const i = prevState.operationFields.indexOf(prevState.newOperationField);
       if (i > -1) {
         prevState.operationFields.splice(i, 1);
@@ -79,7 +79,7 @@ class OperationBuilder extends React.Component<Props, State> {
         operationFields: prevState.operationFields,
         operation: prevState.operation,
         newOperationField: prevState.operationFields[0],
-        newValues: ''
+        newValues: '',
       };
     });
   };
@@ -91,7 +91,7 @@ class OperationBuilder extends React.Component<Props, State> {
         operationFields: Object.assign([], INIT_OPERATION_FIELDS),
         operation: {},
         newOperationField: INIT_OPERATION_FIELDS[0],
-        newValues: ''
+        newValues: '',
       },
       () => {
         this.props.onAddTo(toItem);
@@ -107,7 +107,7 @@ class OperationBuilder extends React.Component<Props, State> {
       onClick: (event, rowIndex, rowData, extraData) => {
         // Fetch sourceField from rowData, it's a fixed string on children
         const removeOperationField = rowData.cells[0].props.children.toString();
-        this.setState(prevState => {
+        this.setState((prevState) => {
           prevState.operationFields.push(removeOperationField);
           delete prevState.operation[removeOperationField];
           const newOperationFields = prevState.operationFields.sort();
@@ -115,10 +115,10 @@ class OperationBuilder extends React.Component<Props, State> {
             operationFields: newOperationFields,
             operation: prevState.operation,
             newOperationField: newOperationFields[0],
-            newValues: ''
+            newValues: '',
           };
         });
-      }
+      },
     };
     if (rowIndex < Object.keys(this.state.operation).length) {
       return [removeAction];
@@ -127,14 +127,14 @@ class OperationBuilder extends React.Component<Props, State> {
   };
 
   rows = () => {
-    return Object.keys(this.state.operation)
-      .map((operationField, i) => {
-        return {
-          key: 'operationKey' + i,
-          cells: [<>{operationField}</>, <>{this.state.operation[operationField].join(',')}</>, <></>]
-        };
-      })
-      .concat([
+    const operatorRows = Object.keys(this.state.operation).map((operationField, i) => {
+      return {
+        key: 'operationKey' + i,
+        cells: [<>{operationField}</>, <>{this.state.operation[operationField].join(',')}</>, <></>],
+      };
+    });
+    if (this.state.operationFields.length > 0) {
+      return operatorRows.concat([
         {
           key: 'operationKeyNew',
           cells: [
@@ -165,10 +165,12 @@ class OperationBuilder extends React.Component<Props, State> {
               {this.state.operationFields.length > 0 && (
                 <Button variant="link" icon={<PlusCircleIcon />} onClick={this.onAddOperation} />
               )}
-            </>
-          ]
-        }
+            </>,
+          ],
+        },
       ]);
+    }
+    return operatorRows;
   };
 
   render() {

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/When/ConditionBuilder.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/When/ConditionBuilder.tsx
@@ -26,22 +26,22 @@ const headerCells: ICell[] = [
   {
     title: 'Condition Key',
     transforms: [cellWidth(30) as any],
-    props: {}
+    props: {},
   },
   {
     title: 'Values',
     transforms: [cellWidth(30) as any],
-    props: {}
+    props: {},
   },
   {
     title: 'Not Values',
     transforms: [cellWidth(30) as any],
-    props: {}
-  }
+    props: {},
+  },
 ];
 
 const noValidKeyStyle = style({
-  color: PfColors.Red100
+  color: PfColors.Red100,
 });
 
 const conditionFixedKeys = [
@@ -53,7 +53,7 @@ const conditionFixedKeys = [
   'request.auth.presenter',
   'destination.ip',
   'destination.port',
-  'connection.sni'
+  'connection.sni',
 ];
 
 class ConditionBuilder extends React.Component<Props, State> {
@@ -61,34 +61,34 @@ class ConditionBuilder extends React.Component<Props, State> {
     super(props);
     this.state = {
       condition: {
-        key: ''
-      }
+        key: '',
+      },
     };
   }
 
   onAddNewConditionKey = (key: string, _) => {
-    this.setState(prevState => {
+    this.setState((prevState) => {
       prevState.condition.key = key;
       return {
-        condition: prevState.condition
+        condition: prevState.condition,
       };
     });
   };
 
   onAddNewValues = (value: string, _) => {
-    this.setState(prevState => {
+    this.setState((prevState) => {
       prevState.condition.values = value.length === 0 ? [] : value.split(',');
       return {
-        condition: prevState.condition
+        condition: prevState.condition,
       };
     });
   };
 
   onAddNewNotValues = (notValues: string, _) => {
-    this.setState(prevState => {
+    this.setState((prevState) => {
       prevState.condition.notValues = notValues.length === 0 ? [] : notValues.split(',');
       return {
-        condition: prevState.condition
+        condition: prevState.condition,
       };
     });
   };
@@ -98,8 +98,8 @@ class ConditionBuilder extends React.Component<Props, State> {
     this.setState(
       {
         condition: {
-          key: ''
-        }
+          key: '',
+        },
       },
       () => {
         this.props.onAddCondition(conditionItem);
@@ -138,9 +138,9 @@ class ConditionBuilder extends React.Component<Props, State> {
     if (key === 'source.ip' || key === 'destination.ip') {
       // If some value is not an IP, then is not valid
       // @ts-ignore
-      const valuesValid = values ? !values.some(value => !isValidIp(value)) : true;
+      const valuesValid = values ? !values.some((value) => !isValidIp(value)) : true;
       // @ts-ignore
-      const notValuesValid = notValues ? !notValues.some(value => !isValidIp(value)) : true;
+      const notValuesValid = notValues ? !notValues.some((value) => !isValidIp(value)) : true;
       return [true, valuesValid, notValuesValid, 'Not valid IP'];
     }
     return [true, true, true, ''];
@@ -199,9 +199,9 @@ class ConditionBuilder extends React.Component<Props, State> {
                 {validText}
               </div>
             )}
-          </>
-        ]
-      }
+          </>,
+        ],
+      },
     ];
   };
 

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/When/ConditionBuilder.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/When/ConditionBuilder.tsx
@@ -77,7 +77,7 @@ class ConditionBuilder extends React.Component<Props, State> {
 
   onAddNewValues = (value: string, _) => {
     this.setState(prevState => {
-      prevState.condition.values = value.split(',');
+      prevState.condition.values = value.length === 0 ? [] : value.split(',');
       return {
         condition: prevState.condition
       };
@@ -86,7 +86,7 @@ class ConditionBuilder extends React.Component<Props, State> {
 
   onAddNewNotValues = (notValues: string, _) => {
     this.setState(prevState => {
-      prevState.condition.notValues = notValues.split(',');
+      prevState.condition.notValues = notValues.length === 0 ? [] : notValues.split(',');
       return {
         condition: prevState.condition
       };
@@ -132,13 +132,15 @@ class ConditionBuilder extends React.Component<Props, State> {
     }
     const values = this.state.condition.values;
     const notValues = this.state.condition.notValues;
-    if ((!values && !notValues) || (values && notValues && values.length === 0 && notValues.length === 0)) {
-      return [true, false, false, 'Values and NotValues cannot be both empty'];
+    if ((!values || values.length === 0) && (!notValues || notValues.length === 0)) {
+      return [true, false, false, 'Values and NotValues cannot be empty'];
     }
-    if (values && notValues && (key === 'source.ip' || key === 'destination.ip')) {
+    if (key === 'source.ip' || key === 'destination.ip') {
       // If some value is not an IP, then is not valid
-      const valuesValid = !values.some(value => !isValidIp(value));
-      const notValuesValid = !notValues.some(value => !isValidIp(value));
+      // @ts-ignore
+      const valuesValid = values ? !values.some(value => !isValidIp(value)) : true;
+      // @ts-ignore
+      const notValuesValid = notValues ? !notValues.some(value => !isValidIp(value)) : true;
       return [true, valuesValid, notValuesValid, 'Not valid IP'];
     }
     return [true, true, true, ''];

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/When/ConditionBuilder.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/When/ConditionBuilder.tsx
@@ -3,6 +3,10 @@ import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/rea
 // Use TextInputBase like workaround while PF4 team work in https://github.com/patternfly/patternfly-react/issues/4072
 import { Button, TextInputBase as TextInput } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
+import { isValidRequestHeaderName } from '../../../../helpers/ValidationHelpers';
+import { style } from 'typestyle';
+import { PfColors } from '../../../../components/Pf/PfColors';
+import { isValidIp } from '../../../../utils/IstioConfigUtils';
 
 export type Condition = {
   key: string;
@@ -34,6 +38,22 @@ const headerCells: ICell[] = [
     transforms: [cellWidth(30) as any],
     props: {}
   }
+];
+
+const noValidKeyStyle = style({
+  color: PfColors.Red100
+});
+
+const conditionFixedKeys = [
+  'source.ip',
+  'source.namespace',
+  'source.principal',
+  'request.auth.principal',
+  'request.auth.audiences',
+  'request.auth.presenter',
+  'destination.ip',
+  'destination.port',
+  'connection.sni'
 ];
 
 class ConditionBuilder extends React.Component<Props, State> {
@@ -87,7 +107,44 @@ class ConditionBuilder extends React.Component<Props, State> {
     );
   };
 
-  rows = () => {
+  isValidKey = (key: string): boolean => {
+    if (key.length === 0) {
+      return false;
+    }
+    if (conditionFixedKeys.includes(key)) {
+      return true;
+    }
+    if (key.startsWith('request.headers')) {
+      return isValidRequestHeaderName(key);
+    }
+    if (key.startsWith('experimental.envoy.filters.')) {
+      return true;
+    }
+    return false;
+  };
+
+  // Helper to mark invalid any of the fields: key, values, notValues with helper text
+  isValidCondition = (): [boolean, boolean, boolean, string] => {
+    const key = this.state.condition.key;
+    const isValidKey = this.isValidKey(key);
+    if (!isValidKey) {
+      return [false, true, true, 'Condition Key not supported'];
+    }
+    const values = this.state.condition.values;
+    const notValues = this.state.condition.notValues;
+    if ((!values && !notValues) || (values && notValues && values.length === 0 && notValues.length === 0)) {
+      return [true, false, false, 'Values and NotValues cannot be both empty'];
+    }
+    if (values && notValues && (key === 'source.ip' || key === 'destination.ip')) {
+      // If some value is not an IP, then is not valid
+      const valuesValid = !values.some(value => !isValidIp(value));
+      const notValuesValid = !notValues.some(value => !isValidIp(value));
+      return [true, valuesValid, notValuesValid, 'Not valid IP'];
+    }
+    return [true, true, true, ''];
+  };
+
+  rows = (validKey: boolean, validValues: boolean, validNotValues: boolean, validText: string) => {
     return [
       {
         key: 'conditionKeyNew',
@@ -101,7 +158,13 @@ class ConditionBuilder extends React.Component<Props, State> {
               aria-describedby="add new condition key"
               name="addNewConditionKey"
               onChange={this.onAddNewConditionKey}
+              isValid={validKey}
             />
+            {!validKey && (
+              <div key="hostsHelperText" className={noValidKeyStyle}>
+                {validText}
+              </div>
+            )}
           </>,
           <>
             <TextInput
@@ -113,6 +176,11 @@ class ConditionBuilder extends React.Component<Props, State> {
               name="addNewConditionValues"
               onChange={this.onAddNewValues}
             />
+            {!validValues && (
+              <div key="hostsHelperText" className={noValidKeyStyle}>
+                {validText}
+              </div>
+            )}
           </>,
           <>
             <TextInput
@@ -124,6 +192,11 @@ class ConditionBuilder extends React.Component<Props, State> {
               name="addNewNotValues"
               onChange={this.onAddNewNotValues}
             />
+            {!validNotValues && (
+              <div key="hostsHelperText" className={noValidKeyStyle}>
+                {validText}
+              </div>
+            )}
           </>
         ]
       }
@@ -131,16 +204,22 @@ class ConditionBuilder extends React.Component<Props, State> {
   };
 
   render() {
+    const [validKey, validValues, validNotValues, validText] = this.isValidCondition();
+    const validCondition = validKey && validValues && validNotValues;
     return (
       <>
-        <Table aria-label="Condition Builder" cells={headerCells} rows={this.rows()}>
+        <Table
+          aria-label="Condition Builder"
+          cells={headerCells}
+          rows={this.rows(validKey, validValues, validNotValues, validText)}
+        >
           <TableHeader />
           <TableBody />
         </Table>
         <Button
           variant="link"
           icon={<PlusCircleIcon />}
-          isDisabled={this.state.condition.key.length === 0}
+          isDisabled={!validCondition}
           onClick={this.onAddConditionToList}
         >
           Add Condition to When List

--- a/src/pages/IstioConfigNew/GatewayForm.tsx
+++ b/src/pages/IstioConfigNew/GatewayForm.tsx
@@ -10,27 +10,27 @@ const headerCells: ICell[] = [
   {
     title: 'Hosts',
     transforms: [cellWidth(60) as any],
-    props: {}
+    props: {},
   },
   {
     title: 'Port Number',
     transforms: [cellWidth(10) as any],
-    props: {}
+    props: {},
   },
   {
     title: 'Port Name',
     transforms: [cellWidth(10) as any],
-    props: {}
+    props: {},
   },
   {
     title: 'Port Protocol',
     transforms: [cellWidth(10) as any],
-    props: {}
+    props: {},
   },
   {
     title: '',
-    props: {}
-  }
+    props: {},
+  },
 ];
 
 export const GATEWAY = 'Gateway';
@@ -40,7 +40,7 @@ const protocols = ['HTTP', 'HTTPS', 'GRPC', 'HTTP2', 'MONGO', 'TCP', 'TLS'];
 
 const noGatewayServerStyle = style({
   marginTop: 15,
-  color: PfColors.Red100
+  color: PfColors.Red100,
 });
 
 const hostsHelperText = 'One or more valid FQDN host separated by comma.';
@@ -70,9 +70,9 @@ export const initGateway = (): GatewayState => ({
     hosts: [],
     portNumber: '80',
     portName: 'http',
-    portProtocol: 'HTTP'
+    portProtocol: 'HTTP',
   },
-  validHosts: false
+  validHosts: false,
 });
 
 export const isGatewayStateValid = (g: GatewayState): boolean => {
@@ -96,15 +96,15 @@ class GatewayForm extends React.Component<Props, GatewayState> {
       // @ts-ignore
       onClick: (event, rowIndex, rowData, extraData) => {
         this.setState(
-          prevState => {
+          (prevState) => {
             prevState.gatewayServers.splice(rowIndex, 1);
             return {
-              gatewayServers: prevState.gatewayServers
+              gatewayServers: prevState.gatewayServers,
             };
           },
           () => this.props.onChange(this.state)
         );
-      }
+      },
     };
     if (rowIndex < this.state.gatewayServers.length) {
       return [removeAction];
@@ -113,54 +113,54 @@ class GatewayForm extends React.Component<Props, GatewayState> {
   };
 
   onAddHosts = (value: string, _) => {
-    const hosts = value.trim().length === 0 ? [] : value.split(',').map(host => host.trim());
-    this.setState(prevState => ({
+    const hosts = value.trim().length === 0 ? [] : value.split(',').map((host) => host.trim());
+    this.setState((prevState) => ({
       addGatewayServer: {
         hosts: hosts,
         portNumber: prevState.addGatewayServer.portNumber,
         portName: prevState.addGatewayServer.portName,
-        portProtocol: prevState.addGatewayServer.portProtocol
+        portProtocol: prevState.addGatewayServer.portProtocol,
       },
-      validHosts: this.areValidHosts(hosts)
+      validHosts: this.areValidHosts(hosts),
     }));
   };
 
   onAddPortNumber = (value: string, _) => {
-    this.setState(prevState => ({
+    this.setState((prevState) => ({
       addGatewayServer: {
         hosts: prevState.addGatewayServer.hosts,
         portNumber: value.trim(),
         portName: prevState.addGatewayServer.portName,
-        portProtocol: prevState.addGatewayServer.portProtocol
-      }
+        portProtocol: prevState.addGatewayServer.portProtocol,
+      },
     }));
   };
 
   onAddPortName = (value: string, _) => {
-    this.setState(prevState => ({
+    this.setState((prevState) => ({
       addGatewayServer: {
         hosts: prevState.addGatewayServer.hosts,
         portNumber: prevState.addGatewayServer.portNumber,
         portName: value.trim(),
-        portProtocol: prevState.addGatewayServer.portProtocol
-      }
+        portProtocol: prevState.addGatewayServer.portProtocol,
+      },
     }));
   };
 
   onAddPortProtocol = (value: string, _) => {
-    this.setState(prevState => ({
+    this.setState((prevState) => ({
       addGatewayServer: {
         hosts: prevState.addGatewayServer.hosts,
         portNumber: prevState.addGatewayServer.portNumber,
         portName: prevState.addGatewayServer.portName,
-        portProtocol: value.trim()
-      }
+        portProtocol: value.trim(),
+      },
     }));
   };
 
   onAddServer = () => {
     this.setState(
-      prevState => {
+      (prevState) => {
         prevState.gatewayServers.push(prevState.addGatewayServer);
         return {
           gatewayServers: prevState.gatewayServers,
@@ -168,8 +168,8 @@ class GatewayForm extends React.Component<Props, GatewayState> {
             hosts: [],
             portNumber: '80',
             portName: 'http',
-            portProtocol: 'HTTP'
-          }
+            portProtocol: 'HTTP',
+          },
         };
       },
       () => this.props.onChange(this.state)
@@ -203,8 +203,8 @@ class GatewayForm extends React.Component<Props, GatewayState> {
           <>{gw.portNumber}</>,
           <>{gw.portName}</>,
           <>{gw.portProtocol}</>,
-          ''
-        ]
+          '',
+        ],
       }))
       .concat([
         {
@@ -278,9 +278,9 @@ class GatewayForm extends React.Component<Props, GatewayState> {
               >
                 Add Server
               </Button>
-            </>
-          ]
-        }
+            </>,
+          ],
+        },
       ]);
   }
 

--- a/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
+++ b/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
@@ -239,7 +239,6 @@ class IstioConfigNewPage extends React.Component<Props, State> {
       default:
         return false;
     }
-    return false;
   };
 
   onChangeAuthorizationPolicy = (authorizationPolicy: AuthorizationPolicyState) => {

--- a/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
+++ b/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
@@ -276,6 +276,8 @@ class IstioConfigNewPage extends React.Component<Props, State> {
   onChangePeerAuthentication = (peerAuthentication: PeerAuthenticationState) => {
     this.setState(prevState => {
       prevState.peerAuthentication.workloadSelector = peerAuthentication.workloadSelector;
+      prevState.peerAuthentication.mtls = peerAuthentication.mtls;
+      prevState.peerAuthentication.portLevelMtls = peerAuthentication.portLevelMtls;
       return {
         peerAuthentication: prevState.peerAuthentication
       };

--- a/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
+++ b/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
@@ -19,7 +19,7 @@ import {
   buildGateway,
   buildPeerAuthentication,
   buildRequestAuthentication,
-  buildSidecar
+  buildSidecar,
 } from '../../components/IstioWizards/IstioWizardActions';
 import { MessageType } from '../../types/MessageCenter';
 import AuthorizationPolicyForm, {
@@ -27,21 +27,21 @@ import AuthorizationPolicyForm, {
   AUTHORIZATION_POLICIES,
   AuthorizationPolicyState,
   initAuthorizationPolicy,
-  isAuthorizationPolicyStateValid
+  isAuthorizationPolicyStateValid,
 } from './AuthorizationPolicyForm';
 import PeerAuthenticationForm, {
   initPeerAuthentication,
   isPeerAuthenticationStateValid,
   PEER_AUTHENTICATION,
   PEER_AUTHENTICATIONS,
-  PeerAuthenticationState
+  PeerAuthenticationState,
 } from './PeerAuthenticationForm';
 import RequestAuthenticationForm, {
   initRequestAuthentication,
   isRequestAuthenticationStateValid,
   REQUEST_AUTHENTICATION,
   REQUEST_AUTHENTICATIONS,
-  RequestAuthenticationState
+  RequestAuthenticationState,
 } from './RequestAuthenticationForm';
 import { isValidK8SName } from '../../helpers/ValidationHelpers';
 
@@ -67,7 +67,7 @@ const DIC = {
   Gateway: GATEWAYS,
   PeerAuthentication: PEER_AUTHENTICATIONS,
   RequestAuthentication: REQUEST_AUTHENTICATIONS,
-  Sidecar: SIDECARS
+  Sidecar: SIDECARS,
 };
 
 const istioResourceOptions = [
@@ -75,7 +75,7 @@ const istioResourceOptions = [
   { value: GATEWAY, label: GATEWAY, disabled: false },
   { value: PEER_AUTHENTICATION, label: PEER_AUTHENTICATION, disabled: false },
   { value: REQUEST_AUTHENTICATION, label: REQUEST_AUTHENTICATION, disabled: false },
-  { value: SIDECAR, label: SIDECAR, disabled: false }
+  { value: SIDECAR, label: SIDECAR, disabled: false },
 ];
 
 const initState = (): State => ({
@@ -87,7 +87,7 @@ const initState = (): State => ({
   peerAuthentication: initPeerAuthentication(),
   requestAuthentication: initRequestAuthentication(),
   // Init with the istio-system/* for sidecar
-  sidecar: initSidecar(serverConfig.istioNamespace + '/*')
+  sidecar: initSidecar(serverConfig.istioNamespace + '/*'),
 });
 
 class IstioConfigNewPage extends React.Component<Props, State> {
@@ -125,14 +125,14 @@ class IstioConfigNewPage extends React.Component<Props, State> {
   fetchPermissions = () => {
     if (this.props.activeNamespaces.length > 0) {
       this.promises
-        .register('permissions', API.getIstioPermissions(this.props.activeNamespaces.map(n => n.name)))
-        .then(permResponse => {
+        .register('permissions', API.getIstioPermissions(this.props.activeNamespaces.map((n) => n.name)))
+        .then((permResponse) => {
           this.setState(
             {
-              istioPermissions: permResponse.data
+              istioPermissions: permResponse.data,
             },
             () => {
-              this.props.activeNamespaces.forEach(ns => {
+              this.props.activeNamespaces.forEach((ns) => {
                 if (!this.canCreate(ns.name)) {
                   AlertUtils.addWarning('User has not permissions to create Istio Config on namespace: ' + ns.name);
                 }
@@ -140,7 +140,7 @@ class IstioConfigNewPage extends React.Component<Props, State> {
             }
           );
         })
-        .catch(error => {
+        .catch((error) => {
           // Canceled errors are expected on this query when page is unmounted
           if (!error.isCanceled) {
             AlertUtils.addError('Could not fetch Permissions.', error);
@@ -152,48 +152,50 @@ class IstioConfigNewPage extends React.Component<Props, State> {
   onIstioResourceChange = (value, _) => {
     this.setState({
       istioResource: value,
-      name: ''
+      name: '',
     });
   };
 
   onNameChange = (value, _) => {
     this.setState({
-      name: value
+      name: value,
     });
   };
 
   onIstioResourceCreate = () => {
     const jsonIstioObjects: { namespace: string; json: string }[] = [];
-    this.props.activeNamespaces.forEach(ns => {
+    this.props.activeNamespaces.forEach((ns) => {
       switch (this.state.istioResource) {
         case AUTHORIZACION_POLICY:
           jsonIstioObjects.push({
             namespace: ns.name,
-            json: JSON.stringify(buildAuthorizationPolicy(this.state.name, ns.name, this.state.authorizationPolicy))
+            json: JSON.stringify(buildAuthorizationPolicy(this.state.name, ns.name, this.state.authorizationPolicy)),
           });
           break;
         case GATEWAY:
           jsonIstioObjects.push({
             namespace: ns.name,
-            json: JSON.stringify(buildGateway(this.state.name, ns.name, this.state.gateway))
+            json: JSON.stringify(buildGateway(this.state.name, ns.name, this.state.gateway)),
           });
           break;
         case PEER_AUTHENTICATION:
           jsonIstioObjects.push({
             namespace: ns.name,
-            json: JSON.stringify(buildPeerAuthentication(this.state.name, ns.name, this.state.peerAuthentication))
+            json: JSON.stringify(buildPeerAuthentication(this.state.name, ns.name, this.state.peerAuthentication)),
           });
           break;
         case REQUEST_AUTHENTICATION:
           jsonIstioObjects.push({
             namespace: ns.name,
-            json: JSON.stringify(buildRequestAuthentication(this.state.name, ns.name, this.state.requestAuthentication))
+            json: JSON.stringify(
+              buildRequestAuthentication(this.state.name, ns.name, this.state.requestAuthentication)
+            ),
           });
           break;
         case SIDECAR:
           jsonIstioObjects.push({
             namespace: ns.name,
-            json: JSON.stringify(buildSidecar(this.state.name, ns.name, this.state.sidecar))
+            json: JSON.stringify(buildSidecar(this.state.name, ns.name, this.state.sidecar)),
           });
           break;
       }
@@ -202,15 +204,15 @@ class IstioConfigNewPage extends React.Component<Props, State> {
     this.promises
       .registerAll(
         'Create ' + DIC[this.state.istioResource],
-        jsonIstioObjects.map(o => API.createIstioConfigDetail(o.namespace, DIC[this.state.istioResource], o.json))
+        jsonIstioObjects.map((o) => API.createIstioConfigDetail(o.namespace, DIC[this.state.istioResource], o.json))
       )
-      .then(results => {
+      .then((results) => {
         if (results.length > 0) {
           AlertUtils.add('Istio ' + this.state.istioResource + ' created', 'default', MessageType.SUCCESS);
         }
         this.backToList();
       })
-      .catch(error => {
+      .catch((error) => {
         AlertUtils.addError('Could not create Istio ' + this.state.istioResource + ' objects.', error);
       });
   };
@@ -241,58 +243,58 @@ class IstioConfigNewPage extends React.Component<Props, State> {
   };
 
   onChangeAuthorizationPolicy = (authorizationPolicy: AuthorizationPolicyState) => {
-    this.setState(prevState => {
+    this.setState((prevState) => {
       Object.keys(prevState.authorizationPolicy).forEach(
-        key => (prevState.authorizationPolicy[key] = authorizationPolicy[key])
+        (key) => (prevState.authorizationPolicy[key] = authorizationPolicy[key])
       );
       return {
-        authorizationPolicy: prevState.authorizationPolicy
+        authorizationPolicy: prevState.authorizationPolicy,
       };
     });
   };
 
   onChangeGateway = (gateway: GatewayState) => {
-    this.setState(prevState => {
-      Object.keys(prevState.gateway).forEach(key => (prevState.gateway[key] = gateway[key]));
+    this.setState((prevState) => {
+      Object.keys(prevState.gateway).forEach((key) => (prevState.gateway[key] = gateway[key]));
       return {
-        gateway: prevState.gateway
+        gateway: prevState.gateway,
       };
     });
   };
 
   onChangePeerAuthentication = (peerAuthentication: PeerAuthenticationState) => {
-    this.setState(prevState => {
+    this.setState((prevState) => {
       Object.keys(prevState.peerAuthentication).forEach(
-        key => (prevState.peerAuthentication[key] = peerAuthentication[key])
+        (key) => (prevState.peerAuthentication[key] = peerAuthentication[key])
       );
       return {
-        peerAuthentication: prevState.peerAuthentication
+        peerAuthentication: prevState.peerAuthentication,
       };
     });
   };
 
   onChangeRequestAuthentication = (requestAuthentication: RequestAuthenticationState) => {
-    this.setState(prevState => {
+    this.setState((prevState) => {
       Object.keys(prevState.requestAuthentication).forEach(
-        key => (prevState.requestAuthentication[key] = requestAuthentication[key])
+        (key) => (prevState.requestAuthentication[key] = requestAuthentication[key])
       );
       return {
-        requestAuthentication: prevState.requestAuthentication
+        requestAuthentication: prevState.requestAuthentication,
       };
     });
   };
 
   onChangeSidecar = (sidecar: SidecarState) => {
-    this.setState(prevState => {
-      Object.keys(prevState.sidecar).forEach(key => (prevState.sidecar[key] = sidecar[key]));
+    this.setState((prevState) => {
+      Object.keys(prevState.sidecar).forEach((key) => (prevState.sidecar[key] = sidecar[key]));
       return {
-        sidecar: prevState.sidecar
+        sidecar: prevState.sidecar,
       };
     });
   };
 
   render() {
-    const canCreate = this.props.activeNamespaces.every(ns => this.canCreate(ns.name));
+    const canCreate = this.props.activeNamespaces.every((ns) => this.canCreate(ns.name));
     const isNameValid = isValidK8SName(this.state.name);
     const isNamespacesValid = this.props.activeNamespaces.length > 0;
     const isFormValid = canCreate && isNameValid && isNamespacesValid && this.isIstioFormValid();
@@ -308,7 +310,7 @@ class IstioConfigNewPage extends React.Component<Props, State> {
             isValid={isNamespacesValid}
           >
             <TextInput
-              value={this.props.activeNamespaces.map(n => n.name).join(',')}
+              value={this.props.activeNamespaces.map((n) => n.name).join(',')}
               isRequired={true}
               type="text"
               id="namespaces"
@@ -389,13 +391,10 @@ class IstioConfigNewPage extends React.Component<Props, State> {
 
 const mapStateToProps = (state: KialiAppState) => {
   return {
-    activeNamespaces: activeNamespacesSelector(state)
+    activeNamespaces: activeNamespacesSelector(state),
   };
 };
 
-const IstioConfigNewPageContainer = connect(
-  mapStateToProps,
-  null
-)(IstioConfigNewPage);
+const IstioConfigNewPageContainer = connect(mapStateToProps, null)(IstioConfigNewPage);
 
 export default IstioConfigNewPageContainer;

--- a/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
+++ b/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
@@ -173,7 +173,7 @@ class IstioConfigNewPage extends React.Component<Props, State> {
 
   onIstioResourceCreate = () => {
     const jsonIstioObjects: { namespace: string; json: string }[] = [];
-    this.props.activeNamespaces.map(ns => {
+    this.props.activeNamespaces.forEach(ns => {
       switch (this.state.istioResource) {
         case AUTHORIZACION_POLICY:
           jsonIstioObjects.push({

--- a/src/pages/IstioConfigNew/PeerAuthenticationForm.tsx
+++ b/src/pages/IstioConfigNew/PeerAuthenticationForm.tsx
@@ -8,24 +8,24 @@ import { PfColors } from '../../components/Pf/PfColors';
 
 const noPortMtlsStyle = style({
   marginTop: 15,
-  color: PfColors.Red100
+  color: PfColors.Red100,
 });
 
 const headerCells: ICell[] = [
   {
     title: 'Port Number',
     transforms: [cellWidth(20) as any],
-    props: {}
+    props: {},
   },
   {
     title: 'Mutual TLS Mode',
     transforms: [cellWidth(20) as any],
-    props: {}
+    props: {},
   },
   {
     title: '',
-    props: {}
-  }
+    props: {},
+  },
 ];
 
 type Props = {
@@ -60,8 +60,8 @@ export const initPeerAuthentication = (): PeerAuthenticationState => ({
   addPortMtls: false,
   addNewPortMtls: {
     port: '',
-    mtls: PeerAuthenticationMutualTLSMode.UNSET
-  }
+    mtls: PeerAuthenticationMutualTLSMode.UNSET,
+  },
 });
 
 export const isPeerAuthenticationStateValid = (pa: PeerAuthenticationState): boolean => {
@@ -83,8 +83,8 @@ class PeerAuthenticationForm extends React.Component<Props, PeerAuthenticationSt
       portLevelMtls: this.props.peerAuthentication.portLevelMtls,
       addNewPortMtls: {
         port: '',
-        mtls: PeerAuthenticationMutualTLSMode.UNSET
-      }
+        mtls: PeerAuthenticationMutualTLSMode.UNSET,
+      },
     };
   }
 
@@ -96,15 +96,15 @@ class PeerAuthenticationForm extends React.Component<Props, PeerAuthenticationSt
       mtls: this.props.peerAuthentication.mtls,
       addPortMtls: this.props.peerAuthentication.addPortMtls,
       portLevelMtls: this.props.peerAuthentication.portLevelMtls,
-      addNewPortMtls: this.props.peerAuthentication.addNewPortMtls
+      addNewPortMtls: this.props.peerAuthentication.addNewPortMtls,
     });
   }
 
   onChangeWorkloadSelector = () => {
     this.setState(
-      prevState => {
+      (prevState) => {
         return {
-          addWorkloadSelector: !prevState.addWorkloadSelector
+          addWorkloadSelector: !prevState.addWorkloadSelector,
         };
       },
       () => this.onPeerAuthenticationChange()
@@ -113,9 +113,9 @@ class PeerAuthenticationForm extends React.Component<Props, PeerAuthenticationSt
 
   onChangeAddPortMtls = () => {
     this.setState(
-      prevState => {
+      (prevState) => {
         return {
-          addPortMtls: !prevState.addPortMtls
+          addPortMtls: !prevState.addPortMtls,
         };
       },
       () => this.onPeerAuthenticationChange()
@@ -127,7 +127,7 @@ class PeerAuthenticationForm extends React.Component<Props, PeerAuthenticationSt
       this.setState(
         {
           workloadSelectorValid: false,
-          workloadSelector: ''
+          workloadSelector: '',
         },
         () => this.onPeerAuthenticationChange()
       );
@@ -156,7 +156,7 @@ class PeerAuthenticationForm extends React.Component<Props, PeerAuthenticationSt
     this.setState(
       {
         workloadSelectorValid: isValid,
-        workloadSelector: value
+        workloadSelector: value,
       },
       () => this.onPeerAuthenticationChange()
     );
@@ -169,7 +169,7 @@ class PeerAuthenticationForm extends React.Component<Props, PeerAuthenticationSt
   onMutualTlsChange = (value, _) => {
     this.setState(
       {
-        mtls: value
+        mtls: value,
       },
       () => this.onPeerAuthenticationChange()
     );
@@ -177,12 +177,12 @@ class PeerAuthenticationForm extends React.Component<Props, PeerAuthenticationSt
 
   onAddPortNumber = (value: string, _) => {
     this.setState(
-      prevState => {
+      (prevState) => {
         return {
           addNewPortMtls: {
             port: value.trim(),
-            mtls: prevState.addNewPortMtls.mtls
-          }
+            mtls: prevState.addNewPortMtls.mtls,
+          },
         };
       },
       () => this.onPeerAuthenticationChange()
@@ -191,12 +191,12 @@ class PeerAuthenticationForm extends React.Component<Props, PeerAuthenticationSt
 
   onAddPortMtlsMode = (value: string, _) => {
     this.setState(
-      prevState => {
+      (prevState) => {
         return {
           addNewPortMtls: {
             port: prevState.addNewPortMtls.port,
-            mtls: value
-          }
+            mtls: value,
+          },
         };
       },
       () => this.onPeerAuthenticationChange()
@@ -205,14 +205,14 @@ class PeerAuthenticationForm extends React.Component<Props, PeerAuthenticationSt
 
   onAddPortMtls = () => {
     this.setState(
-      prevState => {
+      (prevState) => {
         prevState.portLevelMtls.push(prevState.addNewPortMtls);
         return {
           portLevelMtls: prevState.portLevelMtls,
           addNewPortMtls: {
             port: '',
-            mtls: PeerAuthenticationMutualTLSMode.UNSET
-          }
+            mtls: PeerAuthenticationMutualTLSMode.UNSET,
+          },
         };
       },
       () => this.onPeerAuthenticationChange()
@@ -226,15 +226,15 @@ class PeerAuthenticationForm extends React.Component<Props, PeerAuthenticationSt
       // @ts-ignore
       onClick: (event, rowIndex, rowData, extraData) => {
         this.setState(
-          prevState => {
+          (prevState) => {
             prevState.portLevelMtls.splice(rowIndex, 1);
             return {
-              portLevelMtls: prevState.portLevelMtls
+              portLevelMtls: prevState.portLevelMtls,
             };
           },
           () => this.onPeerAuthenticationChange()
         );
-      }
+      },
     };
     if (rowIndex < this.props.peerAuthentication.portLevelMtls.length) {
       return [removeAction];
@@ -246,7 +246,7 @@ class PeerAuthenticationForm extends React.Component<Props, PeerAuthenticationSt
     return this.props.peerAuthentication.portLevelMtls
       .map((pmtls, i) => ({
         key: 'portMtls' + i,
-        cells: [<>{pmtls.port}</>, <>{pmtls.mtls}</>, '']
+        cells: [<>{pmtls.port}</>, <>{pmtls.mtls}</>, ''],
       }))
       .concat([
         {
@@ -285,9 +285,9 @@ class PeerAuthenticationForm extends React.Component<Props, PeerAuthenticationSt
               >
                 Add Port MTLS
               </Button>
-            </>
-          ]
-        }
+            </>,
+          ],
+        },
       ]);
   }
 

--- a/src/pages/IstioConfigNew/PeerAuthenticationForm.tsx
+++ b/src/pages/IstioConfigNew/PeerAuthenticationForm.tsx
@@ -44,7 +44,10 @@ export type PeerAuthenticationState = {
   portLevelMtls: PortMtls[];
 };
 
-export const INIT_PEER_AUTHENTICATION = (): PeerAuthenticationState => ({
+export const PEER_AUTHENTICATION = 'PeerAuthentication';
+export const PEER_AUTHENTICATIONS = 'peerauthentications';
+
+export const initPeerAuthentication = (): PeerAuthenticationState => ({
   workloadSelector: '',
   mtls: PeerAuthenticationMutualTLSMode.UNSET,
   portLevelMtls: []
@@ -58,6 +61,11 @@ type State = {
   addPortMtls: boolean;
   portLevelMtls: PortMtls[];
   addNewPortMtls: PortMtls;
+};
+
+export const isPeerAuthenticationStateValid = (pa: PeerAuthenticationState): boolean => {
+  const validPortsMtls = pa.portLevelMtls.length > 0 && pa.workloadSelector.length === 0 ? false : true;
+  return validPortsMtls;
 };
 
 class PeerAuthenticationForm extends React.Component<Props, State> {

--- a/src/pages/IstioConfigNew/PeerAuthenticationForm.tsx
+++ b/src/pages/IstioConfigNew/PeerAuthenticationForm.tsx
@@ -1,0 +1,320 @@
+import * as React from 'react';
+import { Button, FormGroup, FormSelect, FormSelectOption, Switch } from '@patternfly/react-core';
+import { TextInputBase as TextInput } from '@patternfly/react-core/dist/js/components/TextInput/TextInput';
+import { PeerAuthenticationMutualTLSMode } from '../../types/IstioObjects';
+import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
+import { style } from 'typestyle';
+import { PfColors } from '../../components/Pf/PfColors';
+
+const noPortMtlsStyle = style({
+  marginTop: 15,
+  color: PfColors.Red100
+});
+
+const headerCells: ICell[] = [
+  {
+    title: 'Port Number',
+    transforms: [cellWidth(20) as any],
+    props: {}
+  },
+  {
+    title: 'Mutual TLS Mode',
+    transforms: [cellWidth(20) as any],
+    props: {}
+  },
+  {
+    title: '',
+    props: {}
+  }
+];
+
+type Props = {
+  peerAuthentication: PeerAuthenticationState;
+  onChange: (peerAuthentication: PeerAuthenticationState) => void;
+};
+
+export type PortMtls = {
+  port: string;
+  mtls: string;
+};
+
+export type PeerAuthenticationState = {
+  workloadSelector: string;
+  mtls: string;
+  portLevelMtls: PortMtls[];
+};
+
+export const INIT_PEER_AUTHENTICATION = (): PeerAuthenticationState => ({
+  workloadSelector: '',
+  mtls: PeerAuthenticationMutualTLSMode.UNSET,
+  portLevelMtls: []
+});
+
+type State = {
+  addWorkloadSelector: boolean;
+  workloadSelectorValid: boolean;
+  workloadSelectorLabels: string;
+  mtls: string;
+  addPortMtls: boolean;
+  portLevelMtls: PortMtls[];
+  addNewPortMtls: PortMtls;
+};
+
+class PeerAuthenticationForm extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      addWorkloadSelector: false,
+      workloadSelectorValid: false,
+      workloadSelectorLabels: this.props.peerAuthentication.workloadSelector,
+      mtls: this.props.peerAuthentication.mtls,
+      addPortMtls: false,
+      portLevelMtls: this.props.peerAuthentication.portLevelMtls,
+      addNewPortMtls: {
+        port: '',
+        mtls: PeerAuthenticationMutualTLSMode.UNSET
+      }
+    };
+  }
+
+  addWorkloadLabels = (value: string, _) => {
+    if (value.length === 0) {
+      this.setState({
+        workloadSelectorValid: false,
+        workloadSelectorLabels: ''
+      });
+      return;
+    }
+    value = value.trim();
+    const labels: string[] = value.split(',');
+    let isValid = true;
+    // Some smoke validation rules for the labels
+    for (let i = 0; i < labels.length; i++) {
+      const label = labels[i];
+      if (label.indexOf('=') < 0) {
+        isValid = false;
+        break;
+      }
+      const splitLabel: string[] = label.split('=');
+      if (splitLabel.length !== 2) {
+        isValid = false;
+        break;
+      }
+      if (splitLabel[0].trim().length === 0 || splitLabel[1].trim().length === 0) {
+        isValid = false;
+        break;
+      }
+    }
+    this.setState(
+      {
+        workloadSelectorValid: isValid,
+        workloadSelectorLabels: value
+      },
+      () => this.onPeerAuthenticationChange()
+    );
+  };
+
+  onPeerAuthenticationChange = () => {
+    const peerAuthentication: PeerAuthenticationState = {
+      workloadSelector: this.state.workloadSelectorLabels,
+      mtls: this.state.mtls,
+      portLevelMtls: this.state.portLevelMtls
+    };
+    this.props.onChange(peerAuthentication);
+  };
+
+  onMutualTlsChange = (value, _) => {
+    this.setState(
+      {
+        mtls: value
+      },
+      () => this.onPeerAuthenticationChange()
+    );
+  };
+
+  onAddPortNumber = (value: string, _) => {
+    this.setState(prevState => ({
+      addNewPortMtls: {
+        port: value.trim(),
+        mtls: prevState.addNewPortMtls.mtls
+      }
+    }));
+  };
+
+  onAddPortMtlsMode = (value: string, _) => {
+    this.setState(prevState => ({
+      addNewPortMtls: {
+        port: prevState.addNewPortMtls.port,
+        mtls: value
+      }
+    }));
+  };
+
+  onAddPortMtls = () => {
+    this.setState(
+      prevState => {
+        prevState.portLevelMtls.push(prevState.addNewPortMtls);
+        return {
+          portLevelMtls: prevState.portLevelMtls,
+          addNewPortMtls: {
+            port: '',
+            mtls: PeerAuthenticationMutualTLSMode.UNSET
+          }
+        };
+      },
+      () => this.onPeerAuthenticationChange()
+    );
+  };
+
+  // @ts-ignore
+  actionResolver = (rowData, { rowIndex }) => {
+    const removeAction = {
+      title: 'Remove Port MTLS',
+      // @ts-ignore
+      onClick: (event, rowIndex, rowData, extraData) => {
+        this.setState(
+          prevState => {
+            prevState.portLevelMtls.splice(rowIndex, 1);
+            return {
+              portLevelMtls: prevState.portLevelMtls
+            };
+          },
+          () => this.onPeerAuthenticationChange()
+        );
+      }
+    };
+    if (rowIndex < this.props.peerAuthentication.portLevelMtls.length) {
+      return [removeAction];
+    }
+    return [];
+  };
+
+  rows() {
+    return this.props.peerAuthentication.portLevelMtls
+      .map((pmtls, i) => ({
+        key: 'portMtls' + i,
+        cells: [<>{pmtls.port}</>, <>{pmtls.mtls}</>, '']
+      }))
+      .concat([
+        {
+          key: 'pmtlsNew',
+          cells: [
+            <>
+              <TextInput
+                value={this.state.addNewPortMtls.port}
+                id="addPortNumber"
+                aria-describedby="add port number"
+                name="addPortNumber"
+                onChange={this.onAddPortNumber}
+                isValid={this.state.addNewPortMtls.port.length > 0 && !isNaN(Number(this.state.addNewPortMtls.port))}
+              />
+            </>,
+            <>
+              <FormSelect
+                value={this.state.addNewPortMtls.mtls}
+                id="addPortMtlsMode"
+                name="addPortMtlsMode"
+                onChange={this.onAddPortMtlsMode}
+              >
+                {Object.keys(PeerAuthenticationMutualTLSMode).map((option, index) => (
+                  <FormSelectOption key={'p' + index} value={option} label={option} />
+                ))}
+              </FormSelect>
+            </>,
+            <>
+              <Button
+                id="addServerBtn"
+                variant="secondary"
+                isDisabled={
+                  this.state.addNewPortMtls.port.length === 0 || isNaN(Number(this.state.addNewPortMtls.port))
+                }
+                onClick={this.onAddPortMtls}
+              >
+                Add Port MTLS
+              </Button>
+            </>
+          ]
+        }
+      ]);
+  }
+
+  render() {
+    return (
+      <>
+        <FormGroup label="Add Workload Selector" fieldId="workloadSelectorSwitch">
+          <Switch
+            id="workloadSelectorSwitch"
+            label={' '}
+            labelOff={' '}
+            isChecked={this.state.addWorkloadSelector}
+            onChange={() => {
+              this.setState(prevState => ({
+                addWorkloadSelector: !prevState.addWorkloadSelector
+              }));
+            }}
+          />
+        </FormGroup>
+        {this.state.addWorkloadSelector && (
+          <FormGroup
+            fieldId="workloadLabels"
+            label="Labels"
+            helperText="One or more labels to select a workload where PeerAuthentication is applied. Enter a label in the format <label>=<value>. Enter one or multiple labels separated by comma."
+            helperTextInvalid="Invalid labels format: One or more labels to select a workload where AuthorizationPolicy is applied. Enter a label in the format <label>=<value>. Enter one or multiple labels separated by comma."
+            isValid={this.state.workloadSelectorValid}
+          >
+            <TextInput
+              id="gwHosts"
+              name="gwHosts"
+              isDisabled={!this.state.addWorkloadSelector}
+              value={this.state.workloadSelectorLabels}
+              onChange={this.addWorkloadLabels}
+              isValid={this.state.workloadSelectorValid}
+            />
+          </FormGroup>
+        )}
+        <FormGroup label="Mutual TLS Mode" fieldId="mutualTls">
+          <FormSelect value={this.state.mtls} onChange={this.onMutualTlsChange} id="mutualTls" name="rules-form">
+            {Object.keys(PeerAuthenticationMutualTLSMode).map((option, index) => (
+              <FormSelectOption key={index} value={option} label={option} />
+            ))}
+          </FormSelect>
+        </FormGroup>
+        <FormGroup label="Add Port MTLS" fieldId="addPortMtls">
+          <Switch
+            id="addPortMtls"
+            label={' '}
+            labelOff={' '}
+            isChecked={this.state.addPortMtls}
+            onChange={() => {
+              this.setState(prevState => ({
+                addPortMtls: !prevState.addPortMtls
+              }));
+            }}
+          />
+        </FormGroup>
+        {this.state.addPortMtls && (
+          <FormGroup label="Port Level MTLS" fieldId="portMtlsList">
+            <Table
+              aria-label="Port Level MTLS"
+              cells={headerCells}
+              rows={this.rows()}
+              // @ts-ignore
+              actionResolver={this.actionResolver}
+            >
+              <TableHeader />
+              <TableBody />
+            </Table>
+            {this.props.peerAuthentication.portLevelMtls.length === 0 && (
+              <div className={noPortMtlsStyle}>PeerAuthentication has no Ports MTLS defined</div>
+            )}
+            {!this.state.addWorkloadSelector && (
+              <div className={noPortMtlsStyle}>Ports MTLS require a Workload Selector</div>
+            )}
+          </FormGroup>
+        )}
+      </>
+    );
+  }
+}
+
+export default PeerAuthenticationForm;

--- a/src/pages/IstioConfigNew/RequestAuthenticationForm.tsx
+++ b/src/pages/IstioConfigNew/RequestAuthenticationForm.tsx
@@ -119,8 +119,6 @@ class RequestAuthenticationForm extends React.Component<Props, RequestAuthentica
   };
 
   onAddJwtRule = (jwtRule: JWTRule) => {
-    console.log('TODELETE onAddJwtRule');
-    console.log(jwtRule);
     this.setState(
       (prevState) => {
         prevState.jwtRules.push(jwtRule);

--- a/src/pages/IstioConfigNew/RequestAuthenticationForm.tsx
+++ b/src/pages/IstioConfigNew/RequestAuthenticationForm.tsx
@@ -119,6 +119,8 @@ class RequestAuthenticationForm extends React.Component<Props, RequestAuthentica
   };
 
   onAddJwtRule = (jwtRule: JWTRule) => {
+    console.log('TODELETE onAddJwtRule');
+    console.log(jwtRule);
     this.setState(
       (prevState) => {
         prevState.jwtRules.push(jwtRule);

--- a/src/pages/IstioConfigNew/RequestAuthenticationForm.tsx
+++ b/src/pages/IstioConfigNew/RequestAuthenticationForm.tsx
@@ -26,7 +26,7 @@ export const initRequestAuthentication = (): RequestAuthenticationState => ({
   jwtRules: [],
   addWorkloadSelector: false,
   workloadSelectorValid: false,
-  addJWTRules: false
+  addJWTRules: false,
 });
 
 export const isRequestAuthenticationStateValid = (ra: RequestAuthenticationState): boolean => {
@@ -48,7 +48,7 @@ class RequestAuthenticationForm extends React.Component<Props, RequestAuthentica
       jwtRules: this.props.requestAuthentication.jwtRules,
       addWorkloadSelector: this.props.requestAuthentication.addWorkloadSelector,
       workloadSelectorValid: this.props.requestAuthentication.workloadSelectorValid,
-      addJWTRules: this.props.requestAuthentication.addJWTRules
+      addJWTRules: this.props.requestAuthentication.addJWTRules,
     });
   }
 
@@ -58,9 +58,9 @@ class RequestAuthenticationForm extends React.Component<Props, RequestAuthentica
 
   onChangeWorkloadSelector = () => {
     this.setState(
-      prevState => {
+      (prevState) => {
         return {
-          addWorkloadSelector: !prevState.addWorkloadSelector
+          addWorkloadSelector: !prevState.addWorkloadSelector,
         };
       },
       () => this.onRequestAuthenticationChange()
@@ -69,9 +69,9 @@ class RequestAuthenticationForm extends React.Component<Props, RequestAuthentica
 
   onChangeJwtRules = () => {
     this.setState(
-      prevState => {
+      (prevState) => {
         return {
-          addJWTRules: !prevState.addJWTRules
+          addJWTRules: !prevState.addJWTRules,
         };
       },
       () => this.onRequestAuthenticationChange()
@@ -83,7 +83,7 @@ class RequestAuthenticationForm extends React.Component<Props, RequestAuthentica
       this.setState(
         {
           workloadSelectorValid: false,
-          workloadSelector: ''
+          workloadSelector: '',
         },
         () => this.onRequestAuthenticationChange()
       );
@@ -112,7 +112,7 @@ class RequestAuthenticationForm extends React.Component<Props, RequestAuthentica
     this.setState(
       {
         workloadSelectorValid: isValid,
-        workloadSelector: value
+        workloadSelector: value,
       },
       () => this.onRequestAuthenticationChange()
     );
@@ -120,10 +120,10 @@ class RequestAuthenticationForm extends React.Component<Props, RequestAuthentica
 
   onAddJwtRule = (jwtRule: JWTRule) => {
     this.setState(
-      prevState => {
+      (prevState) => {
         prevState.jwtRules.push(jwtRule);
         return {
-          jwtRules: prevState.jwtRules
+          jwtRules: prevState.jwtRules,
         };
       },
       () => this.onRequestAuthenticationChange()
@@ -132,10 +132,10 @@ class RequestAuthenticationForm extends React.Component<Props, RequestAuthentica
 
   onRemoveJwtRule = (index: number) => {
     this.setState(
-      prevState => {
+      (prevState) => {
         prevState.jwtRules.splice(index, 1);
         return {
-          jwtRules: prevState.jwtRules
+          jwtRules: prevState.jwtRules,
         };
       },
       () => this.onRequestAuthenticationChange()

--- a/src/pages/IstioConfigNew/RequestAuthenticationForm.tsx
+++ b/src/pages/IstioConfigNew/RequestAuthenticationForm.tsx
@@ -1,0 +1,174 @@
+import * as React from 'react';
+import { FormGroup, Switch } from '@patternfly/react-core';
+import { TextInputBase as TextInput } from '@patternfly/react-core/dist/js/components/TextInput/TextInput';
+import { JWTRule } from '../../types/IstioObjects';
+import JwtRuleBuilder from './RequestAuthorizationForm/JwtRuleBuilder';
+import JwtRuleList from './RequestAuthorizationForm/JwtRuleList';
+
+type Props = {
+  requestAuthentication: RequestAuthenticationState;
+  onChange: (requestAuthentication: RequestAuthenticationState) => void;
+};
+
+export type RequestAuthenticationState = {
+  workloadSelector: string;
+  jwtRules: JWTRule[];
+};
+
+export const INIT_REQUEST_AUTHENTICATION = (): RequestAuthenticationState => ({
+  workloadSelector: '',
+  jwtRules: []
+});
+
+type State = {
+  addWorkloadSelector: boolean;
+  workloadSelectorValid: boolean;
+  workloadSelectorLabels: string;
+  addJWTRules: boolean;
+  jwtRules: JWTRule[];
+};
+
+class RequestAuthenticationForm extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      addWorkloadSelector: false,
+      workloadSelectorValid: false,
+      workloadSelectorLabels: this.props.requestAuthentication.workloadSelector,
+      addJWTRules: false,
+      jwtRules: []
+    };
+  }
+
+  addWorkloadLabels = (value: string, _) => {
+    if (value.length === 0) {
+      this.setState({
+        workloadSelectorValid: false,
+        workloadSelectorLabels: ''
+      });
+      return;
+    }
+    value = value.trim();
+    const labels: string[] = value.split(',');
+    let isValid = true;
+    // Some smoke validation rules for the labels
+    for (let i = 0; i < labels.length; i++) {
+      const label = labels[i];
+      if (label.indexOf('=') < 0) {
+        isValid = false;
+        break;
+      }
+      const splitLabel: string[] = label.split('=');
+      if (splitLabel.length !== 2) {
+        isValid = false;
+        break;
+      }
+      if (splitLabel[0].trim().length === 0 || splitLabel[1].trim().length === 0) {
+        isValid = false;
+        break;
+      }
+    }
+    this.setState(
+      {
+        workloadSelectorValid: isValid,
+        workloadSelectorLabels: value
+      },
+      () => this.onRequestAuthenticationChange()
+    );
+  };
+
+  onRequestAuthenticationChange = () => {
+    const requestAuthentication: RequestAuthenticationState = {
+      workloadSelector: this.state.workloadSelectorLabels,
+      jwtRules: this.state.jwtRules
+    };
+    this.props.onChange(requestAuthentication);
+  };
+
+  onAddJwtRule = (jwtRule: JWTRule) => {
+    this.setState(
+      prevState => {
+        prevState.jwtRules.push(jwtRule);
+        return {
+          jwtRules: prevState.jwtRules
+        };
+      },
+      () => this.onRequestAuthenticationChange()
+    );
+  };
+
+  onRemoveJwtRule = (index: number) => {
+    this.setState(
+      prevState => {
+        prevState.jwtRules.splice(index, 1);
+        return {
+          jwtRules: prevState.jwtRules
+        };
+      },
+      () => this.onRequestAuthenticationChange()
+    );
+  };
+
+  render() {
+    return (
+      <>
+        <FormGroup label="Add Workload Selector" fieldId="workloadSelectorSwitch">
+          <Switch
+            id="workloadSelectorSwitch"
+            label={' '}
+            labelOff={' '}
+            isChecked={this.state.addWorkloadSelector}
+            onChange={() => {
+              this.setState(prevState => ({
+                addWorkloadSelector: !prevState.addWorkloadSelector
+              }));
+            }}
+          />
+        </FormGroup>
+        {this.state.addWorkloadSelector && (
+          <FormGroup
+            fieldId="workloadLabels"
+            label="Labels"
+            helperText="One or more labels to select a workload where RequestAuthentication is applied. Enter a label in the format <label>=<value>. Enter one or multiple labels separated by comma."
+            helperTextInvalid="Invalid labels format: One or more labels to select a workload where AuthorizationPolicy is applied. Enter a label in the format <label>=<value>. Enter one or multiple labels separated by comma."
+            isValid={this.state.workloadSelectorValid}
+          >
+            <TextInput
+              id="gwHosts"
+              name="gwHosts"
+              isDisabled={!this.state.addWorkloadSelector}
+              value={this.state.workloadSelectorLabels}
+              onChange={this.addWorkloadLabels}
+              isValid={this.state.workloadSelectorValid}
+            />
+          </FormGroup>
+        )}
+        <FormGroup label="Add JWT Rules" fieldId="addJWTRules">
+          <Switch
+            id="addJWTRules"
+            label={' '}
+            labelOff={' '}
+            isChecked={this.state.addJWTRules}
+            onChange={() => {
+              this.setState(prevState => ({
+                addJWTRules: !prevState.addJWTRules
+              }));
+            }}
+          />
+        </FormGroup>
+        {this.state.addJWTRules && (
+          <>
+            <FormGroup label="JWT Rule Builder" fieldId="jwtRulesBuilder">
+              <JwtRuleBuilder onAddJwtRule={this.onAddJwtRule} />
+            </FormGroup>
+            <FormGroup label="JWT Rules List" fieldId="jwtRulesList">
+              <JwtRuleList jwtRules={this.state.jwtRules} onRemoveJwtRule={this.onRemoveJwtRule} />
+            </FormGroup>
+          </>
+        )}
+      </>
+    );
+  }
+}
+
+export default RequestAuthenticationForm;

--- a/src/pages/IstioConfigNew/RequestAuthenticationForm.tsx
+++ b/src/pages/IstioConfigNew/RequestAuthenticationForm.tsx
@@ -15,7 +15,10 @@ export type RequestAuthenticationState = {
   jwtRules: JWTRule[];
 };
 
-export const INIT_REQUEST_AUTHENTICATION = (): RequestAuthenticationState => ({
+export const REQUEST_AUTHENTICATION = 'RequestAuthentication';
+export const REQUEST_AUTHENTICATIONS = 'requestauthentications';
+
+export const initRequestAuthentication = (): RequestAuthenticationState => ({
   workloadSelector: '',
   jwtRules: []
 });
@@ -26,6 +29,11 @@ type State = {
   workloadSelectorLabels: string;
   addJWTRules: boolean;
   jwtRules: JWTRule[];
+};
+
+export const isRequestAuthenticationStateValid = (_ra: RequestAuthenticationState): boolean => {
+  // Not yet used
+  return true;
 };
 
 class RequestAuthenticationForm extends React.Component<Props, State> {

--- a/src/pages/IstioConfigNew/RequestAuthorizationForm/JwtRuleBuilder.tsx
+++ b/src/pages/IstioConfigNew/RequestAuthorizationForm/JwtRuleBuilder.tsx
@@ -6,6 +6,7 @@ import { PlusCircleIcon } from '@patternfly/react-icons';
 import { TextInputBase as TextInput } from '@patternfly/react-core/dist/js/components/TextInput/TextInput';
 import { style } from 'typestyle';
 import { PfColors } from '../../../components/Pf/PfColors';
+import { isValidUrl } from '../../../utils/IstioConfigUtils';
 
 type Props = {
   onAddJwtRule: (rule: JWTRule) => void;
@@ -83,7 +84,7 @@ export const formatJwtField = (jwtField: string, jwtRule: JWTRule): string => {
     case 'outputPayloadToHeader':
       return jwtRule.outputPayloadToHeader ? jwtRule.outputPayloadToHeader : '';
     case 'forwardOriginalToken':
-      return jwtRule.forwardOriginalToken ? '' + jwtRule.forwardOriginalToken : '';
+      return jwtRule.forwardOriginalToken ? '' + jwtRule.forwardOriginalToken : 'false';
     default:
   }
   return '';
@@ -215,6 +216,9 @@ class JwtRuleBuilder extends React.Component<Props, State> {
     const isEmptyValue = this.state.newValues.split(',').every((v) => v.length === 0);
     if (isEmptyValue) {
       return [false, 'Value cannot be empty'];
+    }
+    if (this.state.newJwtField === 'jwksUri' && !isValidUrl(this.state.newValues)) {
+      return [false, 'jwsUri is not a valid Uri'];
     }
     return [true, ''];
   };

--- a/src/pages/IstioConfigNew/RequestAuthorizationForm/JwtRuleBuilder.tsx
+++ b/src/pages/IstioConfigNew/RequestAuthorizationForm/JwtRuleBuilder.tsx
@@ -24,24 +24,24 @@ const INIT_JWT_RULE_FIELDS = [
   'fromHeaders',
   'fromParams',
   'outputPayloadToHeader',
-  'forwardOriginalToken'
+  'forwardOriginalToken',
 ].sort();
 
 const headerCells: ICell[] = [
   {
     title: 'JWT Rule Field',
     transforms: [cellWidth(30) as any],
-    props: {}
+    props: {},
   },
   {
     title: 'Values',
     transforms: [cellWidth(70) as any],
-    props: {}
+    props: {},
   },
   {
     title: '',
-    props: {}
-  }
+    props: {},
+  },
 ];
 
 export const formatJwtField = (jwtField: string, jwtRule: JWTRule): string => {
@@ -55,7 +55,7 @@ export const formatJwtField = (jwtField: string, jwtRule: JWTRule): string => {
     case 'fromHeaders':
       return jwtRule.fromHeaders
         ? jwtRule.fromHeaders
-            .map(header => {
+            .map((header) => {
               if (header.prefix) {
                 return header.name + ': ' + header.prefix;
               } else {
@@ -82,24 +82,24 @@ class JwtRuleBuilder extends React.Component<Props, State> {
       jwtRuleFields: Object.assign([], INIT_JWT_RULE_FIELDS),
       jwtRule: {},
       newJwtField: 'issuer',
-      newValues: ''
+      newValues: '',
     };
   }
 
   onAddJwtField = (value: string, _) => {
     this.setState({
-      newJwtField: value
+      newJwtField: value,
     });
   };
 
   onAddNewValues = (value: string, _) => {
     this.setState({
-      newValues: value
+      newValues: value,
     });
   };
 
   onUpdateJwtRule = () => {
-    this.setState(prevState => {
+    this.setState((prevState) => {
       const i = prevState.jwtRuleFields.indexOf(prevState.newJwtField);
       if (i > -1) {
         prevState.jwtRuleFields.splice(i, 1);
@@ -119,10 +119,10 @@ class JwtRuleBuilder extends React.Component<Props, State> {
           // "Authorization: Bearer , Authorization: Bearer, Security "
           // In [{name: 'Authorization', prefix: 'Bearer '}, {name: 'Authorization', prefix: 'Bearer'}, {name: 'Security}]
           prevState.jwtRule.fromHeaders = [];
-          prevState.newValues.split(',').forEach(value => {
+          prevState.newValues.split(',').forEach((value) => {
             const values = value.split(':');
             const header: JWTHeader = {
-              name: values[0]
+              name: values[0],
             };
             if (values.length > 1) {
               header.prefix = values[1].trimLeft();
@@ -149,7 +149,7 @@ class JwtRuleBuilder extends React.Component<Props, State> {
         jwtRuleFields: prevState.jwtRuleFields,
         jwtRule: prevState.jwtRule,
         newJwtField: prevState.jwtRuleFields[0],
-        newValues: ''
+        newValues: '',
       };
     });
   };
@@ -161,7 +161,7 @@ class JwtRuleBuilder extends React.Component<Props, State> {
         jwtRuleFields: Object.assign([], INIT_JWT_RULE_FIELDS),
         jwtRule: {},
         newJwtField: INIT_JWT_RULE_FIELDS[0],
-        newValues: ''
+        newValues: '',
       },
       () => this.props.onAddJwtRule(oldJwtRule)
     );
@@ -175,7 +175,7 @@ class JwtRuleBuilder extends React.Component<Props, State> {
       onClick: (event, rowIndex, rowData, extraData) => {
         // Fetch sourceField from rowData, it's a fixed string on children
         const removeJwtRuleField = rowData.cells[0].props.children.toString();
-        this.setState(prevState => {
+        this.setState((prevState) => {
           prevState.jwtRuleFields.push(removeJwtRuleField);
           delete prevState.jwtRule[removeJwtRuleField];
           const newJwtRuleFields = prevState.jwtRuleFields.sort();
@@ -183,10 +183,10 @@ class JwtRuleBuilder extends React.Component<Props, State> {
             jwtRuleFields: newJwtRuleFields,
             jwtRule: prevState.jwtRule,
             newJwtField: newJwtRuleFields[0],
-            newValues: ''
+            newValues: '',
           };
         });
-      }
+      },
     };
     if (rowIndex < Object.keys(this.state.jwtRule).length) {
       return [removeAction];
@@ -203,7 +203,7 @@ class JwtRuleBuilder extends React.Component<Props, State> {
       .map((jwtField, i) => {
         return {
           key: 'jwtField' + i,
-          cells: [<>{jwtField}</>, <>{formatJwtField(jwtField, this.state.jwtRule)}</>, <></>]
+          cells: [<>{jwtField}</>, <>{formatJwtField(jwtField, this.state.jwtRule)}</>, <></>],
         };
       })
       .concat([
@@ -237,9 +237,9 @@ class JwtRuleBuilder extends React.Component<Props, State> {
               {this.state.jwtRuleFields.length > 0 && (
                 <Button variant="link" icon={<PlusCircleIcon />} onClick={this.onUpdateJwtRule} />
               )}
-            </>
-          ]
-        }
+            </>,
+          ],
+        },
       ]);
   };
 

--- a/src/pages/IstioConfigNew/RequestAuthorizationForm/JwtRuleBuilder.tsx
+++ b/src/pages/IstioConfigNew/RequestAuthorizationForm/JwtRuleBuilder.tsx
@@ -1,0 +1,272 @@
+import * as React from 'react';
+import { JWTHeader, JWTRule } from '../../../types/IstioObjects';
+import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
+import { Button, FormSelect, FormSelectOption } from '@patternfly/react-core';
+import { PlusCircleIcon } from '@patternfly/react-icons';
+import { TextInputBase as TextInput } from '@patternfly/react-core/dist/js/components/TextInput/TextInput';
+
+type Props = {
+  onAddJwtRule: (rule: JWTRule) => void;
+};
+
+type State = {
+  jwtRuleFields: string[];
+  jwtRule: JWTRule;
+  newJwtField: string;
+  newValues: string;
+};
+
+const INIT_JWT_RULE_FIELDS = [
+  'issuer',
+  'audiences',
+  'jwksUri',
+  'jwks',
+  'fromHeaders',
+  'fromParams',
+  'outputPayloadToHeader',
+  'forwardOriginalToken'
+].sort();
+
+const headerCells: ICell[] = [
+  {
+    title: 'JWT Rule Field',
+    transforms: [cellWidth(30) as any],
+    props: {}
+  },
+  {
+    title: 'Values',
+    transforms: [cellWidth(70) as any],
+    props: {}
+  },
+  {
+    title: '',
+    props: {}
+  }
+];
+
+export const formatJwtField = (jwtField: string, jwtRule: JWTRule): string => {
+  switch (jwtField) {
+    case 'issuer':
+      return jwtRule.issuer ? jwtRule.issuer : '';
+    case 'audiences':
+      return jwtRule.audiences ? jwtRule.audiences.join(',') : '';
+    case 'jwksUri':
+      return jwtRule.jwksUri ? jwtRule.jwksUri : '';
+    case 'fromHeaders':
+      return jwtRule.fromHeaders
+        ? jwtRule.fromHeaders
+            .map(header => {
+              if (header.prefix) {
+                return header.name + ': ' + header.prefix;
+              } else {
+                return header.name;
+              }
+            })
+            .join(',')
+        : '';
+    case 'fromParams':
+      return jwtRule.fromParams ? jwtRule.fromParams.join(',') : '';
+    case 'outputPayloadToHeader':
+      return jwtRule.outputPayloadToHeader ? jwtRule.outputPayloadToHeader : '';
+    case 'forwardOriginalToken':
+      return jwtRule.forwardOriginalToken ? '' + jwtRule.forwardOriginalToken : '';
+    default:
+  }
+  return '';
+};
+
+class JwtRuleBuilder extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      jwtRuleFields: Object.assign([], INIT_JWT_RULE_FIELDS),
+      jwtRule: {},
+      newJwtField: 'issuer',
+      newValues: ''
+    };
+  }
+
+  onAddJwtField = (value: string, _) => {
+    this.setState({
+      newJwtField: value
+    });
+  };
+
+  onAddNewValues = (value: string, _) => {
+    this.setState({
+      newValues: value
+    });
+  };
+
+  onUpdateJwtRule = () => {
+    this.setState(prevState => {
+      const i = prevState.jwtRuleFields.indexOf(prevState.newJwtField);
+      if (i > -1) {
+        prevState.jwtRuleFields.splice(i, 1);
+      }
+      switch (prevState.newJwtField) {
+        case 'issuer':
+          prevState.jwtRule.issuer = prevState.newValues;
+          break;
+        case 'audiences':
+          prevState.jwtRule.audiences = prevState.newValues.split(',');
+          break;
+        case 'jwksUri':
+          prevState.jwtRule.jwksUri = prevState.newValues;
+          break;
+        case 'fromHeaders':
+          // Parse a string like:
+          // "Authorization: Bearer , Authorization: Bearer, Security "
+          // In [{name: 'Authorization', prefix: 'Bearer '}, {name: 'Authorization', prefix: 'Bearer'}, {name: 'Security}]
+          prevState.jwtRule.fromHeaders = [];
+          prevState.newValues.split(',').forEach(value => {
+            const values = value.split(':');
+            const header: JWTHeader = {
+              name: values[0]
+            };
+            if (values.length > 1) {
+              header.prefix = values[1].trimLeft();
+            }
+            if (prevState.jwtRule.fromHeaders) {
+              prevState.jwtRule.fromHeaders.push(header);
+            }
+          });
+          break;
+        case 'fromParams':
+          prevState.jwtRule.fromParams = prevState.newValues.split(',');
+          break;
+        case 'outputPayloadToHeader':
+          prevState.jwtRule.outputPayloadToHeader = prevState.newValues;
+          break;
+        case 'forwardOriginalToken':
+          // I don't want to put different types for input, perhaps in the future
+          prevState.jwtRule.forwardOriginalToken = prevState.newValues.toLowerCase() === 'true';
+          break;
+        default:
+        // No default action.
+      }
+      return {
+        jwtRuleFields: prevState.jwtRuleFields,
+        jwtRule: prevState.jwtRule,
+        newJwtField: prevState.jwtRuleFields[0],
+        newValues: ''
+      };
+    });
+  };
+
+  onAddJwtRuleToList = () => {
+    const oldJwtRule = this.state.jwtRule;
+    this.setState(
+      {
+        jwtRuleFields: Object.assign([], INIT_JWT_RULE_FIELDS),
+        jwtRule: {},
+        newJwtField: INIT_JWT_RULE_FIELDS[0],
+        newValues: ''
+      },
+      () => this.props.onAddJwtRule(oldJwtRule)
+    );
+  };
+
+  // @ts-ignore
+  actionResolver = (rowData, { rowIndex }) => {
+    const removeAction = {
+      title: 'Remove Field',
+      // @ts-ignore
+      onClick: (event, rowIndex, rowData, extraData) => {
+        // Fetch sourceField from rowData, it's a fixed string on children
+        const removeJwtRuleField = rowData.cells[0].props.children.toString();
+        this.setState(prevState => {
+          prevState.jwtRuleFields.push(removeJwtRuleField);
+          delete prevState.jwtRule[removeJwtRuleField];
+          const newJwtRuleFields = prevState.jwtRuleFields.sort();
+          return {
+            jwtRuleFields: newJwtRuleFields,
+            jwtRule: prevState.jwtRule,
+            newJwtField: newJwtRuleFields[0],
+            newValues: ''
+          };
+        });
+      }
+    };
+    if (rowIndex < Object.keys(this.state.jwtRule).length) {
+      return [removeAction];
+    }
+    return [];
+  };
+
+  isJwtRuleValid = (): boolean => {
+    return this.state.jwtRule.issuer ? this.state.jwtRule.issuer.length > 0 : false;
+  };
+
+  rows = () => {
+    return Object.keys(this.state.jwtRule)
+      .map((jwtField, i) => {
+        return {
+          key: 'jwtField' + i,
+          cells: [<>{jwtField}</>, <>{formatJwtField(jwtField, this.state.jwtRule)}</>, <></>]
+        };
+      })
+      .concat([
+        {
+          key: 'jwtFieldKeyNew',
+          cells: [
+            <>
+              <FormSelect
+                value={this.state.newJwtField}
+                id="addNewJwtField"
+                name="addNewJwtField"
+                onChange={this.onAddJwtField}
+              >
+                {this.state.jwtRuleFields.map((option, index) => (
+                  <FormSelectOption isDisabled={false} key={'jwt' + index} value={option} label={option} />
+                ))}
+              </FormSelect>
+            </>,
+            <>
+              <TextInput
+                value={this.state.newValues}
+                type="text"
+                id="addNewValues"
+                key="addNewValues"
+                aria-describedby="add new source values"
+                name="addNewValues"
+                onChange={this.onAddNewValues}
+              />
+            </>,
+            <>
+              {this.state.jwtRuleFields.length > 0 && (
+                <Button variant="link" icon={<PlusCircleIcon />} onClick={this.onUpdateJwtRule} />
+              )}
+            </>
+          ]
+        }
+      ]);
+  };
+
+  render() {
+    return (
+      <>
+        <Table
+          aria-label="JWT Rule Builder"
+          cells={headerCells}
+          rows={this.rows()}
+          // @ts-ignore
+          actionResolver={this.actionResolver}
+        >
+          <TableHeader />
+          <TableBody />
+        </Table>
+        <Button
+          variant="link"
+          icon={<PlusCircleIcon />}
+          isDisabled={!this.isJwtRuleValid()}
+          onClick={this.onAddJwtRuleToList}
+        >
+          Add JWT Rule
+        </Button>
+      </>
+    );
+  }
+}
+
+export default JwtRuleBuilder;

--- a/src/pages/IstioConfigNew/RequestAuthorizationForm/JwtRuleList.tsx
+++ b/src/pages/IstioConfigNew/RequestAuthorizationForm/JwtRuleList.tsx
@@ -46,6 +46,11 @@ class JwtRuleList extends React.Component<Props> {
                 <b>audiences</b>: [{formatJwtField('audiences', jwtRule)}]
               </div>
             ) : undefined}
+            {jwtRule.jwks ? (
+              <div>
+                <b>jwks</b>: [{formatJwtField('jwks', jwtRule)}]
+              </div>
+            ) : undefined}
             {jwtRule.jwksUri ? (
               <div>
                 <b>jwksUri</b>: [{formatJwtField('jwksUri', jwtRule)}]
@@ -66,7 +71,7 @@ class JwtRuleList extends React.Component<Props> {
                 <b>outputPayloadToHeader</b>: [{formatJwtField('outputPayloadToHeader', jwtRule)}]
               </div>
             ) : undefined}
-            {jwtRule.forwardOriginalToken ? (
+            {jwtRule.forwardOriginalToken !== undefined ? (
               <div>
                 <b>forwardOriginalToken</b>: [{formatJwtField('forwardOriginalToken', jwtRule)}]
               </div>

--- a/src/pages/IstioConfigNew/RequestAuthorizationForm/JwtRuleList.tsx
+++ b/src/pages/IstioConfigNew/RequestAuthorizationForm/JwtRuleList.tsx
@@ -1,0 +1,126 @@
+import { JWTRule } from '../../../types/IstioObjects';
+import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
+import { style } from 'typestyle';
+import { PfColors } from '../../../components/Pf/PfColors';
+import * as React from 'react';
+import { formatJwtField } from './JwtRuleBuilder';
+
+type Props = {
+  jwtRules: JWTRule[];
+  onRemoveJwtRule: (index: number) => void;
+};
+
+const headerCells: ICell[] = [
+  {
+    title: 'JWT Rules to be validated',
+    transforms: [cellWidth(100) as any],
+    props: {}
+  },
+  {
+    title: '',
+    props: {}
+  }
+];
+
+const noJWTRulesStyle = style({
+  marginTop: 10,
+  color: PfColors.Red100,
+  textAlign: 'center',
+  width: '100%'
+});
+
+class JwtRuleList extends React.Component<Props> {
+  rows = () => {
+    return this.props.jwtRules.map((jwtRule, i) => {
+      return {
+        key: 'jwtRule' + i,
+        cells: [
+          <>
+            {jwtRule.issuer ? (
+              <div>
+                <b>issuer</b>: [{formatJwtField('issuer', jwtRule)}]
+              </div>
+            ) : (
+              undefined
+            )}
+            {jwtRule.audiences ? (
+              <div>
+                <b>audiences</b>: [{formatJwtField('audiences', jwtRule)}]
+              </div>
+            ) : (
+              undefined
+            )}
+            {jwtRule.jwksUri ? (
+              <div>
+                <b>jwksUri</b>: [{formatJwtField('jwksUri', jwtRule)}]
+              </div>
+            ) : (
+              undefined
+            )}
+            {jwtRule.fromHeaders ? (
+              <div>
+                <b>fromHeaders</b>: [{formatJwtField('fromHeaders', jwtRule)}]
+              </div>
+            ) : (
+              undefined
+            )}
+            {jwtRule.fromParams ? (
+              <div>
+                <b>fromParams</b>: [{formatJwtField('fromParams', jwtRule)}]
+              </div>
+            ) : (
+              undefined
+            )}
+            {jwtRule.outputPayloadToHeader ? (
+              <div>
+                <b>outputPayloadToHeader</b>: [{formatJwtField('outputPayloadToHeader', jwtRule)}]
+              </div>
+            ) : (
+              undefined
+            )}
+            {jwtRule.forwardOriginalToken ? (
+              <div>
+                <b>forwardOriginalToken</b>: [{formatJwtField('forwardOriginalToken', jwtRule)}]
+              </div>
+            ) : (
+              undefined
+            )}
+          </>,
+          <></>
+        ]
+      };
+    });
+  };
+
+  // @ts-ignore
+  actionResolver = (rowData, { rowIndex }) => {
+    const removeAction = {
+      title: 'Remove JWT Rule',
+      // @ts-ignore
+      onClick: (event, rowIndex, rowData, extraData) => {
+        this.props.onRemoveJwtRule(rowIndex);
+      }
+    };
+    return [removeAction];
+  };
+
+  render() {
+    return (
+      <>
+        <Table
+          aria-label="JWT Rules List"
+          cells={headerCells}
+          rows={this.rows()}
+          // @ts-ignore
+          actionResolver={this.actionResolver}
+        >
+          <TableHeader />
+          <TableBody />
+        </Table>
+        {this.props.jwtRules.length === 0 && <div className={noJWTRulesStyle}>No JWT Rules Defined</div>}
+      </>
+    );
+  }
+}
+
+export default JwtRuleList;

--- a/src/pages/IstioConfigNew/RequestAuthorizationForm/JwtRuleList.tsx
+++ b/src/pages/IstioConfigNew/RequestAuthorizationForm/JwtRuleList.tsx
@@ -14,19 +14,19 @@ const headerCells: ICell[] = [
   {
     title: 'JWT Rules to be validated',
     transforms: [cellWidth(100) as any],
-    props: {}
+    props: {},
   },
   {
     title: '',
-    props: {}
-  }
+    props: {},
+  },
 ];
 
 const noJWTRulesStyle = style({
   marginTop: 10,
   color: PfColors.Red100,
   textAlign: 'center',
-  width: '100%'
+  width: '100%',
 });
 
 class JwtRuleList extends React.Component<Props> {
@@ -40,54 +40,40 @@ class JwtRuleList extends React.Component<Props> {
               <div>
                 <b>issuer</b>: [{formatJwtField('issuer', jwtRule)}]
               </div>
-            ) : (
-              undefined
-            )}
+            ) : undefined}
             {jwtRule.audiences ? (
               <div>
                 <b>audiences</b>: [{formatJwtField('audiences', jwtRule)}]
               </div>
-            ) : (
-              undefined
-            )}
+            ) : undefined}
             {jwtRule.jwksUri ? (
               <div>
                 <b>jwksUri</b>: [{formatJwtField('jwksUri', jwtRule)}]
               </div>
-            ) : (
-              undefined
-            )}
+            ) : undefined}
             {jwtRule.fromHeaders ? (
               <div>
                 <b>fromHeaders</b>: [{formatJwtField('fromHeaders', jwtRule)}]
               </div>
-            ) : (
-              undefined
-            )}
+            ) : undefined}
             {jwtRule.fromParams ? (
               <div>
                 <b>fromParams</b>: [{formatJwtField('fromParams', jwtRule)}]
               </div>
-            ) : (
-              undefined
-            )}
+            ) : undefined}
             {jwtRule.outputPayloadToHeader ? (
               <div>
                 <b>outputPayloadToHeader</b>: [{formatJwtField('outputPayloadToHeader', jwtRule)}]
               </div>
-            ) : (
-              undefined
-            )}
+            ) : undefined}
             {jwtRule.forwardOriginalToken ? (
               <div>
                 <b>forwardOriginalToken</b>: [{formatJwtField('forwardOriginalToken', jwtRule)}]
               </div>
-            ) : (
-              undefined
-            )}
+            ) : undefined}
           </>,
-          <></>
-        ]
+          <></>,
+        ],
       };
     });
   };
@@ -99,7 +85,7 @@ class JwtRuleList extends React.Component<Props> {
       // @ts-ignore
       onClick: (event, rowIndex, rowData, extraData) => {
         this.props.onRemoveJwtRule(rowIndex);
-      }
+      },
     };
     return [removeAction];
   };

--- a/src/pages/IstioConfigNew/SidecarForm.tsx
+++ b/src/pages/IstioConfigNew/SidecarForm.tsx
@@ -10,17 +10,17 @@ const headerCells: ICell[] = [
   {
     title: 'Egress Host',
     transforms: [cellWidth(60) as any],
-    props: {}
+    props: {},
   },
   {
     title: '',
-    props: {}
-  }
+    props: {},
+  },
 ];
 
 const noEgressHostsStyle = style({
   marginTop: 15,
-  color: PfColors.Red100
+  color: PfColors.Red100,
 });
 
 const hostsHelperText = 'Enter a valid namespace/FQDN Egress host.';
@@ -54,17 +54,17 @@ export const isSidecarStateValid = (s: SidecarState): boolean => {
 export const initSidecar = (initHost: string): SidecarState => {
   return {
     addEgressHost: {
-      host: ''
+      host: '',
     },
     addWorkloadSelector: false,
     egressHosts: [
       {
-        host: initHost
-      }
+        host: initHost,
+      },
     ],
     validEgressHost: false,
     workloadSelectorValid: false,
-    workloadSelectorLabels: ''
+    workloadSelectorLabels: '',
   };
 };
 
@@ -85,15 +85,15 @@ class SidecarForm extends React.Component<Props, SidecarState> {
       // @ts-ignore
       onClick: (event, rowIndex, _rowData, _extraData) => {
         this.setState(
-          prevState => {
+          (prevState) => {
             prevState.egressHosts.splice(rowIndex, 1);
             return {
-              egressHosts: prevState.egressHosts
+              egressHosts: prevState.egressHosts,
             };
           },
           () => this.props.onChange(this.state)
         );
-      }
+      },
     };
     if (rowIndex < this.state.egressHosts.length) {
       return [removeAction];
@@ -105,21 +105,21 @@ class SidecarForm extends React.Component<Props, SidecarState> {
     const host = value.trim();
     this.setState({
       addEgressHost: {
-        host: host
+        host: host,
       },
-      validEgressHost: isSidecarHostValid(host)
+      validEgressHost: isSidecarHostValid(host),
     });
   };
 
   onAddEgressHost = () => {
     this.setState(
-      prevState => {
+      (prevState) => {
         prevState.egressHosts.push(this.state.addEgressHost);
         return {
           egressHosts: prevState.egressHosts,
           addEgressHost: {
-            host: ''
-          }
+            host: '',
+          },
         };
       },
       () => this.props.onChange(this.state)
@@ -131,7 +131,7 @@ class SidecarForm extends React.Component<Props, SidecarState> {
       this.setState(
         {
           workloadSelectorValid: false,
-          workloadSelectorLabels: ''
+          workloadSelectorLabels: '',
         },
         () => this.props.onChange(this.state)
       );
@@ -160,7 +160,7 @@ class SidecarForm extends React.Component<Props, SidecarState> {
     this.setState(
       {
         workloadSelectorValid: isValid,
-        workloadSelectorLabels: value
+        workloadSelectorLabels: value,
       },
       () => this.props.onChange(this.state)
     );
@@ -170,7 +170,7 @@ class SidecarForm extends React.Component<Props, SidecarState> {
     return this.state.egressHosts
       .map((eHost, i) => ({
         key: 'eH' + i,
-        cells: [<>{eHost.host}</>, '']
+        cells: [<>{eHost.host}</>, ''],
       }))
       .concat([
         {
@@ -197,9 +197,9 @@ class SidecarForm extends React.Component<Props, SidecarState> {
               <Button variant="secondary" isDisabled={!this.state.validEgressHost} onClick={this.onAddEgressHost}>
                 Add Egress Host
               </Button>
-            </>
-          ]
-        }
+            </>,
+          ],
+        },
       ]);
   }
 
@@ -225,8 +225,8 @@ class SidecarForm extends React.Component<Props, SidecarState> {
             isChecked={this.state.addWorkloadSelector}
             onChange={() => {
               this.setState(
-                prevState => ({
-                  addWorkloadSelector: !prevState.addWorkloadSelector
+                (prevState) => ({
+                  addWorkloadSelector: !prevState.addWorkloadSelector,
                 }),
                 () => this.props.onChange(this.state)
               );

--- a/src/pages/IstioConfigNew/SidecarForm.tsx
+++ b/src/pages/IstioConfigNew/SidecarForm.tsx
@@ -4,7 +4,7 @@ import { style } from 'typestyle';
 import { PfColors } from '../../components/Pf/PfColors';
 // Use TextInputBase like workaround while PF4 team work in https://github.com/patternfly/patternfly-react/issues/4072
 import { Button, FormGroup, Switch, TextInputBase as TextInput } from '@patternfly/react-core';
-import { isServerHostValid } from '../../utils/IstioConfigUtils';
+import { isSidecarHostValid } from '../../utils/IstioConfigUtils';
 
 const headerCells: ICell[] = [
   {
@@ -23,53 +23,59 @@ const noEgressHostsStyle = style({
   color: PfColors.Red100
 });
 
-const hostsHelperText = 'Enter a valid FQDN host.';
+const hostsHelperText = 'Enter a valid namespace/FQDN Egress host.';
 
 export type EgressHost = {
   host: string;
 };
 
 type Props = {
-  egressHosts: EgressHost[];
-  addWorkloadSelector: boolean;
-  workloadSelectorLabels: string;
-  onAddEgressHost: (host: EgressHost) => void;
-  onChangeSelector: (
-    addWorkloadSelector: boolean,
-    workloadSelectorValid: boolean,
-    workloadSelectorLabels: string
-  ) => void;
-  onRemoveEgressHost: (index: number) => void;
+  sidecar: SidecarState;
+  onChange: (sidecar: SidecarState) => void;
 };
+
+export const SIDECAR = 'Sidecar';
+export const SIDECARS = 'sidecars';
 
 // Gateway and Sidecar states are consolidated in the parent page
 export type SidecarState = {
-  egressHosts: EgressHost[];
-  addWorkloadSelector: boolean;
-  workloadSelectorValid: boolean;
-  workloadSelectorLabels: string;
-};
-
-type State = {
   addEgressHost: EgressHost;
   addWorkloadSelector: boolean;
+  egressHosts: EgressHost[];
+  validEgressHost: boolean;
   workloadSelectorValid: boolean;
   workloadSelectorLabels: string;
-  validEgressHost: boolean;
 };
 
-class SidecarForm extends React.Component<Props, State> {
+export const isSidecarStateValid = (s: SidecarState): boolean => {
+  return s.egressHosts.length > 0 && (!s.addWorkloadSelector || (s.addWorkloadSelector && s.workloadSelectorValid));
+};
+
+export const initSidecar = (initHost: string): SidecarState => {
+  return {
+    addEgressHost: {
+      host: ''
+    },
+    addWorkloadSelector: false,
+    egressHosts: [
+      {
+        host: initHost
+      }
+    ],
+    validEgressHost: false,
+    workloadSelectorValid: false,
+    workloadSelectorLabels: ''
+  };
+};
+
+class SidecarForm extends React.Component<Props, SidecarState> {
   constructor(props: Props) {
     super(props);
-    this.state = {
-      addEgressHost: {
-        host: ''
-      },
-      addWorkloadSelector: false,
-      workloadSelectorValid: false,
-      workloadSelectorLabels: '',
-      validEgressHost: false
-    };
+    this.state = initSidecar('');
+  }
+
+  componentDidMount() {
+    this.setState(this.props.sidecar);
   }
 
   // @ts-ignore
@@ -78,10 +84,18 @@ class SidecarForm extends React.Component<Props, State> {
       title: 'Remove Server',
       // @ts-ignore
       onClick: (event, rowIndex, _rowData, _extraData) => {
-        this.props.onRemoveEgressHost(rowIndex);
+        this.setState(
+          prevState => {
+            prevState.egressHosts.splice(rowIndex, 1);
+            return {
+              egressHosts: prevState.egressHosts
+            };
+          },
+          () => this.props.onChange(this.state)
+        );
       }
     };
-    if (rowIndex < this.props.egressHosts.length) {
+    if (rowIndex < this.state.egressHosts.length) {
       return [removeAction];
     }
     return [];
@@ -93,25 +107,34 @@ class SidecarForm extends React.Component<Props, State> {
       addEgressHost: {
         host: host
       },
-      validEgressHost: isServerHostValid(host)
+      validEgressHost: isSidecarHostValid(host)
     });
   };
 
   onAddEgressHost = () => {
-    this.props.onAddEgressHost(this.state.addEgressHost);
-    this.setState({
-      addEgressHost: {
-        host: ''
-      }
-    });
+    this.setState(
+      prevState => {
+        prevState.egressHosts.push(this.state.addEgressHost);
+        return {
+          egressHosts: prevState.egressHosts,
+          addEgressHost: {
+            host: ''
+          }
+        };
+      },
+      () => this.props.onChange(this.state)
+    );
   };
 
   addWorkloadLabels = (value: string, _) => {
     if (value.length === 0) {
-      this.setState({
-        workloadSelectorValid: false,
-        workloadSelectorLabels: ''
-      });
+      this.setState(
+        {
+          workloadSelectorValid: false,
+          workloadSelectorLabels: ''
+        },
+        () => this.props.onChange(this.state)
+      );
       return;
     }
     value = value.trim();
@@ -139,18 +162,12 @@ class SidecarForm extends React.Component<Props, State> {
         workloadSelectorValid: isValid,
         workloadSelectorLabels: value
       },
-      () => {
-        this.props.onChangeSelector(
-          this.state.addWorkloadSelector,
-          this.state.workloadSelectorValid,
-          this.state.workloadSelectorLabels
-        );
-      }
+      () => this.props.onChange(this.state)
     );
   };
 
   rows() {
-    return this.props.egressHosts
+    return this.state.egressHosts
       .map((eHost, i) => ({
         key: 'eH' + i,
         cells: [<>{eHost.host}</>, '']
@@ -211,13 +228,7 @@ class SidecarForm extends React.Component<Props, State> {
                 prevState => ({
                   addWorkloadSelector: !prevState.addWorkloadSelector
                 }),
-                () => {
-                  this.props.onChangeSelector(
-                    this.state.addWorkloadSelector,
-                    this.state.workloadSelectorValid,
-                    this.state.workloadSelectorLabels
-                  );
-                }
+                () => this.props.onChange(this.state)
               );
             }}
           />
@@ -240,7 +251,7 @@ class SidecarForm extends React.Component<Props, State> {
             />
           </FormGroup>
         )}
-        {this.props.egressHosts.length === 0 && (
+        {this.state.egressHosts.length === 0 && (
           <div className={noEgressHostsStyle}>Sidecar has no Egress Hosts Defined</div>
         )}
       </>

--- a/src/pages/extensions/threescale/ThreeScaleHandlerDetails/ThreeScaleHandlerDetailsPage.tsx
+++ b/src/pages/extensions/threescale/ThreeScaleHandlerDetails/ThreeScaleHandlerDetailsPage.tsx
@@ -18,7 +18,7 @@ import {
   TextVariants,
   Title,
   Toolbar,
-  ToolbarSection
+  ToolbarSection,
 } from '@patternfly/react-core';
 import { style } from 'typestyle';
 import { PfColors } from '../../../../components/Pf/PfColors';
@@ -54,10 +54,10 @@ interface State {
 // i.e. no namespaces controllers, then some styles need to be adjusted manually
 const extensionHeader = style({
   padding: '0px 20px 18px 20px',
-  backgroundColor: PfColors.White
+  backgroundColor: PfColors.White,
 });
 const breadcrumbPadding = style({
-  padding: '22px 0 5px 0'
+  padding: '22px 0 5px 0',
 });
 const containerPadding = style({ padding: '20px 20px 20px 20px' });
 // Toolbar in 3scale details page is added manually.
@@ -67,7 +67,7 @@ const rightToolbarStyle = style({
   right: '20px',
   zIndex: 1,
   marginTop: '-30px',
-  backgroundColor: PfColors.White
+  backgroundColor: PfColors.White,
 });
 
 class ThreeScaleHandlerDetailsPage extends React.Component<RouteComponentProps<Props>, State> {
@@ -81,17 +81,17 @@ class ThreeScaleHandlerDetailsPage extends React.Component<RouteComponentProps<P
         permissions: {
           create: false,
           update: false,
-          delete: false
-        }
+          delete: false,
+        },
       },
       handler: {
         name: '',
         serviceId: '',
         systemUrl: '',
-        accessToken: ''
+        accessToken: '',
       },
       dropdownOpen: false,
-      deleteModalOpen: false
+      deleteModalOpen: false,
     };
   }
 
@@ -99,12 +99,12 @@ class ThreeScaleHandlerDetailsPage extends React.Component<RouteComponentProps<P
   // It fetches the specific handler to edit. It ignores handler when creating a new Threescale handler.
   fetchHandler = (handlerName: string | undefined) => {
     API.getThreeScaleInfo()
-      .then(result => {
+      .then((result) => {
         const threeScaleInfo = result.data;
         if (threeScaleInfo.enabled) {
           if (handlerName) {
             API.getThreeScaleHandlers()
-              .then(results => {
+              .then((results) => {
                 let handler: ThreeScaleHandler | undefined = undefined;
                 for (let i = 0; results.data.length; i++) {
                   if (results.data[i].name === handlerName) {
@@ -116,25 +116,25 @@ class ThreeScaleHandlerDetailsPage extends React.Component<RouteComponentProps<P
                   this.setState({
                     isNew: false,
                     threeScaleInfo: threeScaleInfo,
-                    handler: handler
+                    handler: handler,
                   });
                 } else {
                   AlertUtils.addError('Could not fetch ThreeScaleHandler ' + handlerName + '.');
                 }
               })
-              .catch(error => {
+              .catch((error) => {
                 AlertUtils.addError('Could not fetch ThreeScaleHandlers.', error);
               });
           } else {
             this.setState({
-              threeScaleInfo: threeScaleInfo
+              threeScaleInfo: threeScaleInfo,
             });
           }
         } else {
           AlertUtils.addError('Kiali has 3scale extension enabled but 3scale adapter is not detected in the cluster');
         }
       })
-      .catch(error => {
+      .catch((error) => {
         AlertUtils.addError('Could not fetch ThreeScaleInfo.', error);
       });
   };
@@ -163,7 +163,7 @@ class ThreeScaleHandlerDetailsPage extends React.Component<RouteComponentProps<P
           dropdownItems={[
             <DropdownItem key="createIstioConfig" onClick={() => this.setState({ deleteModalOpen: true })}>
               Delete
-            </DropdownItem>
+            </DropdownItem>,
           ]}
         />
         <Modal
@@ -177,7 +177,7 @@ class ThreeScaleHandlerDetailsPage extends React.Component<RouteComponentProps<P
             </Button>,
             <Button key="confirm" variant="danger" onClick={() => this.deleteHandler()}>
               Delete
-            </Button>
+            </Button>,
           ]}
         >
           <Text component={TextVariants.p}>
@@ -240,7 +240,7 @@ class ThreeScaleHandlerDetailsPage extends React.Component<RouteComponentProps<P
 
   // Updates state with modifications of the new/editing handler
   changeHandler = (field: string, value: string) => {
-    this.setState(prevState => {
+    this.setState((prevState) => {
       const newThreeScaleHandler = prevState.handler;
       switch (field) {
         case 'handlerName':
@@ -260,7 +260,7 @@ class ThreeScaleHandlerDetailsPage extends React.Component<RouteComponentProps<P
       return {
         isNew: prevState.isNew,
         isModified: true,
-        handler: newThreeScaleHandler
+        handler: newThreeScaleHandler,
       };
     });
   };
@@ -269,20 +269,20 @@ class ThreeScaleHandlerDetailsPage extends React.Component<RouteComponentProps<P
   updateHandler = () => {
     if (this.state.isNew) {
       API.createThreeScaleHandler(JSON.stringify(this.state.handler))
-        .then(_ => this.goHandlersPage())
-        .catch(error => AlertUtils.addError('Could not create ThreeScaleHandlers.', error));
+        .then((_) => this.goHandlersPage())
+        .catch((error) => AlertUtils.addError('Could not create ThreeScaleHandlers.', error));
     } else {
       API.updateThreeScaleHandler(this.state.handler.name, JSON.stringify(this.state.handler))
-        .then(_ => this.goHandlersPage())
-        .catch(error => AlertUtils.addError('Could not update ThreeScaleHandlers.', error));
+        .then((_) => this.goHandlersPage())
+        .catch((error) => AlertUtils.addError('Could not update ThreeScaleHandlers.', error));
     }
   };
 
   // It invokes backend to delete a 3scale handler
   deleteHandler = () => {
     API.deleteThreeScaleHandler(this.state.handler.name)
-      .then(_ => this.goHandlersPage())
-      .catch(error => AlertUtils.addError('Could not delete ThreeScaleHandlers.', error));
+      .then((_) => this.goHandlersPage())
+      .catch((error) => AlertUtils.addError('Could not delete ThreeScaleHandlers.', error));
   };
 
   render() {
@@ -329,7 +329,7 @@ class ThreeScaleHandlerDetailsPage extends React.Component<RouteComponentProps<P
                   id="handlerName"
                   value={this.state.handler.name}
                   placeholder="3scale Handler Name"
-                  onChange={value => this.changeHandler('handlerName', value)}
+                  onChange={(value) => this.changeHandler('handlerName', value)}
                   isDisabled={!this.state.isNew}
                 />
               </FormGroup>
@@ -343,7 +343,7 @@ class ThreeScaleHandlerDetailsPage extends React.Component<RouteComponentProps<P
                   id="serviceId"
                   value={this.state.handler.serviceId}
                   placeholder="3scale ID for API calls"
-                  onChange={value => this.changeHandler('serviceId', value)}
+                  onChange={(value) => this.changeHandler('serviceId', value)}
                 />
               </FormGroup>
               <FormGroup
@@ -356,7 +356,7 @@ class ThreeScaleHandlerDetailsPage extends React.Component<RouteComponentProps<P
                   id="systemUrl"
                   value={this.state.handler.systemUrl}
                   placeholder="3scale System Url for API"
-                  onChange={value => this.changeHandler('systemUrl', value)}
+                  onChange={(value) => this.changeHandler('systemUrl', value)}
                 />
               </FormGroup>
               <FormGroup
@@ -369,7 +369,7 @@ class ThreeScaleHandlerDetailsPage extends React.Component<RouteComponentProps<P
                   id="accessToken"
                   value={this.state.handler.accessToken}
                   placeholder="3scale access token"
-                  onChange={value => this.changeHandler('accessToken', value)}
+                  onChange={(value) => this.changeHandler('accessToken', value)}
                 />
               </FormGroup>
               <ActionGroup>

--- a/src/pages/extensions/threescale/ThreeScaleHandlerDetails/ThreeScaleHandlerDetailsPage.tsx
+++ b/src/pages/extensions/threescale/ThreeScaleHandlerDetails/ThreeScaleHandlerDetailsPage.tsx
@@ -28,6 +28,7 @@ import { ThreeScaleHandler, ThreeScaleInfo } from '../../../../types/ThreeScale'
 import { RenderContent } from '../../../../components/Nav/Page';
 import history from '../../../../app/History';
 import RefreshButtonContainer from '../../../../components/Refresh/RefreshButton';
+import { isValidK8SName } from '../../../../helpers/ValidationHelpers';
 
 // Properties handled by the component/page
 // Note that ThreeScaleHandlerDetailsPage uses a RouteComponentProps<Props> used to capture the parameters in the route
@@ -68,12 +69,6 @@ const rightToolbarStyle = style({
   marginTop: '-30px',
   backgroundColor: PfColors.White
 });
-
-// Kubernetes ID validation helper, used to allow mark a warning in the form edition
-const k8sRegExpName = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[-a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
-const isValidK8SName = (name: string) => {
-  return name === '' ? false : name.search(k8sRegExpName) === 0;
-};
 
 class ThreeScaleHandlerDetailsPage extends React.Component<RouteComponentProps<Props>, State> {
   constructor(props: RouteComponentProps<Props>) {

--- a/src/types/IstioObjects.ts
+++ b/src/types/IstioObjects.ts
@@ -50,7 +50,7 @@ export type Validations = { [key1: string]: { [key2: string]: ObjectValidation }
 export enum ValidationTypes {
   Error = 'error',
   Warning = 'warning',
-  Correct = 'correct'
+  Correct = 'correct',
 }
 
 export interface ObjectValidation {
@@ -495,7 +495,7 @@ export interface Gateway extends IstioObject {
 export enum CaptureMode {
   DEFAULT = 'DEFAULT',
   IPTABLES = 'IPTABLES',
-  NONE = 'NONE'
+  NONE = 'NONE',
 }
 
 // 1.6
@@ -668,7 +668,7 @@ export interface TargetSelector {
 
 export enum MutualTlsMode {
   STRICT = 'STRICT',
-  PERMISSIVE = 'PERMISSIVE'
+  PERMISSIVE = 'PERMISSIVE',
 }
 
 export interface MutualTls {
@@ -694,7 +694,7 @@ export interface OriginAuthenticationMethod {
 
 export enum PrincipalBinding {
   USE_PEER = 'USE_PEER',
-  USE_ORIGIN = 'USE_ORIGIN'
+  USE_ORIGIN = 'USE_ORIGIN',
 }
 
 export interface PolicySpec {
@@ -856,7 +856,7 @@ export enum PeerAuthenticationMutualTLSMode {
   UNSET = 'UNSET',
   DISABLE = 'DISABLE',
   PERMISSIVE = 'PERMISSIVE',
-  STRICT = 'STRICT'
+  STRICT = 'STRICT',
 }
 
 // 1.6

--- a/src/types/IstioObjects.ts
+++ b/src/types/IstioObjects.ts
@@ -884,7 +884,7 @@ export interface JWTHeader {
 }
 
 export interface JWTRule {
-  issuer: string;
+  issuer?: string;
   audiences?: string[];
   jwksUri?: string;
   jwks?: string;

--- a/src/utils/IstioConfigUtils.ts
+++ b/src/utils/IstioConfigUtils.ts
@@ -73,9 +73,20 @@ export const getIstioObject = (istioObjectDetails?: IstioConfigDetails) => {
 
 const nsRegexp = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[-a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
 const hostRegexp = /(?=^.{4,253}$)(^((?!-)(([a-zA-Z0-9-]{0,62}[a-zA-Z0-9])|\*)\.)+[a-zA-Z]{2,63}$)/;
+const ipRegexp = /^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))?$/;
+
+// Gateway hosts have namespace/dnsName with namespace optional
+export const isGatewayHostValid = (gatewayHost: string): boolean => {
+  return isServerHostValid(gatewayHost, false);
+};
+
+// Sidecar host have namespace/dnsName with both namespace/dnsName mandatory
+export const isSidecarHostValid = (sidecarHost: string): boolean => {
+  return isServerHostValid(sidecarHost, true);
+};
 
 // Used to check if Sidecar and Gateway host expressions are valid
-export const isServerHostValid = (serverHost: string): boolean => {
+export const isServerHostValid = (serverHost: string, nsMandatory: boolean): boolean => {
   if (serverHost.length === 0) {
     return false;
   }
@@ -85,6 +96,11 @@ export const isServerHostValid = (serverHost: string): boolean => {
   if (parts.length > 2) {
     return false;
   }
+  // Force that namespace/dnsName are present
+  if (nsMandatory && parts.length < 2) {
+    return false;
+  }
+
   // parts[0] is a dns
   let dnsValid = true;
   let hostValid = true;
@@ -105,4 +121,8 @@ export const isServerHostValid = (serverHost: string): boolean => {
     hostValid = host.search(hostRegexp) === 0;
   }
   return dnsValid && hostValid;
+};
+
+export const isValidIp = (ip: string): boolean => {
+  return ipRegexp.test(ip);
 };

--- a/src/utils/IstioConfigUtils.ts
+++ b/src/utils/IstioConfigUtils.ts
@@ -126,3 +126,12 @@ export const isServerHostValid = (serverHost: string, nsMandatory: boolean): boo
 export const isValidIp = (ip: string): boolean => {
   return ipRegexp.test(ip);
 };
+
+export const isValidUrl = (url: string): boolean => {
+  try {
+    new URL(url);
+  } catch (_) {
+    return false;
+  }
+  return true;
+};

--- a/src/utils/__tests__/IstioConfigUtils.test.ts
+++ b/src/utils/__tests__/IstioConfigUtils.test.ts
@@ -4,23 +4,23 @@ describe('Validate JSON Patchs', () => {
   const gateway: object = {
     kind: 'Gateway',
     namespace: {
-      name: 'bookinfo'
+      name: 'bookinfo',
     },
     spec: {
       selector: {
-        istio: 'ingressgateway'
+        istio: 'ingressgateway',
       },
       servers: [
         {
           port: {
             number: 80,
             name: 'http',
-            protocol: 'HTTP'
+            protocol: 'HTTP',
           },
-          hosts: ['*']
-        }
-      ]
-    }
+          hosts: ['*'],
+        },
+      ],
+    },
   };
 
   const gatewayModified: object = {
@@ -28,19 +28,19 @@ describe('Validate JSON Patchs', () => {
     kind: 'Gateway',
     spec: {
       selector: {
-        app: 'myapp'
+        app: 'myapp',
       },
       servers: [
         {
           port: {
             number: 80,
             name: 'http',
-            protocol: 'HTTP'
+            protocol: 'HTTP',
           },
-          hosts: ['*']
-        }
-      ]
-    }
+          hosts: ['*'],
+        },
+      ],
+    },
   };
 
   it('Basic Test', () => {

--- a/src/utils/__tests__/IstioConfigUtils.test.ts
+++ b/src/utils/__tests__/IstioConfigUtils.test.ts
@@ -1,4 +1,4 @@
-import { isServerHostValid, mergeJsonPatch } from '../IstioConfigUtils';
+import { isServerHostValid, isValidUrl, mergeJsonPatch } from '../IstioConfigUtils';
 
 describe('Validate JSON Patchs', () => {
   const gateway: object = {
@@ -81,5 +81,17 @@ describe('Validate Gateway/Sidecar Server Host ', () => {
   it('Catch bad urls', () => {
     expect(isServerHostValid('bookinfo//reviews', true)).toBeFalsy();
     expect(isServerHostValid('bookinf*/reviews', true)).toBeFalsy();
+  });
+});
+
+describe('Validate bad urls', () => {
+  it('Good urls', () => {
+    expect(isValidUrl('http://www.googleapis.com/oauth2/v1/certs')).toBeTruthy();
+    expect(isValidUrl('https://www.googleapis.com/oauth2/v1/certs')).toBeTruthy();
+  });
+
+  it('Bad urls', () => {
+    expect(isValidUrl('ramdom')).toBeFalsy();
+    expect(isValidUrl('123test')).toBeFalsy();
   });
 });

--- a/src/utils/__tests__/IstioConfigUtils.test.ts
+++ b/src/utils/__tests__/IstioConfigUtils.test.ts
@@ -56,29 +56,30 @@ describe('Validate JSON Patchs', () => {
 
 describe('Validate Gateway/Sidecar Server Host ', () => {
   it('No Namespace prefix', () => {
-    expect(isServerHostValid('*')).toBeTruthy();
-    expect(isServerHostValid('productpage')).toBeFalsy();
-    expect(isServerHostValid('productpage.example.com')).toBeTruthy();
-    expect(isServerHostValid('*.example.com')).toBeTruthy();
+    expect(isServerHostValid('*', false)).toBeTruthy();
+    expect(isServerHostValid('*', true)).toBeFalsy();
+    expect(isServerHostValid('productpage', false)).toBeFalsy();
+    expect(isServerHostValid('productpage.example.com', false)).toBeTruthy();
+    expect(isServerHostValid('*.example.com', false)).toBeTruthy();
   });
 
   it('Namespace prefix', () => {
-    expect(isServerHostValid('bookinfo/*')).toBeTruthy();
-    expect(isServerHostValid('*/*')).toBeTruthy();
-    expect(isServerHostValid('./*')).toBeTruthy();
-    expect(isServerHostValid('bookinfo/productpage')).toBeFalsy();
-    expect(isServerHostValid('*/productpage')).toBeFalsy();
-    expect(isServerHostValid('./productpage')).toBeFalsy();
-    expect(isServerHostValid('bookinfo/productpage.example.com')).toBeTruthy();
-    expect(isServerHostValid('*/productpage.example.com')).toBeTruthy();
-    expect(isServerHostValid('./productpage.example.com')).toBeTruthy();
-    expect(isServerHostValid('bookinfo/*.example.com')).toBeTruthy();
-    expect(isServerHostValid('*/*.example.com')).toBeTruthy();
-    expect(isServerHostValid('./*.example.com')).toBeTruthy();
+    expect(isServerHostValid('bookinfo/*', true)).toBeTruthy();
+    expect(isServerHostValid('*/*', true)).toBeTruthy();
+    expect(isServerHostValid('./*', true)).toBeTruthy();
+    expect(isServerHostValid('bookinfo/productpage', true)).toBeFalsy();
+    expect(isServerHostValid('*/productpage', true)).toBeFalsy();
+    expect(isServerHostValid('./productpage', true)).toBeFalsy();
+    expect(isServerHostValid('bookinfo/productpage.example.com', true)).toBeTruthy();
+    expect(isServerHostValid('*/productpage.example.com', true)).toBeTruthy();
+    expect(isServerHostValid('./productpage.example.com', true)).toBeTruthy();
+    expect(isServerHostValid('bookinfo/*.example.com', true)).toBeTruthy();
+    expect(isServerHostValid('*/*.example.com', true)).toBeTruthy();
+    expect(isServerHostValid('./*.example.com', true)).toBeTruthy();
   });
 
   it('Catch bad urls', () => {
-    expect(isServerHostValid('bookinfo//reviews')).toBeFalsy();
-    expect(isServerHostValid('bookinf*/reviews')).toBeFalsy();
+    expect(isServerHostValid('bookinfo//reviews', true)).toBeFalsy();
+    expect(isServerHostValid('bookinf*/reviews', true)).toBeFalsy();
   });
 });


### PR DESCRIPTION
This PR adds support to PeerAuthentication and RequestAuthentication objects in Create New IstioConfig.

Now together with AuthorizationPolicy, Kiali should be able to create all type of Security scenarios.

Requires https://github.com/kiali/kiali/issues/2797

How to test:
- Try to create objects described in https://preliminary.istio.io/docs/tasks/security/authentication/authn-policy/ 
- Or try to add objects described in https://preliminary.istio.io/docs/reference/config/security/peer_authentication/ and https://preliminary.istio.io/docs/reference/config/security/request_authentication/

Fixes https://github.com/kiali/kiali/issues/2797
Fixes https://github.com/kiali/kiali/issues/2685
Fixes https://github.com/kiali/kiali/issues/2694