### PR TITLE
Add assessment bar for assessment criteria without threshold

### DIFF
--- a/src/pages/extensions/iter8/Iter8ExperimentList/ExperimentListContainer.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentList/ExperimentListContainer.tsx
@@ -359,7 +359,7 @@ class ExperimentListPage extends React.Component<Props, State> {
         return (
           <Tooltip
             key={'Initializing_' + key}
-            aria-label={'Status Indicatorr'}
+            aria-label={'Status indicator'}
             position={PopoverPosition.auto}
             className={'health_indicator'}
             content={<>{statusString}</>}
@@ -371,7 +371,7 @@ class ExperimentListPage extends React.Component<Props, State> {
         return (
           <Tooltip
             key={'Progressing_' + key}
-            aria-label={'Status Indicatorr'}
+            aria-label={'Status indicator'}
             position={PopoverPosition.auto}
             className={'health_indicator'}
             content={<>{statusString}</>}
@@ -383,7 +383,7 @@ class ExperimentListPage extends React.Component<Props, State> {
         return (
           <Tooltip
             key={'Pause_' + key}
-            aria-label={'Status Indicatorr'}
+            aria-label={'Status indicator'}
             position={PopoverPosition.auto}
             className={'health_indicator'}
             content={<>{statusString}</>}
@@ -396,7 +396,7 @@ class ExperimentListPage extends React.Component<Props, State> {
           return (
             <Tooltip
               key={'Completed_' + key}
-              aria-label={'Status Indicatorr'}
+              aria-label={'Status indicator'}
               position={PopoverPosition.auto}
               className={'health_indicator'}
               content={<>{statusString}</>}
@@ -408,7 +408,7 @@ class ExperimentListPage extends React.Component<Props, State> {
           return (
             <Tooltip
               key={'Completed_' + key}
-              aria-label={'Status Indicatorr'}
+              aria-label={'Status indicator'}
               position={PopoverPosition.auto}
               className={'health_indicator'}
               content={<>{statusString}</>}
@@ -420,7 +420,7 @@ class ExperimentListPage extends React.Component<Props, State> {
         return (
           <Tooltip
             key={'Completed_' + key}
-            aria-label={'Status Indicatorr'}
+            aria-label={'Status indicator'}
             position={PopoverPosition.auto}
             className={'health_indicator'}
             content={<>{statusString}</>}
@@ -432,7 +432,7 @@ class ExperimentListPage extends React.Component<Props, State> {
         return (
           <Tooltip
             key={'default_' + key}
-            aria-label={'Status Indicatorr'}
+            aria-label={'Status indicator'}
             position={PopoverPosition.auto}
             className={'health_indicator'}
             content={<>{statusString}</>}


### PR DESCRIPTION
1. Add assessment bar for assessment criteria without threshold ( for example `mean_book_purchased`)
2. Fix spelling error ( indicatorr -> indicator)


** Screenshot **
![Screen Shot 2020-11-03 at 11 39 05 AM](https://user-images.githubusercontent.com/4615187/98014169-49e04a80-1dc9-11eb-82b3-995934a750df.png)
