### PR TITLE
Trivial: move travis ci to node.js 14 (LTS)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 dist: trusty
 node_js:
-  - '12'
+  - '14'
 before_install: # if "install" is overridden
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.22.4
   - export PATH="$HOME/.yarn/bin:$PATH"


### PR DESCRIPTION
We recently moved to node.js 14 (LTS) for building/testing Kiali-ui. This PR updates the Travis CI to use the newer node version 14.

** Issue reference **
https://github.com/kiali/kiali/issues/3484