### PR TITLE
Remove subtypes. Add Instances/Handlers

### DIFF
--- a/src/components/Link/IstioObjectLink.tsx
+++ b/src/components/Link/IstioObjectLink.tsx
@@ -12,21 +12,11 @@ interface Props {
   query?: string;
 }
 
-export const GetIstioObjectUrl = (
-  name: string,
-  namespace: string,
-  type: string,
-  subType?: string,
-  query?: string
-): string => {
+export const GetIstioObjectUrl = (name: string, namespace: string, type: string, query?: string): string => {
   const istioType = IstioTypes[type];
   let to = '/namespaces/' + namespace + '/' + Paths.ISTIO;
 
-  if (!!subType) {
-    to = to + '/' + istioType + '/' + subType + '/' + name;
-  } else {
-    to = to + '/' + istioType.url + '/' + name;
-  }
+  to = to + '/' + istioType.url + '/' + name;
 
   if (!!query) {
     to = to + '?' + query;
@@ -55,9 +45,9 @@ export class ReferenceIstioObjectLink extends React.Component<Props> {
 
 class IstioObjectLink extends React.Component<Props> {
   render() {
-    const { name, namespace, type, subType, query } = this.props;
+    const { name, namespace, type, query } = this.props;
 
-    return <Link to={GetIstioObjectUrl(name, namespace, type, subType, query)}>{this.props.children}</Link>;
+    return <Link to={GetIstioObjectUrl(name, namespace, type, query)}>{this.props.children}</Link>;
   }
 }
 

--- a/src/components/VirtualList/Config.ts
+++ b/src/components/VirtualList/Config.ts
@@ -172,6 +172,8 @@ export const IstioTypes = {
   rule: { name: 'Rule', url: 'rules', icon: 'R' },
   adapter: { name: 'Adapter', url: 'adapters', icon: 'A' },
   template: { name: 'Template', url: 'templates', icon: 'T' },
+  instance: { name: 'Instance', url: 'instances', icon: 'I' },
+  handler: { name: 'Handler', url: 'handlers', icon: 'H' },
   quotaspec: { name: 'QuotaSpec', url: 'quotaspecs', icon: 'QS' },
   quotaspecbinding: { name: 'QuotaSpecBinding', url: 'quotaspecbindings', icon: 'QSB' },
   policy: { name: 'Policy', url: 'policies', icon: 'P' },

--- a/src/components/VirtualList/Renderers.tsx
+++ b/src/components/VirtualList/Renderers.tsx
@@ -35,14 +35,8 @@ const getLink = (item: TResource, config: Resource, query?: string) => {
 
 const getIstioLink = (item: TResource) => {
   const type = item['type'];
-  let subType;
 
-  // Adapters and Templates need to pass subtype
-  if (type === 'adapter' || type === 'template') {
-    subType = type === 'adapter' ? item['adapter']!.adapters : item['template']!.templates;
-  }
-
-  return GetIstioObjectUrl(item.name, item.namespace, type, subType);
+  return GetIstioObjectUrl(item.name, item.namespace, type);
 };
 
 // Cells
@@ -312,7 +306,7 @@ export const istioType: Renderer<IstioConfigItem> = (item: IstioConfigItem) => {
       key={'VirtuaItem_IstioType_' + item.namespace + '_' + item.name}
       style={{ verticalAlign: 'middle' }}
     >
-      {type === 'adapter' || type === 'template' ? `${object.name}: ${item[type]![type]}` : object.name}
+      {object.name}
     </td>
   );
 };

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -105,12 +105,8 @@ const conf = {
       grafana: 'api/grafana',
       istioConfig: (namespace: string) => `api/namespaces/${namespace}/istio`,
       istioConfigCreate: (namespace: string, objectType: string) => `api/namespaces/${namespace}/istio/${objectType}`,
-      istioConfigCreateSubtype: (namespace: string, objectType: string, objectSubtype: string) =>
-        `api/namespaces/${namespace}/istio/${objectType}/${objectSubtype}`,
       istioConfigDetail: (namespace: string, objectType: string, object: string) =>
         `api/namespaces/${namespace}/istio/${objectType}/${object}`,
-      istioConfigDetailSubtype: (namespace: string, objectType: string, objectSubtype: string, object: string) =>
-        `api/namespaces/${namespace}/istio/${objectType}/${objectSubtype}/${object}`,
       iter8: `api/iter8`,
       iter8Metrics: 'api/iter8/metrics',
       iter8Experiments: `api/iter8/experiments`,

--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -118,9 +118,7 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
   };
 
   newIstioObjectPromise = (props: IstioConfigId, validate: boolean) => {
-    return props.objectSubtype
-      ? API.getIstioConfigDetailSubtype(props.namespace, props.objectType, props.objectSubtype, props.object)
-      : API.getIstioConfigDetail(props.namespace, props.objectType, props.object, validate);
+    return API.getIstioConfigDetail(props.namespace, props.objectType, props.object, validate);
   };
 
   fetchIstioObjectDetailsFromProps = (props: IstioConfigId) => {
@@ -268,19 +266,11 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
   };
 
   onDelete = () => {
-    const deletePromise = this.props.match.params.objectSubtype
-      ? API.deleteIstioConfigDetailSubtype(
-          this.props.match.params.namespace,
-          this.props.match.params.objectType,
-          this.props.match.params.objectSubtype,
-          this.props.match.params.object
-        )
-      : API.deleteIstioConfigDetail(
-          this.props.match.params.namespace,
-          this.props.match.params.objectType,
-          this.props.match.params.object
-        );
-    deletePromise
+    API.deleteIstioConfigDetail(
+      this.props.match.params.namespace,
+      this.props.match.params.objectType,
+      this.props.match.params.object
+    )
       .then(() => this.backToList())
       .catch(error => {
         AlertUtils.addError('Could not delete IstioConfig details.', error);
@@ -290,21 +280,12 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
   onUpdate = () => {
     jsYaml.safeLoadAll(this.state.yamlModified, (objectModified: object) => {
       const jsonPatch = JSON.stringify(mergeJsonPatch(objectModified, getIstioObject(this.state.istioObjectDetails)));
-      const updatePromise = this.props.match.params.objectSubtype
-        ? API.updateIstioConfigDetailSubtype(
-            this.props.match.params.namespace,
-            this.props.match.params.objectType,
-            this.props.match.params.objectSubtype,
-            this.props.match.params.object,
-            jsonPatch
-          )
-        : API.updateIstioConfigDetail(
-            this.props.match.params.namespace,
-            this.props.match.params.objectType,
-            this.props.match.params.object,
-            jsonPatch
-          );
-      updatePromise
+      API.updateIstioConfigDetail(
+        this.props.match.params.namespace,
+        this.props.match.params.objectType,
+        this.props.match.params.object,
+        jsonPatch
+      )
         .then(() => {
           const targetMessage =
             this.props.match.params.namespace +

--- a/src/pages/IstioConfigList/FiltersAndSorts.ts
+++ b/src/pages/IstioConfigList/FiltersAndSorts.ts
@@ -2,14 +2,6 @@ import { SortField } from '../../types/SortFilters';
 import { IstioConfigItem } from '../../types/IstioConfigList';
 import { FILTER_ACTION_APPEND, FilterType, FilterTypes } from '../../types/Filters';
 
-export const getType = (item: IstioConfigItem): string => {
-  return item.type === 'adapter'
-    ? item.type + '_' + item.adapter!.adapter
-    : item.type === 'template'
-    ? item.type + '_' + item.template!.template
-    : item.type;
-};
-
 export const sortFields: SortField<IstioConfigItem>[] = [
   {
     id: 'namespace',
@@ -26,7 +18,7 @@ export const sortFields: SortField<IstioConfigItem>[] = [
     isNumeric: false,
     param: 'it',
     compare: (a: IstioConfigItem, b: IstioConfigItem) => {
-      return getType(a).localeCompare(getType(b)) || a.name.localeCompare(b.name);
+      return a.type.localeCompare(b.type) || a.name.localeCompare(b.name);
     }
   },
   {
@@ -38,9 +30,7 @@ export const sortFields: SortField<IstioConfigItem>[] = [
       // On same name order is not well defined, we need some fallback methods
       // This happens specially on adapters/templates where Istio 1.0.x calls them "handler"
       // So, we have a lot of objects with same namespace+name
-      return (
-        a.name.localeCompare(b.name) || a.namespace.localeCompare(b.namespace) || getType(a).localeCompare(getType(b))
-      );
+      return a.name.localeCompare(b.name) || a.namespace.localeCompare(b.namespace) || a.type.localeCompare(b.type);
     }
   },
   {
@@ -118,12 +108,20 @@ export const istioTypeFilter: FilterType = {
       title: 'Gateway'
     },
     {
+      id: 'Handler',
+      title: 'Handler'
+    },
+    {
       id: 'HTTPAPISpec',
       title: 'HTTPAPISpec'
     },
     {
       id: 'HTTPAPISpecBinding',
       title: 'HTTPAPISpecBinding'
+    },
+    {
+      id: 'Instance',
+      title: 'Instance'
     },
     {
       id: 'MeshPolicy',

--- a/src/pages/IstioConfigList/__tests__/IstioConfigListComponent.test.ts
+++ b/src/pages/IstioConfigList/__tests__/IstioConfigListComponent.test.ts
@@ -14,6 +14,8 @@ const mockIstioConfigList = (names: string[]): IstioConfigList => {
     rules: [],
     adapters: [],
     templates: [],
+    handlers: [],
+    instances: [],
     quotaSpecs: [],
     quotaSpecBindings: [],
     policies: [],
@@ -44,14 +46,10 @@ const mockIstioConfigList = (names: string[]): IstioConfigList => {
     testData.rules.push({ metadata: { name: name + '4' }, spec: { match: '', actions: [] } });
     testData.adapters.push({
       metadata: { name: name + '5' },
-      adapter: name + '5',
-      adapters: name + '5',
       spec: ''
     });
     testData.templates.push({
       metadata: { name: name + '6' },
-      template: name + '6',
-      templates: name + '6',
       spec: ''
     });
     testData.quotaSpecs.push({ metadata: { name: name + '7' }, spec: {} });
@@ -63,6 +61,8 @@ const mockIstioConfigList = (names: string[]): IstioConfigList => {
     testData.serviceRoleBindings.push({ metadata: { name: name + '13' }, spec: {} });
     testData.rbacConfigs.push({ metadata: { name: name + '14' }, spec: {} });
     testData.authorizationPolicies.push({ metadata: { name: name + '15' }, spec: {} });
+    testData.handlers.push({ metadata: { name: name + '16' }, spec: {} });
+    testData.instances.push({ metadata: { name: name + '17' }, spec: {} });
   });
   return testData;
 };
@@ -128,7 +128,7 @@ describe('IstioConfigListContainer#toIstioItems', () => {
     const istioItems = toIstioItems(unfiltered);
 
     expect(istioItems).toBeDefined();
-    expect(istioItems.length).toBe(48);
+    expect(istioItems.length).toBe(54);
     expect(istioItems[0].gateway).toBeDefined();
     expect(istioItems[0].destinationRule).toBeUndefined();
     expect(istioItems[3].virtualService).toBeDefined();
@@ -146,7 +146,7 @@ describe('IstioConfigComponent#sortIstioItems', () => {
 
     return IstioConfigListFilters.sortIstioItems(istioItems, sortField, isAscending).then(sorted => {
       expect(sorted).toBeDefined();
-      expect(sorted.length).toBe(48);
+      expect(sorted.length).toBe(54);
 
       const first = sorted[0];
       expect(first.gateway).toBeDefined();
@@ -156,7 +156,7 @@ describe('IstioConfigComponent#sortIstioItems', () => {
       expect(second.virtualService).toBeDefined();
       expect(second.virtualService!.metadata.name).toBe('blue1');
 
-      const last = sorted[47];
+      const last = sorted[53];
       expect(last.policy).toBeDefined();
       expect(last.policy!.metadata.name).toBe('white9');
     });
@@ -170,13 +170,13 @@ describe('IstioConfigComponent#sortIstioItems', () => {
     // Descending
     return IstioConfigListFilters.sortIstioItems(istioItems, sortField, isAscending).then(sorted => {
       expect(sorted).toBeDefined();
-      expect(sorted.length).toBe(48);
+      expect(sorted.length).toBe(54);
 
       const first = sorted[0];
       expect(first.policy).toBeDefined();
       expect(first.policy!.metadata.name).toBe('white9');
 
-      const last = sorted[47];
+      const last = sorted[53];
       expect(last.gateway).toBeDefined();
       expect(last.gateway!.metadata.name).toBe('blue0');
     });
@@ -189,7 +189,7 @@ describe('IstioConfigComponent#sortIstioItems', () => {
 
     return IstioConfigListFilters.sortIstioItems(istioItems, sortField, isAscending).then(sorted => {
       expect(sorted).toBeDefined();
-      expect(sorted.length).toBe(48);
+      expect(sorted.length).toBe(54);
 
       const first = sorted[0];
       expect(first.adapter).toBeDefined();
@@ -199,7 +199,7 @@ describe('IstioConfigComponent#sortIstioItems', () => {
       expect(second.authorizationPolicy).toBeDefined();
       expect(second.authorizationPolicy!.metadata.name).toBe('blue15');
 
-      const last = sorted[47];
+      const last = sorted[53];
       expect(last.virtualService).toBeDefined();
       expect(last.virtualService!.metadata.name).toBe('white1');
     });
@@ -212,7 +212,7 @@ describe('IstioConfigComponent#sortIstioItems', () => {
 
     return IstioConfigListFilters.sortIstioItems(istioItems, sortField, isAscending).then(sorted => {
       expect(sorted).toBeDefined();
-      expect(sorted.length).toBe(48);
+      expect(sorted.length).toBe(54);
 
       const first = sorted[0];
       expect(first.virtualService).toBeDefined();

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -151,36 +151,8 @@ export const getIstioConfigDetail = (namespace: string, objectType: string, obje
   );
 };
 
-export const getIstioConfigDetailSubtype = (
-  namespace: string,
-  objectType: string,
-  objectSubtype: string,
-  object: string
-) => {
-  return newRequest<IstioConfigDetails>(
-    HTTP_VERBS.GET,
-    urls.istioConfigDetailSubtype(namespace, objectType, objectSubtype, object),
-    {},
-    {}
-  );
-};
-
 export const deleteIstioConfigDetail = (namespace: string, objectType: string, object: string) => {
   return newRequest<string>(HTTP_VERBS.DELETE, urls.istioConfigDetail(namespace, objectType, object), {}, {});
-};
-
-export const deleteIstioConfigDetailSubtype = (
-  namespace: string,
-  objectType: string,
-  objectSubtype: string,
-  object: string
-) => {
-  return newRequest<string>(
-    HTTP_VERBS.DELETE,
-    urls.istioConfigDetailSubtype(namespace, objectType, objectSubtype, object),
-    {},
-    {}
-  );
 };
 
 export const updateIstioConfigDetail = (
@@ -192,36 +164,12 @@ export const updateIstioConfigDetail = (
   return newRequest(HTTP_VERBS.PATCH, urls.istioConfigDetail(namespace, objectType, object), {}, jsonPatch);
 };
 
-export const updateIstioConfigDetailSubtype = (
-  namespace: string,
-  objectType: string,
-  objectSubtype: string,
-  object: string,
-  jsonPatch: string
-): Promise<Response<string>> => {
-  return newRequest(
-    HTTP_VERBS.PATCH,
-    urls.istioConfigDetailSubtype(namespace, objectType, objectSubtype, object),
-    {},
-    jsonPatch
-  );
-};
-
 export const createIstioConfigDetail = (
   namespace: string,
   objectType: string,
   json: string
 ): Promise<Response<string>> => {
   return newRequest(HTTP_VERBS.POST, urls.istioConfigCreate(namespace, objectType), {}, json);
-};
-
-export const createIstioConfigDetailSubtype = (
-  namespace: string,
-  objectType: string,
-  objectSubtype: string,
-  json: string
-): Promise<Response<string>> => {
-  return newRequest(HTTP_VERBS.POST, urls.istioConfigCreateSubtype(namespace, objectType, objectSubtype), {}, json);
 };
 
 export const getServices = (namespace: string) => {

--- a/src/types/IstioConfigDetails.ts
+++ b/src/types/IstioConfigDetails.ts
@@ -27,7 +27,9 @@ import {
   EnvoyFilter,
   AttributeManifest,
   HTTPAPISpec,
-  HTTPAPISpecBinding
+  HTTPAPISpecBinding,
+  IstioHandler,
+  IstioInstance
 } from './IstioObjects';
 
 export interface IstioConfigId {
@@ -49,6 +51,8 @@ export interface IstioConfigDetails {
   rule: IstioRule;
   adapter: IstioAdapter;
   template: IstioTemplate;
+  handler: IstioHandler;
+  instance: IstioInstance;
   quotaSpec: QuotaSpec;
   quotaSpecBinding: QuotaSpecBinding;
   attributeManifest: AttributeManifest;

--- a/src/types/IstioConfigList.ts
+++ b/src/types/IstioConfigList.ts
@@ -260,8 +260,6 @@ export const toIstioItems = (istioConfigList: IstioConfigList): IstioConfigItem[
       return;
     }
 
-    console.log('TODELETE field: ' + field);
-
     const typeNameProto = dicIstioType[field.toLowerCase()]; // ex. serviceEntries -> ServiceEntry
     const typeName = typeNameProto.toLowerCase(); // ex. ServiceEntry -> serviceentry
     const entryName = typeNameProto.charAt(0).toLowerCase() + typeNameProto.slice(1);

--- a/src/types/IstioConfigList.ts
+++ b/src/types/IstioConfigList.ts
@@ -10,6 +10,8 @@ import {
   HTTPAPISpec,
   HTTPAPISpecBinding,
   IstioAdapter,
+  IstioHandler,
+  IstioInstance,
   IstioRule,
   IstioTemplate,
   ObjectValidation,
@@ -42,6 +44,8 @@ export interface IstioConfigItem {
   rule?: IstioRule;
   adapter?: IstioAdapter;
   template?: IstioTemplate;
+  handler?: IstioHandler;
+  instance?: IstioInstance;
   quotaSpec?: QuotaSpec;
   quotaSpecBinding?: QuotaSpecBinding;
   policy?: Policy;
@@ -75,6 +79,8 @@ export interface IstioConfigList {
   rules: IstioRule[];
   adapters: IstioAdapter[];
   templates: IstioTemplate[];
+  instances: IstioInstance[];
+  handlers: IstioHandler[];
   quotaSpecs: QuotaSpec[];
   quotaSpecBindings: QuotaSpecBinding[];
   attributeManifests: AttributeManifest[];
@@ -105,6 +111,8 @@ export const dicIstioType = {
   Rule: 'rules',
   Adapter: 'adapters',
   Template: 'templates',
+  Handler: 'handlers',
+  Instance: 'instances',
   QuotaSpec: 'quotaspecs',
   QuotaSpecBinding: 'quotaspecbindings',
   Policy: 'policies',
@@ -132,8 +140,8 @@ export const dicIstioType = {
   templates: 'Template',
   quotaspecs: 'QuotaSpec',
   quotaspecbindings: 'QuotaSpecBinding',
-  instance: 'Instance',
-  handler: 'Handler',
+  instances: 'Instance',
+  handlers: 'Handler',
   policies: 'Policy',
   meshpolicies: 'MeshPolicy',
   clusterrbacconfigs: 'ClusterRbacConfig',
@@ -181,6 +189,8 @@ export const filterByName = (unfiltered: IstioConfigList, names: string[]): Isti
     rules: unfiltered.rules.filter(r => includeName(r.metadata.name, names)),
     adapters: unfiltered.adapters.filter(r => includeName(r.metadata.name, names)),
     templates: unfiltered.templates.filter(r => includeName(r.metadata.name, names)),
+    handlers: unfiltered.handlers.filter(r => includeName(r.metadata.name, names)),
+    instances: unfiltered.instances.filter(r => includeName(r.metadata.name, names)),
     quotaSpecs: unfiltered.quotaSpecs.filter(qs => includeName(qs.metadata.name, names)),
     quotaSpecBindings: unfiltered.quotaSpecBindings.filter(qsb => includeName(qsb.metadata.name, names)),
     policies: unfiltered.policies.filter(p => includeName(p.metadata.name, names)),
@@ -249,6 +259,8 @@ export const toIstioItems = (istioConfigList: IstioConfigList): IstioConfigItem[
       // These items do not belong to the IstioConfigItem[]
       return;
     }
+
+    console.log('TODELETE field: ' + field);
 
     const typeNameProto = dicIstioType[field.toLowerCase()]; // ex. serviceEntries -> ServiceEntry
     const typeName = typeNameProto.toLowerCase(); // ex. ServiceEntry -> serviceentry

--- a/src/types/IstioObjects.ts
+++ b/src/types/IstioObjects.ts
@@ -615,14 +615,18 @@ export interface IstioRuleActionItem {
 
 export interface IstioAdapter extends IstioObject {
   spec: any;
-  adapter: string;
-  adapters: string;
 }
 
 export interface IstioTemplate extends IstioObject {
   spec: any;
-  template: string;
-  templates: string;
+}
+
+export interface IstioHandler extends IstioObject {
+  spec: any;
+}
+
+export interface IstioInstance extends IstioObject {
+  spec: any;
 }
 
 export interface QuotaSpecSpec {

--- a/src/utils/IstioConfigUtils.ts
+++ b/src/utils/IstioConfigUtils.ts
@@ -40,6 +40,10 @@ export const getIstioObject = (istioObjectDetails?: IstioConfigDetails) => {
       istioObject = istioObjectDetails.adapter;
     } else if (istioObjectDetails.template) {
       istioObject = istioObjectDetails.template;
+    } else if (istioObjectDetails.handler) {
+      istioObject = istioObjectDetails.handler;
+    } else if (istioObjectDetails.instance) {
+      istioObject = istioObjectDetails.instance;
     } else if (istioObjectDetails.quotaSpec) {
       istioObject = istioObjectDetails.quotaSpec;
     } else if (istioObjectDetails.quotaSpecBinding) {


### PR DESCRIPTION
This PR removes the old "subtypes" used for adapter/templates.
In short, in Istio 1.0 there were some legacy mixer adapters that populated a lot of new interfaces.

We managed that in Kiali as logical "subtypes" of adapters/templates to simplify this view to the user.

Now, Istio manages those objects as standard handlers/instances, so we put them as regular object and clean some of the technical debt introduced in the first Kiali versions.

This PR requires the backend:
https://github.com/kiali/kiali/pull/2881

How to test this:
- Check regressions in all related Istio config existing features.
- Check that Handlers and Instances are showed up as normal Istio Config objects (3scale extension can be used for that easily).