### PR TITLE
TrafficControl Frame, min/max RatioStatistics, use TrafficShifting

### DIFF
--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCreatePage.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCreatePage.tsx
@@ -100,7 +100,7 @@ class ExperimentCreatePage extends React.Component<Props, State> {
         candidates: [],
         experimentKind: 'Deployment',
         trafficControl: {
-          algorithm: 'progressive',
+          strategy: 'progressive',
           maxIncrement: 10,
           onTermination: 'to_winner',
           match: {
@@ -416,7 +416,7 @@ class ExperimentCreatePage extends React.Component<Props, State> {
                 showMaxIncrement: false
               });
             }
-            newExperiment.trafficControl.algorithm = value.trim();
+            newExperiment.trafficControl.strategy = value.trim();
             break;
           case 'onTermination':
             newExperiment.trafficControl.onTermination = value.trim();
@@ -772,7 +772,7 @@ class ExperimentCreatePage extends React.Component<Props, State> {
               helperText="Strategy used to analyze the candidate and shift the traffic"
             >
               <FormSelect
-                value={this.state.experiment.trafficControl.algorithm}
+                value={this.state.experiment.trafficControl.strategy}
                 id="algorithm"
                 name="Algorithm"
                 onChange={value => this.changeExperiment('algorithm', value)}

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentDetailsPage.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentDetailsPage.tsx
@@ -13,7 +13,7 @@ import {
   Iter8Info,
   MetricProgressInfo
 } from '../../../../types/Iter8';
-import Iter8Dropdown, { ManualOverride } from './Iter8Dropdown';
+import Iter8Dropdown from './Iter8Dropdown';
 import history from '../../../../app/History';
 import { connect } from 'react-redux';
 
@@ -24,6 +24,7 @@ import { KialiAppState } from '../../../../store/Store';
 import { durationSelector } from '../../../../store/Selectors';
 import { TimeInMilliseconds } from '../../../../types/Common';
 import RefreshContainer from '../../../../components/Refresh/Refresh';
+import { WorkloadWeight } from '../../../../components/IstioWizards/TrafficShifting';
 
 interface ExpeerimentId {
   namespace: string;
@@ -43,7 +44,7 @@ interface State {
   baseline: string;
   actionTaken: string;
   resetActionFlag: boolean;
-  manualOverride: ManualOverride;
+  manualOverride: WorkloadWeight[];
   lastRefreshAt: TimeInMilliseconds;
 }
 
@@ -82,27 +83,33 @@ class ExperimentDetailsPage extends React.Component<Props, State> {
       baseline: baseline,
       actionTaken: '',
       resetActionFlag: false,
-      manualOverride: {
-        TrafficSplit: trafficSplit,
-        totalTrafficSplitPercentage: 0
-      },
+      manualOverride: [],
       lastRefreshAt: Date.now()
     };
   }
 
-  initTrafficSplit = (experiment): ManualOverride => {
-    if (this.state.manualOverride.TrafficSplit.size !== 0) {
+  initTrafficSplit = (experiment): WorkloadWeight[] => {
+    if (this.state.manualOverride.length !== 0) {
       return this.state.manualOverride;
     } else {
-      let trafficSplit = new Map<string, number>();
-      trafficSplit.set(experiment.experimentItem.baseline.name, 0);
-      experiment.experimentItem.candidates.forEach(c => {
-        trafficSplit.set(c.name, 0);
+      let trafficSplit: WorkloadWeight[] = [];
+      trafficSplit.push({
+        name: experiment.experimentItem.baseline.name,
+        weight: 0,
+        maxWeight: 100,
+        locked: false,
+        mirrored: false
       });
-      return {
-        TrafficSplit: trafficSplit,
-        totalTrafficSplitPercentage: 0
-      };
+      experiment.experimentItem.candidates.forEach(c => {
+        trafficSplit.push({
+          name: c.name,
+          weight: 0,
+          maxWeight: 100,
+          locked: false,
+          mirrored: false
+        });
+      });
+      return trafficSplit;
     }
   };
 
@@ -181,12 +188,10 @@ class ExperimentDetailsPage extends React.Component<Props, State> {
       });
   };
 
-  doTrafficSplit = (manualOverride: ManualOverride) => {
-    this.setState(prevState => {
-      prevState.manualOverride.TrafficSplit = manualOverride.TrafficSplit;
-      prevState.manualOverride.totalTrafficSplitPercentage = manualOverride.totalTrafficSplitPercentage;
+  doTrafficSplit = (manualOverride: WorkloadWeight[]) => {
+    this.setState(_ => {
       return {
-        manualOverride: prevState.manualOverride
+        manualOverride: manualOverride
       };
     });
   };
@@ -198,7 +203,12 @@ class ExperimentDetailsPage extends React.Component<Props, State> {
       trafficSplit: []
     };
     if (requestAction === 'terminate') {
-      action.trafficSplit = Array.from(this.state.manualOverride.TrafficSplit.entries());
+      let newrafficSplit = new Map<string, string>();
+
+      this.state.manualOverride.forEach((w, _) => {
+        newrafficSplit.set(w.name, String(w.weight));
+      });
+      action.trafficSplit = Array.from(newrafficSplit);
     }
     this.setState({ actionTaken: requestAction });
     API.updateExperiment(this.props.match.params.namespace, this.props.match.params.name, JSON.stringify(action))
@@ -211,22 +221,19 @@ class ExperimentDetailsPage extends React.Component<Props, State> {
 
   renderRightToolbar = () => {
     return (
-      <span style={{ position: 'absolute', right: '20px', zIndex: 1 }}>
-        <RefreshContainer id="time_range_refresh" hideLabel={true} handleRefresh={this.doRefresh} manageURL={true} />
-        <Iter8Dropdown
-          experimentName={this.props.match.params.name}
-          manualOverride={this.state.manualOverride}
-          canDelete={this.state.canDelete}
-          startTime={this.state.experiment ? this.state.experiment.experimentItem.startTime : ''}
-          endTime={this.state.experiment ? this.state.experiment.experimentItem.endTime : ''}
-          phase={this.state.experiment ? this.state.experiment.experimentItem.phase : ' '}
-          onDelete={this.doDelete}
-          onResume={() => this.doIter8Action('resume')}
-          onPause={() => this.doIter8Action('pause')}
-          onTerminate={() => this.doIter8Action('terminate')}
-          doTrafficSplit={this.doTrafficSplit}
-        />
-      </span>
+      <Iter8Dropdown
+        experimentName={this.props.match.params.name}
+        manualOverride={this.state.manualOverride}
+        canDelete={this.state.canDelete}
+        startTime={this.state.experiment ? this.state.experiment.experimentItem.startTime : ''}
+        endTime={this.state.experiment ? this.state.experiment.experimentItem.endTime : ''}
+        phase={this.state.experiment ? this.state.experiment.experimentItem.phase : ' '}
+        onDelete={this.doDelete}
+        onResume={() => this.doIter8Action('resume')}
+        onPause={() => this.doIter8Action('pause')}
+        onTerminate={() => this.doIter8Action('terminate')}
+        doTrafficSplit={this.doTrafficSplit}
+      />
     );
   };
 
@@ -289,21 +296,7 @@ class ExperimentDetailsPage extends React.Component<Props, State> {
               manageURL={true}
             />
           }
-          actionsToolbar={
-            <Iter8Dropdown
-              experimentName={this.props.match.params.name}
-              manualOverride={this.state.manualOverride}
-              canDelete={this.state.canDelete}
-              startTime={this.state.experiment ? this.state.experiment.experimentItem.startTime : ''}
-              endTime={this.state.experiment ? this.state.experiment.experimentItem.endTime : ''}
-              phase={this.state.experiment ? this.state.experiment.experimentItem.phase : ' '}
-              onDelete={this.doDelete}
-              onResume={() => this.doIter8Action('resume')}
-              onPause={() => this.doIter8Action('pause')}
-              onTerminate={() => this.doIter8Action('terminate')}
-              doTrafficSplit={this.doTrafficSplit}
-            />
-          }
+          actionsToolbar={this.renderRightToolbar()}
         />
         <ParameterizedTabs
           id="basic-tabs"

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/TrafficControlInfo.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/TrafficControlInfo.tsx
@@ -1,0 +1,261 @@
+import * as React from 'react';
+import { TrafficControl } from '../../../../types/Iter8';
+import { IRow, Table, TableBody, TableHeader } from '@patternfly/react-table';
+import {
+  Card,
+  CardBody,
+  DataList,
+  DataListCell,
+  DataListItem,
+  DataListItemCells,
+  DataListItemRow,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  Grid,
+  FlexItem,
+  GridItem,
+  PopoverPosition,
+  Text,
+  Title,
+  Tooltip
+} from '@patternfly/react-core';
+import equal from 'fast-deep-equal';
+import { style } from 'typestyle';
+import { KialiIcon } from '../../../../config/KialiIcon';
+
+const infoStyle = style({
+  margin: '0px 16px 2px 4px'
+});
+const containerPadding = style({ padding: '20px' });
+
+interface TrafficControlInfoProps {
+  trafficControl: TrafficControl;
+}
+
+type State = {
+  columns: any;
+  rows: any;
+};
+
+class TrafficControlInfo extends React.Component<TrafficControlInfoProps, State> {
+  constructor(props: TrafficControlInfoProps) {
+    super(props);
+    this.state = {
+      columns: [{ title: 'Rule order' }, 'Request Matching'],
+      rows: []
+    };
+  }
+
+  componentDidMount() {
+    this.setState(() => {
+      return {
+        rows: this.getRows()
+      };
+    });
+  }
+
+  componentDidUpdate(prevProps) {
+    if (!equal(this.props.trafficControl, prevProps.trafficControl)) {
+      this.setState(() => {
+        return {
+          rows: this.getRows()
+        };
+      });
+    }
+  }
+
+  getRows = (): IRow[] => {
+    let rows: IRow[] = [];
+    this.props.trafficControl?.match.http?.map((matchRule, idx) => {
+      const matchString: string[] = matchRule.headers.map(h => {
+        return 'headers [' + h.key + '] ' + h.match + ' ' + h.stringMatch + ' ';
+      });
+      matchString.push('uri ' + matchRule.uri.match + ' ' + matchRule.uri.stringMatch);
+      rows.push({
+        cells: [
+          { title: <> {idx + 1} </> },
+          {
+            title: (
+              <>
+                {matchString.map((match, i) => (
+                  <div key={'match_' + i}>{match}</div>
+                ))}
+              </>
+            )
+          }
+        ]
+      });
+    });
+    return rows;
+  };
+
+  render() {
+    const { columns, rows } = this.state;
+    return (
+      <Grid>
+        <GridItem span={12}>
+          <Card>
+            <CardBody>
+              <DataList aria-label="detailTraffic">
+                <DataListItem aria-labelledby="altorighm">
+                  <DataListItemRow>
+                    <DataListItemCells
+                      dataListCells={
+                        <DataListCell key="strategy">
+                          <Text>
+                            <b>Traffic Strategy</b>
+                            <Tooltip
+                              key={'winnerTooltip'}
+                              aria-label={'Winner Tooltip'}
+                              position={PopoverPosition.auto}
+                              maxWidth="30rem"
+                              content={
+                                <table>
+                                  <tr className={'tr'}>
+                                    <td style={{ verticalAlign: 'top' }}>
+                                      <div style={{ width: '100px' }}>progressive:</div>
+                                    </td>
+                                    <td>Progressively shift all traffic to the winner.</td>
+                                  </tr>
+                                  <tr>
+                                    <td>top_2:&nbsp;</td>
+                                    <td>Converge towards a 50-50 traffic split between the best two versions</td>
+                                  </tr>
+                                  <tr>
+                                    <td>uniform:&nbsp;</td>
+                                    <td>Converge towards a uniform traffic split across all versions.</td>
+                                  </tr>
+                                </table>
+                              }
+                            >
+                              <KialiIcon.Info className={infoStyle} />
+                            </Tooltip>
+                            : {this.props.trafficControl.strategy ? this.props.trafficControl.strategy : 'progressive'}
+                          </Text>
+                        </DataListCell>
+                      }
+                    />
+                    <DataListItemCells
+                      dataListCells={
+                        <DataListCell key="strategy">
+                          <Text>
+                            <b>Max Increment </b>
+                            <Tooltip
+                              key={'winnerTooltip'}
+                              aria-label={'Winner Tooltip'}
+                              position={PopoverPosition.auto}
+                              content={
+                                <>
+                                  Specifies the maximum percentage by which traffic routed to a candidate can increase
+                                  during a single iteration of the experiment. Default value: 2 (percent)
+                                </>
+                              }
+                            >
+                              <KialiIcon.Info className={infoStyle} />
+                            </Tooltip>
+                            : {this.props.trafficControl.maxIncrement} {'%'}
+                          </Text>
+                        </DataListCell>
+                      }
+                    />
+                    <DataListItemCells
+                      dataListCells={
+                        <DataListCell key="strategy">
+                          <Text>
+                            <b>On Termination </b>
+                            <Tooltip
+                              key={'winnerTooltip'}
+                              aria-label={'Winner Tooltip'}
+                              position={PopoverPosition.auto}
+                              maxWidth="30rem"
+                              content={
+                                <table>
+                                  <tr className={'tr'}>
+                                    <td style={{ verticalAlign: 'top' }}>
+                                      <div style={{ width: '100px' }}>to_winner:</div>
+                                    </td>
+                                    <td>
+                                      ensures that, if a winning version is found at the end of the experiment, all
+                                      traffic will flow to this version after the experiment terminates.
+                                    </td>
+                                  </tr>
+                                  <tr>
+                                    <td>to_baseline:</td>
+                                    <td>
+                                      {' '}
+                                      F ensure that all traffic will flow to the baseline version, after the experiment
+                                      terminates
+                                    </td>
+                                  </tr>
+                                  <tr>
+                                    <td>keep_last:</td>
+                                    <td>
+                                      ensure that the traffic split used during the final iteration of the experiment
+                                      continues even after the experiment has terminated.
+                                    </td>
+                                  </tr>
+                                </table>
+                              }
+                            >
+                              <KialiIcon.Info className={infoStyle} />
+                            </Tooltip>
+                            :{' '}
+                            {this.props.trafficControl.onTermination
+                              ? this.props.trafficControl.onTermination
+                              : 'to_winner'}
+                          </Text>
+                        </DataListCell>
+                      }
+                    />
+                  </DataListItemRow>
+                </DataListItem>
+              </DataList>
+
+              <FlexItem>
+                <div className={containerPadding}>
+                  <Title headingLevel="h6" size="lg">
+                    Match Rules
+                    <Tooltip
+                      key={'winnerTooltip'}
+                      aria-label={'Winner Tooltip'}
+                      position={PopoverPosition.auto}
+                      content={
+                        <>
+                          Match rules used to filter out incoming traffic. With protocol name as a key, its value is an
+                          array of Istio matching clauses. Currently, only http is supported
+                        </>
+                      }
+                    >
+                      <KialiIcon.Info className={infoStyle} />
+                    </Tooltip>
+                  </Title>
+
+                  <Table aria-label="Compound expandable table" rows={this.getRows()} cells={columns}>
+                    <TableHeader />
+                    {rows.length > 0 ? (
+                      <TableBody />
+                    ) : (
+                      <tr>
+                        <td colSpan={columns.length}>
+                          <EmptyState variant={EmptyStateVariant.full}>
+                            <Title headingLevel="h5" size="lg">
+                              No Match Rule found
+                            </Title>
+                            <EmptyStateBody>No Match Rules is defined in Experiment</EmptyStateBody>
+                          </EmptyState>
+                        </td>
+                      </tr>
+                    )}
+                  </Table>
+                </div>
+              </FlexItem>
+            </CardBody>
+          </Card>
+        </GridItem>
+      </Grid>
+    );
+  }
+}
+
+export default TrafficControlInfo;

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/TrafficControlInfo.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/TrafficControlInfo.tsx
@@ -68,10 +68,14 @@ class TrafficControlInfo extends React.Component<TrafficControlInfoProps, State>
   getRows = (): IRow[] => {
     let rows: IRow[] = [];
     this.props.trafficControl?.match.http?.map((matchRule, idx) => {
-      const matchString: string[] = matchRule.headers.map(h => {
-        return 'headers [' + h.key + '] ' + h.match + ' ' + h.stringMatch + ' ';
+      const matchString: string[] = [];
+      matchRule.headers?.map(h => {
+        matchString.push('headers [' + h.key + '] ' + h.match + ' ' + h.stringMatch + ' ');
       });
-      matchString.push('uri ' + matchRule.uri.match + ' ' + matchRule.uri.stringMatch);
+      if (matchRule.uri?.match) {
+        matchString.push('uri ' + matchRule.uri.match + ' ' + matchRule.uri.stringMatch);
+      }
+
       rows.push({
         cells: [
           { title: <> {idx + 1} </> },

--- a/src/types/Iter8.ts
+++ b/src/types/Iter8.ts
@@ -30,7 +30,7 @@ export interface RatioStatitics {
 
 export interface Statistics {
   value: number;
-  ratio_statitics: RatioStatitics;
+  ratio_statistics: RatioStatitics;
 }
 
 export interface ThresholdAssessment {
@@ -53,6 +53,7 @@ export interface MetricProgressInfo {
   unit: string;
   isReward: boolean;
 }
+
 export interface Iter8Experiment {
   name: string;
   phase: string;
@@ -83,7 +84,7 @@ export interface ExpId {
 }
 
 export interface TrafficControl {
-  algorithm: string;
+  strategy: string;
   maxIncrement: number;
   onTermination: string;
   match: {
@@ -95,11 +96,13 @@ export interface HttpMatch {
   headers: HeaderMatch[];
   uri: URIMatch;
 }
+
 export interface Duration {
   interval: string;
   intervalInSecond: number;
   maxIterations: number;
 }
+
 export interface Iter8ExpDetailsInfo {
   experimentItem: Iter8Experiment;
   criterias: CriteriaInfoDetail[];
@@ -145,7 +148,7 @@ export const emptyExperimentDetailsInfo: Iter8ExpDetailsInfo = {
   experimentItem: emptyExperimentItem,
   criterias: [],
   trafficControl: {
-    algorithm: 'check_and_increment',
+    strategy: 'check_and_increment',
     maxIncrement: 2,
     onTermination: 'to_winner',
     match: {
@@ -195,6 +198,7 @@ export interface CriteriaInfoDetail {
   criteria: Iter8Criteria;
   metric: Iter8Metric;
 }
+
 export interface Iter8Criteria {
   metric: string;
   tolerance: number;
@@ -237,7 +241,7 @@ export interface URIMatch {
 
 export interface ExperimentAction {
   action: string;
-  trafficSplit: [string, number][];
+  trafficSplit: [string, string][];
 }
 
 export interface ExperimentSpec {


### PR DESCRIPTION
Improve on the Changes request from [PR#2015](https://github.com/kiali/kiali-ui/pull/2015) 

a)  Add Traffic Control Frame in Experiment Detail page 
> 1.  **_Using Kiali pattern for showing match rules_**
> 2. **_Fix the tab issue for TrafficControl Frame_**

b)  Add Min/Max credible interval in Experiment Assessment tab when the values are available. also add Legend for the assessment chart

c)  Using TrafficShifting Components in Terminate Experiment request

Note: has dependency on PR https://github.com/kiali/kiali/pull/3475

**Screenshot**

a) Traffic Control 
<img width="1186" alt="Screen Shot 2020-12-03 at 1 32 35 PM" src="https://user-images.githubusercontent.com/4615187/101072455-10d3fb00-356c-11eb-8b9d-703d0eccf88f.png">

b) Min/Max Credible Internal 
<img width="1190" alt="Screen Shot 2020-12-03 at 1 33 41 PM" src="https://user-images.githubusercontent.com/4615187/101072533-2d703300-356c-11eb-9986-48dc23db5365.png">

c) TrafficShifting 
<img width="492" alt="Screen Shot 2020-12-03 at 1 37 17 PM" src="https://user-images.githubusercontent.com/4615187/101072910-b25b4c80-356c-11eb-8449-2ff347216747.png">








