### PR TITLE
IstioConfig: ValidationMessages are not mandatory

### DIFF
--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -376,7 +376,9 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
 
   getStatusMessages = (): ValidationMessage[] => {
     const istioObject = getIstioObject(this.state.istioObjectDetails);
-    return istioObject && istioObject.status ? istioObject.status.validationMessages : [];
+    return istioObject && istioObject.status && istioObject.status.validationMessages
+      ? istioObject.status.validationMessages
+      : ([] as ValidationMessage[]);
   };
 
   // Not all Istio types have an overview card
@@ -414,15 +416,15 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
   };
 
   isExpanded = (istioConfigDetails?: IstioConfigDetails) => {
+    let isExpaned = false;
     if (istioConfigDetails) {
-      const istioObject = getIstioObject(this.state.istioObjectDetails);
-      const istioStatusMsgs = istioObject && istioObject.status ? istioObject.status.validationMessages : [];
-      const istioValidations: ObjectValidation = this.state.istioValidations || ({} as ObjectValidation);
-      const objectReferences = istioValidations.references || ([] as ObjectReference[]);
-      const refPresent = objectReferences.length > 0;
-      return refPresent || this.hasOverview() || !!istioStatusMsgs;
+      isExpaned = this.showCards(this.objectReferences().length > 0, this.getStatusMessages());
     }
-    return false;
+    return isExpaned;
+  };
+
+  showCards = (refPresent: boolean, istioStatusMsgs: ValidationMessage[]): boolean => {
+    return refPresent || this.hasOverview() || istioStatusMsgs.length > 0;
   };
 
   renderEditor = () => {
@@ -430,7 +432,7 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
     const istioStatusMsgs = this.getStatusMessages();
     const objectReferences = this.objectReferences();
     const refPresent = objectReferences.length > 0;
-    const showCards = refPresent || this.hasOverview() || (!!istioStatusMsgs && istioStatusMsgs.length > 0);
+    const showCards = this.showCards(refPresent, istioStatusMsgs);
     let editorValidations: AceValidations = {
       markers: [],
       annotations: []

--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -416,11 +416,11 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
   };
 
   isExpanded = (istioConfigDetails?: IstioConfigDetails) => {
-    let isExpaned = false;
+    let isExpanded = false;
     if (istioConfigDetails) {
-      isExpaned = this.showCards(this.objectReferences().length > 0, this.getStatusMessages());
+      isExpanded = this.showCards(this.objectReferences().length > 0, this.getStatusMessages());
     }
-    return isExpaned;
+    return isExpanded;
   };
 
   showCards = (refPresent: boolean, istioStatusMsgs: ValidationMessage[]): boolean => {

--- a/src/types/IstioObjects.ts
+++ b/src/types/IstioObjects.ts
@@ -46,7 +46,7 @@ export interface IstioObject {
 }
 
 export interface IstioStatus {
-  validationMessages: ValidationMessage[];
+  validationMessages?: ValidationMessage[];
   conditions?: any[];
 }
 


### PR DESCRIPTION
This comes from this comment/fix in here: https://github.com/kiali/kiali-ui/pull/1946#pullrequestreview-498583490

It turns out that the `ValidationMessage[]` is not mandatory, therefore it might return null values.
I've changed it in the type and also reorganized two methods that are accessing this field. It makes it more consistent.