### PR TITLE
Relax Warning AlertToasts on Istio Config validations

### DIFF
--- a/src/actions/MessageCenterActions.ts
+++ b/src/actions/MessageCenterActions.ts
@@ -16,8 +16,9 @@ export const MessageCenterActions = {
       content: string,
       detail: string,
       groupId: string = DEFAULT_GROUP_ID,
-      messageType: MessageType = DEFAULT_MESSAGE_TYPE
-    ) => resolve({ content, detail, groupId, messageType })
+      messageType: MessageType = DEFAULT_MESSAGE_TYPE,
+      showNotification: boolean = true
+    ) => resolve({ content, detail, groupId, messageType, showNotification })
   ),
   removeMessage: createAction(ActionKeys.MC_REMOVE_MESSAGE, resolve => (messageId: numberOrNumberArray) =>
     resolve({ messageId: toNumberArray(messageId) })

--- a/src/actions/__tests__/MessageCenterAction.test.ts
+++ b/src/actions/__tests__/MessageCenterAction.test.ts
@@ -14,7 +14,8 @@ describe('MessageCenterActions', () => {
       content: 'my message',
       detail: 'my detail',
       groupId: 'great-messages',
-      messageType: MessageType.WARNING
+      messageType: MessageType.WARNING,
+      showNotification: true
     };
     const action = MessageCenterActions.addMessage('my message', 'my detail', 'great-messages', MessageType.WARNING);
     expect(action.payload).toEqual(expectedPayload);

--- a/src/components/MessageCenter/NotificationList.tsx
+++ b/src/components/MessageCenter/NotificationList.tsx
@@ -10,6 +10,7 @@ type NotificationListProps = {
 
 export default class NotificationList extends React.PureComponent<NotificationListProps> {
   render() {
+    console.log(this.props.messages);
     return (
       <>
         {this.props.messages.map((message, i) => {

--- a/src/components/MessageCenter/NotificationList.tsx
+++ b/src/components/MessageCenter/NotificationList.tsx
@@ -10,7 +10,6 @@ type NotificationListProps = {
 
 export default class NotificationList extends React.PureComponent<NotificationListProps> {
   render() {
-    console.log(this.props.messages);
     return (
       <>
         {this.props.messages.map((message, i) => {

--- a/src/components/MessageCenter/__tests__/MessageCenter.test.tsx
+++ b/src/components/MessageCenter/__tests__/MessageCenter.test.tsx
@@ -32,7 +32,8 @@ describe('MessageCenter', () => {
           count: 0,
           created: new Date(),
           detail: '',
-          showDetail: false
+          showDetail: false,
+          show_notification: true
         }
       ]
     },
@@ -48,7 +49,7 @@ describe('MessageCenter', () => {
           content: 'show me too',
           type: MessageType.SUCCESS,
           count: 0,
-          show_notification: true,
+          show_notification: false,
           created: new Date(),
           detail: '',
           showDetail: false

--- a/src/reducers/MessageCenter.ts
+++ b/src/reducers/MessageCenter.ts
@@ -36,6 +36,7 @@ const createMessage = (
   detail: string,
   type: MessageType,
   count: number,
+  showNotification: boolean,
   created: Date,
   showDetail: boolean,
   firstTriggered?: Date
@@ -46,7 +47,7 @@ const createMessage = (
     detail,
     type,
     count,
-    show_notification: type === MessageType.ERROR || type === MessageType.WARNING || type === MessageType.SUCCESS,
+    show_notification: showNotification,
     seen: false,
     created: created,
     showDetail: showDetail,
@@ -78,7 +79,7 @@ const Messages = (
 ): MessageCenterState => {
   switch (action.type) {
     case getType(MessageCenterActions.addMessage): {
-      const { content, detail, groupId, messageType } = action.payload;
+      const { content, detail, groupId, messageType, showNotification } = action.payload;
 
       const groups = state.groups.map(group => {
         if (group.id === groupId) {
@@ -103,6 +104,7 @@ const Messages = (
               existingMessage.detail,
               messageType,
               existingMessage.count + 1,
+              existingMessage.show_notification,
               new Date(),
               existingMessage.showDetail,
               firstTriggered
@@ -115,7 +117,17 @@ const Messages = (
 
             group = { ...group, messages: filteredArray.concat(newMessage) };
           } else {
-            newMessage = createMessage(state.nextId, content, detail, messageType, 1, new Date(), false, undefined);
+            newMessage = createMessage(
+              state.nextId,
+              content,
+              detail,
+              messageType,
+              1,
+              showNotification,
+              new Date(),
+              false,
+              undefined
+            );
             group = { ...group, messages: group.messages.concat(newMessage) };
           }
 

--- a/src/types/MessageCenter.ts
+++ b/src/types/MessageCenter.ts
@@ -16,7 +16,7 @@ export interface NotificationMessage {
   count: number; // how many times did this message occur
 
   showDetail: boolean;
-  show_notification?: boolean;
+  show_notification: boolean;
   groupId?: string;
 }
 

--- a/src/utils/AlertUtils.ts
+++ b/src/utils/AlertUtils.ts
@@ -37,14 +37,14 @@ export const addError = (message: string, error?: AxiosError, group?: string, ty
 };
 
 // info level message do not generate a toast notification
-export const addInfo = (content: string, group?: string) => {
-  store.dispatch(MessageCenterActions.addMessage(content, '', group, MessageType.INFO));
+export const addInfo = (content: string, showNotification?: boolean, group?: string) => {
+  store.dispatch(MessageCenterActions.addMessage(content, '', group, MessageType.INFO, showNotification));
 };
 
-export const addSuccess = (content: string, group?: string) => {
-  store.dispatch(MessageCenterActions.addMessage(content, '', group, MessageType.SUCCESS));
+export const addSuccess = (content: string, showNotification?: boolean, group?: string) => {
+  store.dispatch(MessageCenterActions.addMessage(content, '', group, MessageType.SUCCESS, showNotification));
 };
 
-export const addWarning = (content: string, group?: string) => {
-  store.dispatch(MessageCenterActions.addMessage(content, '', group, MessageType.WARNING));
+export const addWarning = (content: string, showNotification?: boolean, group?: string) => {
+  store.dispatch(MessageCenterActions.addMessage(content, '', group, MessageType.WARNING, showNotification));
 };

--- a/src/utils/IstioValidationUtils.ts
+++ b/src/utils/IstioValidationUtils.ts
@@ -9,7 +9,7 @@ const showInMessageCenterValidation = (validation: ObjectValidation) => {
   for (let check of validation.checks) {
     switch (check.severity) {
       case ValidationTypes.Warning:
-        AlertUtils.addWarning(validationMessage(validation, check));
+        AlertUtils.addWarning(validationMessage(validation, check), false);
         break;
       case ValidationTypes.Error:
         AlertUtils.addError(validationMessage(validation, check));
@@ -32,8 +32,12 @@ const showInMessageCenterValidations = (validations: ObjectValidation[]) => {
     }
   }
   if (elementsWithFailedValidations.length > 0) {
-    const messageCenterMethod = hasError ? AlertUtils.addError : AlertUtils.addWarning;
-    messageCenterMethod(`Some IstioConfigs (${elementsWithFailedValidations.join(', ')}) have warnings or errors`);
+    const message = `Some IstioConfigs (${elementsWithFailedValidations.join(', ')}) have warnings or errors`;
+    if (hasError) {
+      AlertUtils.addError(message);
+    } else {
+      AlertUtils.addWarning(message, false);
+    }
   }
 };
 


### PR DESCRIPTION
Relax the popup warning for Istio Config validations.
Other notifications (AlertToasts) should remain as default behaviour.

Fixes https://github.com/kiali/kiali/issues/3074