### PR TITLE
Spans table: fix expand state being lost

### DIFF
--- a/src/components/Expandable.tsx
+++ b/src/components/Expandable.tsx
@@ -13,6 +13,7 @@ export type CellProps<R> = R & { isExpanded: boolean };
 
 type ExpandableProps<R> = R & {
   listeners: ExpandListener[];
+  isExpanded: boolean;
   clickToExpand: boolean;
   innerComponent: React.ComponentType<R & { isExpanded: boolean }>;
 };
@@ -24,7 +25,7 @@ type ExpandableState = {
 export class Expandable<R> extends React.Component<ExpandableProps<R>, ExpandableState> {
   constructor(props: ExpandableProps<R>) {
     super(props);
-    this.state = { isExpanded: false };
+    this.state = { isExpanded: props.isExpanded };
   }
 
   componentDidMount() {
@@ -45,10 +46,11 @@ export class Expandable<R> extends React.Component<ExpandableProps<R>, Expandabl
   }
 }
 
-export const renderExpandArrow = (listeners: ExpandListener[]) => {
+export const renderExpandArrow = (listeners: ExpandListener[], isExpanded: boolean) => {
   return (
     <Expandable
       listeners={listeners}
+      isExpanded={isExpanded}
       clickToExpand={true}
       innerComponent={(props: { isExpanded: boolean }) => (props.isExpanded ? <AngleDownIcon /> : <AngleRightIcon />)}
     />

--- a/src/components/JaegerIntegration/JaegerResults/SpanTable.tsx
+++ b/src/components/JaegerIntegration/JaegerResults/SpanTable.tsx
@@ -33,12 +33,13 @@ interface State {
   sortIndex: number;
   sortDirection: SortByDirection;
   metricsStats: { [key: string]: MetricsStats };
+  expandedSpans: Map<string, boolean>;
 }
 
 export class SpanTable extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
-    this.state = { sortIndex: 0, sortDirection: SortByDirection.asc, metricsStats: {} };
+    this.state = { sortIndex: 0, sortDirection: SortByDirection.asc, metricsStats: {}, expandedSpans: new Map() };
   }
 
   componentDidMount() {
@@ -112,6 +113,11 @@ export class SpanTable extends React.Component<Props, State> {
         setToggledLinks: key => this.setState({ toggledLinks: key }),
         onClickFetchStats: () => this.fetchComparisonMetrics([item]),
         metricsStats: this.state.metricsStats,
+        isExpanded: this.state.expandedSpans.get(item.spanID) || false,
+        onExpand: isExpanded => {
+          this.state.expandedSpans.set(item.spanID, isExpanded);
+          this.setState({ expandedSpans: this.state.expandedSpans });
+        },
         ...item
       })
     );

--- a/src/components/JaegerIntegration/JaegerResults/SpanTableItem.tsx
+++ b/src/components/JaegerIntegration/JaegerResults/SpanTableItem.tsx
@@ -74,10 +74,14 @@ type RowProps = SpanItemData & {
   externalURL?: string;
   onClickFetchStats: () => void;
   metricsStats: { [key: string]: MetricsStats };
+  // onExpand and isExpandable are used to keep the extend state at an upper level
+  onExpand: (isExpanded: boolean) => void;
+  isExpanded: boolean;
 };
 
 export const buildRow = (props: RowProps) => {
   const expandListeners = createListeners();
+  expandListeners.push(props.onExpand);
   return {
     className: props.tags.some(isErrorTag) ? dangerErrorStyle : undefined,
     isOpen: false,
@@ -85,7 +89,7 @@ export const buildRow = (props: RowProps) => {
       {
         title: (
           <>
-            {renderExpandArrow(expandListeners)} {formatDuration(props.relativeStartTime)}
+            {renderExpandArrow(expandListeners, props.isExpanded)} {formatDuration(props.relativeStartTime)}
           </>
         )
       },


### PR DESCRIPTION
There was a bug when there are expanded rows in the spans table, and some actions are done that trigger table refresh, such as ordering table by columns or opening the links menu. The expanded rows were back to collapsed state.

Now they are kept expanded.