### PR TITLE
Fix wrong timestamp being use for traces query in graph

### DIFF
--- a/src/pages/Graph/SummaryPanelNode.tsx
+++ b/src/pages/Graph/SummaryPanelNode.tsx
@@ -127,7 +127,7 @@ export class SummaryPanelNode extends React.Component<SummaryPanelNodeProps, Sum
             </div>
           </Tab>
           <Tab style={summaryFont} title="Traces" eventKey={1}>
-            <SummaryPanelNodeTraces nodeData={nodeData} queryTime={this.props.queryTime} />
+            <SummaryPanelNodeTraces nodeData={nodeData} queryTime={this.props.queryTime - this.props.duration} />
           </Tab>
         </SimpleTabs>
       </div>


### PR DESCRIPTION
Unlike in metrics, "queryTime" here is startTime, not endTime.

Fixes https://github.com/kiali/kiali/issues/3359
