### PR TITLE
Trace on graph: comply to opentracing standard

### DIFF
--- a/src/pages/Graph/SummaryPanelTraceDetails.tsx
+++ b/src/pages/Graph/SummaryPanelTraceDetails.tsx
@@ -13,7 +13,12 @@ import { KialiAppAction } from 'actions/KialiAppAction';
 import { JaegerThunkActions } from 'actions/JaegerThunkActions';
 import { getFormattedTraceInfo } from 'components/JaegerIntegration/JaegerResults/FormattedTraceInfo';
 import { PFAlertColor, PfColors } from 'components/Pf/PfColors';
-import { extractEnvoySpanInfo } from 'components/JaegerIntegration/JaegerHelper';
+import {
+  extractEnvoySpanInfo,
+  extractOpenTracingHTTPInfo,
+  extractOpenTracingTCPInfo,
+  getSpanType
+} from 'components/JaegerIntegration/JaegerHelper';
 import { formatDuration } from 'components/JaegerIntegration/JaegerResults/transform';
 import { CytoscapeGraphSelectorBuilder } from 'components/CytoscapeGraph/CytoscapeGraphSelector';
 import { decoratedNodeData } from 'components/CytoscapeGraph/CytoscapeGraphUtils';
@@ -95,16 +100,18 @@ class SummaryPanelTraceDetails extends React.Component<Props, State> {
 
   render() {
     const node = decoratedNodeData(this.props.node);
-    const tracesDetailsURL =
-      `/namespaces/${node.namespace}` +
-      (node.workload
-        ? `/workloads/${node.workload}`
-        : node.service
-        ? `/services/${node.service}`
-        : `/applications/${node.app!}`) +
-      `?tab=traces&${URLParam.JAEGER_TRACE_ID}=${this.props.trace.traceID}`;
-    const jaegerTraceURL =
-      node.app && this.props.jaegerURL ? `${this.props.jaegerURL}/trace/${this.props.trace.traceID}` : undefined;
+    const tracesDetailsURL = node.namespace
+      ? `/namespaces/${node.namespace}` +
+        (node.workload
+          ? `/workloads/${node.workload}`
+          : node.service
+          ? `/services/${node.service}`
+          : `/applications/${node.app!}`) +
+        `?tab=traces&${URLParam.JAEGER_TRACE_ID}=${this.props.trace.traceID}`
+      : undefined;
+    const jaegerTraceURL = this.props.jaegerURL
+      ? `${this.props.jaegerURL}/trace/${this.props.trace.traceID}`
+      : undefined;
     const info = getFormattedTraceInfo(this.props.trace);
     const nameStyleToUse = info.errors ? nameStyle + ' ' + errorStyle : nameStyle;
     const nodeName = node.workload || node.service || node.app!;
@@ -122,9 +129,13 @@ class SummaryPanelTraceDetails extends React.Component<Props, State> {
         </span>
         <div>
           <Tooltip content={info.name}>
-            <Link to={tracesDetailsURL}>
+            {tracesDetailsURL ? (
+              <Link to={tracesDetailsURL}>
+                <span className={nameStyleToUse}>{traceName}</span>
+              </Link>
+            ) : (
               <span className={nameStyleToUse}>{traceName}</span>
-            </Link>
+            )}
           </Tooltip>
           <div className={pStyle}>
             <div className={secondaryStyle}>{'From: ' + info.fromNow}</div>
@@ -163,7 +174,7 @@ class SummaryPanelTraceDetails extends React.Component<Props, State> {
                 this.renderSpan(nodeName + '.' + node.namespace, spans[this.state.selectedSpan])}
             </div>
           )}
-          {tracesDetailsURL && jaegerTraceURL && (
+          {jaegerTraceURL && (
             <>
               <br />
               <a href={jaegerTraceURL} target="_blank" rel="noopener noreferrer">
@@ -177,72 +188,113 @@ class SummaryPanelTraceDetails extends React.Component<Props, State> {
   }
 
   private renderSpan(nodeFullName: string, span: Span) {
-    const info = extractEnvoySpanInfo(span);
-    const reqDetails: string[] = [];
-    if (info) {
-      if (
-        nodeFullName !== span.process.serviceName &&
-        info.inbound &&
-        nodeFullName === info.inbound + '.' + info.otherNamespace
-      ) {
-        // Special case: this span was added to the inbound workload (this node) while originating from the outbound node.
-        // So we need to reverse the logic: it's not an inbound request that we show here, but an outbound request, switching point of view.
-        info.inbound = undefined;
-        const split = span.process.serviceName.split('.');
-        info.outbound = split[0];
-        if (split.length > 1) {
-          info.otherNamespace = split[1];
-        }
-      }
-      if (info.statusCode) {
-        reqDetails.push('code ' + info.statusCode);
-      }
-      if (info.responseFlags) {
-        reqDetails.push('flags ' + info.responseFlags);
-      }
-      if (span.duration) {
-        reqDetails.push(formatDuration(span.duration));
-      }
+    switch (getSpanType(span)) {
+      case 'envoy':
+        return this.renderEnvoySpan(nodeFullName, span);
+      case 'http':
+        return this.renderHTTPSpan(span);
+      case 'tcp':
+        return this.renderTCPSpan(span);
     }
+    // Unknown
+    return this.renderCommonSpan(span);
+  }
+
+  private renderCommonSpan(span: Span) {
     return (
       <>
-        {info?.inbound && (
+        <div className={secondaryStyle}>{`Operation: ${span.operationName}`}</div>
+        <div className={secondaryStyle}>{`Duration: ${formatDuration(span.duration)}`}</div>
+        <div className={secondaryStyle}>{`Started after ${formatDuration(span.relativeStartTime)}`}</div>
+      </>
+    );
+  }
+
+  private renderEnvoySpan(nodeFullName: string, span: Span) {
+    const info = extractEnvoySpanInfo(span);
+    const rsDetails: string[] = [];
+    if (
+      nodeFullName !== span.process.serviceName &&
+      info.direction === 'inbound' &&
+      nodeFullName === info.peer + '.' + info.peerNamespace
+    ) {
+      // Special case: this span was added to the inbound workload (this node) while originating from the outbound node.
+      // So we need to reverse the logic: it's not an inbound request that we show here, but an outbound request, switching point of view.
+      info.direction = 'outbound';
+      const split = span.process.serviceName.split('.');
+      info.peer = split[0];
+      if (split.length > 1) {
+        info.peerNamespace = split[1];
+      }
+    }
+    if (info.statusCode) {
+      rsDetails.push('code ' + info.statusCode);
+    }
+    if (info.responseFlags) {
+      rsDetails.push('flags ' + info.responseFlags);
+    }
+    if (span.duration) {
+      rsDetails.push(formatDuration(span.duration));
+    }
+
+    return (
+      <>
+        {info.direction && info.peer && info.peerNamespace && (
           <>
-            <span className={secondaryStyle}>{'From: '}</span>
+            <span className={secondaryStyle}>{info.direction === 'inbound' ? 'From: ' : 'To: '}</span>
             <Button
               variant={ButtonVariant.link}
-              onClick={() => {
-                this.focusOnWorkload(info.otherNamespace!, info.inbound!);
-              }}
+              onClick={
+                info.direction === 'inbound'
+                  ? () => this.focusOnWorkload(info.peerNamespace!, info.peer!)
+                  : () => this.focusOnService(info.peerNamespace!, info.peer!)
+              }
               isInline
             >
-              <span style={{ fontSize: 'var(--graph-side-panel--font-size)' }}>{info.inbound}</span>
-            </Button>
-          </>
-        )}
-        {info?.outbound && (
-          <>
-            <span className={secondaryStyle}>{'To: '}</span>
-            <Button
-              variant={ButtonVariant.link}
-              onClick={() => {
-                this.focusOnService(info.otherNamespace!, info.outbound!);
-              }}
-              isInline
-            >
-              <span style={{ fontSize: 'var(--graph-side-panel--font-size)' }}>{info.outbound}</span>
+              <span style={{ fontSize: 'var(--graph-side-panel--font-size)' }}>{info.peer}</span>
             </Button>
           </>
         )}
         <div className={secondaryStyle}>{`Operation: ${span.operationName}`}</div>
-        {info ? (
-          <>
-            <div className={secondaryStyle}>{`Request: ${info.method} ${info.url}`}</div>
-            <div className={secondaryStyle}>{`Response: [${reqDetails.join(', ')}]`}</div>
-          </>
-        ) : (
-          <div className={secondaryStyle}>{`Duration: ${formatDuration(span.duration)}`}</div>
-        )}
+        <div className={secondaryStyle}>{`Request: ${info.method} ${info.url}`}</div>
+        <div className={secondaryStyle}>{`Response: [${rsDetails.join(', ')}]`}</div>
+        <div className={secondaryStyle}>{`Started after ${formatDuration(span.relativeStartTime)}`}</div>
+      </>
+    );
+  }
+
+  private renderHTTPSpan(span: Span) {
+    const info = extractOpenTracingHTTPInfo(span);
+    const rsDetails: string[] = [];
+    if (info.statusCode) {
+      rsDetails.push('code ' + info.statusCode);
+    }
+    if (span.duration) {
+      rsDetails.push(formatDuration(span.duration));
+    }
+    const rqLabel =
+      info.direction === 'inbound' ? 'Inbound request' : info.direction === 'outbound' ? 'Outbound request' : 'Request';
+    return (
+      <>
+        <div className={secondaryStyle}>{`Operation: ${span.operationName}`}</div>
+        <div className={secondaryStyle}>{`${rqLabel}: ${info.method} ${info.url}`}</div>
+        <div className={secondaryStyle}>{`Response: [${rsDetails.join(', ')}]`}</div>
+        <div className={secondaryStyle}>{`Started after ${formatDuration(span.relativeStartTime)}`}</div>
+      </>
+    );
+  }
+
+  private renderTCPSpan(span: Span) {
+    const info = extractOpenTracingTCPInfo(span);
+    let actionLabel = info.direction === 'inbound' ? 'Received data' : info.direction === 'outbound' ? 'Sent data' : '';
+    if (info.topic) {
+      actionLabel += ' on topic ' + info.topic;
+    }
+    return (
+      <>
+        <div className={secondaryStyle}>{`Operation: ${span.operationName}`}</div>
+        <div className={secondaryStyle}>{actionLabel}</div>
+        <div className={secondaryStyle}>{`Duration: ${formatDuration(span.duration)}`}</div>
         <div className={secondaryStyle}>{`Started after ${formatDuration(span.relativeStartTime)}`}</div>
       </>
     );

--- a/src/pages/Graph/SummaryPanelTraceDetails.tsx
+++ b/src/pages/Graph/SummaryPanelTraceDetails.tsx
@@ -12,7 +12,7 @@ import { KialiAppState } from 'store/Store';
 import { KialiAppAction } from 'actions/KialiAppAction';
 import { JaegerThunkActions } from 'actions/JaegerThunkActions';
 import { getFormattedTraceInfo } from 'components/JaegerIntegration/JaegerResults/FormattedTraceInfo';
-import { PFAlertColor, PfColors } from 'components/Pf/PfColors';
+import { PFAlertColor } from 'components/Pf/PfColors';
 import {
   extractEnvoySpanInfo,
   extractOpenTracingHTTPInfo,
@@ -59,10 +59,6 @@ const errorStyle = style({
 
 const pStyle = style({
   paddingTop: 9
-});
-
-const secondaryStyle = style({
-  color: PfColors.Black600
 });
 
 const navButtonStyle = style({
@@ -137,13 +133,24 @@ class SummaryPanelTraceDetails extends React.Component<Props, State> {
               <span className={nameStyleToUse}>{traceName}</span>
             )}
           </Tooltip>
-          <div className={pStyle}>
-            <div className={secondaryStyle}>{'From: ' + info.fromNow}</div>
-            {!!info.duration && <div className={secondaryStyle}>{'Full duration: ' + info.duration}</div>}
+          <div>
+            <div>
+              <strong>Started: </strong>
+              {info.fromNow}
+            </div>
+            {info.duration && (
+              <div>
+                <strong>Full duration: </strong>
+                {info.duration}
+              </div>
+            )}
           </div>
           {spans && (
             <div className={pStyle}>
-              <div className={secondaryStyle}>{'Spans for node: ' + nodeName}</div>
+              <div>
+                <strong>Spans for node: </strong>
+                {nodeName}
+              </div>
               <div>
                 <Button
                   className={navButtonStyle}
@@ -203,9 +210,18 @@ class SummaryPanelTraceDetails extends React.Component<Props, State> {
   private renderCommonSpan(span: Span) {
     return (
       <>
-        <div className={secondaryStyle}>{`Operation: ${span.operationName}`}</div>
-        <div className={secondaryStyle}>{`Duration: ${formatDuration(span.duration)}`}</div>
-        <div className={secondaryStyle}>{`Started after ${formatDuration(span.relativeStartTime)}`}</div>
+        <div>
+          <strong>Operation: </strong>
+          {span.operationName}
+        </div>
+        <div>
+          <strong>Started after: </strong>
+          {formatDuration(span.relativeStartTime)}
+        </div>
+        <div>
+          <strong>Duration: </strong>
+          {formatDuration(span.duration)}
+        </div>
       </>
     );
   }
@@ -241,7 +257,9 @@ class SummaryPanelTraceDetails extends React.Component<Props, State> {
       <>
         {info.direction && info.peer && info.peerNamespace && (
           <>
-            <span className={secondaryStyle}>{info.direction === 'inbound' ? 'From: ' : 'To: '}</span>
+            <span>
+              <strong>{info.direction === 'inbound' ? 'From: ' : 'To: '}</strong>
+            </span>
             <Button
               variant={ButtonVariant.link}
               onClick={
@@ -255,10 +273,22 @@ class SummaryPanelTraceDetails extends React.Component<Props, State> {
             </Button>
           </>
         )}
-        <div className={secondaryStyle}>{`Operation: ${span.operationName}`}</div>
-        <div className={secondaryStyle}>{`Request: ${info.method} ${info.url}`}</div>
-        <div className={secondaryStyle}>{`Response: [${rsDetails.join(', ')}]`}</div>
-        <div className={secondaryStyle}>{`Started after ${formatDuration(span.relativeStartTime)}`}</div>
+        <div>
+          <strong>Operation: </strong>
+          {span.operationName}
+        </div>
+        <div>
+          <strong>Started after: </strong>
+          {formatDuration(span.relativeStartTime)}
+        </div>
+        <div>
+          <strong>Request: </strong>
+          {info.method} {info.url}
+        </div>
+        <div>
+          <strong>Response: </strong>
+          {rsDetails.join(', ')}
+        </div>
       </>
     );
   }
@@ -276,26 +306,48 @@ class SummaryPanelTraceDetails extends React.Component<Props, State> {
       info.direction === 'inbound' ? 'Inbound request' : info.direction === 'outbound' ? 'Outbound request' : 'Request';
     return (
       <>
-        <div className={secondaryStyle}>{`Operation: ${span.operationName}`}</div>
-        <div className={secondaryStyle}>{`${rqLabel}: ${info.method} ${info.url}`}</div>
-        <div className={secondaryStyle}>{`Response: [${rsDetails.join(', ')}]`}</div>
-        <div className={secondaryStyle}>{`Started after ${formatDuration(span.relativeStartTime)}`}</div>
+        <div>
+          <strong>Operation: </strong>
+          {span.operationName}
+        </div>
+        <div>
+          <strong>Started after: </strong>
+          {formatDuration(span.relativeStartTime)}
+        </div>
+        <div>
+          <strong>{rqLabel}: </strong>
+          {info.method} {info.url}
+        </div>
+        <div>
+          <strong>Response: </strong>
+          {rsDetails.join(', ')}
+        </div>
       </>
     );
   }
 
   private renderTCPSpan(span: Span) {
     const info = extractOpenTracingTCPInfo(span);
-    let actionLabel = info.direction === 'inbound' ? 'Received data' : info.direction === 'outbound' ? 'Sent data' : '';
-    if (info.topic) {
-      actionLabel += ' on topic ' + info.topic;
-    }
     return (
       <>
-        <div className={secondaryStyle}>{`Operation: ${span.operationName}`}</div>
-        <div className={secondaryStyle}>{actionLabel}</div>
-        <div className={secondaryStyle}>{`Duration: ${formatDuration(span.duration)}`}</div>
-        <div className={secondaryStyle}>{`Started after ${formatDuration(span.relativeStartTime)}`}</div>
+        <div>
+          <strong>Operation: </strong>
+          {span.operationName}
+        </div>
+        <div>
+          <strong>Started after: </strong>
+          {formatDuration(span.relativeStartTime)}
+        </div>
+        {info.topic && (
+          <div>
+            <strong>Topic: </strong>
+            {info.topic}
+          </div>
+        )}
+        <div>
+          <strong>Duration: </strong>
+          {formatDuration(span.duration)}
+        </div>
       </>
     );
   }


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/3226

Read some semantic conventions (https://github.com/opentracing/specification/blob/master/semantic_conventions.md) to extract span data:

- HTTP conventions
- peer / tcp conventions + messaging

Also read Envoy data which is a superset of OT http conventions

As a result, there's 4 different kind of displays depending on span kind:

- The usual Envoy:
![Capture d’écran de 2020-09-22 19-14-50](https://user-images.githubusercontent.com/2153442/93916003-2675aa80-fd09-11ea-9723-e3fbfcc54986.png)

- The non-Envoy HTTP:
![Capture d’écran de 2020-09-22 19-14-39](https://user-images.githubusercontent.com/2153442/93916057-3bead480-fd09-11ea-8589-d9d6ec2134f9.png)

- The TCP / messaging:
![Capture d’écran de 2020-09-22 19-14-12](https://user-images.githubusercontent.com/2153442/93916089-473e0000-fd09-11ea-8aa3-31aa5d6278f8.png)

- The "unknown kind":
![Capture d’écran de 2020-09-22 19-14-07](https://user-images.githubusercontent.com/2153442/93916129-53c25880-fd09-11ea-89db-e0a775bb5044.png)
