### PR TITLE
Traffic Policies actions on Namespace

### DIFF
--- a/src/pages/Overview/NamespaceInfo.ts
+++ b/src/pages/Overview/NamespaceInfo.ts
@@ -1,11 +1,13 @@
 import { TLSStatus } from '../../types/TLSStatus';
 import { TimeSeries } from '../../types/Metrics';
 import { ValidationStatus } from '../../types/IstioObjects';
+import { IstioConfigList } from '../../types/IstioConfigList';
 
 export type NamespaceInfo = {
   name: string;
   status?: NamespaceStatus;
   tlsStatus?: TLSStatus;
+  istioConfig?: IstioConfigList;
   validations?: ValidationStatus;
   metrics?: TimeSeries[];
   labels?: { [key: string]: string };

--- a/src/pages/Overview/OverviewPage.tsx
+++ b/src/pages/Overview/OverviewPage.tsx
@@ -215,13 +215,15 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
           : OverviewDisplayMode.EXPAND;
         // Set state before actually fetching health
         this.setState(
-          {
-            type: type,
-            namespaces: Sorts.sortFunc(allNamespaces, sortField, isAscending),
-            displayMode: displayMode,
-            showConfirmModal: false,
-            nsTarget: '',
-            opTarget: ''
+          prevState => {
+            return {
+              type: type,
+              namespaces: Sorts.sortFunc(allNamespaces, sortField, isAscending),
+              displayMode: displayMode,
+              showConfirmModal: prevState.showConfirmModal,
+              nsTarget: prevState.nsTarget,
+              opTarget: prevState.opTarget
+            };
           },
           () => {
             this.fetchHealth(isAscending, sortField, type);
@@ -654,7 +656,9 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
 
   hideConfirmModal = () => {
     this.setState({
-      showConfirmModal: false
+      showConfirmModal: false,
+      nsTarget: '',
+      opTarget: ''
     });
   };
 
@@ -667,11 +671,15 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
         break;
       }
     }
+    const nsTarget = this.state.nsTarget;
+    const remove = this.state.opTarget === 'delete';
     this.setState(
       {
-        showConfirmModal: false
+        showConfirmModal: false,
+        nsTarget: '',
+        opTarget: ''
       },
-      () => this.onAddRemoveAuthorizationPolicy(this.state.nsTarget, aps, this.state.opTarget === 'delete')
+      () => this.onAddRemoveAuthorizationPolicy(nsTarget, aps, remove)
     );
   };
 

--- a/src/pages/Overview/__tests__/OverviewPage.test.tsx
+++ b/src/pages/Overview/__tests__/OverviewPage.test.tsx
@@ -53,6 +53,7 @@ const mockNamespaceHealth = (obj: NamespaceAppHealth): Promise<void> => {
 mockAPIToPromise('getNamespaceMetrics', null, false);
 mockAPIToPromise('getNamespaceTls', null, false);
 mockAPIToPromise('getNamespaceValidations', null, false);
+mockAPIToPromise('getIstioConfig', null, false);
 
 let mounted: ReactWrapper<any, any> | null;
 

--- a/src/pages/Overview/__tests__/__snapshots__/OverviewPage.test.tsx.snap
+++ b/src/pages/Overview/__tests__/__snapshots__/OverviewPage.test.tsx.snap
@@ -45,5 +45,36 @@ exports[`Overview page renders initial layout 1`] = `
       </EmptyStateBody>
     </EmptyState>
   </div>
+  <Modal
+    actions={
+      Array [
+        <Unknown
+          onClick={[Function]}
+          variant="secondary"
+        >
+          Cancel
+        </Unknown>,
+        <Unknown
+          onClick={[Function]}
+          variant="danger"
+        >
+          
+        </Unknown>,
+      ]
+    }
+    appendTo={<body />}
+    ariaDescribedById=""
+    className=""
+    hideTitle={false}
+    isFooterLeftAligned={false}
+    isLarge={false}
+    isOpen={false}
+    isSmall={true}
+    onClose={[Function]}
+    showClose={true}
+    title="Confirm  Traffic Policies ?"
+  >
+    Namespace  has existing AuthorizationPolicy objects. Do you want to  them ?
+  </Modal>
 </Fragment>
 `;

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
@@ -401,6 +401,7 @@ exports[`#ServiceInfoDescription render correctly with data should render servic
           "fetchDataForNamespaces": [Function],
           "fetchDataForNode": [Function],
           "fetchForApp": [Function],
+          "fetchForNamespace": [Function],
           "fetchForService": [Function],
           "fetchForWorkload": [Function],
           "fetchGraphData": [Function],

--- a/src/pages/WorkloadDetails/WorkloadInfo/__tests__/__snapshots__/WorkloadDescription.test.tsx.snap
+++ b/src/pages/WorkloadDetails/WorkloadInfo/__tests__/__snapshots__/WorkloadDescription.test.tsx.snap
@@ -155,6 +155,7 @@ exports[`WorkloadDescription should render with runtimes 1`] = `
           "fetchDataForNamespaces": [Function],
           "fetchDataForNode": [Function],
           "fetchForApp": [Function],
+          "fetchForNamespace": [Function],
           "fetchForService": [Function],
           "fetchForWorkload": [Function],
           "fetchGraphData": [Function],

--- a/src/services/GraphDataSource.ts
+++ b/src/services/GraphDataSource.ts
@@ -240,6 +240,13 @@ export default class GraphDataSource {
     this.fetchGraphData(params);
   };
 
+  public fetchForNamespace = (duration: DurationInSeconds, namespace: string) => {
+    const params = GraphDataSource.defaultFetchParams(duration, namespace);
+    params.graphType = GraphType.WORKLOAD;
+    params.showSecurity = true;
+    this.fetchGraphData(params);
+  };
+
   // Private methods
 
   private static defaultFetchParams(duration: DurationInSeconds, namespace: string): FetchParams {

--- a/src/types/Graph.ts
+++ b/src/types/Graph.ts
@@ -196,6 +196,8 @@ export interface GraphEdgeData {
   traffic?: ProtocolTraffic;
   responseTime?: number;
   isMTLS?: number;
+  sourcePrincipal?: string;
+  destPrincipal?: string;
 }
 
 export interface GraphNodeWrapper {


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/2924

This PR introduces a new Namespace based action triggered from the Overview page.

Given a certain traffic:

![image](https://user-images.githubusercontent.com/1662329/93219537-c52f6380-f76b-11ea-94d1-98d878d8fcf4.png)

Kiali can apply Traffic Policies (Istio AuthorizationPolicies) to lock in workloads with principals described in the telemetry.

The action is added into the Namespace menu:
![image](https://user-images.githubusercontent.com/1662329/93219689-e85a1300-f76b-11ea-8552-fcdf96b12fde.png)
![image](https://user-images.githubusercontent.com/1662329/93219718-f0b24e00-f76b-11ea-8ab5-e0a3d2b09b4e.png)

And the list of AuthorizationPolicies can be listed from the "Istio Config" page:
![image](https://user-images.githubusercontent.com/1662329/93219781-0293f100-f76c-11ea-8a80-29c54c6819af.png)

Or individually per workload (when workload selectors are used):
![image](https://user-images.githubusercontent.com/1662329/93219840-15a6c100-f76c-11ea-94c3-e74f213d37a3.png)

There is a generic DENY_ALL rule per namespace to protect the workloads, with individual ALLOW rules per workload, like described in this one:

![image](https://user-images.githubusercontent.com/1662329/93220000-41c24200-f76c-11ea-8b7c-fc701e82be24.png)
