### PR TITLE
Support Match Ruls in Iter8-v1.0.0-rc3

### DIFF
--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/AssessmentInfoDescription.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/AssessmentInfoDescription.tsx
@@ -6,6 +6,7 @@ import {
   EmptyStateVariant,
   Grid,
   GridItem,
+  PopoverPosition,
   Title,
   Tooltip
 } from '@patternfly/react-core';
@@ -59,6 +60,10 @@ type State = {
 
 const statusIconStyle = style({
   fontSize: '2.0em'
+});
+
+const infoStyle = style({
+  margin: '0px 16px 2px 4px'
 });
 
 class AssessmentInfoDescriptionTab extends React.Component<AssesmentInfoDescriptionProps, State> {
@@ -218,7 +223,18 @@ class AssessmentInfoDescriptionTab extends React.Component<AssesmentInfoDescript
               {this.props.experimentItem?.winner.winning_version_found &&
               this.props.experimentItem?.winner.name === assessment.name ? (
                 <Grid gutter="md">
-                  <GridItem span={6}>Winner</GridItem>
+                  <GridItem span={6}>
+                    Winner
+                    <Tooltip
+                      key={'winnerTooltip'}
+                      aria-label={'Winner Tooltip'}
+                      position={PopoverPosition.auto}
+                      className={'health_indicator'}
+                      content={<>{'Winning version identified by iter8 analytics'}</>}
+                    >
+                      <KialiIcon.Info className={infoStyle} />
+                    </Tooltip>
+                  </GridItem>
                   <GridItem span={6}>
                     {' '}
                     <KialiIcon.Ok className={statusIconStyle} />

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCriteriaForm.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCriteriaForm.tsx
@@ -68,7 +68,7 @@ type Props = {
   iter8Info: Iter8Info;
   criterias: Criteria[];
   metricNames: string[];
-  onAdd: (server: Criteria, host: Host) => void;
+  onAdd: (criteria: Criteria, host: Host, match: any) => void;
   onRemove: (type: string, index: number) => void;
 };
 
@@ -166,7 +166,8 @@ class ExperimentCriteriaForm extends React.Component<Props, State> {
   };
 
   onAddCriteria = () => {
-    this.props.onAdd(this.state.addCriteria, { name: '', gateway: '' });
+    var NULL = null;
+    this.props.onAdd(this.state.addCriteria, { name: '', gateway: '' }, NULL);
     this.setState({
       addCriteria: initCriteria()
     });
@@ -202,7 +203,7 @@ class ExperimentCriteriaForm extends React.Component<Props, State> {
                 </FormSelect>
               </>,
 
-              <FormGroup fieldId="addTolerancef" isValid={this.state.addCriteria.tolerance > 0}>
+              <FormGroup fieldId="addTolerance" isValid={this.state.addCriteria.tolerance > 0}>
                 <TextInput
                   id="addTolerance"
                   type="number"
@@ -212,7 +213,6 @@ class ExperimentCriteriaForm extends React.Component<Props, State> {
                   isValid={!isNaN(Number(this.state.addCriteria.tolerance))}
                 />
               </FormGroup>,
-
               <>
                 <FormSelect
                   value={this.state.addCriteria.toleranceType}

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentHostForm.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentHostForm.tsx
@@ -24,7 +24,7 @@ type Props = {
   hosts: Host[];
   hostsOfGateway: Host[];
   gateways: string[];
-  onAdd: (criteria: Criteria, host: Host) => void;
+  onAdd: (criteria: Criteria, host: Host, match: any) => void;
   onRemove: (type: string, index: number) => void;
 };
 
@@ -98,7 +98,7 @@ class ExperimentHostForm extends React.Component<Props, HostState> {
   };
 
   onAddHost = () => {
-    this.props.onAdd(initCriteria(), this.state.addHost);
+    this.props.onAdd(initCriteria(), this.state.addHost, null);
     this.setState({
       addHost: {
         name: '',

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentInfoDescription.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentInfoDescription.tsx
@@ -18,11 +18,13 @@ import {
   KebabToggle,
   List,
   ListItem,
+  PopoverPosition,
   Stack,
   StackItem,
   Text,
   TextVariants,
-  Title
+  Title,
+  Tooltip
 } from '@patternfly/react-core';
 
 import LocalTime from '../../../../components/Time/LocalTime';
@@ -34,6 +36,8 @@ import { GraphType } from '../../../../types/Graph';
 import history from '../../../../app/History';
 import jsyaml from 'js-yaml';
 import YAML from 'yaml';
+import { KialiIcon } from '../../../../config/KialiIcon';
+import { style } from 'typestyle';
 
 interface ExperimentInfoDescriptionProps {
   target: string;
@@ -47,6 +51,10 @@ interface ExperimentInfoDescriptionProps {
 type MiniGraphCardState = {
   isKebabOpen: boolean;
 };
+
+const infoStyle = style({
+  margin: '0px 16px 2px 4px'
+});
 
 class ExperimentInfoDescription extends React.Component<ExperimentInfoDescriptionProps, MiniGraphCardState> {
   constructor(props) {
@@ -322,8 +330,17 @@ class ExperimentInfoDescription extends React.Component<ExperimentInfoDescriptio
                           <StackItem>
                             {this.props.experimentDetails.experimentItem.winner.winning_version_found ? (
                               <>
-                                <Text component={TextVariants.h3}> Winner Found: </Text>
+                                <Text component={TextVariants.h3}> Winner Found:</Text>
                                 {this.props.experimentDetails.experimentItem.winner.name}
+                                <Tooltip
+                                  key={'winnerTooltip'}
+                                  aria-label={'Winner Tooltip'}
+                                  position={PopoverPosition.auto}
+                                  className={'health_indicator'}
+                                  content={<>{'Winning version identified by iter8 analytics'}</>}
+                                >
+                                  <KialiIcon.Info className={infoStyle} />
+                                </Tooltip>
                               </>
                             ) : (
                               <Text component={TextVariants.h3}> Winner not Found </Text>

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentTrafficForm.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentTrafficForm.tsx
@@ -1,0 +1,388 @@
+import { cellWidth, ICell, IRow, Table, TableBody, TableHeader, wrappable } from '@patternfly/react-table';
+import { Criteria, HeaderMatch, Host, HttpMatch, initCriteria } from '../../../../types/Iter8';
+import * as React from 'react';
+import {
+  Button,
+  Card,
+  CardHeader,
+  CardBody,
+  Divider,
+  FormGroup,
+  FormSelect,
+  FormSelectOption,
+  Grid,
+  GridItem,
+  TextInput,
+  ButtonVariant
+} from '@patternfly/react-core';
+import { PfColors } from '../../../../components/Pf/PfColors';
+
+const MatchOptions = [
+  { value: '', label: '--- select ---' },
+  { value: 'exact', label: 'exact string match' },
+  { value: 'prefix', label: 'prefix-based match' },
+  { value: 'regex', label: 'ECMAscript style regex-based match' }
+];
+
+const headerCells: ICell[] = [
+  {
+    title: 'header keys',
+    transforms: [wrappable, cellWidth(20) as any],
+    props: {}
+  },
+  {
+    title: 'match',
+    transforms: [cellWidth(35) as any],
+    props: {}
+  },
+  {
+    title: 'string match',
+    transforms: [cellWidth(20) as any],
+    props: {}
+  },
+  {
+    title: '',
+    props: {}
+  }
+];
+
+type Props = {
+  matches: HttpMatch[];
+  onRemove: (type: string, index: number) => void;
+  onAdd: (criteria: Criteria, host: Host, match: any) => void;
+};
+
+export type TrafficState = {
+  addMatch: HttpMatch;
+  addHeader: HeaderMatch;
+  focusElementName: string;
+  validName: boolean;
+};
+
+export const initMatch = (): TrafficState => ({
+  addMatch: {
+    uri: {
+      match: '',
+      stringMatch: ''
+    },
+    headers: []
+  },
+  addHeader: {
+    key: '',
+    match: '',
+    stringMatch: ''
+  },
+  focusElementName: 'Unknown',
+  validName: false
+});
+
+// Create Success Criteria, can be multiple with same metric, but different sampleSize, etc...
+class ExperimentTrafficForm extends React.Component<Props, TrafficState> {
+  constructor(props: Props) {
+    super(props);
+    this.state = initMatch();
+  }
+
+  // @ts-ignore
+  actionResolver = (rowData, { rowIndex }) => {
+    const removeAction = {
+      title: 'Remove Header',
+      // @ts-ignore
+      onClick: (event, rowIndex) => {
+        this.onHeaderRemove(rowIndex);
+      }
+    };
+    if (rowIndex < this.state.addMatch.headers.length) {
+      return [removeAction];
+    }
+    return [];
+  };
+
+  componentDidUpdate() {
+    if (this.state.focusElementName !== '') {
+      const focusElement = document.getElementById(this.state.focusElementName);
+      if (focusElement) {
+        focusElement.focus();
+      }
+    }
+  }
+
+  onAddMatch = (value: string, _) => {
+    this.setState(prevState => ({
+      addMatch: {
+        uri: {
+          match: value.trim(),
+          stringMatch: prevState.addMatch.uri.stringMatch
+        },
+        headers: prevState.addMatch.headers
+      },
+      focusElementName: 'Unknow',
+      validName: true
+    }));
+  };
+
+  onAddUriMatch = (value: string) => {
+    this.setState(prevState => ({
+      addMatch: {
+        uri: {
+          match: value.trim(),
+          stringMatch: prevState.addMatch.uri.stringMatch
+        },
+        headers: prevState.addMatch.headers
+      },
+      focusElementName: 'Unknow',
+      validName: true
+    }));
+  };
+
+  onAddUriMatchString = (value: string) => {
+    this.setState(prevState => ({
+      addMatch: {
+        uri: {
+          match: prevState.addMatch.uri.match,
+          stringMatch: value.trim()
+        },
+        headers: prevState.addMatch.headers
+      },
+      focusElementName: 'Unknow',
+      validName: true
+    }));
+  };
+
+  onAddHeader = () => {
+    this.setState(prevState => ({
+      addMatch: {
+        uri: {
+          match: prevState.addMatch.uri.match,
+          stringMatch: prevState.addMatch.uri.stringMatch
+        },
+        headers: prevState.addMatch.headers.concat(this.state.addHeader)
+      },
+      addHeader: {
+        key: '',
+        match: '',
+        stringMatch: ''
+      },
+      focusElementName: 'Unknown'
+    }));
+  };
+
+  onHeaderRemove = (index: number) => {
+    this.setState(prevState => {
+      prevState.addMatch.headers.splice(index, 1);
+      return {
+        addMatch: prevState.addMatch,
+        addHeader: prevState.addHeader,
+        focusElementName: 'UNknown'
+      };
+    });
+  };
+
+  onAddHeaderValue = (field: string, value: string) => {
+    this.setState(prevState => {
+      const headerInfo = prevState.addHeader;
+      switch (field) {
+        case 'addNewHeaderKey':
+          headerInfo.key = value.trim();
+          break;
+        case 'addNewHeaderMatch':
+          headerInfo.match = value.trim();
+          break;
+        case 'addNewHeaderStringMatch':
+          headerInfo.stringMatch = value.trim();
+          break;
+        default:
+      }
+      return {
+        addMatch: prevState.addMatch,
+        addHeader: headerInfo,
+        focusElementName: field
+      };
+    });
+  };
+
+  onAddMatchRules = () => {
+    this.props.onAdd(initCriteria(), { name: '', gateway: '' }, this.state.addMatch);
+    this.setState({
+      addMatch: {
+        uri: {
+          match: '',
+          stringMatch: ''
+        },
+        headers: []
+      },
+      addHeader: {
+        key: '',
+        match: '',
+        stringMatch: ''
+      },
+      focusElementName: 'Unknown',
+      validName: false
+    });
+  };
+
+  rows = (): IRow[] => {
+    return this.state.addMatch.headers
+      .map((header, i) => ({
+        key: 'header' + i,
+        cells: [<>{header.key}</>, <>{header.match}</>, <>{header.stringMatch}</>]
+      }))
+      .concat([
+        {
+          key: 'Header',
+          cells: [
+            <>
+              <TextInput
+                id="addNewHeaderKey"
+                placeholder="Key"
+                value={this.state.addHeader.key}
+                onChange={value => this.onAddHeaderValue('addNewHeaderKey', value)}
+              />
+            </>,
+            <>
+              <FormSelect
+                id="addNewHeaderMatch"
+                onChange={value => this.onAddHeaderValue('addNewHeaderMatch', value)}
+                value={this.state.addHeader.match}
+              >
+                {MatchOptions.map((mt, index) => (
+                  <FormSelectOption label={mt.label} key={'mt' + index} value={mt.value} />
+                ))}
+              </FormSelect>
+            </>,
+            <FormGroup fieldId="faddNewHeaderStringMatch" isValid={this.state.addHeader.stringMatch.length > 0}>
+              <TextInput
+                id="addNewHeaderStringMatch"
+                placeholder="match string"
+                onChange={value => this.onAddHeaderValue('addNewHeaderStringMatch', value)}
+                value={this.state.addHeader.stringMatch}
+              />
+            </FormGroup>,
+            <>
+              <Button
+                id="addHostBtn"
+                aria-label="slider-text"
+                variant="secondary"
+                isDisabled={
+                  this.state.addHeader.key === '' ||
+                  this.state.addHeader.match === '' ||
+                  this.state.addHeader.stringMatch === ''
+                }
+                onClick={this.onAddHeader}
+              >
+                Add this Header
+              </Button>
+            </>
+          ]
+        }
+      ]);
+  };
+
+  matchrows(match) {
+    return match.headers.map((header, i) => ({
+      key: 'uri' + i,
+      cells: [<>{header.key}</>, <>{header.match}</>, <>{header.stringMatch}</>, '']
+    }));
+  }
+
+  render() {
+    return this.props.matches
+      .map((match, i) => (
+        <>
+          <Card style={{ backgroundColor: i % 2 === 0 ? PfColors.GrayBackground : PfColors.White }}>
+            <CardHeader>
+              HTTP Match Request {i + 1}
+              <span style={{ float: 'right', paddingRight: '5px' }}>
+                <Button variant={ButtonVariant.secondary} onClick={() => this.props.onRemove('Match', i)}>
+                  Remove
+                </Button>
+              </span>
+            </CardHeader>
+            <CardBody>
+              <Grid gutter="md">
+                <GridItem span={6}>
+                  <FormGroup fieldId="matchSelect" label="URI Match criterion">
+                    <FormSelect id="match" value={match.uri.match} isDisabled>
+                      {MatchOptions.map((mt, index) => (
+                        <FormSelectOption label={mt.label} key={'gateway' + index} value={mt.value} />
+                      ))}
+                    </FormSelect>
+                  </FormGroup>
+                </GridItem>
+                <GridItem span={6}>
+                  <FormGroup fieldId="stringMatch" label="URI Match">
+                    <TextInput isDisabled id={'stringMatch'} placeholder="match string" value={match.uri.stringMatch} />
+                  </FormGroup>
+                </GridItem>
+                <GridItem span={12}>
+                  <Table aria-label="HTTP Match Requests" cells={headerCells} rows={this.matchrows(match)}>
+                    <TableHeader />
+                    <TableBody />
+                  </Table>
+                </GridItem>
+              </Grid>
+            </CardBody>
+          </Card>
+          <Divider />
+        </>
+      ))
+      .concat(
+        <>
+          <Card>
+            <CardHeader>
+              New HTTP Match Request
+              <span style={{ float: 'right', paddingRight: '5px' }}>
+                <Button
+                  variant={ButtonVariant.secondary}
+                  isDisabled={
+                    (this.state.addMatch.uri.match.length === 0 || this.state.addMatch.uri.stringMatch.length === 0) &&
+                    this.state.addMatch.headers.length === 0
+                  }
+                  onClick={() => this.onAddMatchRules()}
+                >
+                  Add Match Rule
+                </Button>
+              </span>
+            </CardHeader>
+            <CardBody>
+              <Grid gutter="md">
+                <GridItem span={6}>
+                  <FormGroup fieldId="matchSelect" label="URI Match criterion">
+                    <FormSelect id="match" value={this.state.addMatch.uri.match} onChange={this.onAddUriMatch}>
+                      {MatchOptions.map((mt, index) => (
+                        <FormSelectOption label={mt.label} key={'gateway' + index} value={mt.value} />
+                      ))}
+                    </FormSelect>
+                  </FormGroup>
+                </GridItem>
+                <GridItem span={6}>
+                  <FormGroup fieldId="stringMatch" label="Match String">
+                    <TextInput
+                      id={'stringMatch'}
+                      placeholder="match string"
+                      value={this.state.addMatch.uri.stringMatch}
+                      onChange={value => this.onAddUriMatchString(value)}
+                    />
+                  </FormGroup>
+                </GridItem>
+                <GridItem span={12}>
+                  <Table
+                    aria-label="HTTP Match Requests"
+                    cells={headerCells}
+                    rows={this.rows()}
+                    // @ts-ignore
+                    actionResolver={this.actionResolver}
+                  >
+                    <TableHeader />
+                    <TableBody />
+                  </Table>
+                </GridItem>
+              </Grid>
+            </CardBody>
+          </Card>
+        </>
+      );
+  }
+}
+
+export default ExperimentTrafficForm;

--- a/src/pages/extensions/iter8/Iter8ExperimentList/ExperimentListContainer.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentList/ExperimentListContainer.tsx
@@ -11,6 +11,7 @@ import {
   PopoverPosition,
   Text,
   TextContent,
+  TextVariants,
   Title,
   Tooltip,
   TooltipPosition
@@ -41,7 +42,7 @@ import { PromisesRegistry } from '../../../../utils/CancelablePromises';
 import { namespaceEquals } from '../../../../utils/Common';
 
 import { KialiIcon } from '../../../../config/KialiIcon';
-import { OkIcon } from '@patternfly/react-icons';
+import { OkIcon, PowerOffIcon } from '@patternfly/react-icons';
 import * as Iter8ExperimentListFilters from './FiltersAndSorts';
 import { FilterSelected, StatefulFilters } from '../../../../components/Filters/StatefulFilters';
 import { PfColors } from 'components/Pf/PfColors';
@@ -317,7 +318,8 @@ class ExperimentListPage extends React.Component<Props, State> {
           <h2>{statusValue}</h2> {retStatus}
         </Text>
         <Text>
-          <h2>Winner Found:</h2> {winnerFound ? winnerName : 'False'}
+          <h2>Winner Found: {winnerFound ? winnerName : 'False'}</h2>
+          <Text component={TextVariants.p}>(Winning version as identified by iter8 analytics)</Text>
         </Text>
       </TextContent>
     );
@@ -327,9 +329,12 @@ class ExperimentListPage extends React.Component<Props, State> {
     let className = greenIconStyle;
 
     let statusString = this.getStatusTooltip(phase, status, winnerStatus.winning_version_found, winnerStatus.name);
-    if (!winnerStatus.winning_version_found) {
+    if (status.includes('Abort')) {
+      className = greenIconStyle;
+    } else if (!winnerStatus.winning_version_found) {
       className = redIconStyle;
     }
+
     switch (phase) {
       case 'Initializing':
         return (
@@ -368,6 +373,19 @@ class ExperimentListPage extends React.Component<Props, State> {
           </Tooltip>
         );
       case 'Completed':
+        if (status.includes('Abort')) {
+          return (
+            <Tooltip
+              key={'Completed_' + key}
+              aria-label={'Status Indicatorr'}
+              position={PopoverPosition.auto}
+              className={'health_indicator'}
+              content={<>{statusString}</>}
+            >
+              <PowerOffIcon className={className} />
+            </Tooltip>
+          );
+        }
         return (
           <Tooltip
             key={'Completed_' + key}

--- a/src/types/Iter8.ts
+++ b/src/types/Iter8.ts
@@ -86,8 +86,15 @@ export interface TrafficControl {
   algorithm: string;
   maxIncrement: number;
   onTermination: string;
+  match: {
+    http: HttpMatch[];
+  };
 }
 
+export interface HttpMatch {
+  headers: HeaderMatch[];
+  uri: URIMatch;
+}
 export interface Duration {
   interval: string;
   intervalInSecond: number;
@@ -140,7 +147,10 @@ export const emptyExperimentDetailsInfo: Iter8ExpDetailsInfo = {
   trafficControl: {
     algorithm: 'check_and_increment',
     maxIncrement: 2,
-    onTermination: 'to_winner'
+    onTermination: 'to_winner',
+    match: {
+      http: []
+    }
   },
   duration: {
     interval: '30s',
@@ -212,6 +222,17 @@ export const initCriteria = (): Iter8Criteria => ({
 export interface Host {
   name: string;
   gateway: string;
+}
+
+export interface HeaderMatch {
+  key: string;
+  match: string;
+  stringMatch: string;
+}
+
+export interface URIMatch {
+  match: string;
+  stringMatch: string;
 }
 
 export interface ExperimentAction {


### PR DESCRIPTION
** Describe the change **
1. Add Experiment Match Rule Supports
2. Add Tooltip for Traffic Control, and Match Rules

** Issue reference **
https://github.com/kiali/kiali/issues/2007
Dependency: Kiali PR https://github.com/kiali/kiali/pull/3277

** Screenshot **

Add a screenshot of the UI after your changes.
1. Match Rule Creation
![Screen Shot 2020-10-01 at 2 14 07 PM](https://user-images.githubusercontent.com/4615187/94847615-d2e21b80-03f0-11eb-9b36-d7d7053d73cb.png)

2. Traffic Control Tooltip
![Screen Shot 2020-10-01 at 2 14 18 PM](https://user-images.githubusercontent.com/4615187/94847653-dfff0a80-03f0-11eb-8a59-15f880e790cd.png)

3. Match Rule Tooltip
![Screen Shot 2020-10-01 at 2 14 28 PM](https://user-images.githubusercontent.com/4615187/94847688-e9887280-03f0-11eb-9624-7666dd8d41d9.png)

