### PR TITLE
Don't fetch the config dump before opening the modal

### DIFF
--- a/src/components/Envoy/EnvoyModal.tsx
+++ b/src/components/Envoy/EnvoyModal.tsx
@@ -75,9 +75,12 @@ class EnvoyDetailsModal extends React.Component<EnvoyDetailProps, EnvoyDetailSta
     };
   }
 
-  componentDidUpdate(prevProps: EnvoyDetailProps) {
-    // Fetch data when the modal has just opened or some action request a fetch.
-    if ( (!prevProps.show && this.props.show) || this.state.fetch) {
+  componentDidMount() {
+    this.fetchContent();
+  }
+
+  componentDidUpdate() {
+    if (this.state.fetch) {
       this.fetchContent();
     }
   }

--- a/src/components/Envoy/EnvoyModal.tsx
+++ b/src/components/Envoy/EnvoyModal.tsx
@@ -70,17 +70,14 @@ class EnvoyDetailsModal extends React.Component<EnvoyDetailProps, EnvoyDetailSta
     this.state = {
       config: {},
       resource: 'all',
-      fetch: true,
+      fetch: false,
       pod: this.sortedPods()[0]
     };
   }
 
-  componentDidMount() {
-    this.fetchContent();
-  }
-
-  componentDidUpdate() {
-    if (this.state.fetch) {
+  componentDidUpdate(prevProps: EnvoyDetailProps) {
+    // Fetch data when the modal has just opened or some action request a fetch.
+    if ( (!prevProps.show && this.props.show) || this.state.fetch) {
       this.fetchContent();
     }
   }
@@ -94,6 +91,7 @@ class EnvoyDetailsModal extends React.Component<EnvoyDetailProps, EnvoyDetailSta
     const targetPod: Pod = this.sortedPods()[podIdx];
     if (targetPod.name !== this.state.pod.name) {
       this.setState({
+        config: {},
         fetch: true,
         pod: targetPod
       });
@@ -105,6 +103,7 @@ class EnvoyDetailsModal extends React.Component<EnvoyDetailProps, EnvoyDetailSta
     const targetResource: string = resources[resourceIdx];
     if (targetResource !== this.state.resource) {
       this.setState({
+        config: {},
         fetch: true,
         resource: targetResource
       });
@@ -148,6 +147,10 @@ class EnvoyDetailsModal extends React.Component<EnvoyDetailProps, EnvoyDetailSta
           error
         );
       });
+  };
+
+  isLoadingConfig = () => {
+    return Object.keys(this.state.config).length < 1;
   };
 
   render() {
@@ -197,7 +200,7 @@ class EnvoyDetailsModal extends React.Component<EnvoyDetailProps, EnvoyDetailSta
           </StackItem>
           <StackItem>
             <Card style={{ height: '400px' }}>
-              {this.state.fetch ? (
+              {this.isLoadingConfig() ? (
                 <Loading />
               ) : this.state.resource === 'all' || this.state.resource === 'bootstrap' ? (
                 <AceEditor

--- a/src/components/IstioWizards/WorkloadWizardDropdown.tsx
+++ b/src/components/IstioWizards/WorkloadWizardDropdown.tsx
@@ -177,12 +177,14 @@ class WorkloadWizardDropdown extends React.Component<Props, State> {
     return (
       <>
         {dropdown}
-        <EnvoyDetailsModal
-          namespace={this.props.namespace}
-          workload={this.props.workload}
-          show={this.state.showWizard}
-          onClose={this.onClose}
-        />
+        {this.state.showWizard ? (
+          <EnvoyDetailsModal
+            namespace={this.props.namespace}
+            workload={this.props.workload}
+            show={this.state.showWizard}
+            onClose={this.onClose}
+          />
+        ) : undefined}
       </>
     );
   }


### PR DESCRIPTION
fixes https://github.com/kiali/kiali/issues/3515

Fixing error message when visiting a workload page that doesn't have a sidecar.
There is no call performed under the hood before opening the modal.

![proxy-details-grafana-err](https://user-images.githubusercontent.com/613814/101654119-6f074f00-3a40-11eb-944e-783906c45752.gif)
