### PR TITLE
Iter8 v0.1.1 Integration for Kiali

### DIFF
--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -112,6 +112,8 @@ const conf = {
       iter8Experiments: `api/iter8/experiments`,
       iter8ExperimentsByNamespace: (namespace: string) => `api/iter8/namespaces/${namespace}/experiments`,
       iter8Experiment: (namespace: string, name: string) => `api/iter8/namespaces/${namespace}/experiments/${name}`,
+      iter8ExperimentUpdate: (namespace: string, name: string) =>
+        `api/iter8/namespaces/${namespace}/experiments/${name}`,
       istioPermissions: 'api/istio/permissions',
       jaeger: 'api/jaeger',
       jaegerTraces: (namespace: string, service: string) => `api/namespaces/${namespace}/services/${service}/traces`,

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/CriteriaInfoDescription.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/CriteriaInfoDescription.tsx
@@ -1,26 +1,32 @@
 import * as React from 'react';
 import {
-  Card,
-  CardBody,
-  DataList,
-  DataListItem,
-  DataListItemCells,
-  DataListItemRow,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
   Grid,
   GridItem,
-  DataListCell,
   List,
   ListItem,
-  Text,
-  DataListContent,
-  DataListToggle,
+  Title,
   Tooltip
 } from '@patternfly/react-core';
+import { serverConfig } from '../../../../config/ServerConfig';
 import { SuccessCriteria } from '../../../../types/Iter8';
-import { Table, TableBody, TableHeader, IRow, ICell, cellWidth } from '@patternfly/react-table';
+import {
+  Table,
+  TableBody,
+  TableHeader,
+  IRow,
+  ICell,
+  cellWidth,
+  expandable,
+  RowWrapperProps
+} from '@patternfly/react-table';
 import { KialiIcon } from '../../../../config/KialiIcon';
 import { style } from 'typestyle';
+import { css } from '@patternfly/react-styles';
 import { RenderComponentScroll } from '../../../../components/Nav/Page';
+import styles from '@patternfly/react-styles/css/components/Table/table';
 
 interface ExperimentInfoDescriptionProps {
   criterias: SuccessCriteria[];
@@ -28,6 +34,8 @@ interface ExperimentInfoDescriptionProps {
 
 type State = {
   criteriaExpanded: string[];
+  columns: any;
+  rows: any;
 };
 
 const statusIconStyle = style({
@@ -38,64 +46,74 @@ class CriteriaInfoDescription extends React.Component<ExperimentInfoDescriptionP
   constructor(props: ExperimentInfoDescriptionProps) {
     super(props);
     this.state = {
-      criteriaExpanded: []
+      criteriaExpanded: [],
+      columns: [
+        {
+          title: 'Metric Name',
+          cellFormatters: [expandable]
+        },
+        'Definitions',
+        'Success Criteria Conclusions',
+        'Status'
+      ],
+      rows: this.getRows()
     };
   }
 
-  criteriaHeader() {
-    return [
-      <DataListCell width={2}>
-        <Text style={{ fontWeight: 'bold' }}> Metric Name</Text>
-      </DataListCell>,
-      <DataListCell width={2}>
-        <Text style={{ fontWeight: 'bold' }}>Definitions</Text>
-      </DataListCell>,
-      <DataListCell width={5}>
-        <Text style={{ fontWeight: 'bold' }}>Success Criteria Conclusions</Text>
-      </DataListCell>,
-      <DataListCell width={1}>
-        <Text style={{ fontWeight: 'bold' }}>Status</Text>
-      </DataListCell>
-    ];
-  }
-
-  onCriteriaToggle = id => {
-    const criteriaExpanded = this.state.criteriaExpanded;
-    const index = criteriaExpanded.indexOf(id);
-    const newCriteriaExpanded =
-      index >= 0
-        ? [...criteriaExpanded.slice(0, index), ...criteriaExpanded.slice(index + 1, criteriaExpanded.length)]
-        : [...criteriaExpanded, id];
-    this.setState(() => ({ criteriaExpanded: newCriteriaExpanded }));
+  getRows = (): IRow[] => {
+    let rows: IRow[] = [];
+    this.props.criterias.map(criteria => {
+      const crows: IRow[] = [
+        { cells: [{ title: 'Query Template' }, { title: criteria.metric.query_template }] },
+        { cells: [{ title: 'Sample Size Template' }, { title: criteria.metric.sample_size_template }] }
+      ];
+      let number = rows.push({
+        isOpen: false,
+        cells: [
+          { title: <>{criteria.name}</> },
+          {
+            title: (
+              <ul>
+                <li>
+                  Threshold : {criteria.criteria.tolerance}
+                  {serverConfig.istioTelemetryV2 ? ' ms' : ' s'}
+                </li>
+                <li>Threshold Type: {criteria.criteria.toleranceType}</li>
+                <li>Sample Size: {criteria.criteria.sampleSize}</li>
+              </ul>
+            )
+          },
+          {
+            title: (
+              <List>
+                {criteria.status.conclusions &&
+                  criteria.status.conclusions.map((c, _) => {
+                    return <ListItem> {c} </ListItem>;
+                  })}
+              </List>
+            )
+          },
+          {
+            title: <>{this.getIcon(String(criteria.status.success_criterion_met))}</>
+          }
+        ]
+      });
+      rows.push({
+        parent: number - 1,
+        fullWidth: true,
+        cells: [
+          <>
+            <Table aria-label="Simple Table" cells={this.columns()} rows={crows}>
+              <TableHeader />
+              <TableBody />
+            </Table>
+          </>
+        ]
+      });
+      return rows;
+    });
+    return rows;
   };
-
-  criteriaList(criteria, idx) {
-    return [
-      <DataListCell key={'name_' + idx} width={2}>
-        {criteria.name}
-      </DataListCell>,
-      <DataListCell key={'tolerance' + idx} width={2}>
-        <ul>
-          <li>Threshold : {criteria.criteria.tolerance}</li>
-          <li>Threshold Type: {criteria.criteria.toleranceType}</li>
-          <li>Sample Size: {criteria.criteria.sampleSize}</li>
-        </ul>
-      </DataListCell>,
-
-      <DataListCell key={'tolerance' + idx} width={5}>
-        <List>
-          {criteria.status.conclusions &&
-            criteria.status.conclusions.map((c, _) => {
-              return <ListItem> {c} </ListItem>;
-            })}
-        </List>
-      </DataListCell>,
-
-      <DataListCell key={'success' + idx} width={1}>
-        {this.getIcon(String(criteria.status.success_criterion_met))}
-      </DataListCell>
-    ];
-  }
 
   columns = (): ICell[] => {
     return [{ title: 'Name', transforms: [cellWidth(15) as any] }, { title: 'Template' }];
@@ -124,60 +142,78 @@ class CriteriaInfoDescription extends React.Component<ExperimentInfoDescriptionP
     }
   };
 
+  customRowWrapper = ({ trRef, className, rowProps, row: { isExpanded, isHeightAuto }, ...props }) => {
+    const dangerErrorStyle = {
+      borderLeft: '3px solid var(--pf-global--primary-color--100)'
+    };
+
+    return (
+      <tr
+        {...props}
+        ref={trRef}
+        className={css(
+          className,
+          'custom-static-class',
+          isExpanded !== undefined && styles.tableExpandableRow,
+          isExpanded && styles.modifiers.expanded,
+          isHeightAuto && styles.modifiers.heightAuto
+        )}
+        hidden={isExpanded !== undefined && !isExpanded}
+        style={dangerErrorStyle}
+      />
+    );
+  };
+
+  onCollapse = (_, rowKey, isOpen) => {
+    const { rows } = this.state;
+    /**
+     * Please do not use rowKey as row index for more complex tables.
+     * Rather use some kind of identifier like ID passed with each row.
+     */
+    rows[rowKey].isOpen = isOpen;
+    this.setState({
+      rows
+    });
+  };
+
   render() {
+    const { columns, rows } = this.state;
     return (
       <RenderComponentScroll>
         <Grid gutter="md" style={{ margin: '10px' }}>
           <GridItem span={12}>
-            <Card>
-              <CardBody>
-                <DataList aria-label="simple-item1">
-                  <DataListItemRow>
-                    <DataListToggle
-                      id={'none'}
-                      className={'pf-c-button.pf-m-plain'}
-                      style={{ display: 'block', visibility: 'hidden' }}
-                    />
-                    {this.criteriaHeader()}
-                  </DataListItemRow>
-                </DataList>
-
-                {this.props.criterias.map((criteria, idx) => {
-                  const rows: IRow[] = [
-                    { cells: [{ title: 'Query Template' }, { title: criteria.metric.query_template }] },
-                    { cells: [{ title: 'Sample Size Template' }, { title: criteria.metric.sample_size_template }] }
-                  ];
-                  return (
-                    <DataList aria-label="simple-item2">
-                      <DataListItem
-                        aria-labelledby={'criteria' + idx}
-                        isExpanded={this.state.criteriaExpanded.includes('criteria' + idx)}
-                      >
-                        <DataListItemRow>
-                          <DataListToggle
-                            onClick={() => this.onCriteriaToggle('criteria' + idx)}
-                            isExpanded={this.state.criteriaExpanded.includes('criteria' + idx)}
-                            id={'criteria' + idx}
-                            aria-controls={'criteria' + idx}
-                          />
-                          <DataListItemCells dataListCells={this.criteriaList(criteria, idx)} />
-                        </DataListItemRow>
-                        <DataListContent
-                          aria-label={'criteria' + idx}
-                          id={'criteria' + idx + 'content'}
-                          isHidden={!this.state.criteriaExpanded.includes('criteria' + idx)}
-                        >
-                          <Table aria-label="Simple Table" cells={this.columns()} rows={rows}>
-                            <TableHeader />
-                            <TableBody />
-                          </Table>
-                        </DataListContent>
-                      </DataListItem>
-                    </DataList>
-                  );
-                })}
-              </CardBody>
-            </Card>
+            <Table
+              aria-label="SpanTable"
+              className={'spanTracingTagsTable'}
+              onCollapse={this.onCollapse}
+              rows={rows}
+              cells={columns}
+              rowWrapper={(props: RowWrapperProps) =>
+                this.customRowWrapper({
+                  trRef: props.trRef,
+                  className: props.className,
+                  rowProps: props.rowProps,
+                  row: props.row as any,
+                  ...props
+                })
+              }
+            >
+              <TableHeader />
+              {rows.length > 0 ? (
+                <TableBody />
+              ) : (
+                <tr>
+                  <td colSpan={columns.length}>
+                    <EmptyState variant={EmptyStateVariant.full}>
+                      <Title headingLevel="h5" size="lg">
+                        No Criteria found
+                      </Title>
+                      <EmptyStateBody>Experiment has not been started</EmptyStateBody>
+                    </EmptyState>
+                  </td>
+                </tr>
+              )}
+            </Table>
           </GridItem>
         </Grid>
       </RenderComponentScroll>

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCriteriaForm.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCriteriaForm.tsx
@@ -1,9 +1,10 @@
 import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
 import { Criteria, NameValuePair } from '../../../../types/Iter8';
 import * as React from 'react';
-import { Button, FormSelect, FormGroup, FormSelectOption, TextInput, Checkbox } from '@patternfly/react-core';
+import { Button, Checkbox, FormGroup, FormSelect, FormSelectOption, TextInput } from '@patternfly/react-core';
 import { style } from 'typestyle';
 import { PfColors } from '../../../../components/Pf/PfColors';
+import { serverConfig } from '../../../../config/ServerConfig';
 
 const headerCells: ICell[] = [
   {
@@ -12,7 +13,7 @@ const headerCells: ICell[] = [
     props: {}
   },
   {
-    title: 'Threshold',
+    title: 'Threshold (unit: second)',
     transforms: [cellWidth(10) as any],
     props: {}
   },
@@ -164,7 +165,7 @@ class ExperimentCriteriaForm extends React.Component<Props, State> {
         key: 'criteria' + i,
         cells: [
           <>{gw.metric}</>,
-          <>{gw.tolerance}</>,
+          <>{serverConfig.istioTelemetryV2 ? gw.tolerance / 1000 : gw.tolerance}</>,
           <>{gw.toleranceType === 'threshold' ? 'abosulte' : 'delta'}</>,
           <>{gw.stopOnFailure ? 'true' : 'false'}</>
         ]

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentInfoDescription.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentInfoDescription.tsx
@@ -31,6 +31,7 @@ interface ExperimentInfoDescriptionProps {
   duration: number;
   baseline: string;
   candidate: string;
+  actionTaken: string;
 }
 
 class ExperimentInfoDescription extends React.Component<ExperimentInfoDescriptionProps> {
@@ -110,6 +111,10 @@ class ExperimentInfoDescription extends React.Component<ExperimentInfoDescriptio
     let targetService = this.props.experimentDetails
       ? this.props.experimentDetails.experimentItem.targetService
       : this.props.target;
+    let statusString = this.props.experimentDetails ? this.props.experimentDetails.experimentItem.status : '';
+    if (this.props.actionTaken != '') {
+      statusString = 'Waiting for result of action "' + this.props.actionTaken + '" ';
+    }
     return (
       <RenderComponentScroll>
         <Grid gutter="md" style={{ margin: '10px' }}>
@@ -170,7 +175,7 @@ class ExperimentInfoDescription extends React.Component<ExperimentInfoDescriptio
                 <Stack gutter="md" style={{ marginTop: '10px' }}>
                   <StackItem id={'Status'}>
                     <Text component={TextVariants.h3}> Status: </Text>
-                    {this.props.experimentDetails ? this.props.experimentDetails.experimentItem.status : ''}
+                    {statusString}
                   </StackItem>
                   <StackItem id={'Status'}>
                     <Text component={TextVariants.h3}> Phase: </Text>

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentInfoDescription.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentInfoDescription.tsx
@@ -112,7 +112,7 @@ class ExperimentInfoDescription extends React.Component<ExperimentInfoDescriptio
       ? this.props.experimentDetails.experimentItem.targetService
       : this.props.target;
     let statusString = this.props.experimentDetails ? this.props.experimentDetails.experimentItem.status : '';
-    if (this.props.actionTaken != '') {
+    if (this.props.actionTaken !== '') {
       statusString = 'Waiting for result of action "' + this.props.actionTaken + '" ';
     }
     return (

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/Iter8Dropdown.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/Iter8Dropdown.tsx
@@ -7,26 +7,45 @@ import {
   DropdownToggle,
   Modal,
   Text,
-  TextVariants
+  TextVariants,
+  Tooltip,
+  TooltipPosition
 } from '@patternfly/react-core';
 
 type Props = {
   experimentName: string;
   canDelete: boolean;
+  startedAt: number;
+  endedAt: number;
+  phase: string;
   onDelete: () => void;
+  onPause: () => void;
+  onResume: () => void;
+  onSuccess: () => void;
+  onFailure: () => void;
 };
 
 type State = {
-  showConfirmModal: boolean;
+  showDeleteConfirmModal: boolean;
+  showPauseConfirmModal: boolean;
+  showResumeConfirmModal: boolean;
+  showSuccessConfirmModal: boolean;
+  showFailureConfirmModal: boolean;
   dropdownOpen: boolean;
 };
+
+const ITER8_ACTIONS = ['Pause', 'Resume', 'Terminate with Failure', 'Terminate with Success'];
 
 class Iter8Dropdown extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {
       dropdownOpen: false,
-      showConfirmModal: false
+      showDeleteConfirmModal: false,
+      showPauseConfirmModal: false,
+      showResumeConfirmModal: false,
+      showSuccessConfirmModal: false,
+      showFailureConfirmModal: false
     };
   }
 
@@ -42,17 +61,134 @@ class Iter8Dropdown extends React.Component<Props, State> {
     });
   };
 
-  hideConfirmModal = () => {
-    this.setState({ showConfirmModal: false });
+  actionConfirmModal = (thisType: string, action: boolean) => {
+    switch (thisType) {
+      case 'Delete':
+        this.setState({ showDeleteConfirmModal: action });
+        break;
+      case 'Pause':
+        this.setState({ showPauseConfirmModal: action });
+        break;
+      case 'Resume':
+        this.setState({ showResumeConfirmModal: action });
+        break;
+      case 'Terminate with Success':
+        this.setState({ showSuccessConfirmModal: action });
+        break;
+      case 'Terminate with Failure':
+        this.setState({ showFailureConfirmModal: action });
+        break;
+    }
   };
 
-  onClickDelete = () => {
-    this.setState({ showConfirmModal: true });
+  onAction = (action: string) => {
+    this.actionConfirmModal(action, false);
+    switch (action) {
+      case 'Delete':
+        this.props.onDelete();
+        break;
+      case 'Pause':
+        this.props.onPause();
+        break;
+      case 'Resume':
+        this.props.onResume();
+        break;
+      case 'Terminate with Success':
+        this.props.onSuccess();
+        break;
+      case 'Terminate with Failure':
+        this.props.onFailure();
+        break;
+    }
   };
 
-  onDelete = () => {
-    this.hideConfirmModal();
-    this.props.onDelete();
+  GenConfirmModal = (action: string, extraMsg: string, isThisOpen: boolean) => {
+    let thisTitle = 'Confirm ' + action;
+    return (
+      <Modal
+        title={thisTitle}
+        isSmall={true}
+        isOpen={isThisOpen}
+        onClose={() => this.actionConfirmModal(action, false)}
+        actions={[
+          <Button key="cancel" variant="secondary" onClick={() => this.actionConfirmModal(action, false)}>
+            Cancel
+          </Button>,
+          <Button key="confirm" variant="danger" onClick={() => this.onAction(action)}>
+            {action}
+          </Button>
+        ]}
+      >
+        <Text component={TextVariants.p}>
+          Are you sure you want to {action.toLowerCase().split(' ', 3)[0]} the Iter8 experiment "
+          {this.props.experimentName}"{extraMsg}
+        </Text>
+      </Modal>
+    );
+  };
+
+  canAction = (action: string, phase: string): boolean => {
+    switch (action) {
+      case 'Terminate':
+        return this.props.startedAt !== 0 && this.props.endedAt === 0;
+    }
+    return this.props.startedAt !== 0 && this.props.phase === phase;
+  };
+
+  renderTooltip = (key, position, msg, child): any => {
+    return (
+      <Tooltip key={key} position={position} content={<>{msg}</>}>
+        <div style={{ cursor: 'not-allowed' }}>{child}</div>
+      </Tooltip>
+    );
+  };
+
+  renderDropdownItem = (actionString: string): any => {
+    const actions = actionString.split(' ');
+    let eventKey = actions[0] + 'Experiment';
+    let checkPhase = actionString === 'Pause' ? 'Progressing' : 'Pause';
+
+    let msgString =
+      this.props.startedAt === 0
+        ? '. Action "' + actionString + '" can only be done once experiment is started. '
+        : this.props.endedAt !== 0
+        ? '. Action "' + actionString + '" can only be done while experiment is running. '
+        : '';
+
+    let item = (
+      <DropdownItem
+        key={eventKey}
+        onClick={() => this.actionConfirmModal(actionString, true)}
+        isDisabled={!this.canAction(actions[0], checkPhase)}
+      >
+        {actionString}
+      </DropdownItem>
+    );
+    return !this.canAction(actions[0], checkPhase)
+      ? this.renderTooltip(
+          eventKey,
+          TooltipPosition.left,
+          'Experiment is in state ' + this.props.phase + msgString,
+          item
+        )
+      : item;
+  };
+
+  renderDropdownItems = (): any => {
+    var items: any[] = [];
+    if (this.props.canDelete) {
+      items = items.concat(
+        <DropdownItem
+          key="deleteExperiment"
+          onClick={() => this.actionConfirmModal('Delete', true)}
+          isDisabled={!this.props.canDelete}
+        >
+          Delete
+        </DropdownItem>
+      );
+    }
+    items = items.concat(ITER8_ACTIONS.map(action => this.renderDropdownItem(action)));
+    return items;
   };
 
   render() {
@@ -65,31 +201,29 @@ class Iter8Dropdown extends React.Component<Props, State> {
           onSelect={this.onSelect}
           position={DropdownPosition.right}
           isOpen={this.state.dropdownOpen}
-          dropdownItems={[
-            <DropdownItem key="deleteExperiment" onClick={this.onClickDelete} isDisabled={!this.props.canDelete}>
-              Delete
-            </DropdownItem>
-          ]}
+          dropdownItems={this.renderDropdownItems()}
         />
-        <Modal
-          title="Confirm Delete"
-          isSmall={true}
-          isOpen={this.state.showConfirmModal}
-          onClose={this.hideConfirmModal}
-          actions={[
-            <Button key="cancel" variant="secondary" onClick={this.hideConfirmModal}>
-              Cancel
-            </Button>,
-            <Button key="confirm" variant="danger" onClick={this.onDelete}>
-              Delete
-            </Button>
-          ]}
-        >
-          <Text component={TextVariants.p}>
-            Are you sure you want to delete the Iter8 Experiment {this.props.experimentName} ? It cannot be undone. Make
-            sure this is something you really want to do!
-          </Text>
-        </Modal>
+        {this.GenConfirmModal(
+          'Delete',
+          '? It cannot be undone. Make sure this is something you really want to do!',
+          this.state.showDeleteConfirmModal
+        )}
+        {this.GenConfirmModal('Resume', '? ', this.state.showResumeConfirmModal)}
+        {this.GenConfirmModal(
+          'Pause',
+          '? Once it is paused, please select "resume" to resume the experiment. Or use terminate to stop the experiment. ',
+          this.state.showPauseConfirmModal
+        )}
+        {this.GenConfirmModal(
+          'Terminate with Success',
+          ' indicating that the candidate succeeded?',
+          this.state.showSuccessConfirmModal
+        )}
+        {this.GenConfirmModal(
+          'Terminate with Failure',
+          ' indicating that the candidate failed?',
+          this.state.showFailureConfirmModal
+        )}
       </>
     );
   }

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -516,5 +516,5 @@ export const createExperiment = (namespace: string, specBody: string) => {
 };
 
 export const updateExperiment = (namespace: string, name: string, specBody: string) => {
-  return newRequest<Iter8Experiment>(HTTP_VERBS.POST, urls.iter8Experiment(namespace, name), {}, specBody);
+  return newRequest<Iter8Experiment>(HTTP_VERBS.PATCH, urls.iter8Experiment(namespace, name), {}, specBody);
 };

--- a/src/types/Iter8.ts
+++ b/src/types/Iter8.ts
@@ -61,12 +61,19 @@ export interface SuccessCriteria {
   name: string;
   criteria: Criteria;
   metric: Metric;
+  status: SuccessCriteriaStatus;
 }
 export interface Metric {
   absent_value: string;
   is_count: boolean;
   query_template: string;
   sample_size_template: string;
+}
+
+export interface SuccessCriteriaStatus {
+  conclusions: string[];
+  success_criterion_met: boolean;
+  abort_experiment: boolean;
 }
 
 export type NameValuePair = {
@@ -80,6 +87,10 @@ export interface Criteria {
   toleranceType: string;
   sampleSize: number;
   stopOnFailure: boolean;
+}
+
+export interface ExperimentAction {
+  action: string;
 }
 
 export interface ExperimentSpec {


### PR DESCRIPTION
** Describe the change **
* Add Auto Refresh for Iter8 Detail page
* Auto detect Telemetry v1 vs v2 ( Input field fixed at unit=second, and conversion based on v1 or v2
* Action Design - Pause/Resume, Roll-forward, Roll-Back
* Criteria Tab using compact expandable
* Adding experiment estimate duration in Experiment creation page
* Iter8 Experiment Create page improvement
    1.  Change Show Advance Options -> More / Less
    2.  Default to show More
    3.  Add one paragraph saying "Your experiment will run for x hours ...."
    4.  Allow user to enter non-existing candidate right at the pull down list.


reference original Kiali-UI PR request [Kiali-UI PR  # 1805](https://github.com/kiali/kiali-ui/pull/1805)


** Dependency **
This PR depends on  [Kiali PR# 2815](https://github.com/kiali/kiali/pull/2815)

** Screenshot **
1. Add Action and refresh duration
<img width="686" alt="Screen Shot 2020-06-16 at 4 22 06 PM" src="https://user-images.githubusercontent.com/4615187/84824786-78ae7d80-afee-11ea-8414-d64a1f12cb3e.png">

2. Add Estimated experiment duration
<img width="673" alt="Screen Shot 2020-06-16 at 4 21 21 PM" src="https://user-images.githubusercontent.com/4615187/84824803-7d733180-afee-11ea-8a9b-215c0af7b03d.png">

3.  Criteria Tab using compact expandable 
<img width="1149" alt="Screen Shot 2020-06-16 at 4 28 16 PM" src="https://user-images.githubusercontent.com/4615187/84824817-8237e580-afee-11ea-99e4-f073b30fa8f4.png">



