### PR TITLE
Make sure API logout completes before submitting openshift logout form

### DIFF
--- a/src/components/Nav/Masthead/UserDropdown.tsx
+++ b/src/components/Nav/Masthead/UserDropdown.tsx
@@ -80,8 +80,15 @@ class UserDropdownConnected extends React.Component<UserProps, UserState> {
 
   handleLogout = () => {
     if (authenticationConfig.logoutEndpoint) {
-      API.logout();
-      (document.getElementById('openshiftlogout') as HTMLFormElement).submit();
+      API.logout()
+        .then(_ => {
+          (document.getElementById('openshiftlogout') as HTMLFormElement).submit();
+        })
+        .catch(error => {
+          const errorMsg = error.response && error.response.data.error ? error.response.data.error : error.message;
+          console.error(`Logout failed. "kiali-token" cookie may need to be cleared manually: ${errorMsg}`);
+          (document.getElementById('openshiftlogout') as HTMLFormElement).submit();
+        });
     } else {
       this.props.logout();
     }


### PR DESCRIPTION
This is related to, and possibly the root cause fix for https://github.com/kiali/kiali/issues/3313.   The original PR was also needed but the problem resurfaced during testing for https://github.com/kiali/kiali/issues/2905.  So this is being included as part of the fix for that issue.

SERVER PR: https://github.com/kiali/kiali/pull/3397

Testing this issue is somewhat tedious but a series of successful login/logouts is what you are looking for, with OpenshiftAuth.  The fault was more frequent with a backend load, especially high numbers of oath sessions coming and going.

This fix was a joint effort with @israel-hdez .
