### PR TITLE
Fix regression for RequestRouting Wizard

### DIFF
--- a/src/components/IstioWizards/RequestRouting.tsx
+++ b/src/components/IstioWizards/RequestRouting.tsx
@@ -123,37 +123,15 @@ class RequestRouting extends React.Component<Props, State> {
       } else {
         newMatch = prevState.category + ' [' + prevState.headerName + '] ' + REGEX + ' ' + ANYTHING;
       }
-      this.addNewMatch(prevState.matches, newMatch);
+      if (!prevState.matches.includes(newMatch)) {
+        prevState.matches.push(newMatch);
+      }
       return {
         matches: prevState.matches,
         headerName: '',
         matchValue: ''
       };
     });
-  };
-
-  addNewMatch = (matches: string[], newMatch: string) => {
-    // Non HEADERS matches can only appear once, so, newMatch will update the old one
-    let foundMatch: string | undefined = undefined;
-    let newMatchType = '';
-    if (newMatch.startsWith(HEADERS)) {
-      // We check the headers [<headerName>]
-      newMatchType = newMatch.substring(0, newMatch.indexOf(']') + 1);
-    } else {
-      newMatchType = newMatch.split(' ')[0];
-    }
-    for (let i = 0; i < matches.length; i++) {
-      const match = matches[i];
-      if (match.startsWith(newMatchType)) {
-        foundMatch = match;
-        break;
-      }
-    }
-    if (foundMatch) {
-      const index = matches.indexOf(foundMatch, 0);
-      matches.splice(index, 1);
-    }
-    matches.push(newMatch);
   };
 
   onAddRule = () => {


### PR DESCRIPTION
During https://github.com/kiali/kiali/issues/3174 I've introduced a regression in the Request Routing Wizard.

Wizard allow users to create *multiple* Request Matching for a Route.

![image](https://user-images.githubusercontent.com/1662329/93584646-dcf22c00-f9a5-11ea-9048-a4173b7ff4f6.png)

The case about having a complex *single* Request Matching is not covered by the Wizard and it's delegated to Istio Config yaml editor.
