### PR TITLE
Fix from time parameters on tracing tabs

### DIFF
--- a/src/pages/AppDetails/AppDetailsPage.tsx
+++ b/src/pages/AppDetails/AppDetailsPage.tsx
@@ -194,11 +194,11 @@ class AppDetails extends React.Component<AppDetailsProps, AppDetailsState> {
     switch (this.state.currentTab) {
       case 'info':
       case 'traffic':
-      case 'traces':
         useCustomTime = false;
         break;
       case 'in_metrics':
       case 'out_metrics':
+      case 'traces':
         useCustomTime = true;
         break;
     }

--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -188,10 +188,10 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
     switch (this.state.currentTab) {
       case 'info':
       case 'traffic':
-      case 'traces':
         useCustomTime = false;
         break;
       case 'metrics':
+      case 'traces':
         useCustomTime = true;
         break;
     }

--- a/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -201,12 +201,12 @@ class WorkloadDetails extends React.Component<WorkloadDetailsPageProps, Workload
     switch (this.state.currentTab) {
       case 'info':
       case 'traffic':
-      case 'traces':
         useCustomTime = false;
         break;
       case 'in_metrics':
       case 'out_metrics':
       case 'logs':
+      case 'traces':
         useCustomTime = true;
         break;
     }


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/3503

There was a bug in the TracesComponent using a wrong duration parameter that may fall into the default (10m).
This bug was introduced in latest changes when refactoring the TimeControl component.

I think it's fixed now @israel-hdez, would you mind to test ?
I did some quick tests, but let me know if there is anything else to fix and I'll continue tomorrow my time.