### PR TITLE
Trivial: remove a '.' in Traffic Status wording

### DIFF
--- a/src/components/Health/__tests__/__snapshots__/HealthDetails.test.tsx.snap
+++ b/src/components/Health/__tests__/__snapshots__/HealthDetails.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`HealthDetails renders deployments failure 1`] = `
   key="0"
 >
   <strong>
-     Traffic Status (Last 1m) .
+     Traffic Status (Last 1m)
      
   </strong>
   <ul
@@ -38,7 +38,7 @@ exports[`HealthDetails renders healthy 1`] = `
   key="0"
 >
   <strong>
-     Traffic Status (Last 1m) .
+     Traffic Status (Last 1m)
      
   </strong>
   <ul

--- a/src/components/Health/__tests__/__snapshots__/HealthIndicator.test.tsx.snap
+++ b/src/components/Health/__tests__/__snapshots__/HealthIndicator.test.tsx.snap
@@ -87,7 +87,7 @@ exports[`HealthIndicator renders healthy 1`] = `
                     "name": "No health information",
                     "priority": 0,
                   },
-                  "title": "Traffic Status (Last 10m) .",
+                  "title": "Traffic Status (Last 10m)",
                 },
               ],
               "statusConfig": Object {
@@ -99,7 +99,7 @@ exports[`HealthIndicator renders healthy 1`] = `
                   "priority": 0,
                 },
                 "threshold": undefined,
-                "title": "Traffic Status (Last 10m) .",
+                "title": "Traffic Status (Last 10m)",
                 "value": -1,
               },
             },

--- a/src/types/Health.ts
+++ b/src/types/Health.ts
@@ -47,7 +47,7 @@ export interface WorkloadStatus {
 export const TRAFFICSTATUS = 'Traffic Status';
 
 const createTrafficTitle = (time: string) => {
-  return TRAFFICSTATUS + ' (Last ' + time + ') .';
+  return TRAFFICSTATUS + ' (Last ' + time + ')';
 };
 
 /*


### PR DESCRIPTION
Very trivial change in the wording:
![image](https://user-images.githubusercontent.com/1662329/92737498-7c4a6a00-f37b-11ea-9af3-5ad2a80737fd.png)
![image](https://user-images.githubusercontent.com/1662329/92737545-89675900-f37b-11ea-9688-0e828379a72e.png)
