### PR TITLE
Add Auto-Refresh on Overview/Traffic tabs

### DIFF
--- a/src/components/Metrics/TrafficDetails.tsx
+++ b/src/components/Metrics/TrafficDetails.tsx
@@ -5,11 +5,10 @@ import { GraphDefinition, GraphEdgeWrapper, GraphNodeData, NodeType } from '../.
 import DetailedTrafficList, { TrafficItem, TrafficNode } from '../Details/DetailedTrafficList';
 import { RenderComponentScroll } from '../../components/Nav/Page';
 import { MetricsObjectTypes } from '../../types/Metrics';
-import { DurationDropdownContainer } from 'components/DurationDropdown/DurationDropdown';
-import RefreshButtonContainer from 'components/Refresh/RefreshButton';
 import GraphDataSource from 'services/GraphDataSource';
 import { DurationInSeconds } from 'types/Common';
 import { RightActionBar } from 'components/RightActionBar/RightActionBar';
+import TimeControlsContainer from '../Time/TimeControls';
 
 type AppProps = {
   itemType: MetricsObjectTypes.APP;
@@ -115,8 +114,12 @@ class TrafficDetails extends React.Component<TrafficDetailsProps, TrafficDetails
     return (
       <>
         <RightActionBar>
-          <DurationDropdownContainer id="service-traffic-duration-dropdown" prefix="Last" />
-          <RefreshButtonContainer handleRefresh={this.fetchDataSource} />
+          <TimeControlsContainer
+            key={'DurationDropdown'}
+            id="app-info-duration-dropdown"
+            handleRefresh={this.fetchDataSource}
+            disabled={false}
+          />
         </RightActionBar>
         <RenderComponentScroll>
           <Grid style={{ padding: '10px' }}>

--- a/src/pages/AppDetails/AppInfo.tsx
+++ b/src/pages/AppDetails/AppInfo.tsx
@@ -7,11 +7,10 @@ import { App } from '../../types/App';
 import { RenderComponentScroll } from '../../components/Nav/Page';
 import './AppInfo.css';
 import { DurationInSeconds } from 'types/Common';
-import { DurationDropdownContainer } from 'components/DurationDropdown/DurationDropdown';
-import RefreshButtonContainer from 'components/Refresh/RefreshButton';
 import GraphDataSource from 'services/GraphDataSource';
 import { AppHealth } from 'types/Health';
 import { RightActionBar } from 'components/RightActionBar/RightActionBar';
+import TimeControlsContainer from '../../components/Time/TimeControls';
 
 type AppInfoProps = {
   app?: App;
@@ -56,8 +55,12 @@ class AppInfo extends React.Component<AppInfoProps, AppInfoState> {
     return (
       <>
         <RightActionBar>
-          <DurationDropdownContainer id="app-info-duration-dropdown" prefix="Last" />
-          <RefreshButtonContainer handleRefresh={this.fetchBackend} />
+          <TimeControlsContainer
+            key={'DurationDropdown'}
+            id="app-info-duration-dropdown"
+            handleRefresh={this.fetchBackend}
+            disabled={false}
+          />
         </RightActionBar>
         <RenderComponentScroll>
           <Grid style={{ margin: '10px' }} gutter={'md'}>

--- a/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -16,13 +16,12 @@ import { PromisesRegistry } from 'utils/CancelablePromises';
 import Namespace from 'types/Namespace';
 import DestinationRuleValidator from './ServiceInfo/types/DestinationRuleValidator';
 import { DurationInSeconds } from 'types/Common';
-import { DurationDropdownContainer } from 'components/DurationDropdown/DurationDropdown';
-import RefreshButtonContainer from 'components/Refresh/RefreshButton';
 import ServiceWizardDropdown from 'components/IstioWizards/ServiceWizardDropdown';
 import GraphDataSource from 'services/GraphDataSource';
 import { RightActionBar } from 'components/RightActionBar/RightActionBar';
 import IstioConfigSubList from '../../components/IstioConfigSubList/IstioConfigSubList';
 import { drToIstioItems, vsToIstioItems } from '../../types/IstioConfigList';
+import TimeControlsContainer from '../../components/Time/TimeControls';
 
 interface Props extends ServiceId {
   duration: DurationInSeconds;
@@ -307,8 +306,12 @@ class ServiceInfo extends React.Component<Props, ServiceInfoState> {
     const details = this.state.serviceDetails;
     return (
       <RightActionBar>
-        <DurationDropdownContainer id="service-info-duration-dropdown" prefix="Last" />
-        <RefreshButtonContainer handleRefresh={this.fetchBackend} />
+        <TimeControlsContainer
+          key={'DurationDropdown'}
+          id="service-info-duration-dropdown"
+          handleRefresh={this.fetchBackend}
+          disabled={false}
+        />
         {details && (
           <ServiceWizardDropdown
             namespace={this.props.namespace}

--- a/src/pages/WorkloadDetails/WorkloadInfo.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo.tsx
@@ -17,13 +17,12 @@ import ErrorBoundaryWithMessage from '../../components/ErrorBoundary/ErrorBounda
 import GraphDataSource from '../../services/GraphDataSource';
 import { DurationInSeconds } from 'types/Common';
 import { RightActionBar } from 'components/RightActionBar/RightActionBar';
-import { DurationDropdownContainer } from 'components/DurationDropdown/DurationDropdown';
-import RefreshButtonContainer from 'components/Refresh/RefreshButton';
 import WorkloadWizardDropdown from '../../components/IstioWizards/WorkloadWizardDropdown';
 import { serverConfig } from '../../config';
 import { isIstioNamespace } from '../../config/ServerConfig';
 import { IstioConfigList, toIstioItems } from '../../types/IstioConfigList';
 import IstioConfigSubList from '../../components/IstioConfigSubList/IstioConfigSubList';
+import TimeControlsContainer from '../../components/Time/TimeControls';
 
 type WorkloadInfoProps = {
   namespace: string;
@@ -310,8 +309,12 @@ class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInfoState>
     return (
       <>
         <RightActionBar>
-          <DurationDropdownContainer id="workload-info-duration-dropdown" prefix="Last" />
-          <RefreshButtonContainer handleRefresh={this.props.refreshWorkload} />
+          <TimeControlsContainer
+            key={'DurationDropdown'}
+            id="worload-info-duration-dropdown"
+            handleRefresh={this.props.refreshWorkload}
+            disabled={false}
+          />
           {workload && (
             <WorkloadWizardDropdown
               namespace={this.props.namespace}


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/3163

Now all tabs with health/traffic info that may change during time are aligned and they enable auto-refresh.

cc @jshaughn I touched a minor detail in TrafficDetails.tsx which are being modified in your PR, but I hope it's minor and you could rebase without problem.