### PR TITLE
Support reverse proxy authentication

### DIFF
--- a/src/app/AuthenticationController.tsx
+++ b/src/app/AuthenticationController.tsx
@@ -69,9 +69,12 @@ class AuthenticationController extends React.Component<AuthenticationControllerP
     } else {
       let dispatchLoginCycleOnLoad = false;
 
-      // If login strategy is "anonymous", dispatch login cycle
+      // If login strategy is "anonymous" or "header", dispatch login cycle
       // because there is no need to ask for any credentials
-      if (authenticationConfig.strategy === AuthStrategy.anonymous) {
+      if (
+        authenticationConfig.strategy === AuthStrategy.anonymous ||
+        authenticationConfig.strategy === AuthStrategy.header
+      ) {
         dispatchLoginCycleOnLoad = true;
       }
 

--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -20,6 +20,7 @@ import { authenticationConfig, kialiLogo } from '../../config';
 import { KialiAppAction } from '../../actions/KialiAppAction';
 import LoginThunkActions from '../../actions/LoginThunkActions';
 import { isAuthStrategyOAuth } from '../../config/AuthenticationConfig';
+//import { c_wizard__nav_BoxShadow } from '@patternfly/react-tokens';
 
 type LoginProps = {
   status: LoginStatus;
@@ -78,6 +79,8 @@ export class LoginPage extends React.Component<LoginProps, LoginState> {
     if (isAuthStrategyOAuth()) {
       // If we are using OpenShift or OpenId strategy, take the user back to the authorization endpoint
       window.location.href = authenticationConfig.authorizationEndpoint!;
+    } else if (authenticationConfig.strategy === AuthStrategy.header) {
+      window.location.href = (window as any).WEB_ROOT ? (window as any).WEB_ROOT : '/';
     } else if (authenticationConfig.strategy === AuthStrategy.token) {
       if (this.state.password.trim().length !== 0 && this.props.authenticate) {
         this.props.authenticate('', this.state.password);

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -54,6 +54,17 @@ const getHeaders = () => {
   return { ...loginHeaders };
 };
 
+
+/** Create content type correctly for a given request type */
+const getHeadersWithMethod = (method) => {
+  var allHeaders = getHeaders();
+  if (method === HTTP_VERBS.PATCH) {
+    allHeaders["Content-Type"] = "application/json";
+  }
+
+  return allHeaders;
+};
+
 const basicAuth = (username: UserName, password: Password) => {
   return { username: username, password: password };
 };
@@ -63,7 +74,7 @@ const newRequest = <P>(method: HTTP_VERBS, url: string, queryParams: any, data: 
     method: method,
     url: url,
     data: data,
-    headers: getHeaders(),
+    headers: getHeadersWithMethod(method),
     params: queryParams
   });
 

--- a/src/services/Login.ts
+++ b/src/services/Login.ts
@@ -65,6 +65,21 @@ class TokenLogin implements LoginStrategy<WebLoginData> {
   }
 }
 
+class HeaderLogin implements LoginStrategy<WebLoginData> {
+  public async prepare(_info: AuthConfig) {
+    return AuthResult.CONTINUE;
+  }
+
+  public async perform(_request: NullDispatch): Promise<LoginResult> {
+    const session = (await API.login({ username: '', password: '', token: '' })).data;
+
+    return {
+      status: AuthResult.SUCCESS,
+      session: session
+    };
+  }
+}
+
 class OAuthLogin implements LoginStrategy<unknown> {
   public async prepare(info: AuthConfig) {
     if (!info.authorizationEndpoint) {
@@ -105,6 +120,7 @@ export class LoginDispatcher {
     this.strategyMapping.set(AuthStrategy.openshift, new OAuthLogin());
     this.strategyMapping.set(AuthStrategy.token, new TokenLogin());
     this.strategyMapping.set(AuthStrategy.openid, new OAuthLogin());
+    this.strategyMapping.set(AuthStrategy.header, new HeaderLogin());
   }
 
   public async prepare(): Promise<AuthResult> {

--- a/src/types/Auth.ts
+++ b/src/types/Auth.ts
@@ -13,7 +13,8 @@ export enum AuthStrategy {
   anonymous = 'anonymous',
   openshift = 'openshift',
   token = 'token',
-  openid = 'openid'
+  openid = 'openid',
+  header = 'header'
 }
 
 // Stores the result of a computation:


### PR DESCRIPTION
** Describe the change **

Support for running Kiali behind a reverse proxy with an embedded `Authorization` header and potentially impersonation headers.  For https://github.com/kiali/kiali/issues/3207 

** Issue reference **

https://github.com/kiali/kiali/issues/3207

** Backwards compatible? **

[x ] Is your pull-request introducing changes in behaviour?

backwards compatible.  If the authentication strategy is `header` the login screen is skipped, similar to anonymous.

** Screenshot **

Add a screenshot of the UI after your changes.


![kiali-screenshot](https://user-images.githubusercontent.com/8249283/104030829-fbb94000-5199-11eb-8fff-4fac184b3f8e.png)


** Documentation **

Please provide an update to documentation if appropriate. For configuration options, consider sending a PR to https://github.com/kiali/kiali/blob/master/README.adoc
