### PR TITLE
Fetch Namespace if they arent present while mounting the Istio Status feat

### DIFF
--- a/src/components/IstioStatus/IstioStatus.tsx
+++ b/src/components/IstioStatus/IstioStatus.tsx
@@ -7,7 +7,6 @@ import { MessageType } from '../../types/MessageCenter';
 import Namespace from '../../types/Namespace';
 import { KialiAppState } from '../../store/Store';
 import { istioStatusSelector, lastRefreshAtSelector, namespaceItemsSelector } from '../../store/Selectors';
-import { KialiDispatch } from '../../types/Redux';
 import { bindActionCreators } from 'redux';
 import { IstioStatusActions } from '../../actions/IstioStatusActions';
 import { connect } from 'react-redux';
@@ -16,10 +15,14 @@ import IstioStatusList from './IstioStatusList';
 import { PFAlertColor } from '../Pf/PfColors';
 import './IstioStatus.css';
 import { ResourcesFullIcon } from '@patternfly/react-icons';
+import { ThunkDispatch } from 'redux-thunk';
+import { KialiAppAction } from '../../actions/KialiAppAction';
+import NamespaceThunkActions from '../../actions/NamespaceThunkActions';
 
 type ReduxProps = {
   lastRefreshAt: TimeInMilliseconds;
   setIstioStatus: (istioStatus: ComponentStatus[]) => void;
+  refreshNamespaces: () => void;
   namespaces: Namespace[] | undefined;
   status: ComponentStatus[];
 };
@@ -35,6 +38,7 @@ const ValidToColor = {
 
 export class IstioStatus extends React.Component<Props> {
   componentDidMount() {
+    this.props.refreshNamespaces();
     this.fetchStatus();
   }
 
@@ -107,8 +111,11 @@ const mapStateToProps = (state: KialiAppState) => ({
   namespaces: namespaceItemsSelector(state)
 });
 
-const mapDispatchToProps = (dispatch: KialiDispatch) => ({
-  setIstioStatus: bindActionCreators(IstioStatusActions.setinfo, dispatch)
+const mapDispatchToProps = (dispatch: ThunkDispatch<KialiAppState, void, KialiAppAction>) => ({
+  setIstioStatus: bindActionCreators(IstioStatusActions.setinfo, dispatch),
+  refreshNamespaces: () => {
+    dispatch(NamespaceThunkActions.fetchNamespacesIfNeeded());
+  }
 });
 
 const IstioStatusConnected = connect(mapStateToProps, mapDispatchToProps)(IstioStatus);

--- a/src/components/IstioStatus/__tests__/IstioStatus.test.tsx
+++ b/src/components/IstioStatus/__tests__/IstioStatus.test.tsx
@@ -12,6 +12,7 @@ const mockIcon = (componentList: ComponentStatus[]) => {
       lastRefreshAt={848152}
       namespaces={[{ name: 'bookinfo' }, { name: 'istio-system' }]}
       setIstioStatus={jest.fn()}
+      refreshNamespaces={jest.fn()}
     />
   );
 };


### PR DESCRIPTION
Trying to approach [this](https://github.com/kiali/kiali/issues/3508#issuecomment-742617476) I have realized that the Istio component status feature in the masthead had a minor/little bug.

The component relies in the namespace list (from redux) just for reducing the severity of alerts for that component. This is specially important for multi-tenancy scenarios where users haven't given access to any namespace. Then, we don't want Kiali show an error every other refresh/page navigation.

I have found that since the `Istio Status` feature is rendered in the masthead and the `Namespace Dropdown` is fetch in the second secondary masthead, the first one won't have any namespace rendered. It will only have namespaces right after the `Namespace Dropdown` has been successfully rendered.

This should fix it. Pretty tiny, but the behavior was a bit odd.