### PR TITLE
Enable traces for app and workload nodes

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -216,7 +216,7 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps>
     }
 
     if (this.props.trace) {
-      showTrace(cy, this.props.trace);
+      showTrace(cy, this.props.graphData.fetchParams.graphType, this.props.trace);
     } else if (!this.props.trace && prevProps.trace) {
       hideTrace(cy);
     }

--- a/src/components/Details/DetailedTrafficList.tsx
+++ b/src/components/Details/DetailedTrafficList.tsx
@@ -11,7 +11,7 @@ import {
 import { cellWidth, ICell, IRow, Table, TableBody, TableHeader, TableVariant } from '@patternfly/react-table';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { NodeType, ProtocolTraffic, hasProtocolTraffic } from '../../types/Graph';
+import { NodeType, ProtocolTraffic, hasProtocolTraffic, DestService } from '../../types/Graph';
 import { Direction } from '../../types/MetricsOptions';
 import { REQUESTS_THRESHOLDS } from '../../types/Health';
 import history, { URLParam } from '../../app/History';
@@ -57,7 +57,7 @@ export interface ServiceNode {
   name: string;
   isServiceEntry?: string;
   isInaccessible: boolean;
-  destServices?: { namespace: string; name: string }[];
+  destServices?: DestService[];
 }
 
 export interface UnknownNode {

--- a/src/pages/Graph/SummaryLink.tsx
+++ b/src/pages/Graph/SummaryLink.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { NodeType, GraphNodeData } from '../../types/Graph';
+import { NodeType, GraphNodeData, DestService } from '../../types/Graph';
 import { CyNode, decoratedNodeData } from '../../components/CytoscapeGraph/CytoscapeGraphUtils';
 import { KialiIcon } from 'config/KialiIcon';
 import { Tooltip, Badge, PopoverPosition, TooltipPosition } from '@patternfly/react-core';
@@ -174,7 +174,7 @@ export const renderHealth = (health?: Health) => {
 
 export const renderDestServicesLinks = (node: any) => {
   const nodeData = decoratedNodeData(node);
-  const destServices = node.data(CyNode.destServices);
+  const destServices: DestService[] = node.data(CyNode.destServices);
 
   const links: any[] = [];
   if (!destServices) {

--- a/src/pages/Graph/SummaryPanelEdge.tsx
+++ b/src/pages/Graph/SummaryPanelEdge.tsx
@@ -255,7 +255,9 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
     if (isServiceEntry) {
       // For service entries, metrics are grouped by destination_service_name and we need to match it per "data.destServices"
       return getDatapoints(m, (metric: Metric) => {
-        return data.destServices && data.destServices.some(svc => svc.name === metric['destination_service_name']);
+        return data.destServices
+          ? data.destServices.some(svc => svc.name === metric['destination_service_name'])
+          : false;
       });
     }
     let label: string;

--- a/src/pages/Graph/SummaryPanelNode.tsx
+++ b/src/pages/Graph/SummaryPanelNode.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { renderDestServicesLinks, renderBadgedLink, renderHealth, renderBadgedHost } from './SummaryLink';
-import { NodeType, SummaryPanelPropType, DecoratedGraphNodeData } from '../../types/Graph';
+import { NodeType, SummaryPanelPropType, DecoratedGraphNodeData, DestService } from '../../types/Graph';
 import {
   shouldRefreshData,
   updateHealth,
@@ -79,7 +79,6 @@ export class SummaryPanelNode extends React.Component<SummaryPanelNodeProps, Sum
     const shouldRenderApp = app && ![NodeType.APP, NodeType.UNKNOWN].includes(nodeType);
     const shouldRenderWorkload = workload && ![NodeType.WORKLOAD, NodeType.UNKNOWN].includes(nodeType);
     const shouldRenderTraces =
-      nodeType === NodeType.SERVICE &&
       !nodeData.isInaccessible &&
       this.props.jaegerState.info &&
       this.props.jaegerState.info.enabled &&
@@ -157,11 +156,7 @@ export class SummaryPanelNode extends React.Component<SummaryPanelNodeProps, Sum
             </div>
           </Tab>
           <Tab style={summaryFont} title="Traces" eventKey={1}>
-            <SummaryPanelNodeTraces
-              namespace={nodeData.namespace}
-              app={nodeData.app || nodeData.service!}
-              queryTime={this.props.queryTime}
-            />
+            <SummaryPanelNodeTraces nodeData={nodeData} queryTime={this.props.queryTime} />
           </Tab>
         </SimpleTabs>
       </div>
@@ -207,7 +202,7 @@ export class SummaryPanelNode extends React.Component<SummaryPanelNodeProps, Sum
   };
 
   private renderDestServices = (data: DecoratedGraphNodeData) => {
-    const destServices = data.destServices;
+    const destServices: DestService[] | undefined = data.destServices;
 
     const entries: any[] = [];
     if (!destServices) {

--- a/src/pages/Graph/SummaryPanelNodeTraces.tsx
+++ b/src/pages/Graph/SummaryPanelNodeTraces.tsx
@@ -18,10 +18,10 @@ import { TimeInSeconds } from 'types/Common';
 import { TraceListItem } from 'components/JaegerIntegration/TraceListItem';
 import { summaryFont } from './SummaryPanelCommon';
 import transformTraceData from 'components/JaegerIntegration/JaegerResults/transform';
+import { DecoratedGraphNodeData } from 'types/Graph';
 
 type Props = {
-  namespace: string;
-  app: string;
+  nodeData: DecoratedGraphNodeData;
   queryTime: TimeInSeconds;
   setTraceId: (traceId?: string) => void;
   selectedTrace?: JaegerTrace;
@@ -84,10 +84,11 @@ class SummaryPanelNodeTraces extends React.Component<Props, State> {
 
   componentDidUpdate(prevProps: Props) {
     if (
-      this.state.useGraphRefresh &&
-      (prevProps.queryTime !== this.props.queryTime ||
-        prevProps.namespace !== this.props.namespace ||
-        prevProps.app !== this.props.app)
+      prevProps.queryTime !== this.props.queryTime ||
+      prevProps.nodeData.namespace !== this.props.nodeData.namespace ||
+      prevProps.nodeData.app !== this.props.nodeData.app ||
+      prevProps.nodeData.workload !== this.props.nodeData.workload ||
+      prevProps.nodeData.service !== this.props.nodeData.service
     ) {
       this.loadTraces();
     }
@@ -103,9 +104,15 @@ class SummaryPanelNodeTraces extends React.Component<Props, State> {
       startMicros: this.props.queryTime * 1000000,
       limit: tracesLimit
     };
+    const d = this.props.nodeData;
+    const promise = d.workload
+      ? API.getWorkloadTraces(d.namespace, d.workload, params)
+      : d.service
+      ? API.getServiceTraces(d.namespace, d.service, params)
+      : API.getAppTraces(d.namespace, d.app!, params);
     this.promises.cancelAll();
     this.promises
-      .register('traces', API.getAppTraces(this.props.namespace, this.props.app, params))
+      .register('traces', promise)
       .then(response => {
         const traces = response.data.data
           ? (response.data.data
@@ -133,7 +140,11 @@ class SummaryPanelNodeTraces extends React.Component<Props, State> {
   }
 
   render() {
-    const tracesDetailsURL = `/namespaces/${this.props.namespace}/applications/${this.props.app}?tab=traces`;
+    const d = this.props.nodeData;
+    const tracesDetailsURL =
+      `/namespaces/${d.namespace}` +
+      (d.workload ? `/workloads/${d.workload}` : d.service ? `/services/${d.service}` : `/applications/${d.app!}`) +
+      '?tab=traces';
     const currentID = this.props.selectedTrace?.traceID;
 
     return (

--- a/src/pages/Graph/SummaryPanelTraceDetails.tsx
+++ b/src/pages/Graph/SummaryPanelTraceDetails.tsx
@@ -95,9 +95,14 @@ class SummaryPanelTraceDetails extends React.Component<Props, State> {
 
   render() {
     const node = decoratedNodeData(this.props.node);
-    const tracesDetailsURL = node.app
-      ? `/namespaces/${node.namespace}/applications/${node.app}?tab=traces&${URLParam.JAEGER_TRACE_ID}=${this.props.trace.traceID}`
-      : undefined;
+    const tracesDetailsURL =
+      `/namespaces/${node.namespace}` +
+      (node.workload
+        ? `/workloads/${node.workload}`
+        : node.service
+        ? `/services/${node.service}`
+        : `/applications/${node.app!}`) +
+      `?tab=traces&${URLParam.JAEGER_TRACE_ID}=${this.props.trace.traceID}`;
     const jaegerTraceURL =
       node.app && this.props.jaegerURL ? `${this.props.jaegerURL}/trace/${this.props.trace.traceID}` : undefined;
     const info = getFormattedTraceInfo(this.props.trace);
@@ -117,20 +122,16 @@ class SummaryPanelTraceDetails extends React.Component<Props, State> {
         </span>
         <div>
           <Tooltip content={info.name}>
-            {tracesDetailsURL ? (
-              <Link to={tracesDetailsURL}>
-                <span className={nameStyleToUse}>{traceName}</span>
-              </Link>
-            ) : (
+            <Link to={tracesDetailsURL}>
               <span className={nameStyleToUse}>{traceName}</span>
-            )}
+            </Link>
           </Tooltip>
-          <p className={pStyle}>
+          <div className={pStyle}>
             <div className={secondaryStyle}>{'From: ' + info.fromNow}</div>
             {!!info.duration && <div className={secondaryStyle}>{'Full duration: ' + info.duration}</div>}
-          </p>
+          </div>
           {spans && (
-            <p className={pStyle}>
+            <div className={pStyle}>
               <div className={secondaryStyle}>{'Spans for node: ' + nodeName}</div>
               <div>
                 <Button
@@ -160,7 +161,7 @@ class SummaryPanelTraceDetails extends React.Component<Props, State> {
               </div>
               {this.state.selectedSpan < spans.length &&
                 this.renderSpan(nodeName + '.' + node.namespace, spans[this.state.selectedSpan])}
-            </p>
+            </div>
           )}
           {tracesDetailsURL && jaegerTraceURL && (
             <>

--- a/src/types/Graph.ts
+++ b/src/types/Graph.ts
@@ -156,6 +156,11 @@ export const hasProtocolTraffic = (protocolTraffic: ProtocolTraffic): protocolTr
   );
 };
 
+export interface DestService {
+  namespace: string;
+  name: string;
+}
+
 // Node data expected from server
 export interface GraphNodeData {
   id: string;
@@ -168,7 +173,7 @@ export interface GraphNodeData {
   service?: string;
   aggregate?: string;
   aggregateValue?: string;
-  destServices?: any;
+  destServices?: DestService[];
   traffic?: ProtocolTraffic[];
   hasCB?: boolean;
   hasMissingSC?: boolean;


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/3048

- Update links to point to new trace details pages (app/service/workload)
- Make it work for any graph type
- Did some experiments with service entry / TCP related traces, added a way to not break the trace when such node is reached (e.g. kafka)
(commented as experimental, probably more thoughts on this is necessary, but that's a starting point)
- Side-change: proper typing on destServices
