### PR TITLE
Fix time control not working on custom dashboards

### DIFF
--- a/src/components/Metrics/CustomMetrics.tsx
+++ b/src/components/Metrics/CustomMetrics.tsx
@@ -18,7 +18,6 @@ import MetricsRawAggregation from '../MetricsOptions/MetricsRawAggregation';
 import { GrafanaLinks } from './GrafanaLinks';
 import { MetricsObjectTypes } from 'types/Metrics';
 import { SpanOverlay, JaegerLineInfo } from './SpanOverlay';
-import { retrieveTimeRange } from 'components/Time/TimeRangeHelper';
 import { DashboardModel, ExternalLink } from 'types/Dashboards';
 import { Overlay } from 'types/Overlay';
 import { Aggregator, DashboardQuery } from 'types/MetricsOptions';
@@ -57,7 +56,7 @@ const displayFlex = style({
   display: 'flex'
 });
 
-export class CustomMetrics extends React.Component<Props, MetricsState> {
+class CustomMetrics extends React.Component<Props, MetricsState> {
   options: DashboardQuery;
   spanOverlay: SpanOverlay;
 
@@ -191,7 +190,7 @@ export class CustomMetrics extends React.Component<Props, MetricsState> {
                       expandHandler={this.expandHandler}
                       onClick={this.onClickDataPoint}
                       overlay={this.state.spanOverlay}
-                      timeWindow={evalTimeRange(retrieveTimeRange())}
+                      timeWindow={evalTimeRange(this.props.timeRange)}
                       brushHandlers={{ onDomainChangeEnd: (_, props) => this.onDomainChange(props.currentDomain.x) }}
                     />
                   )}

--- a/src/pages/AppDetails/AppDetailsPage.tsx
+++ b/src/pages/AppDetails/AppDetailsPage.tsx
@@ -190,7 +190,8 @@ class AppDetails extends React.Component<AppDetailsProps, AppDetailsState> {
   }
 
   render() {
-    let useCustomTime = false;
+    // set default to true: all dynamic tabs (unlisted below) are for runtimes dashboards, which uses custom time
+    let useCustomTime = true;
     switch (this.state.currentTab) {
       case 'info':
       case 'traffic':

--- a/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -197,7 +197,8 @@ class WorkloadDetails extends React.Component<WorkloadDetailsPageProps, Workload
   }
 
   render() {
-    let useCustomTime = false;
+    // set default to true: all dynamic tabs (unlisted below) are for runtimes dashboards, which uses custom time
+    let useCustomTime = true;
     switch (this.state.currentTab) {
       case 'info':
       case 'traffic':


### PR DESCRIPTION
I found a bug with custom dashboards, time selection doesn't work anymore. So here's a quick fix.
cc @lucasponce 

This is not ideal, I think it would be preferable that the child component (metrics, traces, whatever) decides which time component to use, instead of the parent deciding on behalf on its child. But not sure how to do it in a nice way, leaving that perhaps for later...