### PR TITLE
Support for Mirror configuration in Kiali Wizards

### DIFF
--- a/src/components/IstioWizards/RequestRouting.tsx
+++ b/src/components/IstioWizards/RequestRouting.tsx
@@ -3,7 +3,7 @@ import { WorkloadOverview } from '../../types/ServiceInfo';
 import Rules, { MOVE_TYPE, Rule } from './RequestRouting/Rules';
 import RuleBuilder from './RequestRouting/RuleBuilder';
 import { ANYTHING, EXACT, HEADERS, PRESENCE, REGEX } from './RequestRouting/MatchBuilder';
-import { WorkloadWeight } from './TrafficShifting';
+import { MSG_WEIGHTS_NOT_VALID, WorkloadWeight } from './TrafficShifting';
 import { getDefaultWeights } from './WizardActions';
 import { FaultInjectionRoute } from './FaultInjection';
 import { TimeoutRetryRoute } from './RequestTimeouts';
@@ -143,7 +143,8 @@ class RequestRouting extends React.Component<Props, State> {
             name: ww.name,
             weight: ww.weight,
             locked: ww.locked,
-            maxWeight: ww.maxWeight
+            maxWeight: ww.maxWeight,
+            mirrored: ww.mirrored
           })
         );
         const newRule: Rule = {
@@ -244,9 +245,10 @@ class RequestRouting extends React.Component<Props, State> {
     });
   };
 
-  onSelectWeights = (_valid: boolean, workloads: WorkloadWeight[]) => {
+  onSelectWeights = (valid: boolean, workloads: WorkloadWeight[]) => {
     this.setState({
-      workloadWeights: workloads
+      workloadWeights: workloads,
+      validationMsg: !valid ? MSG_WEIGHTS_NOT_VALID : ''
     });
   };
 

--- a/src/components/IstioWizards/RequestRouting/RuleBuilder.tsx
+++ b/src/components/IstioWizards/RequestRouting/RuleBuilder.tsx
@@ -90,8 +90,10 @@ class RuleBuilder extends React.Component<Props, State> {
           </Tab>
           <Tab eventKey={1} title={'Route To'}>
             <TrafficShifting
+              showValid={false}
               workloads={this.props.workloads}
               initWeights={this.props.weights}
+              showMirror={true}
               onChange={this.props.onSelectWeights}
             />
           </Tab>

--- a/src/components/IstioWizards/RequestRouting/Rules.tsx
+++ b/src/components/IstioWizards/RequestRouting/Rules.tsx
@@ -132,16 +132,34 @@ class Rules extends React.Component<Props> {
                 </>,
                 <>
                   <div key={'ww_' + order}>
-                    {rule.workloadWeights.map((wk, i) => {
-                      return (
-                        <div key={'wk_' + order + '_' + wk.name + '_' + i}>
-                          <Tooltip position={TooltipPosition.top} content={<>Workload</>}>
-                            <Badge className={'virtualitem_badge_definition'}>WS</Badge>
-                          </Tooltip>
-                          {wk.name} ({wk.weight} %)
-                        </div>
-                      );
-                    })}
+                    {rule.workloadWeights
+                      .filter(wk => !wk.mirrored)
+                      .map((wk, i) => {
+                        return (
+                          <div key={'wk_' + order + '_' + wk.name + '_' + i}>
+                            <Tooltip position={TooltipPosition.top} content={<>Workload</>}>
+                              <Badge className={'virtualitem_badge_definition'}>WS</Badge>
+                            </Tooltip>
+                            {wk.name} ({wk.weight}% routed traffic)
+                          </div>
+                        );
+                      })}
+                    {rule.workloadWeights
+                      .filter(wk => wk.mirrored)
+                      .map((wk, i) => {
+                        return (
+                          <div key={'wk_mirrored_' + order + '_' + wk.name + '_' + i}>
+                            <Tooltip
+                              key={'mirrorred_' + wk.name}
+                              position={TooltipPosition.top}
+                              content={<>Mirrored Workload</>}
+                            >
+                              <Badge className={'faultinjection_badge_definition'}>MI</Badge>
+                            </Tooltip>
+                            {wk.name} ({wk.weight}% mirrored traffic)
+                          </div>
+                        );
+                      })}
                   </div>
                   {rule.delay && (
                     <div key={'delay_' + order}>

--- a/src/components/IstioWizards/ServiceWizard.tsx
+++ b/src/components/IstioWizards/ServiceWizard.tsx
@@ -510,8 +510,10 @@ class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWizardSta
         )}
         {(this.props.type === WIZARD_TRAFFIC_SHIFTING || this.props.type === WIZARD_TCP_TRAFFIC_SHIFTING) && (
           <TrafficShifting
+            showValid={true}
             workloads={this.props.workloads}
             initWeights={getInitWeights(this.props.workloads, this.props.virtualServices, this.props.destinationRules)}
+            showMirror={this.props.type === WIZARD_TRAFFIC_SHIFTING}
             onChange={this.onWeightsChange}
           />
         )}

--- a/src/components/IstioWizards/Slider/Boundaries.tsx
+++ b/src/components/IstioWizards/Slider/Boundaries.tsx
@@ -6,6 +6,7 @@ type BoundariesProps = {
   max: number;
   reversed: boolean;
   showBoundaries: boolean;
+  mirrored: boolean;
   slider?: JSX.Element;
 };
 
@@ -37,7 +38,7 @@ class Boundaries extends React.Component<BoundariesProps, {}> {
     }
 
     return (
-      <div className="slider-pf">
+      <div className={this.props.mirrored ? 'slider-pf-mirrored' : 'slider-pf'}>
         {leftBoundary}
         {slider}
         {rightBoundary}

--- a/src/components/IstioWizards/Slider/Slider.tsx
+++ b/src/components/IstioWizards/Slider/Slider.tsx
@@ -3,7 +3,7 @@ import BootstrapSlider from './BootstrapSlider';
 import { Button, ButtonVariant, InputGroupText, TextInput, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import Boundaries from './Boundaries';
 import { style } from 'typestyle';
-import { MinusIcon, PlusIcon, ThumbTackIcon, MigrationIcon } from '@patternfly/react-icons';
+import { MinusIcon, PlusIcon, ThumbTackIcon, VirtualMachineIcon } from '@patternfly/react-icons';
 import './styles/default.css';
 
 export const noop = Function.prototype;
@@ -186,7 +186,7 @@ class Slider extends React.Component<Props, State> {
           variant={this.props.mirrored ? ButtonVariant.primary : ButtonVariant.secondary}
           onClick={() => this.props.onMirror(!this.props.mirrored)}
         >
-          <MigrationIcon />
+          <VirtualMachineIcon />
         </Button>
       </Tooltip>
     );
@@ -223,8 +223,8 @@ class Slider extends React.Component<Props, State> {
               <InputGroupText>{this.props.inputFormat}</InputGroupText>
             </>
           )}
-          {this.props.showLock ? LockIcon : <></>}
           {this.props.showMirror ? MirrorIcon : <></>}
+          {this.props.showLock ? LockIcon : <></>}
         </Boundaries>
       </>
     );

--- a/src/components/IstioWizards/Slider/Slider.tsx
+++ b/src/components/IstioWizards/Slider/Slider.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import BootstrapSlider from './BootstrapSlider';
-import { Button, ButtonVariant, InputGroupText, TextInput } from '@patternfly/react-core';
+import { Button, ButtonVariant, InputGroupText, TextInput, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import Boundaries from './Boundaries';
 import { style } from 'typestyle';
-import { MinusIcon, PlusIcon, ThumbTackIcon } from '@patternfly/react-icons';
+import { MinusIcon, PlusIcon, ThumbTackIcon, MigrationIcon } from '@patternfly/react-icons';
 import './styles/default.css';
 
 export const noop = Function.prototype;
@@ -28,6 +28,9 @@ type Props = {
   locked: boolean;
   showLock: boolean;
   onLock: (locked: boolean) => void;
+  mirrored: boolean;
+  showMirror: boolean;
+  onMirror: (mirror: boolean) => void;
 };
 
 type State = {
@@ -57,7 +60,9 @@ class Slider extends React.Component<Props, State> {
     inputFormat: '',
     locked: false,
     showLock: true,
-    onLock: noop
+    onLock: noop,
+    showMirror: true,
+    onMirror: noop
   };
 
   constructor(props: Props) {
@@ -120,7 +125,7 @@ class Slider extends React.Component<Props, State> {
   formatter = value => {
     return this.props.tooltipFormatter !== noop
       ? this.props.tooltipFormatter(value)
-      : `${value} ${this.state.tooltipFormat}`;
+      : `${value} ${this.state.tooltipFormat} ${this.props.mirrored ? ' mirrored traffic' : ''}`;
   };
 
   render() {
@@ -159,13 +164,31 @@ class Slider extends React.Component<Props, State> {
       paddingRight: 8
     });
     const LockIcon = (
-      <Button
-        className={pinButtonStyle}
-        variant={this.props.locked ? ButtonVariant.primary : ButtonVariant.secondary}
-        onClick={() => this.props.onLock(!this.props.locked)}
+      <Tooltip
+        position={TooltipPosition.top}
+        content={<>{this.props.locked ? 'Unlock' : 'Lock'} Weight for this Workload</>}
       >
-        <ThumbTackIcon />
-      </Button>
+        <Button
+          className={pinButtonStyle}
+          isDisabled={this.props.mirrored}
+          variant={this.props.locked ? ButtonVariant.primary : ButtonVariant.secondary}
+          onClick={() => this.props.onLock(!this.props.locked)}
+        >
+          <ThumbTackIcon />
+        </Button>
+      </Tooltip>
+    );
+
+    const MirrorIcon = (
+      <Tooltip position={TooltipPosition.top} content={<>Mirror % traffic to this Workload</>}>
+        <Button
+          className={pinButtonStyle}
+          variant={this.props.mirrored ? ButtonVariant.primary : ButtonVariant.secondary}
+          onClick={() => this.props.onMirror(!this.props.mirrored)}
+        >
+          <MigrationIcon />
+        </Button>
+      </Tooltip>
     );
 
     return (
@@ -201,6 +224,7 @@ class Slider extends React.Component<Props, State> {
             </>
           )}
           {this.props.showLock ? LockIcon : <></>}
+          {this.props.showMirror ? MirrorIcon : <></>}
         </Boundaries>
       </>
     );

--- a/src/components/IstioWizards/Slider/_Slider.scss
+++ b/src/components/IstioWizards/Slider/_Slider.scss
@@ -24,6 +24,32 @@ Keep same height that buttons
   }
 }
 
+.slider-pf-mirrored {
+  display: flex;
+  align-items: center;
+
+  * {
+    margin-right: 10px;
+
+    &:last-child {
+      margin: 0;
+    }
+  }
+
+  .slider {
+    width: auto;
+    flex: 1 1 100%;
+
+    .slider-track {
+      .slider-selection {
+        background-image: -webkit-linear-gradient(top, #703fec 0%, #7144e7 100%);
+        background-image: -o-linear-gradient(top, #703fec 0%, #7144e7 100%);
+        background-image: linear-gradient(to bottom, #703fec 0%, #7144e7 100%);
+      }
+    }
+  }
+}
+
 .slider-handle {
   width: 16px;
   height: 16px;

--- a/src/components/IstioWizards/TrafficShifting.tsx
+++ b/src/components/IstioWizards/TrafficShifting.tsx
@@ -217,19 +217,9 @@ class TrafficShifting extends React.Component<Props, State> {
           cells: [
             <>
               <div>
-                {workload.mirrored ? (
-                  <Tooltip
-                    key={'mirrorred_' + workload.name}
-                    position={TooltipPosition.top}
-                    content={<>Mirrored Workload</>}
-                  >
-                    <Badge className={'faultinjection_badge_definition'}>MI</Badge>
-                  </Tooltip>
-                ) : (
-                  <Tooltip key={'tooltip_' + workload.name} position={TooltipPosition.top} content={<>Workload</>}>
-                    <Badge className={'virtualitem_badge_definition'}>WS</Badge>
-                  </Tooltip>
-                )}
+                <Tooltip key={'tooltip_' + workload.name} position={TooltipPosition.top} content={<>Workload</>}>
+                  <Badge className={'virtualitem_badge_definition'}>WS</Badge>
+                </Tooltip>
                 {workload.name}
               </div>
             </>,
@@ -255,7 +245,7 @@ class TrafficShifting extends React.Component<Props, State> {
                 showLock={this.state.workloads.length > 2}
                 onLock={locked => this.onLock(workload.name, locked)}
                 mirrored={workload.mirrored}
-                showMirror={this.props.showMirror && this.state.workloads.length > 2}
+                showMirror={this.props.showMirror && this.state.workloads.length > 1}
                 onMirror={mirrored => this.onMirror(workload.name, mirrored)}
               />
             </>
@@ -281,19 +271,13 @@ class TrafficShifting extends React.Component<Props, State> {
           cells: [
             <>
               <div>
-                {workload.mirrored ? (
-                  <Tooltip
-                    key={'mirrorred_' + workload.name}
-                    position={TooltipPosition.top}
-                    content={<>Mirrored Workload</>}
-                  >
-                    <Badge className={'faultinjection_badge_definition'}>MI</Badge>
-                  </Tooltip>
-                ) : (
-                  <Tooltip key={'tooltip_' + workload.name} position={TooltipPosition.top} content={<>Workload</>}>
-                    <Badge className={'virtualitem_badge_definition'}>WS</Badge>
-                  </Tooltip>
-                )}
+                <Tooltip
+                  key={'mirrorred_' + workload.name}
+                  position={TooltipPosition.top}
+                  content={<>Mirrored Workload</>}
+                >
+                  <Badge className={'faultinjection_badge_definition'}>MI</Badge>
+                </Tooltip>
                 {workload.name}
               </div>
             </>,
@@ -319,7 +303,7 @@ class TrafficShifting extends React.Component<Props, State> {
                 showLock={this.state.workloads.length > 2}
                 onLock={locked => this.onLock(workload.name, locked)}
                 mirrored={workload.mirrored}
-                showMirror={this.props.showMirror && this.state.workloads.length > 2}
+                showMirror={this.props.showMirror}
                 onMirror={mirrored => this.onMirror(workload.name, mirrored)}
               />
             </>

--- a/src/components/Time/Replay.tsx
+++ b/src/components/Time/Replay.tsx
@@ -262,6 +262,8 @@ export class Replay extends React.PureComponent<ReplayProps, ReplayState> {
               input={false}
               locked={false}
               showLock={false}
+              mirrored={false}
+              showMirror={false}
             />
           </div>
           <span className={controlStyle}>

--- a/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -68,7 +68,11 @@ class ServiceInfo extends React.Component<Props, ServiceInfoState> {
     if (this.state.currentTab !== aTab) {
       this.setState({ currentTab: aTab });
     }
-    if (prev.duration !== this.props.duration || prev.lastRefreshAt !== this.props.lastRefreshAt) {
+    if (
+      prev.duration !== this.props.duration ||
+      prev.lastRefreshAt !== this.props.lastRefreshAt ||
+      prev.serviceDetails !== this.props.serviceDetails
+    ) {
       this.fetchBackend();
     }
   }

--- a/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -247,7 +247,8 @@ class WorkloadDetails extends React.Component<WorkloadDetailsPageProps, Workload
 }
 
 const mapStateToProps = (state: KialiAppState) => ({
-  jaegerInfo: state.jaegerState.info
+  jaegerInfo: state.jaegerState.info,
+  lastRefreshAt: state.globalState.lastRefreshAt
 });
 
 const WorkloadDetailsContainer = connect(mapStateToProps)(WorkloadDetails);

--- a/src/pages/WorkloadDetails/WorkloadInfo.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo.tsx
@@ -79,7 +79,11 @@ class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInfoState>
 
   componentDidUpdate(prev: WorkloadInfoProps) {
     // Fetch WorkloadInfo backend on duration changes or WorkloadDetailsPage update
-    if (prev.duration !== this.props.duration || prev.lastRefreshAt !== this.props.lastRefreshAt) {
+    if (
+      prev.duration !== this.props.duration ||
+      prev.lastRefreshAt !== this.props.lastRefreshAt ||
+      prev.workload !== this.props.workload
+    ) {
       this.fetchBackend();
     }
   }


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/3476

This PR add supports for mirrored workloads in the Traffic Shifting and Request Routing wizards.

The user may select one workload that will be used as "mirror" (in the Istio VS terminology)

![image](https://user-images.githubusercontent.com/1662329/100728830-53f56900-33c8-11eb-906f-96a983db86ed.png)

And the Traffic Weight for a mirror workload represents the % of traffic mirrored from the normal routing rule.

The rest of the workload distributes the regular 100% of the traffic as a normal rule but with one workload left.

For QE:

- Test the feature from Traffic Shifting / Request Routing scenarios.
- Validate no regressions and also that VS can be edited after creation and reflected in the Wizard.

There may be some comments from @lwrigh about style of the icon and color used for mirrored but feature is completed to test.

Note that mirror traffic is a concept available on HTTP scenarios, so TCP Traffic Shifting won't show this capability.