### PR TITLE
Fix graph losing focused node context after first refresh

### DIFF
--- a/src/components/CytoscapeGraph/EmptyGraphLayout.tsx
+++ b/src/components/CytoscapeGraph/EmptyGraphLayout.tsx
@@ -43,7 +43,7 @@ export default class EmptyGraphLayout extends React.Component<EmptyGraphLayoutPr
       return true;
     }
     // Do not update if we have elements and the namespace didn't change, as this means we are refreshing
-    return !(!nextIsEmpty && this.props.namespaces === nextProps.namespaces);
+    return !(!nextIsEmpty && _.isEqual(this.props.namespaces, nextProps.namespaces));
   }
 
   namespacesText() {

--- a/src/pages/Graph/GraphToolbar/GraphFind.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphFind.tsx
@@ -62,7 +62,7 @@ const thinGroupStyle = style({
   paddingRight: '10px'
 });
 
-export class GraphFind extends React.PureComponent<GraphFindProps, GraphFindState> {
+export class GraphFind extends React.Component<GraphFindProps, GraphFindState> {
   static contextTypes = {
     router: () => null
   };

--- a/src/pages/Graph/GraphToolbar/GraphSettings.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphSettings.tsx
@@ -292,7 +292,7 @@ class GraphSettings extends React.PureComponent<GraphSettingsProps, GraphSetting
         <div id="graph-display-menu" className={menuStyle}>
           <div className={titleStyle}>Show Edge Labels</div>
           {edgeLabelOptions.map((item: DisplayOptionType) => (
-            <div style={{ display: 'inline-block', cursor: 'not-allowed' }}>
+            <div key={item.id} style={{ display: 'inline-block', cursor: 'not-allowed' }}>
               <label key={item.id} className={itemStyle(!!item.tooltip)}>
                 <Radio
                   id={item.id}
@@ -312,7 +312,7 @@ class GraphSettings extends React.PureComponent<GraphSettingsProps, GraphSetting
           ))}
           <div className={titleStyle}>Show</div>
           {visibilityOptions.map((item: DisplayOptionType) => (
-            <div style={{ display: 'inline-block', cursor: 'not-allowed' }}>
+            <div key={item.id} style={{ display: 'inline-block', cursor: 'not-allowed' }}>
               <label key={item.id} className={itemStyle(!!item.tooltip)}>
                 <Checkbox
                   id={item.id}
@@ -331,7 +331,7 @@ class GraphSettings extends React.PureComponent<GraphSettingsProps, GraphSetting
           ))}
           <div className={titleStyle}>Show Badges</div>
           {badgeOptions.map((item: DisplayOptionType) => (
-            <div style={{ display: 'inline-block', cursor: 'not-allowed' }}>
+            <div key={item.id} style={{ display: 'inline-block', cursor: 'not-allowed' }}>
               <label key={item.id} className={itemStyle(!!item.tooltip)}>
                 <Checkbox id={item.id} isChecked={item.isChecked} label={item.labelText} onChange={item.onChange} />
               </label>

--- a/src/pages/Graph/SummaryPanelGraph.tsx
+++ b/src/pages/Graph/SummaryPanelGraph.tsx
@@ -261,13 +261,13 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
   };
 
   private renderNamespacesSummary = () => {
-    return <>{this.props.namespaces.map(namespace => this.renderNamespace(namespace.name))}</>;
+    return this.props.namespaces.map(namespace => this.renderNamespace(namespace.name));
   };
 
   private renderNamespace = (ns: string) => {
     const validation = this.state.validationsMap[ns];
     return (
-      <>
+      <React.Fragment key={ns}>
         <span>
           <Tooltip position={TooltipPosition.auto} content={<>Namespace</>}>
             <Badge className="virtualitem_badge_definition" style={{ marginBottom: '2px' }}>
@@ -286,7 +286,7 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
           )}
         </span>
         <br />
-      </>
+      </React.Fragment>
     );
   };
 


### PR DESCRIPTION
Was due to improper array equality check in EmptyGraphLayout
Fixing at the same time some warning in dev console:
- Some missing key props in lists
- React complaining that GraphFind should not be PureComponent as it has 'shouldComponentUpdate'

Fixes https://github.com/kiali/kiali/issues/2957
