### PR TITLE
Add one more state for the Istio component status

### DIFF
--- a/src/components/IstioStatus/IstioComponentStatus.tsx
+++ b/src/components/IstioStatus/IstioComponentStatus.tsx
@@ -39,7 +39,8 @@ const validToIcon: { [valid: string]: ComponentIcon } = {
 
 const statusMsg = {
   [Status.NotFound]: 'Not found',
-  [Status.Unhealthy]: 'Not healthy'
+  [Status.Unhealthy]: 'Not healthy',
+  [Status.Unreachable]: 'Unreachable'
 };
 
 class IstioComponentStatus extends React.Component<Props> {

--- a/src/types/IstioStatus.ts
+++ b/src/types/IstioStatus.ts
@@ -1,6 +1,7 @@
 export enum Status {
   Healthy = 'Healthy',
   Unhealthy = 'Unhealthy',
+  Unreachable = 'Unreachable',
   NotFound = 'NotFound'
 }
 


### PR DESCRIPTION
Needs https://github.com/kiali/kiali/pull/3423

Adding one more status for the add-ons (jaeger, grafana, prom) into the Istio Component Status.

![Screencapture](https://user-images.githubusercontent.com/613814/98822620-58fe7280-2431-11eb-8187-d8cfce695eff.png)