### PR TITLE
Find/Hide improvements:

### DIFF
--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -618,8 +618,8 @@ export class GraphStyles {
         selector: '*.find[^isGroup]',
         style: {
           'overlay-color': PfColors.Gold400,
-          'overlay-padding': '8px',
-          'overlay-opacity': 0.5
+          'overlay-padding': '7px',
+          'overlay-opacity': 0.3
         }
       },
       {


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/3072

- For consistency between graph find/hide and logs show/hide, improve graph find handling to report independent errors for find and hide expressions.
- apply a UX-approved tweak to slightly reduce/lighten the find overlay to maintain better visibility of labels and nodes.
- immediately submit a find/hide value selected from the autocomplete dropdown   (or pasted).  Note that there is no native support for this, so we just assume any single input change > 1 character should be applied.  It seems to work well as a rule of thumb.

@mtho11 If you like the immediate submit on autocomplete select, we can add that to log show/hide as well.