### PR TITLE
Better read VS/DR subsets in Wizards

### DIFF
--- a/src/components/IstioWizards/ServiceWizard.tsx
+++ b/src/components/IstioWizards/ServiceWizard.tsx
@@ -482,26 +482,34 @@ class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWizardSta
           <RequestRouting
             serviceName={this.props.serviceName}
             workloads={this.props.workloads}
-            initRules={getInitRules(this.props.workloads, this.props.virtualServices)}
+            initRules={getInitRules(this.props.workloads, this.props.virtualServices, this.props.destinationRules)}
             onChange={this.onRulesChange}
           />
         )}
         {this.props.type === WIZARD_FAULT_INJECTION && (
           <FaultInjection
-            initFaultInjectionRoute={getInitFaultInjectionRoute(this.props.workloads, this.props.virtualServices)}
+            initFaultInjectionRoute={getInitFaultInjectionRoute(
+              this.props.workloads,
+              this.props.virtualServices,
+              this.props.destinationRules
+            )}
             onChange={this.onFaultInjectionRouteChange}
           />
         )}
         {this.props.type === WIZARD_TRAFFIC_SHIFTING && (
           <TrafficShifting
             workloads={this.props.workloads}
-            initWeights={getInitWeights(this.props.workloads, this.props.virtualServices)}
+            initWeights={getInitWeights(this.props.workloads, this.props.virtualServices, this.props.destinationRules)}
             onChange={this.onWeightsChange}
           />
         )}
         {this.props.type === WIZARD_REQUEST_TIMEOUTS && (
           <RequestTimeouts
-            initTimeoutRetry={getInitTimeoutRetryRoute(this.props.workloads, this.props.virtualServices)}
+            initTimeoutRetry={getInitTimeoutRetryRoute(
+              this.props.workloads,
+              this.props.virtualServices,
+              this.props.destinationRules
+            )}
             onChange={this.onTimeoutRetryRouteChange}
           />
         )}


### PR DESCRIPTION
This is required for https://github.com/kiali/kiali/issues/2630.

Kiali Wizards are supported in configuration generated from Kiali, they cannot load any external Istio resource, basically due the complexity of all combinations.

But we want to support some specific scenarios, like the Istio configuration generated by the Iter8 controller.

Iter8 controller would need to add some extra labels on their side, and Kiali should improve the support for additional scenarios.

This PR in particular address the Kiali Wizards when VS/DR uses different naming for subsets.

On this case, Kiali may read those pair of VS/DR in a wizard and update them normally.

cc @hhovsepy Main test here is to validate that there is no regression in normal wizard scenarios.

cc @prachiyadav for Iter8 we can perform a manual test with bookinfo on default namespace, an it's creating manually this pair of vs/dr:

vs:
```
kind: VirtualService
apiVersion: networking.istio.io/v1alpha3
metadata:
  name: reviews.default.svc.cluster.local.iter8router
  namespace: default
  labels:
    iter8-tools/role: stable
    iter8-tools/router: reviews.default.svc.cluster.local
spec:
  hosts:
    - reviews.default.svc.cluster.local
  gateways:
    - mesh
  http:
    - route:
        - destination:
            host: reviews.default.svc.cluster.local
            subset: iter8-baseline
        - destination:
            host: reviews.default.svc.cluster.local
            subset: iter8-candidate-0
          weight: 100

```

dr:
```
kind: DestinationRule
apiVersion: networking.istio.io/v1alpha3
metadata:
  name: reviews.default.svc.cluster.local.iter8router
  namespace: default
  labels:
    iter8-tools/role: stable
    iter8-tools/router: reviews.default.svc.cluster.local
spec:
  host: reviews.default.svc.cluster.local
  subsets:
    - labels:
        app: reviews
        version: v2
      name: iter8-baseline
    - labels:
        app: reviews
        version: v3
      name: iter8-candidate-0
```

Then you will see that Kiali won't open it from a Wizard.

If you add new labels on them:

```
VS=$(kubectl get vs | grep iter8router | awk '{ print $1 }')
DR=$(kubectl get dr | grep iter8router | awk '{ print $1 }')

kubectl label vs $VS kiali_wizard=traffic_shifting
kubectl label dr $DR kiali_wizard=traffic_shifting
```

You would be able to open them from the "reviews" service and modify them normally.

Note that DR subsets will be overwritten but that's expected.
