### PR TITLE
[Maintenance] Make filters "title" only used for display

### DIFF
--- a/src/components/BreadcrumbView/BreadcrumbView.tsx
+++ b/src/components/BreadcrumbView/BreadcrumbView.tsx
@@ -84,7 +84,8 @@ export class BreadcrumbView extends React.Component<BreadCumbViewProps, BreadCum
     // When updateTypeFilter is called, selected filters are already updated with namespace. Just push additional type obj
     const activeFilters: ActiveFiltersInfo = FilterSelected.getSelected();
     activeFilters.filters.push({
-      category: 'Istio Type',
+      id: 'Istio Type',
+      title: 'Istio Type',
       value: dicIstioType[this.state.istioType || '']
     });
     FilterSelected.setSelected(activeFilters);

--- a/src/components/FilterList/FilterHelper.ts
+++ b/src/components/FilterList/FilterHelper.ts
@@ -25,7 +25,8 @@ export const getFiltersFromURL = (filterTypes: FilterType[]): ActiveFiltersInfo 
   filterTypes.forEach(filter => {
     urlParams.getAll(filter.id).forEach(value => {
       activeFilters.push({
-        category: filter.title,
+        id: filter.id,
+        title: filter.title,
         value: value
       });
     });
@@ -42,11 +43,10 @@ export const setFiltersToURL = (filterTypes: FilterType[], filters: ActiveFilter
   filterTypes.forEach(type => {
     urlParams.delete(type.id);
   });
-  urlParams.delete(ID_LABEL_OPERATION);
   const cleanFilters: ActiveFilter[] = [];
 
   filters.filters.forEach(activeFilter => {
-    const filterType = filterTypes.find(filter => filter.title === activeFilter.category);
+    const filterType = filterTypes.find(filter => filter.id === activeFilter.id);
     if (!filterType) {
       return;
     }
@@ -63,8 +63,8 @@ export const filtersMatchURL = (filterTypes: FilterType[], filters: ActiveFilter
   // This can probably be improved and/or simplified?
   const fromFilters: Map<string, string[]> = new Map<string, string[]>();
   filters.filters.forEach(activeFilter => {
-    const existingValue = fromFilters.get(activeFilter.category) || [];
-    fromFilters.set(activeFilter.category, existingValue.concat(activeFilter.value));
+    const existingValue = fromFilters.get(activeFilter.id) || [];
+    fromFilters.set(activeFilter.id, existingValue.concat(activeFilter.value));
   });
 
   const fromURL: Map<string, string[]> = new Map<string, string[]>();
@@ -72,8 +72,8 @@ export const filtersMatchURL = (filterTypes: FilterType[], filters: ActiveFilter
   filterTypes.forEach(filter => {
     const values = urlParams.getAll(filter.id);
     if (values.length > 0) {
-      const existing = fromURL.get(filter.title) || [];
-      fromURL.set(filter.title, existing.concat(values));
+      const existing = fromURL.get(filter.id) || [];
+      fromURL.set(filter.id, existing.concat(values));
     }
   });
 

--- a/src/components/FilterList/__tests__/ListPagesHelper.test.ts
+++ b/src/components/FilterList/__tests__/ListPagesHelper.test.ts
@@ -24,15 +24,18 @@ describe('List page', () => {
     expect(filters).toEqual({
       filters: [
         {
-          category: 'A',
+          id: 'a',
+          title: 'A',
           value: '1'
         },
         {
-          category: 'C',
+          id: 'c',
+          title: 'C',
           value: '3'
         },
         {
-          category: 'C',
+          id: 'c',
+          title: 'C',
           value: '4'
         }
       ],
@@ -45,15 +48,18 @@ describe('List page', () => {
     const cleanFilters = FilterHelper.setFiltersToURL(managedFilterTypes, {
       filters: [
         {
-          category: 'A',
+          id: 'a',
+          title: 'A',
           value: '1'
         },
         {
-          category: 'C',
+          id: 'c',
+          title: 'C',
           value: '3'
         },
         {
-          category: 'C',
+          id: 'c',
+          title: 'C',
           value: '4'
         }
       ],
@@ -68,15 +74,18 @@ describe('List page', () => {
     const cleanFilters = FilterHelper.setFiltersToURL(managedFilterTypes, {
       filters: [
         {
-          category: 'A',
+          id: 'a',
+          title: 'A',
           value: '1'
         },
         {
-          category: 'C',
+          id: 'c',
+          title: 'C',
           value: '3'
         },
         {
-          category: 'C',
+          id: 'c',
+          title: 'C',
           value: '4'
         }
       ],
@@ -93,15 +102,18 @@ describe('List page', () => {
     const match = FilterHelper.filtersMatchURL(managedFilterTypes, {
       filters: [
         {
-          category: 'C',
+          id: 'c',
+          title: 'C',
           value: '3'
         },
         {
-          category: 'A',
+          id: 'a',
+          title: 'A',
           value: '1'
         },
         {
-          category: 'C',
+          id: 'c',
+          title: 'C',
           value: '4'
         }
       ],
@@ -116,15 +128,18 @@ describe('List page', () => {
     let match = FilterHelper.filtersMatchURL(managedFilterTypes, {
       filters: [
         {
-          category: 'A',
+          id: 'a',
+          title: 'A',
           value: '1'
         },
         {
-          category: 'C',
+          id: 'c',
+          title: 'C',
           value: '3'
         },
         {
-          category: 'C',
+          id: 'c',
+          title: 'C',
           value: '5'
         }
       ],
@@ -136,11 +151,13 @@ describe('List page', () => {
     match = FilterHelper.filtersMatchURL(managedFilterTypes, {
       filters: [
         {
-          category: 'A',
+          id: 'a',
+          title: 'A',
           value: '1'
         },
         {
-          category: 'C',
+          id: 'c',
+          title: 'C',
           value: '3'
         }
       ],
@@ -152,19 +169,23 @@ describe('List page', () => {
     match = FilterHelper.filtersMatchURL(managedFilterTypes, {
       filters: [
         {
-          category: 'A',
+          id: 'a',
+          title: 'A',
           value: '1'
         },
         {
-          category: 'C',
+          id: 'c',
+          title: 'C',
           value: '3'
         },
         {
-          category: 'C',
+          id: 'c',
+          title: 'C',
           value: '4'
         },
         {
-          category: 'C',
+          id: 'c',
+          title: 'C',
           value: '5'
         }
       ],
@@ -176,7 +197,8 @@ describe('List page', () => {
     match = FilterHelper.filtersMatchURL(managedFilterTypes, {
       filters: [
         {
-          category: 'A',
+          id: 'a',
+          title: 'A',
           value: '1'
         }
       ],
@@ -188,19 +210,23 @@ describe('List page', () => {
     match = FilterHelper.filtersMatchURL(managedFilterTypes, {
       filters: [
         {
-          category: 'A',
+          id: 'a',
+          title: 'A',
           value: '1'
         },
         {
-          category: 'C',
+          id: 'c',
+          title: 'C',
           value: '3'
         },
         {
-          category: 'C',
+          id: 'c',
+          title: 'C',
           value: '4'
         },
         {
-          category: 'D',
+          id: 'd',
+          title: 'D',
           value: '5'
         }
       ],

--- a/src/components/Filters/CommonFilters.ts
+++ b/src/components/Filters/CommonFilters.ts
@@ -55,15 +55,24 @@ export const healthFilter: FilterType = {
   ]
 };
 
+export const labelFilter: FilterType = {
+  id: 'label',
+  title: 'Label',
+  placeholder: 'Filter by Label',
+  filterType: FilterTypes.label,
+  action: FILTER_ACTION_APPEND,
+  filterValues: []
+};
+
 export const getFilterSelectedValues = (filter: FilterType, activeFilters: ActiveFiltersInfo): string[] => {
   const selected: string[] = activeFilters.filters
-    .filter(activeFilter => activeFilter.category === filter.title)
+    .filter(activeFilter => activeFilter.id === filter.id)
     .map(activeFilter => activeFilter.value);
   return removeDuplicatesArray(selected);
 };
 
 export const getPresenceFilterValue = (filter: FilterType, activeFilters: ActiveFiltersInfo): boolean | undefined => {
-  const presenceFilters = activeFilters.filters.filter(activeFilter => activeFilter.category === filter.title);
+  const presenceFilters = activeFilters.filters.filter(activeFilter => activeFilter.id === filter.id);
 
   if (presenceFilters.length > 0) {
     return presenceFilters[0].value === 'Present';

--- a/src/components/Filters/LabelFilter.tsx
+++ b/src/components/Filters/LabelFilter.tsx
@@ -6,7 +6,7 @@ interface LabelFiltersProps {
   onChange: (value: any) => void;
   value: string;
   filterAdd: (value: string) => void;
-  duplicatesFilter: (value: string) => boolean;
+  isActive: (value: string) => boolean;
 }
 
 export class LabelFilters extends React.Component<LabelFiltersProps, { sortOperation: string }> {
@@ -18,7 +18,7 @@ export class LabelFilters extends React.Component<LabelFiltersProps, { sortOpera
   onkeyPress = (e: any) => {
     if (e.key === 'Enter') {
       if (this.props.value && this.props.value.length > 0) {
-        this.props.value.split(' ').map(val => !this.props.duplicatesFilter(val) && this.props.filterAdd(val));
+        this.props.value.split(' ').map(val => !this.props.isActive(val) && this.props.filterAdd(val));
       }
     }
   };

--- a/src/components/VirtualList/Renderers.tsx
+++ b/src/components/VirtualList/Renderers.tsx
@@ -12,7 +12,7 @@ import { WorkloadListItem } from '../../types/Workload';
 import { IstioConfigItem } from '../../types/IstioConfigList';
 import { AppListItem } from '../../types/AppList';
 import { ServiceListItem } from '../../types/ServiceList';
-import { ActiveFilter, LabelFilter } from '../../types/Filters';
+import { ActiveFilter } from '../../types/Filters';
 import { PfColors } from '../Pf/PfColors';
 import { renderAPILogo } from '../Logo/Logos';
 import { Health } from '../../types/Health';
@@ -25,6 +25,7 @@ import { OverviewToolbar } from '../../pages/Overview/OverviewToolbar';
 import OverviewCardLinks from '../../pages/Overview/OverviewCardLinks';
 import { StatefulFilters } from '../Filters/StatefulFilters';
 import { GetIstioObjectUrl } from '../Link/IstioObjectLink';
+import { labelFilter } from 'components/Filters/CommonFilters';
 
 // Links
 
@@ -197,7 +198,7 @@ export const namespace: Renderer<TResource> = (item: TResource) => {
 
 const labelActivate = (filters: ActiveFilter[], key: string, value: string) => {
   return filters.some(filter => {
-    if (filter.category === LabelFilter.title) {
+    if (filter.id === labelFilter.id) {
       if (filter.value.includes(':')) {
         const [k, v] = filter.value.split(':');
         if (k === key) {
@@ -207,7 +208,7 @@ const labelActivate = (filters: ActiveFilter[], key: string, value: string) => {
       }
       return key === filter.value;
     } else {
-      if (filter.category === appLabelFilter.title) {
+      if (filter.id === appLabelFilter.id) {
         return filter.value === 'Present' && key === 'app';
       }
       return filter.value === 'Present' && key === 'version';
@@ -222,7 +223,7 @@ export const labels: Renderer<SortResource | NamespaceInfo> = (
   ___?: Health,
   statefulFilter?: React.RefObject<StatefulFilters>
 ) => {
-  const filters = FilterHelper.getFiltersFromURL([LabelFilter, appLabelFilter, versionLabelFilter]);
+  const filters = FilterHelper.getFiltersFromURL([labelFilter, appLabelFilter, versionLabelFilter]);
   return (
     <td
       role="gridcell"
@@ -233,7 +234,7 @@ export const labels: Renderer<SortResource | NamespaceInfo> = (
         Object.entries(item.labels).map(([key, value]) => {
           const label = `${key}:${value}`;
           const labelAct = labelActivate(filters.filters, key, value);
-          const isExactlyLabelFilter = FilterHelper.getFiltersFromURL([LabelFilter]).filters.some(f =>
+          const isExactlyLabelFilter = FilterHelper.getFiltersFromURL([labelFilter]).filters.some(f =>
             f.value.includes(label)
           );
           const badgeComponent = (
@@ -247,8 +248,8 @@ export const labels: Renderer<SortResource | NamespaceInfo> = (
               onClick={() =>
                 statefulFilter
                   ? labelAct
-                    ? isExactlyLabelFilter && statefulFilter.current!.removeFilter(LabelFilter.title, label)
-                    : statefulFilter.current!.filterAdded(LabelFilter, label)
+                    ? isExactlyLabelFilter && statefulFilter.current!.removeFilter(labelFilter.id, label)
+                    : statefulFilter.current!.filterAdded(labelFilter, label)
                   : {}
               }
             >

--- a/src/helpers/LabelFilterHelper.ts
+++ b/src/helpers/LabelFilterHelper.ts
@@ -30,7 +30,6 @@ const orLabelOperation = (labels: { [key: string]: string }, filters: string[]):
           .trim()
           .split(',')
           .some(labelValue => labelValue.trim().startsWith(v.trim()));
-        console.log();
       }
       return undefined;
     });
@@ -69,8 +68,6 @@ const andLabelOperation = (labels: { [key: string]: string }, filters: string[])
         value.split(',').map(val => {
           // Split label values for serviceList Case where we can have multiple values for a label
           if (!labels[key].split(',').some(labelVal => labelVal.trim().startsWith(val.trim()))) {
-            console.log(labels[key].split(','));
-            console.log(val);
             filterOkForLabel = false;
           }
           return undefined;

--- a/src/pages/AppList/FiltersAndSorts.ts
+++ b/src/pages/AppList/FiltersAndSorts.ts
@@ -1,4 +1,4 @@
-import { ActiveFiltersInfo, FILTER_ACTION_APPEND, FilterType, LabelFilter } from '../../types/Filters';
+import { ActiveFiltersInfo, FILTER_ACTION_APPEND, FilterType } from '../../types/Filters';
 import { AppListItem } from '../../types/AppList';
 import { SortField } from '../../types/SortFilters';
 import { getRequestErrorsStatus, WithAppHealth, hasHealth } from '../../types/Health';
@@ -7,7 +7,8 @@ import {
   healthFilter,
   getPresenceFilterValue,
   getFilterSelectedValues,
-  filterByHealth
+  filterByHealth,
+  labelFilter
 } from '../../components/Filters/CommonFilters';
 import { hasMissingSidecar } from '../../components/VirtualList/Config';
 import { TextInputTypes } from '@patternfly/react-core';
@@ -84,7 +85,7 @@ const appNameFilter: FilterType = {
   filterValues: []
 };
 
-export const availableFilters: FilterType[] = [appNameFilter, istioSidecarFilter, healthFilter, LabelFilter];
+export const availableFilters: FilterType[] = [appNameFilter, istioSidecarFilter, healthFilter, labelFilter];
 
 /** Filter Method */
 
@@ -123,7 +124,7 @@ export const filterBy = (
     ret = filterByName(ret, appNamesSelected);
   }
 
-  const appLabelsSelected = getFilterSelectedValues(LabelFilter, filters);
+  const appLabelsSelected = getFilterSelectedValues(labelFilter, filters);
   if (appLabelsSelected.length > 0) {
     ret = filterByLabel(ret, appLabelsSelected, filters.op) as AppListItem[];
   }

--- a/src/pages/Overview/Filters.ts
+++ b/src/pages/Overview/Filters.ts
@@ -9,7 +9,6 @@ import { DEGRADED, FAILURE, HEALTHY } from '../../types/Health';
 import { NamespaceInfo } from './NamespaceInfo';
 import { MTLSStatuses } from '../../types/TLSStatus';
 import { TextInputTypes } from '@patternfly/react-core';
-import { LabelFilters } from '../../components/Filters/LabelFilter';
 
 export const nameFilter: FilterTypeWithFilter<NamespaceInfo> = {
   id: 'namespace_search',
@@ -55,7 +54,6 @@ export const labelFilter: FilterTypeWithFilter<NamespaceInfo> = {
   title: 'Namespace Label',
   placeholder: 'Filter by Label',
   filterType: FilterTypes.nsLabel,
-  customComponent: LabelFilters,
   action: FILTER_ACTION_APPEND,
   filterValues: [],
   filter: (namespaces: NamespaceInfo[], filters: ActiveFiltersInfo) => {
@@ -144,7 +142,7 @@ export const filterBy = (namespaces: NamespaceInfo[], filters: ActiveFiltersInfo
   let filteredNamespaces: NamespaceInfo[] = namespaces;
 
   availableFilters.forEach(availableFilter => {
-    const activeFilters = filters.filters.filter(af => af.category === availableFilter.title);
+    const activeFilters = filters.filters.filter(af => af.id === availableFilter.id);
     if (activeFilters.length) {
       filteredNamespaces = availableFilter.filter(filteredNamespaces, { filters: activeFilters, op: filters.op });
     }

--- a/src/pages/Overview/OverviewPage.tsx
+++ b/src/pages/Overview/OverviewPage.tsx
@@ -145,7 +145,7 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
     this.promises
       .register('namespaces', API.getNamespaces())
       .then(namespacesResponse => {
-        const nameFilters = FilterSelected.getSelected().filters.filter(f => f.category === Filters.nameFilter.title);
+        const nameFilters = FilterSelected.getSelected().filters.filter(f => f.id === Filters.nameFilter.id);
         const allNamespaces: NamespaceInfo[] = namespacesResponse.data
           .filter(ns => {
             return nameFilters.length === 0 || nameFilters.some(f => ns.name.includes(f.value));
@@ -469,7 +469,7 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
         content={
           <ul>
             {Object.entries(ns.labels || []).map(([key, value]) => (
-              <li>
+              <li key={key}>
                 {key}: {value}
               </li>
             ))}

--- a/src/pages/Overview/OverviewStatus.tsx
+++ b/src/pages/Overview/OverviewStatus.tsx
@@ -20,10 +20,10 @@ type Props = {
 
 class OverviewStatus extends React.Component<Props, {}> {
   setFilters = () => {
-    const filters: (ActiveFilter & { id: string })[] = [
+    const filters: ActiveFilter[] = [
       {
         id: healthFilter.id,
-        category: healthFilter.title,
+        title: healthFilter.title,
         value: this.props.status.name
       }
     ];

--- a/src/pages/Overview/__tests__/OverviewPage.test.tsx
+++ b/src/pages/Overview/__tests__/OverviewPage.test.tsx
@@ -11,6 +11,9 @@ import * as API from '../../../services/Api';
 import { AppHealth, NamespaceAppHealth, HEALTHY, FAILURE, DEGRADED } from '../../../types/Health';
 import { store } from '../../../store/ConfigStore';
 import { MTLSStatuses } from '../../../types/TLSStatus';
+import { FilterType, ActiveFiltersInfo } from 'types/Filters';
+import { healthFilter } from 'components/Filters/CommonFilters';
+import { nameFilter } from '../Filters';
 import { DEFAULT_LABEL_OPERATION } from '../../../types/Filters';
 
 const mockAPIToPromise = (func: keyof typeof API, obj: any, encapsData: boolean): Promise<void> => {
@@ -63,6 +66,26 @@ const mountPage = () => {
   );
 };
 
+const genActiveFilters = (filter: FilterType, values: string[]): ActiveFiltersInfo => {
+  return {
+    filters: values.map(v => {
+      return {
+        id: filter.id,
+        title: filter.filterType,
+        value: v
+      };
+    }),
+    op: 'or'
+  };
+};
+
+const concat = (f1: ActiveFiltersInfo, f2: ActiveFiltersInfo): ActiveFiltersInfo => {
+  return {
+    filters: f1.filters.concat(f2.filters),
+    op: f1.op
+  };
+};
+
 describe('Overview page', () => {
   beforeEach(() => {
     mounted = null;
@@ -102,15 +125,7 @@ describe('Overview page', () => {
   });
 
   it('filters failures match', done => {
-    FilterSelected.setSelected({
-      filters: [
-        {
-          category: 'Health',
-          value: 'Failure'
-        }
-      ],
-      op: DEFAULT_LABEL_OPERATION
-    });
+    FilterSelected.setSelected(genActiveFilters(healthFilter, ['Failure']));
     Promise.all([
       mockNamespaces(['a']),
       mockNamespaceHealth({
@@ -133,15 +148,7 @@ describe('Overview page', () => {
   });
 
   it('filters failures no match', done => {
-    FilterSelected.setSelected({
-      filters: [
-        {
-          category: 'Health',
-          value: 'Failure'
-        }
-      ],
-      op: DEFAULT_LABEL_OPERATION
-    });
+    FilterSelected.setSelected(genActiveFilters(healthFilter, ['Failure']));
     Promise.all([
       mockNamespaces(['a']),
       mockNamespaceHealth({
@@ -164,19 +171,7 @@ describe('Overview page', () => {
   });
 
   it('multi-filters health match', done => {
-    FilterSelected.setSelected({
-      filters: [
-        {
-          category: 'Health',
-          value: 'Failure'
-        },
-        {
-          category: 'Health',
-          value: 'Degraded'
-        }
-      ],
-      op: DEFAULT_LABEL_OPERATION
-    });
+    FilterSelected.setSelected(genActiveFilters(healthFilter, ['Failure', 'Degraded']));
     Promise.all([
       mockNamespaces(['a']),
       mockNamespaceHealth({
@@ -196,19 +191,7 @@ describe('Overview page', () => {
   });
 
   it('multi-filters health no match', done => {
-    FilterSelected.setSelected({
-      filters: [
-        {
-          category: 'Health',
-          value: 'Failure'
-        },
-        {
-          category: 'Health',
-          value: 'Degraded'
-        }
-      ],
-      op: DEFAULT_LABEL_OPERATION
-    });
+    FilterSelected.setSelected(genActiveFilters(healthFilter, ['Failure', 'Degraded']));
     Promise.all([
       mockNamespaces(['a']),
       mockNamespaceHealth({
@@ -228,15 +211,7 @@ describe('Overview page', () => {
   });
 
   it('filters namespaces info name match', done => {
-    FilterSelected.setSelected({
-      filters: [
-        {
-          category: 'Namespace',
-          value: 'bc'
-        }
-      ],
-      op: DEFAULT_LABEL_OPERATION
-    });
+    FilterSelected.setSelected(genActiveFilters(nameFilter, ['bc']));
     Promise.all([
       mockNamespaces(['abc', 'bce', 'ced']),
       mockNamespaceHealth({
@@ -253,15 +228,7 @@ describe('Overview page', () => {
   });
 
   it('filters namespaces info name no match', done => {
-    FilterSelected.setSelected({
-      filters: [
-        {
-          category: 'Namespace',
-          value: 'yz'
-        }
-      ],
-      op: DEFAULT_LABEL_OPERATION
-    });
+    FilterSelected.setSelected(genActiveFilters(nameFilter, ['yz']));
     mockNamespaces(['abc', 'bce', 'ced']).then(() => {
       mounted!.update();
       expect(mounted!.find('Card')).toHaveLength(0);
@@ -271,19 +238,9 @@ describe('Overview page', () => {
   });
 
   it('filters namespaces info name and health match', done => {
-    FilterSelected.setSelected({
-      filters: [
-        {
-          category: 'Namespace',
-          value: 'bc'
-        },
-        {
-          category: 'Health',
-          value: 'Healthy'
-        }
-      ],
-      op: DEFAULT_LABEL_OPERATION
-    });
+    FilterSelected.setSelected(
+      concat(genActiveFilters(nameFilter, ['bc']), genActiveFilters(healthFilter, ['Healthy']))
+    );
     Promise.all([
       mockNamespaces(['abc', 'bce', 'ced']),
       mockNamespaceHealth({
@@ -300,19 +257,9 @@ describe('Overview page', () => {
   });
 
   it('filters namespaces info name and health no match', done => {
-    FilterSelected.setSelected({
-      filters: [
-        {
-          category: 'Name',
-          value: 'bc'
-        },
-        {
-          category: 'Health',
-          value: 'Healthy'
-        }
-      ],
-      op: DEFAULT_LABEL_OPERATION
-    });
+    FilterSelected.setSelected(
+      concat(genActiveFilters(nameFilter, ['bc']), genActiveFilters(healthFilter, ['Healthy']))
+    );
     Promise.all([
       mockNamespaces(['abc', 'bce', 'ced']),
       mockNamespaceHealth({

--- a/src/pages/ServiceList/FiltersAndSorts.ts
+++ b/src/pages/ServiceList/FiltersAndSorts.ts
@@ -1,10 +1,11 @@
-import { ActiveFiltersInfo, FilterType, FILTER_ACTION_APPEND, LabelFilter } from '../../types/Filters';
+import { ActiveFiltersInfo, FilterType, FILTER_ACTION_APPEND } from '../../types/Filters';
 import { getRequestErrorsStatus, WithServiceHealth, hasHealth } from '../../types/Health';
 import { ServiceListItem } from '../../types/ServiceList';
 import { SortField } from '../../types/SortFilters';
 import {
   istioSidecarFilter,
   healthFilter,
+  labelFilter,
   getPresenceFilterValue,
   getFilterSelectedValues,
   filterByHealth
@@ -126,7 +127,7 @@ const serviceNameFilter: FilterType = {
   filterValues: []
 };
 
-export const availableFilters: FilterType[] = [serviceNameFilter, istioSidecarFilter, healthFilter, LabelFilter];
+export const availableFilters: FilterType[] = [serviceNameFilter, istioSidecarFilter, healthFilter, labelFilter];
 
 const filterByIstioSidecar = (items: ServiceListItem[], istioSidecar: boolean): ServiceListItem[] => {
   return items.filter(item => item.istioSidecar === istioSidecar);
@@ -163,7 +164,7 @@ export const filterBy = (
     ret = filterByName(ret, serviceNamesSelected);
   }
 
-  const serviceFilterSelected = getFilterSelectedValues(LabelFilter, filters);
+  const serviceFilterSelected = getFilterSelectedValues(labelFilter, filters);
   if (serviceFilterSelected.length > 0) {
     ret = filterByLabel(ret, serviceFilterSelected, filters.op) as ServiceListItem[];
   }

--- a/src/pages/WorkloadList/FiltersAndSorts.ts
+++ b/src/pages/WorkloadList/FiltersAndSorts.ts
@@ -3,8 +3,7 @@ import {
   FILTER_ACTION_APPEND,
   FILTER_ACTION_UPDATE,
   FilterType,
-  FilterTypes,
-  LabelFilter
+  FilterTypes
 } from '../../types/Filters';
 import { WorkloadListItem, WorkloadType } from '../../types/Workload';
 import { SortField } from '../../types/SortFilters';
@@ -13,6 +12,7 @@ import {
   presenceValues,
   istioSidecarFilter,
   healthFilter,
+  labelFilter,
   getFilterSelectedValues,
   getPresenceFilterValue,
   filterByHealth
@@ -251,7 +251,7 @@ export const availableFilters: FilterType[] = [
   healthFilter,
   appLabelFilter,
   versionLabelFilter,
-  LabelFilter
+  labelFilter
 ];
 
 /** Filter Method */
@@ -306,7 +306,7 @@ export const filterBy = (
   const istioSidecar = getPresenceFilterValue(istioSidecarFilter, filters);
   const appLabel = getPresenceFilterValue(appLabelFilter, filters);
   const versionLabel = getPresenceFilterValue(versionLabelFilter, filters);
-  const labelFilters = getFilterSelectedValues(LabelFilter, filters);
+  const labelFilters = getFilterSelectedValues(labelFilter, filters);
 
   let ret = items;
   ret = filterByType(ret, workloadTypeFilters);

--- a/src/types/Filters.ts
+++ b/src/types/Filters.ts
@@ -1,5 +1,4 @@
 import { TextInputTypes } from '@patternfly/react-core';
-import { LabelFilters } from '../components/Filters/LabelFilter';
 
 // FilterValue maps a Patternfly property. Modify with care.
 export interface FilterValue {
@@ -27,7 +26,6 @@ export interface FilterType {
   title: string;
   placeholder: string;
   filterType: FilterTypes;
-  customComponent?: any;
   action: string;
   filterValues: FilterValue[];
   loader?: () => Promise<FilterValue[]>;
@@ -41,7 +39,8 @@ export const FILTER_ACTION_APPEND = 'append';
 export const FILTER_ACTION_UPDATE = 'update';
 
 export interface ActiveFilter {
-  category: string;
+  id: string;
+  title: string;
   value: string;
 }
 
@@ -53,15 +52,3 @@ export interface ActiveFiltersInfo {
   filters: ActiveFilter[];
   op: LabelOperation;
 }
-
-// labelFilter common to lists
-
-export const LabelFilter: FilterType = {
-  id: 'label',
-  title: 'Label',
-  placeholder: 'Filter by Label',
-  filterType: FilterTypes.label,
-  customComponent: LabelFilters,
-  action: FILTER_ACTION_APPEND,
-  filterValues: []
-};

--- a/src/utils/Common.ts
+++ b/src/utils/Common.ts
@@ -16,3 +16,13 @@ export const arrayEquals = <T>(a1: T[], a2: T[], comparator: (v1: T, v2: T) => b
 
 export const namespaceEquals = (ns1: Namespace[], ns2: Namespace[]): boolean =>
   arrayEquals(ns1, ns2, (n1, n2) => n1.name === n2.name);
+
+export function groupBy<T>(items: T[], key: keyof T): { [key: string]: T[] } {
+  return items.reduce(
+    (result, item) => ({
+      ...result,
+      [item[key as string]]: [...(result[item[key as string]] || []), item]
+    }),
+    {} as { [key: string]: T[] }
+  );
+}

--- a/src/utils/__tests__/Common.test.ts
+++ b/src/utils/__tests__/Common.test.ts
@@ -1,4 +1,4 @@
-import { removeDuplicatesArray } from '../Common';
+import { removeDuplicatesArray, groupBy } from '../Common';
 
 const arrayDuplicates = ['bookinfo', 'default', 'bookinfo'];
 const arrayNoDuplicates = ['bookinfo', 'default'];
@@ -12,5 +12,41 @@ describe('Unique elements in Array', () => {
   it('should return the same array', () => {
     expect(removeDuplicatesArray(arrayNoDuplicates)).toEqual(arrayNoDuplicates);
     expect(removeDuplicatesArray(arrayNoDuplicates).length).toEqual(arrayNoDuplicates.length);
+  });
+});
+
+describe('Group by', () => {
+  const arr = [
+    {
+      id: '1',
+      value: 'foo'
+    },
+    {
+      id: '2',
+      value: 'bar'
+    },
+    {
+      id: '3',
+      value: 'foo'
+    }
+  ];
+
+  it('should group by id', () => {
+    const grouped = groupBy(arr, 'id');
+    expect(grouped['1']).toHaveLength(1);
+    expect(grouped['1'][0]).toEqual(arr[0]);
+    expect(grouped['2']).toHaveLength(1);
+    expect(grouped['2'][0]).toEqual(arr[1]);
+    expect(grouped['3']).toHaveLength(1);
+    expect(grouped['3'][0]).toEqual(arr[2]);
+  });
+
+  it('should group by value', () => {
+    const grouped = groupBy(arr, 'value');
+    expect(grouped['foo']).toHaveLength(2);
+    expect(grouped['foo'][0]).toEqual(arr[0]);
+    expect(grouped['foo'][1]).toEqual(arr[2]);
+    expect(grouped['bar']).toHaveLength(1);
+    expect(grouped['bar'][0]).toEqual(arr[1]);
   });
 });


### PR DESCRIPTION
This triggered some refactoring:
- New ActiveFilter "title" field
- Some simplification in StatefulFilters
- More typing: "groupBy" function, LabelFilters explicit call to avoid 'any'
- Move labelFilter type to CommonFilters.ts

Fixes https://github.com/kiali/kiali/issues/2785
