### PR TITLE
Add tooltip info to the "Requests Per Second" edge label option

### DIFF
--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -310,7 +310,7 @@ export class GraphStyles {
       const edgeData = decoratedEdgeData(ele);
 
       switch (edgeLabelMode) {
-        case EdgeLabelMode.REQUESTS_PER_SECOND: {
+        case EdgeLabelMode.REQUEST_RATE: {
           let rate = 0;
           let pErr = 0;
           if (edgeData.http > 0) {
@@ -348,7 +348,7 @@ export class GraphStyles {
           }
           break;
         }
-        case EdgeLabelMode.REQUESTS_PERCENTAGE: {
+        case EdgeLabelMode.REQUEST_DISTRIBUTION: {
           let pReq;
           if (edgeData.httpPercentReq > 0) {
             pReq = edgeData.httpPercentReq;

--- a/src/pages/Graph/GraphToolbar/GraphSettings.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphSettings.tsx
@@ -50,7 +50,7 @@ const marginBottom = 20;
 
 const containerStyle = style({
   overflow: 'auto',
-  width: '225px'
+  width: '230px'
 });
 
 // this emulates Select component .pf-c-select__menu

--- a/src/pages/Graph/GraphToolbar/GraphSettings.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphSettings.tsx
@@ -49,7 +49,8 @@ interface DisplayOptionType {
 const marginBottom = 20;
 
 const containerStyle = style({
-  overflow: 'auto'
+  overflow: 'auto',
+  width: '225px'
 });
 
 // this emulates Select component .pf-c-select__menu
@@ -74,7 +75,7 @@ const itemStyle = (hasInfo: boolean) =>
   });
 
 const infoStyle = style({
-  margin: '0px 16px 2px 4px'
+  margin: '0px 5px 2px 4px'
 });
 
 class GraphSettings extends React.PureComponent<GraphSettingsProps, GraphSettingsState> {
@@ -168,14 +169,27 @@ class GraphSettings extends React.PureComponent<GraphSettingsProps, GraphSetting
         isChecked: edgeLabelMode === EdgeLabelMode.NONE
       },
       {
-        id: EdgeLabelMode.REQUESTS_PER_SECOND,
-        labelText: _.startCase(EdgeLabelMode.REQUESTS_PER_SECOND),
-        isChecked: edgeLabelMode === EdgeLabelMode.REQUESTS_PER_SECOND
+        id: EdgeLabelMode.REQUEST_RATE,
+        labelText: _.startCase(EdgeLabelMode.REQUEST_RATE),
+        isChecked: edgeLabelMode === EdgeLabelMode.REQUEST_RATE,
+        tooltip: (
+          <div style={{ textAlign: 'left' }}>
+            HTTP and GRPC rates are in requests-per-second. The percentage of error responses is shown below the rate,
+            when non-zero. TCP rates are in bytes-sent-per-second. Rates are rounded to 2 significant digits.
+          </div>
+        )
       },
       {
-        id: EdgeLabelMode.REQUESTS_PERCENTAGE,
-        labelText: _.startCase(EdgeLabelMode.REQUESTS_PERCENTAGE),
-        isChecked: edgeLabelMode === EdgeLabelMode.REQUESTS_PERCENTAGE
+        id: EdgeLabelMode.REQUEST_DISTRIBUTION,
+        labelText: _.startCase(EdgeLabelMode.REQUEST_DISTRIBUTION),
+        isChecked: edgeLabelMode === EdgeLabelMode.REQUEST_DISTRIBUTION,
+        tooltip: (
+          <div style={{ textAlign: 'left' }}>
+            HTTP and GRPC Edges display the percentage of outgoing requests for that edge. For a source node, the sum
+            for outgoing edges should be equal to or near 100%, given rounding. TCP edges are not included in the
+            distribution because their rates reflect bytes sent, not requests sent.
+          </div>
+        )
       },
       {
         id: EdgeLabelMode.RESPONSE_TIME_95TH_PERCENTILE,
@@ -203,8 +217,8 @@ class GraphSettings extends React.PureComponent<GraphSettingsProps, GraphSetting
         onChange: toggleCompressOnHide,
         tooltip: (
           <div style={{ textAlign: 'left' }}>
-            When enabled the graph is compressed after graph-hide removes matching elements. Otherwise the graph
-            maintains the space consumed by the hidden elements.
+            Compress the graph after graph-hide removes matching elements. Otherwise the graph maintains the space
+            consumed by the hidden elements.
           </div>
         )
       },
@@ -241,19 +255,39 @@ class GraphSettings extends React.PureComponent<GraphSettingsProps, GraphSetting
         disabled: this.props.graphType === GraphType.SERVICE,
         labelText: 'Service Nodes',
         isChecked: showServiceNodes,
-        onChange: toggleServiceNodes
+        onChange: toggleServiceNodes,
+        tooltip: (
+          <div style={{ textAlign: 'left' }}>
+            Reflect service routing by injecting the destination service nodes into the graph. This can be useful for
+            grouping requests for the same service, but routed to different workloads. Edges leading into service nodes
+            are logical aggregations and will not show response time labels, but if selected the side panel will provide
+            a response time chart.
+          </div>
+        )
       },
       {
         id: 'filterTrafficAnimation',
         labelText: 'Traffic Animation',
         isChecked: showTrafficAnimation,
-        onChange: toggleTrafficAnimation
+        onChange: toggleTrafficAnimation,
+        tooltip: (
+          <div style={{ textAlign: 'left' }}>
+            Animate the graph to reflect traffic flow. The particle density and speed roughly reflects an edge's request
+            load relevant to the other edges. Animation can be CPU intensive.
+          </div>
+        )
       },
       {
         id: 'filterUnusedNodes',
         labelText: 'Unused Nodes',
         isChecked: showUnusedNodes,
-        onChange: toggleUnusedNodes
+        onChange: toggleUnusedNodes,
+        tooltip: (
+          <div style={{ textAlign: 'left' }}>
+            Display orphan nodes for defined services that have never received traffic. This can help locate
+            misconfigured or obsolete services.
+          </div>
+        )
       }
     ];
 

--- a/src/pages/Graph/GraphToolbar/GraphSettings.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphSettings.tsx
@@ -49,13 +49,19 @@ interface DisplayOptionType {
 const marginBottom = 20;
 
 const containerStyle = style({
-  overflow: 'auto',
-  width: '230px'
+  overflow: 'auto'
 });
 
 // this emulates Select component .pf-c-select__menu
 const menuStyle = style({
   fontSize: '14px'
+});
+
+// this emulates Select component .pf-c-select__menu
+const menuEntryStyle = style({
+  cursor: 'not-allowed',
+  display: 'inline-block',
+  width: '15.5em'
 });
 
 // this emulates Select component .pf-c-select__menu-group-title but with less bottom padding to conserve space
@@ -336,7 +342,7 @@ class GraphSettings extends React.PureComponent<GraphSettingsProps, GraphSetting
         <div id="graph-display-menu" className={menuStyle}>
           <div className={titleStyle}>Show Edge Labels</div>
           {edgeLabelOptions.map((item: DisplayOptionType) => (
-            <div key={item.id} style={{ display: 'inline-block', cursor: 'not-allowed' }}>
+            <div key={item.id} className={menuEntryStyle}>
               <label key={item.id} className={itemStyle(!!item.tooltip)}>
                 <Radio
                   id={item.id}

--- a/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
+++ b/src/pages/ServiceDetails/ServiceInfo/__tests__/__snapshots__/ServiceInfoDescription.test.tsx.snap
@@ -382,7 +382,7 @@ exports[`#ServiceInfoDescription render correctly with data should render servic
           "_errorMessage": null,
           "_fetchParams": Object {
             "duration": 0,
-            "edgeLabelMode": "noEdgeLabels",
+            "edgeLabelMode": "noLabel",
             "graphType": "versionedApp",
             "includeHealth": true,
             "injectServiceNodes": true,

--- a/src/pages/WorkloadDetails/WorkloadInfo/__tests__/__snapshots__/WorkloadDescription.test.tsx.snap
+++ b/src/pages/WorkloadDetails/WorkloadInfo/__tests__/__snapshots__/WorkloadDescription.test.tsx.snap
@@ -136,7 +136,7 @@ exports[`WorkloadDescription should render with runtimes 1`] = `
           "_errorMessage": null,
           "_fetchParams": Object {
             "duration": 0,
-            "edgeLabelMode": "noEdgeLabels",
+            "edgeLabelMode": "noLabel",
             "graphType": "versionedApp",
             "includeHealth": true,
             "injectServiceNodes": true,

--- a/src/services/GraphDataSource.ts
+++ b/src/services/GraphDataSource.ts
@@ -182,8 +182,8 @@ export default class GraphDataSource {
         appenders += ',responseTime';
         break;
 
-      case EdgeLabelMode.REQUESTS_PER_SECOND:
-      case EdgeLabelMode.REQUESTS_PERCENTAGE:
+      case EdgeLabelMode.REQUEST_RATE:
+      case EdgeLabelMode.REQUEST_DISTRIBUTION:
       case EdgeLabelMode.NONE:
       default:
         break;

--- a/src/types/Graph.ts
+++ b/src/types/Graph.ts
@@ -31,9 +31,9 @@ export interface SummaryPanelPropType {
 }
 
 export enum EdgeLabelMode {
-  NONE = 'noEdgeLabels',
-  REQUESTS_PER_SECOND = 'requestsPerSecond',
-  REQUESTS_PERCENTAGE = 'requestsPercentage',
+  NONE = 'noLabel',
+  REQUEST_RATE = 'requestRate',
+  REQUEST_DISTRIBUTION = 'requestDistribution',
   RESPONSE_TIME_95TH_PERCENTILE = 'responseTime'
 }
 


### PR DESCRIPTION
Add tooltip info to the "Requests Per Second" edge label option to better explain the resulting edge labeling.

Also, take care of some other improvements in the Display menu:
- rename "Requests Per Second" to "Request Rate"
- rename "Requests Percentage" to "Request Distribution"
- use consistent plurals in the edge label options
- add tooltip info for all non-obvious options

Fixes https://github.com/kiali/kiali/issues/3477

![image](https://user-images.githubusercontent.com/2104052/101528250-11e69d00-395d-11eb-9fd8-7c04c6b29f7e.png)


