### PR TITLE
Navigation to other detail pages using mini-graph

### DIFF
--- a/src/components/CytoscapeGraph/MiniGraphCard.tsx
+++ b/src/components/CytoscapeGraph/MiniGraphCard.tsx
@@ -13,8 +13,8 @@ import {
 } from '@patternfly/react-core';
 import history from '../../app/History';
 import GraphDataSource from '../../services/GraphDataSource';
-import { EdgeLabelMode, GraphType, NodeType, DecoratedGraphElements } from '../../types/Graph';
-import CytoscapeGraph from './CytoscapeGraph';
+import { DecoratedGraphElements, EdgeLabelMode, GraphType, NodeType } from '../../types/Graph';
+import CytoscapeGraph, { GraphNodeDoubleTapEvent } from './CytoscapeGraph';
 import { CytoscapeGraphSelectorBuilder } from './CytoscapeGraphSelector';
 import { DagreGraph } from './graphs/DagreGraph';
 
@@ -92,6 +92,7 @@ export default class MiniGraphCard extends React.Component<MiniGraphCardProps, M
               isMTLSEnabled={false}
               isMiniGraph={true}
               layout={DagreGraph.getLayout()}
+              onNodeDoubleTap={this.handleDoubleTap}
               refreshInterval={0}
               showCircuitBreakers={false}
               showMissingSidecars={true}
@@ -107,6 +108,30 @@ export default class MiniGraphCard extends React.Component<MiniGraphCardProps, M
       </Card>
     );
   }
+
+  private handleDoubleTap = (e: GraphNodeDoubleTapEvent) => {
+    // Do nothing on inaccessible nodes or service entry nodes
+    if (e.isInaccessible || e.isServiceEntry) {
+      return;
+    }
+
+    // If we are already on the details page of the double-tapped node, do nothing.
+    const displayedNode = this.props.dataSource.fetchParameters.node;
+    const isSameResource =
+      displayedNode?.namespace.name === e.namespace &&
+      displayedNode.nodeType === e.nodeType &&
+      displayedNode[displayedNode.nodeType] === e[e.nodeType];
+
+    if (isSameResource) {
+      return;
+    }
+
+    // Redirect to the details page of the double-tapped node.
+    let resource = e[e.nodeType];
+    let resourceType: string = e.nodeType === NodeType.APP ? 'application' : e.nodeType;
+
+    history.push(`/namespaces/${e.namespace}/${resourceType}s/${resource}`);
+  };
 
   private onGraphActionsToggle = (isOpen: boolean) => {
     this.setState({

--- a/src/components/CytoscapeGraph/MiniGraphCard.tsx
+++ b/src/components/CytoscapeGraph/MiniGraphCard.tsx
@@ -92,7 +92,7 @@ export default class MiniGraphCard extends React.Component<MiniGraphCardProps, M
               isMTLSEnabled={false}
               isMiniGraph={true}
               layout={DagreGraph.getLayout()}
-              onNodeDoubleTap={this.handleDoubleTap}
+              onNodeTap={this.handleNodeTap}
               refreshInterval={0}
               showCircuitBreakers={false}
               showMissingSidecars={true}
@@ -109,7 +109,7 @@ export default class MiniGraphCard extends React.Component<MiniGraphCardProps, M
     );
   }
 
-  private handleDoubleTap = (e: GraphNodeDoubleTapEvent) => {
+  private handleNodeTap = (e: GraphNodeDoubleTapEvent) => {
     // Do nothing on inaccessible nodes or service entry nodes
     if (e.isInaccessible || e.isServiceEntry) {
       return;

--- a/src/types/Graph.ts
+++ b/src/types/Graph.ts
@@ -63,7 +63,7 @@ export interface NodeParamsType {
   namespace: Namespace;
   nodeType: NodeType;
   service: string;
-  version: string;
+  version?: string;
   workload: string;
 }
 


### PR DESCRIPTION
Double clicks on mini-graph card is enabled. When double-clicking, the mini-graph will redirect the user to the detail page of the selected node. No redirection is done if the detail page of chosen node is the one already being displayed. Also, nodes with no detail page (like service entries and inaccessible nodes) are ignored.

A small refactor had to be done to the CytoscapeGraph component. The double-tap event handlers were pulled up to the GraphPage component in order to be able to perform a different action depending on the page hosting the CytoscapeGraph component.

Fixes kiali/kiali#2790.