### PR TITLE
Trivial: Remove the deprecated React.SFC and replace with FunctionComponent

### DIFF
--- a/src/components/JaegerIntegration/TraceListItem.tsx
+++ b/src/components/JaegerIntegration/TraceListItem.tsx
@@ -36,7 +36,7 @@ const secondaryRightStyle = style({
   float: 'right'
 });
 
-export const TraceListItem: React.SFC<Props> = props => {
+export const TraceListItem: React.FunctionComponent<Props> = props => {
   const formattedTrace = getFormattedTraceInfo(props.trace);
   const tooltipContent = `${formattedTrace.name} (${props.trace.traceID.slice(0, 7)})`;
   const nameStyleToUse = formattedTrace.errors ? nameStyle + ' ' + errorStyle : nameStyle;

--- a/src/components/PfSpinner.tsx
+++ b/src/components/PfSpinner.tsx
@@ -11,7 +11,7 @@ const mapStateToProps = (state: KialiAppState) => ({
   isLoading: state.globalState.loadingCounter > 0
 });
 
-export const PfSpinner: React.SFC<PfSpinnerProps> = props => {
+export const PfSpinner: React.FunctionComponent<PfSpinnerProps> = props => {
   const { isLoading } = props;
   // It is more than likely it won't have any children; but it could.
   return isLoading ? <Spinner id="loading_kiali_spinner" size={'lg'} /> : <></>;

--- a/src/components/RightActionBar/RightActionBar.tsx
+++ b/src/components/RightActionBar/RightActionBar.tsx
@@ -9,6 +9,6 @@ export const actionBarStyle = style({
   display: 'flex'
 });
 
-export const RightActionBar: React.SFC<{}> = props => {
+export const RightActionBar: React.FunctionComponent = props => {
   return <span className={actionBarStyle}>{props.children}</span>;
 };

--- a/src/components/TextOrLink.tsx
+++ b/src/components/TextOrLink.tsx
@@ -5,7 +5,7 @@ type Props = {
   urlTruncate?: number;
 };
 
-export const TextOrLink: React.SFC<Props> = props => {
+export const TextOrLink: React.FunctionComponent<Props> = props => {
   if (props.text.startsWith('http://') || props.text.startsWith('https://')) {
     let truncated = props.text;
     if (props.urlTruncate && props.text.length > props.urlTruncate) {

--- a/src/pages/AppList/AppListPage.tsx
+++ b/src/pages/AppList/AppListPage.tsx
@@ -4,7 +4,7 @@ import { RenderContent } from '../../components/Nav/Page';
 import AppListContainer from './AppListComponent';
 import * as AppListFilters from './FiltersAndSorts';
 
-const AppListPage: React.SFC<{}> = () => {
+const AppListPage: React.FunctionComponent = () => {
   return (
     <RenderContent>
       <AppListContainer

--- a/src/pages/IstioConfigList/IstioConfigListPage.tsx
+++ b/src/pages/IstioConfigList/IstioConfigListPage.tsx
@@ -4,7 +4,7 @@ import { RenderContent } from '../../components/Nav/Page';
 import * as IstioConfigListFilters from './FiltersAndSorts';
 import IstioConfigListContainer from './IstioConfigListComponent';
 
-const IstioConfigListPage: React.SFC<{}> = () => {
+const IstioConfigListPage: React.FunctionComponent = () => {
   return (
     <RenderContent>
       <IstioConfigListContainer

--- a/src/pages/ServiceList/ServiceListPage.tsx
+++ b/src/pages/ServiceList/ServiceListPage.tsx
@@ -4,7 +4,7 @@ import * as FilterHelper from '../../components/FilterList/FilterHelper';
 import { RenderContent } from '../../components/Nav/Page';
 import * as ServiceListFilters from './FiltersAndSorts';
 
-const ServiceListPage: React.SFC<{}> = () => {
+const ServiceListPage: React.FunctionComponent = () => {
   return (
     <RenderContent>
       <ServiceListContainer

--- a/src/pages/WorkloadList/WorkloadListPage.tsx
+++ b/src/pages/WorkloadList/WorkloadListPage.tsx
@@ -4,7 +4,7 @@ import { RenderContent } from '../../components/Nav/Page';
 import WorkloadListContainer from './WorkloadListComponent';
 import * as WorkloadListFilters from './FiltersAndSorts';
 
-const WorkloadListPage: React.SFC<{}> = () => {
+const WorkloadListPage: React.FunctionComponent = () => {
   return (
     <RenderContent>
       <WorkloadListContainer

--- a/src/pages/extensions/iter8/Iter8ExperimentList/ExperimentListPage.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentList/ExperimentListPage.tsx
@@ -4,7 +4,7 @@ import { RenderContent } from '../../../../components/Nav/Page';
 import ExperimentListContainer from './ExperimentListContainer';
 import * as ExpListFilters from './FiltersAndSorts';
 
-const ExperimentListPage: React.SFC<{}> = () => {
+const ExperimentListPage: React.FunctionComponent = () => {
   return (
     <RenderContent>
       <ExperimentListContainer


### PR DESCRIPTION

** Describe the change **
Remove the deprecated `React.SFC` and replace with `React.FunctionComponent` as docs specify.
No behavioral changes just syntax change.

** Documentation **
<img width="780" alt="kiali-ui_–_PfSpinner_tsx" src="https://user-images.githubusercontent.com/1312165/90553882-f2c3c580-e149-11ea-9e74-09aa4b1c3a3b.png">
