### PR TITLE
Refactor refresh log tab

### DIFF
--- a/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -98,7 +98,11 @@ class WorkloadDetails extends React.Component<WorkloadDetailsPageProps, Workload
     const logTab = (
       <Tab title="Logs" eventKey={2} key={'Logs'}>
         {hasPods ? (
-          <WorkloadPodLogs namespace={this.props.match.params.namespace} pods={this.state.workload!.pods} />
+          <WorkloadPodLogs
+            namespace={this.props.match.params.namespace}
+            pods={this.state.workload!.pods}
+            duration={this.props.duration}
+          />
         ) : (
           <EmptyState variant={EmptyStateVariant.full}>
             <Title headingLevel="h5" size="lg">

--- a/src/pages/WorkloadDetails/WorkloadInfo/FullScreenLogModal.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/FullScreenLogModal.tsx
@@ -49,29 +49,51 @@ export class FullScreenLogModal extends React.PureComponent<FullScreenLogProps, 
     this.setState({ show: false });
   };
 
+  componentDidUpdate(
+    _prevProps: Readonly<FullScreenLogProps>,
+    _prevState: Readonly<FullScreenLogState>,
+    _snapshot?: any
+  ) {
+    if (this.textareaRef.current) {
+      this.textareaRef.current.scrollTop = this.textareaRef.current.scrollHeight;
+    }
+  }
+
+  renderToolbar = () => {
+    return (
+      <Toolbar>
+        <ToolbarGroup>
+          <ToolbarItem>
+            <h2>{this.props.title}</h2>
+          </ToolbarItem>
+        </ToolbarGroup>
+        <ToolbarGroup style={{ marginLeft: 'auto' }}>
+          <ToolbarItem>
+            <Tooltip key="collapse_fs" position="top" content="Collapse full screen">
+              <Button variant={ButtonVariant.link} onClick={this.close} isInline>
+                <KialiIcon.Compress className={defaultIconStyle} />
+              </Button>
+            </Tooltip>
+          </ToolbarItem>
+        </ToolbarGroup>
+      </Toolbar>
+    );
+  };
+
   render() {
     if (!this.state.show || !this.props.logText) {
       return null;
     }
 
     return (
-      <Modal isSmall={false} isOpen={this.state.show} title="" className={modalStyle} showClose={false}>
-        <Toolbar>
-          <ToolbarGroup>
-            <ToolbarItem>
-              <h2>{this.props.title}</h2>
-            </ToolbarItem>
-          </ToolbarGroup>
-          <ToolbarGroup style={{ marginLeft: 'auto' }}>
-            <ToolbarItem>
-              <Tooltip key="collapse_fs" position="top" content="Collapse full screen">
-                <Button variant={ButtonVariant.link} onClick={this.close} isInline>
-                  <KialiIcon.Compress className={defaultIconStyle} />
-                </Button>
-              </Tooltip>
-            </ToolbarItem>
-          </ToolbarGroup>
-        </Toolbar>
+      <Modal
+        isSmall={false}
+        isOpen={this.state.show}
+        header={this.renderToolbar()}
+        title=""
+        className={modalStyle}
+        showClose={false}
+      >
         <textarea ref={this.textareaRef} value={this.props.logText} className={textAreaStyle} readOnly={true} />
       </Modal>
     );


### PR DESCRIPTION
** Describe the change **
Moves the refresh controls from inside the logging tab to outside the logging tab to match other tabs for consistency.

** Issue reference **
fixes #https://github.com/kiali/kiali/issues/3011


** Backwards compatible? **
Yes


** Screenshot **
Before:

![Kiali_Console_and_Kiali_Console_and_kxr_ocp4_setup_upi_kvm__Script_to_Setup_an_OpenShift_4_UPI_Cluster_on_KVM__Based_on_this_guide__https___kxr_me_2019_08_17_openshift-4-upi-install-libvirt-kvm_](https://user-images.githubusercontent.com/1312165/90439481-7c13c300-e08a-11ea-9e73-bcbf9ec03ffb.png)


After:

![Kiali_Console](https://user-images.githubusercontent.com/1312165/90439041-bc267600-e089-11ea-89ae-bc4c94d05700.png)

