### PR TITLE
Expose Istio Telemetry Version to Public Config

### DIFF
--- a/src/config/ServerConfig.ts
+++ b/src/config/ServerConfig.ts
@@ -61,7 +61,8 @@ let serverConfig: ComputedServerConfig = {
     globalScrapeInterval: 15,
     storageTsdbRetention: 21600
   },
-  durations: {}
+  durations: {},
+  canonicalMetrics: true
 };
 computeValidDurations(serverConfig);
 export { serverConfig };

--- a/src/config/ServerConfig.ts
+++ b/src/config/ServerConfig.ts
@@ -62,7 +62,8 @@ let serverConfig: ComputedServerConfig = {
     storageTsdbRetention: 21600
   },
   durations: {},
-  canonicalMetrics: true
+  canonicalMetrics: true,
+  isMixerDisabled: true
 };
 computeValidDurations(serverConfig);
 export { serverConfig };

--- a/src/config/ServerConfig.ts
+++ b/src/config/ServerConfig.ts
@@ -62,8 +62,7 @@ let serverConfig: ComputedServerConfig = {
     storageTsdbRetention: 21600
   },
   durations: {},
-  canonicalMetrics: true,
-  isMixerDisabled: true
+  istioTelemetryV2: true
 };
 computeValidDurations(serverConfig);
 export { serverConfig };

--- a/src/types/ServerConfig.ts
+++ b/src/types/ServerConfig.ts
@@ -27,4 +27,5 @@ export interface ServerConfig {
     storageTsdbRetention?: DurationInSeconds;
   };
   canonicalMetrics: boolean;
+  isMixerDisabled: boolean;
 }

--- a/src/types/ServerConfig.ts
+++ b/src/types/ServerConfig.ts
@@ -26,4 +26,5 @@ export interface ServerConfig {
     globalScrapeInterval?: DurationInSeconds;
     storageTsdbRetention?: DurationInSeconds;
   };
+  canonicalMetrics: boolean;
 }

--- a/src/types/ServerConfig.ts
+++ b/src/types/ServerConfig.ts
@@ -26,6 +26,5 @@ export interface ServerConfig {
     globalScrapeInterval?: DurationInSeconds;
     storageTsdbRetention?: DurationInSeconds;
   };
-  canonicalMetrics: boolean;
-  isMixerDisabled: boolean;
+  istioTelemetryV2: boolean;
 }


### PR DESCRIPTION
Counterpart of https://github.com/kiali/kiali/pull/2846 to have access to the canonicalMetrics flag to check if telemetry is based on v1/v2 metrics.

