### PR TITLE
[multi-cluter] Add network column to clusters list

### DIFF
--- a/src/components/DefaultSecondaryMasthead/DefaultSecondaryMasthead.tsx
+++ b/src/components/DefaultSecondaryMasthead/DefaultSecondaryMasthead.tsx
@@ -7,7 +7,7 @@ const titles = [
   'applications',
   'istio',
   'istio/new',
-  'mesh_structure',
+  'mesh',
   'extensions/iter8',
   'extensions/iter8/new',
   'extensions/iter8/newfromfile',
@@ -37,7 +37,7 @@ export default class DefaultSecondaryMasthead extends React.Component<DefaultSec
         disabled = true;
       } else if (path === 'extensions/iter8/newfromfile') {
         title = 'Create New Iter8 Experiment from File';
-      } else if (path === 'mesh_structure') {
+      } else if (path === 'mesh') {
         title = 'Mesh';
       }
       return {

--- a/src/pages/Mesh/MeshPage.tsx
+++ b/src/pages/Mesh/MeshPage.tsx
@@ -20,8 +20,12 @@ const MeshPage: React.FunctionComponent = () => {
       transforms: [sortable, cellWidth(30)]
     },
     {
+      title: 'Network',
+      transforms: [sortable, cellWidth(20)]
+    },
+    {
       title: 'API Endpoint',
-      transforms: [sortable, cellWidth(30)]
+      transforms: [sortable, cellWidth(20)]
     },
     {
       title: 'Secret name',
@@ -34,7 +38,7 @@ const MeshPage: React.FunctionComponent = () => {
       return [];
     }
 
-    const sortAttributes = ['name', 'apiEndpoint', 'secretName'];
+    const sortAttributes = ['name', 'apiEndpoint', 'network', 'secretName'];
     const sortByAttr = sortAttributes[sortBy.index];
     const sortedList = Array.from(meshClustersList).sort((a, b) =>
       a[sortByAttr].localeCompare(b[sortByAttr], undefined, { sensitivity: 'base' })
@@ -45,6 +49,7 @@ const MeshPage: React.FunctionComponent = () => {
         <>
           {cluster.isKialiHome ? <StarIcon /> : null} {cluster.name}
         </>,
+        cluster.network,
         cluster.apiEndpoint,
         cluster.secretName
       ]

--- a/src/types/Mesh.ts
+++ b/src/types/Mesh.ts
@@ -2,6 +2,7 @@ export interface MeshCluster {
   apiEndpoint: string;
   isKialiHome: boolean;
   name: string;
+  network: string;
   secretName: string;
 }
 


### PR DESCRIPTION
The back-end API is now providing the network ID of each discovered cluster (if possible to resolve). This adds a column in the UI to show the new data.

Related kiali/kiali#3448
Back-end PR: https://github.com/kiali/kiali/pull/3458

![image](https://user-images.githubusercontent.com/23639005/100025497-87c00580-2dae-11eb-9bfb-fc99e338995b.png)
