### PR TITLE
Fix validation layout on find/hide

### DIFF
--- a/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
@@ -169,9 +169,9 @@ export class GraphToolbar extends React.PureComponent<GraphToolbarProps> {
             )}
             <TourStopContainer info={GraphTourStops.Display}>
               <GraphSettingsContainer graphType={this.props.graphType} />
+              <GraphFindContainer cy={this.props.cy} />
             </TourStopContainer>
           </div>
-          <GraphFindContainer cy={this.props.cy} />
           <ToolbarGroup className={rightToolbarStyle} aria-label="graph_refresh_toolbar">
             <TourStopContainer info={GraphTourStops.TimeRange}>
               <TimeControlsContainer


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/3275

I've just made a quick change and I was talking about this fix:
![image](https://user-images.githubusercontent.com/1662329/96165005-584eeb00-0f1c-11eb-99ef-eeb960880037.png)

Then when "Find/Hide" text boxes shows a validations are aligned with previous "Display".

