### PR TITLE
Fix style issues with in-graph tracing

### DIFF
--- a/src/pages/Graph/SummaryPanelCommon.tsx
+++ b/src/pages/Graph/SummaryPanelCommon.tsx
@@ -38,7 +38,7 @@ const summaryPanelCommon: CSSProperties = {
 
 export const summaryPanel = style(summaryPanelCommon);
 export const summaryPanelTopSplit = style({ ...summaryPanelCommon, height: '50%' });
-export const summaryPanelBottomSplit = style({ ...summaryPanelCommon, height: '50%', overflowY: 'initial' });
+export const summaryPanelBottomSplit = style({ ...summaryPanelCommon, height: '50%', overflowY: 'auto' });
 
 export const summaryFont: React.CSSProperties = {
   fontSize: 'var(--graph-side-panel--font-size)'


### PR DESCRIPTION
- Non-envoy traces now look consistent with envoy ones
- Fixed panel overflow
- Removed to full ID display as it's not a very important information; add a smaller ID slice instead
- Replaced some 'br' with 'p', and try to fit everything in height without scroll bars as much as possible

Fixes https://github.com/kiali/kiali/issues/3100

Screenshots:

- With envoy spans and short urls:

![Capture d’écran de 2020-08-07 12-29-50](https://user-images.githubusercontent.com/2153442/89637713-ea969b00-d8aa-11ea-8743-72f75285b652.png)

- With envoy spans and longer urls:

![Capture d’écran de 2020-08-07 12-31-18](https://user-images.githubusercontent.com/2153442/89637732-f3876c80-d8aa-11ea-9996-99ded4f0424b.png)

- With user-defined spans:

![Capture d’écran de 2020-08-07 12-29-55](https://user-images.githubusercontent.com/2153442/89637751-fe420180-d8aa-11ea-98a3-77ea4164be4b.png)


