### PR TITLE
Iter8 v1.0.0 ratiostatistics - add traffic control, min/max in assessment and warning msg in terminate 

### DIFF
--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCreatePage.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCreatePage.tsx
@@ -100,7 +100,7 @@ class ExperimentCreatePage extends React.Component<Props, State> {
         candidates: [],
         experimentKind: 'Deployment',
         trafficControl: {
-          algorithm: 'progressive',
+          strategy: 'progressive',
           maxIncrement: 10,
           onTermination: 'to_winner',
           match: {
@@ -416,7 +416,7 @@ class ExperimentCreatePage extends React.Component<Props, State> {
                 showMaxIncrement: false
               });
             }
-            newExperiment.trafficControl.algorithm = value.trim();
+            newExperiment.trafficControl.strategy = value.trim();
             break;
           case 'onTermination':
             newExperiment.trafficControl.onTermination = value.trim();
@@ -772,7 +772,7 @@ class ExperimentCreatePage extends React.Component<Props, State> {
               helperText="Strategy used to analyze the candidate and shift the traffic"
             >
               <FormSelect
-                value={this.state.experiment.trafficControl.algorithm}
+                value={this.state.experiment.trafficControl.strategy}
                 id="algorithm"
                 name="Algorithm"
                 onChange={value => this.changeExperiment('algorithm', value)}

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentDetailsPage.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentDetailsPage.tsx
@@ -211,22 +211,19 @@ class ExperimentDetailsPage extends React.Component<Props, State> {
 
   renderRightToolbar = () => {
     return (
-      <span style={{ position: 'absolute', right: '20px', zIndex: 1 }}>
-        <RefreshContainer id="time_range_refresh" hideLabel={true} handleRefresh={this.doRefresh} manageURL={true} />
-        <Iter8Dropdown
-          experimentName={this.props.match.params.name}
-          manualOverride={this.state.manualOverride}
-          canDelete={this.state.canDelete}
-          startTime={this.state.experiment ? this.state.experiment.experimentItem.startTime : ''}
-          endTime={this.state.experiment ? this.state.experiment.experimentItem.endTime : ''}
-          phase={this.state.experiment ? this.state.experiment.experimentItem.phase : ' '}
-          onDelete={this.doDelete}
-          onResume={() => this.doIter8Action('resume')}
-          onPause={() => this.doIter8Action('pause')}
-          onTerminate={() => this.doIter8Action('terminate')}
-          doTrafficSplit={this.doTrafficSplit}
-        />
-      </span>
+      <Iter8Dropdown
+        experimentName={this.props.match.params.name}
+        manualOverride={this.state.manualOverride}
+        canDelete={this.state.canDelete}
+        startTime={this.state.experiment ? this.state.experiment.experimentItem.startTime : ''}
+        endTime={this.state.experiment ? this.state.experiment.experimentItem.endTime : ''}
+        phase={this.state.experiment ? this.state.experiment.experimentItem.phase : ' '}
+        onDelete={this.doDelete}
+        onResume={() => this.doIter8Action('resume')}
+        onPause={() => this.doIter8Action('pause')}
+        onTerminate={() => this.doIter8Action('terminate')}
+        doTrafficSplit={this.doTrafficSplit}
+      />
     );
   };
 
@@ -289,21 +286,7 @@ class ExperimentDetailsPage extends React.Component<Props, State> {
               manageURL={true}
             />
           }
-          actionsToolbar={
-            <Iter8Dropdown
-              experimentName={this.props.match.params.name}
-              manualOverride={this.state.manualOverride}
-              canDelete={this.state.canDelete}
-              startTime={this.state.experiment ? this.state.experiment.experimentItem.startTime : ''}
-              endTime={this.state.experiment ? this.state.experiment.experimentItem.endTime : ''}
-              phase={this.state.experiment ? this.state.experiment.experimentItem.phase : ' '}
-              onDelete={this.doDelete}
-              onResume={() => this.doIter8Action('resume')}
-              onPause={() => this.doIter8Action('pause')}
-              onTerminate={() => this.doIter8Action('terminate')}
-              doTrafficSplit={this.doTrafficSplit}
-            />
-          }
+          actionsToolbar={this.renderRightToolbar()}
         />
         <ParameterizedTabs
           id="basic-tabs"

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentInfoDescription.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentInfoDescription.tsx
@@ -21,6 +21,7 @@ import {
   PopoverPosition,
   Stack,
   StackItem,
+  Tab,
   Text,
   TextVariants,
   Title,
@@ -38,6 +39,12 @@ import jsyaml from 'js-yaml';
 import YAML from 'yaml';
 import { KialiIcon } from '../../../../config/KialiIcon';
 import { style } from 'typestyle';
+import equal from 'fast-deep-equal';
+import TrafficControlInfo from './TrafficControlInfo';
+import ParameterizedTabs, { activeTab } from '../../../../components/Tab/Tabs';
+import { PfColors } from '../../../../components/Pf/PfColors';
+
+const containerWhite = style({ backgroundColor: PfColors.White });
 
 interface ExperimentInfoDescriptionProps {
   target: string;
@@ -47,19 +54,31 @@ interface ExperimentInfoDescriptionProps {
   actionTaken: string;
 }
 
-type MiniGraphCardState = {
+type ExperimentInfoState = {
   isKebabOpen: boolean;
+  isUpdated: boolean;
+  currentTab: string;
 };
 
 const infoStyle = style({
   margin: '0px 16px 2px 4px'
 });
 
-class ExperimentInfoDescription extends React.Component<ExperimentInfoDescriptionProps, MiniGraphCardState> {
+const tabName = 'tab';
+const defaultTab = 'traffic control';
+const paramToTab: { [key: string]: number } = {
+  trafficControl: 0
+};
+
+class ExperimentInfoDescription extends React.Component<ExperimentInfoDescriptionProps, ExperimentInfoState> {
   constructor(props) {
     super(props);
 
-    this.state = { isKebabOpen: false };
+    this.state = {
+      isKebabOpen: false,
+      isUpdated: false,
+      currentTab: activeTab(tabName, defaultTab)
+    };
   }
 
   serviceLink(namespace: string, workload: string) {
@@ -206,6 +225,16 @@ class ExperimentInfoDescription extends React.Component<ExperimentInfoDescriptio
         </CardHeader>
       </CardHead>
     ];
+  }
+
+  componentDidMount() {}
+
+  componentDidUpdate(prevProps) {
+    if (!equal(this.props.experiment, prevProps.experiment)) {
+      this.setState({ isUpdated: true });
+    } else if (equal(this.props.experiment, prevProps.experiment) && this.state.isUpdated) {
+      this.setState({ isUpdated: false });
+    }
   }
 
   render() {
@@ -412,6 +441,24 @@ class ExperimentInfoDescription extends React.Component<ExperimentInfoDescriptio
                 </Stack>
               </CardBody>
             </Card>
+          </GridItem>
+          <GridItem span={12}>
+            <div className={`${containerWhite}`}>
+              <ParameterizedTabs
+                id="expmoredetail-tabs"
+                onSelect={tabValue => {
+                  this.setState({ currentTab: tabValue });
+                }}
+                tabMap={paramToTab}
+                tabName={tabName}
+                defaultTab={defaultTab}
+                activeTab={this.state.currentTab}
+              >
+                <Tab title={defaultTab} eventKey={0}>
+                  <TrafficControlInfo trafficControl={this.props.experimentDetails.trafficControl}></TrafficControlInfo>
+                </Tab>
+              </ParameterizedTabs>
+            </div>
           </GridItem>
         </Grid>
       </RenderComponentScroll>

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/TrafficControlInfo.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/TrafficControlInfo.tsx
@@ -1,0 +1,298 @@
+import * as React from 'react';
+import { TrafficControl } from '../../../../types/Iter8';
+import { compoundExpand, IRow, Table, TableBody, TableHeader, TableVariant } from '@patternfly/react-table';
+import {
+  DataList,
+  DataListCell,
+  DataListItem,
+  DataListItemCells,
+  DataListItemRow,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  Flex,
+  FlexItem,
+  FlexModifiers,
+  PopoverPosition,
+  Text,
+  Title,
+  Tooltip
+} from '@patternfly/react-core';
+import equal from 'fast-deep-equal';
+import CodeBranchIcon from '@patternfly/react-icons/dist/js/icons/code-branch-icon';
+import { style } from 'typestyle';
+import { KialiIcon } from '../../../../config/KialiIcon';
+
+const infoStyle = style({
+  margin: '0px 16px 2px 4px'
+});
+const containerPadding = style({ padding: '20px' });
+
+interface TrafficControlInfoProps {
+  trafficControl: TrafficControl;
+}
+
+type State = {
+  columns: any;
+  childColumns: any;
+  rows: any;
+};
+
+class TrafficControlInfo extends React.Component<TrafficControlInfoProps, State> {
+  constructor(props: TrafficControlInfoProps) {
+    super(props);
+    this.state = {
+      columns: [
+        'URL Match Policy',
+        'Match String',
+        {
+          title: 'Headers',
+          cellTransforms: [compoundExpand]
+        }
+      ],
+      childColumns: ['Header Key', 'Match Policy', 'Match String'],
+      rows: []
+    };
+  }
+
+  componentDidMount() {
+    this.setState(() => {
+      return {
+        rows: this.getRows()
+      };
+    });
+  }
+
+  componentDidUpdate(prevProps) {
+    if (!equal(this.props.trafficControl, prevProps.trafficControl)) {
+      this.setState(() => {
+        return {
+          rows: this.getRows()
+        };
+      });
+    }
+  }
+
+  getRows = (): IRow[] => {
+    let rows: IRow[] = [];
+    this.props.trafficControl?.match.http?.map((matchRule, idx) => {
+      const parentCount = idx * 2;
+      const childRows: IRow[] = matchRule.headers.map(h => {
+        return {
+          isOpen: false,
+          cells: [{ title: <>{h.key}</> }, { title: <>{h.match}</> }, { title: <>{h.stringMatch}</> }]
+        };
+      });
+
+      rows.push({
+        cells: [
+          { title: <> {matchRule.uri.match}</>, props: { component: 'th' } },
+          { title: <> {matchRule.uri.stringMatch}</>, props: { component: 'th' } },
+          {
+            title: (
+              <React.Fragment>
+                <CodeBranchIcon key="icon" /> {matchRule.headers.length}
+              </React.Fragment>
+            ),
+            props: { isOpen: false, ariaControls: 'childTable' + parentCount }
+          }
+        ]
+      });
+      rows.push({
+        isOpen: false,
+        parent: parentCount,
+        compoundParent: 2,
+        cells: [
+          {
+            title: (
+              <Table
+                cells={this.state.childColumns}
+                variant={TableVariant.compact}
+                rows={childRows}
+                className="pf-m-no-border-rows"
+              >
+                <TableHeader />
+                <TableBody />
+              </Table>
+            ),
+            props: { isOpen: false, className: 'pf-m-no-padding', colSpan: 3 }
+          }
+        ]
+      });
+    });
+    return rows;
+  };
+
+  onExpand = (_, rowIndex, colIndex, isOpen) => {
+    const { rows } = this.state;
+    rows[rowIndex].cells[colIndex].props.isOpen = !isOpen;
+
+    this.setState({
+      rows
+    });
+  };
+
+  render() {
+    const { columns, rows } = this.state;
+    return (
+      <Flex breakpointMods={[{ modifier: FlexModifiers.column }]}>
+        <FlexItem>
+          <DataList aria-label="detailTraffic">
+            <DataListItem aria-labelledby="altorighm">
+              <DataListItemRow>
+                <DataListItemCells
+                  dataListCells={
+                    <DataListCell key="strategy">
+                      <Text>
+                        <b>Traffic Strategy</b>
+                        <Tooltip
+                          key={'winnerTooltip'}
+                          aria-label={'Winner Tooltip'}
+                          position={PopoverPosition.auto}
+                          maxWidth="30rem"
+                          content={
+                            <table>
+                              <tr className={'tr'}>
+                                <td style={{ verticalAlign: 'top' }}>
+                                  <div style={{ width: '100px' }}>progressive:</div>
+                                </td>
+                                <td>Progressively shift all traffic to the winner.</td>
+                              </tr>
+                              <tr>
+                                <td>top_2:&nbsp;</td>
+                                <td>Converge towards a 50-50 traffic split between the best two versions</td>
+                              </tr>
+                              <tr>
+                                <td>uniform:&nbsp;</td>
+                                <td>Converge towards a uniform traffic split across all versions.</td>
+                              </tr>
+                            </table>
+                          }
+                        >
+                          <KialiIcon.Info className={infoStyle} />
+                        </Tooltip>
+                        : {this.props.trafficControl.strategy ? this.props.trafficControl.strategy : 'progressive'}
+                      </Text>
+                    </DataListCell>
+                  }
+                />
+                <DataListItemCells
+                  dataListCells={
+                    <DataListCell key="strategy">
+                      <Text>
+                        <b>Max Increment </b>
+                        <Tooltip
+                          key={'winnerTooltip'}
+                          aria-label={'Winner Tooltip'}
+                          position={PopoverPosition.auto}
+                          content={
+                            <>
+                              Specifies the maximum percentage by which traffic routed to a candidate can increase
+                              during a single iteration of the experiment. Default value: 2 (percent)
+                            </>
+                          }
+                        >
+                          <KialiIcon.Info className={infoStyle} />
+                        </Tooltip>
+                        : {this.props.trafficControl.maxIncrement} {'%'}
+                      </Text>
+                    </DataListCell>
+                  }
+                />
+                <DataListItemCells
+                  dataListCells={
+                    <DataListCell key="strategy">
+                      <Text>
+                        <b>On Termination </b>
+                        <Tooltip
+                          key={'winnerTooltip'}
+                          aria-label={'Winner Tooltip'}
+                          position={PopoverPosition.auto}
+                          maxWidth="30rem"
+                          content={
+                            <table>
+                              <tr className={'tr'}>
+                                <td style={{ verticalAlign: 'top' }}>
+                                  <div style={{ width: '100px' }}>to_winner:</div>
+                                </td>
+                                <td>
+                                  ensures that, if a winning version is found at the end of the experiment, all traffic
+                                  will flow to this version after the experiment terminates.
+                                </td>
+                              </tr>
+                              <tr>
+                                <td>to_baseline:</td>
+                                <td>
+                                  {' '}
+                                  F ensure that all traffic will flow to the baseline version, after the experiment
+                                  terminates
+                                </td>
+                              </tr>
+                              <tr>
+                                <td>keep_last:</td>
+                                <td>
+                                  ensure that the traffic split used during the final iteration of the experiment
+                                  continues even after the experiment has terminated.
+                                </td>
+                              </tr>
+                            </table>
+                          }
+                        >
+                          <KialiIcon.Info className={infoStyle} />
+                        </Tooltip>
+                        :{' '}
+                        {this.props.trafficControl.onTermination
+                          ? this.props.trafficControl.onTermination
+                          : 'to_winner'}
+                      </Text>
+                    </DataListCell>
+                  }
+                />
+              </DataListItemRow>
+            </DataListItem>
+          </DataList>
+        </FlexItem>
+        <FlexItem>
+          <div className={containerPadding}>
+            <Title headingLevel="h6" size="lg">
+              Match Rules
+              <Tooltip
+                key={'winnerTooltip'}
+                aria-label={'Winner Tooltip'}
+                position={PopoverPosition.auto}
+                content={
+                  <>
+                    Match rules used to filter out incoming traffic. With protocol name as a key, its value is an array
+                    of Istio matching clauses. Currently, only http is supported
+                  </>
+                }
+              >
+                <KialiIcon.Info className={infoStyle} />
+              </Tooltip>
+            </Title>
+
+            <Table aria-label="Compound expandable table" onExpand={this.onExpand} rows={rows} cells={columns}>
+              <TableHeader />
+              {rows.length > 0 ? (
+                <TableBody />
+              ) : (
+                <tr>
+                  <td colSpan={columns.length}>
+                    <EmptyState variant={EmptyStateVariant.full}>
+                      <Title headingLevel="h5" size="lg">
+                        No Match Rule found
+                      </Title>
+                      <EmptyStateBody>No Match Rules is defined in Experiment</EmptyStateBody>
+                    </EmptyState>
+                  </td>
+                </tr>
+              )}
+            </Table>
+          </div>
+        </FlexItem>
+      </Flex>
+    );
+  }
+}
+
+export default TrafficControlInfo;

--- a/src/types/Iter8.ts
+++ b/src/types/Iter8.ts
@@ -30,7 +30,7 @@ export interface RatioStatitics {
 
 export interface Statistics {
   value: number;
-  ratio_statitics: RatioStatitics;
+  ratio_statistics: RatioStatitics;
 }
 
 export interface ThresholdAssessment {
@@ -53,6 +53,7 @@ export interface MetricProgressInfo {
   unit: string;
   isReward: boolean;
 }
+
 export interface Iter8Experiment {
   name: string;
   phase: string;
@@ -83,7 +84,7 @@ export interface ExpId {
 }
 
 export interface TrafficControl {
-  algorithm: string;
+  strategy: string;
   maxIncrement: number;
   onTermination: string;
   match: {
@@ -95,11 +96,13 @@ export interface HttpMatch {
   headers: HeaderMatch[];
   uri: URIMatch;
 }
+
 export interface Duration {
   interval: string;
   intervalInSecond: number;
   maxIterations: number;
 }
+
 export interface Iter8ExpDetailsInfo {
   experimentItem: Iter8Experiment;
   criterias: CriteriaInfoDetail[];
@@ -145,7 +148,7 @@ export const emptyExperimentDetailsInfo: Iter8ExpDetailsInfo = {
   experimentItem: emptyExperimentItem,
   criterias: [],
   trafficControl: {
-    algorithm: 'check_and_increment',
+    strategy: 'check_and_increment',
     maxIncrement: 2,
     onTermination: 'to_winner',
     match: {
@@ -195,6 +198,7 @@ export interface CriteriaInfoDetail {
   criteria: Iter8Criteria;
   metric: Iter8Metric;
 }
+
 export interface Iter8Criteria {
   metric: string;
   tolerance: number;


### PR DESCRIPTION
** Describe the change **
1. Add Traffic Control Frame in Experiment Detail page
2. Add Min/Max credible interval in Experiment Assessment tab when the values are available. also add Legend for the assessment chart
3. Check Traffic Split Percentage in Terminate, display warning message when the "Terminate" button is pressed if the total percentage is not 100

** Screenshot **
1) Traffic Control pane 
![Screen Shot 2020-11-25 at 4 58 17 PM](https://user-images.githubusercontent.com/4615187/100387283-bbd93780-2ff5-11eb-8506-e7e4e817b45b.png)

2) Min/Max credoble interval in Assessment
![Screen Shot 2020-11-25 at 4 58 37 PM](https://user-images.githubusercontent.com/4615187/100387324-d6abac00-2ff5-11eb-99d6-56cd4d1c420d.png)


3) Warning message on Terminate Experiment 
Add a screenshot of the UI after your changes.
![Screen Shot 2020-11-25 at 4 59 09 PM](https://user-images.githubusercontent.com/4615187/100387344-dd3a2380-2ff5-11eb-9e41-9e905da73be6.png)
