### PR TITLE
Traces list in side-panel

### DIFF
--- a/src/app/History.ts
+++ b/src/app/History.ts
@@ -31,7 +31,8 @@ export enum URLParam {
   SHOW_AVERAGE = 'avg',
   SORT = 'sort',
   TO = 'to',
-  UNUSED_NODES = 'unusedNodes'
+  UNUSED_NODES = 'unusedNodes',
+  EXPERIMENTAL_FLAGS = 'xflags'
 }
 
 export interface URLParamValue {

--- a/src/components/JaegerIntegration/JaegerResults/FormattedTraceInfo.ts
+++ b/src/components/JaegerIntegration/JaegerResults/FormattedTraceInfo.ts
@@ -1,0 +1,31 @@
+import { JaegerTrace } from '../../../types/JaegerInfo';
+import moment from 'moment';
+import { formatDuration, formatRelativeDate } from './transform';
+import { isErrorTag } from '../RouteHelper';
+
+export type FormattedTraceInfo = {
+  name: string;
+  spans: string;
+  duration?: string;
+  errors?: string;
+  relativeDate: string;
+  absTime: string;
+  fromNow: string;
+};
+
+export const getFormattedTraceInfo = (trace: JaegerTrace): FormattedTraceInfo => {
+  const { traceName, duration, spans, startTime } = trace;
+  const numSpans = spans.length;
+  const mDate = moment(startTime / 1000);
+  const timeStr = mDate.format('h:mm:ss a');
+  const numErredSpans = spans.filter(sp => sp.tags.some(isErrorTag)).length;
+  return {
+    name: traceName ? traceName : '<trace-without-root-span>',
+    spans: `${numSpans} Span${numSpans !== 1 ? 's' : ''}`,
+    duration: duration ? formatDuration(duration) : undefined,
+    errors: numErredSpans > 0 ? `${numErredSpans} Error${numErredSpans !== 1 ? 's' : ''}` : undefined,
+    relativeDate: formatRelativeDate(startTime / 1000),
+    absTime: timeStr.slice(0, -3) + ' ' + timeStr.slice(-2),
+    fromNow: mDate.fromNow()
+  };
+};

--- a/src/components/JaegerIntegration/JaegerResults/JaegerItem.tsx
+++ b/src/components/JaegerIntegration/JaegerResults/JaegerItem.tsx
@@ -6,12 +6,12 @@ import { JaegerTrace, Span } from '../../../types/JaegerInfo';
 import { JaegerTraceTitle } from './JaegerTraceTitle';
 import { SpanDetail } from './SpanDetail';
 import { style } from 'typestyle';
-import moment from 'moment';
-import { formatRelativeDate, cleanServiceSelector } from './transform';
+import { cleanServiceSelector } from './transform';
 import { isErrorTag } from '../RouteHelper';
 import { KialiAppState } from '../../../store/Store';
 import { connect } from 'react-redux';
 import { PfColors } from '../../Pf/PfColors';
+import { getFormattedTraceInfo } from './FormattedTraceInfo';
 
 const labelStyle = style({
   margin: '5px'
@@ -56,34 +56,25 @@ class JaegerItemC extends React.Component<JaegerScatterProps, JaegerScatterState
   };
 
   render() {
-    const { trace } = this.props;
-    const { duration, services, spans, startTime } = trace;
-    const numSpans = spans.length;
-    const mDate = moment(startTime / 1000);
-    const fromNow = mDate.fromNow();
-    const timeStr = mDate.format('h:mm:ss a');
-    const numErredSpans = spans.filter(sp => sp.tags.some(isErrorTag)).length;
+    const { trace, jaegerURL } = this.props;
+    const formattedTrace = getFormattedTraceInfo(trace);
     return (
       <Card isCompact style={{ border: '1px solid #e6e6e6' }}>
         <JaegerTraceTitle
-          trace={trace}
-          duration={duration}
-          onClickLink={this.props.jaegerURL !== '' ? `${this.props.jaegerURL}/trace/${this.props.trace.traceID}` : ''}
+          traceID={trace.traceID}
+          formattedTrace={formattedTrace}
+          onClickLink={jaegerURL !== '' ? `${jaegerURL}/trace/${trace.traceID}` : ''}
         />
         <CardBody>
           <Grid style={{ marginTop: '20px' }}>
             <GridItem span={2}>
-              <Label>
-                {numSpans} Span{numSpans > 1 && 's'}
-              </Label>
-              {Boolean(numErredSpans) && (
-                <Label style={{ marginLeft: '10px', backgroundColor: PfColors.Red200 }}>
-                  {numErredSpans} Error{numErredSpans > 1 && 's'}
-                </Label>
+              <Label>{formattedTrace.spans}</Label>
+              {formattedTrace.errors && (
+                <Label style={{ marginLeft: '10px', backgroundColor: PfColors.Red200 }}>{formattedTrace.errors}</Label>
               )}
             </GridItem>
             <GridItem span={8}>
-              {sortBy(services, s => s.name).map(service => {
+              {sortBy(trace.services, s => s.name).map(service => {
                 const { name, numberOfSpans: count } = service;
                 const spans = trace.spans.filter(span => span.process.serviceName === name);
                 const errorSpans = spans.filter(span => span.tags.some(isErrorTag)).length;
@@ -100,11 +91,11 @@ class JaegerItemC extends React.Component<JaegerScatterProps, JaegerScatterState
               })}
             </GridItem>
             <GridItem span={2} style={{ textAlign: 'right' }}>
-              {formatRelativeDate(startTime / 1000)}
+              {formattedTrace.relativeDate}
               <span style={{ padding: '0 10px 0 10px' }}>|</span>
-              {timeStr.slice(0, -3)}&nbsp;{timeStr.slice(-2)}
+              {formattedTrace.absTime}
               <br />
-              <small>{fromNow}</small>
+              <small>{formattedTrace.fromNow}</small>
             </GridItem>
             {this.state.spansSelected.length > 0 && (
               <GridItem span={12}>

--- a/src/components/JaegerIntegration/JaegerResults/JaegerTraceTitle.tsx
+++ b/src/components/JaegerIntegration/JaegerResults/JaegerTraceTitle.tsx
@@ -1,24 +1,22 @@
 import * as React from 'react';
 import { CardHeader, Text, TextVariants, Tooltip } from '@patternfly/react-core';
-import { JaegerTrace } from '../../../types/JaegerInfo';
 import { PfColors } from '../../Pf/PfColors';
-import { formatDuration } from './transform';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { FormattedTraceInfo } from './FormattedTraceInfo';
 
-interface JaegerScatterProps {
-  trace: JaegerTrace;
-  duration?: number;
+interface Props {
+  traceID: string;
+  formattedTrace: FormattedTraceInfo;
   onClickLink: string;
 }
 
-export class JaegerTraceTitle extends React.Component<JaegerScatterProps> {
+export class JaegerTraceTitle extends React.Component<Props> {
   render() {
-    const { trace, duration } = this.props;
-    const { traceID, traceName } = trace;
+    const { traceID, formattedTrace } = this.props;
     return (
       <CardHeader style={{ backgroundColor: PfColors.Black200, height: '50px' }}>
         <Text component={TextVariants.h3} style={{ margin: 0, position: 'relative' }}>
-          {traceName === '' ? '<trace-without-root-span>' : traceName}
+          {formattedTrace.name}
           <Tooltip content={<>{traceID}</>}>
             <span style={{ color: PfColors.Black600, paddingLeft: '10px', fontSize: '14px' }}>
               {traceID.slice(0, 7)}
@@ -36,7 +34,9 @@ export class JaegerTraceTitle extends React.Component<JaegerScatterProps> {
               </a>
             </Tooltip>
           )}
-          {duration != null && <span style={{ float: 'right', position: 'relative' }}>{formatDuration(duration)}</span>}
+          {formattedTrace.duration && (
+            <span style={{ float: 'right', position: 'relative' }}>{formattedTrace.duration}</span>
+          )}
         </Text>
       </CardHeader>
     );

--- a/src/components/JaegerIntegration/TraceListItem.tsx
+++ b/src/components/JaegerIntegration/TraceListItem.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import { style } from 'typestyle';
+import { Tooltip } from '@patternfly/react-core';
+
+import { JaegerTrace } from '../../types/JaegerInfo';
+import { getFormattedTraceInfo } from './JaegerResults/FormattedTraceInfo';
+import { PFAlertColor, PfColors } from 'components/Pf/PfColors';
+
+interface Props {
+  trace: JaegerTrace;
+}
+
+const parentDivStyle = style({
+  fontSize: 'var(--graph-side-panel--font-size)',
+  lineHeight: 1.3
+});
+
+const nameStyle = style({
+  display: 'inline-block',
+  maxWidth: 175,
+  textOverflow: 'ellipsis',
+  overflow: 'hidden',
+  whiteSpace: 'nowrap'
+});
+
+const errorStyle = style({
+  color: PFAlertColor.Danger
+});
+
+const secondaryLeftStyle = style({
+  color: PfColors.Black600
+});
+
+const secondaryRightStyle = style({
+  color: PfColors.Black600,
+  float: 'right'
+});
+
+export const TraceListItem: React.SFC<Props> = props => {
+  const formattedTrace = getFormattedTraceInfo(props.trace);
+  const tooltipContent = `${formattedTrace.name} (${props.trace.traceID.slice(0, 7)})`;
+  const nameStyleToUse = formattedTrace.errors ? nameStyle + ' ' + errorStyle : nameStyle;
+  return (
+    <Tooltip content={tooltipContent}>
+      <div className={parentDivStyle}>
+        <span className={nameStyleToUse}>{formattedTrace.name}</span>
+        {formattedTrace.duration ? <span className={secondaryRightStyle}>{formattedTrace.duration}</span> : ''}
+        <br />
+        <span className={secondaryLeftStyle}>{formattedTrace.spans}</span>
+        <span className={secondaryRightStyle}>{formattedTrace.fromNow}</span>
+      </div>
+    </Tooltip>
+  );
+};

--- a/src/pages/Graph/SummaryPanelNode.tsx
+++ b/src/pages/Graph/SummaryPanelNode.tsx
@@ -1,93 +1,36 @@
 import * as React from 'react';
 import { renderDestServicesLinks, renderBadgedLink, renderHealth, renderBadgedHost } from './SummaryLink';
-import {
-  getAccumulatedTrafficRateGrpc,
-  getAccumulatedTrafficRateHttp,
-  getTrafficRateGrpc,
-  getTrafficRateHttp
-} from '../../utils/TrafficRate';
-import { InOutRateTableGrpc, InOutRateTableHttp } from '../../components/SummaryPanel/InOutRateTable';
-import { RpsChart, TcpChart } from '../../components/SummaryPanel/RpsChart';
-import {
-  GraphType,
-  NodeType,
-  SummaryPanelPropType,
-  Protocol,
-  DecoratedGraphNodeData,
-  UNKNOWN
-} from '../../types/Graph';
-import { Metrics, Metric, Datapoint } from '../../types/Metrics';
+import { NodeType, SummaryPanelPropType, DecoratedGraphNodeData } from '../../types/Graph';
 import {
   shouldRefreshData,
   updateHealth,
-  NodeMetricType,
-  getDatapoints,
-  getNodeMetrics,
-  getNodeMetricType,
-  renderNoTraffic,
-  mergeMetricsResponses,
   summaryHeader,
-  hr,
-  summaryPanel
+  summaryPanel,
+  summaryBodyTabs,
+  summaryFont
 } from './SummaryPanelCommon';
 import { Health } from '../../types/Health';
-import { CancelablePromise, makeCancelablePromise } from '../../utils/CancelablePromises';
-import { Response } from '../../services/Api';
-import { Reporter } from '../../types/MetricsOptions';
-import { CyNode, decoratedNodeData } from '../../components/CytoscapeGraph/CytoscapeGraphUtils';
+import { decoratedNodeData } from '../../components/CytoscapeGraph/CytoscapeGraphUtils';
 import { KialiIcon } from 'config/KialiIcon';
 import { getOptions, clickHandler } from 'components/CytoscapeGraph/ContextMenu/NodeContextMenu';
-import { Dropdown, DropdownItem, DropdownPosition, KebabToggle } from '@patternfly/react-core';
+import { Dropdown, DropdownItem, DropdownPosition, KebabToggle, Tab } from '@patternfly/react-core';
 import { KialiAppState } from 'store/Store';
 import { connect } from 'react-redux';
 import { JaegerInfo } from 'types/JaegerInfo';
+import { SummaryPanelNodeTraffic } from './SummaryPanelNodeTraffic';
+import { SummaryPanelNodeTraces } from './SummaryPanelNodeTraces';
+import SimpleTabs from 'components/Tab/SimpleTabs';
+import { hasExperimentalFlag } from 'utils/SearchParamUtils';
 
-type SummaryPanelNodeMetricsState = {
-  grpcRequestCountIn: Datapoint[];
-  grpcRequestCountOut: Datapoint[];
-  grpcErrorCountIn: Datapoint[];
-  grpcErrorCountOut: Datapoint[];
-  httpRequestCountIn: Datapoint[] | null;
-  httpRequestCountOut: Datapoint[];
-  httpErrorCountIn: Datapoint[];
-  httpErrorCountOut: Datapoint[];
-  tcpSentIn: Datapoint[];
-  tcpSentOut: Datapoint[];
-  tcpReceivedIn: Datapoint[];
-  tcpReceivedOut: Datapoint[];
-};
-
-type SummaryPanelNodeState = SummaryPanelNodeMetricsState & {
-  node: any;
-  loading: boolean;
+type SummaryPanelNodeState = {
   healthLoading: boolean;
   health?: Health;
-  isOpen: boolean;
-  metricsLoadError: string | null;
-};
-
-const defaultMetricsState: SummaryPanelNodeMetricsState = {
-  grpcRequestCountIn: [],
-  grpcRequestCountOut: [],
-  grpcErrorCountIn: [],
-  grpcErrorCountOut: [],
-  httpRequestCountIn: [],
-  httpRequestCountOut: [],
-  httpErrorCountIn: [],
-  httpErrorCountOut: [],
-  tcpSentIn: [],
-  tcpSentOut: [],
-  tcpReceivedIn: [],
-  tcpReceivedOut: []
+  isActionOpen: boolean;
 };
 
 const defaultState: SummaryPanelNodeState = {
-  node: null,
-  loading: false,
   healthLoading: false,
-  isOpen: false,
-  metricsLoadError: null,
-  ...defaultMetricsState
+  isActionOpen: false
 };
 
 type ReduxProps = {
@@ -97,27 +40,16 @@ type ReduxProps = {
 type SummaryPanelNodeProps = ReduxProps & SummaryPanelPropType;
 
 export class SummaryPanelNode extends React.Component<SummaryPanelNodeProps, SummaryPanelNodeState> {
-  private metricsPromise?: CancelablePromise<Response<Metrics>[]>;
   private readonly mainDivRef: React.RefObject<HTMLDivElement>;
 
   constructor(props: SummaryPanelNodeProps) {
     super(props);
-    this.showRequestCountMetrics = this.showRequestCountMetrics.bind(this);
 
     this.state = { ...defaultState };
     this.mainDivRef = React.createRef<HTMLDivElement>();
   }
 
-  static getDerivedStateFromProps(props: SummaryPanelNodeProps, state: SummaryPanelNodeState) {
-    // if the summaryTarget (i.e. selected node) has changed, then init the state and set to loading. The loading
-    // will actually be kicked off after the render (in componentDidMount/Update).
-    return props.data.summaryTarget !== state.node
-      ? { node: props.data.summaryTarget, loading: true, ...defaultMetricsState }
-      : null;
-  }
-
   componentDidMount() {
-    this.updateCharts(this.props);
     updateHealth(this.props.data.summaryTarget, this.setState.bind(this));
   }
 
@@ -128,193 +60,9 @@ export class SummaryPanelNode extends React.Component<SummaryPanelNodeProps, Sum
       }
     }
     if (shouldRefreshData(prevProps, this.props)) {
-      this.updateCharts(this.props);
       updateHealth(this.props.data.summaryTarget, this.setState.bind(this));
     }
   }
-
-  componentWillUnmount() {
-    if (this.metricsPromise) {
-      this.metricsPromise.cancel();
-    }
-  }
-
-  updateCharts(props: SummaryPanelNodeProps) {
-    const target = props.data.summaryTarget;
-    const nodeData = decoratedNodeData(target);
-    const nodeMetricType = getNodeMetricType(nodeData);
-
-    if (this.metricsPromise) {
-      this.metricsPromise.cancel();
-      this.metricsPromise = undefined;
-    }
-
-    if (!this.hasGrpcTraffic(nodeData) && !this.hasHttpTraffic(nodeData) && !this.hasTcpTraffic(nodeData)) {
-      this.setState({ loading: false });
-      return;
-    }
-
-    // If destination node is inaccessible, we cannot query the data.
-    if (nodeData.isInaccessible) {
-      this.setState({ loading: false });
-      return;
-    }
-
-    let promiseOut: Promise<Response<Metrics>> = Promise.resolve({ data: { metrics: {}, histograms: {} } });
-    let promiseIn: Promise<Response<Metrics>> = Promise.resolve({ data: { metrics: {}, histograms: {} } });
-
-    // Ignore outgoing traffic if it is a non-root outsider (because they have no outgoing edges) or a
-    // service node (because they don't have "real" outgoing edges).
-    if (nodeData.nodeType !== NodeType.SERVICE && (nodeData.isRoot || !nodeData.isOutside)) {
-      const filters = ['request_count', 'request_error_count', 'tcp_sent', 'tcp_received'];
-      // use source metrics for outgoing, except for:
-      // - unknown nodes (no source telemetry)
-      // - istio namespace nodes (no source telemetry)
-      const reporter: Reporter = nodeData.nodeType === NodeType.UNKNOWN || nodeData.isIstio ? 'destination' : 'source';
-      // note: request_protocol is not a valid byLabel for tcp filters but it is ignored by prometheus
-      const byLabels = nodeData.isOutside
-        ? ['destination_service_namespace', 'request_protocol']
-        : ['request_protocol'];
-      promiseOut = getNodeMetrics(
-        nodeMetricType,
-        target,
-        props,
-        filters,
-        'outbound',
-        reporter,
-        undefined,
-        undefined,
-        byLabels
-      );
-    }
-
-    // set incoming unless it is a root (because they have no incoming edges)
-    if (!nodeData.isRoot) {
-      const filtersRps = ['request_count', 'request_error_count'];
-      // use dest metrics for incoming, except for service nodes which need source metrics to capture source errors
-      const reporter: Reporter = nodeData.nodeType === NodeType.SERVICE && nodeData.isIstio ? 'source' : 'destination';
-      // For special service dest nodes we want to narrow the data to only TS with 'unknown' workloads (see the related
-      // comparator in getNodeDatapoints).
-      const isServiceDestCornerCase = this.isServiceDestCornerCase(nodeMetricType);
-      const byLabelsRps = isServiceDestCornerCase ? ['destination_workload', 'request_protocol'] : ['request_protocol'];
-      if (nodeData.isOutside) {
-        byLabelsRps.push('source_workload_namespace');
-      }
-      const promiseRps = getNodeMetrics(
-        nodeMetricType,
-        target,
-        props,
-        filtersRps,
-        'inbound',
-        reporter,
-        undefined,
-        undefined,
-        byLabelsRps
-      );
-      const filtersTCP = ['tcp_sent', 'tcp_received'];
-      const byLabelsTCP = isServiceDestCornerCase ? ['destination_workload'] : [];
-      if (nodeData.isOutside) {
-        byLabelsTCP.push('source_workload_namespace');
-      }
-      const promiseTCP = getNodeMetrics(
-        nodeMetricType,
-        target,
-        props,
-        filtersTCP,
-        'inbound',
-        'source',
-        undefined,
-        undefined,
-        byLabelsTCP
-      );
-      promiseIn = mergeMetricsResponses([promiseRps, promiseTCP]);
-    }
-
-    this.metricsPromise = makeCancelablePromise(Promise.all([promiseOut, promiseIn]));
-    this.metricsPromise.promise
-      .then(responses => {
-        this.showRequestCountMetrics(responses[0].data, responses[1].data, nodeData, nodeMetricType);
-      })
-      .catch(error => {
-        if (error.isCanceled) {
-          console.debug('SummaryPanelNode: Ignore fetch error (canceled).');
-          return;
-        }
-        const errorMsg = error.response && error.response.data.error ? error.response.data.error : error.message;
-        this.setState({
-          loading: false,
-          metricsLoadError: errorMsg,
-          ...defaultMetricsState
-        });
-      });
-
-    this.setState({ loading: true, metricsLoadError: null });
-  }
-
-  showRequestCountMetrics(
-    outbound: Metrics,
-    inbound: Metrics,
-    data: DecoratedGraphNodeData,
-    nodeMetricType: NodeMetricType
-  ) {
-    let comparator = (metric: Metric, protocol?: Protocol) => {
-      return protocol ? metric.request_protocol === protocol : true;
-    };
-    if (this.isServiceDestCornerCase(nodeMetricType)) {
-      comparator = (metric: Metric, protocol?: Protocol) => {
-        return (protocol ? metric.request_protocol === protocol : true) && metric.destination_workload === UNKNOWN;
-      };
-    } else if (data.isOutside) {
-      // filter out traffic completely outside the active namespaces
-      comparator = (metric: Metric, protocol?: Protocol) => {
-        if (protocol && metric.request_protocol !== protocol) {
-          return false;
-        }
-        if (metric.destination_service_namespace && !this.isActiveNamespace(metric.destination_service_namespace)) {
-          return false;
-        }
-        if (metric.source_workload_namespace && !this.isActiveNamespace(metric.source_workload_namespace)) {
-          return false;
-        }
-        return true;
-      };
-    }
-    const rcOut = outbound.metrics.request_count;
-    const ecOut = outbound.metrics.request_error_count;
-    const tcpSentOut = outbound.metrics.tcp_sent;
-    const tcpReceivedOut = outbound.metrics.tcp_received;
-    const rcIn = inbound.metrics.request_count;
-    const ecIn = inbound.metrics.request_error_count;
-    const tcpSentIn = inbound.metrics.tcp_sent;
-    const tcpReceivedIn = inbound.metrics.tcp_received;
-    this.setState({
-      loading: false,
-      grpcRequestCountOut: getDatapoints(rcOut, comparator, Protocol.GRPC),
-      grpcErrorCountOut: getDatapoints(ecOut, comparator, Protocol.GRPC),
-      grpcRequestCountIn: getDatapoints(rcIn, comparator, Protocol.GRPC),
-      grpcErrorCountIn: getDatapoints(ecIn, comparator, Protocol.GRPC),
-      httpRequestCountOut: getDatapoints(rcOut, comparator, Protocol.HTTP),
-      httpErrorCountOut: getDatapoints(ecOut, comparator, Protocol.HTTP),
-      httpRequestCountIn: getDatapoints(rcIn, comparator, Protocol.HTTP),
-      httpErrorCountIn: getDatapoints(ecIn, comparator, Protocol.HTTP),
-      tcpSentOut: getDatapoints(tcpSentOut, comparator),
-      tcpReceivedOut: getDatapoints(tcpReceivedOut, comparator),
-      tcpSentIn: getDatapoints(tcpSentIn, comparator),
-      tcpReceivedIn: getDatapoints(tcpReceivedIn, comparator)
-    });
-  }
-
-  isActiveNamespace = (namespace: string): boolean => {
-    if (!namespace) {
-      return false;
-    }
-    for (const ns of this.props.namespaces) {
-      if (ns.name === namespace) {
-        return true;
-      }
-    }
-    return false;
-  };
 
   render() {
     const node = this.props.data.summaryTarget;
@@ -326,6 +74,13 @@ export class SummaryPanelNode extends React.Component<SummaryPanelNodeProps, Sum
     const shouldRenderDestsList = destsList && destsList.length > 0;
     const shouldRenderSvcList = servicesList && servicesList.length > 0;
     const shouldRenderWorkload = nodeType !== NodeType.WORKLOAD && nodeType !== NodeType.UNKNOWN && workload;
+    const shouldRenderTraces =
+      nodeType === NodeType.SERVICE &&
+      !nodeData.isInaccessible &&
+      this.props.jaegerInfo &&
+      this.props.jaegerInfo.enabled &&
+      this.props.jaegerInfo.integration &&
+      hasExperimentalFlag('igt');
 
     const actions = getOptions(nodeData, this.props.jaegerInfo).map(o => {
       return (
@@ -346,7 +101,7 @@ export class SummaryPanelNode extends React.Component<SummaryPanelNodeProps, Sum
                 style={{ float: 'right' }}
                 isPlain={true}
                 dropdownItems={actions}
-                isOpen={this.state.isOpen}
+                isOpen={this.state.isActionOpen}
                 position={DropdownPosition.right}
                 toggle={<KebabToggle id="summary-node-kebab" onToggle={this.onToggleActions} />}
               />
@@ -360,215 +115,43 @@ export class SummaryPanelNode extends React.Component<SummaryPanelNodeProps, Sum
             {shouldRenderWorkload && <div>{renderBadgedLink(nodeData, NodeType.WORKLOAD)}</div>}
           </div>
         </div>
-        <div className="panel-body">
-          {this.hasGrpcTraffic(nodeData) && (
-            <>
-              {this.renderGrpcRates(node)}
-              {hr()}
-            </>
-          )}
-          {this.hasHttpTraffic(nodeData) && (
-            <>
-              {this.renderHttpRates(node)}
-              {hr()}
-            </>
-          )}
-          <div>
-            {this.renderCharts(node)}
-            {hr()}
-          </div>
-          {!this.hasGrpcTraffic(nodeData) && renderNoTraffic('GRPC')}
-          {!this.hasHttpTraffic(nodeData) && renderNoTraffic('HTTP')}
-        </div>
+        {shouldRenderTraces ? this.renderWithTabs(nodeData) : this.renderTrafficOnly()}
+      </div>
+    );
+  }
+
+  private renderTrafficOnly() {
+    return (
+      <div className="panel-body">
+        <SummaryPanelNodeTraffic {...this.props} />
+      </div>
+    );
+  }
+
+  private renderWithTabs(nodeData: DecoratedGraphNodeData) {
+    return (
+      <div className={summaryBodyTabs}>
+        <SimpleTabs id="graph_summary_tabs" defaultTab={0} style={{ paddingBottom: '10px' }}>
+          <Tab style={summaryFont} title="Traffic" eventKey={0}>
+            <div style={summaryFont}>
+              <SummaryPanelNodeTraffic {...this.props} />
+            </div>
+          </Tab>
+          <Tab style={summaryFont} title="Traces" eventKey={1}>
+            <SummaryPanelNodeTraces
+              namespace={nodeData.namespace}
+              service={nodeData.service!}
+              jaegerInfo={this.props.jaegerInfo}
+              queryTime={this.props.queryTime}
+            />
+          </Tab>
+        </SimpleTabs>
       </div>
     );
   }
 
   private onToggleActions = isOpen => {
-    this.setState({ isOpen: isOpen });
-  };
-
-  private renderGrpcRates = node => {
-    const incoming = getTrafficRateGrpc(node);
-    const outgoing = getAccumulatedTrafficRateGrpc(this.props.data.summaryTarget.edgesTo('*'));
-
-    return (
-      <>
-        <InOutRateTableGrpc
-          title="GRPC Traffic (requests per second):"
-          inRate={incoming.rate}
-          inRateErr={incoming.rateErr}
-          outRate={outgoing.rate}
-          outRateErr={outgoing.rateErr}
-        />
-      </>
-    );
-  };
-
-  private renderHttpRates = node => {
-    const incoming = getTrafficRateHttp(node);
-    const outgoing = getAccumulatedTrafficRateHttp(this.props.data.summaryTarget.edgesTo('*'));
-
-    return (
-      <>
-        <InOutRateTableHttp
-          title="HTTP (requests per second):"
-          inRate={incoming.rate}
-          inRate3xx={incoming.rate3xx}
-          inRate4xx={incoming.rate4xx}
-          inRate5xx={incoming.rate5xx}
-          outRate={outgoing.rate}
-          outRate3xx={outgoing.rate3xx}
-          outRate4xx={outgoing.rate4xx}
-          outRate5xx={outgoing.rate5xx}
-        />
-      </>
-    );
-  };
-
-  private renderCharts = node => {
-    const nodeData = decoratedNodeData(node);
-
-    if (NodeType.UNKNOWN === nodeData.nodeType) {
-      return (
-        <>
-          <div>
-            <KialiIcon.Info /> Sparkline charts not supported for unknown node. Use edge for details.
-          </div>
-        </>
-      );
-    } else if (nodeData.isInaccessible) {
-      return (
-        <>
-          <div>
-            <KialiIcon.Info /> Sparkline charts cannot be shown because the selected node is inaccessible.
-          </div>
-        </>
-      );
-    } else if (nodeData.isServiceEntry) {
-      return (
-        <>
-          <div>
-            <KialiIcon.Info /> Sparkline charts cannot be shown because the selected node is a serviceEntry.
-          </div>
-        </>
-      );
-    }
-    if (this.state.loading) {
-      return <strong>Loading charts...</strong>;
-    }
-    if (this.state.metricsLoadError) {
-      return (
-        <div>
-          <KialiIcon.Warning /> <strong>Error loading metrics: </strong>
-          {this.state.metricsLoadError}
-        </div>
-      );
-    }
-
-    const isServiceNode = nodeData.nodeType === NodeType.SERVICE;
-    let serviceWithUnknownSource: boolean = false;
-    if (isServiceNode) {
-      node.incomers().forEach(n => {
-        if (NodeType.UNKNOWN === n.data(CyNode.nodeType)) {
-          serviceWithUnknownSource = true;
-          return false; // Equivalent of break for cytoscapejs forEach API
-        }
-        return undefined; // Every code paths needs to return something to avoid the wrath of the linter.
-      });
-    }
-
-    let grpcCharts, httpCharts, tcpCharts;
-
-    if (this.hasGrpcTraffic(nodeData)) {
-      grpcCharts = (
-        <>
-          <RpsChart
-            label={isServiceNode ? 'GRPC - Request Traffic' : 'GRPC - Inbound Request Traffic'}
-            dataRps={this.state.grpcRequestCountIn!}
-            dataErrors={this.state.grpcErrorCountIn}
-          />
-          {serviceWithUnknownSource && (
-            <>
-              <div>
-                <KialiIcon.Info /> Traffic from unknown not included. Use edge for details.
-              </div>
-            </>
-          )}
-          <RpsChart
-            label="GRPC - Outbound Request Traffic"
-            dataRps={this.state.grpcRequestCountOut}
-            dataErrors={this.state.grpcErrorCountOut}
-            hide={isServiceNode}
-          />
-          {this.isIstioOutgoingCornerCase(node) && (
-            <>
-              <div>
-                <KialiIcon.Info /> Traffic to Istio namespaces not included. Use edge for details.
-              </div>
-            </>
-          )}
-        </>
-      );
-    }
-
-    if (this.hasHttpTraffic(nodeData)) {
-      httpCharts = (
-        <>
-          <RpsChart
-            label={isServiceNode ? 'HTTP - Request Traffic' : 'HTTP - Inbound Request Traffic'}
-            dataRps={this.state.httpRequestCountIn!}
-            dataErrors={this.state.httpErrorCountIn}
-          />
-          {serviceWithUnknownSource && (
-            <>
-              <div>
-                <KialiIcon.Info /> Traffic from unknown not included. Use edge for details.
-              </div>
-            </>
-          )}
-          <RpsChart
-            label="HTTP - Outbound Request Traffic"
-            dataRps={this.state.httpRequestCountOut}
-            dataErrors={this.state.httpErrorCountOut}
-            hide={isServiceNode}
-          />
-          {this.isIstioOutgoingCornerCase(node) && (
-            <>
-              <div>
-                <KialiIcon.Info />" /> Traffic to Istio namespaces not included. Use edge for details.
-              </div>
-            </>
-          )}
-        </>
-      );
-    }
-
-    if (this.hasTcpTraffic(nodeData)) {
-      tcpCharts = (
-        <>
-          <TcpChart
-            label={isServiceNode ? 'TCP - Traffic' : 'TCP - Inbound Traffic'}
-            receivedRates={this.state.tcpReceivedIn}
-            sentRates={this.state.tcpSentIn}
-          />
-          <TcpChart
-            label="TCP - Outbound Traffic"
-            receivedRates={this.state.tcpReceivedOut}
-            sentRates={this.state.tcpSentOut}
-            hide={isServiceNode}
-          />
-        </>
-      );
-    }
-
-    return (
-      <>
-        {grpcCharts}
-        {httpCharts}
-        {tcpCharts}
-      </>
-    );
+    this.setState({ isActionOpen: isOpen });
   };
 
   // TODO:(see https://github.com/kiali/kiali-design/issues/63) If we want to show an icon for SE uncomment below
@@ -620,38 +203,6 @@ export class SummaryPanelNode extends React.Component<SummaryPanelNodeProps, Sum
     });
 
     return entries;
-  };
-
-  // We need to handle the special case of a dest service node showing client failures. These service nodes show up in
-  // non-service graphs, even when not injecting service nodes.
-  private isServiceDestCornerCase = (nodeMetricType: NodeMetricType): boolean => {
-    return (
-      nodeMetricType === NodeMetricType.SERVICE &&
-      !this.props.injectServiceNodes &&
-      this.props.graphType !== GraphType.SERVICE
-    );
-  };
-
-  // We need to handle the special case of a non-istio, non-unknown node with outgoing traffic to istio.
-  // The traffic is lost because it is dest-only and we use source-reporting.
-  private isIstioOutgoingCornerCase = (node): boolean => {
-    const nodeData = decoratedNodeData(node);
-    if (nodeData.nodeType === NodeType.UNKNOWN || nodeData.isIstio) {
-      return false;
-    }
-    return node.edgesTo(`node[?${CyNode.isIstio}]`).size() > 0;
-  };
-
-  private hasGrpcTraffic = (data: DecoratedGraphNodeData): boolean => {
-    return data.grpcIn > 0 || data.grpcOut > 0;
-  };
-
-  private hasHttpTraffic = (data: DecoratedGraphNodeData): boolean => {
-    return data.httpIn > 0 || data.httpOut > 0;
-  };
-
-  private hasTcpTraffic = (data: DecoratedGraphNodeData): boolean => {
-    return data.tcpIn > 0 || data.tcpOut > 0;
   };
 }
 

--- a/src/pages/Graph/SummaryPanelNodeTraces.tsx
+++ b/src/pages/Graph/SummaryPanelNodeTraces.tsx
@@ -1,0 +1,123 @@
+import * as React from 'react';
+import { SimpleList, SimpleListItem, Button, Checkbox, Tooltip } from '@patternfly/react-core';
+import { style } from 'typestyle';
+
+import history from '../../app/History';
+import * as API from '../../services/Api';
+import * as AlertUtils from '../../utils/AlertUtils';
+import { JaegerInfo, JaegerTrace } from 'types/JaegerInfo';
+import { PromisesRegistry } from 'utils/CancelablePromises';
+import { TracingQuery } from 'types/Tracing';
+import { TimeInSeconds } from 'types/Common';
+import { transformTraceData } from 'components/JaegerIntegration/JaegerResults';
+import { TraceListItem } from 'components/JaegerIntegration/TraceListItem';
+import { summaryFont } from './SummaryPanelCommon';
+
+type Props = {
+  jaegerInfo?: JaegerInfo;
+  namespace: string;
+  service: string;
+  queryTime: TimeInSeconds;
+};
+
+type State = {
+  traces: JaegerTrace[];
+  keepList: boolean;
+};
+
+const tracesLimit = 15;
+
+const checkboxStyle = style({
+  paddingBottom: 10,
+  float: 'right',
+  $nest: {
+    '& > label': {
+      fontSize: 'var(--graph-side-panel--font-size)'
+    }
+  }
+});
+
+export class SummaryPanelNodeTraces extends React.Component<Props, State> {
+  private promises = new PromisesRegistry();
+
+  constructor(props: Props) {
+    super(props);
+    this.state = { traces: [], keepList: false };
+  }
+
+  componentDidMount() {
+    this.loadTraces();
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    if (
+      !this.state.keepList &&
+      (prevProps.queryTime !== this.props.queryTime ||
+        prevProps.namespace !== this.props.namespace ||
+        prevProps.service !== this.props.service)
+    ) {
+      this.loadTraces();
+    }
+  }
+
+  componentWillUnmount() {
+    this.promises.cancelAll();
+  }
+
+  private loadTraces() {
+    // Convert seconds to microseconds
+    const params: TracingQuery = {
+      startMicros: this.props.queryTime * 1000000,
+      limit: tracesLimit
+    };
+    this.promises.cancelAll();
+    this.promises
+      .register('traces', API.getJaegerTraces(this.props.namespace, this.props.service, params))
+      .then(response => {
+        const traces = response.data.data
+          ? (response.data.data
+              .map(trace => transformTraceData(trace))
+              .filter(trace => trace !== null) as JaegerTrace[])
+          : [];
+        this.setState({ traces: traces });
+      })
+      .catch(error => {
+        AlertUtils.addError('Could not fetch traces.', error);
+      });
+  }
+
+  private onSelect() {}
+
+  render() {
+    if (this.state.traces.length === 0) {
+      return null;
+    }
+    const tracesDetailsURL = `/namespaces/${this.props.namespace}/services/${this.props.service}?tab=traces`;
+
+    return (
+      <div style={{ marginBottom: 8 }}>
+        <Tooltip content="When checked, traces won't be reloaded with Graph refresh">
+          <Checkbox
+            id="disable-refresh"
+            label="Keep list"
+            className={checkboxStyle}
+            isChecked={this.state.keepList}
+            onChange={checked => this.setState({ keepList: checked })}
+          />
+        </Tooltip>
+        <SimpleList style={{ marginBottom: 8 }} onSelect={this.onSelect} aria-label="Traces list">
+          {this.state.traces.map((trace, idx) => {
+            return (
+              <SimpleListItem key={'trace_' + idx}>
+                <TraceListItem trace={trace} />
+              </SimpleListItem>
+            );
+          })}
+        </SimpleList>
+        <Button style={summaryFont} onClick={() => history.push(tracesDetailsURL)}>
+          Find more traces
+        </Button>
+      </div>
+    );
+  }
+}

--- a/src/pages/Graph/SummaryPanelNodeTraffic.tsx
+++ b/src/pages/Graph/SummaryPanelNodeTraffic.tsx
@@ -1,0 +1,533 @@
+import * as React from 'react';
+import {
+  getAccumulatedTrafficRateGrpc,
+  getAccumulatedTrafficRateHttp,
+  getTrafficRateGrpc,
+  getTrafficRateHttp
+} from '../../utils/TrafficRate';
+import { InOutRateTableGrpc, InOutRateTableHttp } from '../../components/SummaryPanel/InOutRateTable';
+import { RpsChart, TcpChart } from '../../components/SummaryPanel/RpsChart';
+import {
+  GraphType,
+  NodeType,
+  SummaryPanelPropType,
+  Protocol,
+  DecoratedGraphNodeData,
+  UNKNOWN
+} from '../../types/Graph';
+import { Metrics, Metric, Datapoint } from '../../types/Metrics';
+import {
+  shouldRefreshData,
+  NodeMetricType,
+  getDatapoints,
+  getNodeMetrics,
+  getNodeMetricType,
+  renderNoTraffic,
+  mergeMetricsResponses,
+  hr
+} from './SummaryPanelCommon';
+import { CancelablePromise, makeCancelablePromise } from '../../utils/CancelablePromises';
+import { Response } from '../../services/Api';
+import { Reporter } from '../../types/MetricsOptions';
+import { CyNode, decoratedNodeData } from '../../components/CytoscapeGraph/CytoscapeGraphUtils';
+import { KialiIcon } from 'config/KialiIcon';
+
+type SummaryPanelNodeMetricsState = {
+  grpcRequestCountIn: Datapoint[];
+  grpcRequestCountOut: Datapoint[];
+  grpcErrorCountIn: Datapoint[];
+  grpcErrorCountOut: Datapoint[];
+  httpRequestCountIn: Datapoint[] | null;
+  httpRequestCountOut: Datapoint[];
+  httpErrorCountIn: Datapoint[];
+  httpErrorCountOut: Datapoint[];
+  tcpSentIn: Datapoint[];
+  tcpSentOut: Datapoint[];
+  tcpReceivedIn: Datapoint[];
+  tcpReceivedOut: Datapoint[];
+};
+
+type SummaryPanelNodeState = SummaryPanelNodeMetricsState & {
+  node: any;
+  loading: boolean;
+  metricsLoadError: string | null;
+};
+
+const defaultMetricsState: SummaryPanelNodeMetricsState = {
+  grpcRequestCountIn: [],
+  grpcRequestCountOut: [],
+  grpcErrorCountIn: [],
+  grpcErrorCountOut: [],
+  httpRequestCountIn: [],
+  httpRequestCountOut: [],
+  httpErrorCountIn: [],
+  httpErrorCountOut: [],
+  tcpSentIn: [],
+  tcpSentOut: [],
+  tcpReceivedIn: [],
+  tcpReceivedOut: []
+};
+
+const defaultState: SummaryPanelNodeState = {
+  node: null,
+  loading: false,
+  metricsLoadError: null,
+  ...defaultMetricsState
+};
+
+type SummaryPanelNodeProps = SummaryPanelPropType;
+
+export class SummaryPanelNodeTraffic extends React.Component<SummaryPanelNodeProps, SummaryPanelNodeState> {
+  private metricsPromise?: CancelablePromise<Response<Metrics>[]>;
+
+  constructor(props: SummaryPanelNodeProps) {
+    super(props);
+    this.showRequestCountMetrics = this.showRequestCountMetrics.bind(this);
+
+    this.state = { ...defaultState };
+  }
+
+  static getDerivedStateFromProps(props: SummaryPanelNodeProps, state: SummaryPanelNodeState) {
+    // if the summaryTarget (i.e. selected node) has changed, then init the state and set to loading. The loading
+    // will actually be kicked off after the render (in componentDidMount/Update).
+    return props.data.summaryTarget !== state.node
+      ? { node: props.data.summaryTarget, loading: true, ...defaultMetricsState }
+      : null;
+  }
+
+  componentDidMount() {
+    this.updateCharts(this.props);
+  }
+
+  componentDidUpdate(prevProps: SummaryPanelNodeProps) {
+    if (shouldRefreshData(prevProps, this.props)) {
+      this.updateCharts(this.props);
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.metricsPromise) {
+      this.metricsPromise.cancel();
+    }
+  }
+
+  private updateCharts(props: SummaryPanelNodeProps) {
+    const target = props.data.summaryTarget;
+    const nodeData = decoratedNodeData(target);
+    const nodeMetricType = getNodeMetricType(nodeData);
+
+    if (this.metricsPromise) {
+      this.metricsPromise.cancel();
+      this.metricsPromise = undefined;
+    }
+
+    if (!this.hasGrpcTraffic(nodeData) && !this.hasHttpTraffic(nodeData) && !this.hasTcpTraffic(nodeData)) {
+      this.setState({ loading: false });
+      return;
+    }
+
+    // If destination node is inaccessible, we cannot query the data.
+    if (nodeData.isInaccessible) {
+      this.setState({ loading: false });
+      return;
+    }
+
+    let promiseOut: Promise<Response<Metrics>> = Promise.resolve({ data: { metrics: {}, histograms: {} } });
+    let promiseIn: Promise<Response<Metrics>> = Promise.resolve({ data: { metrics: {}, histograms: {} } });
+
+    // Ignore outgoing traffic if it is a non-root outsider (because they have no outgoing edges) or a
+    // service node (because they don't have "real" outgoing edges).
+    if (nodeData.nodeType !== NodeType.SERVICE && (nodeData.isRoot || !nodeData.isOutside)) {
+      const filters = ['request_count', 'request_error_count', 'tcp_sent', 'tcp_received'];
+      // use source metrics for outgoing, except for:
+      // - unknown nodes (no source telemetry)
+      // - istio namespace nodes (no source telemetry)
+      const reporter: Reporter = nodeData.nodeType === NodeType.UNKNOWN || nodeData.isIstio ? 'destination' : 'source';
+      // note: request_protocol is not a valid byLabel for tcp filters but it is ignored by prometheus
+      const byLabels = nodeData.isOutside
+        ? ['destination_service_namespace', 'request_protocol']
+        : ['request_protocol'];
+      promiseOut = getNodeMetrics(
+        nodeMetricType,
+        target,
+        props,
+        filters,
+        'outbound',
+        reporter,
+        undefined,
+        undefined,
+        byLabels
+      );
+    }
+
+    // set incoming unless it is a root (because they have no incoming edges)
+    if (!nodeData.isRoot) {
+      const filtersRps = ['request_count', 'request_error_count'];
+      // use dest metrics for incoming, except for service nodes which need source metrics to capture source errors
+      const reporter: Reporter = nodeData.nodeType === NodeType.SERVICE && nodeData.isIstio ? 'source' : 'destination';
+      // For special service dest nodes we want to narrow the data to only TS with 'unknown' workloads (see the related
+      // comparator in getNodeDatapoints).
+      const isServiceDestCornerCase = this.isServiceDestCornerCase(nodeMetricType);
+      const byLabelsRps = isServiceDestCornerCase ? ['destination_workload', 'request_protocol'] : ['request_protocol'];
+      if (nodeData.isOutside) {
+        byLabelsRps.push('source_workload_namespace');
+      }
+      const promiseRps = getNodeMetrics(
+        nodeMetricType,
+        target,
+        props,
+        filtersRps,
+        'inbound',
+        reporter,
+        undefined,
+        undefined,
+        byLabelsRps
+      );
+      const filtersTCP = ['tcp_sent', 'tcp_received'];
+      const byLabelsTCP = isServiceDestCornerCase ? ['destination_workload'] : [];
+      if (nodeData.isOutside) {
+        byLabelsTCP.push('source_workload_namespace');
+      }
+      const promiseTCP = getNodeMetrics(
+        nodeMetricType,
+        target,
+        props,
+        filtersTCP,
+        'inbound',
+        'source',
+        undefined,
+        undefined,
+        byLabelsTCP
+      );
+      promiseIn = mergeMetricsResponses([promiseRps, promiseTCP]);
+    }
+
+    this.metricsPromise = makeCancelablePromise(Promise.all([promiseOut, promiseIn]));
+    this.metricsPromise.promise
+      .then(responses => {
+        this.showRequestCountMetrics(responses[0].data, responses[1].data, nodeData, nodeMetricType);
+      })
+      .catch(error => {
+        if (error.isCanceled) {
+          console.debug('SummaryPanelNode: Ignore fetch error (canceled).');
+          return;
+        }
+        const errorMsg = error.response && error.response.data.error ? error.response.data.error : error.message;
+        this.setState({
+          loading: false,
+          metricsLoadError: errorMsg,
+          ...defaultMetricsState
+        });
+      });
+
+    this.setState({ loading: true, metricsLoadError: null });
+  }
+
+  private showRequestCountMetrics(
+    outbound: Metrics,
+    inbound: Metrics,
+    data: DecoratedGraphNodeData,
+    nodeMetricType: NodeMetricType
+  ) {
+    let comparator = (metric: Metric, protocol?: Protocol) => {
+      return protocol ? metric.request_protocol === protocol : true;
+    };
+    if (this.isServiceDestCornerCase(nodeMetricType)) {
+      comparator = (metric: Metric, protocol?: Protocol) => {
+        return (protocol ? metric.request_protocol === protocol : true) && metric.destination_workload === UNKNOWN;
+      };
+    } else if (data.isOutside) {
+      // filter out traffic completely outside the active namespaces
+      comparator = (metric: Metric, protocol?: Protocol) => {
+        if (protocol && metric.request_protocol !== protocol) {
+          return false;
+        }
+        if (metric.destination_service_namespace && !this.isActiveNamespace(metric.destination_service_namespace)) {
+          return false;
+        }
+        if (metric.source_workload_namespace && !this.isActiveNamespace(metric.source_workload_namespace)) {
+          return false;
+        }
+        return true;
+      };
+    }
+    const rcOut = outbound.metrics.request_count;
+    const ecOut = outbound.metrics.request_error_count;
+    const tcpSentOut = outbound.metrics.tcp_sent;
+    const tcpReceivedOut = outbound.metrics.tcp_received;
+    const rcIn = inbound.metrics.request_count;
+    const ecIn = inbound.metrics.request_error_count;
+    const tcpSentIn = inbound.metrics.tcp_sent;
+    const tcpReceivedIn = inbound.metrics.tcp_received;
+    this.setState({
+      loading: false,
+      grpcRequestCountOut: getDatapoints(rcOut, comparator, Protocol.GRPC),
+      grpcErrorCountOut: getDatapoints(ecOut, comparator, Protocol.GRPC),
+      grpcRequestCountIn: getDatapoints(rcIn, comparator, Protocol.GRPC),
+      grpcErrorCountIn: getDatapoints(ecIn, comparator, Protocol.GRPC),
+      httpRequestCountOut: getDatapoints(rcOut, comparator, Protocol.HTTP),
+      httpErrorCountOut: getDatapoints(ecOut, comparator, Protocol.HTTP),
+      httpRequestCountIn: getDatapoints(rcIn, comparator, Protocol.HTTP),
+      httpErrorCountIn: getDatapoints(ecIn, comparator, Protocol.HTTP),
+      tcpSentOut: getDatapoints(tcpSentOut, comparator),
+      tcpReceivedOut: getDatapoints(tcpReceivedOut, comparator),
+      tcpSentIn: getDatapoints(tcpSentIn, comparator),
+      tcpReceivedIn: getDatapoints(tcpReceivedIn, comparator)
+    });
+  }
+
+  private isActiveNamespace = (namespace: string): boolean => {
+    if (!namespace) {
+      return false;
+    }
+    for (const ns of this.props.namespaces) {
+      if (ns.name === namespace) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  render() {
+    const node = this.props.data.summaryTarget;
+    const nodeData = decoratedNodeData(node);
+
+    return (
+      <>
+        {this.hasGrpcTraffic(nodeData) && (
+          <>
+            {this.renderGrpcRates(node)}
+            {hr()}
+          </>
+        )}
+        {this.hasHttpTraffic(nodeData) && (
+          <>
+            {this.renderHttpRates(node)}
+            {hr()}
+          </>
+        )}
+        <div>
+          {this.renderCharts(node)}
+          {hr()}
+        </div>
+        {!this.hasGrpcTraffic(nodeData) && renderNoTraffic('GRPC')}
+        {!this.hasHttpTraffic(nodeData) && renderNoTraffic('HTTP')}
+      </>
+    );
+  }
+
+  private renderGrpcRates = node => {
+    const incoming = getTrafficRateGrpc(node);
+    const outgoing = getAccumulatedTrafficRateGrpc(this.props.data.summaryTarget.edgesTo('*'));
+
+    return (
+      <>
+        <InOutRateTableGrpc
+          title="GRPC Traffic (requests per second):"
+          inRate={incoming.rate}
+          inRateErr={incoming.rateErr}
+          outRate={outgoing.rate}
+          outRateErr={outgoing.rateErr}
+        />
+      </>
+    );
+  };
+
+  private renderHttpRates = node => {
+    const incoming = getTrafficRateHttp(node);
+    const outgoing = getAccumulatedTrafficRateHttp(this.props.data.summaryTarget.edgesTo('*'));
+
+    return (
+      <>
+        <InOutRateTableHttp
+          title="HTTP (requests per second):"
+          inRate={incoming.rate}
+          inRate3xx={incoming.rate3xx}
+          inRate4xx={incoming.rate4xx}
+          inRate5xx={incoming.rate5xx}
+          outRate={outgoing.rate}
+          outRate3xx={outgoing.rate3xx}
+          outRate4xx={outgoing.rate4xx}
+          outRate5xx={outgoing.rate5xx}
+        />
+      </>
+    );
+  };
+
+  private renderCharts = node => {
+    const nodeData = decoratedNodeData(node);
+
+    if (NodeType.UNKNOWN === nodeData.nodeType) {
+      return (
+        <>
+          <div>
+            <KialiIcon.Info /> Sparkline charts not supported for unknown node. Use edge for details.
+          </div>
+        </>
+      );
+    } else if (nodeData.isInaccessible) {
+      return (
+        <>
+          <div>
+            <KialiIcon.Info /> Sparkline charts cannot be shown because the selected node is inaccessible.
+          </div>
+        </>
+      );
+    } else if (nodeData.isServiceEntry) {
+      return (
+        <>
+          <div>
+            <KialiIcon.Info /> Sparkline charts cannot be shown because the selected node is a serviceEntry.
+          </div>
+        </>
+      );
+    }
+    if (this.state.loading) {
+      return <strong>Loading charts...</strong>;
+    }
+    if (this.state.metricsLoadError) {
+      return (
+        <div>
+          <KialiIcon.Warning /> <strong>Error loading metrics: </strong>
+          {this.state.metricsLoadError}
+        </div>
+      );
+    }
+
+    const isServiceNode = nodeData.nodeType === NodeType.SERVICE;
+    let serviceWithUnknownSource: boolean = false;
+    if (isServiceNode) {
+      node.incomers().forEach(n => {
+        if (NodeType.UNKNOWN === n.data(CyNode.nodeType)) {
+          serviceWithUnknownSource = true;
+          return false; // Equivalent of break for cytoscapejs forEach API
+        }
+        return undefined; // Every code paths needs to return something to avoid the wrath of the linter.
+      });
+    }
+
+    let grpcCharts, httpCharts, tcpCharts;
+
+    if (this.hasGrpcTraffic(nodeData)) {
+      grpcCharts = (
+        <>
+          <RpsChart
+            label={isServiceNode ? 'GRPC - Request Traffic' : 'GRPC - Inbound Request Traffic'}
+            dataRps={this.state.grpcRequestCountIn!}
+            dataErrors={this.state.grpcErrorCountIn}
+          />
+          {serviceWithUnknownSource && (
+            <>
+              <div>
+                <KialiIcon.Info /> Traffic from unknown not included. Use edge for details.
+              </div>
+            </>
+          )}
+          <RpsChart
+            label="GRPC - Outbound Request Traffic"
+            dataRps={this.state.grpcRequestCountOut}
+            dataErrors={this.state.grpcErrorCountOut}
+            hide={isServiceNode}
+          />
+          {this.isIstioOutgoingCornerCase(node) && (
+            <>
+              <div>
+                <KialiIcon.Info /> Traffic to Istio namespaces not included. Use edge for details.
+              </div>
+            </>
+          )}
+        </>
+      );
+    }
+
+    if (this.hasHttpTraffic(nodeData)) {
+      httpCharts = (
+        <>
+          <RpsChart
+            label={isServiceNode ? 'HTTP - Request Traffic' : 'HTTP - Inbound Request Traffic'}
+            dataRps={this.state.httpRequestCountIn!}
+            dataErrors={this.state.httpErrorCountIn}
+          />
+          {serviceWithUnknownSource && (
+            <>
+              <div>
+                <KialiIcon.Info /> Traffic from unknown not included. Use edge for details.
+              </div>
+            </>
+          )}
+          <RpsChart
+            label="HTTP - Outbound Request Traffic"
+            dataRps={this.state.httpRequestCountOut}
+            dataErrors={this.state.httpErrorCountOut}
+            hide={isServiceNode}
+          />
+          {this.isIstioOutgoingCornerCase(node) && (
+            <>
+              <div>
+                <KialiIcon.Info /> Traffic to Istio namespaces not included. Use edge for details.
+              </div>
+            </>
+          )}
+        </>
+      );
+    }
+
+    if (this.hasTcpTraffic(nodeData)) {
+      tcpCharts = (
+        <>
+          <TcpChart
+            label={isServiceNode ? 'TCP - Traffic' : 'TCP - Inbound Traffic'}
+            receivedRates={this.state.tcpReceivedIn}
+            sentRates={this.state.tcpSentIn}
+          />
+          <TcpChart
+            label="TCP - Outbound Traffic"
+            receivedRates={this.state.tcpReceivedOut}
+            sentRates={this.state.tcpSentOut}
+            hide={isServiceNode}
+          />
+        </>
+      );
+    }
+
+    return (
+      <>
+        {grpcCharts}
+        {httpCharts}
+        {tcpCharts}
+      </>
+    );
+  };
+
+  // We need to handle the special case of a dest service node showing client failures. These service nodes show up in
+  // non-service graphs, even when not injecting service nodes.
+  private isServiceDestCornerCase = (nodeMetricType: NodeMetricType): boolean => {
+    return (
+      nodeMetricType === NodeMetricType.SERVICE &&
+      !this.props.injectServiceNodes &&
+      this.props.graphType !== GraphType.SERVICE
+    );
+  };
+
+  // We need to handle the special case of a non-istio, non-unknown node with outgoing traffic to istio.
+  // The traffic is lost because it is dest-only and we use source-reporting.
+  private isIstioOutgoingCornerCase = (node): boolean => {
+    const nodeData = decoratedNodeData(node);
+    if (nodeData.nodeType === NodeType.UNKNOWN || nodeData.isIstio) {
+      return false;
+    }
+    return node.edgesTo(`node[?${CyNode.isIstio}]`).size() > 0;
+  };
+
+  private hasGrpcTraffic = (data: DecoratedGraphNodeData): boolean => {
+    return data.grpcIn > 0 || data.grpcOut > 0;
+  };
+
+  private hasHttpTraffic = (data: DecoratedGraphNodeData): boolean => {
+    return data.httpIn > 0 || data.httpOut > 0;
+  };
+
+  private hasTcpTraffic = (data: DecoratedGraphNodeData): boolean => {
+    return data.tcpIn > 0 || data.tcpOut > 0;
+  };
+}

--- a/src/utils/SearchParamUtils.ts
+++ b/src/utils/SearchParamUtils.ts
@@ -12,3 +12,15 @@ export const getFocusSelector = () => {
 export const unsetFocusSelector = () => {
   HistoryManager.deleteParam(URLParam.FOCUS_SELECTOR, true);
 };
+
+export const getExperimentalFlags = (): string[] => {
+  const flags = HistoryManager.getParam(URLParam.EXPERIMENTAL_FLAGS);
+  if (!flags) {
+    return [];
+  }
+  return flags.split(',');
+};
+
+export const hasExperimentalFlag = (flag: string): boolean => {
+  return getExperimentalFlags().includes(flag);
+};


### PR DESCRIPTION
- Split file SummaryPanelNode => (SummaryPanelNode + SummaryPanelNodeMetrics)
- When traces are enabled & service is selected, show a tabbed view Traces/Metrics below contextual node info

Fixes https://github.com/kiali/kiali/issues/2840
