### PR TITLE
Add Status field into Istio Objects

### DIFF
--- a/src/components/Validations/Validation.tsx
+++ b/src/components/Validations/Validation.tsx
@@ -1,5 +1,10 @@
 import React, { CSSProperties } from 'react';
-import { CheckCircleIcon, ExclamationCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons';
+import {
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+  ExclamationTriangleIcon,
+  InfoCircleIcon
+} from '@patternfly/react-icons';
 import { IconType } from '@patternfly/react-icons/dist/js/createIcon';
 import { ValidationTypes } from '../../types/IstioObjects';
 import { Text, TextVariants } from '@patternfly/react-core';
@@ -36,6 +41,12 @@ const WarningValidation: ValidationType = {
   icon: ExclamationTriangleIcon
 };
 
+const InfoValidation: ValidationType = {
+  name: 'Info',
+  color: PFAlertColor.Info,
+  icon: InfoCircleIcon
+};
+
 const CorrectValidation: ValidationType = {
   name: 'Valid',
   color: PFAlertColor.Success,
@@ -45,7 +56,8 @@ const CorrectValidation: ValidationType = {
 export const severityToValidation: { [severity: string]: ValidationType } = {
   error: ErrorValidation,
   warning: WarningValidation,
-  correct: CorrectValidation
+  correct: CorrectValidation,
+  info: InfoValidation
 };
 
 class Validation extends React.Component<Props> {

--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -353,8 +353,8 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
 
   getStatusRange = (yaml: string | undefined): any => {
     let range = {
-      startRow: 0,
-      endRow: 0
+      startRow: -1,
+      endRow: -1
     };
 
     if (!!yaml) {
@@ -363,7 +363,7 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
         if (line.startsWith('status:')) {
           range.startRow = i;
         }
-        if (line.startsWith('spec:') && range.startRow !== 0) {
+        if (line.startsWith('spec:') && range.startRow !== -1) {
           range.endRow = i;
         }
       });
@@ -430,7 +430,7 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
                   namespace={this.state.istioObjectDetails.namespace.name}
                 />
               )}
-              {istioStatusMsgs && <IstioStatusMessageList messages={istioStatusMsgs} />}
+              {istioStatusMsgs && istioStatusMsgs.length > 0 && <IstioStatusMessageList messages={istioStatusMsgs} />}
               {refPresent && (
                 <Card>
                   <CardHeader>

--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -12,7 +12,7 @@ import * as API from '../../services/Api';
 import AceEditor, { Annotation } from 'react-ace';
 import 'brace/mode/yaml';
 import 'brace/theme/eclipse';
-import { ObjectReference, ObjectValidation } from '../../types/IstioObjects';
+import { ObjectReference, ObjectValidation, ValidationMessage } from '../../types/IstioObjects';
 import { AceValidations, jsYaml, parseKialiValidations, parseYamlValidations } from '../../types/AceValidations';
 import IstioActionDropdown from '../../components/IstioActions/IstioActionsDropdown';
 import { RenderComponentScroll, RenderHeader } from '../../components/Nav/Page';
@@ -44,6 +44,7 @@ import { ReferenceIstioObjectLink } from '../../components/Link/IstioObjectLink'
 import VirtualServiceCard from './IstioObjectDetails/VirtualServiceCard';
 import DestinationRuleCard from './IstioObjectDetails/DestinationRuleCard';
 import { AxiosError } from 'axios';
+import IstioStatusMessageList from './IstioObjectDetails/IstioStatusMessageList';
 
 const rightToolbarStyle = style({
   position: 'absolute',
@@ -324,6 +325,11 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
     return istioObject ? jsYaml.safeDump(istioObject, safeDumpOptions) : '';
   };
 
+  getStatusMessages = (): ValidationMessage[] => {
+    const istioObject = getIstioObject(this.state.istioObjectDetails);
+    return istioObject && istioObject.status ? istioObject.status.validationMessages : [];
+  };
+
   // Not all Istio types have an overview card
   hasOverview = (): boolean => {
     return (
@@ -339,9 +345,10 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
 
   renderEditor = () => {
     const yamlSource = this.fetchYaml();
+    const istioStatusMsgs = this.getStatusMessages();
     const objectReferences = this.objectReferences();
     const refPresent = objectReferences.length > 0;
-    const showCards = refPresent || this.hasOverview();
+    const showCards = refPresent || this.hasOverview() || !!istioStatusMsgs;
     const editorSpan = showCards ? 9 : 12;
     let editorValidations: AceValidations = {
       markers: [],
@@ -394,6 +401,7 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
                   namespace={this.state.istioObjectDetails.namespace.name}
                 />
               )}
+              {istioStatusMsgs && <IstioStatusMessageList messages={istioStatusMsgs} />}
               {refPresent && (
                 <Card>
                   <CardHeader>

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/IstioStatusMessageList.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/IstioStatusMessageList.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import { ValidationMessage, ValidationTypes } from '../../../types/IstioObjects';
+import {
+  Card,
+  CardBody,
+  CardHeader,
+  Split,
+  SplitItem,
+  Stack,
+  StackItem,
+  Text,
+  TextVariants,
+  Title,
+  TitleLevel,
+  TitleSize
+} from '@patternfly/react-core';
+import Validation from '../../../components/Validations/Validation';
+
+interface Props {
+  messages: ValidationMessage[];
+}
+
+class IstioStatusMessageList extends React.Component<Props> {
+  render() {
+    return (
+      <Card key={'istioMessagesCard'}>
+        <CardHeader>
+          <Title headingLevel={TitleLevel.h3} size={TitleSize.xl}>
+            Analyzer Messages
+          </Title>
+        </CardHeader>
+        <CardBody>
+          <Stack gutter="lg">
+            {this.props.messages.map((msg: ValidationMessage, i: number) => {
+              return (
+                <StackItem id={'msg-' + i}>
+                  <Split gutter="sm">
+                    <SplitItem>
+                      <Validation severity={ValidationTypes[msg.level]} />
+                    </SplitItem>
+                    <SplitItem>
+                      <Text component={TextVariants.h5}>
+                        <a href={msg.documentation_url} target="_blank" rel="noopener noreferrer">
+                          {msg.code}
+                        </a>
+                        {': ' + msg.message}
+                      </Text>
+                    </SplitItem>
+                  </Split>
+                </StackItem>
+              );
+            })}
+          </Stack>
+        </CardBody>
+      </Card>
+    );
+  }
+}
+
+export default IstioStatusMessageList;

--- a/src/types/IstioObjects.ts
+++ b/src/types/IstioObjects.ts
@@ -42,6 +42,19 @@ export interface IstioObject {
   kind?: string;
   apiVersion?: string;
   metadata: K8sMetadata;
+  status?: IstioStatus;
+}
+
+export interface IstioStatus {
+  validationMessages: ValidationMessage[];
+  conditions?: any[];
+}
+
+export interface ValidationMessage {
+  code: string;
+  documentation_url: string;
+  level: string;
+  message: string;
 }
 
 // validations are grouped per 'objectType' first in the first map and 'name' in the inner map
@@ -50,7 +63,8 @@ export type Validations = { [key1: string]: { [key2: string]: ObjectValidation }
 export enum ValidationTypes {
   Error = 'error',
   Warning = 'warning',
-  Correct = 'correct'
+  Correct = 'correct',
+  Info = 'info'
 }
 
 export interface ObjectValidation {


### PR DESCRIPTION
Requires https://github.com/kiali/kiali/pull/3188
Fixes kiali/kiali#2236

There is a decoration: the status field is folded in order not to eat a lot of space and also avoid showing redundant information.

Demo:
![analyzer-messages](https://user-images.githubusercontent.com/613814/92494896-898a1c00-f1f6-11ea-930a-af98a1f44aa5.gif)
