### PR TITLE
Graph: navigate in trace

### DIFF
--- a/src/actions/JaegerThunkActions.ts
+++ b/src/actions/JaegerThunkActions.ts
@@ -1,4 +1,5 @@
 import { ThunkDispatch } from 'redux-thunk';
+import { AxiosError } from 'axios';
 
 import * as AlertUtils from '../utils/AlertUtils';
 import { KialiAppState } from '../store/Store';
@@ -6,8 +7,7 @@ import * as API from '../services/Api';
 import { KialiAppAction } from './KialiAppAction';
 import { JaegerActions } from './JaegerActions';
 import { setTraceId as setURLTraceId } from 'utils/SearchParamUtils';
-import transformTraceData from 'components/JaegerIntegration/JaegerResults/transform';
-import { AxiosError } from 'axios';
+import transformTraceData from 'utils/tracing/TraceTransform';
 
 export const JaegerThunkActions = {
   setTraceId: (traceId?: string) => {

--- a/src/components/CytoscapeGraph/CytoscapeTrace.ts
+++ b/src/components/CytoscapeGraph/CytoscapeTrace.ts
@@ -117,10 +117,10 @@ const addSpan = (ele: Cy.NodeSingular | Cy.EdgeSingular | undefined, span: Span)
   }
 
   if (ele.hasClass('span')) {
-    ele.data('spans').push(span.spanID);
+    ele.data('spans').push(span);
   } else {
     ele.addClass('span');
-    ele.data('spans', [span.spanID]);
+    ele.data('spans', [span]);
   }
 };
 

--- a/src/components/CytoscapeGraph/CytoscapeTrace.ts
+++ b/src/components/CytoscapeGraph/CytoscapeTrace.ts
@@ -1,13 +1,13 @@
 import * as Cy from 'cytoscape';
 import { CyNode } from './CytoscapeGraphUtils';
 import { JaegerTrace, Span } from 'types/JaegerInfo';
+import { NodeType, DestService, GraphType } from 'types/Graph';
 import {
-  getWorkloadFromSpan,
   getAppFromSpan,
+  getWorkloadFromSpan,
   searchParentApp,
   searchParentWorkload
-} from 'components/JaegerIntegration/JaegerHelper';
-import { NodeType, DestService, GraphType } from 'types/Graph';
+} from 'utils/tracing/TracingHelper';
 
 export const showTrace = (cy: Cy.Core, graphType: GraphType, trace: JaegerTrace) => {
   if (!cy) {
@@ -117,10 +117,10 @@ const addSpan = (ele: Cy.NodeSingular | Cy.EdgeSingular | undefined, span: Span)
   }
 
   if (ele.hasClass('span')) {
-    ele.data('spans').push(span);
+    ele.data('spans').push(span.spanID);
   } else {
     ele.addClass('span');
-    ele.data('spans', [span]);
+    ele.data('spans', [span.spanID]);
   }
 };
 

--- a/src/components/JaegerIntegration/JaegerResults/FormattedTraceInfo.ts
+++ b/src/components/JaegerIntegration/JaegerResults/FormattedTraceInfo.ts
@@ -1,9 +1,8 @@
 import { JaegerTrace } from '../../../types/JaegerInfo';
 import moment from 'moment';
-import { formatDuration, formatRelativeDate } from './transform';
-import { isErrorTag } from '../JaegerHelper';
 import { style } from 'typestyle';
 import { PfColors } from 'components/Pf/PfColors';
+import { formatDuration, formatRelativeDate, isErrorTag } from 'utils/tracing/TracingHelper';
 
 export const shortIDStyle = style({
   color: PfColors.Black600,

--- a/src/components/JaegerIntegration/JaegerResults/SpanTable.tsx
+++ b/src/components/JaegerIntegration/JaegerResults/SpanTable.tsx
@@ -21,9 +21,9 @@ import { KialiAppState } from 'store/Store';
 import { KialiAppAction } from 'actions/KialiAppAction';
 import { MetricsStatsQuery } from 'types/MetricsOptions';
 import MetricsStatsThunkActions from 'actions/MetricsStatsThunkActions';
-import { sameSpans } from '../JaegerHelper';
 import { RichSpanData } from 'types/JaegerInfo';
-import { buildQueriesFromSpans } from 'utils/TraceStats';
+import { sameSpans } from 'utils/tracing/TracingHelper';
+import { buildQueriesFromSpans } from 'utils/tracing/TraceStats';
 
 type SortableCell<T> = ICell & {
   compare?: (a: T, b: T) => number;

--- a/src/components/JaegerIntegration/JaegerResults/SpanTableItem.tsx
+++ b/src/components/JaegerIntegration/JaegerResults/SpanTableItem.tsx
@@ -7,11 +7,10 @@ import { ExternalLinkAltIcon, ExclamationCircleIcon } from '@patternfly/react-ic
 import history from 'app/History';
 import { PFAlertColor } from 'components/Pf/PfColors';
 import { EnvoySpanInfo, OpenTracingHTTPInfo, OpenTracingTCPInfo, RichSpanData } from 'types/JaegerInfo';
-import { isErrorTag } from '../JaegerHelper';
-import { formatDuration } from './transform';
 import { renderMetricsComparison } from './StatsComparison';
 import { MetricsStats } from 'types/Metrics';
 import { CellProps, createListeners, Expandable, renderExpandArrow } from 'components/Expandable';
+import { formatDuration, isErrorTag } from 'utils/tracing/TracingHelper';
 
 const dangerErrorStyle = style({
   borderLeft: '3px solid var(--pf-global--danger-color--100)'

--- a/src/components/JaegerIntegration/JaegerResults/StatsComparison.tsx
+++ b/src/components/JaegerIntegration/JaegerResults/StatsComparison.tsx
@@ -17,7 +17,7 @@ import {
   StatsWithIntervalIndex,
   statsPerPeer,
   statsCompareKind
-} from 'utils/TraceStats';
+} from 'utils/tracing/TraceStats';
 
 const statToText = {
   avg: { short: 'avg', long: 'average' },

--- a/src/components/JaegerIntegration/JaegerResults/TraceDetails.tsx
+++ b/src/components/JaegerIntegration/JaegerResults/TraceDetails.tsx
@@ -10,7 +10,6 @@ import { JaegerTraceTitle } from './JaegerTraceTitle';
 import { CytoscapeGraphSelectorBuilder } from 'components/CytoscapeGraph/CytoscapeGraphSelector';
 import { GraphType, NodeType } from 'types/Graph';
 import { FormattedTraceInfo, shortIDStyle } from './FormattedTraceInfo';
-import { formatDuration } from './transform';
 import { PfColors } from 'components/Pf/PfColors';
 import { KialiAppState } from 'store/Store';
 import { KialiAppAction } from 'actions/KialiAppAction';
@@ -23,14 +22,14 @@ import {
   isSimilarTrace,
   reduceMetricsStats,
   StatsMatrix
-} from 'utils/TraceStats';
+} from 'utils/tracing/TraceStats';
 import { TraceLabels } from './TraceLabels';
 import { TargetKind } from 'types/Common';
 import { MetricsStatsQuery } from 'types/MetricsOptions';
 import MetricsStatsThunkActions from 'actions/MetricsStatsThunkActions';
 import { renderTraceHeatMap } from './StatsComparison';
-import { sameSpans } from '../JaegerHelper';
 import { HeatMap } from 'components/HeatMap/HeatMap';
+import { formatDuration, sameSpans } from 'utils/tracing/TracingHelper';
 
 interface Props {
   otherTraces: JaegerTrace[];

--- a/src/components/JaegerIntegration/JaegerResults/TraceLabels.tsx
+++ b/src/components/JaegerIntegration/JaegerResults/TraceLabels.tsx
@@ -3,7 +3,7 @@ import { Label, pluralize } from '@patternfly/react-core';
 
 import { PFAlertColor } from 'components/Pf/PfColors';
 import { Span } from 'types/JaegerInfo';
-import { isErrorTag } from '../JaegerHelper';
+import { isErrorTag } from 'utils/tracing/TracingHelper';
 
 type Props = {
   spans: Span[];

--- a/src/components/JaegerIntegration/JaegerScatter.tsx
+++ b/src/components/JaegerIntegration/JaegerScatter.tsx
@@ -5,7 +5,6 @@ import { ChartScatter } from '@patternfly/react-charts';
 import { Title, EmptyState, EmptyStateVariant, EmptyStateBody } from '@patternfly/react-core';
 
 import { JaegerError, JaegerTrace } from '../../types/JaegerInfo';
-import { isErrorTag } from './JaegerHelper';
 import { PfColors } from '../Pf/PfColors';
 
 import jaegerIcon from '../../assets/img/jaeger-icon.svg';
@@ -17,6 +16,7 @@ import { LineInfo, makeLegend, VCDataPoint } from 'types/VictoryChartInfo';
 import ChartWithLegend from 'components/Charts/ChartWithLegend';
 import { durationSelector } from '../../store/Selectors';
 import { TraceTooltip } from './TraceTooltip';
+import { isErrorTag } from 'utils/tracing/TracingHelper';
 
 interface JaegerScatterProps {
   duration: number;

--- a/src/components/JaegerIntegration/TraceTooltip.tsx
+++ b/src/components/JaegerIntegration/TraceTooltip.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { ThunkDispatch } from 'redux-thunk';
+import { pluralize } from '@patternfly/react-core';
 import { ChartLabelProps } from '@patternfly/react-charts';
 import { Flyout } from 'victory';
+import { style } from 'typestyle';
 
 import { KialiAppState } from 'store/Store';
 import {
@@ -11,7 +13,7 @@ import {
   allStatsIntervals,
   reduceMetricsStats,
   StatsMatrix
-} from 'utils/TraceStats';
+} from 'utils/tracing/TraceStats';
 import { KialiAppAction } from 'actions/KialiAppAction';
 import { MetricsStatsQuery } from 'types/MetricsOptions';
 import MetricsStatsThunkActions from 'actions/MetricsStatsThunkActions';
@@ -19,10 +21,8 @@ import { JaegerLineInfo } from './JaegerScatter';
 import { JaegerTrace } from 'types/JaegerInfo';
 import { renderTraceHeatMap } from './JaegerResults/StatsComparison';
 import { PfColors } from 'components/Pf/PfColors';
-import { formatDuration } from './JaegerResults/transform';
 import { HookedChartTooltip, HookedTooltipProps } from 'components/Charts/CustomTooltip';
-import { style } from 'typestyle';
-import { pluralize } from '@patternfly/react-core';
+import { formatDuration } from 'utils/tracing/TracingHelper';
 
 const flyoutWidth = 280;
 const flyoutHeight = 130;

--- a/src/components/JaegerIntegration/TracesComponent.tsx
+++ b/src/components/JaegerIntegration/TracesComponent.tsx
@@ -26,10 +26,10 @@ import JaegerScatter from './JaegerScatter';
 import { HistoryManager, URLParam } from '../../app/History';
 import { config } from '../../config';
 import { TracesFetcher } from './TracesFetcher';
-import { getTimeRangeMicros, buildTags } from './JaegerHelper';
 import { SpanDetails } from './JaegerResults/SpanDetails';
 import { isEqualTimeRange, TargetKind, TimeInMilliseconds, TimeRange } from 'types/Common';
 import { timeRangeSelector } from '../../store/Selectors';
+import { buildTags, getTimeRangeMicros } from 'utils/tracing/TracingHelper';
 
 interface TracesProps {
   namespace: string;

--- a/src/components/JaegerIntegration/TracesFetcher.ts
+++ b/src/components/JaegerIntegration/TracesFetcher.ts
@@ -2,9 +2,9 @@ import * as API from '../../services/Api';
 import * as AlertUtils from '../../utils/AlertUtils';
 import { JaegerTrace, JaegerError } from 'types/JaegerInfo';
 import { TracingQuery } from 'types/Tracing';
-import { getTimeRangeMicros } from './JaegerHelper';
-import transformTraceData from './JaegerResults/transform';
 import { TargetKind } from 'types/Common';
+import { getTimeRangeMicros } from 'utils/tracing/TracingHelper';
+import transformTraceData from 'utils/tracing/TraceTransform';
 
 type FetchOptions = {
   namespace: string;

--- a/src/components/SimplerSelect.tsx
+++ b/src/components/SimplerSelect.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { Select, SelectOptionObject, SelectProps } from '@patternfly/react-core';
+
+type Props = Omit<Omit<Omit<SelectProps, 'isExpanded'>, 'onSelect'>, 'onToggle'> & {
+  onSelect?: (selection: string | SelectOptionObject) => void;
+  onToggle?: (isExpanded: boolean) => void;
+};
+
+const SimplerSelect = (props: Props) => {
+  const [isExpanded, setExpanded] = React.useState(false);
+  return (
+    <Select
+      {...props}
+      onToggle={isExpanded => {
+        if (props.onToggle) {
+          props.onToggle(isExpanded);
+        }
+        setExpanded(isExpanded);
+      }}
+      onSelect={(_, selection, isPlaceholder) => {
+        setExpanded(false);
+        if (!isPlaceholder && props.onSelect) {
+          props.onSelect(selection);
+        }
+      }}
+      isExpanded={isExpanded}
+    >
+      {props.children}
+    </Select>
+  );
+};
+
+export default SimplerSelect;

--- a/src/pages/Graph/SummaryPanel.tsx
+++ b/src/pages/Graph/SummaryPanel.tsx
@@ -140,6 +140,7 @@ class SummaryPanel extends React.Component<MainSummaryPanelPropType, SummaryPane
               <SummaryPanelTraceDetailsContainer
                 trace={this.props.jaegerState.selectedTrace}
                 node={this.props.data.summaryTarget}
+                graphType={this.props.graphType}
                 jaegerURL={this.props.jaegerState.info?.url}
               />
             </div>

--- a/src/pages/Graph/SummaryPanelNodeTraces.tsx
+++ b/src/pages/Graph/SummaryPanelNodeTraces.tsx
@@ -17,8 +17,8 @@ import { TracingQuery } from 'types/Tracing';
 import { TimeInSeconds } from 'types/Common';
 import { TraceListItem } from 'components/JaegerIntegration/TraceListItem';
 import { summaryFont } from './SummaryPanelCommon';
-import transformTraceData from 'components/JaegerIntegration/JaegerResults/transform';
 import { DecoratedGraphNodeData } from 'types/Graph';
+import transformTraceData from 'utils/tracing/TraceTransform';
 
 type Props = {
   nodeData: DecoratedGraphNodeData;

--- a/src/types/JaegerInfo.ts
+++ b/src/types/JaegerInfo.ts
@@ -95,15 +95,15 @@ export type EnvoySpanInfo = OpenTracingHTTPInfo & {
   peer?: Target;
 };
 
-export type TraceData = {
+export type TraceData<S extends SpanData> = {
   processes: Record<string, Process>;
   traceID: string;
+  spans: S[];
 };
 
-export type JaegerTrace = TraceData & {
+export type JaegerTrace = TraceData<RichSpanData> & {
   duration: number;
   endTime: number;
-  spans: RichSpanData[];
   startTime: number;
   traceName: string;
   services: { name: string; numberOfSpans: number }[];

--- a/src/utils/tracing/TraceStats.ts
+++ b/src/utils/tracing/TraceStats.ts
@@ -1,7 +1,7 @@
 import { EnvoySpanInfo, JaegerTrace, RichSpanData } from 'types/JaegerInfo';
 import { MetricsStats } from 'types/Metrics';
 import { genStatsKey, MetricsStatsQuery, statsQueryToKey } from 'types/MetricsOptions';
-import { average } from './MathUtils';
+import { average } from '../MathUtils';
 
 export const averageSpanDuration = (trace: JaegerTrace): number | undefined => {
   const spansWithDuration = trace.spans.filter(s => s.duration && s.duration > 0);

--- a/src/utils/tracing/TracingHelper.ts
+++ b/src/utils/tracing/TracingHelper.ts
@@ -3,6 +3,7 @@ import moment from 'moment';
 import logfmtParser from 'logfmt/lib/logfmt_parser';
 import {
   EnvoySpanInfo,
+  JaegerTrace,
   KeyValuePair,
   OpenTracingBaseInfo,
   OpenTracingHTTPInfo,
@@ -11,6 +12,7 @@ import {
 } from 'types/JaegerInfo';
 import { retrieveTimeRange } from 'components/Time/TimeRangeHelper';
 import { guardTimeRange, durationToBounds, DurationInSeconds } from 'types/Common';
+import { spansSort } from './TraceTransform';
 
 export const defaultTracingDuration: DurationInSeconds = 600;
 
@@ -127,37 +129,9 @@ export const findParent = (span: Span): Span | undefined => {
   return undefined;
 };
 
-// export const findChildren = (span: Span, trace: JaegerTrace): Span[] => {
-//   const children = trace.spans.filter(s => findParent(s)?.spanID === span.spanID);
-//   return children.sort(spansSort);
-// };
-
-// export const findDepthFirstNext = (current: Span, trace: JaegerTrace): Span | undefined => {
-//   // Check children
-//   const children = findChildren(current, trace);
-//   console.log('children of ', current.spanID, ' are ', children.map(s => s.spanID));
-//   if (children.length > 0) {
-//     return children[0];
-//   }
-//   // Leaf reached => check siblings
-//   return findNextSibling(current, trace);
-// };
-
-// export const findNextSibling = (current: Span, trace: JaegerTrace): Span | undefined => {
-//   const parent = findParent(current);
-//   if (parent) {
-//     const siblings = findChildren(parent, trace);
-//     const nextIdx = 1 + siblings.findIndex(s => s.spanID === current.spanID);
-//     if (nextIdx < siblings.length) {
-//       // There's a next sibling
-//       return siblings[nextIdx];
-//     }
-//     // End of siblings => repeat on parent (recursive)
-//     return findNextSibling(parent, trace);
-//   }
-//   // Reached root => end of depth-first
-//   return undefined;
-// };
+export const findChildren = (span: Span, trace: JaegerTrace): Span[] => {
+  return trace.spans.filter(s => findParent(s)?.spanID === span.spanID).sort(spansSort);
+};
 
 export const searchParentWorkload = (span: Span): WorkloadAndNamespace | undefined => {
   const parent = findParent(span);

--- a/src/utils/tracing/__tests__/TraceStats.test.ts
+++ b/src/utils/tracing/__tests__/TraceStats.test.ts
@@ -1,7 +1,7 @@
 import { EnvoySpanInfo, JaegerTrace, Span, RichSpanData } from 'types/JaegerInfo';
 import { MetricsStats } from 'types/Metrics';
 import { statsQueryToKey } from 'types/MetricsOptions';
-import { averageSpanDuration, buildQueriesFromSpans, isSimilarTrace, reduceMetricsStats } from 'utils/TraceStats';
+import { averageSpanDuration, buildQueriesFromSpans, isSimilarTrace, reduceMetricsStats } from '../TraceStats';
 
 const traceBase = {
   spans: [

--- a/src/utils/tracing/__tests__/TracingHelper.test.ts
+++ b/src/utils/tracing/__tests__/TracingHelper.test.ts
@@ -1,4 +1,4 @@
-import { buildTags, findParent, getWorkloadFromSpan, searchParentWorkload } from '../TracingHelper';
+import { buildTags, findChildren, findParent, getWorkloadFromSpan, searchParentWorkload } from '../TracingHelper';
 import { Span, KeyValuePair, SpanData } from 'types/JaegerInfo';
 import transformTraceData from '../TraceTransform';
 
@@ -140,7 +140,7 @@ describe('TracingHelper', () => {
   });
 });
 
-describe('Trace depth-first iterate', () => {
+describe('Trace find related', () => {
   const trace = transformTraceData({
     traceID: 't-1234',
     processes: { p: { serviceName: 'svc', tags: [] } },
@@ -189,5 +189,20 @@ describe('Trace depth-first iterate', () => {
     expect(p3?.spanID).toEqual('s-1');
     expect(p4?.spanID).toEqual('s-2');
     expect(p5?.spanID).toEqual('s-2');
+  });
+
+  it('should find children', () => {
+    const [c1, c2, c3, c4, c5] = [
+      findChildren(s1, trace),
+      findChildren(s2, trace),
+      findChildren(s3, trace),
+      findChildren(s4, trace),
+      findChildren(s5, trace)
+    ];
+    expect(c1.map(s => s.spanID)).toEqual(['s-2', 's-3']);
+    expect(c2.map(s => s.spanID)).toEqual(['s-4', 's-5']);
+    expect(c3.map(s => s.spanID)).toEqual([]);
+    expect(c4.map(s => s.spanID)).toEqual([]);
+    expect(c5.map(s => s.spanID)).toEqual([]);
   });
 });


### PR DESCRIPTION
Redesign the trace details panel in graph to allow navigating in a given
trace, from span to span, following parent/children relationships

Fixes kiali/kiali#3361

Prior refactoring (1st commit): move tracing utility functions to 'utils/' 