### PR TITLE
Show login error message returned from back-end

### DIFF
--- a/src/reducers/LoginState.ts
+++ b/src/reducers/LoginState.ts
@@ -36,7 +36,10 @@ const loginState = (state: LoginStateInterface = INITIAL_LOGIN_STATE, action: Ki
     case getType(LoginActions.loginFailure):
       let message = 'Error connecting to Kiali';
 
-      if (action.payload.error.request.status === 401) {
+      const response_data = action.payload.error.response.data;
+      if (response_data && typeof response_data.error == 'string' && response_data.error.length > 0) {
+        message = `Login unsuccessful: ${response_data.error}`;
+      } else if (action.payload.error.response.status === 401) {
         message =
           'Unauthorized. The provided credentials are not valid to access Kiali. Please check your credentials and try again.';
       }


### PR DESCRIPTION
Show in login screen the error that the back-end is outputting to better inform to the user what went wrong.

Now, we should see:

![image](https://user-images.githubusercontent.com/23639005/91230297-e236c080-e6f0-11ea-9d89-ae8cf5f24adf.png)

Fixes kiali/kiali#3150