### PR TITLE
Bump k-charted 0.6.0 final (no change)

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "snyk-protect": "snyk protect"
   },
   "dependencies": {
-    "@kiali/k-charted-pf4": "0.6.0-rc5",
+    "@kiali/k-charted-pf4": "0.6.0",
     "@patternfly/patternfly": "2.71.3",
     "@patternfly/react-charts": "5.3.18",
     "@patternfly/react-core": "3.153.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1899,10 +1899,10 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@kiali/k-charted-pf4@0.6.0-rc5":
-  version "0.6.0-rc5"
-  resolved "https://registry.yarnpkg.com/@kiali/k-charted-pf4/-/k-charted-pf4-0.6.0-rc5.tgz#4f33505b24fab684cac11bbacaebd30e52207d49"
-  integrity sha512-Amc2aa+AeCfQEDd3gfQVuKz/T51VA0yf8N5aC2ywO952xCce6vudDtTOaXzgAlpovJPD96t3ydwJyq1rb9F1uQ==
+"@kiali/k-charted-pf4@0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@kiali/k-charted-pf4/-/k-charted-pf4-0.6.0.tgz#74f211b5afa5c9205af005907ec809327c824948"
+  integrity sha512-I+0pmjpDB8O7dA6HkdYuGVqgzmYUXfqsT+PTjqcuI8/jB7JGTcR6OY2p3aiAOfatHoiZg3zzWLmE78enU2GhsQ==
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"


### PR DESCRIPTION
Bump k-charted 0.6.0-rc5 => 0.6.0 (no change, just use released final version)