### PR TITLE
Bump k-charted, handle zooming on buckets

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "snyk-protect": "snyk protect"
   },
   "dependencies": {
-    "@kiali/k-charted-pf4": "0.6.0-rc1",
+    "@kiali/k-charted-pf4": "0.6.0-rc3",
     "@patternfly/patternfly": "2.71.3",
     "@patternfly/react-charts": "5.3.18",
     "@patternfly/react-core": "3.153.3",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "snyk-protect": "snyk protect"
   },
   "dependencies": {
-    "@kiali/k-charted-pf4": "0.6.0-rc3",
+    "@kiali/k-charted-pf4": "0.6.0-rc5",
     "@patternfly/patternfly": "2.71.3",
     "@patternfly/react-charts": "5.3.18",
     "@patternfly/react-core": "3.153.3",

--- a/src/components/JaegerIntegration/JaegerScatter.tsx
+++ b/src/components/JaegerIntegration/JaegerScatter.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ChartWithLegend, makeLegend, VCDataPoint } from '@kiali/k-charted-pf4';
+import { ChartWithLegend, makeLegend, LineInfo, VCDataPoint } from '@kiali/k-charted-pf4';
 import { ChartScatter } from '@patternfly/react-charts';
 import { JaegerError, JaegerTrace } from '../../types/JaegerInfo';
 import { isErrorTag } from './RouteHelper';
@@ -23,6 +23,9 @@ const ONE_MILLISECOND = 1000000;
 
 const MINIMAL_SIZE = 2;
 
+type JaegerLineInfo = LineInfo & { id: string };
+type Datapoint = VCDataPoint & JaegerLineInfo;
+
 export class JaegerScatter extends React.Component<JaegerScatterProps> {
   renderFetchEmtpy = (title, msg) => {
     return (
@@ -36,12 +39,12 @@ export class JaegerScatter extends React.Component<JaegerScatterProps> {
     );
   };
   render() {
-    let tracesRaw: VCDataPoint[] = [];
-    let tracesError: VCDataPoint[] = [];
+    const tracesRaw: Datapoint[] = [];
+    const tracesError: Datapoint[] = [];
 
     this.props.traces.forEach(trace => {
-      let traceError = trace.spans.filter(sp => sp.tags.some(isErrorTag)).length > 0;
-      let traceItem = {
+      const traceError = trace.spans.filter(sp => sp.tags.some(isErrorTag)).length > 0;
+      const traceItem = {
         x: new Date(trace.startTime / 1000),
         y: Number(trace.duration / ONE_MILLISECOND),
         name: `${trace.traceName !== '' ? trace.traceName : '<trace-without-root-span>'} (${trace.traceID.slice(
@@ -75,7 +78,7 @@ export class JaegerScatter extends React.Component<JaegerScatterProps> {
     return this.props.errorFetchTraces && this.props.errorFetchTraces.length > 0 ? (
       this.renderFetchEmtpy('Error fetching Traces in Tracing tool', this.props.errorFetchTraces![0].msg)
     ) : this.props.traces.length > 0 ? (
-      <ChartWithLegend
+      <ChartWithLegend<Datapoint, JaegerLineInfo>
         data={[traces, errorTraces]}
         fill={true}
         unit="seconds"

--- a/src/components/Metrics/SpanOverlay.ts
+++ b/src/components/Metrics/SpanOverlay.ts
@@ -8,40 +8,30 @@ import { Span, TracingQuery } from 'types/Tracing';
 
 export class SpanOverlay {
   private spans: Span[] = [];
-  private lastFetchMicros: number | undefined;
   private lastFetchError = false;
 
-  constructor(public onChange: (overlay?: Overlay) => void) {}
+  constructor(private namespace: string, private service: string, public onChange: (overlay?: Overlay) => void) {}
 
-  fetch(namespace: string, service: string, range: TimeRange) {
+  fetch(range: TimeRange) {
     const boundsMillis = guardTimeRange(range, durationToBounds, b => b);
-    // Convert start time to microseconds with 1min margin
-    const frameStart = (boundsMillis.from - 60000) * 1000;
-    const frameEnd = boundsMillis.to ? boundsMillis.to * 1000 : undefined;
-    if (frameEnd) {
-      // Closed time frame (looking in past)
-      // Turning off incremental refresh as it doesn't make sense with bounded end time
-      this.lastFetchMicros = undefined;
-    }
     const opts: TracingQuery = {
-      startMicros: this.lastFetchMicros || frameStart,
-      endMicros: frameEnd
+      startMicros: boundsMillis.from * 1000,
+      endMicros: boundsMillis.to ? boundsMillis.to * 1000 : undefined
     };
-    API.getServiceSpans(namespace, service, opts)
+    // Remove any out-of-bound spans
+    this.spans = this.spans.filter(
+      s => s.startTime >= opts.startMicros && (opts.endMicros === undefined || s.startTime <= opts.endMicros)
+    );
+    // Start fetching from last fetched data when available
+    if (this.spans.length > 0) {
+      opts.startMicros = 1 + Math.max(...this.spans.map(s => s.startTime));
+    }
+    API.getServiceSpans(this.namespace, this.service, opts)
       .then(res => {
         this.lastFetchError = false;
-        if (this.lastFetchMicros) {
-          // Incremental refresh
-          this.spans = this.spans.filter(s => s.startTime >= frameStart).concat(res.data);
-        } else {
-          this.spans = res.data;
-        }
+        // Incremental refresh: we keep existing spans
+        this.spans = this.spans.concat(res.data);
         this.onChange(this.buildOverlay());
-        // Update last fetch time only if we had some results
-        // So that if Jaeger DB hadn't time to ingest data, it's still going to be fetched next time
-        if (this.spans.length > 0) {
-          this.lastFetchMicros = Math.max(...this.spans.map(s => s.startTime));
-        }
       })
       .catch(err => {
         if (!this.lastFetchError) {
@@ -49,10 +39,6 @@ export class SpanOverlay {
           this.lastFetchError = true;
         }
       });
-  }
-
-  resetLastFetchTime() {
-    this.lastFetchMicros = undefined;
   }
 
   private buildOverlay(): Overlay | undefined {
@@ -63,7 +49,8 @@ export class SpanOverlay {
         dataStyle: { fill: ({ datum }) => (datum.error ? PFAlertColor.Danger : PfColors.Cyan300), fillOpacity: 0.6 },
         color: PfColors.Cyan300,
         symbol: 'circle',
-        size: 10
+        size: 10,
+        buckets: this.spans.length > 1000 ? 15 : 0
       };
       const dps = this.spans.map(span => {
         const hasError = span.tags.some(tag => tag.key === 'error' && tag.value);

--- a/src/components/Metrics/SpanOverlay.ts
+++ b/src/components/Metrics/SpanOverlay.ts
@@ -1,16 +1,22 @@
 import { PfColors, PFAlertColor } from 'components/Pf/PfColors';
-import { toOverlay, OverlayInfo, Overlay } from '@kiali/k-charted-pf4';
+import { toOverlay, OverlayInfo, Overlay, LineInfo } from '@kiali/k-charted-pf4';
 
 import * as API from '../../services/Api';
 import { TimeRange, durationToBounds, guardTimeRange } from '../../types/Common';
 import * as AlertUtils from '../../utils/AlertUtils';
 import { Span, TracingQuery } from 'types/Tracing';
 
+export type JaegerLineInfo = LineInfo & { traceId?: string };
+
 export class SpanOverlay {
   private spans: Span[] = [];
   private lastFetchError = false;
 
-  constructor(private namespace: string, private service: string, public onChange: (overlay?: Overlay) => void) {}
+  constructor(
+    private namespace: string,
+    private service: string,
+    public onChange: (overlay?: Overlay<JaegerLineInfo>) => void
+  ) {}
 
   fetch(range: TimeRange) {
     const boundsMillis = guardTimeRange(range, durationToBounds, b => b);
@@ -41,15 +47,17 @@ export class SpanOverlay {
       });
   }
 
-  private buildOverlay(): Overlay | undefined {
+  private buildOverlay(): Overlay<JaegerLineInfo> | undefined {
     if (this.spans.length > 0) {
-      const info: OverlayInfo = {
-        title: 'Span duration',
-        unit: 'seconds',
+      const info: OverlayInfo<JaegerLineInfo> = {
+        lineInfo: {
+          name: 'Span duration',
+          unit: 'seconds',
+          color: PfColors.Cyan300,
+          symbol: 'circle',
+          size: 10
+        },
         dataStyle: { fill: ({ datum }) => (datum.error ? PFAlertColor.Danger : PfColors.Cyan300), fillOpacity: 0.6 },
-        color: PfColors.Cyan300,
-        symbol: 'circle',
-        size: 10,
         buckets: this.spans.length > 1000 ? 15 : 0
       };
       const dps = this.spans.map(span => {

--- a/src/components/Metrics/__tests__/IstioMetrics.test.tsx
+++ b/src/components/Metrics/__tests__/IstioMetrics.test.tsx
@@ -30,7 +30,8 @@ const createMetricChart = (name: string): ChartModel => {
           [2222, 10]
         ]
       }
-    ]
+    ],
+    startCollapsed: false
   };
 };
 
@@ -68,7 +69,8 @@ const createHistogramChart = (name: string): ChartModel => {
           [2222, 41]
         ]
       }
-    ]
+    ],
+    startCollapsed: false
   };
 };
 

--- a/src/components/SummaryPanel/RateChart.tsx
+++ b/src/components/SummaryPanel/RateChart.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { VCLines, addLegendEvent, VCEvent } from '@kiali/k-charted-pf4';
+import { VCLines, addLegendEvent, VCEvent, RichDataPoint } from '@kiali/k-charted-pf4';
 import { Chart, ChartBar, ChartStack, ChartAxis, ChartTooltip } from '@patternfly/react-charts';
 import { VictoryLegend } from 'victory';
 
@@ -11,7 +11,7 @@ export const legendTopMargin = 20;
 
 type Props = {
   baseName: string;
-  series: VCLines;
+  series: VCLines<RichDataPoint>;
   height: number;
   xLabelsWidth: number;
 };
@@ -129,7 +129,7 @@ export class RateChart extends React.Component<Props, State> {
 
 export const renderRateChartHttp = (percent2xx: number, percent3xx: number, percent4xx: number, percent5xx: number) => {
   const colorVals = getPFAlertColorVals();
-  const vcLines: VCLines = [
+  const vcLines: VCLines<RichDataPoint> = [
     { name: 'OK', x: 'rate', y: percent2xx, color: colorVals.Success },
     { name: '3xx', x: 'rate', y: percent3xx, color: colorVals.Info },
     { name: '4xx', x: 'rate', y: percent4xx, color: colorVals.ChartWarning }, // 4xx is also an error use close but distinct color
@@ -149,7 +149,7 @@ export const renderRateChartHttp = (percent2xx: number, percent3xx: number, perc
 
 export const renderRateChartGrpc = (percentOK: number, percentErr: number) => {
   const colorVals = getPFAlertColorVals();
-  const vcLines: VCLines = [
+  const vcLines: VCLines<RichDataPoint> = [
     { name: 'OK', x: 'rate', y: percentOK, color: colorVals.Success },
     { name: 'Err', x: 'rate', y: percentErr, color: colorVals.Danger }
   ].map(dp => {
@@ -176,7 +176,7 @@ export const renderInOutRateChartHttp = (
   percent5xxOut: number
 ) => {
   const colorVals = getPFAlertColorVals();
-  const vcLines: VCLines = [
+  const vcLines: VCLines<RichDataPoint> = [
     {
       name: 'OK',
       dp: [
@@ -233,7 +233,7 @@ export const renderInOutRateChartGrpc = (
   percentErrOut: number
 ) => {
   const colorVals = getPFAlertColorVals();
-  const vcLines: VCLines = [
+  const vcLines: VCLines<RichDataPoint> = [
     {
       name: 'OK',
       dp: [

--- a/src/components/SummaryPanel/RpsChart.tsx
+++ b/src/components/SummaryPanel/RpsChart.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { style } from 'typestyle';
 import { InfoAltIcon, SquareFullIcon } from '@patternfly/react-icons';
-import { SparklineChart, VCLines, VCLine, VCDataPoint } from '@kiali/k-charted-pf4';
+import { SparklineChart, VCLines, VCLine, VCDataPoint, RichDataPoint } from '@kiali/k-charted-pf4';
 
 import { PfColors, PFAlertColor } from '../Pf/PfColors';
 import { SUMMARY_PANEL_CHART_WIDTH } from '../../types/Graph';
@@ -45,11 +45,11 @@ const renderNoTrafficLegend = () => {
   );
 };
 
-const thereIsTrafficData = (seriesData: VCLine) => {
+const thereIsTrafficData = (seriesData: VCLine<RichDataPoint>) => {
   return seriesData.datapoints.reduce((accum, val) => accum + val.y, 0) > 0;
 };
 
-const renderSparklines = (series: VCLines, yTickFormat?: (val: number) => string) => {
+const renderSparklines = (series: VCLines<RichDataPoint>, yTickFormat?: (val: number) => string) => {
   const yFormat = yTickFormat ? yTickFormat : y => y;
   return (
     <SparklineChart

--- a/src/utils/Graphing.ts
+++ b/src/utils/Graphing.ts
@@ -1,15 +1,15 @@
-import { VCLine, toVCLine, toVCDatapoints, VCLines } from '@kiali/k-charted-pf4';
+import { VCLine, toVCLine, toVCDatapoints, VCLines, RichDataPoint } from '@kiali/k-charted-pf4';
 import { TimeSeries, Datapoint } from '../types/Metrics';
 
 export default {
-  toVCLine(dps: Datapoint[], name: string, color?: string): VCLine {
+  toVCLine(dps: Datapoint[], name: string, color: string): VCLine<RichDataPoint> {
     return toVCLine(toVCDatapoints(dps, name), { name: name, color: color });
   },
 
-  toVCLines(ts: TimeSeries[], colors?: string[], title?: string): VCLines {
+  toVCLines(ts: TimeSeries[], colors: string[], title?: string): VCLines<RichDataPoint> {
     return ts.map((line, idx) => {
       const name = title || line.name || '';
-      const color = colors ? colors[idx % colors.length] : undefined;
+      const color = colors[idx % colors.length];
       return this.toVCLine(line.values, name, color);
     });
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1899,10 +1899,10 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@kiali/k-charted-pf4@0.6.0-rc3":
-  version "0.6.0-rc3"
-  resolved "https://registry.yarnpkg.com/@kiali/k-charted-pf4/-/k-charted-pf4-0.6.0-rc3.tgz#5cc9c1ae1074afa726d39571901c74feba02064e"
-  integrity sha512-EthtLh3fngyg7v1aXM5KYfT4YnvQ8of/B9gK+J0EhYcM7e9Hgtl2jjfr0grZX+cT5Em2y1supjA8JxYKFGpaTA==
+"@kiali/k-charted-pf4@0.6.0-rc5":
+  version "0.6.0-rc5"
+  resolved "https://registry.yarnpkg.com/@kiali/k-charted-pf4/-/k-charted-pf4-0.6.0-rc5.tgz#4f33505b24fab684cac11bbacaebd30e52207d49"
+  integrity sha512-Amc2aa+AeCfQEDd3gfQVuKz/T51VA0yf8N5aC2ywO952xCce6vudDtTOaXzgAlpovJPD96t3ydwJyq1rb9F1uQ==
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1899,10 +1899,10 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@kiali/k-charted-pf4@0.6.0-rc1":
-  version "0.6.0-rc1"
-  resolved "https://registry.yarnpkg.com/@kiali/k-charted-pf4/-/k-charted-pf4-0.6.0-rc1.tgz#b2cc50578fa85cca0c5329f3038a5dfc02d5d442"
-  integrity sha512-+PiZT5asr0naf2CPofam/KWhfoqZziD66r/ryMS8hnSS4KulicfO4/47V25L7fd/pkFY4vH/EoaHdEmZMrT5LQ==
+"@kiali/k-charted-pf4@0.6.0-rc3":
+  version "0.6.0-rc3"
+  resolved "https://registry.yarnpkg.com/@kiali/k-charted-pf4/-/k-charted-pf4-0.6.0-rc3.tgz#5cc9c1ae1074afa726d39571901c74feba02064e"
+  integrity sha512-EthtLh3fngyg7v1aXM5KYfT4YnvQ8of/B9gK+J0EhYcM7e9Hgtl2jjfr0grZX+cT5Em2y1supjA8JxYKFGpaTA==
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"


### PR DESCRIPTION
Bumping k-charted to enable:
- Overlay bucketed display (https://github.com/kiali/kiali/issues/2198)
- Collapsible blocks (https://github.com/kiali/kiali/issues/2614)

For overlay buckets, they are active when number of spans reaches 1000.
Clicking on a bucket will "zoom" in the related time frame.
