### PR TITLE
Sync VS/GW hosts on new GW

### DIFF
--- a/src/components/IstioWizards/RequestRouting/Rules.tsx
+++ b/src/components/IstioWizards/RequestRouting/Rules.tsx
@@ -131,14 +131,18 @@ class Rules extends React.Component<Props> {
                   )}
                 </>,
                 <>
-                  {rule.workloadWeights.map((wk, i) => (
-                    <div key={'wk_' + i}>
-                      <Tooltip position={TooltipPosition.top} content={<>Workload</>}>
-                        <Badge className={'virtualitem_badge_definition'}>WS</Badge>
-                      </Tooltip>
-                      {wk.name} ({wk.weight} %)
-                    </div>
-                  ))}
+                  <div key={'ww_' + order}>
+                    {rule.workloadWeights.map((wk, i) => {
+                      return (
+                        <div key={'wk_' + order + '_' + wk.name + '_' + i}>
+                          <Tooltip position={TooltipPosition.top} content={<>Workload</>}>
+                            <Badge className={'virtualitem_badge_definition'}>WS</Badge>
+                          </Tooltip>
+                          {wk.name} ({wk.weight} %)
+                        </div>
+                      );
+                    })}
+                  </div>
                   {rule.delay && (
                     <div key={'delay_' + order}>
                       <Tooltip position={TooltipPosition.top} content={<>Fault Injection: Delay</>}>
@@ -177,6 +181,7 @@ class Rules extends React.Component<Props> {
           })
         : [
             {
+              key: 'rowEmpty',
               cells: [
                 {
                   title: (


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/3280

This is a convenient fix to make the user experience better when adding Gateways from the Wizards.

Wizards in the Advanced Options allow to define the VirtualService hosts; also in the "Advanced Options" is possible to create a "New Gateway".

This PR syncs GW + VH hosts in that case, when Wizard defines a new Gateway.

In https://github.com/kiali/kiali/issues/3280 was reported that if not sync-ed, user would always need to manually updated those config.

Note, only this is fixed in the scenario when a New Gateway is generated, when user selects an existing one, or updates, then Wizard won't sync the VS with the Gateway.

Basically Gateways are shared config and can't be always linked in 1-to-1 mapping with a VS so, trying to automate a sync here may introduce more weird situations.

