### PR TITLE
Bump dot-prop and lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "eventemitter3": "4.0.0",
     "js-yaml": "3.13.1",
     "json-beautify": "1.0.1",
-    "lodash": "4.17.19",
+    "lodash": "4.17.20",
     "logfmt": "1.2.1",
     "m-react-splitters": "1.2.0",
     "moment": "2.24.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "cytoscape-dagre": "2.2.2",
     "cytoscape-popper": "1.0.7",
     "deep-freeze": "0.0.1",
-    "dot-prop": "^4.2.1",
     "eventemitter3": "4.0.0",
     "js-yaml": "3.13.1",
     "json-beautify": "1.0.1",
@@ -128,6 +127,7 @@
     "typescript": "3.8.3"
   },
   "resolutions": {
+    "dot-prop": "4.2.1",
     "hoist-non-react-statics": "3.3.0",
     "kind-of": "6.0.3",
     "victory": "~34.0.1",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "cytoscape-dagre": "2.2.2",
     "cytoscape-popper": "1.0.7",
     "deep-freeze": "0.0.1",
+    "dot-prop": "^4.2.1",
     "eventemitter3": "4.0.0",
     "js-yaml": "3.13.1",
     "json-beautify": "1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5430,14 +5430,7 @@ dot-case@^3.0.3:
     no-case "^3.0.3"
     tslib "^1.10.0"
 
-dot-prop@^4.1.0, dot-prop@^4.1.1:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.0.tgz#1f19e0c2e1aa0e32797c49799f2837ac6af69c57"
-  integrity sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==
-  dependencies:
-    is-obj "^1.0.0"
-
-dot-prop@^4.2.1:
+dot-prop@4.2.1, dot-prop@^4.1.0, dot-prop@^4.1.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.1.tgz#45884194a71fc2cda71cbb4bceb3a4dd2f433ba4"
   integrity sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5437,6 +5437,13 @@ dot-prop@^4.1.0, dot-prop@^4.1.1:
   dependencies:
     is-obj "^1.0.0"
 
+dot-prop@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.1.tgz#45884194a71fc2cda71cbb4bceb3a4dd2f433ba4"
+  integrity sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==
+  dependencies:
+    is-obj "^1.0.0"
+
 dotenv-expand@5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-5.1.0.tgz#3fbaf020bfd794884072ea26b1e9791d45a629f0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8981,10 +8981,10 @@ lodash.unset@^4.5.2:
   resolved "https://registry.yarnpkg.com/lodash.unset/-/lodash.unset-4.5.2.tgz#370d1d3e85b72a7e1b0cdf2d272121306f23e4ed"
   integrity sha1-Nw0dPoW3Kn4bDN8tJyEhMG8j5O0=
 
-lodash@4.17.19:
-  version "4.17.19"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
-  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
+lodash@4.17.20:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
 lodash@4.x, "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.7.14, lodash@~4.17.10:
   version "4.17.15"


### PR DESCRIPTION
Address a vulnerability detected by github in the 3rd party libraries.

I've addressed this in k-charted as well https://github.com/kiali/k-charted/pull/110.

I'd require more testing, smoke tests seem ok, but these changes may be good if are tested by anyone else as they can easily introduce side effects.