### PR TITLE
Fix tooltip not being rendered in Workload pods

### DIFF
--- a/src/components/Validations/ValidationList.tsx
+++ b/src/components/Validations/ValidationList.tsx
@@ -26,7 +26,9 @@ class ValidationList extends React.Component<Props> {
         enableFlip={true}
         content={isValid ? 'Valid' : this.content()}
       >
-        <Validation severity={severity} />
+        <span>
+          <Validation severity={severity} />
+        </span>
       </Tooltip>
     );
     return tooltip;


### PR DESCRIPTION
It's probably because Validation is directly a SVG ; tooltip wouldn't be rendered; adding a span fixes it

Fixes https://github.com/kiali/kiali/issues/3288
