### PR TITLE
Support setting history mode by parameter

### DIFF
--- a/src/app/History.ts
+++ b/src/app/History.ts
@@ -1,10 +1,15 @@
-import { createBrowserHistory, createMemoryHistory } from 'history';
+import { createBrowserHistory, createMemoryHistory, createHashHistory } from 'history';
 import { toValidDuration } from '../config/ServerConfig';
 import { BoundsInMilliseconds } from 'types/Common';
 
 const webRoot = (window as any).WEB_ROOT ? (window as any).WEB_ROOT : undefined;
 const baseName = webRoot && webRoot !== '/' ? webRoot + '/console' : '/console';
-const history = process.env.TEST_RUNNER ? createMemoryHistory() : createBrowserHistory({ basename: baseName });
+const historyMode = (window as any).HISTORY_MODE ? (window as any).HISTORY_MODE : 'browser';
+const history = process.env.TEST_RUNNER
+  ? createMemoryHistory()
+  : historyMode === 'browser'
+  ? createBrowserHistory({ basename: baseName })
+  : createHashHistory();
 
 export default history;
 

--- a/src/app/History.ts
+++ b/src/app/History.ts
@@ -7,9 +7,9 @@ const baseName = webRoot && webRoot !== '/' ? webRoot + '/console' : '/console';
 const historyMode = (window as any).HISTORY_MODE ? (window as any).HISTORY_MODE : 'browser';
 const history = process.env.TEST_RUNNER
   ? createMemoryHistory()
-  : historyMode === 'browser'
-  ? createBrowserHistory({ basename: baseName })
-  : createHashHistory();
+  : historyMode === 'hash'
+  ? createHashHistory()
+  : createBrowserHistory({ basename: baseName });
 
 export default history;
 


### PR DESCRIPTION
** Describe the change **

Read the base path set to WEB_ROOT, useful when using `kubectl proxy`.

Setting ``web_root` to `/api/v1/namespaces/istio-system/services/kiali:20001/` in the previous setup for `kiali` does not work as expected. Although the `env.js` setting is read in the previous logic, it doesn't seem to work properly with `subpath` in the working mode.

When I open `http://127.0.0.1:8001/api/v1/namespaces/istio-system/services/kiali:20001/` kiali will change the address to `http://127.0.0.1:8001/console/overview?pi=15000&duration=60`

I think the normal expectation is `http://127.0.0.1:8001/api/v1/namespaces/istio-system/services/kiali:20001/console/overview?pi=15000&duration=60`.

So, this code change is the solution to that problem. 

** Issue reference **

* If this is a fix for a JIRA, please put JIRA-reference in the PR title like _`KIALI-7 New icons`_ (Jira-id, one space, description)
* If this is a fix for a GH-issue, please link it here

** Backwards compatible? **

- [ ] Is your pull-request introducing changes in behaviour?

No changes will occur and the program will become more robust.

** Screenshot **

Add a screenshot of the UI after your changes.
![image](https://user-images.githubusercontent.com/17666471/89890680-5445da80-dc06-11ea-8d57-00bafacc0938.png)


** Documentation **

Please provide an update to documentation if appropriate. For configuration options, consider sending a PR to https://github.com/kiali/kiali/blob/master/README.adoc
