### PR TITLE
Typescript compiler: use es2019

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "outDir": "build/dist",
     "module": "esnext",
     "target": "es5",
-    "lib": ["es2016", "dom"],
+    "lib": ["es2019", "dom"],
     "sourceMap": true,
     "allowJs": true,
     "jsx": "preserve",


### PR DESCRIPTION
Switching to es2019 (we're on es2016) would allow for instance to use `Array.flatMap` : https://www.ecma-international.org/ecma-262/10.0/index.html#sec-array.prototype.flatmap

This doesn't change the compilation target which is still es5.