### PR TITLE
Fix test to determine OpenId/OAuth preparation

### DIFF
--- a/src/services/Login.ts
+++ b/src/services/Login.ts
@@ -101,7 +101,8 @@ class OAuthLogin implements LoginStrategy<unknown> {
       return AuthResult.FAILURE;
     }
 
-    if (window.location.hash.startsWith('#access_token')) {
+    const pattern = /[#&](access_token|id_token)=/;
+    if (pattern.test(window.location.hash)) {
       return AuthResult.CONTINUE;
     } else {
       return AuthResult.HOLD;


### PR DESCRIPTION
OAuthLogin class is being used for both openshift and openid login strategies. OpenShift passes always the `access_token` parameter. OpenId providers *may* pass the access_token parameter, but id_token is warranted to be present (because of the asked response_type).

This is fixing a blocked login if the OpenId provider is not passing the access_token.

Fixes kiali/kiali#2925