### PR TITLE
Align select-all namespaces in List pages

### DIFF
--- a/src/components/VirtualList/VirtualList.tsx
+++ b/src/components/VirtualList/VirtualList.tsx
@@ -153,17 +153,28 @@ class VirtualListC<R extends RenderResource> extends React.Component<VirtualList
             ) : (
               <tr>
                 <td colSpan={tableProps.cells.length}>
-                  <EmptyState variant={EmptyStateVariant.full}>
-                    <Title headingLevel="h5" size="lg">
-                      No {typeDisplay} found
-                    </Title>
-                    <EmptyStateBody>
-                      No {typeDisplay} in namespace
-                      {this.props.activeNamespaces.length === 1
-                        ? ` ${this.props.activeNamespaces[0].name}`
-                        : `s: ${this.props.activeNamespaces.map(ns => ns.name).join(', ')}`}
-                    </EmptyStateBody>
-                  </EmptyState>
+                  {this.props.activeNamespaces.length > 0 ? (
+                    <EmptyState variant={EmptyStateVariant.full}>
+                      <Title headingLevel="h5" size="lg">
+                        No {typeDisplay} found
+                      </Title>
+                      <EmptyStateBody>
+                        No {typeDisplay} in namespace
+                        {this.props.activeNamespaces.length === 1
+                          ? ` ${this.props.activeNamespaces[0].name}`
+                          : `s: ${this.props.activeNamespaces.map(ns => ns.name).join(', ')}`}
+                      </EmptyStateBody>
+                    </EmptyState>
+                  ) : (
+                    <EmptyState variant={EmptyStateVariant.full}>
+                      <Title headingLevel="h5" size="lg">
+                        No namespace is selected
+                      </Title>
+                      <EmptyStateBody>
+                        There is currently no namespace selected, please select one using the Namespace selector.
+                      </EmptyStateBody>
+                    </EmptyState>
+                  )}
                 </td>
               </tr>
             )}

--- a/src/pages/IstioConfigList/IstioConfigListPage.tsx
+++ b/src/pages/IstioConfigList/IstioConfigListPage.tsx
@@ -30,8 +30,7 @@ import DefaultSecondaryMasthead from '../../components/DefaultSecondaryMasthead/
 
 interface IstioConfigListPageState extends FilterComponent.State<IstioConfigItem> {}
 interface IstioConfigListPageProps extends FilterComponent.Props<IstioConfigItem> {
-  // We keep this as Optional because it does not come from the params
-  activeNamespaces?: Namespace[];
+  activeNamespaces: Namespace[];
 }
 
 class IstioConfigListPageComponent extends FilterComponent.Component<
@@ -60,8 +59,11 @@ class IstioConfigListPageComponent extends FilterComponent.Component<
   componentDidUpdate(prevProps: IstioConfigListPageProps, _prevState: IstioConfigListPageState, _snapshot: any) {
     const prevCurrentSortField = FilterHelper.currentSortField(IstioConfigListFilters.sortFields);
     const prevIsSortAscending = FilterHelper.isCurrentSortAscending();
-    const [paramsSynced] = this.paramsAreSynced(prevProps);
-    if (!paramsSynced) {
+    if (
+      !namespaceEquals(this.props.activeNamespaces, prevProps.activeNamespaces) ||
+      this.state.currentSortField !== prevCurrentSortField ||
+      this.state.isSortAscending !== prevIsSortAscending
+    ) {
       this.setState({
         currentSortField: prevCurrentSortField,
         isSortAscending: prevIsSortAscending
@@ -99,25 +101,10 @@ class IstioConfigListPageComponent extends FilterComponent.Component<
       activeFilters
     );
 
-    if (namespacesSelected.length === 0) {
-      this.promises
-        .register('namespaces', API.getNamespaces())
-        .then(namespacesResponse => {
-          const namespaces: Namespace[] = namespacesResponse.data;
-          this.fetchConfigs(
-            namespaces.map(namespace => namespace.name),
-            istioTypeFilters,
-            istioNameFilters,
-            configValidationFilters
-          );
-        })
-        .catch(namespacesError => {
-          if (!namespacesError.isCanceled) {
-            this.handleAxiosError('Could not fetch namespace list', namespacesError);
-          }
-        });
-    } else {
+    if (namespacesSelected.length !== 0) {
       this.fetchConfigs(namespacesSelected, istioTypeFilters, istioNameFilters, configValidationFilters);
+    } else {
+      this.setState({ listItems: [] });
     }
   }
 

--- a/src/pages/IstioConfigList/IstioConfigListPage.tsx
+++ b/src/pages/IstioConfigList/IstioConfigListPage.tsx
@@ -77,12 +77,6 @@ class IstioConfigListPageComponent extends FilterComponent.Component<
     this.promises.cancelAll();
   }
 
-  paramsAreSynced = (prevProps: IstioConfigListPageProps): [boolean, boolean] => {
-    const activeNamespacesCompare = namespaceEquals(prevProps.activeNamespaces!, this.props.activeNamespaces!);
-    const paramsSynced = activeNamespacesCompare;
-    return [paramsSynced, activeNamespacesCompare];
-  };
-
   sortItemList(apps: IstioConfigItem[], sortField: SortField<IstioConfigItem>, isAscending: boolean) {
     return IstioConfigListFilters.sortIstioItems(apps, sortField, isAscending);
   }


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/3437

Also fixes the sorting on table from main list pages.

Fetching all items for all namespaces is now unified using the "select-all" option in the Namespace Selector.

Note that Overview page is out of the scope of this work, that page have not namespace selection on purpose, but just filtering.

![image](https://user-images.githubusercontent.com/1662329/99783816-3ba96280-2b1b-11eb-8998-32c9d1721700.png)

![image](https://user-images.githubusercontent.com/1662329/99783853-46fc8e00-2b1b-11eb-954b-de56a0577afa.png)

![image](https://user-images.githubusercontent.com/1662329/99783873-4ebc3280-2b1b-11eb-9290-19e3f86d1472.png)

![image](https://user-images.githubusercontent.com/1662329/99783902-554aaa00-2b1b-11eb-8a7c-1d7ec00642b9.png)

![image](https://user-images.githubusercontent.com/1662329/99783925-5d0a4e80-2b1b-11eb-9a4f-cd3e3f3f09c7.png)

![image](https://user-images.githubusercontent.com/1662329/99783961-6a273d80-2b1b-11eb-9922-4486e17d43db.png)
