### PR TITLE
Mutual TLS actions

### DIFF
--- a/src/components/IstioWizards/WizardActions.ts
+++ b/src/components/IstioWizards/WizardActions.ts
@@ -1172,6 +1172,24 @@ export const buildPeerAuthentication = (
   return pa;
 };
 
+export const buildMutualTlsPeerAuthentication = (name: string, namespace: string): PeerAuthentication => {
+  const pa: PeerAuthentication = {
+    metadata: {
+      name: name,
+      namespace: namespace,
+      labels: {
+        [KIALI_WIZARD_LABEL]: 'PeerAuthentication'
+      }
+    },
+    spec: {
+      mtls: {
+        mode: PeerAuthenticationMutualTLSMode.STRICT
+      }
+    }
+  };
+  return pa;
+};
+
 export const buildRequestAuthentication = (
   name: string,
   namespace: string,


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/3363

@xeviknal this PR is relatively simple but perhaps I missed something. I'd like if you could review the whole feature.

It simply adds a new Enable/Disable MutualTLS at namespace level to add a specific PeerAuthentication per namespace in STRICT mode:

![image](https://user-images.githubusercontent.com/1662329/97440365-a7871980-1927-11eb-888b-c2596b4d8855.png)

But I see that tls info is different from the graph one.

In the Kiali tls endpoint I get this:

```
{"status":"MTLS_NOT_ENABLED"}
```

And feature works as expected:

![image](https://user-images.githubusercontent.com/1662329/97440616-f7fe7700-1927-11eb-8008-c0f11a9aebf5.png)

But in the Graph I see a different semantic on the "Security" locks, which doesn't honor the status or Kiali is not collecting the right mutual TLS global status.

I don't know, perhaps I'm spotting a new issue.

Note the feature/business context was to help user to apprach this task [1]
Also reading [2] and wondering if the default mode perhaps it changes this and we don't need to add this action after all.
(That's also valid, this is a very minor PR)

[1] https://istio.io/latest/docs/tasks/security/authentication/mtls-migration/
[2] https://istio.io/latest/docs/reference/config/istio.mesh.v1alpha1/#MeshConfig