### PR TITLE
Bump k-charted 0.6.1-rc2 + default grouping on remote app

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "snyk-protect": "snyk protect"
   },
   "dependencies": {
-    "@kiali/k-charted-pf4": "0.6.0",
+    "@kiali/k-charted-pf4": "0.6.1-rc2",
     "@patternfly/patternfly": "2.71.3",
     "@patternfly/react-charts": "5.3.18",
     "@patternfly/react-core": "3.153.3",

--- a/src/components/Metrics/CustomMetrics.tsx
+++ b/src/components/Metrics/CustomMetrics.tsx
@@ -72,7 +72,7 @@ export class CustomMetrics extends React.Component<Props, MetricsState> {
     this.spanOverlay = new SpanOverlay(props.namespace, props.app, changed => this.setState({ spanOverlay: changed }));
   }
 
-  initOptions(settings: MetricsSettings): DashboardQuery {
+  private initOptions(settings: MetricsSettings): DashboardQuery {
     const filters = `${serverConfig.istioLabels.appLabelName}:${this.props.app}`;
     const options: DashboardQuery = this.props.version
       ? {
@@ -82,7 +82,7 @@ export class CustomMetrics extends React.Component<Props, MetricsState> {
           labelsFilters: filters,
           additionalLabels: 'version:Version'
         };
-    MetricsHelper.settingsToOptions(settings, options);
+    MetricsHelper.settingsToOptions(settings, options, []);
     return options;
   }
 
@@ -90,14 +90,14 @@ export class CustomMetrics extends React.Component<Props, MetricsState> {
     this.refresh();
   }
 
-  refresh = () => {
+  private refresh = () => {
     this.fetchMetrics();
     if (this.props.jaegerIntegration) {
       this.spanOverlay.fetch(this.state.timeRange);
     }
   };
 
-  fetchMetrics = () => {
+  private fetchMetrics = () => {
     // Time range needs to be reevaluated everytime fetching
     MetricsHelper.timeRangeToOptions(this.state.timeRange, this.options);
     API.getCustomDashboard(this.props.namespace, this.props.template, this.options)
@@ -114,27 +114,27 @@ export class CustomMetrics extends React.Component<Props, MetricsState> {
       });
   };
 
-  onMetricsSettingsChanged = (settings: MetricsSettings) => {
-    MetricsHelper.settingsToOptions(settings, this.options);
+  private onMetricsSettingsChanged = (settings: MetricsSettings) => {
+    MetricsHelper.settingsToOptions(settings, this.options, []);
     this.fetchMetrics();
   };
 
-  onLabelsFiltersChanged = (labelsFilters: LabelsSettings) => {
+  private onLabelsFiltersChanged = (labelsFilters: LabelsSettings) => {
     this.setState({ labelsSettings: labelsFilters });
   };
 
-  onTimeFrameChanged = (range: TimeRange) => {
+  private onTimeFrameChanged = (range: TimeRange) => {
     this.setState({ timeRange: range }, () => {
       this.refresh();
     });
   };
 
-  onRawAggregationChanged = (aggregator: Aggregator) => {
+  private onRawAggregationChanged = (aggregator: Aggregator) => {
     this.options.rawDataAggregator = aggregator;
     this.fetchMetrics();
   };
 
-  onClickDataPoint = (_, datum: RawOrBucket<JaegerLineInfo>) => {
+  private onClickDataPoint = (_, datum: RawOrBucket<JaegerLineInfo>) => {
     if ('start' in datum && 'end' in datum) {
       // Zoom-in bucket
       this.onDomainChange([datum.start as Date, datum.end as Date]);
@@ -199,7 +199,7 @@ export class CustomMetrics extends React.Component<Props, MetricsState> {
     );
   }
 
-  renderOptionsBar() {
+  private renderOptionsBar() {
     const hasHistograms =
       this.state.dashboard !== undefined &&
       this.state.dashboard.charts.some(chart => {

--- a/src/components/Metrics/Helper.ts
+++ b/src/components/Metrics/Helper.ts
@@ -107,15 +107,20 @@ export const convertAsPromLabels = (lblSettings: LabelsSettings): AllPromLabelsV
   return promLabels;
 };
 
-export const settingsToOptions = (settings: MetricsSettings, opts: MetricsQuery) => {
+export const settingsToOptions = (settings: MetricsSettings, opts: MetricsQuery, defaultLabels: string[]) => {
   opts.avg = settings.showAverage;
   opts.quantiles = settings.showQuantiles;
-  opts.byLabels = [];
-  settings.labelsSettings.forEach((objLbl, k) => {
-    if (objLbl.checked) {
-      opts.byLabels!.push(k);
-    }
-  });
+  let byLabels = defaultLabels;
+  if (settings.labelsSettings.size > 0) {
+    // Labels have been fetched, so use what comes from labelsSettings
+    byLabels = [];
+    settings.labelsSettings.forEach((objLbl, k) => {
+      if (objLbl.checked) {
+        byLabels.push(k);
+      }
+    });
+  }
+  opts.byLabels = byLabels;
 };
 
 export const timeRangeToOptions = (range: TimeRange, opts: MetricsQuery) => {
@@ -137,7 +142,7 @@ export const retrieveMetricsSettings = (): MetricsSettings => {
   const urlParams = new URLSearchParams(history.location.search);
   const settings: MetricsSettings = {
     showAverage: true,
-    showQuantiles: ['0.5', '0.95', '0.99'],
+    showQuantiles: ['0.5', '0.99'],
     labelsSettings: new Map()
   };
   const avg = urlParams.get(URLParam.SHOW_AVERAGE);

--- a/src/components/Metrics/IstioMetrics.tsx
+++ b/src/components/Metrics/IstioMetrics.tsx
@@ -73,12 +73,15 @@ class IstioMetrics extends React.Component<Props, MetricsState> {
     );
   }
 
-  initOptions(settings: MetricsSettings): IstioMetricsOptions {
+  private initOptions(settings: MetricsSettings): IstioMetricsOptions {
     const options: IstioMetricsOptions = {
       reporter: MetricsReporter.initialReporter(this.props.direction),
       direction: this.props.direction
     };
-    MetricsHelper.settingsToOptions(settings, options);
+    const defaultLabels = [
+      this.props.direction === 'inbound' ? 'source_canonical_service' : 'destination_canonical_service'
+    ];
+    MetricsHelper.settingsToOptions(settings, options, defaultLabels);
     return options;
   }
 
@@ -87,14 +90,14 @@ class IstioMetrics extends React.Component<Props, MetricsState> {
     this.refresh();
   }
 
-  refresh = () => {
+  private refresh = () => {
     this.fetchMetrics();
     if (this.props.jaegerIntegration) {
       this.spanOverlay.fetch(this.state.timeRange);
     }
   };
 
-  fetchMetrics = () => {
+  private fetchMetrics = () => {
     // Time range needs to be reevaluated everytime fetching
     MetricsHelper.timeRangeToOptions(this.state.timeRange, this.options);
     let promise: Promise<API.Response<DashboardModel>>;
@@ -124,7 +127,7 @@ class IstioMetrics extends React.Component<Props, MetricsState> {
       });
   };
 
-  fetchGrafanaInfo() {
+  private fetchGrafanaInfo() {
     if (!IstioMetrics.grafanaInfoPromise) {
       IstioMetrics.grafanaInfoPromise = API.getGrafanaInfo().then(response => {
         if (response.status === 204) {
@@ -151,27 +154,30 @@ class IstioMetrics extends React.Component<Props, MetricsState> {
       });
   }
 
-  onMetricsSettingsChanged = (settings: MetricsSettings) => {
-    MetricsHelper.settingsToOptions(settings, this.options);
+  private onMetricsSettingsChanged = (settings: MetricsSettings) => {
+    const defaultLabels = [
+      this.props.direction === 'inbound' ? 'source_canonical_service' : 'destination_canonical_service'
+    ];
+    MetricsHelper.settingsToOptions(settings, this.options, defaultLabels);
     this.fetchMetrics();
   };
 
-  onLabelsFiltersChanged = (labelsFilters: LabelsSettings) => {
+  private onLabelsFiltersChanged = (labelsFilters: LabelsSettings) => {
     this.setState({ labelsSettings: labelsFilters });
   };
 
-  onTimeFrameChanged = (range: TimeRange) => {
+  private onTimeFrameChanged = (range: TimeRange) => {
     this.setState({ timeRange: range }, () => {
       this.refresh();
     });
   };
 
-  onReporterChanged = (reporter: Reporter) => {
+  private onReporterChanged = (reporter: Reporter) => {
     this.options.reporter = reporter;
     this.fetchMetrics();
   };
 
-  onClickDataPoint = (_, datum: RawOrBucket<JaegerLineInfo>) => {
+  private onClickDataPoint = (_, datum: RawOrBucket<JaegerLineInfo>) => {
     if ('start' in datum && 'end' in datum) {
       // Zoom-in bucket
       this.onDomainChange([datum.start as Date, datum.end as Date]);
@@ -237,7 +243,7 @@ class IstioMetrics extends React.Component<Props, MetricsState> {
     );
   }
 
-  renderOptionsBar() {
+  private renderOptionsBar() {
     return (
       <Toolbar style={{ paddingBottom: 8 }}>
         <ToolbarGroup>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1899,10 +1899,10 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@kiali/k-charted-pf4@0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@kiali/k-charted-pf4/-/k-charted-pf4-0.6.0.tgz#74f211b5afa5c9205af005907ec809327c824948"
-  integrity sha512-I+0pmjpDB8O7dA6HkdYuGVqgzmYUXfqsT+PTjqcuI8/jB7JGTcR6OY2p3aiAOfatHoiZg3zzWLmE78enU2GhsQ==
+"@kiali/k-charted-pf4@0.6.1-rc2":
+  version "0.6.1-rc2"
+  resolved "https://registry.yarnpkg.com/@kiali/k-charted-pf4/-/k-charted-pf4-0.6.1-rc2.tgz#1da924b484262412a8fbe712c2f007c27790a828"
+  integrity sha512-3CedTeQCLqKTaMdiTTPaqVvveLOOG49Dlhobv3eULkxhlg641D9kFE73tZdYgmf7+i/kU43UR7+guhjhAVGvyg==
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"


### PR DESCRIPTION
Includes several changes for iter8
Removed p95 as visible by default

Backend PR required: https://github.com/kiali/kiali/pull/3046