### PR TITLE
Support Iter8-v1.0.0

### DIFF
--- a/src/components/DefaultSecondaryMasthead/DefaultSecondaryMasthead.tsx
+++ b/src/components/DefaultSecondaryMasthead/DefaultSecondaryMasthead.tsx
@@ -11,7 +11,8 @@ const titles = [
   'istio/new',
   'extensions/threescale/new',
   'extensions/iter8',
-  'extensions/iter8/new'
+  'extensions/iter8/new',
+  'extensions/iter8/newfromfile'
 ];
 export default class DefaultSecondaryMasthead extends React.Component {
   showTitle() {
@@ -30,6 +31,9 @@ export default class DefaultSecondaryMasthead extends React.Component {
         title = 'Iter8 Experiments';
       } else if (path === 'extensions/iter8/new') {
         title = 'Create New Iter8 Experiment';
+        disabled = true;
+      } else if (path === 'extensions/iter8/newfromfile') {
+        title = 'Create New Iter8 Experiment from File';
         disabled = true;
       }
       return {

--- a/src/components/DefaultSecondaryMasthead/DefaultSecondaryMasthead.tsx
+++ b/src/components/DefaultSecondaryMasthead/DefaultSecondaryMasthead.tsx
@@ -34,7 +34,6 @@ export default class DefaultSecondaryMasthead extends React.Component {
         disabled = true;
       } else if (path === 'extensions/iter8/newfromfile') {
         title = 'Create New Iter8 Experiment from File';
-        disabled = true;
       }
       return {
         title: (

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -123,6 +123,8 @@ const conf = {
       iter8Experiments: `api/iter8/experiments`,
       iter8ExperimentsByNamespace: (namespace: string) => `api/iter8/namespaces/${namespace}/experiments`,
       iter8Experiment: (namespace: string, name: string) => `api/iter8/namespaces/${namespace}/experiments/${name}`,
+      iter8ExperimentYAML: (namespace: string, name: string) =>
+        `api/iter8/namespaces/${namespace}/experiments/${name}/yaml`,
       iter8ExperimentUpdate: (namespace: string, name: string) =>
         `api/iter8/namespaces/${namespace}/experiments/${name}`,
       istioPermissions: 'api/istio/permissions',

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/AssessmentInfoDescription.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/AssessmentInfoDescription.tsx
@@ -1,0 +1,384 @@
+import * as React from 'react';
+import {
+  Divider,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  Grid,
+  GridItem,
+  // Progress,
+  // ProgressMeasureLocation,
+  // ProgressVariant,
+  // ProgressSize,
+  Title,
+  Tooltip
+} from '@patternfly/react-core';
+import { ChartBullet, ChartThemeColor } from '@patternfly/react-charts';
+
+import { Iter8Info, Iter8Experiment, MetricProgressInfo, emptyExperimentItem } from '../../../../types/Iter8';
+import {
+  Table,
+  TableBody,
+  TableHeader,
+  IRow,
+  ICell,
+  cellWidth,
+  expandable,
+  RowWrapperProps
+} from '@patternfly/react-table';
+import { KialiIcon } from '../../../../config/KialiIcon';
+import { style } from 'typestyle';
+import { css } from '@patternfly/react-styles';
+import { RenderComponentScroll } from '../../../../components/Nav/Page';
+import styles from '@patternfly/react-styles/css/components/Table/table';
+import { DurationInSeconds, TimeInMilliseconds } from '../../../../types/Common';
+import * as AlertUtils from '../../../../utils/AlertUtils';
+import { DurationDropdownContainer } from '../../../../components/DurationDropdown/DurationDropdown';
+import RefreshButtonContainer from '../../../../components/Refresh/RefreshButton';
+import { RightActionBar } from '../../../../components/RightActionBar/RightActionBar';
+import { KialiAppState } from '../../../../store/Store';
+import { durationSelector, lastRefreshAtSelector } from '../../../../store/Selectors';
+import { connect } from 'react-redux';
+import * as API from '../../../../services/Api';
+var classNames = require('classnames');
+const paddingStyle = style({ padding: '0px 0px 0px 0px' });
+
+interface AssesmentInfoDescriptionProps {
+  lastRefreshAt: TimeInMilliseconds;
+  iter8Info: Iter8Info;
+  name: string;
+  namespace: string;
+  experimentItem: Iter8Experiment;
+  metricInfo: Map<string, MetricProgressInfo>;
+  duration: DurationInSeconds;
+  fetchOp: () => void;
+}
+
+type State = {
+  experimentItem: Iter8Experiment;
+  columns: any;
+  rows: any;
+};
+
+const statusIconStyle = style({
+  fontSize: '2.0em'
+});
+
+class AssessmentInfoDescriptionTab extends React.Component<AssesmentInfoDescriptionProps, State> {
+  constructor(props: AssesmentInfoDescriptionProps) {
+    super(props);
+    this.state = {
+      experimentItem: emptyExperimentItem,
+      columns: [
+        { title: 'Type', cellFormatters: [expandable], transforms: [cellWidth(10) as any] },
+        'Assessment',
+        'Statistics'
+      ],
+      rows: this.getRows()
+    };
+  }
+
+  componentDidMount() {
+    this.setState({
+      experimentItem: this.props.experimentItem,
+      rows: this.getRows()
+    });
+  }
+
+  componentDidUpdate(prevProps: AssesmentInfoDescriptionProps) {
+    if (this.props.experimentItem !== prevProps.experimentItem || prevProps.duration !== this.props.duration) {
+      this.rederRows();
+    }
+  }
+
+  fetchAssesment = () => {
+    const namespace = this.props.namespace;
+    const name = this.props.name;
+    API.getExperiment(namespace, name)
+      .then(result => {
+        this.setState({
+          experimentItem: result.data.experimentItem,
+          rows: this.getRows()
+        });
+      })
+      .catch(error => {
+        AlertUtils.addError('Could not fetch Iter8 Experiment', error);
+      });
+  };
+
+  rederRows() {
+    this.setState({
+      experimentItem: this.props.experimentItem,
+      rows: this.getRows()
+    });
+  }
+
+  renderTresholdBar(idx, name, value) {
+    if (value === undefined) {
+      return (
+        <>
+          {idx === 0 ? '' : <Divider />}
+          <Grid gutter="md">
+            <GridItem span={4}>{name}:</GridItem>
+            <GridItem span={2}>{value}</GridItem>
+            <GridItem span={6}></GridItem>
+          </Grid>
+        </>
+      );
+    }
+    let valueString = value.toFixed(2);
+    let tInfo = this.props.metricInfo.get(name);
+    if (tInfo === undefined) return <></>;
+    if (tInfo.isReward && tInfo.threshold === 0) {
+      return (
+        <>
+          {idx === 0 ? '' : <Divider />}
+          <Grid gutter="md">
+            <GridItem span={4}>{name}:</GridItem>
+            <GridItem span={2}>{valueString}</GridItem>
+            <GridItem span={6}></GridItem>
+          </Grid>
+        </>
+      );
+    }
+    let baseLineValue = 1;
+    if (tInfo.thresholdType === 'relative') {
+      this.props.experimentItem.baseline.criterionAssessment?.map((ca, _) => {
+        if (ca.metric_id === name) baseLineValue = ca.statistics.value;
+      });
+    }
+
+    let maxDomain = Number((tInfo.threshold * baseLineValue).toFixed(2)) * 1.5;
+    maxDomain = value > maxDomain ? value.toFixed(2) : maxDomain.toFixed(2);
+
+    let color;
+    let range1 = 0;
+    let range2 = Number((baseLineValue * tInfo.threshold).toFixed(2));
+    if (tInfo.preferred_direction === 'lower') {
+      if (value >= baseLineValue * tInfo.threshold) {
+        color = ChartThemeColor.orange;
+      } else {
+        color = ChartThemeColor.blue;
+      }
+    } else {
+      range1 = baseLineValue * tInfo.threshold;
+      range2 = maxDomain;
+      if (value >= baseLineValue * tInfo.threshold) {
+        color = ChartThemeColor.blue;
+      } else {
+        color = ChartThemeColor.orange;
+      }
+    }
+    let range1Name = 'Lower limit';
+    let range2Name = 'Range';
+    if (range1 === 0) {
+      range1Name = '';
+      range2Name = 'Upper Limit';
+    }
+
+    return (
+      <>
+        {idx === 0 ? '' : <Divider />}
+        <Grid gutter="md">
+          <GridItem span={4}>{name}</GridItem>
+          <GridItem span={2}>{valueString}</GridItem>
+          <GridItem span={6}>
+            <div className={classNames(paddingStyle)}>
+              <ChartBullet
+                legendPosition={'right'}
+                qualitativeRangeData={[
+                  { name: range1Name, y: range1 },
+                  { name: range2Name, y: range2 }
+                ]}
+                maxDomain={{ y: Number(maxDomain) }}
+                primarySegmentedMeasureData={[{ name: 'Measure', y: valueString }]}
+                constrainToVisibleArea
+                themeColor={color}
+                padding={{
+                  bottom: 0,
+                  left: 0,
+                  right: 0,
+                  top: 0
+                }}
+                height={110}
+                standalone={true}
+                labels={({ datum }) => `${datum.name}: ${datum.y}`}
+              />
+            </div>
+          </GridItem>
+        </Grid>
+      </>
+    );
+  }
+
+  renderRow(type, assessment) {
+    return {
+      cells: [
+        { title: <>{type}</> },
+        {
+          title: (
+            <>
+              {this.props.experimentItem?.winner.winning_version_found &&
+              this.props.experimentItem?.winner.name === assessment.name ? (
+                <Grid gutter="md">
+                  <GridItem span={6}>Winner</GridItem>
+                  <GridItem span={6}>
+                    {' '}
+                    <KialiIcon.Ok className={statusIconStyle} />
+                  </GridItem>
+                </Grid>
+              ) : (
+                <></>
+              )}
+              <Grid gutter="md">
+                <GridItem span={6}>Name:</GridItem>
+                <GridItem span={6}>{assessment.name}</GridItem>
+              </Grid>
+              <Grid gutter="md">
+                <GridItem span={6}>Weight:</GridItem>
+                <GridItem span={6}>{assessment.weight}</GridItem>
+              </Grid>
+              <Grid gutter="md">
+                <GridItem span={6}>Win Probability:</GridItem>
+                <GridItem span={6}>{assessment.winProbability}</GridItem>
+              </Grid>
+              <Grid gutter="md">
+                <GridItem span={6}>Request Count:</GridItem>
+                <GridItem span={6}>{assessment.requestCount}</GridItem>
+              </Grid>
+            </>
+          )
+        },
+        {
+          props: { nonPadding: true },
+          title: (
+            <>
+              {assessment.criterionAssessment &&
+                assessment.criterionAssessment.map((c, i) => {
+                  return (
+                    <Grid gutter="md">
+                      <GridItem span={12}>{this.renderTresholdBar(i, c.metric_id, c.statistics.value)}</GridItem>
+                    </Grid>
+                  );
+                })}
+            </>
+          )
+        }
+      ]
+    };
+  }
+
+  getRows = (): IRow[] => {
+    let rows: IRow[] = [];
+
+    rows.push(this.renderRow('Baseline', this.props.experimentItem?.baseline));
+    this.props.experimentItem?.candidates.map(assessment => {
+      rows.push(this.renderRow('Candidate', assessment));
+      return rows;
+    });
+    return rows;
+  };
+
+  columns = (): ICell[] => {
+    return [{ title: 'Name', transforms: [cellWidth(15) as any] }, { title: 'Template' }];
+  };
+
+  getIcon = (s: number) => {
+    switch (s) {
+      case 1:
+        return (
+          <Tooltip content={<>{s}</>}>
+            <KialiIcon.Ok className={statusIconStyle} />
+          </Tooltip>
+        );
+      case 0:
+        return (
+          <Tooltip content={<>{s}</>}>
+            <KialiIcon.Error className={statusIconStyle} />
+          </Tooltip>
+        );
+      default:
+        return s;
+    }
+  };
+
+  customRowWrapper = ({ trRef, className, rowProps, row: { isExpanded, isHeightAuto }, ...props }) => {
+    const dangerErrorStyle = {
+      borderLeft: '3px solid var(--pf-global--primary-color--100)'
+    };
+
+    return (
+      <tr
+        {...props}
+        ref={trRef}
+        className={css(
+          className,
+          'custom-static-class',
+          isExpanded !== undefined && styles.tableExpandableRow,
+          isExpanded && styles.modifiers.expanded,
+          isHeightAuto && styles.modifiers.heightAuto
+        )}
+        hidden={isExpanded !== undefined && !isExpanded}
+        style={dangerErrorStyle}
+      />
+    );
+  };
+
+  render() {
+    const { columns, rows } = this.state;
+    return (
+      <>
+        <RightActionBar>
+          <DurationDropdownContainer id="assesment-duration-dropdown" prefix="Last" />
+          <RefreshButtonContainer handleRefresh={this.fetchAssesment} />
+        </RightActionBar>
+        <RenderComponentScroll>
+          <Grid gutter="md" style={{ margin: '10px' }}>
+            <GridItem span={12}>
+              <Table
+                aria-label="SpanTable"
+                className={'spanTracingTagsTable'}
+                rows={rows}
+                cells={columns}
+                rowWrapper={(props: RowWrapperProps) =>
+                  this.customRowWrapper({
+                    trRef: props.trRef,
+                    className: props.className,
+                    rowProps: props.rowProps,
+                    row: props.row as any,
+                    ...props
+                  })
+                }
+              >
+                <TableHeader />
+                {rows.length > 0 ? (
+                  <TableBody />
+                ) : (
+                  <tr>
+                    <td colSpan={columns.length}>
+                      <EmptyState variant={EmptyStateVariant.full}>
+                        <Title headingLevel="h5" size="lg">
+                          No Criteria found
+                        </Title>
+                        <EmptyStateBody>Experiment has not been started</EmptyStateBody>
+                      </EmptyState>
+                    </td>
+                  </tr>
+                )}
+              </Table>
+            </GridItem>
+          </Grid>
+        </RenderComponentScroll>
+      </>
+    );
+  }
+}
+
+const mapStateToProps = (state: KialiAppState) => ({
+  duration: durationSelector(state),
+  lastRefreshAt: lastRefreshAtSelector(state)
+});
+
+const AssessmentInfoDescription = connect(mapStateToProps, null)(AssessmentInfoDescriptionTab);
+
+export default AssessmentInfoDescription;

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/AssessmentInfoDescription.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/AssessmentInfoDescription.tsx
@@ -6,10 +6,6 @@ import {
   EmptyStateVariant,
   Grid,
   GridItem,
-  // Progress,
-  // ProgressMeasureLocation,
-  // ProgressVariant,
-  // ProgressSize,
   Title,
   Tooltip
 } from '@patternfly/react-core';
@@ -40,7 +36,8 @@ import { KialiAppState } from '../../../../store/Store';
 import { durationSelector, lastRefreshAtSelector } from '../../../../store/Selectors';
 import { connect } from 'react-redux';
 import * as API from '../../../../services/Api';
-var classNames = require('classnames');
+
+const classNames = require('classnames');
 const paddingStyle = style({ padding: '0px 0px 0px 0px' });
 
 interface AssesmentInfoDescriptionProps {

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/CriteriaInfoDescription.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/CriteriaInfoDescription.tsx
@@ -1,26 +1,7 @@
 import * as React from 'react';
-import {
-  EmptyState,
-  EmptyStateBody,
-  EmptyStateVariant,
-  Grid,
-  GridItem,
-  List,
-  ListItem,
-  Title,
-  Tooltip
-} from '@patternfly/react-core';
-import { Iter8Info, SuccessCriteria } from '../../../../types/Iter8';
-import {
-  Table,
-  TableBody,
-  TableHeader,
-  IRow,
-  ICell,
-  cellWidth,
-  expandable,
-  RowWrapperProps
-} from '@patternfly/react-table';
+import { EmptyState, EmptyStateBody, EmptyStateVariant, Grid, GridItem, Title, Tooltip } from '@patternfly/react-core';
+import { CriteriaInfoDetail, Iter8Info } from '../../../../types/Iter8';
+import { Table, TableBody, TableHeader, IRow, ICell, cellWidth, RowWrapperProps } from '@patternfly/react-table';
 import { KialiIcon } from '../../../../config/KialiIcon';
 import { style } from 'typestyle';
 import { css } from '@patternfly/react-styles';
@@ -29,7 +10,7 @@ import styles from '@patternfly/react-styles/css/components/Table/table';
 
 interface ExperimentInfoDescriptionProps {
   iter8Info: Iter8Info;
-  criterias: SuccessCriteria[];
+  criterias: CriteriaInfoDetail[];
 }
 
 type State = {
@@ -49,12 +30,13 @@ class CriteriaInfoDescription extends React.Component<ExperimentInfoDescriptionP
       criteriaExpanded: [],
       columns: [
         {
-          title: 'Metric Name',
-          cellFormatters: [expandable]
+          title: 'Metric Name'
         },
-        'Definitions',
-        'Success Criteria Conclusions',
-        'Status'
+        'Threshold Type:',
+        'Threshold ',
+        'Is Reward',
+        'Stop On Failure',
+        'Preferred Direction'
       ],
       rows: this.getRows()
     };
@@ -64,35 +46,30 @@ class CriteriaInfoDescription extends React.Component<ExperimentInfoDescriptionP
     let rows: IRow[] = [];
     this.props.criterias.map(criteria => {
       const crows: IRow[] = [
-        { cells: [{ title: 'Query Template' }, { title: criteria.metric.query_template }] },
-        { cells: [{ title: 'Sample Size Template' }, { title: criteria.metric.sample_size_template }] }
+        {
+          cells: [
+            { title: <>{'Numerator'}</> },
+            { title: <>{criteria.metric.numerator.name}</> },
+            { title: <>{criteria.metric.numerator.query_template}</> }
+          ]
+        },
+        {
+          cells: [
+            { title: <>{'Denominator'}</> },
+            { title: <>{criteria.metric.denominator.name}</> },
+            { title: <>{criteria.metric.denominator.query_template}</> }
+          ]
+        }
       ];
       let number = rows.push({
         isOpen: false,
         cells: [
           { title: <>{criteria.name}</> },
-          {
-            title: (
-              <ul>
-                <li>Threshold : {criteria.criteria.tolerance}</li>
-                <li>Threshold Type: {criteria.criteria.toleranceType}</li>
-                <li>Sample Size: {criteria.criteria.sampleSize}</li>
-              </ul>
-            )
-          },
-          {
-            title: (
-              <List>
-                {criteria.status.conclusions &&
-                  criteria.status.conclusions.map((c, _) => {
-                    return <ListItem> {c} </ListItem>;
-                  })}
-              </List>
-            )
-          },
-          {
-            title: <>{this.getIcon(String(criteria.status.success_criterion_met))}</>
-          }
+          { title: <>{criteria.criteria.toleranceType}</> },
+          { title: <>{criteria.criteria.tolerance}</> },
+          { title: <>{criteria.criteria.isReward ? 'YES' : '-'}</> },
+          { title: <>{criteria.criteria.stopOnFailure ? 'True' : 'False'}</> },
+          { title: <>{criteria.metric.preferred_direction}</> }
         ]
       });
       rows.push({
@@ -113,7 +90,11 @@ class CriteriaInfoDescription extends React.Component<ExperimentInfoDescriptionP
   };
 
   columns = (): ICell[] => {
-    return [{ title: 'Name', transforms: [cellWidth(15) as any] }, { title: 'Template' }];
+    return [
+      { title: 'Type', transforms: [cellWidth(15) as any] },
+      { title: 'Name', transforms: [cellWidth(15) as any] },
+      { title: 'Template' }
+    ];
   };
 
   getIcon = (s: string) => {

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCreateFromFile.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCreateFromFile.tsx
@@ -14,18 +14,16 @@ import {
   Text
 } from '@patternfly/react-core';
 import history from '../../../../app/History';
-import { RenderContent } from '../../../../components/Nav/Page';
 import Namespace, { namespacesToString } from '../../../../types/Namespace';
 import { PromisesRegistry } from '../../../../utils/CancelablePromises';
 import { KialiAppState } from '../../../../store/Store';
 import { activeNamespacesSelector } from '../../../../store/Selectors';
 import { connect } from 'react-redux';
 import { style } from 'typestyle';
-import { parseYamlValidations } from '../../../../types/AceValidations';
+import { jsYaml, parseYamlValidations } from '../../../../types/AceValidations';
 import AceEditor from 'react-ace';
 import { aceOptions } from '../../../../types/IstioConfigDetails';
 import { TextInputBase as TextInput } from '@patternfly/react-core/dist/js/components/TextInput/TextInput';
-import { jsYaml } from '../../../../types/AceValidations';
 import { PfColors } from '../../../../components/Pf/PfColors';
 
 interface Props {
@@ -112,7 +110,7 @@ class ExperimentCreateFromFile extends React.Component<Props, State> {
               theme="eclipse"
               onChange={this.onEditorChange}
               width={'100%'}
-              height={'calc(var(--kiali-details-pages-tab-content-height) - 240px'}
+              height={'calc(var(--kiali-details-pages-tab-content-height) - 340px)'}
               className={'istio-ace-editor'}
               wrapEnabled={true}
               readOnly={false}
@@ -183,106 +181,108 @@ class ExperimentCreateFromFile extends React.Component<Props, State> {
     const { filename, isLoading, experimentYaml } = this.state;
     return (
       <>
-        <RenderContent>
-          <Form isHorizontal={true} className={containerPadding}>
-            <FormGroup
-              fieldId="title"
-              label="Load from Local"
-              isRequired={true}
-              helperTextInvalid="Name cannot be empty and must be a DNS subdomain name as defined in RFC 1123."
-            >
-              <FileUpload
-                id="text-file-with-edits-allowed"
-                type="text"
-                value={experimentYaml}
-                filename={filename}
-                onChange={this.handleFileChange}
-                onReadStarted={this.handleFileReadStarted}
-                onReadFinished={this.handleFileReadFinished}
-                isLoading={isLoading}
-                hideDefaultPreview
-                isReadOnly={false}
-              />
-            </FormGroup>
-
-            <FormGroup
-              fieldId="title"
-              label="Load from Github"
-              isRequired={true}
-              helperText="example: https://raw.githubusercontent.com/iter8-tools/iter8/master/test/data/bookinfo/canary/canary_reviews-v2_to_reviews-v3.yaml"
-              helperTextInvalid="Name cannot be empty and must be a DNS subdomain name as defined in RFC 1123."
-            >
-              <InputGroup>
-                <TextInput
-                  id="url"
-                  value={this.state.yamlFilename}
-                  onChange={value => this.updateValue(value)}
-                  onKeyPress={e => {
-                    if (e.key === 'Enter') {
-                      this.loadFromURL();
-                    }
-                  }}
+        <Grid style={{ margin: '10px' }} gutter={'md'}>
+          <GridItem span={12}>
+            <Form isHorizontal={true} className={containerPadding}>
+              <FormGroup fieldId="title" label="Load from Local" isRequired={true}>
+                <FileUpload
+                  id="text-file-with-edits-allowed"
+                  type="text"
+                  value={experimentYaml}
+                  filename={filename}
+                  onChange={this.handleFileChange}
+                  onReadStarted={this.handleFileReadStarted}
+                  onReadFinished={this.handleFileReadFinished}
+                  isLoading={isLoading}
+                  hideDefaultPreview
+                  isReadOnly={false}
                 />
-                <Button
-                  style={{ paddingLeft: '29px', paddingRight: '29px' }}
-                  variant={ButtonVariant.primary}
-                  isDisabled={this.state.yamlFilename === ''}
-                  onClick={() => {
-                    this.loadFromURL();
-                  }}
-                >
-                  Load
-                </Button>
-                <Button
-                  variant={ButtonVariant.primary}
-                  isDisabled={this.state.yamlFilename === ''}
-                  onClick={() => {
-                    this.clearURL();
-                  }}
-                >
-                  Clear
-                </Button>
-              </InputGroup>
-            </FormGroup>
+              </FormGroup>
 
-            <Grid gutter="sm" style={{ padding: '10px 10px 0 10px', height: '100%' }}>
-              <GridItem span={8}>
-                {this.props.activeNamespaces.length === 1 ? (
-                  <Text>
-                    Experiment will be created at namespace: {namespacesToString(this.props.activeNamespaces)}
-                  </Text>
-                ) : (
-                  <Text style={{ color: PfColors.Red }}>namespace missing</Text>
-                )}
-              </GridItem>
-              <GridItem span={4}>
-                <div className="pf-u-float-right">
-                  <ActionGroup>
-                    <Button
-                      variant={ButtonVariant.primary}
-                      isDisabled={!this.isFormValid()}
-                      onClick={() => this.createExperiment()}
-                    >
-                      Create
-                    </Button>
-                    <span style={{ float: 'right', paddingRight: '5px' }}>
-                      <Button
-                        variant={ButtonVariant.secondary}
-                        onClick={() => {
-                          this.goExperimentsPage();
-                        }}
-                      >
-                        Cancel
-                      </Button>
-                    </span>
-                  </ActionGroup>
-                </div>
-              </GridItem>
-            </Grid>
+              <FormGroup
+                fieldId="title"
+                label="Load from Github"
+                isRequired={true}
+                helperText="example: https://raw.githubusercontent.com/iter8-tools/iter8/master/test/data/bookinfo/canary/canary_reviews-v2_to_reviews-v3.yaml"
+                helperTextInvalid="Name cannot be empty and must be a DNS subdomain name as defined in RFC 1123."
+              >
+                <InputGroup>
+                  <TextInput
+                    id="url"
+                    value={this.state.yamlFilename}
+                    onChange={value => this.updateValue(value)}
+                    onKeyPress={e => {
+                      if (e.key === 'Enter') {
+                        this.loadFromURL();
+                      }
+                    }}
+                  />
+                  <Button
+                    style={{ paddingLeft: '29px', paddingRight: '29px' }}
+                    variant={ButtonVariant.primary}
+                    isDisabled={this.state.yamlFilename === ''}
+                    onClick={() => {
+                      this.loadFromURL();
+                    }}
+                  >
+                    Load
+                  </Button>
+                  <Button
+                    variant={ButtonVariant.primary}
+                    isDisabled={this.state.yamlFilename === ''}
+                    onClick={() => {
+                      this.clearURL();
+                    }}
+                  >
+                    Clear
+                  </Button>
+                </InputGroup>
+              </FormGroup>
+            </Form>
+          </GridItem>
+          <GridItem span={2}></GridItem>
+          <GridItem span={7}>
+            {this.props.activeNamespaces.length === 1 ? (
+              <Text>Experiment will be created at namespace: {namespacesToString(this.props.activeNamespaces)}</Text>
+            ) : (
+              <Text style={{ color: PfColors.Red }}>namespace missing</Text>
+            )}
+          </GridItem>
+          <GridItem span={3}>
+            <ActionGroup>
+              <span
+                style={{
+                  float: 'left',
+                  paddingTop: '10px',
+                  paddingBottom: '10px',
+                  width: '100%'
+                }}
+              >
+                <span style={{ float: 'right', paddingRight: '20px' }}>
+                  <Button
+                    variant={ButtonVariant.primary}
+                    isDisabled={!this.isFormValid()}
+                    onClick={() => this.createExperiment()}
+                  >
+                    Create
+                  </Button>
+                </span>
+                <span style={{ float: 'right', paddingRight: '5px' }}>
+                  <Button
+                    variant={ButtonVariant.secondary}
+                    onClick={() => {
+                      this.goExperimentsPage();
+                    }}
+                  >
+                    Cancel
+                  </Button>
+                </span>
+              </span>
+            </ActionGroup>
+          </GridItem>
 
-            {this.renderEditor()}
-          </Form>
-        </RenderContent>
+          <GridItem> {this.renderEditor()}</GridItem>
+        </Grid>
       </>
     );
   }

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCreateFromFile.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCreateFromFile.tsx
@@ -1,0 +1,264 @@
+import * as React from 'react';
+import * as API from '../../../../services/Api';
+import * as AlertUtils from '../../../../utils/AlertUtils';
+import {
+  ActionGroup,
+  Button,
+  ButtonVariant,
+  FileUpload,
+  Form,
+  FormGroup,
+  Grid,
+  GridItem
+} from '@patternfly/react-core';
+import history from '../../../../app/History';
+import { RenderComponentScroll, RenderContent } from '../../../../components/Nav/Page';
+import Namespace, { namespacesToString } from '../../../../types/Namespace';
+import { PromisesRegistry } from '../../../../utils/CancelablePromises';
+import { KialiAppState } from '../../../../store/Store';
+import { activeNamespacesSelector } from '../../../../store/Selectors';
+import { connect } from 'react-redux';
+import { style } from 'typestyle';
+import { parseYamlValidations } from '../../../../types/AceValidations';
+import AceEditor from 'react-ace';
+import { aceOptions } from '../../../../types/IstioConfigDetails';
+import { TextInputBase as TextInput } from '@patternfly/react-core/dist/js/components/TextInput/TextInput';
+import { jsYaml } from '../../../../types/AceValidations';
+
+interface Props {
+  activeNamespaces: Namespace[];
+  serviceName: string;
+  namespace: string;
+  showAdvanced: boolean;
+}
+
+interface State {
+  filename: string;
+  experimentYaml: any;
+  isLoading: boolean;
+  yamlModified: boolean;
+  isModified: boolean;
+  yamlFilename: string;
+}
+
+const containerPadding = style({ padding: '20px 20px 20px 20px' });
+
+class ExperimentCreateFromFile extends React.Component<Props, State> {
+  aceEditorRef: React.RefObject<AceEditor>;
+  private promises = new PromisesRegistry();
+
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      filename: '',
+      yamlFilename: '',
+      experimentYaml: '',
+      isLoading: false,
+      isModified: false,
+      yamlModified: false
+    };
+    this.aceEditorRef = React.createRef();
+  }
+
+  handleFileChange = (experimentYaml, filename, _) => this.setState({ experimentYaml, filename });
+  handleFileReadStarted = () => this.setState({ isLoading: true });
+  handleFileReadFinished = () => this.setState({ isLoading: false });
+
+  componentWillUnmount() {
+    this.promises.cancelAll();
+  }
+
+  // Invoke the history object to update and URL and start a routing
+  goExperimentsPage = () => {
+    history.push('/extensions/iter8');
+  };
+
+  onEditorChange = (value: string) => {
+    this.setState({
+      isModified: true,
+      yamlModified: false,
+      experimentYaml: value
+    });
+  };
+
+  // It invokes backend to create  a new experiment
+  createExperiment = () => {
+    // if (this.props.activeNamespaces.length === 1) {
+    const nsName = this.props.activeNamespaces[0].name;
+    const params: any = {};
+    params.type = 'json';
+    let experimentJson = jsYaml.safeLoad(this.state.experimentYaml);
+    this.promises
+      .register('Create Iter8 Experiment', API.createExperiment(nsName, JSON.stringify(experimentJson), params))
+      .then(_ => this.goExperimentsPage())
+      .catch(error => AlertUtils.addError('Could not create Experiment.', error));
+  };
+
+  renderEditor = () => {
+    const yamlSource = this.state.experimentYaml;
+    const editorSpan = 12;
+    let editorValidations = parseYamlValidations(yamlSource);
+
+    return (
+      <>
+        <Grid style={{ margin: '10px' }} gutter={'md'}>
+          <GridItem span={editorSpan}>
+            <AceEditor
+              ref={this.aceEditorRef}
+              mode="yaml"
+              theme="eclipse"
+              onChange={this.onEditorChange}
+              width={'100%'}
+              height={'var(--kiali-yaml-editor-height)'}
+              className={'istio-ace-editor'}
+              wrapEnabled={true}
+              readOnly={false}
+              setOptions={aceOptions}
+              value={yamlSource}
+              annotations={editorValidations.annotations}
+              markers={editorValidations.markers}
+            />
+          </GridItem>
+        </Grid>
+      </>
+    );
+  };
+
+  updateValue = (val: string) => {
+    this.setState({ yamlFilename: val });
+  };
+
+  loadFromURL = () => {
+    this.setState({ isLoading: true });
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), 5000);
+    const promise = fetch(this.state.yamlFilename, { signal: controller.signal })
+      .then(resp => {
+        if (!resp.ok) {
+          AlertUtils.addError(resp.statusText);
+          this.setState({ isLoading: false });
+          throw resp;
+        }
+        return resp.text();
+      })
+      .then(data => {
+        this.setState(prevState => {
+          return {
+            experimentYaml: data,
+            isLoading: !prevState.isLoading
+          };
+        });
+      });
+    promise.catch(err => {
+      if (err.name === 'AbortError') {
+        AlertUtils.addError('Request took more than 5 seconds. Automatically cancelled.', err);
+        this.setState({ isLoading: false });
+        return;
+      }
+      AlertUtils.addError('Invalid fetch URL', err);
+
+      this.setState({ isLoading: false });
+    });
+  };
+
+  isFormValid = (): boolean => {
+    return this.props.activeNamespaces.length === 1 && this.state.experimentYaml !== undefined;
+  };
+
+  render() {
+    const { filename, isLoading, experimentYaml } = this.state;
+    return (
+      <>
+        <RenderContent>
+          <Form isHorizontal={true}>
+            <div className={containerPadding}>
+              <FormGroup
+                fieldId="title"
+                label="Load from Local"
+                isRequired={true}
+                helperTextInvalid="Name cannot be empty and must be a DNS subdomain name as defined in RFC 1123."
+              >
+                <FileUpload
+                  id="text-file-with-edits-allowed"
+                  type="text"
+                  value={experimentYaml}
+                  filename={filename}
+                  onChange={this.handleFileChange}
+                  onReadStarted={this.handleFileReadStarted}
+                  onReadFinished={this.handleFileReadFinished}
+                  isLoading={isLoading}
+                  hideDefaultPreview
+                  isReadOnly={false}
+                />
+              </FormGroup>
+              <FormGroup
+                fieldId="title"
+                label="Load from URL"
+                isRequired={true}
+                helperTextInvalid="Name cannot be empty and must be a DNS subdomain name as defined in RFC 1123."
+              >
+                <TextInput
+                  id="url"
+                  placeholder="https://raw.githubusercontent.com/iter8-tools/iter8-controller/v0.2.1/doc/tutorials/istio/bookinfo/canary_reviews-v2_to_reviews-v3.yaml"
+                  value={this.state.yamlFilename}
+                  onChange={value => this.updateValue(value)}
+                  onKeyPress={e => {
+                    if (e.key === 'Enter') {
+                      this.loadFromURL();
+                    }
+                  }}
+                />
+              </FormGroup>
+              <ActionGroup>
+                <span
+                  style={{
+                    float: 'left',
+                    paddingTop: '0px',
+                    paddingBottom: '10px',
+                    width: '100%'
+                  }}
+                >
+                  {this.props.activeNamespaces.length === 1 ? (
+                    <span style={{ float: 'left' }}>
+                      Experiment will be created at namespace: {namespacesToString(this.props.activeNamespaces)}
+                    </span>
+                  ) : (
+                    <span style={{ float: 'left', color: 'red' }}>namespace missing</span>
+                  )}
+                  <span style={{ float: 'right', paddingRight: '5px' }}>
+                    <Button
+                      variant={ButtonVariant.primary}
+                      isDisabled={!this.isFormValid()}
+                      onClick={() => this.createExperiment()}
+                    >
+                      Create
+                    </Button>
+                  </span>
+                  <span style={{ float: 'right', paddingRight: '5px' }}>
+                    <Button
+                      variant={ButtonVariant.secondary}
+                      onClick={() => {
+                        this.goExperimentsPage();
+                      }}
+                    >
+                      Cancel
+                    </Button>
+                  </span>
+                </span>
+              </ActionGroup>
+              <RenderComponentScroll>{this.renderEditor()}</RenderComponentScroll>
+            </div>
+          </Form>
+        </RenderContent>
+      </>
+    );
+  }
+}
+
+const mapStateToProps = (state: KialiAppState) => ({
+  activeNamespaces: activeNamespacesSelector(state)
+});
+
+const ExperimentCreateFromFileContainer = connect(mapStateToProps, null)(ExperimentCreateFromFile);
+
+export default ExperimentCreateFromFileContainer;

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCreatePage.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCreatePage.tsx
@@ -106,7 +106,8 @@ class ExperimentCreatePage extends React.Component<Props, State> {
           maxIterations: 10
         },
         criterias: [],
-        hosts: []
+        hosts: [],
+        routerID: ''
       },
       namespaces: [],
       services: [],
@@ -435,7 +436,9 @@ class ExperimentCreatePage extends React.Component<Props, State> {
           case 'toleranceType':
             newExperiment.criterias[0].toleranceType = value.trim();
             break;
-
+          case 'routerID':
+            newExperiment.routerID = value.trim();
+            break;
           default:
         }
         return {
@@ -697,7 +700,8 @@ class ExperimentCreatePage extends React.Component<Props, State> {
           criterias: prevState.experiment.criterias,
           hosts: prevState.experiment.hosts,
           duration: prevState.experiment.duration,
-          experimentKind: prevState.experiment.experimentKind
+          experimentKind: prevState.experiment.experimentKind,
+          routerID: prevState.experiment.routerID
         }
       };
     });
@@ -802,7 +806,7 @@ class ExperimentCreatePage extends React.Component<Props, State> {
                 id="maxIncrement"
                 value={this.state.experiment.trafficControl.maxIncrement}
                 placeholder="Max Increment"
-                onChange={value => this.changeExperimentNumber('maxIncrement', parseFloat(value))}
+                onChange={value => this.changeExperimentNumber('maxIncrement', Number(value))}
               />
             </FormGroup>
           </GridItem>
@@ -832,7 +836,8 @@ class ExperimentCreatePage extends React.Component<Props, State> {
           criterias: prevState.experiment.criterias,
           hosts: prevState.experiment.hosts,
           duration: prevState.experiment.duration,
-          experimentKind: prevState.experiment.experimentKind
+          experimentKind: prevState.experiment.experimentKind,
+          routerID: prevState.experiment.routerID
         }
       };
     });
@@ -856,13 +861,32 @@ class ExperimentCreatePage extends React.Component<Props, State> {
   renderHost() {
     return (
       <>
-        <ExperimentHostForm
-          hosts={this.state.experiment.hosts}
-          hostsOfGateway={this.state.hostsOfGateway}
-          gateways={this.state.gateways}
-          onAdd={this.onAddToList}
-          onRemove={this.onRemoveFromList}
-        />
+        <Grid gutter="md">
+          <GridItem span={12}>
+            <FormGroup
+              fieldId="routerID"
+              label="Router ID"
+              isValid={this.state.experiment.routerID !== ''}
+              helperText="Refers to the id of router used to handle traffic for the experiment. Default value: first entry of effective host."
+            >
+              <TextInput
+                id="routerID"
+                value={this.state.experiment.routerID}
+                placeholder="ID of router"
+                onChange={value => this.changeExperiment('routerID', value)}
+              />
+            </FormGroup>
+          </GridItem>
+          <GridItem span={12}>
+            <ExperimentHostForm
+              hosts={this.state.experiment.hosts}
+              hostsOfGateway={this.state.hostsOfGateway}
+              gateways={this.state.gateways}
+              onAdd={this.onAddToList}
+              onRemove={this.onRemoveFromList}
+            />
+          </GridItem>
+        </Grid>
       </>
     );
   }
@@ -969,7 +993,7 @@ class ExperimentCreatePage extends React.Component<Props, State> {
               </FormGroup>
             </>
           )}
-          <FormGroup label="Add Host/Gateway" fieldId="addHostGateway">
+          <FormGroup label="Show Networking Control" fieldId="addHostGateway">
             <Switch
               id="addHostGateway"
               label={' '}
@@ -979,7 +1003,7 @@ class ExperimentCreatePage extends React.Component<Props, State> {
             />
           </FormGroup>
           {this.state.addHostGateway && (
-            <FormGroup label="Hosts" fieldId="hostsGateways">
+            <FormGroup label="Networking" fieldId="hostsGateways">
               {this.renderHost()}
             </FormGroup>
           )}

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCreatePage.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCreatePage.tsx
@@ -913,7 +913,11 @@ class ExperimentCreatePage extends React.Component<Props, State> {
                           service during and after the experiment.
                         </p>{' '}
                         <b>Traffic Control Strategies:</b> (reference{' '}
-                        <a href="https://iter8.tools/reference/algorithms/#traffic-control-strategies" target="_blank">
+                        <a
+                          href="https://iter8.tools/reference/algorithms/#traffic-control-strategies"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
                           here
                         </a>{' '}
                         for detail )

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCreatePage.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCreatePage.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Iter8Info } from '../../../../types/Iter8';
+import { Criteria, ExperimentSpec, Host, Iter8Info } from '../../../../types/Iter8';
 import { style } from 'typestyle';
 import * as API from '../../../../services/Api';
 import * as AlertUtils from '../../../../utils/AlertUtils';
@@ -7,13 +7,13 @@ import {
   ActionGroup,
   Button,
   ButtonVariant,
-  Expandable,
   Form,
   FormGroup,
   FormSelect,
   FormSelectOption,
   Grid,
   GridItem,
+  Popover,
   Switch,
   TextInputBase as TextInput
 } from '@patternfly/react-core';
@@ -27,6 +27,7 @@ import { KialiAppState } from '../../../../store/Store';
 import { activeNamespacesSelector } from '../../../../store/Selectors';
 import { connect } from 'react-redux';
 import { PfColors } from '../../../../components/Pf/PfColors';
+import HelpIcon from '@patternfly/react-icons/dist/js/icons/help-icon';
 
 interface Props {
   serviceName: string;
@@ -45,7 +46,7 @@ interface State {
   hostsOfGateway: Host[];
   metricNames: string[];
   showAdvanced: boolean;
-  showTrafficStep: boolean;
+  showMaxIncrement: boolean;
   reloadService: boolean;
   totalDuration: string;
   hostState: HostState;
@@ -53,41 +54,7 @@ interface State {
   filename: string;
   addHostGateway: boolean;
   showTrafficControl: boolean;
-}
-
-interface ExperimentSpec {
-  name: string;
-  namespace: string;
-  service: string;
-  apiversion: string;
-  baseline: string;
-  candidate: string;
-  experimentKind: string;
-  trafficControl: TrafficControl;
-  criterias: Criteria[];
-  hosts: Host[];
-}
-
-interface TrafficControl {
-  algorithm: string;
-  interval: string;
-  intervalInSecond: number;
-  maxIterations: number;
-  maxTrafficPercentage: number;
-  trafficStepSize: number;
-}
-
-export interface Criteria {
-  metric: string;
-  toleranceType: string;
-  tolerance: number;
-  sampleSize: number;
-  stopOnFailure: boolean;
-}
-
-export interface Host {
-  name: string;
-  gateway: string;
+  showDurationControl: boolean;
 }
 
 // Style constants
@@ -99,16 +66,8 @@ const durationTimeStyle = style({
   paddingTop: 8,
   color: PfColors.Blue400
 });
-const algorithms = [
-  'check_and_increment',
-  'epsilon_greedy',
-  'increment_without_check',
-  'posterior_bayesian_routing',
-  'optimistic_bayesian_routing'
-];
-
-const toggleTextFlat = ['More', 'Less'];
-const toggleTextWizard = ['Show Advanced Options', 'Hide Advanced Options'];
+const algorithms = ['progressive', 'top_2', 'uniform'];
+const onTermination = ['to_winner', 'to_baseline', 'keep_last'];
 
 const iter8oExpOptions = [
   { value: 'Deployment', label: 'WORKLOAD' },
@@ -134,15 +93,17 @@ class ExperimentCreatePage extends React.Component<Props, State> {
         apiversion: 'v1',
         service: this.props.serviceName,
         baseline: '',
-        candidate: '',
+        candidates: [],
         experimentKind: 'Deployment',
         trafficControl: {
-          algorithm: 'check_and_increment',
+          algorithm: 'progressive',
+          maxIncrement: 10,
+          onTermination: 'to_winner'
+        },
+        duration: {
           interval: '30s',
           intervalInSecond: 30,
-          maxIterations: 10,
-          maxTrafficPercentage: 50,
-          trafficStepSize: 10
+          maxIterations: 10
         },
         criterias: [],
         hosts: []
@@ -154,14 +115,15 @@ class ExperimentCreatePage extends React.Component<Props, State> {
       hostsOfGateway: [],
       metricNames: [],
       showAdvanced: history.location.pathname.endsWith('/new') ? true : this.props.showAdvanced,
-      showTrafficStep: true,
+      showMaxIncrement: true,
       reloadService: false,
-      totalDuration: '50 minutes',
+      totalDuration: '5 mins',
       hostState: initHost(''),
       value: '',
       filename: '',
       addHostGateway: false,
-      showTrafficControl: false
+      showTrafficControl: false,
+      showDurationControl: false
     };
   }
 
@@ -177,7 +139,7 @@ class ExperimentCreatePage extends React.Component<Props, State> {
       this.setState(prevState => {
         const newExperiment = prevState.experiment;
         newExperiment.baseline = '';
-        newExperiment.candidate = '';
+        newExperiment.candidates = [];
         newExperiment.namespace = allNamespaces[0];
         return {
           experiment: newExperiment,
@@ -414,7 +376,7 @@ class ExperimentCreatePage extends React.Component<Props, State> {
   createExperiment = () => {
     const nsName = this.state.experiment.namespace;
     this.promises
-      .register('Create Iter8 Experiment', API.createExperiment(nsName, JSON.stringify(this.state.experiment)))
+      .register('Create Iter8 Experiment', API.createExperiment(nsName, JSON.stringify(this.state.experiment), {}))
       .then(_ => this.goExperimentsPage())
       .catch(error => AlertUtils.addError('Could not create Experiment.', error));
   };
@@ -437,22 +399,29 @@ class ExperimentCreatePage extends React.Component<Props, State> {
             newExperiment.service = value.trim();
             break;
           case 'algorithm':
-            if (value.trim() === 'check_and_increment') {
+            if (value.trim() === 'progressive') {
               this.setState({
-                showTrafficStep: true
+                showMaxIncrement: true
               });
             } else {
               this.setState({
-                showTrafficStep: false
+                showMaxIncrement: false
               });
             }
             newExperiment.trafficControl.algorithm = value.trim();
+            break;
+          case 'onTermination':
+            newExperiment.trafficControl.onTermination = value.trim();
             break;
           case 'baseline':
             newExperiment.baseline = value.trim();
             break;
           case 'candidate':
-            newExperiment.candidate = value.trim();
+            let candidates = value.trim().split(',');
+            candidates = candidates.map(function (el) {
+              return el.trim();
+            });
+            newExperiment.candidates = candidates;
             break;
           case 'kubernets':
             newExperiment.apiversion = 'v1';
@@ -489,24 +458,21 @@ class ExperimentCreatePage extends React.Component<Props, State> {
         const newExperiment = prevState.experiment;
         switch (field) {
           case 'maxIteration':
-            newExperiment.trafficControl.maxIterations = value;
+            newExperiment.duration.maxIterations = value;
             break;
-          case 'maxTrafficPercentage':
-            newExperiment.trafficControl.maxTrafficPercentage = value;
-            break;
-          case 'trafficStepSize':
-            newExperiment.trafficControl.trafficStepSize = value;
+          case 'maxIncrement':
+            newExperiment.trafficControl.maxIncrement = value;
             break;
           case 'tolerance':
             newExperiment.criterias[0].tolerance = value;
             break;
           case 'interval':
-            newExperiment.trafficControl.intervalInSecond = value;
-            newExperiment.trafficControl.interval = newExperiment.trafficControl.intervalInSecond + 's';
+            newExperiment.duration.intervalInSecond = value;
+            newExperiment.duration.interval = newExperiment.duration.intervalInSecond + 's';
             break;
           default:
         }
-        const totalSecond = newExperiment.trafficControl.maxIterations * newExperiment.trafficControl.intervalInSecond;
+        const totalSecond = newExperiment.duration.maxIterations * newExperiment.duration.intervalInSecond;
         const hours = Math.floor(totalSecond / 60 / 60);
         const minutes = Math.floor(totalSecond / 60) - hours * 60;
         return {
@@ -530,101 +496,17 @@ class ExperimentCreatePage extends React.Component<Props, State> {
         this.state.experiment.experimentKind === 'Service') &&
       this.state.experiment.namespace !== '' &&
       this.state.experiment.baseline !== '' &&
-      this.state.experiment.candidate !== ''
+      this.state.experiment.candidates.length !== 0
     );
   };
 
   isTCFormValid = (): boolean => {
-    return (
-      this.state.experiment.trafficControl.interval !== '' && this.state.experiment.trafficControl.maxIterations > 0
-    );
+    return this.state.experiment.duration.interval !== '' && this.state.experiment.duration.maxIterations > 0;
   };
 
   isSCFormValid = (): boolean => {
     return this.state.experiment.criterias.length !== 0;
   };
-
-  renderGeneral() {
-    return (
-      <>
-        <FormGroup
-          fieldId="name"
-          label="Experiment Name"
-          isRequired={true}
-          isValid={this.state.experiment.name !== '' && this.state.experiment.name.search(regex) === 0}
-          helperTextInvalid="Name cannot be empty and must be a DNS subdomain name as defined in RFC 1123."
-        >
-          <TextInput
-            id="name"
-            value={this.state.experiment.name}
-            placeholder="Experiment Name"
-            onChange={value => this.changeExperiment('name', value)}
-          />
-        </FormGroup>
-        <FormGroup label="Istio Resource" fieldId="istio-resource">
-          <FormSelect
-            value={this.state.experiment.experimentKind}
-            onChange={this.onExperimentKindChange}
-            id="istio-resource"
-            name="istio-resource"
-          >
-            {iter8oExpOptions.map((option, index) => (
-              <FormSelectOption key={index} value={option.value} label={option.label} />
-            ))}
-          </FormSelect>
-        </FormGroup>
-
-        <FormGroup
-          fieldId="baseline"
-          label="Baseline"
-          isRequired={true}
-          isValid={this.state.experiment.baseline !== ''}
-          helperText="The baseline deployment of the target service (i.e. reviews-v1)"
-          helperTextInvalid="Baseline deployment cannot be empty"
-        >
-          <FormSelect
-            id="baseline"
-            value={this.state.experiment.baseline}
-            placeholder="Baseline Deployment"
-            onChange={value => this.changeExperiment('baseline', value)}
-          >
-            {this.state.workloads.map((wk, index) => (
-              <FormSelectOption label={wk} key={'workloadBaseline' + index} value={wk} />
-            ))}
-          </FormSelect>
-        </FormGroup>
-
-        <FormGroup
-          fieldId="candidate"
-          label="Select Candidate"
-          isRequired={true}
-          isValid={this.state.experiment.candidate !== ''}
-          helperText="The candidate deployment of the target service (i.e. reviews-v2)"
-          helperTextInvalid="Candidate deployment cannot be empty"
-        >
-          <TextInput
-            id="candidate"
-            value={this.state.experiment.candidate}
-            placeholder="Select from list or enter a new one"
-            onChange={value => this.changeExperiment('candidate', value)}
-            list={'candidateName'}
-            autoComplete={'off'}
-          />
-          <datalist id="candidateName">
-            {this.state.workloads.map((wk, index) =>
-              wk !== this.state.experiment.baseline ? (
-                <option label={wk} key={'workloadCandidate' + index} value={wk}>
-                  {wk}
-                </option>
-              ) : (
-                ''
-              )
-            )}
-          </datalist>
-        </FormGroup>
-      </>
-    );
-  }
 
   renderBaselineSelect() {
     const isDeployment = this.state.experiment.experimentKind === 'Deployment';
@@ -661,20 +543,20 @@ class ExperimentCreatePage extends React.Component<Props, State> {
     const usingMap = this.state.experiment.experimentKind === 'Deployment' ? this.state.workloads : this.state.services;
     return [
       <FormGroup
-        fieldId="candidate"
-        label={isDeployment ? 'Deployment Candidate' : 'Service Candidate'}
+        fieldId="candidates"
+        label={isDeployment ? 'Deployment Candidate(s)' : 'Service Candidate(s)'}
         isRequired={true}
-        isValid={this.state.experiment.candidate !== ''}
+        isValid={this.state.experiment.candidates.length !== 0}
         helperText={
           isDeployment
-            ? 'The candidate deployment of the target service (i.e. reviews-v2)'
-            : 'The candidate service (i.e. reviews)'
+            ? 'Name or a List of names of candidate deployment of the target service (i.e. reviews-v2, or reviews-v2,reviews-v3)'
+            : 'Name or a List of names of candidate service (i.e. reviews)'
         }
         helperTextInvalid={isDeployment ? 'Candidate deployment cannot be empty' : 'Candidate service cannot be empty'}
       >
         <TextInput
           id="candidate"
-          value={this.state.experiment.candidate}
+          value={this.state.experiment.candidates.join(',')}
           placeholder="Select from list or enter a new one"
           onChange={value => this.changeExperiment('candidate', value)}
           list={'candidateName'}
@@ -795,77 +677,33 @@ class ExperimentCreatePage extends React.Component<Props, State> {
     );
   }
 
-  renderTrafficInWizard() {
-    return (
-      <>
-        <FormGroup
-          fieldId="interval"
-          label="Interval (seconds)"
-          isValid={this.state.experiment.trafficControl.interval !== ''}
-          helperText="Frequency with which the controller calls the analytics service"
-          helperTextInvalid="Interval cannot be empty"
-        >
-          <TextInput
-            id="interval"
-            value={this.state.experiment.trafficControl.intervalInSecond}
-            placeholder="Time interval i.e. 30s"
-            onChange={value => this.changeExperimentNumber('interval', Number(value))}
-          />
-        </FormGroup>
+  onAddToList = (newCriteria: Criteria, newHost: Host) => {
+    this.setState(prevState => {
+      if (newHost != null && newHost.name !== '') {
+        prevState.experiment.hosts.push(newHost);
+      } else if (newCriteria != null) {
+        prevState.experiment.criterias.push(newCriteria);
+      }
+      return {
+        iter8Info: prevState.iter8Info,
+        experiment: {
+          name: prevState.experiment.name,
+          namespace: prevState.experiment.namespace,
+          service: prevState.experiment.service,
+          apiversion: prevState.experiment.apiversion,
+          baseline: prevState.experiment.baseline,
+          candidates: prevState.experiment.candidates,
+          trafficControl: prevState.experiment.trafficControl,
+          criterias: prevState.experiment.criterias,
+          hosts: prevState.experiment.hosts,
+          duration: prevState.experiment.duration,
+          experimentKind: prevState.experiment.experimentKind
+        }
+      };
+    });
+  };
 
-        <FormGroup
-          fieldId="maxIteration"
-          label="Maximum Iteration"
-          isValid={this.state.experiment.trafficControl.maxIterations > 0}
-          helperText="Maximum number of iterations for this experiment"
-          helperTextInvalid="Maximun Iteration cannot be empty"
-        >
-          <TextInput
-            id="maxIteration"
-            type="number"
-            value={this.state.experiment.trafficControl.maxIterations}
-            placeholder="Maximum Iteration"
-            onChange={value => this.changeExperimentNumber('maxIteration', Number(value))}
-          />
-        </FormGroup>
-
-        <FormGroup
-          fieldId="algorithm"
-          label="Algorithm"
-          helperText="Strategy used to analyze the candidate and shift the traffic"
-        >
-          <FormSelect
-            value={this.state.experiment.trafficControl.algorithm}
-            id="algorithm"
-            name="Algorithm"
-            onChange={value => this.changeExperiment('algorithm', value)}
-          >
-            {algorithms.map((option, index) => (
-              <FormSelectOption isDisabled={false} key={'p' + index} value={option} label={option} />
-            ))}
-          </FormSelect>
-        </FormGroup>
-
-        <FormGroup
-          style={this.state.showTrafficStep ? {} : { display: 'none' }}
-          fieldId="trafficStepSize"
-          label="Traffic Step Size"
-          isValid={this.state.experiment.trafficControl.trafficStepSize > 0}
-          helperText="The maximum traffic increment per iteration"
-          helperTextInvalid="Traffic Step Size must be > 0"
-        >
-          <TextInput
-            id="trafficStepSize"
-            value={this.state.experiment.trafficControl.trafficStepSize}
-            placeholder="Traffic Step Size"
-            onChange={value => this.changeExperimentNumber('trafficStepSize', parseFloat(value))}
-          />
-        </FormGroup>
-      </>
-    );
-  }
-
-  renderTraffic() {
+  renderDuration() {
     return (
       <>
         <Grid gutter="md">
@@ -876,13 +714,13 @@ class ExperimentCreatePage extends React.Component<Props, State> {
             <FormGroup
               fieldId="interval"
               label="Interval (seconds)"
-              isValid={this.state.experiment.trafficControl.interval !== ''}
+              isValid={this.state.experiment.duration.interval !== ''}
               helperText="Frequency with which the controller calls the analytics service"
               helperTextInvalid="Interval cannot be empty"
             >
               <TextInput
                 id="interval"
-                value={this.state.experiment.trafficControl.intervalInSecond}
+                value={this.state.experiment.duration.intervalInSecond}
                 placeholder="Time interval i.e. 30s"
                 onChange={value => this.changeExperimentNumber('interval', Number(value))}
               />
@@ -892,19 +730,28 @@ class ExperimentCreatePage extends React.Component<Props, State> {
             <FormGroup
               fieldId="maxIteration"
               label="Maximum Iteration"
-              isValid={this.state.experiment.trafficControl.maxIterations > 0}
+              isValid={this.state.experiment.duration.maxIterations > 0}
               helperText="Maximum number of iterations for this experiment"
               helperTextInvalid="Maximun Iteration cannot be empty"
             >
               <TextInput
                 id="maxIteration"
                 type="number"
-                value={this.state.experiment.trafficControl.maxIterations}
+                value={this.state.experiment.duration.maxIterations}
                 placeholder="Maximum Iteration"
                 onChange={value => this.changeExperimentNumber('maxIteration', Number(value))}
               />
             </FormGroup>
           </GridItem>
+        </Grid>
+      </>
+    );
+  }
+
+  renderTraffic() {
+    return (
+      <>
+        <Grid gutter="md">
           <GridItem span={6}>
             <FormGroup
               fieldId="algorithm"
@@ -925,18 +772,37 @@ class ExperimentCreatePage extends React.Component<Props, State> {
           </GridItem>
           <GridItem span={6}>
             <FormGroup
-              style={this.state.showTrafficStep ? {} : { display: 'none' }}
-              fieldId="trafficStepSize"
-              label="Traffic Step Size"
-              isValid={this.state.experiment.trafficControl.trafficStepSize > 0}
-              helperText="The maximum traffic increment per iteration"
-              helperTextInvalid="Traffic Step Size must be > 0"
+              fieldId="onTermination"
+              label="onTermination"
+              helperText="The traffic split behavior after the termination of the experiment."
+            >
+              <FormSelect
+                value={this.state.experiment.trafficControl.onTermination}
+                id="onTermination"
+                name="On Termination"
+                onChange={value => this.changeExperiment('onTermination', value)}
+              >
+                {onTermination.map((option, index) => (
+                  <FormSelectOption isDisabled={false} key={'ot' + index} value={option} label={option} />
+                ))}
+              </FormSelect>
+            </FormGroup>
+          </GridItem>
+
+          <GridItem span={12}>
+            <FormGroup
+              style={this.state.showMaxIncrement ? {} : { display: 'none' }}
+              fieldId="maxIncrement"
+              label="Max Increment"
+              isValid={this.state.experiment.trafficControl.maxIncrement > 0}
+              helperText="Maximum possible increase in traffic for a candidate in a single iteration (measured in percent). Default value: 2 (percent)"
+              helperTextInvalid="Max Increment must be > 0"
             >
               <TextInput
-                id="trafficStepSize"
-                value={this.state.experiment.trafficControl.trafficStepSize}
-                placeholder="Traffic Step Size"
-                onChange={value => this.changeExperimentNumber('trafficStepSize', parseFloat(value))}
+                id="maxIncrement"
+                value={this.state.experiment.trafficControl.maxIncrement}
+                placeholder="Max Increment"
+                onChange={value => this.changeExperimentNumber('maxIncrement', parseFloat(value))}
               />
             </FormGroup>
           </GridItem>
@@ -944,31 +810,6 @@ class ExperimentCreatePage extends React.Component<Props, State> {
       </>
     );
   }
-
-  onAddToList = (newCriteria: Criteria, newHost: Host) => {
-    this.setState(prevState => {
-      if (newHost != null && newHost.name !== '') {
-        prevState.experiment.hosts.push(newHost);
-      } else if (newCriteria != null) {
-        prevState.experiment.criterias.push(newCriteria);
-      }
-      return {
-        iter8Info: prevState.iter8Info,
-        experiment: {
-          name: prevState.experiment.name,
-          namespace: prevState.experiment.namespace,
-          service: prevState.experiment.service,
-          apiversion: prevState.experiment.apiversion,
-          baseline: prevState.experiment.baseline,
-          candidate: prevState.experiment.candidate,
-          trafficControl: prevState.experiment.trafficControl,
-          criterias: prevState.experiment.criterias,
-          hosts: prevState.experiment.hosts,
-          experimentKind: prevState.experiment.experimentKind
-        }
-      };
-    });
-  };
 
   onRemoveFromList = (type: string, index: number) => {
     this.setState(prevState => {
@@ -986,10 +827,11 @@ class ExperimentCreatePage extends React.Component<Props, State> {
           service: prevState.experiment.service,
           apiversion: prevState.experiment.apiversion,
           baseline: prevState.experiment.baseline,
-          candidate: prevState.experiment.candidate,
+          candidates: prevState.experiment.candidates,
           trafficControl: prevState.experiment.trafficControl,
           criterias: prevState.experiment.criterias,
           hosts: prevState.experiment.hosts,
+          duration: prevState.experiment.duration,
           experimentKind: prevState.experiment.experimentKind
         }
       };
@@ -1025,45 +867,25 @@ class ExperimentCreatePage extends React.Component<Props, State> {
     );
   }
 
-  renderSimplePage() {
-    return (
-      <>
-        <hr />
-        <Expandable
-          toggleText={
-            this.state.showAdvanced
-              ? history.location.pathname.endsWith('/new')
-                ? toggleTextFlat[1]
-                : toggleTextWizard[1]
-              : history.location.pathname.endsWith('/new')
-              ? toggleTextFlat[0]
-              : toggleTextWizard[0]
-          }
-          isExpanded={this.state.showAdvanced}
-          onToggle={() => {
-            this.setState({
-              showAdvanced: !this.state.showAdvanced
-            });
-          }}
-        >
-          {this.renderCriteria()}
-          <hr />
-          <p>&nbsp; &nbsp;&nbsp;</p>
-          <h1 className="pf-c-title pf-m-xl">Traffic Control </h1>
-          <div className={durationTimeStyle}>Total Experiment Duration: {this.state.totalDuration}</div>
-          {this.renderTrafficInWizard()}
-          <p>&nbsp; &nbsp;&nbsp;</p>
-          {this.renderHost()}
-        </Expandable>{' '}
-      </>
-    );
-  }
-
   renderFullPage() {
     return (
       <>
         {this.renderCriteria()}
         <Form>
+          <FormGroup label="Show Duration" fieldId="showDuration">
+            <Switch
+              id="showDuration"
+              label={' '}
+              labelOff={' '}
+              isChecked={this.state.showDurationControl}
+              onChange={this.onChangeShowDurationControl}
+            />
+          </FormGroup>
+          {this.state.showDurationControl && (
+            <FormGroup label="Experiment Duration" fieldId="drationControall">
+              {this.renderDuration()}
+            </FormGroup>
+          )}
           <FormGroup label="Show Traffic Control" fieldId="showTrafficControl">
             <Switch
               id="showTrafficControl"
@@ -1074,9 +896,74 @@ class ExperimentCreatePage extends React.Component<Props, State> {
             />
           </FormGroup>
           {this.state.showTrafficControl && (
-            <FormGroup label="Traffic Control" fieldId="trafficControl">
-              {this.renderTraffic()}
-            </FormGroup>
+            <>
+              <FormGroup
+                /* label="Traffic Control"*/
+                fieldId="trafficControl"
+                label={
+                  <Popover
+                    position={'right'}
+                    hideOnOutsideClick={true}
+                    maxWidth={'40rem'}
+                    headerContent={<div>Traffic Control</div>}
+                    bodyContent={
+                      <div>
+                        <p>
+                          Configuration that affect how application traffic is split across different versions of the
+                          service during and after the experiment.
+                        </p>{' '}
+                        <b>Traffic Control Strategies:</b> (reference{' '}
+                        <a href="https://iter8.tools/reference/algorithms/#traffic-control-strategies" target="_blank">
+                          here
+                        </a>{' '}
+                        for detail )
+                        <table>
+                          <tr className={'tr'}>
+                            <td>Progressive:&nbsp;</td>
+                            <td>Progressively shift all traffic to the winner.</td>
+                          </tr>
+                          <tr>
+                            <td>top_2:&nbsp;</td>
+                            <td>Converge towards a 50-50 traffic split between the best two versions</td>
+                          </tr>
+                          <tr>
+                            <td>uniform:&nbsp;</td>
+                            <td>Converge towards a uniform traffic split across all versions.</td>
+                          </tr>
+                        </table>{' '}
+                        <b>On Termination: </b>
+                        <table>
+                          <tr>
+                            <td valign={'top'}>to_winner:&nbsp;</td>
+                            <td>
+                              If a winning version is found at the end of the experiment, all traffic will flow to this
+                              version after the experiment terminates.
+                            </td>
+                          </tr>
+                          <tr>
+                            <td valign={'top'}>to_baseline:&nbsp;</td>
+                            <td>All traffic will flow to the baseline version, after the experiment terminates. </td>
+                          </tr>
+                          <tr>
+                            <td valign={'top'}>keep_last:&nbsp;</td>
+                            <td>
+                              Ensure that the traffic split used during the final iteration of the experiment continues
+                              even after the experiment has terminated
+                            </td>
+                          </tr>
+                        </table>
+                      </div>
+                    }
+                  >
+                    <Button variant="link">
+                      Traffic Control <HelpIcon noVerticalAlign />
+                    </Button>
+                  </Popover>
+                }
+              >
+                {this.renderTraffic()}
+              </FormGroup>
+            </>
           )}
           <FormGroup label="Add Host/Gateway" fieldId="addHostGateway">
             <Switch
@@ -1113,6 +1000,14 @@ class ExperimentCreatePage extends React.Component<Props, State> {
     });
   };
 
+  onChangeShowDurationControl = () => {
+    this.setState(prevState => {
+      return {
+        showDurationControl: !prevState.showDurationControl
+      };
+    });
+  };
+
   render() {
     const isFormValid = this.isMainFormValid() && this.isSCFormValid();
     return (
@@ -1120,43 +1015,38 @@ class ExperimentCreatePage extends React.Component<Props, State> {
         <RenderContent>
           <div className={containerPadding}>
             <Form className={formPadding} isHorizontal={true}>
-              {history.location.pathname.endsWith('/new') ? this.renderFullGeneral() : this.renderGeneral()}
-              {history.location.pathname.endsWith('/new') ? this.renderFullPage() : this.renderSimplePage()}
-
-              {history.location.pathname.endsWith('/new') ? (
-                <ActionGroup>
-                  <span
-                    style={{
-                      float: 'left',
-                      paddingTop: '10px',
-                      paddingBottom: '10px',
-                      width: '100%'
-                    }}
-                  >
-                    <span style={{ float: 'right', paddingRight: '5px' }}>
-                      <Button
-                        variant={ButtonVariant.primary}
-                        isDisabled={!isFormValid}
-                        onClick={() => this.createExperiment()}
-                      >
-                        Create
-                      </Button>
-                    </span>
-                    <span style={{ float: 'right', paddingRight: '5px' }}>
-                      <Button
-                        variant={ButtonVariant.secondary}
-                        onClick={() => {
-                          this.goExperimentsPage();
-                        }}
-                      >
-                        Cancel
-                      </Button>
-                    </span>
+              {this.renderFullGeneral()}
+              {this.renderFullPage()}
+              <ActionGroup>
+                <span
+                  style={{
+                    float: 'left',
+                    paddingTop: '10px',
+                    paddingBottom: '10px',
+                    width: '100%'
+                  }}
+                >
+                  <span style={{ float: 'right', paddingRight: '5px' }}>
+                    <Button
+                      variant={ButtonVariant.primary}
+                      isDisabled={!isFormValid}
+                      onClick={() => this.createExperiment()}
+                    >
+                      Create
+                    </Button>
                   </span>
-                </ActionGroup>
-              ) : (
-                ''
-              )}
+                  <span style={{ float: 'right', paddingRight: '5px' }}>
+                    <Button
+                      variant={ButtonVariant.secondary}
+                      onClick={() => {
+                        this.goExperimentsPage();
+                      }}
+                    >
+                      Cancel
+                    </Button>
+                  </span>
+                </span>
+              </ActionGroup>
             </Form>
           </div>
         </RenderContent>

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCriteriaForm.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCriteriaForm.tsx
@@ -91,8 +91,7 @@ class ExperimentCriteriaForm extends React.Component<Props, State> {
   actionResolver = (rowData, { rowIndex }) => {
     const removeAction = {
       title: 'Remove Criteria',
-      // @ts-ignore
-      onClick: (event, rowIndex, rowData, extraData) => {
+      onClick: (_, rowIndex) => {
         this.props.onRemove('Criteria', rowIndex);
       }
     };

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCriteriaForm.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCriteriaForm.tsx
@@ -17,21 +17,26 @@ import history from '../../../../app/History';
 const headerCells: ICell[] = [
   {
     title: 'Metric Name',
-    transforms: [cellWidth(20) as any],
+    transforms: [cellWidth(30) as any],
     props: {}
   },
   {
     title: 'Threshold',
-    transforms: [wrappable],
+    transforms: [wrappable, cellWidth(10) as any],
     props: {}
   },
   {
     title: 'Threshold Type',
-    transforms: [wrappable, cellWidth(20) as any],
+    transforms: [wrappable, cellWidth(15) as any],
     props: {}
   },
   {
     title: 'Stop on Failure',
+    transforms: [wrappable],
+    props: {}
+  },
+  {
+    title: 'Reward',
     transforms: [wrappable],
     props: {}
   },
@@ -43,12 +48,12 @@ const headerCells: ICell[] = [
 
 const toleranceType: NameValuePair[] = [
   {
-    name: 'threshold',
+    name: 'absolute',
     value: 'absolute'
   },
   {
-    name: 'delta',
-    value: 'delta'
+    name: 'relative',
+    value: 'relative'
   }
 ];
 
@@ -104,7 +109,7 @@ class ExperimentCriteriaForm extends React.Component<Props, State> {
         tolerance: prevState.addCriteria.tolerance,
         toleranceType: prevState.addCriteria.toleranceType,
         stopOnFailure: prevState.addCriteria.stopOnFailure,
-        sampleSize: 5
+        isReward: prevState.addCriteria.isReward
       },
       validName: true
     }));
@@ -117,7 +122,7 @@ class ExperimentCriteriaForm extends React.Component<Props, State> {
         tolerance: parseFloat(value.trim()),
         toleranceType: prevState.addCriteria.toleranceType,
         stopOnFailure: prevState.addCriteria.stopOnFailure,
-        sampleSize: 5
+        isReward: prevState.addCriteria.isReward
       },
       validName: true
     }));
@@ -129,7 +134,7 @@ class ExperimentCriteriaForm extends React.Component<Props, State> {
         tolerance: prevState.addCriteria.tolerance,
         toleranceType: value.trim(),
         stopOnFailure: prevState.addCriteria.stopOnFailure,
-        sampleSize: 5
+        isReward: prevState.addCriteria.isReward
       },
       validName: true
     }));
@@ -142,7 +147,20 @@ class ExperimentCriteriaForm extends React.Component<Props, State> {
         tolerance: prevState.addCriteria.tolerance,
         toleranceType: prevState.addCriteria.toleranceType,
         stopOnFailure: !prevState.addCriteria.stopOnFailure,
-        sampleSize: 5
+        isReward: prevState.addCriteria.isReward
+      },
+      validName: true
+    }));
+  };
+
+  onIsReward = () => {
+    this.setState(prevState => ({
+      addCriteria: {
+        metric: prevState.addCriteria.metric,
+        tolerance: prevState.addCriteria.tolerance,
+        toleranceType: prevState.addCriteria.toleranceType,
+        stopOnFailure: prevState.addCriteria.stopOnFailure,
+        isReward: !prevState.addCriteria.isReward
       },
       validName: true
     }));
@@ -163,8 +181,9 @@ class ExperimentCriteriaForm extends React.Component<Props, State> {
           cells: [
             <>{gw.metric}</>,
             <>{gw.tolerance}</>,
-            <>{gw.toleranceType === 'threshold' ? 'abosulte' : 'delta'}</>,
-            <>{gw.stopOnFailure ? 'true' : 'false'}</>
+            <>{gw.toleranceType}</>,
+            <>{gw.stopOnFailure ? 'true' : 'false'}</>,
+            <>{gw.isReward ? 'true' : 'false'}</>
           ]
         }))
         .concat([
@@ -209,12 +228,22 @@ class ExperimentCriteriaForm extends React.Component<Props, State> {
               </>,
               <>
                 <Checkbox
-                  label="Stop On Failure"
+                  label="YES"
                   id="stopOnFailure"
                   name="stopOnFailure"
                   aria-label="Stop On Failure"
                   isChecked={this.state.addCriteria.stopOnFailure}
                   onChange={this.onAddStopOnFailure}
+                />
+              </>,
+              <>
+                <Checkbox
+                  label="YES"
+                  id="isReward"
+                  name="isReward"
+                  aria-label="Reward"
+                  isChecked={this.state.addCriteria.isReward}
+                  onChange={this.onIsReward}
                 />
               </>,
               <>
@@ -236,7 +265,7 @@ class ExperimentCriteriaForm extends React.Component<Props, State> {
         cells: [
           <>{gw.metric}</>,
           <>{gw.tolerance}</>,
-          <>{gw.toleranceType === 'threshold' ? 'abosulte' : 'delta'}</>,
+          <>{gw.toleranceType}</>,
           <>{gw.stopOnFailure ? 'true' : 'false'}</>
         ]
       }));

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentDetailsPage.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentDetailsPage.tsx
@@ -3,33 +3,29 @@ import * as React from 'react';
 import ParameterizedTabs, { activeTab } from '../../../../components/Tab/Tabs';
 import { Link, RouteComponentProps } from 'react-router-dom';
 import { RenderHeader } from '../../../../components/Nav/Page';
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  Card,
-  CardBody,
-  Stack,
-  StackItem,
-  Tab,
-  Text,
-  TextVariants,
-  Title
-} from '@patternfly/react-core';
+import { Breadcrumb, BreadcrumbItem, Tab } from '@patternfly/react-core';
 import { style } from 'typestyle';
 import * as API from '../../../../services/Api';
 import * as AlertUtils from '../../../../utils/AlertUtils';
-import { ExperimentAction, Iter8ExpDetailsInfo, Iter8Info } from '../../../../types/Iter8';
-import Iter8Dropdown from './Iter8Dropdown';
+import {
+  emptyExperimentDetailsInfo,
+  ExperimentAction,
+  Iter8ExpDetailsInfo,
+  Iter8Info,
+  MetricProgressInfo
+} from '../../../../types/Iter8';
+import Iter8Dropdown, { ManualOverride } from './Iter8Dropdown';
 import history from '../../../../app/History';
 import * as FilterHelper from '../../../../components/FilterList/FilterHelper';
 import { connect } from 'react-redux';
 
 import ExperimentInfoDescription from './ExperimentInfoDescription';
 import CriteriaInfoDescription from './CriteriaInfoDescription';
+import AssessmentInfoDescription from './AssessmentInfoDescription';
 import { KialiAppState } from '../../../../store/Store';
 import { durationSelector } from '../../../../store/Selectors';
 import { PfColors } from '../../../../components/Pf/PfColors';
-import { DurationInSeconds } from '../../../../types/Common';
+import { DurationInSeconds, TimeInMilliseconds } from '../../../../types/Common';
 import RefreshContainer from '../../../../components/Refresh/Refresh';
 
 interface ExpeerimentId {
@@ -43,14 +39,15 @@ interface Props extends RouteComponentProps<ExpeerimentId> {
 
 interface State {
   iter8Info: Iter8Info;
-  experiment?: Iter8ExpDetailsInfo;
+  experiment: Iter8ExpDetailsInfo;
   currentTab: string;
   canDelete: boolean;
   target: string;
   baseline: string;
-  candidate: string;
   actionTaken: string;
   resetActionFlag: boolean;
+  manualOverride: ManualOverride;
+  lastRefreshAt: TimeInMilliseconds;
 }
 
 const tabName = 'tab';
@@ -58,7 +55,8 @@ const defaultTab = 'overview';
 
 const tabIndex: { [tab: string]: number } = {
   info: 0,
-  criteria: 1
+  assessment: 1,
+  criteria: 2
 };
 const extensionHeader = style({
   padding: '0px 20px 16px 0px',
@@ -71,8 +69,15 @@ const breadcrumbPadding = style({
 class ExperimentDetailsPage extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
-
     const urlParams = new URLSearchParams(history.location.search);
+
+    let baseline = urlParams.get('baseline') || '';
+    let candidates = urlParams.get('candidates')?.split(',') || [];
+    let trafficSplit = new Map<string, number>();
+    trafficSplit.set(baseline, 0);
+    candidates.forEach(c => {
+      trafficSplit.set(c, 0);
+    });
     this.state = {
       iter8Info: {
         enabled: false,
@@ -80,16 +85,36 @@ class ExperimentDetailsPage extends React.Component<Props, State> {
         analyticsImageVersion: '',
         controllerImageVersion: ''
       },
-      experiment: undefined,
+      experiment: emptyExperimentDetailsInfo,
       canDelete: false,
       currentTab: activeTab(tabName, defaultTab),
       target: urlParams.get('target') || '',
-      baseline: urlParams.get('baseline') || '',
-      candidate: urlParams.get('candidate') || '',
+      baseline: baseline,
       actionTaken: '',
-      resetActionFlag: false
+      resetActionFlag: false,
+      manualOverride: {
+        TrafficSplit: trafficSplit,
+        totalTrafficSplitPercentage: 0
+      },
+      lastRefreshAt: Date.now()
     };
   }
+
+  initTrafficSplit = (experiment): ManualOverride => {
+    if (this.state.manualOverride.TrafficSplit.size !== 0) {
+      return this.state.manualOverride;
+    } else {
+      let trafficSplit = new Map<string, number>();
+      trafficSplit.set(experiment.experimentItem.baseline.name, 0);
+      experiment.experimentItem.candidates.forEach(c => {
+        trafficSplit.set(c.name, 0);
+      });
+      return {
+        TrafficSplit: trafficSplit,
+        totalTrafficSplitPercentage: 0
+      };
+    }
+  };
 
   fetchExperiment = () => {
     const namespace = this.props.match.params.namespace;
@@ -100,19 +125,24 @@ class ExperimentDetailsPage extends React.Component<Props, State> {
         if (iter8Info.enabled) {
           API.getExperiment(namespace, name)
             .then(result => {
+              let manualOverride = this.initTrafficSplit(result.data);
               if (this.state.resetActionFlag) {
                 this.setState({
                   iter8Info: iter8Info,
                   actionTaken: '',
                   experiment: result.data,
                   canDelete: result.data.permissions.delete,
-                  resetActionFlag: false
+                  resetActionFlag: false,
+                  manualOverride: manualOverride,
+                  lastRefreshAt: Date.now()
                 });
               } else {
                 this.setState({
                   experiment: result.data,
                   canDelete: result.data.permissions.delete,
-                  resetActionFlag: true
+                  resetActionFlag: true,
+                  manualOverride: manualOverride,
+                  lastRefreshAt: Date.now()
                 });
               }
             })
@@ -123,6 +153,7 @@ class ExperimentDetailsPage extends React.Component<Props, State> {
           AlertUtils.addError('Kiali has Iter8 extension enabled but it is not detected in the cluster');
         }
       })
+
       .catch(error => {
         AlertUtils.addError('Could not fetch Iter8 Info.', error);
       });
@@ -132,14 +163,11 @@ class ExperimentDetailsPage extends React.Component<Props, State> {
     this.fetchExperiment();
   }
 
-  componentDidUpdate() {
-    if (this.state.currentTab !== activeTab(tabName, defaultTab)) {
-      this.setState(
-        {
-          currentTab: activeTab(tabName, defaultTab)
-        },
-        () => this.doRefresh()
-      );
+  componentDidUpdate(prevProps: Props) {
+    if (this.state.currentTab !== activeTab(tabName, defaultTab) || prevProps.duration !== this.props.duration) {
+      this.setState({
+        currentTab: activeTab(tabName, defaultTab)
+      });
     }
   }
 
@@ -170,105 +198,6 @@ class ExperimentDetailsPage extends React.Component<Props, State> {
     );
   };
 
-  renderOverview = () => {
-    return (
-      <Card style={{ height: '100%' }}>
-        <CardBody>
-          <Title headingLevel="h3" size="2xl">
-            {' '}
-            Target Service{' '}
-          </Title>
-          <Stack>
-            <StackItem id={'targetService'}>
-              <Text component={TextVariants.h3}> Service </Text>
-              {this.state.experiment ? this.state.experiment.experimentItem.targetService : ''}
-            </StackItem>
-            <StackItem id={'baseline'}>
-              <Text component={TextVariants.h3}> Baseline / Traffic Split</Text>
-              {this.state.experiment
-                ? this.state.experiment.experimentItem.baseline +
-                  ' / ' +
-                  this.state.experiment.experimentItem.baselinePercentage +
-                  ' % '
-                : ''}
-            </StackItem>
-            <StackItem id={'candidate'}>
-              <Text component={TextVariants.h3}> Candidate / Traffic Split</Text>
-              {this.state.experiment
-                ? this.state.experiment.experimentItem.candidate +
-                  ' / ' +
-                  this.state.experiment.experimentItem.candidatePercentage +
-                  ' % '
-                : ''}
-            </StackItem>
-          </Stack>
-        </CardBody>
-      </Card>
-    );
-  };
-
-  renderTrafficControl = () => {
-    return (
-      <Card style={{ height: '100%' }}>
-        <CardBody>
-          <Title headingLevel="h3" size="2xl">
-            {' '}
-            Traffic Control{' '}
-          </Title>
-          <Stack>
-            <StackItem id={'strategy'}>
-              <Text component={TextVariants.h3}> Strategy </Text>
-              {this.state.experiment ? this.state.experiment.trafficControl.algorithm : ''}
-            </StackItem>
-            <StackItem id={'maxIterations'}>
-              <Text component={TextVariants.h3}> Max Iterations </Text>
-              {this.state.experiment ? this.state.experiment.trafficControl.maxIterations : ''}
-            </StackItem>
-            <StackItem id={'maxTrafficPercentage'}>
-              <Text component={TextVariants.h3}> Max Traffic Percentage </Text>
-              {this.state.experiment ? this.state.experiment.trafficControl.maxTrafficPercentage : ''}
-            </StackItem>
-            <StackItem id={'trafficStepSide'}>
-              <Text component={TextVariants.h3}> Traffic Step Side </Text>
-              {this.state.experiment ? this.state.experiment.trafficControl.trafficStepSize : ''}
-            </StackItem>
-          </Stack>
-        </CardBody>
-      </Card>
-    );
-  };
-
-  renderStatus = () => {
-    return (
-      <Card style={{ height: '100%' }}>
-        <CardBody>
-          <Title headingLevel="h3" size="2xl">
-            {' '}
-            Status{' '}
-          </Title>
-          <Stack>
-            <StackItem id={'phase'}>
-              <Text component={TextVariants.h3}> Phase </Text>
-              {this.state.experiment ? this.state.experiment.experimentItem.phase : ''}
-            </StackItem>
-            <StackItem id={'status'}>
-              <Text component={TextVariants.h3}> Status </Text>
-              {this.state.experiment ? this.state.experiment.experimentItem.status : ''}
-            </StackItem>
-            <StackItem id={'started'}>
-              <Text component={TextVariants.h3}> Started </Text>
-              {this.state.experiment ? this.state.experiment.experimentItem.startedAt : ''}
-            </StackItem>
-            <StackItem id={'ended'}>
-              <Text component={TextVariants.h3}> Ended </Text>
-              {this.state.experiment ? this.state.experiment.experimentItem.endedAt : ''}
-            </StackItem>
-          </Stack>
-        </CardBody>
-      </Card>
-    );
-  };
-
   backToList = () => {
     // Back to list page
     history.push(`/extensions/iter8?namespaces=${this.props.match.params.namespace}`);
@@ -286,11 +215,25 @@ class ExperimentDetailsPage extends React.Component<Props, State> {
       });
   };
 
+  doTrafficSplit = (manualOverride: ManualOverride) => {
+    this.setState(prevState => {
+      prevState.manualOverride.TrafficSplit = manualOverride.TrafficSplit;
+      prevState.manualOverride.totalTrafficSplitPercentage = manualOverride.totalTrafficSplitPercentage;
+      return {
+        manualOverride: prevState.manualOverride
+      };
+    });
+  };
+
   doIter8Action = (requestAction: string): void => {
     let errMsg = 'Could not' + requestAction + ' Iter8 Experiment';
     const action: ExperimentAction = {
-      action: requestAction
+      action: requestAction,
+      trafficSplit: []
     };
+    if (requestAction === 'terminate') {
+      action.trafficSplit = Array.from(this.state.manualOverride.TrafficSplit.entries());
+    }
     this.setState({ actionTaken: requestAction });
     API.updateExperiment(this.props.match.params.namespace, this.props.match.params.name, JSON.stringify(action))
       .then(() => this.doRefresh())
@@ -300,37 +243,22 @@ class ExperimentDetailsPage extends React.Component<Props, State> {
       });
   };
 
-  canAction = (action: string): boolean => {
-    switch (action) {
-      case 'Completed':
-        return (
-          this.state.experiment !== undefined &&
-          this.state.experiment.experimentItem.startedAt !== 0 &&
-          this.state.experiment.experimentItem.endedAt === 0
-        );
-    }
-    return (
-      this.state.experiment !== undefined &&
-      this.state.experiment.experimentItem.startedAt !== 0 &&
-      this.state.experiment.experimentItem.phase === action
-    );
-  };
-
   renderRightToolbar = () => {
     return (
       <span style={{ position: 'absolute', right: '20px', zIndex: 1 }}>
         <RefreshContainer id="time_range_refresh" hideLabel={true} handleRefresh={this.doRefresh} manageURL={true} />
         <Iter8Dropdown
           experimentName={this.props.match.params.name}
+          manualOverride={this.state.manualOverride}
           canDelete={this.state.canDelete}
-          startedAt={this.state.experiment ? this.state.experiment.experimentItem.startedAt : 0}
-          endedAt={this.state.experiment ? this.state.experiment.experimentItem.endedAt : 0}
+          startTime={this.state.experiment ? this.state.experiment.experimentItem.startTime : ''}
+          endTime={this.state.experiment ? this.state.experiment.experimentItem.endTime : ''}
           phase={this.state.experiment ? this.state.experiment.experimentItem.phase : ' '}
           onDelete={this.doDelete}
           onResume={() => this.doIter8Action('resume')}
           onPause={() => this.doIter8Action('pause')}
-          onSuccess={() => this.doIter8Action('override_success')}
-          onFailure={() => this.doIter8Action('override_failure')}
+          onTerminate={() => this.doIter8Action('terminate')}
+          doTrafficSplit={this.doTrafficSplit}
         />
       </span>
     );
@@ -345,21 +273,46 @@ class ExperimentDetailsPage extends React.Component<Props, State> {
           target={this.state.target}
           experimentDetails={this.state.experiment}
           duration={FilterHelper.currentDuration()}
-          baseline={this.state.baseline}
-          candidate={this.state.candidate}
           actionTaken={this.state.actionTaken}
         />
       </Tab>
     );
+    var metricProgressInfo: Map<string, MetricProgressInfo> = new Map<string, MetricProgressInfo>(); //= new Array(this.state.experiment.criterias.length);
+    for (const c of this.state.experiment.criterias) {
+      metricProgressInfo.set(c.name, {
+        name: c.name,
+        threshold: c.criteria.tolerance,
+        thresholdType: c.criteria.toleranceType,
+        preferred_direction: c.metric.preferred_direction,
+        isReward: c.criteria.isReward,
+        unit: c.metric.numerator.unit
+      });
+    }
+
+    const assessmentTab = (
+      <Tab eventKey={1} title="Assessment" key="Assessment">
+        <AssessmentInfoDescription
+          lastRefreshAt={this.state.lastRefreshAt}
+          iter8Info={this.state.iter8Info}
+          name={this.props.match.params.name}
+          namespace={this.props.match.params.namespace}
+          experimentItem={this.state.experiment.experimentItem}
+          metricInfo={metricProgressInfo}
+          duration={this.props.duration}
+          fetchOp={() => this.fetchExperiment()}
+        />
+      </Tab>
+    );
+
     const criteriaTab = (
-      <Tab eventKey={1} title="Criteria" key="Criteria">
+      <Tab eventKey={2} title="Criteria" key="Criteria">
         <CriteriaInfoDescription
           iter8Info={this.state.iter8Info}
           criterias={this.state.experiment ? this.state.experiment.criterias : []}
         />
       </Tab>
     );
-    const tabsArray: any[] = [overviewTab, criteriaTab];
+    const tabsArray: any[] = [overviewTab, assessmentTab, criteriaTab];
     return (
       <>
         <RenderHeader>
@@ -377,7 +330,7 @@ class ExperimentDetailsPage extends React.Component<Props, State> {
           defaultTab={defaultTab}
           postHandler={this.fetchExperiment}
           activeTab={this.state.currentTab}
-          mountOnEnter={false}
+          mountOnEnter={true}
           unmountOnExit={true}
         >
           {tabsArray}

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentDetailsPage.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentDetailsPage.tsx
@@ -277,7 +277,7 @@ class ExperimentDetailsPage extends React.Component<Props, State> {
         />
       </Tab>
     );
-    var metricProgressInfo: Map<string, MetricProgressInfo> = new Map<string, MetricProgressInfo>(); //= new Array(this.state.experiment.criterias.length);
+    const metricProgressInfo: Map<string, MetricProgressInfo> = new Map<string, MetricProgressInfo>(); //= new Array(this.state.experiment.criterias.length);
     for (const c of this.state.experiment.criterias) {
       metricProgressInfo.set(c.name, {
         name: c.name,

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentHostForm.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentHostForm.tsx
@@ -57,7 +57,7 @@ class ExperimentHostForm extends React.Component<Props, HostState> {
     const removeAction = {
       title: 'Remove Host',
       // @ts-ignore
-      onClick: (event, rowIndex, rowData, extraData) => {
+      onClick: (event, rowIndex) => {
         this.props.onRemove('Host', rowIndex);
       }
     };

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentInfoDescription.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentInfoDescription.tsx
@@ -35,11 +35,9 @@ import history from '../../../../app/History';
 interface ExperimentInfoDescriptionProps {
   target: string;
   namespace: string;
-  experimentDetails?: Iter8ExpDetailsInfo;
+  experimentDetails: Iter8ExpDetailsInfo;
   experiment: string;
   duration: number;
-  baseline: string;
-  candidate: string;
   actionTaken: string;
 }
 
@@ -50,6 +48,7 @@ type MiniGraphCardState = {
 class ExperimentInfoDescription extends React.Component<ExperimentInfoDescriptionProps, MiniGraphCardState> {
   constructor(props) {
     super(props);
+
     this.state = { isKebabOpen: false };
   }
 
@@ -60,7 +59,7 @@ class ExperimentInfoDescription extends React.Component<ExperimentInfoDescriptio
   serviceInfo() {
     return [
       <DataListCell key="service-icon" isIcon={true}>
-        <Badge>S</Badge>
+        <Badge className={'virtualitem_badge_definition'}>S</Badge>
       </DataListCell>,
       <DataListCell key="targetService">
         <Text component={TextVariants.h3}>Service</Text>
@@ -95,33 +94,43 @@ class ExperimentInfoDescription extends React.Component<ExperimentInfoDescriptio
     let badgeKind = kind === 'Deployment' ? 'W' : 'S';
     return [
       <DataListCell key="workload-icon" isIcon={true}>
-        <Badge>{badgeKind}</Badge>
+        <Badge className={'virtualitem_badge_definition'}>{badgeKind}</Badge>
       </DataListCell>,
-      <DataListCell key="baseline">
+      <DataListCell key={bname}>
         <Text component={TextVariants.h3}>{bname}</Text>
         <List>{workloadList}</List>
       </DataListCell>
     ];
   }
 
+  candidatesInfo() {
+    this.props.experimentDetails?.experimentItem.candidates.map(can => {
+      let kind = this.props.experimentDetails?.experimentItem.kind
+        ? this.props.experimentDetails?.experimentItem.kind
+        : 'Deployment';
+      return this.baselineInfo('Candidate', can.name, kind);
+    });
+  }
+
   percentageInfo(bname: string, bpercentage: number) {
     return [
       <DataListCell key={bname}>
-        <Text component={TextVariants.h3}>Percentage</Text>
+        <Text component={TextVariants.h3}>Weight</Text>
         <Text>{bpercentage} %</Text>
       </DataListCell>
     ];
   }
 
-  gatewayInfo(badgeKind: string, nameString: string, namespace: string, gatewayname: string) {
+  gatewayInfo(badgeKind: string, namespace: string, gatewayname: string) {
     let linkTo = '/namespaces/' + namespace + '/istio/gateways/' + gatewayname;
     return [
       <DataListCell key="workload-icon" isIcon={true}>
-        <Badge>{badgeKind}</Badge>
+        <Badge className={'virtualitem_badge_definition'}>{badgeKind}</Badge>
       </DataListCell>,
       <DataListCell key="gateway">
+        <Text>Gateway</Text>
         <Text component={TextVariants.h3}>
-          <Link to={linkTo}>{nameString}</Link>
+          <Link to={linkTo}>{gatewayname}</Link>
         </Text>
       </DataListCell>
     ];
@@ -146,6 +155,7 @@ class ExperimentInfoDescription extends React.Component<ExperimentInfoDescriptio
         Show traffic graph
       </DropdownItem>
     ];
+
     return [
       <CardHead>
         <CardActions>
@@ -159,6 +169,8 @@ class ExperimentInfoDescription extends React.Component<ExperimentInfoDescriptio
         </CardActions>
         <CardHeader>
           <Title style={{ float: 'left' }} headingLevel="h3" size="2xl">
+            <Badge className={'virtualitem_badge_definition'}>{this.props.experimentDetails.experimentType}</Badge>
+            &nbsp;&nbsp;
             {this.props.experimentDetails !== undefined ? this.props.experimentDetails.experimentItem.name : 'N/A'}
           </Title>
         </CardHeader>
@@ -184,6 +196,7 @@ class ExperimentInfoDescription extends React.Component<ExperimentInfoDescriptio
         ? true
         : false
       : false;
+
     return (
       <RenderComponentScroll>
         <Grid gutter="md" style={{ margin: '10px' }}>
@@ -208,49 +221,51 @@ class ExperimentInfoDescription extends React.Component<ExperimentInfoDescriptio
                       <DataListItemCells
                         dataListCells={this.baselineInfo(
                           'Baseline',
-                          this.props.experimentDetails ? this.props.experimentDetails.experimentItem.baseline : '',
+                          this.props.experimentDetails ? this.props.experimentDetails.experimentItem.baseline.name : '',
                           this.props.experimentDetails ? this.props.experimentDetails.experimentItem.kind : ''
                         )}
                       />
                       <DataListItemCells
                         dataListCells={this.percentageInfo(
                           'Baseline',
-                          this.props.experimentDetails
-                            ? this.props.experimentDetails.experimentItem.baselinePercentage
-                            : 0
+                          this.props.experimentDetails ? this.props.experimentDetails.experimentItem.baseline.weight : 0
                         )}
                       />
                     </DataListItemRow>
                   </DataListItem>
-                  <DataListItem aria-labelledby="Candidate">
-                    <DataListItemRow>
-                      <DataListItemCells
-                        dataListCells={this.baselineInfo(
-                          'Candidate',
-                          this.props.experimentDetails ? this.props.experimentDetails.experimentItem.candidate : '',
-                          this.props.experimentDetails ? this.props.experimentDetails.experimentItem.kind : ''
-                        )}
-                      />
-                      <DataListItemCells
-                        dataListCells={this.percentageInfo(
-                          'Candidate',
-                          this.props.experimentDetails
-                            ? this.props.experimentDetails.experimentItem.candidatePercentage
-                            : 0
-                        )}
-                      />
-                    </DataListItemRow>
-                  </DataListItem>
+                  {this.props.experimentDetails?.experimentItem.candidates.map(can => {
+                    let kind = this.props.experimentDetails?.experimentItem.kind
+                      ? this.props.experimentDetails?.experimentItem.kind
+                      : 'Deployment';
+                    return (
+                      <DataListItem aria-labelledby="Candidate">
+                        <DataListItemRow>
+                          <DataListItemCells dataListCells={this.baselineInfo('Candidate', can.name, kind)} />
+                          <DataListItemCells dataListCells={this.percentageInfo('Candidate', can.weight)} />
+                        </DataListItemRow>
+                      </DataListItem>
+                    );
+                  })}
                   {hasHosts ? (
                     <DataListItem aria-labelledby="Gateway">
                       <DataListItemRow>
                         <DataListItemCells
                           dataListCells={this.gatewayInfo(
-                            'G',
-                            this.props.experimentDetails ? this.props.experimentDetails.hosts[0].name : '',
+                            'H',
+
                             this.props.namespace,
                             this.props.experimentDetails ? this.props.experimentDetails.hosts[0].gateway : ''
                           )}
+                        />
+                        <DataListItemCells
+                          dataListCells={
+                            <DataListCell key="gateway">
+                              <Text>Name</Text>
+                              <Text component={TextVariants.h3}>
+                                {this.props.experimentDetails ? this.props.experimentDetails.hosts[0].name : ''}
+                              </Text>
+                            </DataListCell>
+                          }
                         />
                       </DataListItemRow>
                     </DataListItem>
@@ -273,11 +288,43 @@ class ExperimentInfoDescription extends React.Component<ExperimentInfoDescriptio
                     <Text component={TextVariants.h3}> Phase: </Text>
                     {this.props.experimentDetails ? this.props.experimentDetails.experimentItem.phase : ''}
                   </StackItem>
-                  <StackItem id={'assessment'}>
-                    <Text component={TextVariants.h3}> Assessment: </Text>
-                    {this.props.experimentDetails && this.props.experimentDetails.experimentItem.assessmentConclusion
-                      ? this.getConclusionList(this.props.experimentDetails.experimentItem.assessmentConclusion)
-                      : ''}
+                  <StackItem id={'Winner'}>
+                    {this.props.experimentDetails.experimentItem.endTime !== '' ? (
+                      <Grid>
+                        <GridItem span={12}>
+                          <StackItem>
+                            {this.props.experimentDetails.experimentItem.winner.winning_version_found ? (
+                              <>
+                                <Text component={TextVariants.h3}> Winner Found: </Text>
+                                {this.props.experimentDetails.experimentItem.winner.name}
+                              </>
+                            ) : (
+                              <Text component={TextVariants.h3}> Winner not Found </Text>
+                            )}
+                          </StackItem>
+                        </GridItem>
+                      </Grid>
+                    ) : (
+                      <Grid>
+                        <GridItem span={6}>
+                          <StackItem>
+                            <Text component={TextVariants.h3}>
+                              {' '}
+                              {this.props.experimentDetails.experimentItem.endTime == ''
+                                ? 'Current Best Version'
+                                : 'Winner Version'}{' '}
+                            </Text>
+                            {this.props.experimentDetails.experimentItem.winner.name}
+                          </StackItem>
+                        </GridItem>
+                        <GridItem span={6}>
+                          <StackItem>
+                            <Text component={TextVariants.h3}> Probability of Winning: </Text>
+                            {this.props.experimentDetails.experimentItem.winner.probability_of_winning_for_best_version}
+                          </StackItem>
+                        </GridItem>
+                      </Grid>
+                    )}
                   </StackItem>
                   <StackItem>
                     <Grid>
@@ -286,10 +333,8 @@ class ExperimentInfoDescription extends React.Component<ExperimentInfoDescriptio
                           <Text component={TextVariants.h3}> Created at </Text>
                           <LocalTime
                             time={
-                              this.props.experimentDetails && this.props.experimentDetails.experimentItem.createdAt
-                                ? new Date(
-                                    this.props.experimentDetails.experimentItem.createdAt / 1000000
-                                  ).toISOString()
+                              this.props.experimentDetails && this.props.experimentDetails.experimentItem.initTime
+                                ? this.props.experimentDetails.experimentItem.initTime
                                 : ''
                             }
                           />
@@ -300,10 +345,8 @@ class ExperimentInfoDescription extends React.Component<ExperimentInfoDescriptio
                           <Text component={TextVariants.h3}> Started at </Text>
                           <LocalTime
                             time={
-                              this.props.experimentDetails && this.props.experimentDetails.experimentItem.startedAt
-                                ? new Date(
-                                    this.props.experimentDetails.experimentItem.startedAt / 1000000
-                                  ).toISOString()
+                              this.props.experimentDetails && this.props.experimentDetails.experimentItem.startTime
+                                ? this.props.experimentDetails.experimentItem.startTime
                                 : ''
                             }
                           />
@@ -314,8 +357,8 @@ class ExperimentInfoDescription extends React.Component<ExperimentInfoDescriptio
                           <Text component={TextVariants.h3}> Ended at </Text>
                           <LocalTime
                             time={
-                              this.props.experimentDetails && this.props.experimentDetails.experimentItem.endedAt
-                                ? new Date(this.props.experimentDetails.experimentItem.endedAt / 1000000).toISOString()
+                              this.props.experimentDetails && this.props.experimentDetails.experimentItem.endTime
+                                ? this.props.experimentDetails.experimentItem.endTime
                                 : ''
                             }
                           />
@@ -346,9 +389,13 @@ class ExperimentInfoDescription extends React.Component<ExperimentInfoDescriptio
 
   private showFullMetric = () => {
     const graphUrl = `/namespaces/${this.props.namespace}/services/${this.props.target}?tab=metrics&bylbl=destination_version`;
-
+    var candidateVersions: string[];
+    candidateVersions = [];
+    this.props.experimentDetails?.experimentItem.candidates.map(can => {
+      candidateVersions.push(can.version);
+    });
     if (this.props.experimentDetails !== undefined) {
-      const params = `=${this.props.experimentDetails.experimentItem.baselineVersion},${this.props.experimentDetails.experimentItem.candidateVersion}`;
+      const params = `=${this.props.experimentDetails.experimentItem.baseline.version},${candidateVersions.join()}`;
       history.push(graphUrl + encodeURIComponent(params));
     } else {
       history.push(graphUrl);

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentInfoDescription.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentInfoDescription.tsx
@@ -310,7 +310,7 @@ class ExperimentInfoDescription extends React.Component<ExperimentInfoDescriptio
                           <StackItem>
                             <Text component={TextVariants.h3}>
                               {' '}
-                              {this.props.experimentDetails.experimentItem.endTime == ''
+                              {this.props.experimentDetails.experimentItem.endTime === ''
                                 ? 'Current Best Version'
                                 : 'Winner Version'}{' '}
                             </Text>

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/Iter8Dropdown.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/Iter8Dropdown.tsx
@@ -233,7 +233,7 @@ class Iter8Dropdown extends React.Component<Props, State> {
   };
 
   renderDropdownItems = (): any => {
-    var items: any[] = [];
+    let items: any[] = [];
     if (this.props.canDelete) {
       items = items.concat(
         <DropdownItem

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/Iter8Dropdown.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/Iter8Dropdown.tsx
@@ -5,47 +5,63 @@ import {
   DropdownItem,
   DropdownPosition,
   DropdownToggle,
+  Form,
+  FormGroup,
   Modal,
   Text,
   TextVariants,
   Tooltip,
   TooltipPosition
 } from '@patternfly/react-core';
+import { TextInputBase as TextInput } from '@patternfly/react-core/dist/js/components/TextInput/TextInput';
+
+export type ManualOverride = {
+  TrafficSplit: Map<string, number>;
+  totalTrafficSplitPercentage: number;
+};
 
 type Props = {
   experimentName: string;
+  manualOverride: ManualOverride;
   canDelete: boolean;
-  startedAt: number;
-  endedAt: number;
+  startTime: string;
+  endTime: string;
   phase: string;
   onDelete: () => void;
   onPause: () => void;
   onResume: () => void;
-  onSuccess: () => void;
-  onFailure: () => void;
+  onTerminate: () => void;
+  doTrafficSplit: (manualOverride: ManualOverride) => void;
 };
 
 type State = {
   showDeleteConfirmModal: boolean;
   showPauseConfirmModal: boolean;
   showResumeConfirmModal: boolean;
-  showSuccessConfirmModal: boolean;
-  showFailureConfirmModal: boolean;
+  showTerminateConfirmModal: boolean;
   dropdownOpen: boolean;
+  manualOverride: ManualOverride;
+  candidates: string[];
 };
 
-const ITER8_ACTIONS = ['Pause', 'Resume', 'Terminate with Failure', 'Terminate with Success'];
+const ITER8_ACTIONS = ['Pause', 'Resume', 'Terminate'];
 
 class Iter8Dropdown extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
+    let candidates: string[] = [];
+    this.props.manualOverride.TrafficSplit.forEach((_, key: string) => {
+      candidates.push(key);
+    });
+
     this.state = {
       dropdownOpen: false,
       showDeleteConfirmModal: false,
       showPauseConfirmModal: false,
       showResumeConfirmModal: false,
-      showSuccessConfirmModal: false,
-      showFailureConfirmModal: false
+      showTerminateConfirmModal: false,
+      manualOverride: this.props.manualOverride,
+      candidates: candidates
     };
   }
 
@@ -72,11 +88,8 @@ class Iter8Dropdown extends React.Component<Props, State> {
       case 'Resume':
         this.setState({ showResumeConfirmModal: action });
         break;
-      case 'Terminate with Success':
-        this.setState({ showSuccessConfirmModal: action });
-        break;
-      case 'Terminate with Failure':
-        this.setState({ showFailureConfirmModal: action });
+      case 'Terminate':
+        this.setState({ showTerminateConfirmModal: action });
         break;
     }
   };
@@ -93,13 +106,56 @@ class Iter8Dropdown extends React.Component<Props, State> {
       case 'Resume':
         this.props.onResume();
         break;
-      case 'Terminate with Success':
-        this.props.onSuccess();
-        break;
-      case 'Terminate with Failure':
-        this.props.onFailure();
+      case 'Terminate':
+        this.props.onTerminate();
         break;
     }
+  };
+
+  setTrafficSplit(val, name) {
+    this.setState(
+      prevState => {
+        let total = 0;
+        prevState.manualOverride.TrafficSplit.set(name, val);
+        for (let entry of Array.from(prevState.manualOverride.TrafficSplit.entries())) {
+          total = total + Number(entry[1]);
+        }
+        prevState.manualOverride.totalTrafficSplitPercentage = total;
+
+        return {
+          manualOverride: prevState.manualOverride
+        };
+      },
+      () => this.props.doTrafficSplit(this.state.manualOverride)
+    );
+  }
+
+  trafficSplitRules = () => {
+    return (
+      <Form isHorizontal={true}>
+        {this.state.candidates.map(c => {
+          return (
+            <>
+              <FormGroup
+                fieldId={c}
+                label={c}
+                isRequired={true}
+                helperTextInvalid="Total Percentage must be equal to 100%"
+                isValid={this.state.manualOverride.totalTrafficSplitPercentage === 100}
+              >
+                <TextInput
+                  id={c}
+                  type="number"
+                  value={this.state.manualOverride[c]}
+                  placeholder="Traffic Split Percentage"
+                  onChange={value => this.setTrafficSplit(value, c)}
+                />
+              </FormGroup>
+            </>
+          );
+        })}
+      </Form>
+    );
   };
 
   GenConfirmModal = (action: string, extraMsg: string, isThisOpen: boolean) => {
@@ -123,6 +179,8 @@ class Iter8Dropdown extends React.Component<Props, State> {
           Are you sure you want to {action.toLowerCase().split(' ', 3)[0]} the Iter8 experiment "
           {this.props.experimentName}"{extraMsg}
         </Text>
+
+        {action === 'Terminate' ? <>{this.trafficSplitRules()}</> : ''}
       </Modal>
     );
   };
@@ -130,9 +188,9 @@ class Iter8Dropdown extends React.Component<Props, State> {
   canAction = (action: string, phase: string): boolean => {
     switch (action) {
       case 'Terminate':
-        return this.props.startedAt !== 0 && this.props.endedAt === 0;
+        return this.props.startTime !== '' && this.props.endTime === '';
     }
-    return this.props.startedAt !== 0 && this.props.phase === phase;
+    return this.props.startTime !== '' && this.props.phase === phase;
   };
 
   renderTooltip = (key, position, msg, child): any => {
@@ -149,9 +207,9 @@ class Iter8Dropdown extends React.Component<Props, State> {
     let checkPhase = actionString === 'Pause' ? 'Progressing' : 'Pause';
 
     let msgString =
-      this.props.startedAt === 0
+      this.props.startTime === ''
         ? '. Action "' + actionString + '" can only be done once experiment is started. '
-        : this.props.endedAt !== 0
+        : this.props.endTime !== ''
         ? '. Action "' + actionString + '" can only be done while experiment is running. '
         : '';
 
@@ -215,14 +273,9 @@ class Iter8Dropdown extends React.Component<Props, State> {
           this.state.showPauseConfirmModal
         )}
         {this.GenConfirmModal(
-          'Terminate with Success',
-          ' indicating that the candidate succeeded?',
-          this.state.showSuccessConfirmModal
-        )}
-        {this.GenConfirmModal(
-          'Terminate with Failure',
-          ' indicating that the candidate failed?',
-          this.state.showFailureConfirmModal
+          'Terminate',
+          '? Please specify traffic split rule ',
+          this.state.showTerminateConfirmModal
         )}
       </>
     );

--- a/src/pages/extensions/iter8/Iter8ExperimentList/FiltersAndSorts.ts
+++ b/src/pages/extensions/iter8/Iter8ExperimentList/FiltersAndSorts.ts
@@ -70,29 +70,13 @@ const filterByBaseline = (items: Iter8Experiment[], names: string[]): Iter8Exper
     if (names.length > 0) {
       baselineFiltered = false;
       for (let i = 0; i < names.length; i++) {
-        if (item.baseline.includes(names[i])) {
+        if (item.baseline.name.includes(names[i])) {
           baselineFiltered = true;
           break;
         }
       }
     }
     return baselineFiltered;
-  });
-};
-
-const filterByCandidate = (items: Iter8Experiment[], names: string[]): Iter8Experiment[] => {
-  return items.filter(item => {
-    let candidateFiltered = true;
-    if (names.length > 0) {
-      candidateFiltered = false;
-      for (let i = 0; i < names.length; i++) {
-        if (item.candidate.includes(names[i])) {
-          candidateFiltered = true;
-          break;
-        }
-      }
-    }
-    return candidateFiltered;
   });
 };
 
@@ -123,13 +107,6 @@ export const filterBy = (iter8Experiment: Iter8Experiment[], filters: ActiveFilt
   const baselineSelected = getFilterSelectedValues(baselineFilter, filters);
   if (baselineSelected.length > 0) {
     ret = filterByBaseline(ret, baselineSelected);
-  }
-
-  // We may have to perform a second round of filtering, using data fetched asynchronously (health)
-  // If not, exit fast
-  const candidateSelected = getFilterSelectedValues(candidateFilter, filters);
-  if (candidateSelected.length > 0) {
-    return filterByCandidate(ret, candidateSelected);
   }
 
   const phaseSelected = getFilterSelectedValues(phaseFilter, filters);

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -16,6 +16,7 @@ import ExperimentListPage from './pages/extensions/iter8/Iter8ExperimentList/Exp
 import ExperimentCreatePageContainer from './pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCreatePage';
 import ExperimentDetailsPage from './pages/extensions/iter8/Iter8ExperimentDetails/ExperimentDetailsPage';
 import ThreeScaleNewPageContainer from './pages/extensions/threescale/ThreeScaleNew/ThreeScaleNewPage';
+import ExperimentCreateFromFileContainer from './pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCreateFromFile';
 
 /**
  * Return array of objects that describe vertical menu
@@ -194,6 +195,10 @@ const extensionsRoutes: Path[] = [
   {
     path: '/extensions/iter8/new',
     component: ExperimentCreatePageContainer
+  },
+  {
+    path: '/extensions/iter8/newFromFile',
+    component: ExperimentCreateFromFileContainer
   },
   {
     path: '/extensions/iter8',

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -175,6 +175,10 @@ const secondaryMastheadRoutes: Path[] = [
     component: DefaultSecondaryMasthead
   },
   {
+    path: '/extensions/threescale/newfromfile',
+    component: DefaultSecondaryMasthead
+  },
+  {
     path: '/extensions/iter8',
     component: DefaultSecondaryMasthead
   }

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -175,10 +175,6 @@ const secondaryMastheadRoutes: Path[] = [
     component: DefaultSecondaryMasthead
   },
   {
-    path: '/extensions/threescale/newfromfile',
-    component: DefaultSecondaryMasthead
-  },
-  {
     path: '/extensions/iter8',
     component: DefaultSecondaryMasthead
   }

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -537,8 +537,8 @@ export const deleteExperiment = (namespace: string, name: string) => {
   return newRequest<Iter8Experiment>(HTTP_VERBS.DELETE, urls.iter8Experiment(namespace, name), {}, {});
 };
 
-export const createExperiment = (namespace: string, specBody: string) => {
-  return newRequest<string>(HTTP_VERBS.POST, urls.iter8ExperimentsByNamespace(namespace), {}, specBody);
+export const createExperiment = (namespace: string, specBody: string, params) => {
+  return newRequest<string>(HTTP_VERBS.POST, urls.iter8ExperimentsByNamespace(namespace), params, specBody);
 };
 
 export const updateExperiment = (namespace: string, name: string, specBody: string) => {

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -31,7 +31,7 @@ import { TLSStatus } from '../types/TLSStatus';
 import { Pod, PodLogs, ValidationStatus } from '../types/IstioObjects';
 import { GrafanaInfo } from '../types/GrafanaInfo';
 import { Span, TracingQuery } from 'types/Tracing';
-import { Iter8ExpDetailsInfo, Iter8Experiment, Iter8Info } from '../types/Iter8';
+import { Iter8ExpDetailsInfo, Iter8Experiment, Iter8Info, ExperimentSpec } from '../types/Iter8';
 import { ComponentStatus } from '../types/IstioStatus';
 
 export const ANONYMOUS_USER = 'anonymous';
@@ -531,6 +531,10 @@ export const getExperimentsByNamespace = (namespace: string) => {
 
 export const getExperiment = (namespace: string, name: string) => {
   return newRequest<Iter8ExpDetailsInfo>(HTTP_VERBS.GET, urls.iter8Experiment(namespace, name), {}, {});
+};
+
+export const getExperimentYAML = (namespace: string, name: string) => {
+  return newRequest<ExperimentSpec>(HTTP_VERBS.GET, urls.iter8ExperimentYAML(namespace, name), {}, {});
 };
 
 export const deleteExperiment = (namespace: string, name: string) => {

--- a/src/types/Iter8.ts
+++ b/src/types/Iter8.ts
@@ -98,7 +98,10 @@ export interface Iter8ExpDetailsInfo {
   criterias: CriteriaInfoDetail[];
   trafficControl: TrafficControl;
   duration: Duration;
-  hosts: Host[];
+  networking: {
+    id: string;
+    hosts: Host[];
+  };
   permissions: ResourcePermissions;
   experimentType: string;
 }
@@ -145,7 +148,10 @@ export const emptyExperimentDetailsInfo: Iter8ExpDetailsInfo = {
     intervalInSecond: 30,
     maxIterations: 100
   },
-  hosts: [],
+  networking: {
+    id: '',
+    hosts: []
+  },
   permissions: {
     create: true,
     update: true,
@@ -225,6 +231,7 @@ export interface ExperimentSpec {
   criterias: Iter8Criteria[];
   duration: Duration;
   hosts: Host[];
+  routerID: string;
   experimentKind: string;
 }
 

--- a/src/types/Iter8.ts
+++ b/src/types/Iter8.ts
@@ -7,22 +7,74 @@ export interface Iter8Info {
   analyticsImageVersion: string;
 }
 
+export interface Iter8CandidateStatus {
+  name: string;
+  version: string;
+  weight: number;
+  winProbability: number;
+  requestCount: number;
+  criterionAssessment?: CriterionAssessment[];
+}
+
+export interface LowerUpper {
+  lower: number;
+  upper: number;
+}
+
+export interface RatioStatitics {
+  improvement_over_baseline: LowerUpper;
+  probability_of_beating_baseline: number;
+  probability_of_being_best_version: number;
+  credible_interval: LowerUpper;
+}
+
+export interface Statistics {
+  value: number;
+  ratio_statitics: RatioStatitics;
+}
+
+export interface ThresholdAssessment {
+  threshold_breached: boolean;
+  probability_of_satisfying_threshold: number;
+}
+
+export interface CriterionAssessment {
+  id: string;
+  metric_id: string;
+  statistics: Statistics;
+  threshold_assessment: ThresholdAssessment;
+}
+
+export interface MetricProgressInfo {
+  name: string;
+  threshold: number;
+  thresholdType: string;
+  preferred_direction: string;
+  unit: string;
+  isReward: boolean;
+}
 export interface Iter8Experiment {
   name: string;
   phase: string;
   targetService: string;
+  targetServiceNamespace: string;
   status: string;
-  baseline: string;
-  baselinePercentage: number;
-  baselineVersion: string;
-  candidate: string;
-  candidatePercentage: number;
-  candidateVersion: string;
+  baseline: Iter8CandidateStatus;
+  candidates: Iter8CandidateStatus[];
   namespace: string;
-  createdAt: number;
-  startedAt: number;
-  endedAt: number;
+  initTime: string;
+  startTime: string;
+  endTime: string;
+  winner: Winner;
   kind: string;
+  experimentKind: string;
+}
+
+export interface Winner {
+  name: string;
+  winning_version_found: boolean;
+  current_best_version: string;
+  probability_of_winning_for_best_version: number;
 }
 
 export interface ExpId {
@@ -32,78 +84,123 @@ export interface ExpId {
 
 export interface TrafficControl {
   algorithm: string;
-  interval: string;
-  maxIterations: number;
-  maxTrafficPercentage: number;
-  trafficStepSize: number;
+  maxIncrement: number;
+  onTermination: string;
 }
 
+export interface Duration {
+  interval: string;
+  intervalInSecond: number;
+  maxIterations: number;
+}
 export interface Iter8ExpDetailsInfo {
-  experimentItem: ExperimentItem;
-  criterias: SuccessCriteria[];
+  experimentItem: Iter8Experiment;
+  criterias: CriteriaInfoDetail[];
   trafficControl: TrafficControl;
+  duration: Duration;
   hosts: Host[];
   permissions: ResourcePermissions;
+  experimentType: string;
 }
 
-export interface ExperimentItem {
-  name: string;
-  namespace: string;
-  phase: string;
-  status: string;
-  createdAt: number;
-  startedAt: number;
-  endedAt: number;
-  baseline: string;
-  baselinePercentage: number;
-  baselineVersion: string;
-  candidate: string;
-  candidatePercentage: number;
-  candidateVersion: string;
-  targetService: string;
-  targetServiceNamespace: string;
-  assessmentConclusion: string[];
-  labels?: { [key: string]: string };
-  resourceVersion: string;
-  kind: string;
-}
-export interface SuccessCriteria {
-  name: string;
-  criteria: Criteria;
-  metric: Metric;
-  status: SuccessCriteriaStatus;
-}
-export interface Metric {
-  absent_value: string;
-  is_count: boolean;
-  query_template: string;
-  sample_size_template: string;
-}
+export const emptyExperimentItem: Iter8Experiment = {
+  name: '',
+  phase: '',
+  targetService: '',
+  targetServiceNamespace: '',
+  status: '',
+  baseline: {
+    name: '',
+    version: '',
+    weight: 0,
+    winProbability: 0,
+    requestCount: 0
+  },
+  candidates: [],
+  namespace: '',
+  initTime: '',
+  startTime: '',
+  endTime: '',
+  winner: {
+    name: '',
+    winning_version_found: false,
+    current_best_version: '',
+    probability_of_winning_for_best_version: 0
+  },
+  experimentKind: 'Canary',
+  kind: 'Deployment'
+};
 
-export interface SuccessCriteriaStatus {
-  conclusions: string[];
-  success_criterion_met: boolean;
-  abort_experiment: boolean;
-}
+export const emptyExperimentDetailsInfo: Iter8ExpDetailsInfo = {
+  experimentItem: emptyExperimentItem,
+  criterias: [],
+  trafficControl: {
+    algorithm: 'check_and_increment',
+    maxIncrement: 2,
+    onTermination: 'to_winner'
+  },
+  duration: {
+    interval: '30s',
+
+    intervalInSecond: 30,
+    maxIterations: 100
+  },
+  hosts: [],
+  permissions: {
+    create: true,
+    update: true,
+    delete: true
+  },
+  experimentType: 'C'
+};
 
 export type NameValuePair = {
   name: string;
   value: any;
 };
 
+export interface CounterMetric {
+  name: string;
+  query_template: string;
+  preferred_direction: string;
+  unit: string;
+}
+
+export interface Iter8Metric {
+  name: string;
+  numerator: CounterMetric;
+  denominator: CounterMetric;
+  zero_to_one: boolean;
+  preferred_direction: string;
+}
+
+export interface CriteriaInfoDetail {
+  name: string;
+  criteria: Iter8Criteria;
+  metric: Iter8Metric;
+}
+export interface Iter8Criteria {
+  metric: string;
+  tolerance: number;
+  toleranceType: string;
+  isReward: boolean;
+  stopOnFailure: boolean;
+}
+
 export interface Criteria {
   metric: string;
   tolerance: number;
   toleranceType: string;
-  sampleSize: number;
   stopOnFailure: boolean;
+  isReward: boolean;
 }
-export const initCriteria = (): Criteria => ({
+
+export const initCriteria = (): Iter8Criteria => ({
   metric: '',
   tolerance: 200,
-  toleranceType: 'threshold',
+  toleranceType: 'absolute',
   stopOnFailure: false,
-  sampleSize: 5
+  isReward: false
 });
 
 export interface Host {
@@ -113,6 +210,7 @@ export interface Host {
 
 export interface ExperimentAction {
   action: string;
+  trafficSplit: [string, number][];
 }
 
 export interface ExperimentSpec {
@@ -121,10 +219,13 @@ export interface ExperimentSpec {
   service: string;
   apiversion: string;
   baseline: string;
-  candidate: string;
+  candidates: string[];
   // canaryVersion: string;
   trafficControl: TrafficControl;
-  criterias: Criteria[];
+  criterias: Iter8Criteria[];
+  duration: Duration;
+  hosts: Host[];
+  experimentKind: string;
 }
 
 export const EmptyExperimentSpec = {
@@ -133,13 +234,17 @@ export const EmptyExperimentSpec = {
   apiversion: 'v1',
   service: '',
   baseline: '',
-  candidate: '',
+  candidate: [],
   trafficControl: {
-    algorithm: 'check_and_increment',
-    interval: '30s',
-    maxIterations: 100,
-    maxTrafficPercentage: 50,
-    trafficStepSize: 2
+    algorithm: 'progressive',
+    maxIncrement: 10
   },
-  criterias: []
+  duration: {
+    interval: '30s',
+    intervalInSecond: 30,
+    maxIterations: 10
+  },
+  criterias: [],
+  hosts: [],
+  experimentKind: 'Deployment'
 };


### PR DESCRIPTION
** Describe the change **
Support Iter8 v1.0.0 (Documentation - https://iter8.tools/)
Require PR [#3179] (https://github.com/kiali/kiali/pull/3179)
** Issue reference **
issue #2007

** Backwards compatible? **
Only support  Iter8 v1.0.0

[ ] Is your pull-request introducing changes in behaviour?

_Describe the changes if appropriate. E.g. a new link, a change on what a click does, etc_
Major changes
1. Add A/B/n support ( new badge for Experiment Type: Canary and A/B/n
2. Experiment Create Page, with additional CRD requirement
3. Experiment Detail page, with new tab "Assessment"
4. Allow creation of Experiment using YAML file ( with YAML editor or file upload)

** Screen Shot ***

![Screen Shot 2020-09-06 at 4 44 14 PM](https://user-images.githubusercontent.com/4615187/92334953-79d8cf00-f060-11ea-8f1a-fd03df79f056.png)

![Screen Shot 2020-09-06 at 4 44 35 PM](https://user-images.githubusercontent.com/4615187/92334958-80674680-f060-11ea-8730-86e886ba67a4.png)

![Screen Shot 2020-09-06 at 4 45 02 PM](https://user-images.githubusercontent.com/4615187/92334960-86f5be00-f060-11ea-8789-5ae108c4dc2d.png)
