### PR TITLE
Enhance graph find/hide expression power

### DIFF
--- a/src/pages/Graph/GraphHelpFind.tsx
+++ b/src/pages/Graph/GraphHelpFind.tsx
@@ -171,7 +171,8 @@ export default class GraphHelpFind extends React.Component<GraphHelpFindProps> {
       ['!traffic', 'edges with no traffic'],
       ['http > 0.5', `edges with http rate > 0.5 rps`],
       ['rt > 500', `edges with response time > 500ms. (requires response time edge labels)`],
-      ['%httptraffic >= 50.0', `edges with >= 50% of the outgoing http request traffic of the parent`]
+      ['%httptraffic >= 50.0', `edges with >= 50% of the outgoing http request traffic of the parent`],
+      ['node = svc and svc startswith det or !traffic', 'service node starting with "det" or edges with no traffic']
     ];
   };
 
@@ -209,12 +210,11 @@ export default class GraphHelpFind extends React.Component<GraphHelpFindProps> {
   };
   private noteRows = (): string[][] => {
     return [
-      ['Expressions can not combine "AND" with "OR".'],
       ['Parentheses are not supported (or needed).'],
-      ['The "name" operand expands internally to an "OR" expression (an "AND" when negated).'],
-      ['Expressions can not combine node and edge criteria.'],
+      ['Use OR to combine node and edge criteria.'],
       ['Use "<operand> = NaN" to test for no activity. Use "!= NaN" for any activity. (e.g. httpout = NaN)'],
       [`Unary operands may optionally be prefixed with "is" or "has". (i.e. "has mtls")`],
+      ['The "name" operand expands internally to an "OR" expression (an "AND" when negated).'],
       ['Abbrevations: namespace|ns, service|svc, workload|wl operation|op'],
       ['Abbrevations: circuitbreaker|cb, responsetime|rt, serviceentry->se, sidecar|sc, virtualservice|vs'],
       ['Hiding nodes will automatically hide connected edges.'],

--- a/src/pages/Graph/GraphToolbar/__tests__/GraphFind.test.tsx
+++ b/src/pages/Graph/GraphToolbar/__tests__/GraphFind.test.tsx
@@ -210,9 +210,23 @@ describe('Parse find value test', () => {
 
     // check composites
     // @ts-ignore
-    expect(instance.parseValue('ns=foo OR ns=bar')).toEqual('node[namespace = "foo"],[namespace = "bar"]');
+    expect(instance.parseValue('ns=foo OR ns=bar')).toEqual('node[namespace = "foo"],node[namespace = "bar"]'); // OR same target
     // @ts-ignore
-    expect(instance.parseValue('ns=foo AND ns=bar')).toEqual('node[namespace = "foo"][namespace = "bar"]');
+    expect(instance.parseValue('ns=foo AND ns=bar')).toEqual('node[namespace = "foo"][namespace = "bar"]'); // AND same target
+    // @ts-ignore
+    expect(instance.parseValue('ns=foo OR ns=bar AND app=foo')).toEqual(
+      'node[namespace = "foo"],node[namespace = "bar"][app = "foo"]'
+    ); // AND and OR same target
+    // @ts-ignore
+    expect(instance.parseValue('ns=foo OR protocol=http')).toEqual('node[namespace = "foo"],edge[protocol = "http"]'); // OR different targets
+    // @ts-ignore
+    expect(instance.parseValue('ns=foo OR protocol=http OR !traffic')).toEqual(
+      'node[namespace = "foo"],edge[protocol = "http"],edge[^hasTraffic]'
+    ); // OR different targets
+    // @ts-ignore
+    expect(instance.parseValue('ns=foo AND ns=bar OR protocol=http AND !traffic')).toEqual(
+      'node[namespace = "foo"][namespace = "bar"],edge[protocol = "http"][^hasTraffic]'
+    ); // OR different targets, each with AND
 
     // check find by name
     // @ts-ignore
@@ -231,8 +245,6 @@ describe('Parse find value test', () => {
     expect(instance.parseValue('!foo')).toEqual(undefined); // invalid negated unary
     // @ts-ignore
     expect(instance.parseValue('node = appp')).toEqual(undefined); // invalid node type
-    // @ts-ignore
-    expect(instance.parseValue('ns=foo OR ns=bar AND app=foo')).toEqual(undefined); // AND and OR
     // @ts-ignore
     expect(instance.parseValue('ns=foo AND http > 5.0')).toEqual(undefined); // Node and Edge
   });


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/3165

Introduce the ability to combine AND and OR, as well as mix Node and Edge criteria.  For example, these expressions previously would generate an error, and now they work:

node=svc OR protocol=tcp

namespace=foo OR namespace=bar AND node=svc


cc @josejulio I think this is one you had wanted for a while (or maybe I am just dreaming)