### PR TITLE
Fix Kiali analysis messages to render them with only istio code and documentation url

### DIFF
--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -496,7 +496,7 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
     ) : null;
 
     return (
-      <div className={editorDrawer}>
+      <div className={`object-drawer ${editorDrawer}`}>
         {showCards ? (
           <Drawer isExpanded={this.state.isExpanded} isInline={true}>
             <DrawerContent panelContent={showCards ? panelContent : undefined}>

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/DestinationRuleOverview.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/DestinationRuleOverview.tsx
@@ -17,6 +17,7 @@ import { checkForPath } from '../../../types/ServiceInfo';
 import ValidationList from '../../../components/Validations/ValidationList';
 import Labels from '../../../components/Label/Labels';
 import ServiceLink from './ServiceLink';
+import './IstioObjectDetails.css';
 
 interface DestinationRuleProps {
   namespace: string;

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/IstioObjectDetails.scss
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/IstioObjectDetails.scss
@@ -19,7 +19,7 @@ h1 {
 
   .validation-message {
     .pf-l-split__item:first-child {
-       margin-right: 10px;
+      margin-right: 10px;
     }
   }
 }

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/IstioObjectDetails.scss
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/IstioObjectDetails.scss
@@ -2,3 +2,24 @@ h1 {
   margin-top: 0;
   margin-left: -12px;
 }
+
+.object-drawer {
+  h3 {
+    margin-bottom: 0.5rem;
+    margin-top: 1.5rem;
+
+    &:first-child {
+      margin-top: 0;
+    }
+  }
+
+  .pf-l-stack {
+    height: auto;
+  }
+
+  .validation-message {
+    .pf-l-split__item:first-child {
+       margin-right: 10px;
+    }
+  }
+}

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/IstioStatusMessageList.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/IstioStatusMessageList.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ValidationMessage, ValidationTypes } from '../../../types/IstioObjects';
+import { IstioLevelToSeverity, ValidationMessage, ValidationTypes } from '../../../types/IstioObjects';
 import {
   Card,
   CardBody,
@@ -32,18 +32,19 @@ class IstioStatusMessageList extends React.Component<Props> {
         <CardBody>
           <Stack gutter="lg">
             {this.props.messages.map((msg: ValidationMessage, i: number) => {
+              let severity: ValidationTypes = IstioLevelToSeverity[msg.level || 'info'] || ValidationTypes.Info;
               return (
                 <StackItem id={'msg-' + i}>
                   <Split gutter="sm">
                     <SplitItem>
-                      <Validation severity={ValidationTypes[msg.level]} />
+                      <Validation severity={severity} />
                     </SplitItem>
                     <SplitItem>
                       <Text component={TextVariants.h5}>
                         <a href={msg.documentation_url} target="_blank" rel="noopener noreferrer">
-                          {msg.code}
+                          {msg.type.code}
                         </a>
-                        {': ' + msg.message}
+                        {msg.description ? ': ' + msg.description : undefined}
                       </Text>
                     </SplitItem>
                   </Split>

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/IstioStatusMessageList.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/IstioStatusMessageList.tsx
@@ -1,19 +1,6 @@
 import * as React from 'react';
 import { IstioLevelToSeverity, ValidationMessage, ValidationTypes } from '../../../types/IstioObjects';
-import {
-  Card,
-  CardBody,
-  CardHeader,
-  Split,
-  SplitItem,
-  Stack,
-  StackItem,
-  Text,
-  TextVariants,
-  Title,
-  TitleLevel,
-  TitleSize
-} from '@patternfly/react-core';
+import { Split, SplitItem, Stack, StackItem, Title, TitleLevel, TitleSize } from '@patternfly/react-core';
 import Validation from '../../../components/Validations/Validation';
 
 interface Props {
@@ -23,37 +10,31 @@ interface Props {
 class IstioStatusMessageList extends React.Component<Props> {
   render() {
     return (
-      <Card key={'istioMessagesCard'}>
-        <CardHeader>
-          <Title headingLevel={TitleLevel.h3} size={TitleSize.xl}>
-            Analyzer Messages
-          </Title>
-        </CardHeader>
-        <CardBody>
-          <Stack gutter="lg">
-            {this.props.messages.map((msg: ValidationMessage, i: number) => {
-              let severity: ValidationTypes = IstioLevelToSeverity[msg.level || 'info'] || ValidationTypes.Info;
-              return (
-                <StackItem id={'msg-' + i}>
-                  <Split gutter="sm">
-                    <SplitItem>
-                      <Validation severity={severity} />
-                    </SplitItem>
-                    <SplitItem>
-                      <Text component={TextVariants.h5}>
-                        <a href={msg.documentation_url} target="_blank" rel="noopener noreferrer">
-                          {msg.type.code}
-                        </a>
-                        {msg.description ? ': ' + msg.description : undefined}
-                      </Text>
-                    </SplitItem>
-                  </Split>
-                </StackItem>
-              );
-            })}
-          </Stack>
-        </CardBody>
-      </Card>
+      <>
+        <Title headingLevel={TitleLevel.h3} size={TitleSize.xl}>
+          Analyzer Messages
+        </Title>
+        <Stack gutter="lg">
+          {this.props.messages.map((msg: ValidationMessage, i: number) => {
+            const severity: ValidationTypes = IstioLevelToSeverity[msg.level || 0];
+            return (
+              <StackItem id={'msg-' + i} className={"validation-message"}>
+                <Split>
+                  <SplitItem>
+                    <Validation severity={severity} />
+                  </SplitItem>
+                  <SplitItem>
+                    <a href={msg.documentation_url} target="_blank" rel="noopener noreferrer">
+                      {msg.type.code}
+                    </a>
+                    {msg.description ? ': ' + msg.description : undefined}
+                  </SplitItem>
+                </Split>
+              </StackItem>
+            );
+          })}
+        </Stack>
+      </>
     );
   }
 }

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/IstioStatusMessageList.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/IstioStatusMessageList.tsx
@@ -18,7 +18,7 @@ class IstioStatusMessageList extends React.Component<Props> {
           {this.props.messages.map((msg: ValidationMessage, i: number) => {
             const severity: ValidationTypes = IstioLevelToSeverity[msg.level || 0];
             return (
-              <StackItem id={'msg-' + i} className={"validation-message"}>
+              <StackItem id={'msg-' + i} className={'validation-message'}>
                 <Split>
                   <SplitItem>
                     <Validation severity={severity} />

--- a/src/types/IstioObjects.ts
+++ b/src/types/IstioObjects.ts
@@ -53,11 +53,22 @@ export interface IstioStatus {
 }
 
 export interface ValidationMessage {
-  code: string;
+  description?: string;
   documentation_url: string;
-  level: string;
-  message: string;
+  level?: number;
+  type: ValidationMessageType;
 }
+
+export interface ValidationMessageType {
+  code: string;
+}
+
+export const IstioLevelToSeverity = {
+  0: 'info',
+  3: 'error',
+  8: 'warning',
+  12: 'info'
+};
 
 // validations are grouped per 'objectType' first in the first map and 'name' in the inner map
 export type Validations = { [key1: string]: { [key2: string]: ObjectValidation } };

--- a/src/types/IstioObjects.ts
+++ b/src/types/IstioObjects.ts
@@ -77,7 +77,7 @@ export const IstioLevelToSeverity = {
   0: ValidationTypes.Info,
   3: ValidationTypes.Error,
   8: ValidationTypes.Warning,
-  12: ValidationTypes.Info,
+  12: ValidationTypes.Info
 };
 
 export interface ObjectValidation {

--- a/src/types/IstioObjects.ts
+++ b/src/types/IstioObjects.ts
@@ -63,13 +63,6 @@ export interface ValidationMessageType {
   code: string;
 }
 
-export const IstioLevelToSeverity = {
-  0: 'info',
-  3: 'error',
-  8: 'warning',
-  12: 'info'
-};
-
 // validations are grouped per 'objectType' first in the first map and 'name' in the inner map
 export type Validations = { [key1: string]: { [key2: string]: ObjectValidation } };
 
@@ -79,6 +72,13 @@ export enum ValidationTypes {
   Correct = 'correct',
   Info = 'info'
 }
+
+export const IstioLevelToSeverity = {
+  0: ValidationTypes.Info,
+  3: ValidationTypes.Error,
+  8: ValidationTypes.Warning,
+  12: ValidationTypes.Info,
+};
 
 export interface ObjectValidation {
   name: string;


### PR DESCRIPTION
fixes https://github.com/kiali/kiali/issues/3505

Right now, Istio only persists the following info in the `status.validationMessages` field:

```
  validationMessages:
  - documentation_url: https://istio.io/v1.8/docs/reference/config/analysis/ist0130/?ref=status-controller
    type:
      code: IST0130
```

Therefore, this PR only will rely on this fields being present. See how the UI is shown:

![Screenshot of Kiali Console](https://user-images.githubusercontent.com/613814/102211451-e96a2000-3ed3-11eb-8913-912a71799dd0.png)


When istio includes also the severity code and the message description, the UI will be like:
![Screenshot of Kiali Console (1)](https://user-images.githubusercontent.com/613814/102213274-cb51ef00-3ed6-11eb-8baa-686dc7a53a1b.png)
(this last screenshot can't be tested right now without modifying the code in order to add mock data. Needs Istio to fix a couple of issues first)
