### PR TITLE
Fix bad padding at bottom of the pages

### DIFF
--- a/src/components/Nav/Page/RenderComponentScroll.tsx
+++ b/src/components/Nav/Page/RenderComponentScroll.tsx
@@ -1,10 +1,25 @@
 import React from 'react';
 
 // TOP_PADDING constant is used to adjust the height of the main div to allow scrolling in the inner container layer.
+// Overview page
+// 76px (header) + 76px (overview toolbar)
+const TOP_PADDING_OVERVIEW_NO_FILTER = 76 + 76;
+// 76px (header) + 128px (overview toolbar + filters)
+const TOP_PADDING_OVERVIEW_FILTERED = 76 + 128;
+// List & Details pages
 // 76px (header) + 118px (breadcrumb + title)
 const TOP_PADDING = 76 + 118;
 
-export class RenderComponentScroll extends React.Component<{ className?: any }, { height: number }> {
+interface Props {
+  className?: any;
+  overview?: boolean;
+}
+
+interface State {
+  height: number;
+}
+
+export class RenderComponentScroll extends React.Component<Props, State> {
   constructor(props) {
     super(props);
     this.state = { height: 0 };
@@ -15,12 +30,22 @@ export class RenderComponentScroll extends React.Component<{ className?: any }, 
     window.addEventListener('resize', this.updateWindowDimensions);
   }
 
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps.overview !== this.props.overview) {
+      this.updateWindowDimensions();
+    }
+  }
+
   componentWillUnmount() {
     window.removeEventListener('resize', this.updateWindowDimensions);
   }
 
   updateWindowDimensions = () => {
-    this.setState({ height: window.innerHeight - TOP_PADDING });
+    let topPadding = TOP_PADDING;
+    if (this.props.overview !== undefined) {
+      topPadding = this.props.overview ? TOP_PADDING_OVERVIEW_FILTERED : TOP_PADDING_OVERVIEW_NO_FILTER;
+    }
+    this.setState({ height: window.innerHeight - topPadding });
   };
 
   render() {

--- a/src/components/Nav/Page/RenderComponentScroll.tsx
+++ b/src/components/Nav/Page/RenderComponentScroll.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
 
+// TOP_PADDING constant is used to adjust the height of the main div to allow scrolling in the inner container layer.
+// 76px (header) + 118px (breadcrumb + title)
+const TOP_PADDING = 76 + 118;
+
 export class RenderComponentScroll extends React.Component<{ className?: any }, { height: number }> {
   constructor(props) {
     super(props);
@@ -16,8 +20,7 @@ export class RenderComponentScroll extends React.Component<{ className?: any }, 
   }
 
   updateWindowDimensions = () => {
-    // 76px (header) + 115px (breadcrumb + title) + 40px (tabs)
-    this.setState({ height: window.innerHeight - 231 });
+    this.setState({ height: window.innerHeight - TOP_PADDING });
   };
 
   render() {

--- a/src/pages/Overview/OverviewPage.tsx
+++ b/src/pages/Overview/OverviewPage.tsx
@@ -19,7 +19,7 @@ import {
 import { style } from 'typestyle';
 import { AxiosError } from 'axios';
 import _ from 'lodash';
-import { FilterSelected } from '../../components/Filters/StatefulFilters';
+import { FilterSelected, StatefulFilters } from '../../components/Filters/StatefulFilters';
 import * as FilterHelper from '../../components/FilterList/FilterHelper';
 import * as API from '../../services/Api';
 import {
@@ -55,7 +55,6 @@ import { Link } from 'react-router-dom';
 import { Paths, serverConfig } from '../../config';
 import { PfColors } from '../../components/Pf/PfColors';
 import VirtualList from '../../components/VirtualList/VirtualList';
-import { StatefulFilters } from '../../components/Filters/StatefulFilters';
 import { OverviewNamespaceAction, OverviewNamespaceActions } from './OverviewNamespaceActions';
 import history from '../../app/History';
 import {
@@ -70,7 +69,7 @@ import { AuthorizationPolicy } from '../../types/IstioObjects';
 const gridStyleCompact = style({
   backgroundColor: '#f5f5f5',
   paddingBottom: '20px',
-  marginTop: '20px'
+  marginTop: '0px'
 });
 
 const gridStyleList = style({
@@ -78,7 +77,7 @@ const gridStyleList = style({
   // The VirtualTable component has a different style than cards
   // We need to adjust the grid style if we are on compact vs list view
   padding: '0 !important',
-  marginTop: '20px'
+  marginTop: '0px'
 });
 
 const cardGridStyle = style({ borderTop: '2px solid #39a5dc', textAlign: 'center', marginTop: '10px' });
@@ -729,6 +728,11 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
         {filteredNamespaces.length > 0 ? (
           <RenderComponentScroll
             className={this.state.displayMode === OverviewDisplayMode.LIST ? gridStyleList : gridStyleCompact}
+            overview={
+              this.sFOverviewToolbar.current && this.sFOverviewToolbar.current.state.activeFilters.filters.length > 0
+                ? true
+                : false
+            }
           >
             {this.state.displayMode === OverviewDisplayMode.LIST ? (
               <VirtualList


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/3273

I think I introduced this bug time ago when we aligned the style between pages making all of them look similar in terms of header size, no matter if they were located in Overview, Graph or Details.

Now in long pages like lists or trace span details scroll would be adjusted to the bottom of the browser size:

![image](https://user-images.githubusercontent.com/1662329/95328401-ce60ab80-08a5-11eb-9c6c-a0c0dd49af65.png)

![image](https://user-images.githubusercontent.com/1662329/95328462-e0dae500-08a5-11eb-8998-02a0c0e001fd.png)

I think main testing here is to check there is no side effect/regression around this.