### PR TITLE
Trivial. Fix bad string.

### DIFF
--- a/src/components/Metrics/IstioMetrics.tsx
+++ b/src/components/Metrics/IstioMetrics.tsx
@@ -250,7 +250,6 @@ class IstioMetrics extends React.Component<Props, MetricsState> {
                       brushHandlers={{ onDomainChangeEnd: (_, props) => this.onDomainChange(props.currentDomain.x) }}
                     />
                   )}
-                  IstioMetricsProps
                 </CardBody>
               </Card>
             </GridItem>


### PR DESCRIPTION
I realized there was a literal left in the Metrics tab.