### PR TITLE
Show message if Kiali is configured with LDAP or login strategy for authentication

### DIFF
--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -178,7 +178,16 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
       messages.push(
         this.renderMessage(
           `Authentication with LDAP strategy is deprecated and will be removed in a following release.
-        As an alternative, use "openid" strategy using an OpenId provider with an LDAP connector.`,
+        As an alternative, use the "openid" strategy using an OpenId provider with an LDAP connector.`,
+          'warning'
+        )
+      );
+    }
+    if (authenticationConfig.strategy == AuthStrategy.login) {
+      messages.push(
+        this.renderMessage(
+          `Authentication with "login" strategy is deprecated and will be removed in a following release.
+          As an alternative, use the "token" strategy.`,
           'warning'
         )
       );

--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -174,7 +174,7 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
     if (this.props.postLoginErrorMsg) {
       messages.push(this.renderMessage(this.props.postLoginErrorMsg));
     }
-    if (authenticationConfig.strategy == AuthStrategy.ldap) {
+    if (authenticationConfig.strategy === AuthStrategy.ldap) {
       messages.push(
         this.renderMessage(
           `Authentication with LDAP strategy is deprecated and will be removed in a following release.
@@ -183,7 +183,7 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
         )
       );
     }
-    if (authenticationConfig.strategy == AuthStrategy.login) {
+    if (authenticationConfig.strategy === AuthStrategy.login) {
       messages.push(
         this.renderMessage(
           `Authentication with "login" strategy is deprecated and will be removed in a following release.

--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -174,6 +174,15 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
     if (this.props.postLoginErrorMsg) {
       messages.push(this.renderMessage(this.props.postLoginErrorMsg));
     }
+    if (authenticationConfig.strategy == AuthStrategy.ldap) {
+      messages.push(
+        this.renderMessage(
+          `Authentication with LDAP strategy is deprecated and will be removed in a following release.
+        As an alternative, use "openid" strategy using an OpenId provider with an LDAP connector.`,
+          'warning'
+        )
+      );
+    }
     return messages;
   };
 

--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -130,7 +130,7 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
       }
     }
   };
-  renderMessage = (message: string | undefined, type?: string) => {
+  renderMessage = (message: React.ReactNode | undefined, type: string | undefined, key: string) => {
     if (!message) {
       return '';
     }
@@ -141,10 +141,7 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
       : 'warning';
     const icon = variant === 'danger' ? <ExclamationCircleIcon /> : <ExclamationTriangleIcon />;
     return (
-      <span
-        key={message}
-        style={{ color: variant === 'danger' ? '#c00' : '#f0ab00', fontWeight: 'bold', fontSize: 16 }}
-      >
+      <span key={key} style={{ color: variant === 'danger' ? '#c00' : '#f0ab00', fontWeight: 'bold', fontSize: 16 }}>
         {icon}
         &nbsp; {message}
       </span>
@@ -154,41 +151,56 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
   getHelperMessage = () => {
     const messages: any[] = [];
     if (this.state.showHelperText) {
-      messages.push(this.renderMessage(this.state.errorInput));
+      messages.push(this.renderMessage(this.state.errorInput, undefined, 'helperText'));
     }
     if (authenticationConfig.secretMissing) {
       messages.push(
         this.renderMessage(
           `The Kiali secret is missing. Users are prohibited from accessing Kiali until an administrator
           creates a valid secret. Please refer to the Kiali documentation for more details.`,
-          'danger'
+          'danger',
+          'secretMissing'
         )
       );
     }
     if (this.props.status === LoginStatus.expired) {
-      messages.push(this.renderMessage('Your session has expired or was terminated in another window.', 'warning'));
+      messages.push(
+        this.renderMessage('Your session has expired or was terminated in another window.', 'warning', 'sessionExpired')
+      );
     }
     if (!authenticationConfig.secretMissing && this.props.status === LoginStatus.error) {
       messages.push(this.props.message);
     }
     if (this.props.postLoginErrorMsg) {
-      messages.push(this.renderMessage(this.props.postLoginErrorMsg));
+      messages.push(this.renderMessage(this.props.postLoginErrorMsg, undefined, 'postLoginError'));
     }
     if (authenticationConfig.strategy === AuthStrategy.ldap) {
       messages.push(
         this.renderMessage(
-          `Authentication with LDAP strategy is deprecated and will be removed in a following release.
-        As an alternative, use the "openid" strategy using an OpenId provider with an LDAP connector.`,
-          'warning'
+          <>
+            Authentication with LDAP strategy is deprecated and will be removed in a following release. As an
+            alternative, use the "openid" strategy using an OpenId provider with an LDAP connector. See{' '}
+            <a href="https://kiali.io/news/release-notes/#_1_19_0" target="_blank" rel="noreferrer noopener">
+              release notes for version 1.19.
+            </a>
+          </>,
+          'warning',
+          'deprecatedLdap'
         )
       );
     }
     if (authenticationConfig.strategy === AuthStrategy.login) {
       messages.push(
         this.renderMessage(
-          `Authentication with "login" strategy is deprecated and will be removed in a following release.
-          As an alternative, use the "token" strategy.`,
-          'warning'
+          <>
+            Authentication with "login" strategy is deprecated and will be removed in a following release. As an
+            alternative, use the "token" strategy. See{' '}
+            <a href="https://kiali.io/news/release-notes/#_1_19_0" target="_blank" rel="noreferrer noopener">
+              release notes for version 1.19.
+            </a>
+          </>,
+          'warning',
+          'deprecatedLogin'
         )
       );
     }

--- a/src/pages/Login/__tests__/__snapshots__/LoginPage.test.tsx.snap
+++ b/src/pages/Login/__tests__/__snapshots__/LoginPage.test.tsx.snap
@@ -27,7 +27,29 @@ exports[`#LoginPage render correctly should render LoginPage 1`] = `
   textContent="Service Mesh Observability."
 >
   <LoginForm
-    helperText={<React.Fragment />}
+    helperText={
+      <React.Fragment>
+        <span
+          style={
+            Object {
+              "color": "#f0ab00",
+              "fontSize": 16,
+              "fontWeight": "bold",
+            }
+          }
+        >
+          <ExclamationTriangleIcon
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
+            title={null}
+          />
+            
+          Authentication with "login" strategy is deprecated and will be removed in a following release.
+          As an alternative, use the "token" strategy.
+        </span>
+      </React.Fragment>
+    }
     isLoginButtonDisabled={false}
     isValidPassword={true}
     isValidUsername={true}

--- a/src/pages/Login/__tests__/__snapshots__/LoginPage.test.tsx.snap
+++ b/src/pages/Login/__tests__/__snapshots__/LoginPage.test.tsx.snap
@@ -45,8 +45,17 @@ exports[`#LoginPage render correctly should render LoginPage 1`] = `
             title={null}
           />
             
-          Authentication with "login" strategy is deprecated and will be removed in a following release.
-          As an alternative, use the "token" strategy.
+          <React.Fragment>
+            Authentication with "login" strategy is deprecated and will be removed in a following release. As an alternative, use the "token" strategy. See
+             
+            <a
+              href="https://kiali.io/news/release-notes/#_1_19_0"
+              rel="noreferrer noopener"
+              target="_blank"
+            >
+              release notes for version 1.19.
+            </a>
+          </React.Fragment>
         </span>
       </React.Fragment>
     }


### PR DESCRIPTION
Results on the following when LDAP is configured:

![image](https://user-images.githubusercontent.com/23639005/83816413-f4700800-a687-11ea-9ba3-52bfc41f9857.png)

Results on the following when "login" is configured:

![image](https://user-images.githubusercontent.com/23639005/83816404-efab5400-a687-11ea-9130-b029a1be70f8.png)

Part of kiali/kiali#2863, kiali/kiali#2862.