### PR TITLE
Add TCP Traffic Shifting Support

### DIFF
--- a/src/components/IstioWizards/ServiceWizard.tsx
+++ b/src/components/IstioWizards/ServiceWizard.tsx
@@ -35,7 +35,8 @@ import {
   WIZARD_REQUEST_TIMEOUTS,
   getInitTimeoutRetryRoute,
   getInitConnectionPool,
-  getInitOutlierDetection
+  getInitOutlierDetection,
+  WIZARD_TCP_TRAFFIC_SHIFTING
 } from './WizardActions';
 import { MessageType } from '../../types/MessageCenter';
 import GatewaySelector, { GatewaySelectorState } from './GatewaySelector';
@@ -269,6 +270,7 @@ class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWizardSta
     const promises: Promise<Response<string>>[] = [];
     switch (this.props.type) {
       case WIZARD_TRAFFIC_SHIFTING:
+      case WIZARD_TCP_TRAFFIC_SHIFTING:
       case WIZARD_REQUEST_ROUTING:
       case WIZARD_FAULT_INJECTION:
       case WIZARD_REQUEST_TIMEOUTS:
@@ -506,7 +508,7 @@ class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWizardSta
             onChange={this.onFaultInjectionRouteChange}
           />
         )}
-        {this.props.type === WIZARD_TRAFFIC_SHIFTING && (
+        {(this.props.type === WIZARD_TRAFFIC_SHIFTING || this.props.type === WIZARD_TCP_TRAFFIC_SHIFTING) && (
           <TrafficShifting
             workloads={this.props.workloads}
             initWeights={getInitWeights(this.props.workloads, this.props.virtualServices, this.props.destinationRules)}
@@ -526,6 +528,7 @@ class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWizardSta
         {(this.props.type === WIZARD_REQUEST_ROUTING ||
           this.props.type === WIZARD_FAULT_INJECTION ||
           this.props.type === WIZARD_TRAFFIC_SHIFTING ||
+          this.props.type === WIZARD_TCP_TRAFFIC_SHIFTING ||
           this.props.type === WIZARD_REQUEST_TIMEOUTS) && (
           <Expandable
             className={advancedOptionsStyle}
@@ -575,17 +578,19 @@ class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWizardSta
                   />
                 </div>
               </Tab>
-              <Tab eventKey={3} title={'Circuit Breaker'}>
-                <div style={{ marginTop: '20px', marginBottom: '10px' }}>
-                  <CircuitBreaker
-                    hasConnectionPool={this.state.trafficPolicy.addConnectionPool}
-                    connectionPool={this.state.trafficPolicy.connectionPool}
-                    hasOutlierDetection={this.state.trafficPolicy.addOutlierDetection}
-                    outlierDetection={this.state.trafficPolicy.outlierDetection}
-                    onCircuitBreakerChange={this.onCircuitBreaker}
-                  />
-                </div>
-              </Tab>
+              {this.props.type !== WIZARD_TCP_TRAFFIC_SHIFTING && (
+                <Tab eventKey={3} title={'Circuit Breaker'}>
+                  <div style={{ marginTop: '20px', marginBottom: '10px' }}>
+                    <CircuitBreaker
+                      hasConnectionPool={this.state.trafficPolicy.addConnectionPool}
+                      connectionPool={this.state.trafficPolicy.connectionPool}
+                      hasOutlierDetection={this.state.trafficPolicy.addOutlierDetection}
+                      outlierDetection={this.state.trafficPolicy.outlierDetection}
+                      onCircuitBreakerChange={this.onCircuitBreaker}
+                    />
+                  </div>
+                </Tab>
+              )}
             </Tabs>
           </Expandable>
         )}

--- a/src/components/IstioWizards/ServiceWizardDropdown.tsx
+++ b/src/components/IstioWizards/ServiceWizardDropdown.tsx
@@ -26,7 +26,8 @@ import {
   WIZARD_FAULT_INJECTION,
   WIZARD_TITLES,
   WIZARD_TRAFFIC_SHIFTING,
-  WIZARD_REQUEST_TIMEOUTS
+  WIZARD_REQUEST_TIMEOUTS,
+  WIZARD_TCP_TRAFFIC_SHIFTING
 } from './WizardActions';
 import ServiceWizard from './ServiceWizard';
 
@@ -180,6 +181,7 @@ class ServiceWizardDropdown extends React.Component<Props, State> {
       case WIZARD_REQUEST_ROUTING:
       case WIZARD_FAULT_INJECTION:
       case WIZARD_TRAFFIC_SHIFTING:
+      case WIZARD_TCP_TRAFFIC_SHIFTING:
       case WIZARD_REQUEST_TIMEOUTS: {
         this.setState({ showWizard: true, wizardType: key, updateWizard: key === updateLabel });
         break;
@@ -269,6 +271,7 @@ class ServiceWizardDropdown extends React.Component<Props, State> {
       case WIZARD_REQUEST_ROUTING:
       case WIZARD_FAULT_INJECTION:
       case WIZARD_TRAFFIC_SHIFTING:
+      case WIZARD_TCP_TRAFFIC_SHIFTING:
       case WIZARD_REQUEST_TIMEOUTS:
         // An Item is rendered under two conditions:
         // a) No traffic -> Wizard can create new one


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/3327

Add support for TCP scenarios and align Kiali Wizards with Istio Tasks.
![image](https://user-images.githubusercontent.com/1662329/100373656-63ad3000-300b-11eb-808e-9c0220d3f69f.png)

TCP Traffic Shifting is similar as Traffic Shifting (focused on HTTP) but it doesn't have specific Advanced Features for HTTP (as Circuit Breaker).

![image](https://user-images.githubusercontent.com/1662329/100373910-c7cff400-300b-11eb-95b5-f834206b8ef0.png)

For QE:
- You can use the travels demo https://github.com/kiali/demos/tree/master/travels
- Add mysql-v2 and mysql-v3 workloads.
- Try to operate with TCP Traffic Shifting and validate the results

![image](https://user-images.githubusercontent.com/1662329/100374005-f221b180-300b-11eb-96f7-f51516e45e24.png)
