### PR TITLE
OSSM-310 Fix lost settings on metrics page

### DIFF
--- a/src/components/Metrics/Helper.ts
+++ b/src/components/Metrics/Helper.ts
@@ -22,23 +22,22 @@ export const combineLabelsSettings = (newSettings: LabelsSettings, stateSettings
   // This is allowed because the labels filters state is managed only from this component,
   // so we can override them in props from state
   // LabelsSettings received from props contains the names of the filters with only a default on/off flag.
+  const result: LabelsSettings = new Map();
   newSettings.forEach((lblObj, promLabel) => {
+    const resultValues: SingleLabelValues = {};
     const stateObj = stateSettings.get(promLabel);
+    Object.entries(lblObj.values).forEach(e => {
+      resultValues[e[0]] = stateObj && stateObj.defaultValue === false ? false : e[1];
+    });
     if (stateObj) {
       lblObj.checked = stateObj.checked;
-      if (stateObj.defaultValue === false) {
-        // 1st pass: override default filters (this case only happens when filters are defined from URL)
-        Object.keys(lblObj.values).forEach(k => {
-          lblObj.values[k] = false;
-        });
-      }
-      // 2nd pass: retrieve previous filters
-      Object.keys(stateObj.values).forEach(k => {
-        lblObj.values[k] = stateObj.values[k];
+      Object.entries(stateObj.values).forEach(e => {
+        resultValues[e[0]] = e[1];
       });
     }
+    result.set(promLabel, { ...lblObj, values: resultValues });
   });
-  return newSettings;
+  return result;
 };
 
 export const extractLabelsSettingsOnSeries = (


### PR DESCRIPTION
'combineLabelsSettings' should not mutate input labels

(to be backported)