### PR TITLE
Adjust wording between traces in graph and details

### DIFF
--- a/src/pages/Graph/SummaryPanelNodeTraces.tsx
+++ b/src/pages/Graph/SummaryPanelNodeTraces.tsx
@@ -174,7 +174,7 @@ class SummaryPanelNodeTraces extends React.Component<Props, State> {
           </SimpleList>
         )}
         <Button style={summaryFont} onClick={() => history.push(tracesDetailsURL)}>
-          View App Traces
+          Show Traces
         </Button>
       </div>
     );

--- a/src/pages/Graph/SummaryPanelNodeTraces.tsx
+++ b/src/pages/Graph/SummaryPanelNodeTraces.tsx
@@ -174,7 +174,7 @@ class SummaryPanelNodeTraces extends React.Component<Props, State> {
           </SimpleList>
         )}
         <Button style={summaryFont} onClick={() => history.push(tracesDetailsURL)}>
-          Go to Tracing
+          View App Traces
         </Button>
       </div>
     );

--- a/src/pages/Graph/SummaryPanelTraceDetails.tsx
+++ b/src/pages/Graph/SummaryPanelTraceDetails.tsx
@@ -166,7 +166,7 @@ class SummaryPanelTraceDetails extends React.Component<Props, State> {
             <>
               <br />
               <a href={jaegerTraceURL} target="_blank" rel="noopener noreferrer">
-                View Trace in Tracing <ExternalLinkAltIcon size="sm" />
+                Show in Tracing <ExternalLinkAltIcon size="sm" />
               </a>
             </>
           )}

--- a/src/pages/Graph/SummaryPanelTraceDetails.tsx
+++ b/src/pages/Graph/SummaryPanelTraceDetails.tsx
@@ -125,14 +125,6 @@ class SummaryPanelTraceDetails extends React.Component<Props, State> {
               <span className={nameStyleToUse}>{traceName}</span>
             )}
           </Tooltip>
-          {tracesDetailsURL && jaegerTraceURL && (
-            <>
-              <br />
-              <a href={jaegerTraceURL} target="_blank" rel="noopener noreferrer">
-                See trace in Jaeger <ExternalLinkAltIcon size="sm" />
-              </a>
-            </>
-          )}
           <p className={pStyle}>
             <div className={secondaryStyle}>{'From: ' + info.fromNow}</div>
             {!!info.duration && <div className={secondaryStyle}>{'Full duration: ' + info.duration}</div>}
@@ -169,6 +161,14 @@ class SummaryPanelTraceDetails extends React.Component<Props, State> {
               {this.state.selectedSpan < spans.length &&
                 this.renderSpan(nodeName + '.' + node.namespace, spans[this.state.selectedSpan])}
             </p>
+          )}
+          {tracesDetailsURL && jaegerTraceURL && (
+            <>
+              <br />
+              <a href={jaegerTraceURL} target="_blank" rel="noopener noreferrer">
+                View Trace in Tracing <ExternalLinkAltIcon size="sm" />
+              </a>
+            </>
           )}
         </div>
       </>


### PR DESCRIPTION
Two trivial changes about wording used in graph traces.

"Go to Tracing" -> "View App Traces"
"See trace in Jaeger" -> "View Trace in Tracing"

- Tracing is used in "Traces" Tab to refer to the external tracing tool, better to refer to "App Traces" on this case.
- The same external link is used in "traces" tab, so better to unify the same wording instead o introduce new one.

Place the external link at the bottom, when the app/service is too long, it's hardly differentiated from the trace title one.
![image](https://user-images.githubusercontent.com/1662329/90612361-37ae3180-e208-11ea-9a96-321b59da34e6.png)

I think with this little change it's more clear and it seems clean.