### PR TITLE
Fix bug in Hide logs when backspace or delete is used to reset 

### DIFF
--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
@@ -398,6 +398,7 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
 
   private handleHideLogLines = (filterValue: string) => {
     if (filterValue === '') {
+      this.clearHide();
       this.setState({ showClearHideLogButton: false });
     }
     if (filterValue !== '' && this.state.appLogs?.logs && this.state.proxyLogs?.logs) {


### PR DESCRIPTION
Fix bug in Hide logs when `backspace` or `delete` is used to reset the hide filter. 
Note: using the 'x' already does the proper resetting of the hide filter.


** Issue reference **
fixes: https://github.com/kiali/kiali/issues/2878

** Screenshot **


![hide-fix](https://user-images.githubusercontent.com/1312165/84084666-b9781800-a998-11ea-873d-1eb725837612.gif)
