### PR TITLE
Traffic wizards - handle PeerAuthentications

### DIFF
--- a/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -9,7 +9,7 @@ import { ServiceDetailsInfo, validationToSeverity } from '../../types/ServiceInf
 import ServiceInfoVirtualServices from './ServiceInfo/ServiceInfoVirtualServices';
 import ServiceInfoDestinationRules from './ServiceInfo/ServiceInfoDestinationRules';
 import ServiceInfoWorkload from './ServiceInfo/ServiceInfoWorkload';
-import { ObjectValidation, Validations, ValidationTypes } from '../../types/IstioObjects';
+import { ObjectValidation, PeerAuthentication, Validations, ValidationTypes } from '../../types/IstioObjects';
 import ParameterizedTabs, { activeTab } from '../../components/Tab/Tabs';
 import ErrorBoundaryWithMessage from '../../components/ErrorBoundary/ErrorBoundaryWithMessage';
 import Validation from '../../components/Validations/Validation';
@@ -31,6 +31,7 @@ interface Props extends ServiceId {
 type ServiceInfoState = {
   serviceDetails?: ServiceDetailsInfo;
   gateways: string[];
+  peerAuthentications: PeerAuthentication[];
   validations: Validations;
   currentTab: string;
 };
@@ -60,6 +61,7 @@ class ServiceInfo extends React.Component<Props, ServiceInfoState> {
     super(props);
     this.state = {
       gateways: [],
+      peerAuthentications: [],
       validations: {},
       currentTab: activeTab(tabName, defaultTab)
     };
@@ -117,6 +119,16 @@ class ServiceInfo extends React.Component<Props, ServiceInfoState> {
       })
       .catch(error => {
         AlertUtils.addError('Could not fetch Service Details.', error);
+      });
+
+    API.getIstioConfig(this.props.namespace, ['peerauthentications'], false, '')
+      .then(results => {
+        this.setState({
+          peerAuthentications: results.data.peerAuthentications
+        });
+      })
+      .catch(error => {
+        AlertUtils.addError('Could not fetch PeerAuthentications.', error);
       });
 
     this.graphDataSource.fetchForService(this.props.duration, this.props.namespace, this.props.service);
@@ -317,6 +329,7 @@ class ServiceInfo extends React.Component<Props, ServiceInfoState> {
             virtualServices={details.virtualServices}
             destinationRules={details.destinationRules}
             gateways={this.state.gateways}
+            peerAuthentications={this.state.peerAuthentications}
             tlsStatus={details.namespaceMTLS}
             onChange={this.fetchBackend}
           />


### PR DESCRIPTION
This PR's handles the fact of creating/editing/removing a PeerAuthentication while user is performing any traffic management wizard from the service details page.

When the user switch on the 'Add PeerAuthentication', the wizard will create a PeerAuthentication object with the selected dropdown. In case, the user switch off the selector, the wizard will remove that PeerAuthentication object.

The PeerAuthentication object it always apply to the workload in the same namespace and applying to the same 'app' label.
There is not option to indicate the tls mode at port-level. IMO, this scenario is a bit advanced.

![peerauthn-wizard](https://user-images.githubusercontent.com/613814/88049524-9757e500-cb55-11ea-817c-01698ce6e78e.gif)

Fixes https://github.com/kiali/kiali/issues/1381