### PR TITLE
Revise namespace selector (add select all)

### DIFF
--- a/src/components/NamespaceDropdown.tsx
+++ b/src/components/NamespaceDropdown.tsx
@@ -3,7 +3,15 @@ import { connect } from 'react-redux';
 import { ThunkDispatch } from 'redux-thunk';
 import _ from 'lodash';
 import { style } from 'typestyle';
-import { Button, Dropdown, DropdownToggle, TextInput, Tooltip, DropdownToggleCheckbox } from '@patternfly/react-core';
+import {
+  Button,
+  Dropdown,
+  DropdownToggle,
+  TextInput,
+  Tooltip,
+  DropdownToggleCheckbox,
+  Divider
+} from '@patternfly/react-core';
 import { KialiAppState } from '../store/Store';
 import { activeNamespacesSelector, namespaceFilterSelector, namespaceItemsSelector } from '../store/Selectors';
 import { KialiAppAction } from '../actions/KialiAppAction';
@@ -39,28 +47,22 @@ type NamespaceDropdownState = {
   selectedNamespaces: Namespace[];
 };
 
+const checkboxBulkStyle = style({
+  marginLeft: '0.5em',
+  position: 'relative',
+  top: 8
+});
+
+const checkboxStyle = style({ marginLeft: '1.0em' });
+
 const checkboxLabelStyle = style({ marginLeft: '0.5em' });
 
 const headerStyle = style({
-  height: 40,
-  margin: '5px 10px 5px 0.5em',
-  width: 375
+  margin: '0 0.5em 10px 0.5em',
+  width: 300
 });
 
-const filterStyle = style({
-  float: 'right',
-  width: 225
-});
-
-const namespaceLabelStyle = style({
-  fontWeight: 400
-});
-
-const namespaceValueStyle = style({
-  fontWeight: 400
-});
-
-const popoverMarginBottom = 20;
+const marginBottom = 20;
 
 const namespaceContainerStyle = style({
   overflow: 'auto'
@@ -112,21 +114,20 @@ export class NamespaceDropdown extends React.PureComponent<NamespaceDropdownProp
 
   private namespaceButtonText() {
     if (this.state.selectedNamespaces.length === 0) {
-      return <span className={namespaceValueStyle}>Select Namespaces</span>;
+      return <span>Select Namespaces</span>;
     } else if (this.state.selectedNamespaces.length === 1) {
       return (
         <>
-          <span className={namespaceLabelStyle}>Namespace:</span>
+          <span>Namespace:</span>
           <span>&nbsp;</span>
-          <span className={namespaceValueStyle}>{this.state.selectedNamespaces[0].name}</span>
+          <span>{this.state.selectedNamespaces[0].name}</span>
         </>
       );
     } else {
       return (
         <>
-          <span className={namespaceLabelStyle}>Namespaces:</span>
           <span>&nbsp;</span>
-          <span className={namespaceValueStyle}>{`${this.state.selectedNamespaces.length} namespaces`}</span>
+          <span>{`[${this.state.selectedNamespaces.length}] Namespaces`}</span>
         </>
       );
     }
@@ -141,35 +142,28 @@ export class NamespaceDropdown extends React.PureComponent<NamespaceDropdownProp
     const isChecked = allSelected ? true : someChecked;
 
     return (
-      <span style={{ position: 'relative', top: 8 }}>
+      <div className={checkboxBulkStyle}>
         <DropdownToggleCheckbox
           id="bulk-select-id"
           key="bulk-select-key"
-          aria-label={anySelected ? 'Clear all' : 'Select all'}
+          aria-label="Select all"
           isChecked={isChecked}
           onClick={() => {
             anySelected ? this.onBulkNone() : this.onBulkAll();
           }}
         ></DropdownToggleCheckbox>
-        <span className={checkboxLabelStyle}>{anySelected ? 'Clear all' : 'Select all'}</span>
-      </span>
+        <span className={checkboxLabelStyle}>Select all</span>
+      </div>
     );
   }
 
   private getHeader() {
+    const hasFilter = !!this.props.filter;
     return (
       <div className={headerStyle}>
-        {this.getBulkSelector()}
-        <span>
-          {!!this.props.filter && (
-            <Tooltip key="ot_clear_namespace_filter" position="top" content="Clear Filter by Name">
-              <Button onClick={this.clearFilter} style={{ float: 'right' }}>
-                <KialiIcon.Close />
-              </Button>
-            </Tooltip>
-          )}
+        <span style={{ width: '100%' }}>
           <TextInput
-            className={filterStyle}
+            style={{ width: hasFilter ? 'calc(100% - 44px)' : '100%' }}
             aria-label="filter-namespace"
             type="text"
             name="namespace-filter"
@@ -177,7 +171,16 @@ export class NamespaceDropdown extends React.PureComponent<NamespaceDropdownProp
             value={this.props.filter}
             onChange={this.onFilterChange}
           />
+          {hasFilter && (
+            <Tooltip key="ot_clear_namespace_filter" position="top" content="Clear Filter by Name">
+              <Button onClick={this.clearFilter} isInline>
+                <KialiIcon.Close />
+              </Button>
+            </Tooltip>
+          )}
         </span>
+        {this.getBulkSelector()}
+        <Divider style={{ paddingTop: '5px' }} />
       </div>
     );
   }
@@ -190,19 +193,17 @@ export class NamespaceDropdown extends React.PureComponent<NamespaceDropdownProp
       }, {});
       const namespaces = this.filtered().map((namespace: Namespace) => (
         <div
-          style={{ marginLeft: '0.5em' }}
+          className={checkboxStyle}
           id={`namespace-list-item[${namespace.name}]`}
           key={`namespace-list-item[${namespace.name}]`}
         >
-          <label>
-            <input
-              type="checkbox"
-              value={namespace.name}
-              checked={!!selectedMap[namespace.name]}
-              onChange={this.onNamespaceToggled}
-            />
-            <span className={checkboxLabelStyle}>{namespace.name}</span>
-          </label>
+          <input
+            type="checkbox"
+            value={namespace.name}
+            checked={!!selectedMap[namespace.name]}
+            onChange={this.onNamespaceToggled}
+          />
+          <span className={checkboxLabelStyle}>{namespace.name}</span>
         </div>
       ));
 
@@ -210,7 +211,7 @@ export class NamespaceDropdown extends React.PureComponent<NamespaceDropdownProp
         <>
           <BoundingClientAwareComponent
             className={namespaceContainerStyle}
-            maxHeight={{ type: PropertyType.VIEWPORT_HEIGHT_MINUS_TOP, margin: popoverMarginBottom }}
+            maxHeight={{ type: PropertyType.VIEWPORT_HEIGHT_MINUS_TOP, margin: marginBottom }}
           >
             {namespaces}
           </BoundingClientAwareComponent>
@@ -243,6 +244,7 @@ export class NamespaceDropdown extends React.PureComponent<NamespaceDropdownProp
       this.props.refresh();
     } else {
       this.props.setNamespaces(this.state.selectedNamespaces);
+      this.clearFilter();
     }
     this.setState({
       isOpen

--- a/src/components/NamespaceDropdown.tsx
+++ b/src/components/NamespaceDropdown.tsx
@@ -53,7 +53,7 @@ const checkboxLabelStyle = style({ marginLeft: '0.5em' });
 const headerStyle = style({
   height: 40,
   margin: '5px 10px 5px 0.5em',
-  width: 350
+  width: 375
 });
 
 const filterStyle = style({
@@ -265,6 +265,7 @@ export class NamespaceDropdown extends React.PureComponent<NamespaceDropdownProp
             </DropdownToggle>
           }
           isOpen={this.state.isOpen}
+          onKeyDownCapture={this.checkSpecialKey}
         >
           {this.getHeader()}
           {this.getBody()}
@@ -307,6 +308,17 @@ export class NamespaceDropdown extends React.PureComponent<NamespaceDropdownProp
     this.setState({
       isOpen
     });
+  };
+
+  private checkSpecialKey = event => {
+    const keyCode = event.keyCode ? event.keyCode : event.which;
+    switch (keyCode) {
+      case 27: // Esc
+        this.onClose(false);
+        break;
+      default:
+        break;
+    }
   };
 
   private onClose = (isUpdate: boolean) => {

--- a/src/components/NamespaceDropdown.tsx
+++ b/src/components/NamespaceDropdown.tsx
@@ -10,7 +10,8 @@ import {
   TextInput,
   Tooltip,
   DropdownToggleCheckbox,
-  Divider
+  Divider,
+  Badge
 } from '@patternfly/react-core';
 import { KialiAppState } from '../store/Store';
 import { activeNamespacesSelector, namespaceFilterSelector, namespaceItemsSelector } from '../store/Selectors';
@@ -115,22 +116,18 @@ export class NamespaceDropdown extends React.PureComponent<NamespaceDropdownProp
   private namespaceButtonText() {
     if (this.state.selectedNamespaces.length === 0) {
       return <span>Select Namespaces</span>;
-    } else if (this.state.selectedNamespaces.length === 1) {
-      return (
-        <>
-          <span>Namespace:</span>
-          <span>&nbsp;</span>
-          <span>{this.state.selectedNamespaces[0].name}</span>
-        </>
-      );
-    } else {
-      return (
-        <>
-          <span>&nbsp;</span>
-          <span>{`[${this.state.selectedNamespaces.length}] Namespaces`}</span>
-        </>
-      );
     }
+
+    return (
+      <>
+        <span style={{ paddingRight: '0.75em' }}>Namespace:</span>
+        {this.state.selectedNamespaces.length === 1 ? (
+          <span>{this.state.selectedNamespaces[0].name}</span>
+        ) : (
+          <Badge>{this.state.selectedNamespaces.length}</Badge>
+        )}
+      </>
+    );
   }
 
   private getBulkSelector() {


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/3173

This PR revises the namespace selector in a few ways:

- adds select/deselect all
  - this is the primary RFE addition for 3173
  - note that select/deselect all applies only to the filtered set of namespaces.  Without a name filter it is a "true" all.  This allows the user to easily modify the state of a subset of namespaces, without affecting prior selections.
- batches changes
  - an important behavioral change.  prior to this PR each individual namespace select/deselect generated a state change.  this was distracting and inefficient as even changing from one namespace to another would generate 2 changes and cause pages to update while the user was still working with the dropdown.  now all changes are applied when the dropdown is closed (by clicking the button or outside the dropdown, or via the Escape key (I still wonder whether escape should act as cancel...)).
- changes button label
  - apply badging pattern to indicate multiple namespace selection

See the issue for screenshots/videos.
