### PR TITLE
[v1.26] backport of fix for empty pod logs

### DIFF
--- a/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo/WorkloadPodLogs.tsx
@@ -436,18 +436,17 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
 
   private getAppDiv = () => {
     const appLogs = this.hasEntries(this.state.filteredAppLogs)
-      ? this.entryToString(this.state.filteredAppLogs)
+      ? this.entriesToString(this.state.filteredAppLogs)
       : NoAppLogsFoundMessage;
+    const title = this.state.containerInfo!.containerOptions[this.state.containerInfo!.container];
     return (
       <div id="appLogDiv" className={this.state.sideBySideOrientation ? appLogsDivHorizontal : appLogsDivVertical}>
         <Toolbar className={toolbarTitle()}>
-          <ToolbarItem className={logsTitle(this.isFullscreen())}>
-            {this.state.containerInfo!.containerOptions[this.state.containerInfo!.container]}
-          </ToolbarItem>
+          <ToolbarItem className={logsTitle(this.isFullscreen())}>{title}</ToolbarItem>
           <ToolbarGroup className={toolbarRight}>
             <ToolbarItem>
               <Tooltip key="copy_app_logs" position="top" content="Copy app logs to clipboard">
-                <CopyToClipboard onCopy={this.copyAppLogCallback} text={this.entryToString(this.state.filteredAppLogs)}>
+                <CopyToClipboard onCopy={this.copyAppLogCallback} text={appLogs}>
                   <Button variant={ButtonVariant.link} isInline>
                     <KialiIcon.Copy className={defaultIconStyle} />
                   </Button>
@@ -485,7 +484,7 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
 
   private getProxyDiv = () => {
     const proxyLogs = this.hasEntries(this.state.filteredProxyLogs)
-      ? this.entryToString(this.state.filteredProxyLogs)
+      ? this.entriesToString(this.state.filteredProxyLogs)
       : NoProxyLogsFoundMessage;
     return (
       <div id="proxyLogDiv" className={proxyLogsDiv}>
@@ -494,10 +493,7 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
           <ToolbarGroup className={toolbarRight}>
             <ToolbarItem>
               <Tooltip key="copy_proxy_logs" position="top" content="Copy Istio proxy logs to clipboard">
-                <CopyToClipboard
-                  onCopy={this.copyProxyLogCallback}
-                  text={this.entryToString(this.state.filteredProxyLogs)}
-                >
+                <CopyToClipboard onCopy={this.copyProxyLogCallback} text={proxyLogs}>
                   <Button variant={ButtonVariant.link} isInline>
                     <KialiIcon.Copy className={defaultIconStyle} />
                   </Button>
@@ -862,9 +858,8 @@ export default class WorkloadPodLogs extends React.Component<WorkloadPodLogsProp
     });
   };
 
-  private entryToString = (entries: LogEntry[]): string => {
+  private entriesToString = (entries: LogEntry[]): string => {
     return entries.map(le => (this.state.showTimestamps ? `${le.timestamp} ${le.message}` : le.message)).join('\n');
   };
-
-  private hasEntries = (entries: LogEntry[]): boolean => entries.length > 0;
+  private hasEntries = (entries: LogEntry[]): boolean => !!entries && entries.length > 0;
 }


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/3504

I don't understand how this bug manged it's way into 1.26.  I remember fixing it in the dev phase, but somehow that fix must have been lost.  Anyway, this problem is already fixed in 1.27+ of Kiali, but because Istio 1.8 is tied to 1.26 we should backport and make a patch release, so that Istio 1.8 users that install Kiali as an addon do not hit this issue.

Verification Steps:
Without the fix the following should show the reported error:

1) Navigate to Workload Details for istio-system, grafana workload
2) Select Logs tab

With the fix you should not see a crash and the two log windows should show messages about no logs.