### PR TITLE
Add IstioConfig under Workload Details

### DIFF
--- a/src/components/IstioConfigSubList/IstioConfigSubList.tsx
+++ b/src/components/IstioConfigSubList/IstioConfigSubList.tsx
@@ -92,7 +92,7 @@ class IstioConfigSubList extends React.Component<Props> {
           },
           { title: this.overviewLink(item) },
           { title: dicIstioType[item.type] },
-          { title: <LocalTime time={item.creationTimeStamp || ''} /> },
+          { title: <LocalTime time={item.creationTimestamp || ''} /> },
           { title: item.resourceVersion },
           { title: this.yamlLink(item) }
         ]

--- a/src/components/IstioConfigSubList/IstioConfigSubList.tsx
+++ b/src/components/IstioConfigSubList/IstioConfigSubList.tsx
@@ -28,11 +28,11 @@ class IstioConfigSubList extends React.Component<Props> {
     // https://github.com/patternfly/patternfly-next/issues/2373
     return [
       { title: 'Status', transforms: [cellWidth(10) as any] },
-      { title: 'Name', transforms: [cellWidth(10) as any] },
-      { title: 'Type', transforms: [cellWidth(10) as any] },
-      { title: 'Created at', transforms: [cellWidth(20) as any] },
-      { title: 'Resource version', transforms: [cellWidth(10) as any] },
-      { title: 'Actions', transforms: [cellWidth(10) as any] }
+      { title: 'Name' },
+      { title: 'Type' },
+      { title: 'Created at' },
+      { title: 'Resource version' },
+      { title: 'Actions' }
     ];
   }
 
@@ -102,7 +102,7 @@ class IstioConfigSubList extends React.Component<Props> {
 
     return rows;
   }
-
+  table;
   render() {
     return (
       <Grid>

--- a/src/pages/IstioConfigList/IstioConfigListComponent.tsx
+++ b/src/pages/IstioConfigList/IstioConfigListComponent.tsx
@@ -160,7 +160,7 @@ class IstioConfigListComponent extends FilterComponent.Component<
     return this.promises
       .registerAll(
         'configs',
-        namespaces.map(ns => API.getIstioConfig(ns, typeFilters, true, ''))
+        namespaces.map(ns => API.getIstioConfig(ns, typeFilters, true, '', ''))
       )
       .then(responses => {
         let istioItems: IstioConfigItem[] = [];

--- a/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -89,7 +89,7 @@ class ServiceInfo extends React.Component<Props, ServiceInfoState> {
         this.promises
           .registerAll(
             'gateways',
-            namespaces.map(ns => API.getIstioConfig(ns.name, ['gateways'], false, ''))
+            namespaces.map(ns => API.getIstioConfig(ns.name, ['gateways'], false, '', ''))
           )
           .then(responses => {
             let gatewayList: string[] = [];
@@ -120,7 +120,7 @@ class ServiceInfo extends React.Component<Props, ServiceInfoState> {
         AlertUtils.addError('Could not fetch Service Details.', error);
       });
 
-    API.getIstioConfig(this.props.namespace, ['peerauthentications'], false, '')
+    API.getIstioConfig(this.props.namespace, ['peerauthentications'], false, '', '')
       .then(results => {
         this.setState({
           peerAuthentications: results.data.peerAuthentications
@@ -290,7 +290,7 @@ class ServiceInfo extends React.Component<Props, ServiceInfoState> {
                     </ErrorBoundaryWithMessage>
                   </Tab>
                   <Tab eventKey={1} title={istioTabTitle}>
-                    <ErrorBoundaryWithMessage message={this.errorBoundaryMessage('Destination Rules')}>
+                    <ErrorBoundaryWithMessage message={this.errorBoundaryMessage('Istio Config')}>
                       <IstioConfigSubList name={this.state.serviceDetails.service.name} items={istioConfigItems} />
                     </ErrorBoundaryWithMessage>
                   </Tab>

--- a/src/pages/ServiceDetails/ServiceInfo/ServiceInfoWorkload.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo/ServiceInfoWorkload.tsx
@@ -32,10 +32,10 @@ class ServiceInfoWorkload extends React.Component<ServiceInfoWorkloadProps> {
     // https://github.com/patternfly/patternfly-next/issues/2373
     return [
       { title: 'Name', transforms: [cellWidth(10) as any] },
-      { title: 'Type', transforms: [cellWidth(10) as any] },
-      { title: 'Labels', transforms: [cellWidth(60) as any] },
-      { title: 'Created at', transforms: [cellWidth(20) as any] },
-      { title: 'Resource version', transforms: [cellWidth(10) as any] }
+      { title: 'Type' },
+      { title: 'Labels' },
+      { title: 'Created at' },
+      { title: 'Resource version' }
     ];
   }
 

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoWorkloads.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoWorkloads.test.tsx.snap
@@ -19,27 +19,15 @@ exports[`#ServiceInfoWorkload render correctly with data should render service p
               },
               Object {
                 "title": "Type",
-                "transforms": Array [
-                  [Function],
-                ],
               },
               Object {
                 "title": "Labels",
-                "transforms": Array [
-                  [Function],
-                ],
               },
               Object {
                 "title": "Created at",
-                "transforms": Array [
-                  [Function],
-                ],
               },
               Object {
                 "title": "Resource version",
-                "transforms": Array [
-                  [Function],
-                ],
               },
             ]
           }

--- a/src/pages/WorkloadDetails/WorkloadInfo.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo.tsx
@@ -232,7 +232,7 @@ class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInfoState>
       </span>
     );
 
-    const getIstioValidationIcon = () => {
+    const getIstioValidationIcon = (typeNames: { [key: string]: string[] }) => {
       let severity = ValidationTypes.Correct;
       if (this.state.workloadIstioConfig && this.state.workloadIstioConfig.validations) {
         const istioValidations = this.state.workloadIstioConfig.validations;
@@ -240,12 +240,14 @@ class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInfoState>
           const typeValidations = istioValidations[type];
           Object.keys(typeValidations).forEach(name => {
             const nameValidation = typeValidations[name];
-            const itemSeverity = validationToSeverity(nameValidation);
-            if (
-              (itemSeverity === ValidationTypes.Warning && severity !== ValidationTypes.Error) ||
-              itemSeverity === ValidationTypes.Error
-            ) {
-              severity = itemSeverity;
+            if (typeNames[type] && typeNames[type].includes(name)) {
+              const itemSeverity = validationToSeverity(nameValidation);
+              if (
+                (itemSeverity === ValidationTypes.Warning && severity !== ValidationTypes.Error) ||
+                itemSeverity === ValidationTypes.Error
+              ) {
+                severity = itemSeverity;
+              }
             }
           });
         });
@@ -280,33 +282,37 @@ class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInfoState>
     let istioTabTitle: JSX.Element | undefined;
     let istioConfigIcon = undefined;
     if (this.state.workloadIstioConfig?.validations) {
-      const names: string[] = [];
-      const types: string[] = [];
+      const typeNames: { [key: string]: string[] } = {};
       if (this.state.workloadIstioConfig.validations['gateway']) {
-        this.state.workloadIstioConfig.gateways?.forEach(gw => names.push(gw.metadata.name));
-        types.push('gateway');
+        this.state.workloadIstioConfig.gateways?.forEach(gw => typeNames['gateway'].push(gw.metadata.name));
       }
       if (this.state.workloadIstioConfig.validations['sidecar']) {
-        this.state.workloadIstioConfig.sidecars?.forEach(sc => names.push(sc.metadata.name));
-        types.push('sidecar');
+        typeNames['sidecar'] = [];
+        this.state.workloadIstioConfig.sidecars?.forEach(sc => typeNames['sidecar'].push(sc.metadata.name));
       }
       if (this.state.workloadIstioConfig.validations['envoyfilter']) {
-        this.state.workloadIstioConfig.envoyFilters?.forEach(ef => names.push(ef.metadata.name));
-        types.push('envoyfilter');
+        typeNames['envoyfilter'] = [];
+        this.state.workloadIstioConfig.envoyFilters?.forEach(ef => typeNames['envoyfilter'].push(ef.metadata.name));
       }
       if (this.state.workloadIstioConfig.validations['requestauthentication']) {
-        this.state.workloadIstioConfig.requestAuthentications?.forEach(ra => names.push(ra.metadata.name));
-        types.push('requestauthentication');
+        typeNames['requestauthentication'] = [];
+        this.state.workloadIstioConfig.requestAuthentications?.forEach(ra =>
+          typeNames['requestauthentication'].push(ra.metadata.name)
+        );
       }
       if (this.state.workloadIstioConfig.validations['authorizationpolicy']) {
-        this.state.workloadIstioConfig.authorizationPolicies?.forEach(ap => names.push(ap.metadata.name));
-        types.push('authorizationpolicy');
+        typeNames['authorizationpolicy'] = [];
+        this.state.workloadIstioConfig.authorizationPolicies?.forEach(ap =>
+          typeNames['authorizationpolicy'].push(ap.metadata.name)
+        );
       }
       if (this.state.workloadIstioConfig.validations['peerauthentication']) {
-        this.state.workloadIstioConfig.peerAuthentications?.forEach(pa => names.push(pa.metadata.name));
-        types.push('perrauthentication');
+        typeNames['peerauthentication'] = [];
+        this.state.workloadIstioConfig.peerAuthentications?.forEach(pa =>
+          typeNames['peerauthentication'].push(pa.metadata.name)
+        );
       }
-      istioConfigIcon = getIstioValidationIcon();
+      istioConfigIcon = getIstioValidationIcon(typeNames);
     }
     istioTabTitle = (
       <>

--- a/src/pages/WorkloadDetails/WorkloadInfo.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo.tsx
@@ -22,6 +22,8 @@ import RefreshButtonContainer from 'components/Refresh/RefreshButton';
 import WorkloadWizardDropdown from '../../components/IstioWizards/WorkloadWizardDropdown';
 import { serverConfig } from '../../config';
 import { isIstioNamespace } from '../../config/ServerConfig';
+import { IstioConfigList, toIstioItems } from '../../types/IstioConfigList';
+import IstioConfigSubList from '../../components/IstioConfigSubList/IstioConfigSubList';
 
 type WorkloadInfoProps = {
   namespace: string;
@@ -39,6 +41,7 @@ type WorkloadInfoState = {
   currentTab: string;
   health?: WorkloadHealth;
   threescaleRules: IstioRule[];
+  workloadIstioConfig?: IstioConfigList;
 };
 
 const tabIconStyle = style({
@@ -49,8 +52,18 @@ const tabName = 'list';
 const defaultTab = 'pods';
 const paramToTab: { [key: string]: number } = {
   pods: 0,
-  services: 1
+  services: 1,
+  istioconfig: 2
 };
+
+const workloadIstioResources = [
+  'gateways',
+  'authorizationpolicies',
+  'peerauthentications',
+  'sidecars',
+  'requestauthentications',
+  'envoyfilters'
+];
 
 class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInfoState> {
   private graphDataSource = new GraphDataSource();
@@ -97,10 +110,21 @@ class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInfoState>
       )
         .then(health => this.setState({ health: health }))
         .catch(error => AlertUtils.addError('Could not fetch Health.', error));
+
+      const labels = this.props.workload.labels;
+      const wkLabels: string[] = [];
+      Object.keys(labels).forEach(key => {
+        const label = key + (labels[key] ? '=' + labels[key] : '');
+        wkLabels.push(label);
+      });
+      const workloadSelector = wkLabels.join(',');
+      API.getIstioConfig(this.props.namespace, workloadIstioResources, true, '', workloadSelector)
+        .then(response => this.setState({ workloadIstioConfig: response.data }))
+        .catch(error => AlertUtils.addError('Could not fetch Istio Config.', error));
     }
     if (serverConfig.extensions?.threescale.enabled) {
       // 3scale info should be placed under control plane namespace
-      API.getIstioConfig(serverConfig.istioNamespace, ['rules'], false, 'kiali_wizard=threescale')
+      API.getIstioConfig(serverConfig.istioNamespace, ['rules'], false, 'kiali_wizard=threescale', '')
         .then(response => {
           this.setState({
             threescaleRules: response.data.rules
@@ -231,6 +255,9 @@ class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInfoState>
       </>
     );
 
+    const istioConfigItems = this.state.workloadIstioConfig ? toIstioItems(this.state.workloadIstioConfig) : [];
+    let istioTabTitle: JSX.Element | undefined;
+    istioTabTitle = <>Istio Config ({istioConfigItems.length})</>;
     return (
       <>
         <RightActionBar>
@@ -283,6 +310,11 @@ class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInfoState>
                       workload={this.props.workload?.name || ''}
                       namespace={this.props.namespace}
                     />
+                  </ErrorBoundaryWithMessage>
+                </Tab>
+                <Tab title={istioTabTitle} eventKey={2}>
+                  <ErrorBoundaryWithMessage message={this.errorBoundaryMessage('Istio Config')}>
+                    <IstioConfigSubList name={this.props.workload?.name || ''} items={istioConfigItems} />
                   </ErrorBoundaryWithMessage>
                 </Tab>
               </ParameterizedTabs>

--- a/src/pages/WorkloadDetails/WorkloadInfo.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo.tsx
@@ -281,37 +281,25 @@ class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInfoState>
     const istioConfigItems = this.state.workloadIstioConfig ? toIstioItems(this.state.workloadIstioConfig) : [];
     let istioTabTitle: JSX.Element | undefined;
     let istioConfigIcon = undefined;
+    // Helper to iterate at same time on workloadIstioConfig resources and validations
+    const wkIstioTypes = [
+      { field: 'gateways', validation: 'gateway' },
+      { field: 'sidecars', validation: 'sidecar' },
+      { field: 'envoyFilters', validation: 'envoyfilter' },
+      { field: 'requestAuthentications', validation: 'requestauthentication' },
+      { field: 'authorizationPolicies', validation: 'authorizationpolicy' },
+      { field: 'peerAuthentications', validation: 'peerauthentication' }
+    ];
     if (this.state.workloadIstioConfig?.validations) {
       const typeNames: { [key: string]: string[] } = {};
-      if (this.state.workloadIstioConfig.validations['gateway']) {
-        this.state.workloadIstioConfig.gateways?.forEach(gw => typeNames['gateway'].push(gw.metadata.name));
-      }
-      if (this.state.workloadIstioConfig.validations['sidecar']) {
-        typeNames['sidecar'] = [];
-        this.state.workloadIstioConfig.sidecars?.forEach(sc => typeNames['sidecar'].push(sc.metadata.name));
-      }
-      if (this.state.workloadIstioConfig.validations['envoyfilter']) {
-        typeNames['envoyfilter'] = [];
-        this.state.workloadIstioConfig.envoyFilters?.forEach(ef => typeNames['envoyfilter'].push(ef.metadata.name));
-      }
-      if (this.state.workloadIstioConfig.validations['requestauthentication']) {
-        typeNames['requestauthentication'] = [];
-        this.state.workloadIstioConfig.requestAuthentications?.forEach(ra =>
-          typeNames['requestauthentication'].push(ra.metadata.name)
-        );
-      }
-      if (this.state.workloadIstioConfig.validations['authorizationpolicy']) {
-        typeNames['authorizationpolicy'] = [];
-        this.state.workloadIstioConfig.authorizationPolicies?.forEach(ap =>
-          typeNames['authorizationpolicy'].push(ap.metadata.name)
-        );
-      }
-      if (this.state.workloadIstioConfig.validations['peerauthentication']) {
-        typeNames['peerauthentication'] = [];
-        this.state.workloadIstioConfig.peerAuthentications?.forEach(pa =>
-          typeNames['peerauthentication'].push(pa.metadata.name)
-        );
-      }
+      wkIstioTypes.forEach(wkIstioType => {
+        if (this.state.workloadIstioConfig && this.state.workloadIstioConfig.validations[wkIstioType.validation]) {
+          typeNames[wkIstioType.validation] = [];
+          this.state.workloadIstioConfig[wkIstioType.field]?.forEach(r =>
+            typeNames[wkIstioType.validation].push(r.metadata.name)
+          );
+        }
+      });
       istioConfigIcon = getIstioValidationIcon(typeNames);
     }
     istioTabTitle = (

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPods.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPods.tsx
@@ -31,13 +31,13 @@ class WorkloadPods extends React.Component<WorkloadPodsProps> {
     // https://github.com/patternfly/patternfly-next/issues/2373
     return [
       { title: 'Status', transforms: [cellWidth(10) as any] },
-      { title: 'Name', transforms: [cellWidth(10) as any] },
-      { title: 'Created at', transforms: [cellWidth(10) as any] },
-      { title: 'Created by', transforms: [cellWidth(10) as any] },
-      { title: 'Labels', transforms: [cellWidth(60) as any] },
-      { title: 'Istio Init Containers', transforms: [cellWidth(60) as any] },
-      { title: 'Istio Containers', transforms: [cellWidth(60) as any] },
-      { title: 'Phase', transforms: [cellWidth(10) as any] }
+      { title: 'Name' },
+      { title: 'Created at' },
+      { title: 'Created by' },
+      { title: 'Labels' },
+      { title: 'Istio Init Containers' },
+      { title: 'Istio Containers' },
+      { title: 'Phase' }
     ];
   }
 

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadServices.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadServices.tsx
@@ -30,12 +30,12 @@ class WorkloadServices extends React.Component<WorkloadServicesProps> {
     // https://github.com/patternfly/patternfly-next/issues/2373
     return [
       { title: 'Name', transforms: [cellWidth(10) as any] },
-      { title: 'Created at', transforms: [cellWidth(10) as any] },
-      { title: 'Type', transforms: [cellWidth(10) as any] },
-      { title: 'Labels', transforms: [cellWidth(30) as any] },
-      { title: 'Resource Version', transforms: [cellWidth(10) as any] },
-      { title: 'Ip', transforms: [cellWidth(40) as any] },
-      { title: 'Ports', transforms: [cellWidth(20) as any] }
+      { title: 'Created at' },
+      { title: 'Type' },
+      { title: 'Labels' },
+      { title: 'Resource Version' },
+      { title: 'Ip' },
+      { title: 'Ports' }
     ];
   }
 

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCreatePage.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCreatePage.tsx
@@ -286,7 +286,7 @@ class ExperimentCreatePage extends React.Component<Props, State> {
   };
 
   fetchGateways = (namespace: string) => {
-    this.promises.register('gateways', API.getIstioConfig(namespace, ['gateways'], false, '')).then(response => {
+    this.promises.register('gateways', API.getIstioConfig(namespace, ['gateways'], false, '', '')).then(response => {
       let gatewayhostpair: Host[] = [];
       let gateways: string[] = [];
       gateways.push('-- select gateway --');

--- a/src/pages/extensions/threescale/ThreeScaleNew/ThreeScaleNewPage.tsx
+++ b/src/pages/extensions/threescale/ThreeScaleNew/ThreeScaleNewPage.tsx
@@ -131,7 +131,7 @@ class ThreeScaleNewPage extends React.Component<Props, ThreeScaleState> {
         .registerAll(
           'handlers',
           this.props.activeNamespaces.map(n =>
-            API.getIstioConfig(n.name, ['handlers'], false, 'kiali_wizard=threescale')
+            API.getIstioConfig(n.name, ['handlers'], false, 'kiali_wizard=threescale', '')
           )
         )
         .then(responses => {

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -137,13 +137,22 @@ export const updateNamespace = (namespace: string, jsonPatch: string): Promise<R
   return newRequest(HTTP_VERBS.PATCH, urls.namespace(namespace), {}, jsonPatch);
 };
 
-export const getIstioConfig = (namespace: string, objects: string[], validate: boolean, labelSelector: string) => {
+export const getIstioConfig = (
+  namespace: string,
+  objects: string[],
+  validate: boolean,
+  labelSelector: string,
+  workloadSelector: string
+) => {
   const params: any = objects && objects.length > 0 ? { objects: objects.join(',') } : {};
   if (validate) {
     params.validate = validate;
   }
   if (labelSelector) {
     params.labelSelector = labelSelector;
+  }
+  if (workloadSelector) {
+    params.workloadSelector = workloadSelector;
   }
   return newRequest<IstioConfigList>(HTTP_VERBS.GET, urls.istioConfig(namespace), params, {});
 };

--- a/src/types/IstioConfigList.ts
+++ b/src/types/IstioConfigList.ts
@@ -333,7 +333,7 @@ export const vsToIstioItems = (vss: VirtualService[], validations: Validations):
       namespace: vs.metadata.namespace || '',
       type: typeName,
       name: vs.metadata.name,
-      creationTimeStamp: vs.metadata.creationTimestamp,
+      creationTimestamp: vs.metadata.creationTimestamp,
       resourceVersion: vs.metadata.resourceVersion,
       validation: hasValidations(vs.metadata.name) ? validations.virtualservice[vs.metadata.name] : undefined
     };
@@ -356,7 +356,7 @@ export const drToIstioItems = (drs: DestinationRule[], validations: Validations)
       namespace: dr.metadata.namespace || '',
       type: typeName,
       name: dr.metadata.name,
-      creationTimeStamp: dr.metadata.creationTimestamp,
+      creationTimestamp: dr.metadata.creationTimestamp,
       resourceVersion: dr.metadata.resourceVersion,
       validation: hasValidations(dr.metadata.name) ? validations.destinationrule[dr.metadata.name] : undefined
     };

--- a/src/types/IstioConfigList.ts
+++ b/src/types/IstioConfigList.ts
@@ -37,7 +37,7 @@ export interface IstioConfigItem {
   namespace: string;
   type: string;
   name: string;
-  creationTimeStamp?: string;
+  creationTimestamp?: string;
   resourceVersion?: string;
   gateway?: Gateway;
   virtualService?: VirtualService;
@@ -305,7 +305,7 @@ export const toIstioItems = (istioConfigList: IstioConfigList): IstioConfigItem[
         namespace: istioConfigList.namespace.name,
         type: typeName,
         name: entry.metadata.name,
-        creationTimeStamp: entry.metadata.creationTimeStamp,
+        creationTimestamp: entry.metadata.creationTimestamp,
         resourceVersion: entry.metadata.resourceVersion,
         validation: hasValidations(typeName, entry.metadata.name)
           ? istioConfigList.validations[typeName][entry.metadata.name]

--- a/src/types/ServiceInfo.ts
+++ b/src/types/ServiceInfo.ts
@@ -92,14 +92,7 @@ const numberOfChecks = (type: ValidationTypes, object: ObjectValidation) =>
 export const validationToSeverity = (object: ObjectValidation): ValidationTypes => {
   const warnChecks = numberOfChecks(ValidationTypes.Warning, object);
   const errChecks = numberOfChecks(ValidationTypes.Error, object);
-
-  return object && object.valid
-    ? ValidationTypes.Correct
-    : object && !object.valid && errChecks > 0
-    ? ValidationTypes.Error
-    : object && !object.valid && warnChecks > 0
-    ? ValidationTypes.Warning
-    : ValidationTypes.Correct;
+  return errChecks > 0 ? ValidationTypes.Error : warnChecks > 0 ? ValidationTypes.Warning : ValidationTypes.Correct;
 };
 
 export const checkForPath = (object: ObjectValidation | undefined, path: string): ObjectCheck[] => {


### PR DESCRIPTION
Related to https://github.com/kiali/kiali/issues/3015

Requires https://github.com/kiali/kiali/pull/3157

It adds IstioConfig linked with a workload (resources with some workloadSelector that matches the workload labels).

![image](https://user-images.githubusercontent.com/1662329/91715898-e3536c00-eb8e-11ea-92f5-9aacbf236a59.png)


For testers, I've used this (somehow artificial) example (you can modify it inside Kiali to check that validations are working):

```
apiVersion: security.istio.io/v1beta1
kind: PeerAuthentication
metadata:
  name: details-pa
  namespace: default
spec:
  selector:
    matchLabels:
      app: details
  mtls:
    mode: PERMISSIVE
---
apiVersion: security.istio.io/v1beta1
kind: RequestAuthentication
metadata:
  name: details-ra
  namespace: default
spec:
  selector:
    matchLabels:
      app: details
  jwtRules:
    - issuer: "issuer-foo"
      jwksUri: https://example.com/.well-known/jwks.json
---
apiVersion: security.istio.io/v1beta1
kind: AuthorizationPolicy
metadata:
  name: details-ap
  namespace: default
spec:
  selector:
    matchLabels:
      app: details
  rules:
    - from:
        - source:
            requestPrincipals: ["*"]
---
apiVersion: networking.istio.io/v1alpha3
kind: Sidecar
metadata:
  name: details-sc
  namespace: default
spec:
  workloadSelector:
    labels:
      app: details
  ingress:
    - port:
        number: 9080
        protocol: HTTP
        name: somename
      defaultEndpoint: unix:///var/run/someuds.sock
  egress:
    - port:
        number: 9080
        protocol: HTTP
        name: egresshttp
      hosts:
        - "prod-us1/*"
    - hosts:
        - "istio-system/*"
---
apiVersion: networking.istio.io/v1alpha3
kind: EnvoyFilter
metadata:
  name: details-ef
  namespace: default
spec:
  workloadSelector:
    labels:
      app: details
  configPatches:
    # The first patch adds the lua filter to the listener/http connection manager
    - applyTo: HTTP_FILTER
      match:
        context: SIDECAR_INBOUND
        listener:
          portNumber: 8080
          filterChain:
            filter:
              name: "envoy.http_connection_manager"
              subFilter:
                name: "envoy.router"
      patch:
        operation: INSERT_BEFORE
        value: # lua filter specification
          name: envoy.lua
          typed_config:
            "@type": "type.googleapis.com/envoy.config.filter.http.lua.v2.Lua"
            inlineCode: |
              function envoy_on_request(request_handle)
                -- Make an HTTP call to an upstream host with the following headers, body, and timeout.
                local headers, body = request_handle:httpCall(
                 "lua_cluster",
                 {
                  [":method"] = "POST",
                  [":path"] = "/acl",
                  [":authority"] = "internal.org.net"
                 },
                "authorize call",
                5000)
              end
    # The second patch adds the cluster that is referenced by the lua code
    # cds match is omitted as a new cluster is being added
    - applyTo: CLUSTER
      match:
        context: SIDECAR_OUTBOUND
      patch:
        operation: ADD
        value: # cluster specification
          name: "lua_cluster"
          type: STRICT_DNS
          connect_timeout: 0.5s
          lb_policy: ROUND_ROBIN
          hosts:
            - socket_address:
                protocol: TCP
                address: "internal.org.net"
                port_value: 8888
```
