### PR TITLE
workload logs - use new LogEntry and Duration support

### DIFF
--- a/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -103,11 +103,7 @@ class WorkloadDetails extends React.Component<WorkloadDetailsPageProps, Workload
     const logTab = (
       <Tab title="Logs" eventKey={2} key={'Logs'}>
         {hasPods ? (
-          <WorkloadPodLogs
-            namespace={this.props.match.params.namespace}
-            pods={this.state.workload!.pods}
-            duration={this.props.duration}
-          />
+          <WorkloadPodLogs namespace={this.props.match.params.namespace} pods={this.state.workload!.pods} />
         ) : (
           <EmptyState variant={EmptyStateVariant.full}>
             <Title headingLevel="h5" size="lg">

--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
@@ -760,9 +760,15 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
     tailLines: number,
     timeRange: TimeRange
   ) => {
+    const now = Date.now();
     const timeRangeDates = evalTimeRange(timeRange);
     const sinceTime = Math.floor(timeRangeDates[0].getTime() / 1000);
-    const duration = Math.floor(timeRangeDates[1].getTime() / 1000) - sinceTime;
+    const endTime = timeRangeDates[1].getTime();
+    // to save work on the server-side, only supply duration when time range is in the past
+    let duration = 0;
+    if (endTime < now) {
+      duration = Math.floor(timeRangeDates[1].getTime() / 1000) - sinceTime;
+    }
     const appPromise: Promise<Response<PodLogs>> = getPodLogs(
       namespace,
       podName,

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -471,7 +471,8 @@ export const getPodLogs = (
   name: string,
   container?: string,
   tailLines?: number,
-  sinceTime?: number
+  sinceTime?: number,
+  duration?: DurationInSeconds
 ) => {
   const params: any = {};
   if (container) {
@@ -482,6 +483,9 @@ export const getPodLogs = (
   }
   if (tailLines && tailLines > 0) {
     params.tailLines = tailLines;
+  }
+  if (duration && duration > 0) {
+    params.duration = `${duration}s`;
   }
   return newRequest<PodLogs>(HTTP_VERBS.GET, urls.podLogs(namespace, name), params, {});
 };

--- a/src/types/Common.ts
+++ b/src/types/Common.ts
@@ -37,8 +37,6 @@ export type BoundsInMilliseconds = {
   to?: TimeInMilliseconds;
 };
 
-export type LogLines = string[];
-
 export type TimeRange = DurationInSeconds | BoundsInMilliseconds;
 
 // Type-guarding TimeRange: executes first callback when range is a duration, or second callback when it's a bounded range, mapping to a value

--- a/src/types/IstioObjects.ts
+++ b/src/types/IstioObjects.ts
@@ -2,6 +2,7 @@ import Namespace from './Namespace';
 import { ResourcePermissions } from './Permissions';
 import { ServicePort } from './ServiceInfo';
 import { ProxyStatus } from './Health';
+import { TimeInSeconds } from './Common';
 
 // Common types
 
@@ -125,10 +126,15 @@ export interface Pod {
   proxyStatus?: ProxyStatus;
 }
 
-export type Logs = string;
+export type LogEntry = {
+  message: string;
+  severity: string;
+  timestamp: string;
+  timestampUnix: TimeInSeconds;
+};
 
 export interface PodLogs {
-  logs?: Logs;
+  entries: LogEntry[];
 }
 
 export interface Service {


### PR DESCRIPTION
Convert from using the logs blob string to the new structured LogEntry return supported by the backend.  With that support we also get support for Duration, so also add custome time range support.  And finally, add a switch to be able to toggle the k8s timestamps which take up a lot of space and may not be needed depending on the log message format.

Fixes https://github.com/kiali/kiali/issues/3067

REQUIRES SERVER PR: https://github.com/kiali/kiali/pull/3352