### PR TITLE
Display more info about the Pod phase/status when looking at workload pods

### DIFF
--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPods.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPods.tsx
@@ -12,7 +12,8 @@ import {
   EmptyStateVariant,
   Grid,
   GridItem,
-  Title
+  Title,
+  Tooltip
 } from '@patternfly/react-core';
 import { CogsIcon } from '@patternfly/react-icons';
 import PodStatus from './PodStatus';
@@ -61,6 +62,27 @@ class WorkloadPods extends React.Component<WorkloadPodsProps> {
     ];
   }
 
+  phase(pod: Pod): React.ReactFragment {
+    const phase = !!pod.statusReason ? pod.statusReason : pod.status;
+    const tooltipPhase = !!pod.statusReason ? `${pod.status}: ${pod.statusReason}` : pod.status;
+    const tooltip = !!pod.statusMessage ? (
+      <>
+        {tooltipPhase}
+        <br></br>
+        {pod.statusMessage}
+      </>
+    ) : (
+      tooltipPhase
+    );
+    return (
+      <>
+        <Tooltip content={<>{tooltip}</>}>
+          <span style={{ whiteSpace: 'nowrap' }}>{phase}</span>
+        </Tooltip>
+      </>
+    );
+  }
+
   rows(): IRow[] {
     if ((this.props.pods || []).length === 0) {
       return this.noPods();
@@ -87,7 +109,9 @@ class WorkloadPods extends React.Component<WorkloadPodsProps> {
           { title: <Labels key={'labels' + podIdx} labels={pod.labels} /> },
           { title: pod.istioInitContainers ? pod.istioInitContainers.map(c => `${c.image}`).join(', ') : '' },
           { title: pod.istioContainers ? pod.istioContainers.map(c => `${c.image}`).join(', ') : '' },
-          { title: <span style={{ whiteSpace: 'nowrap' }}>{pod.status}</span> }
+          {
+            title: this.phase(pod)
+          }
         ]
       });
       return rows;

--- a/src/types/IstioObjects.ts
+++ b/src/types/IstioObjects.ts
@@ -121,6 +121,8 @@ export interface Pod {
   istioContainers?: ContainerInfo[];
   istioInitContainers?: ContainerInfo[];
   status: string;
+  statusMessage?: string;
+  statusReason?: string;
   appLabel: boolean;
   versionLabel: boolean;
   proxyStatus?: ProxyStatus;


### PR DESCRIPTION
REQUIRES SERVER PR: https://github.com/kiali/kiali/pull/3377

Fixes https://github.com/kiali/kiali/issues/1399

![image](https://user-images.githubusercontent.com/2104052/97638452-ef369f80-1a12-11eb-8274-5699d9fea84c.png)
