### PR TITLE
In-graph tracing: show trace details

### DIFF
--- a/src/actions/JaegerThunkActions.ts
+++ b/src/actions/JaegerThunkActions.ts
@@ -6,9 +6,11 @@ import * as API from '../services/Api';
 import { KialiAppAction } from './KialiAppAction';
 import { transformTraceData } from 'components/JaegerIntegration/JaegerResults';
 import { JaegerActions } from './JaegerActions';
+import { setTraceId as setURLTraceId } from 'utils/SearchParamUtils';
 
 export const JaegerThunkActions = {
-  fetchTrace: (traceId?: string) => {
+  setTraceId: (traceId?: string) => {
+    setURLTraceId(traceId);
     return (dispatch: ThunkDispatch<KialiAppState, void, KialiAppAction>) => {
       if (traceId) {
         API.getJaegerTrace(traceId)

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -55,6 +55,7 @@ type CytoscapeGraphProps = {
   refreshInterval: IntervalInMilliseconds;
   setActiveNamespaces?: (namespace: Namespace[]) => void;
   setNode?: (node?: NodeParamsType) => void;
+  setTraceId?: (traceId?: string) => void;
   setUpdateTime?: (val: TimeInMilliseconds) => void;
   showCircuitBreakers: boolean;
   showMissingSidecars: boolean;
@@ -136,7 +137,7 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps>
   }
 
   componentDidMount() {
-    this.cyInitialization(this.getCy());
+    this.cyInitialization(this.getCy()!);
   }
 
   shouldComponentUpdate(nextProps: CytoscapeGraphProps) {
@@ -213,6 +214,7 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps>
     if (this.props.graphData.elements !== prevProps.graphData.elements) {
       this.updateHealth(cy);
     }
+
     if (this.props.trace) {
       showTrace(cy, this.props.trace);
     } else if (!this.props.trace && prevProps.trace) {
@@ -247,7 +249,7 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps>
     );
   }
 
-  getCy() {
+  getCy(): Cy.Core | null {
     return this.cytoscapeReactWrapperRef.current ? this.cytoscapeReactWrapperRef.current.getCy() : null;
   }
 
@@ -276,7 +278,7 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps>
 
   private setCytoscapeReactWrapperRef(cyRef: any) {
     this.cytoscapeReactWrapperRef.current = cyRef;
-    this.cyInitialization(this.getCy());
+    this.cyInitialization(this.getCy()!);
   }
 
   private onResize = () => {
@@ -625,6 +627,11 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps>
       this.cy.$(':selected').selectify().unselect().unselectify();
       if (target && !isCore(target)) {
         target.selectify().select().unselectify();
+      }
+
+      if (this.props.setTraceId && this.props.trace && this.cy.$('.span:selected').length === 0) {
+        // No selected node in trace => clear trace selection
+        this.props.setTraceId(undefined);
       }
     }
   };

--- a/src/components/CytoscapeGraph/CytoscapeGraphSelector.ts
+++ b/src/components/CytoscapeGraph/CytoscapeGraphSelector.ts
@@ -17,6 +17,7 @@ interface CytoscapeElementData {
 
 export class CytoscapeGraphSelectorBuilder {
   private data: CytoscapeElementData = {};
+  private clazz: string = '';
 
   aggregate(aggregate: string, aggregateValue: string) {
     this.data.aggregate = aggregate;
@@ -26,6 +27,11 @@ export class CytoscapeGraphSelectorBuilder {
 
   app(app: string) {
     this.data.app = app;
+    return this;
+  }
+
+  class(clazz: string) {
+    this.clazz = '.' + clazz;
     return this;
   }
 
@@ -65,7 +71,7 @@ export class CytoscapeGraphSelectorBuilder {
   }
 
   build(): CytoscapeGraphSelector {
-    return 'node' + this.buildDataSelector();
+    return 'node' + this.clazz + this.buildDataSelector();
   }
 
   private buildDataSelector() {

--- a/src/components/CytoscapeGraph/CytoscapeTrace.ts
+++ b/src/components/CytoscapeGraph/CytoscapeTrace.ts
@@ -17,8 +17,8 @@ export const showTrace = (cy: Cy.Core, trace: JaegerTrace) => {
 
   trace.spans.forEach(span => {
     const split = span.process.serviceName.split('.');
-    const service = split[0];
-    let selector = `[${CyNode.nodeType}="${NodeType.SERVICE}"][${CyNode.service}="${service}"]`;
+    const app = split[0];
+    let selector = `[${CyNode.nodeType}="${NodeType.SERVICE}"][${CyNode.app}="${app}"]`;
     selector = split.length > 1 ? `${selector}[${CyNode.namespace}="${split[1]}"]` : selector;
     const serviceSelection = cy.elements(selector);
     if (!!serviceSelection) {

--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -627,7 +627,7 @@ export class GraphStyles {
         style: {
           'overlay-color': PfColors.Purple200,
           'overlay-padding': '7px',
-          'overlay-opacity': 0.2
+          'overlay-opacity': 0.3
         }
       }
     ];

--- a/src/pages/Graph/GraphPage.tsx
+++ b/src/pages/Graph/GraphPage.tsx
@@ -350,9 +350,9 @@ export class GraphPage extends React.Component<GraphPageProps, GraphPageState> {
       this.errorBoundaryRef.current.cleanError();
     }
 
-    if (prev.summaryData !== this.props.summaryData) {
-      this.props.setTraceId(undefined);
-    }
+    // if (prev.summaryData !== curr.summaryData && curr.node && curr.node.) {
+    //   this.props.setTraceId(undefined);
+    // }
 
     if (curr.showLegend && this.props.activeTour) {
       this.props.endTour();
@@ -702,7 +702,7 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<KialiAppState, void, KialiAp
   setActiveNamespaces: (namespaces: Namespace[]) => dispatch(NamespaceActions.setActiveNamespaces(namespaces)),
   setGraphDefinition: bindActionCreators(GraphActions.setGraphDefinition, dispatch),
   setNode: bindActionCreators(GraphActions.setNode, dispatch),
-  setTraceId: (traceId?: string) => dispatch(JaegerThunkActions.fetchTrace(traceId)),
+  setTraceId: (traceId?: string) => dispatch(JaegerThunkActions.setTraceId(traceId)),
   setUpdateTime: (val: TimeInMilliseconds) => dispatch(GraphActions.setUpdateTime(val)),
   startTour: bindActionCreators(TourActions.startTour, dispatch),
   toggleLegend: bindActionCreators(GraphToolbarActions.toggleLegend, dispatch),

--- a/src/pages/Graph/GraphPage.tsx
+++ b/src/pages/Graph/GraphPage.tsx
@@ -350,10 +350,6 @@ export class GraphPage extends React.Component<GraphPageProps, GraphPageState> {
       this.errorBoundaryRef.current.cleanError();
     }
 
-    // if (prev.summaryData !== curr.summaryData && curr.node && curr.node.) {
-    //   this.props.setTraceId(undefined);
-    // }
-
     if (curr.showLegend && this.props.activeTour) {
       this.props.endTour();
     }

--- a/src/pages/Graph/SummaryPanelCommon.tsx
+++ b/src/pages/Graph/SummaryPanelCommon.tsx
@@ -10,6 +10,7 @@ import { Response } from '../../services/Api';
 import { decoratedNodeData } from 'components/CytoscapeGraph/CytoscapeGraphUtils';
 import { PfColors } from 'components/Pf/PfColors';
 import { KialiIcon } from 'config/KialiIcon';
+import { CSSProperties } from 'typestyle/lib/types';
 
 export enum NodeMetricType {
   APP = 1,
@@ -26,14 +27,18 @@ export const summaryHeader: React.CSSProperties = {
   backgroundColor: PfColors.White
 };
 
-export const summaryPanel = style({
+const summaryPanelCommon: CSSProperties = {
   height: '100%',
   margin: 0,
   minWidth: '25em',
   overflowY: 'scroll',
   backgroundColor: PfColors.White,
   width: '25em'
-});
+};
+
+export const summaryPanel = style(summaryPanelCommon);
+export const summaryPanelTopSplit = style({ ...summaryPanelCommon, height: '60%' });
+export const summaryPanelBottomSplit = style({ ...summaryPanelCommon, height: '40%', overflowY: 'initial' });
 
 export const summaryFont: React.CSSProperties = {
   fontSize: 'var(--graph-side-panel--font-size)'

--- a/src/pages/Graph/SummaryPanelCommon.tsx
+++ b/src/pages/Graph/SummaryPanelCommon.tsx
@@ -37,8 +37,8 @@ const summaryPanelCommon: CSSProperties = {
 };
 
 export const summaryPanel = style(summaryPanelCommon);
-export const summaryPanelTopSplit = style({ ...summaryPanelCommon, height: '60%' });
-export const summaryPanelBottomSplit = style({ ...summaryPanelCommon, height: '40%', overflowY: 'initial' });
+export const summaryPanelTopSplit = style({ ...summaryPanelCommon, height: '50%' });
+export const summaryPanelBottomSplit = style({ ...summaryPanelCommon, height: '50%', overflowY: 'initial' });
 
 export const summaryFont: React.CSSProperties = {
   fontSize: 'var(--graph-side-panel--font-size)'

--- a/src/pages/Graph/SummaryPanelNode.tsx
+++ b/src/pages/Graph/SummaryPanelNode.tsx
@@ -127,7 +127,11 @@ export class SummaryPanelNode extends React.Component<SummaryPanelNodeProps, Sum
         {this.props.jaegerState.selectedTrace && (
           <div className={`panel panel-default ${summaryPanelBottomSplit}`}>
             <div className="panel-body">
-              <SummaryPanelTraceDetails trace={this.props.jaegerState.selectedTrace} node={node} />
+              <SummaryPanelTraceDetails
+                trace={this.props.jaegerState.selectedTrace}
+                node={node}
+                jaegerURL={this.props.jaegerState.info?.url}
+              />
             </div>
           </div>
         )}
@@ -155,7 +159,7 @@ export class SummaryPanelNode extends React.Component<SummaryPanelNodeProps, Sum
           <Tab style={summaryFont} title="Traces" eventKey={1}>
             <SummaryPanelNodeTraces
               namespace={nodeData.namespace}
-              service={nodeData.service!}
+              app={nodeData.app || nodeData.service!}
               queryTime={this.props.queryTime}
             />
           </Tab>

--- a/src/pages/Graph/SummaryPanelNode.tsx
+++ b/src/pages/Graph/SummaryPanelNode.tsx
@@ -21,7 +21,6 @@ import { KialiAppState } from 'store/Store';
 import { SummaryPanelNodeTraffic } from './SummaryPanelNodeTraffic';
 import SummaryPanelNodeTraces from './SummaryPanelNodeTraces';
 import SimpleTabs from 'components/Tab/SimpleTabs';
-import { hasExperimentalFlag } from 'utils/SearchParamUtils';
 import { JaegerState } from 'reducers/JaegerState';
 import SummaryPanelTraceDetails from './SummaryPanelTraceDetails';
 
@@ -84,8 +83,7 @@ export class SummaryPanelNode extends React.Component<SummaryPanelNodeProps, Sum
       !nodeData.isInaccessible &&
       this.props.jaegerState.info &&
       this.props.jaegerState.info.enabled &&
-      this.props.jaegerState.info.integration &&
-      hasExperimentalFlag('igt');
+      this.props.jaegerState.info.integration;
     const mainStyle = this.props.jaegerState.selectedTrace ? summaryPanelTopSplit : summaryPanel;
 
     const actions = getOptions(nodeData, this.props.jaegerState.info).map(o => {

--- a/src/pages/Graph/SummaryPanelNodeTraces.tsx
+++ b/src/pages/Graph/SummaryPanelNodeTraces.tsx
@@ -133,7 +133,7 @@ class SummaryPanelNodeTraces extends React.Component<Props, State> {
   }
 
   render() {
-    const tracesDetailsURL = `/namespaces/${this.props.namespace}/services/${this.props.app}?tab=traces`;
+    const tracesDetailsURL = `/namespaces/${this.props.namespace}/applications/${this.props.app}?tab=traces`;
     const currentID = this.props.selectedTrace?.traceID;
 
     return (

--- a/src/pages/Graph/SummaryPanelNodeTraces.tsx
+++ b/src/pages/Graph/SummaryPanelNodeTraces.tsx
@@ -21,7 +21,7 @@ import { summaryFont } from './SummaryPanelCommon';
 
 type Props = {
   namespace: string;
-  service: string;
+  app: string;
   queryTime: TimeInSeconds;
   setTraceId: (traceId?: string) => void;
   selectedTrace?: JaegerTrace;
@@ -82,7 +82,7 @@ class SummaryPanelNodeTraces extends React.Component<Props, State> {
       this.state.useGraphRefresh &&
       (prevProps.queryTime !== this.props.queryTime ||
         prevProps.namespace !== this.props.namespace ||
-        prevProps.service !== this.props.service)
+        prevProps.app !== this.props.app)
     ) {
       this.loadTraces();
     }
@@ -100,7 +100,7 @@ class SummaryPanelNodeTraces extends React.Component<Props, State> {
     };
     this.promises.cancelAll();
     this.promises
-      .register('traces', API.getJaegerTraces(this.props.namespace, this.props.service, params))
+      .register('traces', API.getJaegerTraces(this.props.namespace, this.props.app, params))
       .then(response => {
         const traces = response.data.data
           ? (response.data.data
@@ -128,9 +128,6 @@ class SummaryPanelNodeTraces extends React.Component<Props, State> {
   }
 
   render() {
-    if (this.state.traces.length === 0) {
-      return null;
-    }
     const tracesDetailsURL = `/namespaces/${this.props.namespace}/applications/${this.props.service}?tab=traces`;
     const currentID = this.props.selectedTrace?.traceID;
 
@@ -155,19 +152,21 @@ class SummaryPanelNodeTraces extends React.Component<Props, State> {
             <SyncAltIcon />
           </Button>
         </div>
-        <SimpleList style={{ marginBottom: 8 }} aria-label="Traces list">
-          {this.state.traces.map(trace => {
-            return (
-              <SimpleListItem
-                key={'trace_' + trace.traceID}
-                onClick={() => this.onClickTrace(trace)}
-                isCurrent={trace.traceID === currentID}
-              >
-                <TraceListItem trace={trace} />
-              </SimpleListItem>
-            );
-          })}
-        </SimpleList>
+        {this.state.traces.length > 0 && (
+          <SimpleList style={{ marginBottom: 8 }} aria-label="Traces list">
+            {this.state.traces.map(trace => {
+              return (
+                <SimpleListItem
+                  key={'trace_' + trace.traceID}
+                  onClick={() => this.onClickTrace(trace)}
+                  isCurrent={trace.traceID === currentID}
+                >
+                  <TraceListItem trace={trace} />
+                </SimpleListItem>
+              );
+            })}
+          </SimpleList>
+        )}
         <Button style={summaryFont} onClick={() => history.push(tracesDetailsURL)}>
           Go to Tracing
         </Button>

--- a/src/pages/Graph/SummaryPanelNodeTraces.tsx
+++ b/src/pages/Graph/SummaryPanelNodeTraces.tsx
@@ -181,7 +181,7 @@ const mapStateToProps = (state: KialiAppState) => ({
 });
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<KialiAppState, void, KialiAppAction>) => ({
-  setTraceId: (traceId?: string) => dispatch(JaegerThunkActions.fetchTrace(traceId))
+  setTraceId: (traceId?: string) => dispatch(JaegerThunkActions.setTraceId(traceId))
 });
 
 const SummaryPanelNodeTracesContainer = connect(mapStateToProps, mapDispatchToProps)(SummaryPanelNodeTraces);

--- a/src/pages/Graph/SummaryPanelTraceDetails.tsx
+++ b/src/pages/Graph/SummaryPanelTraceDetails.tsx
@@ -92,6 +92,7 @@ class SummaryPanelTraceDetails extends React.Component<Props, State> {
       node.app && this.props.jaegerURL ? `${this.props.jaegerURL}/trace/${this.props.trace.traceID}` : undefined;
     const info = getFormattedTraceInfo(this.props.trace);
     const nameStyleToUse = info.errors ? nameStyle + ' ' + errorStyle : nameStyle;
+    const nodeName = node.workload || node.service || node.app;
     const spans: Span[] | undefined = this.props.node.data('spans');
     return (
       <>
@@ -143,7 +144,9 @@ class SummaryPanelTraceDetails extends React.Component<Props, State> {
               >
                 <AngleLeftIcon />
               </Button>
-              <span className={navSpanStyle}>Span {this.state.selectedSpan + 1 + ' / ' + spans.length}</span>
+              <span className={navSpanStyle}>
+                Span on {nodeName} {this.state.selectedSpan + 1 + ' / ' + spans.length}
+              </span>
               <Button
                 variant={ButtonVariant.plain}
                 isDisabled={this.state.selectedSpan >= spans.length - 1}

--- a/src/pages/Graph/SummaryPanelTraceDetails.tsx
+++ b/src/pages/Graph/SummaryPanelTraceDetails.tsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { ThunkDispatch } from 'redux-thunk';
 import { style } from 'typestyle';
 import { Tooltip, Button, ButtonVariant } from '@patternfly/react-core';
-import { CloseIcon, AngleLeftIcon, AngleRightIcon } from '@patternfly/react-icons';
+import { CloseIcon, AngleLeftIcon, AngleRightIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 import { URLParam } from '../../app/History';
 import { JaegerTrace, Span } from 'types/JaegerInfo';
@@ -22,6 +22,7 @@ import FocusAnimation from 'components/CytoscapeGraph/FocusAnimation';
 type Props = {
   trace: JaegerTrace;
   node: any;
+  jaegerURL?: string;
   close: () => void;
 };
 
@@ -84,9 +85,11 @@ class SummaryPanelTraceDetails extends React.Component<Props, State> {
 
   render() {
     const node = decoratedNodeData(this.props.node);
-    const tracesDetailsURL = node.service
-      ? `/namespaces/${node.namespace}/services/${node.service}?tab=traces&${URLParam.JAEGER_TRACE_ID}=${this.props.trace.traceID}`
+    const tracesDetailsURL = node.app
+      ? `/namespaces/${node.namespace}/services/${node.app}?tab=traces&${URLParam.JAEGER_TRACE_ID}=${this.props.trace.traceID}`
       : undefined;
+    const jaegerTraceURL =
+      node.app && this.props.jaegerURL ? `${this.props.jaegerURL}/trace/${this.props.trace.traceID}` : undefined;
     const info = getFormattedTraceInfo(this.props.trace);
     const nameStyleToUse = info.errors ? nameStyle + ' ' + errorStyle : nameStyle;
     const spans: Span[] | undefined = this.props.node.data('spans');
@@ -97,7 +100,16 @@ class SummaryPanelTraceDetails extends React.Component<Props, State> {
           {tracesDetailsURL && (
             <>
               {' '}
-              (<Link to={tracesDetailsURL}>Details</Link>)
+              (<Link to={tracesDetailsURL}>Details</Link>
+              {jaegerTraceURL && (
+                <>
+                  {' - '}
+                  <a href={jaegerTraceURL} target="_blank" rel="noopener noreferrer">
+                    Jaeger <ExternalLinkAltIcon size="sm" />
+                  </a>
+                </>
+              )}
+              )
             </>
           )}
         </span>

--- a/src/pages/Graph/SummaryPanelTraceDetails.tsx
+++ b/src/pages/Graph/SummaryPanelTraceDetails.tsx
@@ -1,0 +1,242 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { connect } from 'react-redux';
+import { ThunkDispatch } from 'redux-thunk';
+import { style } from 'typestyle';
+import { Tooltip, Button, ButtonVariant } from '@patternfly/react-core';
+import { CloseIcon, AngleLeftIcon, AngleRightIcon } from '@patternfly/react-icons';
+
+import { URLParam } from '../../app/History';
+import { JaegerTrace, Span } from 'types/JaegerInfo';
+import { KialiAppState } from 'store/Store';
+import { KialiAppAction } from 'actions/KialiAppAction';
+import { JaegerThunkActions } from 'actions/JaegerThunkActions';
+import { getFormattedTraceInfo } from 'components/JaegerIntegration/JaegerResults/FormattedTraceInfo';
+import { PFAlertColor, PfColors } from 'components/Pf/PfColors';
+import { extractEnvoySpanInfo } from 'components/JaegerIntegration/JaegerHelper';
+import { formatDuration } from 'components/JaegerIntegration/JaegerResults/transform';
+import { CytoscapeGraphSelectorBuilder } from 'components/CytoscapeGraph/CytoscapeGraphSelector';
+import { decoratedNodeData } from 'components/CytoscapeGraph/CytoscapeGraphUtils';
+import FocusAnimation from 'components/CytoscapeGraph/FocusAnimation';
+
+type Props = {
+  trace: JaegerTrace;
+  node: any;
+  close: () => void;
+};
+
+type State = {
+  selectedSpan: number;
+};
+
+const textHeaderStyle = style({
+  fontWeight: 'bold',
+  fontSize: '16px'
+});
+
+const closeBoxStyle = style({
+  float: 'right',
+  marginTop: '-7px'
+});
+
+const nameStyle = style({});
+
+const errorStyle = style({
+  color: PFAlertColor.Danger
+});
+
+const secondaryStyle = style({
+  color: PfColors.Black600
+});
+
+const navButtonStyle = style({
+  paddingTop: 10,
+  paddingLeft: 0
+});
+
+const navSpanStyle = style({
+  position: 'relative',
+  top: -1
+});
+
+class SummaryPanelTraceDetails extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { selectedSpan: 0 };
+  }
+
+  componentDidUpdate(props: Props) {
+    if (props.trace.traceID !== this.props.trace.traceID) {
+      this.setState({ selectedSpan: 0 });
+    } else {
+      // Current active span changed?
+      const oldSpans: Span[] | undefined = props.node.data('spans');
+      const newSpans: Span[] | undefined = this.props.node.data('spans');
+      const oldSpan =
+        oldSpans && this.state.selectedSpan < oldSpans.length ? oldSpans[this.state.selectedSpan] : undefined;
+      const newSpan =
+        newSpans && this.state.selectedSpan < newSpans.length ? newSpans[this.state.selectedSpan] : undefined;
+      if (oldSpan?.spanID !== newSpan?.spanID) {
+        this.setState({ selectedSpan: 0 });
+      }
+    }
+  }
+
+  render() {
+    const node = decoratedNodeData(this.props.node);
+    const tracesDetailsURL = node.service
+      ? `/namespaces/${node.namespace}/services/${node.service}?tab=traces&${URLParam.JAEGER_TRACE_ID}=${this.props.trace.traceID}`
+      : undefined;
+    const info = getFormattedTraceInfo(this.props.trace);
+    const nameStyleToUse = info.errors ? nameStyle + ' ' + errorStyle : nameStyle;
+    const spans: Span[] | undefined = this.props.node.data('spans');
+    return (
+      <>
+        <span className={textHeaderStyle}>
+          Trace
+          {tracesDetailsURL && (
+            <>
+              {' '}
+              (<Link to={tracesDetailsURL}>Details</Link>)
+            </>
+          )}
+        </span>
+        <span className={closeBoxStyle}>
+          <Tooltip content="Close and clear trace selection">
+            <Button id="close-trace" variant="plain" onClick={this.props.close}>
+              <CloseIcon />
+            </Button>
+          </Tooltip>
+        </span>
+        <div>
+          <span className={nameStyleToUse}>{info.name}</span>
+          <br />
+          <span className={secondaryStyle}>
+            {this.props.trace.traceID}
+            <br />
+            {info.fromNow + (info.duration ? ', full duration: ' + info.duration : '')}
+            <br />
+          </span>
+          {spans && (
+            <>
+              <Button
+                className={navButtonStyle}
+                variant={ButtonVariant.plain}
+                isDisabled={this.state.selectedSpan === 0}
+                onClick={_ => {
+                  if (this.state.selectedSpan > 0) {
+                    this.setState({ selectedSpan: this.state.selectedSpan - 1 });
+                  }
+                }}
+              >
+                <AngleLeftIcon />
+              </Button>
+              <span className={navSpanStyle}>Span {this.state.selectedSpan + 1 + ' / ' + spans.length}</span>
+              <Button
+                variant={ButtonVariant.plain}
+                isDisabled={this.state.selectedSpan >= spans.length - 1}
+                onClick={_ => {
+                  if (this.state.selectedSpan < spans.length) {
+                    this.setState({ selectedSpan: this.state.selectedSpan + 1 });
+                  }
+                }}
+              >
+                <AngleRightIcon />
+              </Button>
+              <br />
+              {this.state.selectedSpan < spans.length && this.renderSpan(spans[this.state.selectedSpan])}
+            </>
+          )}
+        </div>
+      </>
+    );
+  }
+
+  private renderSpan(span: Span) {
+    const info = extractEnvoySpanInfo(span);
+    if (info) {
+      const details: string[] = [];
+      if (info.statusCode) {
+        details.push('code ' + info.statusCode);
+      }
+      if (info.responseFlags) {
+        details.push('flags ' + info.responseFlags);
+      }
+      if (span.duration) {
+        details.push(formatDuration(span.duration));
+      }
+      return (
+        <>
+          Operation: {span.operationName}
+          <br />
+          <br />
+          Started at +{formatDuration(span.relativeStartTime)}
+          <br />
+          {info.inbound && (
+            <>
+              From{' '}
+              <Button
+                variant="link"
+                isInline={true}
+                onClick={() => {
+                  this.focusOnWorkload(info.otherNamespace!, info.inbound!);
+                }}
+              >
+                {info.inbound}
+              </Button>
+              {': '}
+            </>
+          )}
+          {info.outbound && (
+            <>
+              To{' '}
+              <Button
+                variant="link"
+                isInline={true}
+                onClick={() => {
+                  this.focusOnService(info.otherNamespace!, info.outbound!);
+                }}
+              >
+                {info.outbound}
+              </Button>
+              {': '}
+            </>
+          )}
+          {info.method} {info.url} {details.length > 0 && ' [' + details.join(', ') + ']'}
+        </>
+      );
+    }
+    // Else => this is probably a user-defined span
+    return (
+      <>
+        Operation: {span.operationName}
+        <br />
+        <br />
+        Started at +{formatDuration(span.relativeStartTime)}
+        <br />
+        Duration: {formatDuration(span.duration)}
+        <br />
+      </>
+    );
+  }
+
+  private focusOnWorkload = (namespace: string, workload: string) => {
+    this.focusOn(new CytoscapeGraphSelectorBuilder().namespace(namespace).workload(workload).class('span').build());
+  };
+
+  private focusOnService = (namespace: string, service: string) => {
+    this.focusOn(new CytoscapeGraphSelectorBuilder().namespace(namespace).service(service).class('span').build());
+  };
+
+  private focusOn = (selector: string) => {
+    const cy = this.props.node.cy();
+    new FocusAnimation(cy).start(cy.elements(selector));
+  };
+}
+
+const mapDispatchToProps = (dispatch: ThunkDispatch<KialiAppState, void, KialiAppAction>) => ({
+  close: () => dispatch(JaegerThunkActions.setTraceId(undefined))
+});
+
+const SummaryPanelTraceDetailsContainer = connect(() => ({}), mapDispatchToProps)(SummaryPanelTraceDetails);
+export default SummaryPanelTraceDetailsContainer;

--- a/src/utils/SearchParamUtils.ts
+++ b/src/utils/SearchParamUtils.ts
@@ -29,6 +29,10 @@ export const getTraceId = () => {
   return new URLSearchParams(window.location.search).get(URLParam.JAEGER_TRACE_ID) || undefined;
 };
 
-export const setTraceId = (traceId: string) => {
-  HistoryManager.setParam(URLParam.JAEGER_TRACE_ID, traceId);
+export const setTraceId = (traceId?: string) => {
+  if (traceId) {
+    HistoryManager.setParam(URLParam.JAEGER_TRACE_ID, traceId);
+  } else {
+    HistoryManager.deleteParam(URLParam.JAEGER_TRACE_ID);
+  }
 };


### PR DESCRIPTION
- Add trace ID to URL
- Split side-panel with a bottom section to show trace info when a trace is selected
- Allow selecting other nodes from that trace, keeping that panel opened
- Show some trace information
- Show spans information for each span within the trace for the selected node
- Link to Trace Details
- Focus animation triggered to localize span other-end client/server

Fixes https://github.com/kiali/kiali/issues/3010
