### PR TITLE
Add ability to drag nodes

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeReactWrapper.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeReactWrapper.tsx
@@ -81,7 +81,6 @@ export class CytoscapeReactWrapper extends React.Component<CytoscapeReactWrapper
     const opts = {
       container: this.divParentRef.current,
       boxSelectionEnabled: false,
-      autounselectify: true,
       style: GraphStyles.styles(),
       ...GraphStyles.options()
     };

--- a/src/pages/Graph/GraphPage.tsx
+++ b/src/pages/Graph/GraphPage.tsx
@@ -147,7 +147,7 @@ const cytoscapeGraphContainerStyle = style({ flex: '1', minWidth: '350px', zInde
 const cytoscapeGraphWrapperDivStyle = style({ position: 'relative', backgroundColor: PfColors.GrayBackground });
 const cytoscapeToolbarWrapperDivStyle = style({
   position: 'absolute',
-  bottom: '10px',
+  bottom: '5px',
   zIndex: 2,
   borderStyle: 'hidden'
 });


### PR DESCRIPTION
Introduce a new control on the cytoscape toolbar to toggle the ability to drag nodes (default=no drag).  This allows users to move nodes around to improve the layout manually for for visual inspection, screenshots, etc.

The manual repositioning is lost (and the toggle disabled) whenever there is a:

- change of graph type
- navigation away and back to the graph page (including node detail graphs)
- browser refresh

The manual repositioning is maintained on graph refresh unless a layout is required.  A layout change will not disable the toggle if it is currently enabled.   A layout is required when:

- the graph refreshes and nodes are lost or gained for the new time period.
- nodes are hidden via graph hide (and the Compress Hidden Display option is enabled)
- manual layout change via the cytoscape toolbar

Fixes https://github.com/kiali/kiali/issues/1342
