### PR TITLE
Fetch permisssions for Overview actions

### DIFF
--- a/src/pages/IstioConfigList/__tests__/IstioConfigListComponent.test.ts
+++ b/src/pages/IstioConfigList/__tests__/IstioConfigListComponent.test.ts
@@ -123,8 +123,6 @@ describe('IstioConfigComponent#sortIstioItems', () => {
       expect(sorted).toBeDefined();
       expect(sorted.length).toBe(15);
 
-      console.log(sorted);
-
       const first = sorted[0];
       expect(first.authorizationPolicy).toBeDefined();
       expect(first.authorizationPolicy!.metadata.name).toBe('blue0');

--- a/src/pages/Overview/OverviewNamespaceActions.tsx
+++ b/src/pages/Overview/OverviewNamespaceActions.tsx
@@ -1,9 +1,18 @@
 import * as React from 'react';
-import { Dropdown, DropdownGroup, DropdownItem, DropdownSeparator, KebabToggle } from '@patternfly/react-core';
+import {
+  Dropdown,
+  DropdownGroup,
+  DropdownItem,
+  DropdownSeparator,
+  KebabToggle,
+  Tooltip,
+  TooltipPosition
+} from '@patternfly/react-core';
 
 export type OverviewNamespaceAction = {
   isGroup: boolean;
   isSeparator: boolean;
+  isDisabled: boolean;
   title?: string;
   children?: OverviewNamespaceAction[];
   action?: (namespace: string) => void;
@@ -32,6 +41,14 @@ export class OverviewNamespaceActions extends React.Component<Props, State> {
     });
   };
 
+  renderTooltip = (key, position, msg, child): any => {
+    return (
+      <Tooltip key={'tooltip_' + key} position={position} content={<>{msg}</>}>
+        <div style={{ display: 'inline-block', cursor: 'not-allowed' }}>{child}</div>
+      </Tooltip>
+    );
+  };
+
   componentDidUpdate(_: Readonly<Props>, prevState: Readonly<State>) {
     if (prevState.isKebabOpen) {
       this.setState({
@@ -52,14 +69,23 @@ export class OverviewNamespaceActions extends React.Component<Props, State> {
             label={action.title}
             className="kiali-group-menu"
             children={action.children.map((subaction, j) => {
-              return (
+              const itemKey = 'subaction_' + i + '_' + j;
+              const item = (
                 <DropdownItem
-                  key={'subaction_' + i + '_' + j}
+                  key={itemKey}
                   onClick={() => (subaction.action ? subaction.action(this.props.namespace) : undefined)}
                 >
                   {subaction.title}
                 </DropdownItem>
               );
+              return subaction.isDisabled
+                ? this.renderTooltip(
+                    'tooltip_' + itemKey,
+                    TooltipPosition.left,
+                    'User has not enough permissions for this action',
+                    item
+                  )
+                : item;
             })}
           />
         );

--- a/src/pages/Overview/OverviewNamespaceActions.tsx
+++ b/src/pages/Overview/OverviewNamespaceActions.tsx
@@ -73,6 +73,7 @@ export class OverviewNamespaceActions extends React.Component<Props, State> {
               const item = (
                 <DropdownItem
                   key={itemKey}
+                  isDisabled={subaction.isDisabled}
                   onClick={() => (subaction.action ? subaction.action(this.props.namespace) : undefined)}
                 >
                   {subaction.title}
@@ -90,14 +91,23 @@ export class OverviewNamespaceActions extends React.Component<Props, State> {
           />
         );
       } else if (action.title && action.action) {
-        return (
+        const item = (
           <DropdownItem
             key={'action_' + i}
+            isDisabled={action.isDisabled}
             onClick={() => (action.action ? action.action(this.props.namespace) : undefined)}
           >
             {action.title}
           </DropdownItem>
         );
+        return action.isDisabled
+          ? this.renderTooltip(
+              'tooltip_action_' + i,
+              TooltipPosition.left,
+              'User has not enough permissions for this action',
+              item
+            )
+          : item;
       }
       return undefined;
     });

--- a/src/pages/Overview/__tests__/OverviewPage.test.tsx
+++ b/src/pages/Overview/__tests__/OverviewPage.test.tsx
@@ -54,6 +54,7 @@ mockAPIToPromise('getNamespaceMetrics', null, false);
 mockAPIToPromise('getNamespaceTls', null, false);
 mockAPIToPromise('getNamespaceValidations', null, false);
 mockAPIToPromise('getIstioConfig', null, false);
+mockAPIToPromise('getIstioPermissions', {}, false);
 
 let mounted: ReactWrapper<any, any> | null;
 


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/3333

It's not adding a feature flag, but checking permissions to enable/disable this feature.

How to test:

- Deploy Kiali in view_only_mode with a limited number of namespaces (i.e. default):

```
spec:
  auth:
    strategy: anonymous
  deployment:
    accessible_namespaces:
    - default
    image_name: localhost:5000/kiali/kiali
    image_pull_policy: Always
    image_version: dev
    namespace: istio-system
    service_type: ClusterIP
    verbose_mode: 3
    view_only_mode: true
```

- Validate that in this case actions on Overview are disabled:
![image](https://user-images.githubusercontent.com/1662329/97415323-57975b00-1905-11eb-8763-01da52b01446.png)
