### PR TITLE
Allow specify Weights in Matching Routing Wizard

### DIFF
--- a/src/components/IstioWizards/MatchingRouting/MatchBuilder.tsx
+++ b/src/components/IstioWizards/MatchingRouting/MatchBuilder.tsx
@@ -120,7 +120,7 @@ class MatchBuilder extends React.Component<Props, State> {
             placeholder={placeholderText[this.props.category]}
           />
         )}
-        <Button disabled={!this.props.isValid} onClick={this.props.onAddMatch}>
+        <Button variant="secondary" disabled={!this.props.isValid} onClick={this.props.onAddMatch}>
           Add Match
         </Button>
       </InputGroup>

--- a/src/components/IstioWizards/MatchingRouting/Matches.tsx
+++ b/src/components/IstioWizards/MatchingRouting/Matches.tsx
@@ -16,7 +16,9 @@ class Matches extends React.Component<Props> {
   render() {
     const matches: any[] = this.props.matches.map((match, index) => (
       <span key={match + '-' + index}>
-        <Chip onClick={() => this.props.onRemoveMatch(match)}>{match}</Chip>{' '}
+        <Chip onClick={() => this.props.onRemoveMatch(match)} isOverflowChip={true}>
+          {match}
+        </Chip>{' '}
       </span>
     ));
     return (

--- a/src/components/IstioWizards/MatchingRouting/Matches.tsx
+++ b/src/components/IstioWizards/MatchingRouting/Matches.tsx
@@ -8,7 +8,8 @@ type Props = {
 };
 
 const labelContainerStyle = style({
-  marginTop: 5
+  marginTop: 5,
+  height: 30
 });
 
 class Matches extends React.Component<Props> {

--- a/src/components/IstioWizards/MatchingRouting/RuleBuilder.tsx
+++ b/src/components/IstioWizards/MatchingRouting/RuleBuilder.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
-import { Button, InputGroup, Select, SelectVariant, SelectOption, Tabs, Tab } from '@patternfly/react-core';
+import { Button, Tabs, Tab } from '@patternfly/react-core';
 import MatchBuilder from './MatchBuilder';
 import Matches from './Matches';
 import { style } from 'typestyle';
 import { WorkloadOverview } from '../../../types/ServiceInfo';
-import { PfColors } from '../../Pf/PfColors';
+import WeightedRouting, { WorkloadWeight } from '../WeightedRouting';
+import { getDefaultWeights } from '../WizardActions';
 
 type Props = {
   // MatchBuilder props
@@ -24,8 +25,7 @@ type Props = {
   onRemoveMatch: (match: string) => void;
 
   workloads: WorkloadOverview[];
-  routes: string[];
-  onSelectRoutes: (routes: string[]) => void;
+  onSelectWeights: (valid: boolean, workloads: WorkloadWeight[]) => void;
 
   // RuleBuilder
   validationMsg: string;
@@ -36,12 +36,6 @@ type State = {
   isWorkloadSelector: boolean;
   ruleTabKey: number;
 };
-
-const validationStyle = style({
-  marginTop: 5,
-  height: 30,
-  color: PfColors.Red100
-});
 
 const addRuleStyle = style({
   width: '100%',
@@ -80,37 +74,11 @@ class RuleBuilder extends React.Component<Props, State> {
             </div>
           </Tab>
           <Tab eventKey={1} title={'Select Routes'}>
-            <div style={{ marginTop: '20px' }}>
-              <InputGroup>
-                <span id="select-workloads-id" hidden>
-                  Checkbox Title
-                </span>
-                <Select
-                  aria-label="Select Input"
-                  variant={SelectVariant.checkbox}
-                  onToggle={this.onWorkloadsToggle}
-                  onSelect={(_, selection) => {
-                    if (this.props.routes.includes(selection as string)) {
-                      this.props.onSelectRoutes(this.props.routes.filter(item => item !== selection));
-                    } else {
-                      this.props.onSelectRoutes([...this.props.routes, selection as string]);
-                    }
-                  }}
-                  onClear={() => {
-                    this.props.onSelectRoutes([]);
-                  }}
-                  selections={this.props.routes}
-                  isExpanded={this.state.isWorkloadSelector}
-                  placeholderText="Select workloads"
-                  ariaLabelledBy="select-workloads-id"
-                >
-                  {this.props.workloads.map(wk => (
-                    <SelectOption key={wk.name} value={wk.name} />
-                  ))}
-                </Select>
-              </InputGroup>
-              <div className={validationStyle}>{!this.props.isValid && this.props.validationMsg}</div>
-            </div>
+            <WeightedRouting
+              workloads={this.props.workloads}
+              initWeights={getDefaultWeights(this.props.workloads)}
+              onChange={this.props.onSelectWeights}
+            />
           </Tab>
         </Tabs>
         <div className={addRuleStyle}>

--- a/src/components/IstioWizards/MatchingRouting/RuleBuilder.tsx
+++ b/src/components/IstioWizards/MatchingRouting/RuleBuilder.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, InputGroup, Select, SelectVariant, SelectOption } from '@patternfly/react-core';
+import { Button, InputGroup, Select, SelectVariant, SelectOption, Tabs, Tab } from '@patternfly/react-core';
 import MatchBuilder from './MatchBuilder';
 import Matches from './Matches';
 import { style } from 'typestyle';
@@ -34,18 +34,26 @@ type Props = {
 
 type State = {
   isWorkloadSelector: boolean;
+  ruleTabKey: number;
 };
 
 const validationStyle = style({
-  marginTop: 15,
+  marginTop: 5,
+  height: 30,
   color: PfColors.Red100
+});
+
+const addRuleStyle = style({
+  width: '100%',
+  textAlign: 'right'
 });
 
 class RuleBuilder extends React.Component<Props, State> {
   constructor(props) {
     super(props);
     this.state = {
-      isWorkloadSelector: false
+      isWorkloadSelector: false,
+      ruleTabKey: 0
     };
   }
 
@@ -55,50 +63,61 @@ class RuleBuilder extends React.Component<Props, State> {
     });
   };
 
+  ruleHandleTabClick = (_event, tabIndex) => {
+    this.setState({
+      ruleTabKey: tabIndex
+    });
+  };
+
   render() {
     return (
       <>
-        <>
-          Select Matching:
-          <MatchBuilder {...this.props} />
-          <Matches {...this.props} />
-        </>
-        <br />
-        <>
-          Select Routes:
-          <InputGroup>
-            <span id="select-workloads-id" hidden>
-              Checkbox Title
-            </span>
-            <Select
-              aria-label="Select Input"
-              variant={SelectVariant.checkbox}
-              onToggle={this.onWorkloadsToggle}
-              onSelect={(_, selection) => {
-                if (this.props.routes.includes(selection as string)) {
-                  this.props.onSelectRoutes(this.props.routes.filter(item => item !== selection));
-                } else {
-                  this.props.onSelectRoutes([...this.props.routes, selection as string]);
-                }
-              }}
-              onClear={() => {
-                this.props.onSelectRoutes([]);
-              }}
-              selections={this.props.routes}
-              isExpanded={this.state.isWorkloadSelector}
-              placeholderText="Select workloads"
-              ariaLabelledBy="select-workloads-id"
-            >
-              {this.props.workloads.map(wk => (
-                <SelectOption key={wk.name} value={wk.name} />
-              ))}
-            </Select>
-            <Button isDisabled={!this.props.isValid} onClick={this.props.onAddRule}>
-              Add Rule
-            </Button>
-          </InputGroup>
-          {!this.props.isValid && <div className={validationStyle}>{this.props.validationMsg}</div>}
-        </>
+        <Tabs isFilled={true} activeKey={this.state.ruleTabKey} onSelect={this.ruleHandleTabClick}>
+          <Tab eventKey={0} title={'Select Matching'}>
+            <div style={{ marginTop: '20px' }}>
+              <MatchBuilder {...this.props} />
+              <Matches {...this.props} />
+            </div>
+          </Tab>
+          <Tab eventKey={1} title={'Select Routes'}>
+            <div style={{ marginTop: '20px' }}>
+              <InputGroup>
+                <span id="select-workloads-id" hidden>
+                  Checkbox Title
+                </span>
+                <Select
+                  aria-label="Select Input"
+                  variant={SelectVariant.checkbox}
+                  onToggle={this.onWorkloadsToggle}
+                  onSelect={(_, selection) => {
+                    if (this.props.routes.includes(selection as string)) {
+                      this.props.onSelectRoutes(this.props.routes.filter(item => item !== selection));
+                    } else {
+                      this.props.onSelectRoutes([...this.props.routes, selection as string]);
+                    }
+                  }}
+                  onClear={() => {
+                    this.props.onSelectRoutes([]);
+                  }}
+                  selections={this.props.routes}
+                  isExpanded={this.state.isWorkloadSelector}
+                  placeholderText="Select workloads"
+                  ariaLabelledBy="select-workloads-id"
+                >
+                  {this.props.workloads.map(wk => (
+                    <SelectOption key={wk.name} value={wk.name} />
+                  ))}
+                </Select>
+              </InputGroup>
+              <div className={validationStyle}>{!this.props.isValid && this.props.validationMsg}</div>
+            </div>
+          </Tab>
+        </Tabs>
+        <div className={addRuleStyle}>
+          <Button variant="secondary" isDisabled={!this.props.isValid} onClick={this.props.onAddRule}>
+            Add Rule
+          </Button>
+        </div>
       </>
     );
   }

--- a/src/components/IstioWizards/MatchingRouting/Rules.tsx
+++ b/src/components/IstioWizards/MatchingRouting/Rules.tsx
@@ -3,6 +3,7 @@ import { cellWidth, ICell, Table, TableHeader, TableBody } from '@patternfly/rea
 import { style } from 'typestyle';
 import { PfColors } from '../../Pf/PfColors';
 import { Badge, Tooltip, TooltipPosition } from '@patternfly/react-core';
+import { WorkloadWeight } from '../WeightedRouting';
 
 export enum MOVE_TYPE {
   UP,
@@ -11,7 +12,7 @@ export enum MOVE_TYPE {
 
 export type Rule = {
   matches: string[];
-  routes: string[];
+  workloadWeights: WorkloadWeight[];
 };
 
 type Props = {
@@ -112,12 +113,12 @@ class Rules extends React.Component<Props> {
             )}
           </>,
           <>
-            {rule.routes.map((route, i) => (
-              <div key={'route_' + i}>
+            {rule.workloadWeights.map((wk, i) => (
+              <div key={'wk_' + i}>
                 <Tooltip position={TooltipPosition.top} content={<>Workload</>}>
                   <Badge className={'virtualitem_badge_definition'}>WS</Badge>
                 </Tooltip>
-                {route}
+                {wk.name} ({wk.weight} %)
               </div>
             ))}
           </>

--- a/src/components/IstioWizards/ServiceWizard.tsx
+++ b/src/components/IstioWizards/ServiceWizard.tsx
@@ -370,7 +370,6 @@ class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWizardSta
       >
         {this.props.type === WIZARD_WEIGHTED_ROUTING && (
           <WeightedRouting
-            serviceName={this.props.serviceName}
             workloads={this.props.workloads}
             initWeights={getInitWeights(this.props.workloads, this.props.virtualServices)}
             onChange={this.onWeightsChange}

--- a/src/components/IstioWizards/WeightedRouting.tsx
+++ b/src/components/IstioWizards/WeightedRouting.tsx
@@ -9,7 +9,6 @@ import { EqualizerIcon } from '@patternfly/react-icons';
 import { getDefaultWeights } from './WizardActions';
 
 type Props = {
-  serviceName: string;
   workloads: WorkloadOverview[];
   initWeights: WorkloadWeight[];
   onChange: (valid: boolean, workloads: WorkloadWeight[], reset: boolean) => void;


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/1374

Re-arrange the wizard to separate "Select Matching" / "Select Routes":

![image](https://user-images.githubusercontent.com/1662329/89553929-78707880-d80e-11ea-8636-728ce14a14df.png)

Introduce workload weights as opposed as simple workload names:

![image](https://user-images.githubusercontent.com/1662329/89554041-9c33be80-d80e-11ea-961d-6b252b4e0450.png)

Allow to combine multiple routes with matching and different weights:

![image](https://user-images.githubusercontent.com/1662329/89554172-c6857c00-d80e-11ea-8dd0-a8aaeb1e2a22.png)
