### PR TITLE
Support Iter8 v0.2

### DIFF
--- a/src/components/DefaultSecondaryMasthead/DefaultSecondaryMasthead.tsx
+++ b/src/components/DefaultSecondaryMasthead/DefaultSecondaryMasthead.tsx
@@ -19,6 +19,7 @@ export default class DefaultSecondaryMasthead extends React.Component {
     path = path.substr(path.lastIndexOf('/console') + '/console'.length + 1);
     if (titles.includes(path)) {
       let title = path.charAt(0).toUpperCase() + path.slice(1);
+      let disabled = false;
       if (path === 'istio/new') {
         title = 'Create New Istio Config';
       } else if (path === 'istio') {
@@ -29,22 +30,26 @@ export default class DefaultSecondaryMasthead extends React.Component {
         title = 'Iter8 Experiments';
       } else if (path === 'extensions/iter8/new') {
         title = 'Create New Iter8 Experiment';
+        disabled = true;
       }
-      return (
-        <Title headingLevel="h1" size="3xl" style={{ margin: '18px 0 18px' }}>
-          {title}
-        </Title>
-      );
+      return {
+        title: (
+          <Title headingLevel="h1" size="3xl" style={{ margin: '18px 0 18px' }}>
+            {title}
+          </Title>
+        ),
+        disabled: disabled
+      };
     }
 
-    return undefined;
+    return { title: undefined, disabled: false };
   }
 
   render() {
-    const title = this.showTitle();
+    const { title, disabled } = this.showTitle();
     return (
       <SecondaryMasthead title={title ? true : false}>
-        <NamespaceDropdownContainer disabled={false} />
+        <NamespaceDropdownContainer disabled={disabled} />
         {title}
       </SecondaryMasthead>
     );

--- a/src/components/NamespaceDropdown.tsx
+++ b/src/components/NamespaceDropdown.tsx
@@ -241,7 +241,7 @@ export class NamespaceDropdown extends React.PureComponent<NamespaceDropdownProp
       <TourStopContainer info={GraphTourStops.Namespaces}>
         <Dropdown
           toggle={
-            <DropdownToggle id={'namespace-selector'} onToggle={this.onToggle}>
+            <DropdownToggle id={'namespace-selector'} onToggle={this.onToggle} isDisabled={this.props.disabled}>
               {this.namespaceButtonText()}
             </DropdownToggle>
           }

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/CriteriaInfoDescription.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/CriteriaInfoDescription.tsx
@@ -10,8 +10,7 @@ import {
   Title,
   Tooltip
 } from '@patternfly/react-core';
-import { serverConfig } from '../../../../config/ServerConfig';
-import { SuccessCriteria } from '../../../../types/Iter8';
+import { Iter8Info, SuccessCriteria } from '../../../../types/Iter8';
 import {
   Table,
   TableBody,
@@ -29,6 +28,7 @@ import { RenderComponentScroll } from '../../../../components/Nav/Page';
 import styles from '@patternfly/react-styles/css/components/Table/table';
 
 interface ExperimentInfoDescriptionProps {
+  iter8Info: Iter8Info;
   criterias: SuccessCriteria[];
 }
 
@@ -74,10 +74,7 @@ class CriteriaInfoDescription extends React.Component<ExperimentInfoDescriptionP
           {
             title: (
               <ul>
-                <li>
-                  Threshold : {criteria.criteria.tolerance}
-                  {serverConfig.istioTelemetryV2 ? ' ms' : ' s'}
-                </li>
+                <li>Threshold : {criteria.criteria.tolerance}</li>
                 <li>Threshold Type: {criteria.criteria.toleranceType}</li>
                 <li>Sample Size: {criteria.criteria.sampleSize}</li>
               </ul>

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCreatePage.scss
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCreatePage.scss
@@ -1,0 +1,7 @@
+.pf-c-switch__toggle {
+  --pf-c-switch__toggle--BackgroundColor: #ec7a08;
+}
+
+.pf-c-switch__label {
+  --pf-c-switch__label--Color: #ec7a08;
+}

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCreatePage.scss
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCreatePage.scss
@@ -1,7 +1,0 @@
-.pf-c-switch__toggle {
-  --pf-c-switch__toggle--BackgroundColor: #ec7a08;
-}
-
-.pf-c-switch__label {
-  --pf-c-switch__label--Color: #ec7a08;
-}

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCreatePage.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCreatePage.tsx
@@ -26,7 +26,6 @@ import { KialiAppState } from '../../../../store/Store';
 import { activeNamespacesSelector } from '../../../../store/Selectors';
 import { connect } from 'react-redux';
 import { PfColors } from '../../../../components/Pf/PfColors';
-import './ExperimentCreatePage.scss';
 
 interface Props {
   serviceName: string;

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCreatePage.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCreatePage.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { Iter8Info } from '../../../../types/Iter8';
 import { style } from 'typestyle';
 import * as API from '../../../../services/Api';
-import { serverConfig } from '../../../../config/ServerConfig';
 import * as AlertUtils from '../../../../utils/AlertUtils';
 import {
   ActionGroup,
@@ -15,23 +14,25 @@ import {
   FormSelectOption,
   Grid,
   GridItem,
-  TextInput
+  TextInputBase as TextInput
 } from '@patternfly/react-core';
 import history from '../../../../app/History';
 import { RenderContent } from '../../../../components/Nav/Page';
 import Namespace from '../../../../types/Namespace';
 import ExperimentCriteriaForm from './ExperimentCriteriaForm';
+import ExperimentHostForm, { HostState, initHost } from './ExperimentHostForm';
 import { PromisesRegistry } from '../../../../utils/CancelablePromises';
 import { KialiAppState } from '../../../../store/Store';
 import { activeNamespacesSelector } from '../../../../store/Selectors';
 import { connect } from 'react-redux';
 import { PfColors } from '../../../../components/Pf/PfColors';
+import './ExperimentCreatePage.scss';
 
 interface Props {
-  activeNamespaces: Namespace[];
   serviceName: string;
   namespace: string;
-  onChange: (experiment: ExperimentSpec) => void;
+  onChange: (valid: boolean, experiment: ExperimentSpec) => void;
+  showAdvanced: boolean;
 }
 
 interface State {
@@ -40,11 +41,16 @@ interface State {
   namespaces: string[];
   services: string[];
   workloads: string[];
+  gateways: string[];
+  hostsOfGateway: Host[];
   metricNames: string[];
   showAdvanced: boolean;
   showTrafficStep: boolean;
   reloadService: boolean;
   totalDuration: string;
+  hostState: HostState;
+  value: string;
+  filename: string;
 }
 
 interface ExperimentSpec {
@@ -54,9 +60,10 @@ interface ExperimentSpec {
   apiversion: string;
   baseline: string;
   candidate: string;
-  // canaryVersion: string;
+  experimentKind: string;
   trafficControl: TrafficControl;
   criterias: Criteria[];
+  hosts: Host[];
 }
 
 interface TrafficControl {
@@ -76,10 +83,17 @@ export interface Criteria {
   stopOnFailure: boolean;
 }
 
+export interface Host {
+  name: string;
+  gateway: string;
+}
+
 // Style constants
 const containerPadding = style({ padding: '20px 20px 20px 20px' });
 const regex = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[-a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
-const noCriteriaStyle = style({
+const formPadding = style({ padding: '30px 20px 30px 20px' });
+
+const durationTimeStyle = style({
   marginTop: 15,
   marginBottom: 15,
   color: PfColors.Blue400
@@ -92,6 +106,14 @@ const algorithms = [
   'optimistic_bayesian_routing'
 ];
 
+const toggleTextFlat = ['More', 'Less'];
+const toggleTextWizard = ['Show Advanced Options', 'Hide Advanced Options'];
+
+const iter8oExpOptions = [
+  { value: 'Deployment', label: 'deployment/workload based' },
+  { value: 'Service', label: 'service based' }
+];
+
 class ExperimentCreatePage extends React.Component<Props, State> {
   private promises = new PromisesRegistry();
 
@@ -100,7 +122,10 @@ class ExperimentCreatePage extends React.Component<Props, State> {
 
     this.state = {
       iter8Info: {
-        enabled: false
+        enabled: false,
+        supportedVersion: false,
+        analyticsImageVersion: '',
+        controllerImageVersion: ''
       },
       experiment: {
         name: '',
@@ -109,24 +134,31 @@ class ExperimentCreatePage extends React.Component<Props, State> {
         service: this.props.serviceName,
         baseline: '',
         candidate: '',
+        experimentKind: 'Deployment',
         trafficControl: {
           algorithm: 'check_and_increment',
           interval: '30s',
           intervalInSecond: 30,
-          maxIterations: 100,
+          maxIterations: 10,
           maxTrafficPercentage: 50,
-          trafficStepSize: 2
+          trafficStepSize: 10
         },
-        criterias: []
+        criterias: [],
+        hosts: []
       },
       namespaces: [],
       services: [],
       workloads: [],
+      gateways: [],
+      hostsOfGateway: [],
       metricNames: [],
-      showAdvanced: true,
+      showAdvanced: history.location.pathname.endsWith('/new') ? true : this.props.showAdvanced,
       showTrafficStep: true,
       reloadService: false,
-      totalDuration: '50 minutes'
+      totalDuration: '50 minutes',
+      hostState: initHost(''),
+      value: '',
+      filename: ''
     };
   }
 
@@ -143,12 +175,7 @@ class ExperimentCreatePage extends React.Component<Props, State> {
         const newExperiment = prevState.experiment;
         newExperiment.baseline = '';
         newExperiment.candidate = '';
-        if (this.props.activeNamespaces.length === 1 && prevState.experiment.namespace === '') {
-          newExperiment.namespace = this.props.activeNamespaces[0].name;
-        } else {
-          newExperiment.namespace = allNamespaces[0];
-        }
-
+        newExperiment.namespace = allNamespaces[0];
         return {
           experiment: newExperiment,
           namespaces: allNamespaces,
@@ -156,6 +183,27 @@ class ExperimentCreatePage extends React.Component<Props, State> {
         };
       });
     });
+  };
+
+  fetchIter8Info = () => {
+    this.promises
+      .register('iter8Metrics', API.getIter8Info())
+      .then(result => {
+        const iter8Info = result.data;
+        this.setState(prevState => {
+          return {
+            iter8Info: iter8Info,
+            experiment: prevState.experiment,
+            reloadService: prevState.reloadService,
+            metricNames: prevState.metricNames
+          };
+        });
+      })
+      .catch(infoerror => {
+        if (!infoerror.isCanceled) {
+          AlertUtils.addError('Could not fetch Iter8 Info Detail.', infoerror);
+        }
+      });
   };
 
   fetchMetrics = () => {
@@ -186,12 +234,9 @@ class ExperimentCreatePage extends React.Component<Props, State> {
       _namespace = selectedNS;
     } else if (this.state.experiment.namespace !== '') {
       _namespace = this.state.experiment.namespace;
-    } else if (this.props.activeNamespaces.length > 0) {
-      _namespace = this.props.activeNamespaces[0].name;
     }
 
     if (_namespace.length > 0) {
-      // const ns = this.props.activeNamespaces[0];
       if (!this.promises.has('servicesByNamespace')) {
         this.promises
           .register('servicesByNamespace', API.getServices(_namespace))
@@ -237,6 +282,36 @@ class ExperimentCreatePage extends React.Component<Props, State> {
     }
   };
 
+  fetchGateways = (namespace: string) => {
+    this.promises.register('gateways', API.getIstioConfig(namespace, ['gateways'], false, '')).then(response => {
+      let gatewayhostpair: Host[] = [];
+      let gateways: string[] = [];
+      gateways.push('-- select gateway --');
+      response.data.gateways.forEach(gt => {
+        gt.spec.servers?.forEach(svc => {
+          gateways.push(gt.metadata.name);
+          svc.hosts.forEach(hs => {
+            gatewayhostpair.push({
+              name: hs,
+              gateway: gt.metadata.name
+            });
+          });
+        });
+      });
+      this.setState(prevState => {
+        return {
+          services: prevState.services,
+          workloads: prevState.workloads,
+          gateways: gateways,
+          hostsOfGateway: gatewayhostpair,
+          experiment: prevState.experiment,
+          reloadService: false,
+          hostState: initHost(gateways[0])
+        };
+      });
+    });
+  };
+
   fetchWorkloads = (namespace, serviceName: string) => {
     this.promises
       .register('serviceDetails', API.getServiceDetail(namespace, serviceName, false))
@@ -273,11 +348,7 @@ class ExperimentCreatePage extends React.Component<Props, State> {
           });
           this.setState(prevState => {
             const newExperiment = prevState.experiment;
-            if (this.props.activeNamespaces.length === 1) {
-              newExperiment.namespace = this.props.activeNamespaces[0].name;
-            } else {
-              newExperiment.namespace = allNamespaces[0];
-            }
+            newExperiment.namespace = allNamespaces[0];
             return {
               experiment: newExperiment,
               namespaces: allNamespaces,
@@ -286,7 +357,13 @@ class ExperimentCreatePage extends React.Component<Props, State> {
           });
         })
         .then(() => {
+          this.fetchIter8Info();
+        })
+        .then(() => {
           this.fetchServices(this.state.experiment.namespace);
+        })
+        .then(() => {
+          this.fetchGateways(this.state.experiment.namespace);
         })
         .then(() => {
           this.fetchMetrics();
@@ -298,6 +375,7 @@ class ExperimentCreatePage extends React.Component<Props, State> {
         });
     } else if (this.props.namespace !== undefined && this.props.serviceName !== undefined) {
       this.fetchWorkloads(this.props.namespace, this.props.serviceName);
+      this.fetchGateways(this.props.namespace);
       this.fetchMetrics();
     }
   }
@@ -313,6 +391,17 @@ class ExperimentCreatePage extends React.Component<Props, State> {
       experiment: newexperiment
     });
   };
+
+  onExperimentKindChange = (value, _) => {
+    this.setState(prevState => {
+      const newExperiment = prevState.experiment;
+      newExperiment.experimentKind = value;
+      return {
+        experiment: newExperiment
+      };
+    });
+  };
+
   // Invoke the history object to update and URL and start a routing
   goExperimentsPage = () => {
     history.push('/extensions/iter8');
@@ -320,7 +409,6 @@ class ExperimentCreatePage extends React.Component<Props, State> {
 
   // It invokes backend to create  a new experiment
   createExperiment = () => {
-    // if (this.props.activeNamespaces.length === 1) {
     const nsName = this.state.experiment.namespace;
     this.promises
       .register('Create Iter8 Experiment', API.createExperiment(nsName, JSON.stringify(this.state.experiment)))
@@ -386,7 +474,7 @@ class ExperimentCreatePage extends React.Component<Props, State> {
       () => {
         history.location.pathname.endsWith('/new')
           ? this.onExperimentChange(this.state.experiment)
-          : this.props.onChange(this.state.experiment);
+          : this.props.onChange(this.isMainFormValid(), this.state.experiment);
       }
     );
   };
@@ -426,7 +514,7 @@ class ExperimentCreatePage extends React.Component<Props, State> {
       () => {
         history.location.pathname.endsWith('/new')
           ? this.onExperimentChange(this.state.experiment)
-          : this.props.onChange(this.state.experiment);
+          : this.props.onChange(this.isMainFormValid(), this.state.experiment);
       }
     );
   };
@@ -435,7 +523,8 @@ class ExperimentCreatePage extends React.Component<Props, State> {
     return (
       this.state.experiment.name !== '' &&
       this.state.experiment.name.search(regex) === 0 &&
-      this.state.experiment.service !== '' &&
+      ((this.state.experiment.experimentKind === 'Deployment' && this.state.experiment.service !== '') ||
+        this.state.experiment.experimentKind === 'Service') &&
       this.state.experiment.namespace !== '' &&
       this.state.experiment.baseline !== '' &&
       this.state.experiment.candidate !== ''
@@ -452,266 +541,559 @@ class ExperimentCreatePage extends React.Component<Props, State> {
     return this.state.experiment.criterias.length !== 0;
   };
 
+  renderGeneral() {
+    return (
+      <>
+        <FormGroup
+          fieldId="name"
+          label="Experiment Name"
+          isRequired={true}
+          isValid={this.state.experiment.name !== '' && this.state.experiment.name.search(regex) === 0}
+          helperTextInvalid="Name cannot be empty and must be a DNS subdomain name as defined in RFC 1123."
+        >
+          <TextInput
+            id="name"
+            value={this.state.experiment.name}
+            placeholder="Experiment Name"
+            onChange={value => this.changeExperiment('name', value)}
+          />
+        </FormGroup>
+        <FormGroup label="Istio Resource" fieldId="istio-resource">
+          <FormSelect
+            value={this.state.experiment.experimentKind}
+            onChange={this.onExperimentKindChange}
+            id="istio-resource"
+            name="istio-resource"
+          >
+            {iter8oExpOptions.map((option, index) => (
+              <FormSelectOption key={index} value={option.value} label={option.label} />
+            ))}
+          </FormSelect>
+        </FormGroup>
+
+        <FormGroup
+          fieldId="baseline"
+          label="Baseline"
+          isRequired={true}
+          isValid={this.state.experiment.baseline !== ''}
+          helperText="The baseline deployment of the target service (i.e. reviews-v1)"
+          helperTextInvalid="Baseline deployment cannot be empty"
+        >
+          <FormSelect
+            id="baseline"
+            value={this.state.experiment.baseline}
+            placeholder="Baseline Deployment"
+            onChange={value => this.changeExperiment('baseline', value)}
+          >
+            {this.state.workloads.map((wk, index) => (
+              <FormSelectOption label={wk} key={'workloadBaseline' + index} value={wk} />
+            ))}
+          </FormSelect>
+        </FormGroup>
+
+        <FormGroup
+          fieldId="candidate"
+          label="Select Candidate"
+          isRequired={true}
+          isValid={this.state.experiment.candidate !== ''}
+          helperText="The candidate deployment of the target service (i.e. reviews-v2)"
+          helperTextInvalid="Candidate deployment cannot be empty"
+        >
+          <TextInput
+            id="candidate"
+            value={this.state.experiment.candidate}
+            placeholder="Select from list or enter a new one"
+            onChange={value => this.changeExperiment('candidate', value)}
+            list={'candidateName'}
+            autoComplete={'off'}
+          />
+          <datalist id="candidateName">
+            {this.state.workloads.map((wk, index) =>
+              wk !== this.state.experiment.baseline ? (
+                <option label={wk} key={'workloadCandidate' + index} value={wk}>
+                  {wk}
+                </option>
+              ) : (
+                ''
+              )
+            )}
+          </datalist>
+        </FormGroup>
+      </>
+    );
+  }
+
+  renderBaselineSelect() {
+    const usingMap = this.state.experiment.experimentKind === 'Deployment' ? this.state.workloads : this.state.services;
+    return [
+      <FormGroup
+        fieldId="baseline"
+        label="Baseline"
+        isRequired={true}
+        isValid={this.state.experiment.baseline !== ''}
+        helperText="The baseline deployment of the target service (i.e. reviews-v1)"
+        helperTextInvalid="Baseline deployment cannot be empty"
+      >
+        <FormSelect
+          id="baseline"
+          value={this.state.experiment.baseline}
+          placeholder="Baseline Deployment"
+          onChange={value => this.changeExperiment('baseline', value)}
+        >
+          {usingMap.map((wk, index) => (
+            <FormSelectOption label={wk} key={'workloadBaseline' + index} value={wk} />
+          ))}
+        </FormSelect>
+      </FormGroup>
+    ];
+  }
+
+  renderCandidateSelect() {
+    const usingMap = this.state.experiment.experimentKind === 'Deployment' ? this.state.workloads : this.state.services;
+
+    return [
+      <FormGroup
+        fieldId="candidate"
+        label="Select Candidate"
+        isRequired={true}
+        isValid={this.state.experiment.candidate !== ''}
+        helperText="The candidate deployment of the target service (i.e. reviews-v2)"
+        helperTextInvalid="Candidate deployment cannot be empty"
+      >
+        <TextInput
+          id="candidate"
+          value={this.state.experiment.candidate}
+          placeholder="Select from list or enter a new one"
+          onChange={value => this.changeExperiment('candidate', value)}
+          list={'candidateName'}
+          autoComplete={'off'}
+        />
+        <datalist id="candidateName">
+          {usingMap.map((wk, index) =>
+            wk !== this.state.experiment.baseline ? (
+              <option label={wk} key={'workloadCandidate' + index} value={wk}>
+                {wk}
+              </option>
+            ) : (
+              ''
+            )
+          )}
+        </datalist>
+      </FormGroup>
+    ];
+  }
+
+  renderFullGeneral() {
+    const isNamespacesValid = false;
+
+    return (
+      <>
+        <FormGroup
+          fieldId="name"
+          label="Experiment Name"
+          isRequired={true}
+          isValid={this.state.experiment.name !== '' && this.state.experiment.name.search(regex) === 0}
+          helperTextInvalid="Name cannot be empty and must be a DNS subdomain name as defined in RFC 1123."
+        >
+          <TextInput
+            id="name"
+            value={this.state.experiment.name}
+            placeholder="Experiment Name"
+            onChange={value => this.changeExperiment('name', value)}
+          />
+        </FormGroup>
+        <FormGroup
+          fieldId="experimentKind"
+          label="Kind of Target"
+          isRequired={true}
+          helperTextInvalid="Kind of experiment target"
+        >
+          <FormSelect
+            value={this.state.experiment.experimentKind}
+            onChange={this.onExperimentKindChange}
+            id="targetKind"
+            name="targetKinde"
+          >
+            {iter8oExpOptions.map((option, index) => (
+              <FormSelectOption key={index} value={option.value} label={option.label} />
+            ))}
+          </FormSelect>
+        </FormGroup>
+        {history.location.pathname.endsWith('/new') ? (
+          <>
+            <FormGroup
+              label="Namespaces"
+              isRequired={true}
+              fieldId="namespaces"
+              helperText={'Select namespace where this configuration will be applied'}
+              isValid={isNamespacesValid}
+            >
+              <FormSelect
+                id="namespaces"
+                value={this.state.experiment.namespace}
+                placeholder="Namespace"
+                onChange={value => {
+                  this.changeExperiment('namespace', value);
+                  this.fetchServices(value);
+                  this.fetchGateways(value);
+                }}
+              >
+                {this.state.namespaces.map((svc, index) => (
+                  <FormSelectOption label={svc} key={'namespace' + index} value={svc} />
+                ))}
+              </FormSelect>
+            </FormGroup>
+
+            {this.state.experiment.experimentKind === 'Deployment' ? (
+              <>
+                <FormGroup
+                  fieldId="service"
+                  label="Target Service"
+                  isRequired={true}
+                  isValid={this.state.experiment.service !== ''}
+                  helperText="Target Service specifies the reference to experiment targets (i.e. reviews)"
+                  helperTextInvalid="Target Service cannot be empty"
+                >
+                  <FormSelect
+                    id="service"
+                    value={this.state.experiment.service}
+                    placeholder="Target Service"
+                    onChange={value => {
+                      this.changeExperiment('service', value);
+                      const ns = this.state.experiment.namespace;
+                      this.fetchWorkloads(ns, value);
+                    }}
+                  >
+                    {this.state.services.map((svc, index) => (
+                      <FormSelectOption label={svc} key={'service' + index} value={svc} />
+                    ))}
+                  </FormSelect>
+                </FormGroup>
+              </>
+            ) : (
+              <></>
+            )}
+          </>
+        ) : (
+          ''
+        )}
+        {this.renderBaselineSelect()}
+        {this.renderCandidateSelect()}
+      </>
+    );
+  }
+
+  renderTrafficInWizard() {
+    return (
+      <>
+        <FormGroup
+          fieldId="interval"
+          label="Interval (seconds)"
+          isValid={this.state.experiment.trafficControl.interval !== ''}
+          helperText="Frequency with which the controller calls the analytics service"
+          helperTextInvalid="Interval cannot be empty"
+        >
+          <TextInput
+            id="interval"
+            value={this.state.experiment.trafficControl.intervalInSecond}
+            placeholder="Time interval i.e. 30s"
+            onChange={value => this.changeExperimentNumber('interval', Number(value))}
+          />
+        </FormGroup>
+
+        <FormGroup
+          fieldId="maxIteration"
+          label="Maximum Iteration"
+          isValid={this.state.experiment.trafficControl.maxIterations > 0}
+          helperText="Maximum number of iterations for this experiment"
+          helperTextInvalid="Maximun Iteration cannot be empty"
+        >
+          <TextInput
+            id="maxIteration"
+            type="number"
+            value={this.state.experiment.trafficControl.maxIterations}
+            placeholder="Maximum Iteration"
+            onChange={value => this.changeExperimentNumber('maxIteration', Number(value))}
+          />
+        </FormGroup>
+
+        <FormGroup
+          fieldId="algorithm"
+          label="Algorithm"
+          helperText="Strategy used to analyze the candidate and shift the traffic"
+        >
+          <FormSelect
+            value={this.state.experiment.trafficControl.algorithm}
+            id="algorithm"
+            name="Algorithm"
+            onChange={value => this.changeExperiment('algorithm', value)}
+          >
+            {algorithms.map((option, index) => (
+              <FormSelectOption isDisabled={false} key={'p' + index} value={option} label={option} />
+            ))}
+          </FormSelect>
+        </FormGroup>
+
+        <FormGroup
+          style={this.state.showTrafficStep ? {} : { display: 'none' }}
+          fieldId="trafficStepSize"
+          label="Traffic Step Size"
+          isValid={this.state.experiment.trafficControl.trafficStepSize > 0}
+          helperText="The maximum traffic increment per iteration"
+          helperTextInvalid="Traffic Step Size must be > 0"
+        >
+          <TextInput
+            id="trafficStepSize"
+            value={this.state.experiment.trafficControl.trafficStepSize}
+            placeholder="Traffic Step Size"
+            onChange={value => this.changeExperimentNumber('trafficStepSize', parseFloat(value))}
+          />
+        </FormGroup>
+      </>
+    );
+  }
+
+  renderTraffic() {
+    return (
+      <>
+        <Grid gutter="md">
+          <GridItem span={6}>
+            <FormGroup
+              fieldId="interval"
+              label="Interval (seconds)"
+              isValid={this.state.experiment.trafficControl.interval !== ''}
+              helperText="Frequency with which the controller calls the analytics service"
+              helperTextInvalid="Interval cannot be empty"
+            >
+              <TextInput
+                id="interval"
+                value={this.state.experiment.trafficControl.intervalInSecond}
+                placeholder="Time interval i.e. 30s"
+                onChange={value => this.changeExperimentNumber('interval', Number(value))}
+              />
+            </FormGroup>
+          </GridItem>
+          <GridItem span={6}>
+            <FormGroup
+              fieldId="maxIteration"
+              label="Maximum Iteration"
+              isValid={this.state.experiment.trafficControl.maxIterations > 0}
+              helperText="Maximum number of iterations for this experiment"
+              helperTextInvalid="Maximun Iteration cannot be empty"
+            >
+              <TextInput
+                id="maxIteration"
+                type="number"
+                value={this.state.experiment.trafficControl.maxIterations}
+                placeholder="Maximum Iteration"
+                onChange={value => this.changeExperimentNumber('maxIteration', Number(value))}
+              />
+            </FormGroup>
+          </GridItem>
+        </Grid>
+
+        <Grid gutter="md">
+          <GridItem span={6}>
+            <FormGroup
+              fieldId="algorithm"
+              label="Algorithm"
+              helperText="Strategy used to analyze the candidate and shift the traffic"
+            >
+              <FormSelect
+                value={this.state.experiment.trafficControl.algorithm}
+                id="algorithm"
+                name="Algorithm"
+                onChange={value => this.changeExperiment('algorithm', value)}
+              >
+                {algorithms.map((option, index) => (
+                  <FormSelectOption isDisabled={false} key={'p' + index} value={option} label={option} />
+                ))}
+              </FormSelect>
+            </FormGroup>
+          </GridItem>
+          <GridItem span={6}>
+            <FormGroup
+              style={this.state.showTrafficStep ? {} : { display: 'none' }}
+              fieldId="trafficStepSize"
+              label="Traffic Step Size"
+              isValid={this.state.experiment.trafficControl.trafficStepSize > 0}
+              helperText="The maximum traffic increment per iteration"
+              helperTextInvalid="Traffic Step Size must be > 0"
+            >
+              <TextInput
+                id="trafficStepSize"
+                value={this.state.experiment.trafficControl.trafficStepSize}
+                placeholder="Traffic Step Size"
+                onChange={value => this.changeExperimentNumber('trafficStepSize', parseFloat(value))}
+              />
+            </FormGroup>
+          </GridItem>
+        </Grid>
+      </>
+    );
+  }
+
+  onAddToList = (newCriteria: Criteria, newHost: Host) => {
+    this.setState(prevState => {
+      if (newHost != null && newHost.name !== '') {
+        prevState.experiment.hosts.push(newHost);
+      } else if (newCriteria != null) {
+        prevState.experiment.criterias.push(newCriteria);
+      }
+      return {
+        iter8Info: prevState.iter8Info,
+        experiment: {
+          name: prevState.experiment.name,
+          namespace: prevState.experiment.namespace,
+          service: prevState.experiment.service,
+          apiversion: prevState.experiment.apiversion,
+          baseline: prevState.experiment.baseline,
+          candidate: prevState.experiment.candidate,
+          trafficControl: prevState.experiment.trafficControl,
+          criterias: prevState.experiment.criterias,
+          hosts: prevState.experiment.hosts,
+          experimentKind: prevState.experiment.experimentKind
+        }
+      };
+    });
+  };
+
+  onRemoveFromList = (type: string, index: number) => {
+    this.setState(prevState => {
+      if (type === 'Criteria') {
+        prevState.experiment.criterias.splice(index, 1);
+      } else if (type === 'Host') {
+        prevState.experiment.hosts.splice(index, 1);
+      }
+
+      return {
+        iter8Info: prevState.iter8Info,
+        experiment: {
+          name: prevState.experiment.name,
+          namespace: prevState.experiment.namespace,
+          service: prevState.experiment.service,
+          apiversion: prevState.experiment.apiversion,
+          baseline: prevState.experiment.baseline,
+          candidate: prevState.experiment.candidate,
+          trafficControl: prevState.experiment.trafficControl,
+          criterias: prevState.experiment.criterias,
+          hosts: prevState.experiment.hosts,
+          experimentKind: prevState.experiment.experimentKind
+        }
+      };
+    });
+  };
+
+  renderCriteria() {
+    return (
+      <>
+        <h1 className="pf-c-title pf-m-xl">
+          <p>Assessment Criteria</p>
+        </h1>
+        <ExperimentCriteriaForm
+          iter8Info={this.state.iter8Info}
+          criterias={this.state.experiment.criterias}
+          metricNames={this.state.metricNames}
+          onAdd={this.onAddToList}
+          onRemove={this.onRemoveFromList}
+        />
+      </>
+    );
+  }
+
+  renderHost() {
+    return (
+      <>
+        <h1 className="pf-c-title pf-m-xl">
+          <p>Host / Gateways (Optional)</p>
+        </h1>
+        <ExperimentHostForm
+          hosts={this.state.experiment.hosts}
+          hostsOfGateway={this.state.hostsOfGateway}
+          gateways={this.state.gateways}
+          onAdd={this.onAddToList}
+          onRemove={this.onRemoveFromList}
+        />
+      </>
+    );
+  }
+
+  renderSimplePage() {
+    return (
+      <>
+        <hr />
+        <Expandable
+          toggleText={
+            this.state.showAdvanced
+              ? history.location.pathname.endsWith('/new')
+                ? toggleTextFlat[1]
+                : toggleTextWizard[1]
+              : history.location.pathname.endsWith('/new')
+              ? toggleTextFlat[0]
+              : toggleTextWizard[0]
+          }
+          isExpanded={this.state.showAdvanced}
+          onToggle={() => {
+            this.setState({
+              showAdvanced: !this.state.showAdvanced
+            });
+          }}
+        >
+          {this.renderCriteria()}
+          <hr />
+          <p>&nbsp; &nbsp;&nbsp;</p>
+          <h1 className="pf-c-title pf-m-xl">Traffic Control </h1>
+          <div className={durationTimeStyle}>Total Experiment Duration: {this.state.totalDuration}</div>
+          {this.renderTrafficInWizard()}
+          <p>&nbsp; &nbsp;&nbsp;</p>
+          {this.renderHost()}
+        </Expandable>{' '}
+      </>
+    );
+  }
+
+  renderFullPage() {
+    return (
+      <>
+        <hr />
+        {this.renderCriteria()}
+        <Expandable
+          toggleText={
+            this.state.showAdvanced
+              ? history.location.pathname.endsWith('/new')
+                ? toggleTextFlat[1]
+                : toggleTextWizard[1]
+              : history.location.pathname.endsWith('/new')
+              ? toggleTextFlat[0]
+              : toggleTextWizard[0]
+          }
+          isExpanded={this.state.showAdvanced}
+          onToggle={() => {
+            this.setState({
+              showAdvanced: !this.state.showAdvanced
+            });
+          }}
+        >
+          <h1 className="pf-c-title pf-m-xl">Traffic Control </h1>
+          <div className={durationTimeStyle}>Total Experiment Duration: {this.state.totalDuration}</div>
+          {this.renderTraffic()}
+          <p>&nbsp; &nbsp;&nbsp;</p>
+          {this.renderHost()}
+        </Expandable>
+      </>
+    );
+  }
+
   render() {
-    const isNamespacesValid = this.props.activeNamespaces.length === 1;
     const isFormValid = this.isMainFormValid() && this.isSCFormValid();
-    // @ts-ignore
     return (
       <>
         <RenderContent>
           <div className={containerPadding}>
-            <Form isHorizontal={true}>
-              <FormGroup
-                fieldId="name"
-                label="Experiment Name"
-                isRequired={true}
-                isValid={this.state.experiment.name !== '' && this.state.experiment.name.search(regex) === 0}
-                helperTextInvalid="Name cannot be empty and must be a DNS subdomain name as defined in RFC 1123."
-              >
-                <TextInput
-                  id="name"
-                  value={this.state.experiment.name}
-                  placeholder="Experiment Name"
-                  onChange={value => this.changeExperiment('name', value)}
-                />
-              </FormGroup>
-              {history.location.pathname.endsWith('/new') ? (
-                <Grid gutter="md">
-                  <GridItem span={6}>
-                    <FormGroup
-                      label="Namespaces"
-                      isRequired={true}
-                      fieldId="namespaces"
-                      helperText={'Select namespace where this configuration will be applied'}
-                      isValid={isNamespacesValid}
-                    >
-                      <FormSelect
-                        id="namespaces"
-                        value={this.state.experiment.namespace}
-                        placeholder="Namespace"
-                        onChange={value => {
-                          this.changeExperiment('namespace', value);
-                          this.fetchServices(value);
-                        }}
-                      >
-                        {this.state.namespaces.map((svc, index) => (
-                          <FormSelectOption label={svc} key={'namespace' + index} value={svc} />
-                        ))}
-                      </FormSelect>
-                    </FormGroup>
-                  </GridItem>
-                  <GridItem span={6}>
-                    <FormGroup
-                      fieldId="service"
-                      label="Target Service"
-                      isRequired={true}
-                      isValid={this.state.experiment.service !== ''}
-                      helperText="Target Service specifies the reference to experiment targets (i.e. reviews)"
-                      helperTextInvalid="Target Service cannot be empty"
-                    >
-                      <FormSelect
-                        id="service"
-                        value={this.state.experiment.service}
-                        placeholder="Target Service"
-                        onChange={value => {
-                          this.changeExperiment('service', value);
-                          const ns = this.state.experiment.namespace;
-                          this.fetchWorkloads(ns, value);
-                        }}
-                      >
-                        {this.state.services.map((svc, index) => (
-                          <FormSelectOption label={svc} key={'service' + index} value={svc} />
-                        ))}
-                      </FormSelect>
-                    </FormGroup>
-                  </GridItem>
-                </Grid>
-              ) : (
-                ''
-              )}
-              <Grid gutter="md">
-                <GridItem span={6}>
-                  <FormGroup
-                    fieldId="baseline"
-                    label="Baseline"
-                    isRequired={true}
-                    isValid={this.state.experiment.baseline !== ''}
-                    helperText="The baseline deployment of the target service (i.e. reviews-v1)"
-                    helperTextInvalid="Baseline deployment cannot be empty"
-                  >
-                    <FormSelect
-                      id="baseline"
-                      value={this.state.experiment.baseline}
-                      placeholder="Baseline Deployment"
-                      onChange={value => this.changeExperiment('baseline', value)}
-                    >
-                      {this.state.workloads.map((wk, index) => (
-                        <FormSelectOption label={wk} key={'workloadBaseline' + index} value={wk} />
-                      ))}
-                    </FormSelect>
-                  </FormGroup>
-                </GridItem>
-                <GridItem span={6}>
-                  <FormGroup
-                    fieldId="candidate"
-                    label="Select Candidate"
-                    isRequired={true}
-                    isValid={this.state.experiment.candidate !== ''}
-                    helperText="The candidate deployment of the target service (i.e. reviews-v2)"
-                    helperTextInvalid="Candidate deployment cannot be empty"
-                  >
-                    <TextInput
-                      id="candidate"
-                      value={this.state.experiment.candidate}
-                      placeholder="Select from list or enter a new one"
-                      onChange={value => this.changeExperiment('candidate', value)}
-                      list={'candidateName'}
-                      autoComplete={'off'}
-                    />
-                    <datalist id="candidateName">
-                      {this.state.workloads.map((wk, index) =>
-                        wk !== this.state.experiment.baseline ? (
-                          <option label={wk} key={'workloadCandidate' + index} value={wk}>
-                            {wk}
-                          </option>
-                        ) : (
-                          ''
-                        )
-                      )}
-                    </datalist>
-                  </FormGroup>
-                </GridItem>
-              </Grid>
-              <hr />
-              <h1 className="pf-c-title pf-m-xl">Assessment Criteria</h1>
-              <ExperimentCriteriaForm
-                criterias={this.state.experiment.criterias}
-                metricNames={this.state.metricNames}
-                onAdd={newCriteria => {
-                  this.setState(prevState => {
-                    newCriteria.tolerance = newCriteria.tolerance * (serverConfig.istioTelemetryV2 ? 1000 : 1);
-                    prevState.experiment.criterias.push(newCriteria);
-                    return {
-                      iter8Info: prevState.iter8Info,
-                      experiment: {
-                        name: prevState.experiment.name,
-                        namespace: prevState.experiment.namespace,
-                        service: prevState.experiment.service,
-                        apiversion: prevState.experiment.apiversion,
-                        baseline: prevState.experiment.baseline,
-                        candidate: prevState.experiment.candidate,
-                        trafficControl: prevState.experiment.trafficControl,
-                        criterias: prevState.experiment.criterias
-                      }
-                    };
-                  });
-                }}
-                onRemove={index => {
-                  this.setState(prevState => {
-                    prevState.experiment.criterias.splice(index, 1);
-                    return {
-                      iter8Info: prevState.iter8Info,
-                      experiment: {
-                        name: prevState.experiment.name,
-                        namespace: prevState.experiment.namespace,
-                        service: prevState.experiment.service,
-                        apiversion: prevState.experiment.apiversion,
-                        baseline: prevState.experiment.baseline,
-                        candidate: prevState.experiment.candidate,
-                        trafficControl: prevState.experiment.trafficControl,
-                        criterias: prevState.experiment.criterias
-                      }
-                    };
-                  });
-                }}
-              />
+            <Form className={formPadding} isHorizontal={true}>
+              {history.location.pathname.endsWith('/new') ? this.renderFullGeneral() : this.renderGeneral()}
+              {history.location.pathname.endsWith('/new') ? this.renderFullPage() : this.renderSimplePage()}
 
-              <Expandable
-                toggleText={(this.state.showAdvanced ? 'Hide' : 'Show') + ' Advanced Options'}
-                isExpanded={this.state.showAdvanced}
-                onToggle={() => {
-                  this.setState({
-                    showAdvanced: !this.state.showAdvanced
-                  });
-                }}
-              >
-                <h1 className="pf-c-title pf-m-xl">Traffic Control </h1>
-                <div className={noCriteriaStyle}>Total Experiment Duration: {this.state.totalDuration}</div>
-
-                <Grid gutter="md">
-                  <GridItem span={6}>
-                    <FormGroup
-                      fieldId="interval"
-                      label="Interval (seconds)"
-                      isValid={this.state.experiment.trafficControl.interval !== ''}
-                      helperText="Frequency with which the controller calls the analytics service"
-                      helperTextInvalid="Interval cannot be empty"
-                    >
-                      <TextInput
-                        id="interval"
-                        value={this.state.experiment.trafficControl.intervalInSecond}
-                        placeholder="Time interval i.e. 30s"
-                        onChange={value => this.changeExperimentNumber('interval', Number(value))}
-                      />
-                    </FormGroup>
-                  </GridItem>
-                  <GridItem span={6}>
-                    <FormGroup
-                      fieldId="maxIteration"
-                      label="Maximum Iteration"
-                      isValid={this.state.experiment.trafficControl.maxIterations > 0}
-                      helperText="Maximum number of iterations for this experiment"
-                      helperTextInvalid="Maximun Iteration cannot be empty"
-                    >
-                      <TextInput
-                        id="maxIteration"
-                        type="number"
-                        value={this.state.experiment.trafficControl.maxIterations}
-                        placeholder="Maximum Iteration"
-                        onChange={value => this.changeExperimentNumber('maxIteration', Number(value))}
-                      />
-                    </FormGroup>
-                  </GridItem>
-                </Grid>
-
-                <Grid gutter="md">
-                  <GridItem span={6}>
-                    <FormGroup
-                      fieldId="algorithm"
-                      label="Algorithm"
-                      helperText="Strategy used to analyze the candidate and shift the traffic"
-                    >
-                      <FormSelect
-                        value={this.state.experiment.trafficControl.algorithm}
-                        id="algorithm"
-                        name="Algorithm"
-                        onChange={value => this.changeExperiment('algorithm', value)}
-                      >
-                        {algorithms.map((option, index) => (
-                          <FormSelectOption isDisabled={false} key={'p' + index} value={option} label={option} />
-                        ))}
-                      </FormSelect>
-                    </FormGroup>
-                  </GridItem>
-                  <GridItem span={6}>
-                    <FormGroup
-                      style={this.state.showTrafficStep ? {} : { display: 'none' }}
-                      fieldId="trafficStepSize"
-                      label="Traffic Step Size"
-                      isValid={this.state.experiment.trafficControl.trafficStepSize > 0}
-                      helperText="The maximum traffic increment per iteration"
-                      helperTextInvalid="Traffic Step Size must be > 0"
-                    >
-                      <TextInput
-                        id="trafficStepSize"
-                        value={this.state.experiment.trafficControl.trafficStepSize}
-                        placeholder="Traffic Step Size"
-                        onChange={value => this.changeExperimentNumber('trafficStepSize', parseFloat(value))}
-                      />
-                    </FormGroup>
-                  </GridItem>
-                </Grid>
-              </Expandable>
               {history.location.pathname.endsWith('/new') ? (
                 <ActionGroup>
                   <span

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentDetailsPage.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentDetailsPage.tsx
@@ -18,7 +18,7 @@ import {
 import { style } from 'typestyle';
 import * as API from '../../../../services/Api';
 import * as AlertUtils from '../../../../utils/AlertUtils';
-import { ExperimentAction, Iter8ExpDetailsInfo } from '../../../../types/Iter8';
+import { ExperimentAction, Iter8ExpDetailsInfo, Iter8Info } from '../../../../types/Iter8';
 import Iter8Dropdown from './Iter8Dropdown';
 import history from '../../../../app/History';
 import * as FilterHelper from '../../../../components/FilterList/FilterHelper';
@@ -42,6 +42,7 @@ interface Props extends RouteComponentProps<ExpeerimentId> {
 }
 
 interface State {
+  iter8Info: Iter8Info;
   experiment?: Iter8ExpDetailsInfo;
   currentTab: string;
   canDelete: boolean;
@@ -73,6 +74,12 @@ class ExperimentDetailsPage extends React.Component<Props, State> {
 
     const urlParams = new URLSearchParams(history.location.search);
     this.state = {
+      iter8Info: {
+        enabled: false,
+        supportedVersion: false,
+        analyticsImageVersion: '',
+        controllerImageVersion: ''
+      },
       experiment: undefined,
       canDelete: false,
       currentTab: activeTab(tabName, defaultTab),
@@ -95,6 +102,7 @@ class ExperimentDetailsPage extends React.Component<Props, State> {
             .then(result => {
               if (this.state.resetActionFlag) {
                 this.setState({
+                  iter8Info: iter8Info,
                   actionTaken: '',
                   experiment: result.data,
                   canDelete: result.data.permissions.delete,
@@ -134,8 +142,8 @@ class ExperimentDetailsPage extends React.Component<Props, State> {
       );
     }
   }
+
   // Extensions breadcrumb,
-  // It is a simplified view of BreadcrumbView with fixed rendering
   breadcrumb = () => {
     return (
       <div className={extensionHeader}>
@@ -345,7 +353,10 @@ class ExperimentDetailsPage extends React.Component<Props, State> {
     );
     const criteriaTab = (
       <Tab eventKey={1} title="Criteria" key="Criteria">
-        <CriteriaInfoDescription criterias={this.state.experiment ? this.state.experiment.criterias : []} />
+        <CriteriaInfoDescription
+          iter8Info={this.state.iter8Info}
+          criterias={this.state.experiment ? this.state.experiment.criterias : []}
+        />
       </Tab>
     );
     const tabsArray: any[] = [overviewTab, criteriaTab];

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentHostForm.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentHostForm.tsx
@@ -1,0 +1,190 @@
+import { ICell, Table, TableBody, TableHeader, wrappable } from '@patternfly/react-table';
+import { Criteria, Host, initCriteria } from '../../../../types/Iter8';
+import * as React from 'react';
+import { Button, FormSelect, FormSelectOption } from '@patternfly/react-core';
+
+const headerCells: ICell[] = [
+  {
+    title: 'Gateway name',
+    transforms: [wrappable],
+    props: {}
+  },
+  {
+    title: 'Host name',
+    transforms: [wrappable],
+    props: {}
+  },
+  {
+    title: '',
+    props: {}
+  }
+];
+
+type Props = {
+  hosts: Host[];
+  hostsOfGateway: Host[];
+  gateways: string[];
+  onAdd: (criteria: Criteria, host: Host) => void;
+  onRemove: (type: string, index: number) => void;
+};
+
+export type HostState = {
+  addHost: Host;
+  validName: boolean;
+};
+
+export const initHost = (gw: string): HostState => ({
+  addHost: {
+    name: '',
+    gateway: gw
+  },
+  validName: false
+});
+
+// Create Success Criteria, can be multiple with same metric, but different sampleSize, etc...
+class ExperimentHostForm extends React.Component<Props, HostState> {
+  constructor(props: Props) {
+    super(props);
+    if (this.props.gateways.length > 0) {
+      this.state = initHost(this.props.gateways[0]);
+    } else {
+      this.state = initHost('');
+    }
+  }
+
+  // @ts-ignore
+  actionResolver = (rowData, { rowIndex }) => {
+    const removeAction = {
+      title: 'Remove Host',
+      // @ts-ignore
+      onClick: (event, rowIndex, rowData, extraData) => {
+        this.props.onRemove('Host', rowIndex);
+      }
+    };
+    if (rowIndex < this.props.hosts.length) {
+      return [removeAction];
+    }
+    return [];
+  };
+
+  loadHostName = (gw: string) => {
+    this.setState(prevState => ({
+      addHost: {
+        name: prevState.addHost.name,
+        gateway: gw
+      },
+      validName: true
+    }));
+  };
+
+  onAddName = (value: string) => {
+    this.setState(prevState => ({
+      addHost: {
+        name: value.trim(),
+        gateway: prevState.addHost.gateway
+      },
+      validName: true
+    }));
+  };
+
+  onAddGateway = (value: string, _) => {
+    this.setState(prevState => ({
+      addHost: {
+        name: prevState.addHost.name,
+        gateway: value.trim()
+      },
+      validName: true
+    }));
+  };
+
+  onAddHost = () => {
+    this.props.onAdd(initCriteria(), this.state.addHost);
+    this.setState({
+      addHost: {
+        name: '',
+        gateway: ''
+      }
+    });
+  };
+
+  rows() {
+    let hostlist: string[] = [];
+    hostlist.push('-- select hostname --');
+    if (this.props.hostsOfGateway.length > 0) {
+      this.props.hostsOfGateway.forEach(hs => {
+        if (this.state.addHost.gateway !== '') {
+          if (hs.gateway === this.state.addHost.gateway) hostlist.push(hs.name);
+        } else {
+          if (hs.gateway === this.props.gateways[0]) hostlist.push(hs.name);
+        }
+      });
+    }
+
+    return this.props.hosts
+      .map((host, i) => ({
+        key: 'host' + i,
+        cells: [<>{host.gateway}</>, <>{host.name}</>, '']
+      }))
+      .concat([
+        {
+          key: 'hostNew',
+          cells: [
+            <>
+              <FormSelect
+                id="gateway"
+                value={this.state.addHost.gateway}
+                placeholder="Baseline Deployment"
+                onChange={gw => this.loadHostName(gw)}
+              >
+                {this.props.gateways.map((gw, index) => (
+                  <FormSelectOption label={gw} key={'gateway' + index} value={gw} />
+                ))}
+              </FormSelect>
+            </>,
+            <>
+              <FormSelect
+                id="name"
+                value={this.state.addHost.name}
+                placeholder="Host"
+                onChange={host => this.onAddName(host)}
+              >
+                {hostlist.map((host, index) => (
+                  <FormSelectOption label={host} key={'host' + index} value={host} />
+                ))}
+              </FormSelect>
+            </>,
+            <>
+              <Button
+                id="addHostBtn"
+                aria-label="slider-text"
+                variant="secondary"
+                isDisabled={this.state.addHost.gateway.length === 0 || this.state.addHost.name.length === 0}
+                onClick={this.onAddHost}
+              >
+                Add this Host
+              </Button>
+            </>
+          ]
+        }
+      ]);
+  }
+
+  render() {
+    return (
+      <>
+        <Table
+          aria-label="Host / Gateway"
+          cells={headerCells}
+          rows={this.rows()}
+          // @ts-ignore
+          actionResolver={this.actionResolver}
+        >
+          <TableHeader />
+          <TableBody />
+        </Table>
+      </>
+    );
+  }
+}
+
+export default ExperimentHostForm;

--- a/src/types/Iter8.ts
+++ b/src/types/Iter8.ts
@@ -2,6 +2,9 @@ import { ResourcePermissions } from './Permissions';
 
 export interface Iter8Info {
   enabled: boolean;
+  supportedVersion: boolean;
+  controllerImageVersion: string;
+  analyticsImageVersion: string;
 }
 
 export interface Iter8Experiment {
@@ -11,12 +14,15 @@ export interface Iter8Experiment {
   status: string;
   baseline: string;
   baselinePercentage: number;
+  baselineVersion: string;
   candidate: string;
   candidatePercentage: number;
+  candidateVersion: string;
   namespace: string;
   createdAt: number;
   startedAt: number;
   endedAt: number;
+  kind: string;
 }
 
 export interface ExpId {
@@ -36,6 +42,7 @@ export interface Iter8ExpDetailsInfo {
   experimentItem: ExperimentItem;
   criterias: SuccessCriteria[];
   trafficControl: TrafficControl;
+  hosts: Host[];
   permissions: ResourcePermissions;
 }
 
@@ -49,13 +56,16 @@ export interface ExperimentItem {
   endedAt: number;
   baseline: string;
   baselinePercentage: number;
+  baselineVersion: string;
   candidate: string;
   candidatePercentage: number;
+  candidateVersion: string;
   targetService: string;
   targetServiceNamespace: string;
   assessmentConclusion: string[];
   labels?: { [key: string]: string };
   resourceVersion: string;
+  kind: string;
 }
 export interface SuccessCriteria {
   name: string;
@@ -87,6 +97,18 @@ export interface Criteria {
   toleranceType: string;
   sampleSize: number;
   stopOnFailure: boolean;
+}
+export const initCriteria = (): Criteria => ({
+  metric: '',
+  tolerance: 200,
+  toleranceType: 'threshold',
+  stopOnFailure: false,
+  sampleSize: 5
+});
+
+export interface Host {
+  name: string;
+  gateway: string;
 }
 
 export interface ExperimentAction {


### PR DESCRIPTION
** Describe the change **
1. Iter8 v0.2 supports deployment/service-based experiment
2. add Host/Gateway support
3. Warning message if not running Iter8 v0.2
4. disable default namespace dropdown for experiment create page

Note: Replace the original [PR#1841] (https://github.com/kiali/kiali-ui/pull/1841)

** Issue reference **
[#1007](https://github.com/kiali/kiali/issues/2007)

** Backwards compatible? **
This PR depends on [PR#3033](https://github.com/kiali/kiali/pull/3033)

[ ] Is your pull-request introducing changes in behaviour?

_Describe the changes if appropriate. E.g. a new link, a change on what a click does, etc_

** Screenshot **
1. Iter8 v0.2 supports deployment/service-based experiment
A. Deployment-Based
<img width="1300" alt="Screen Shot 2020-08-03 at 11 28 16 AM" src="https://user-images.githubusercontent.com/4615187/89201040-e56ddf00-d57e-11ea-9ed3-4f097b5632ba.png">
B. Service-Based
<img width="1313" alt="Screen Shot 2020-08-03 at 11 28 25 AM" src="https://user-images.githubusercontent.com/4615187/89201069-f0c10a80-d57e-11ea-81c9-0f6c6a67a93f.png">
C. Experiment Listing page show the two different experiment ( deployment-base vs service-based)
<img width="1171" alt="86421486-36e92c80-bca8-11ea-9e53-2317b3432484" src="https://user-images.githubusercontent.com/4615187/89201257-31b91f00-d57f-11ea-81e1-65fcf6404b1f.png">

=====

2.add Host/Gateway support
<img width="1204" alt="86421438-0b664200-bca8-11ea-9d62-d7092dfa3228" src="https://user-images.githubusercontent.com/4615187/89201193-1bab5e80-d57f-11ea-89e1-8192931ebad9.png">

=====

3. Warning message if not running Iter8 v0.2
<img width="479" alt="86421450-18833100-bca8-11ea-895e-5065808ba6f4" src="https://user-images.githubusercontent.com/4615187/89201269-38479680-d57f-11ea-996e-9cbc48d77831.png">


