### PR TITLE
Display cluster_id on page title and masthead

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -21,7 +21,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Kiali Console</title>
+    <title>Kiali</title>
   </head>
   <body class="pf-m-redhat-font">
     <noscript> You need to enable JavaScript to run this app. </noscript>

--- a/src/components/Nav/Masthead/Masthead.tsx
+++ b/src/components/Nav/Masthead/Masthead.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import { style } from 'typestyle';
-import { Toolbar as ToolbarNext, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
+import { Label, Toolbar as ToolbarNext, ToolbarGroup, ToolbarItem, Tooltip } from '@patternfly/react-core';
+import { ClusterIcon } from '@patternfly/react-icons';
 
+import { serverConfig } from '../../../config';
 import { default as MeshMTLSStatus } from '../../../components/MTls/MeshMTLSStatus';
 import { default as IstioStatus } from '../../IstioStatus/IstioStatus';
 import PfSpinner from '../../PfSpinner';
@@ -23,6 +25,21 @@ class Masthead extends React.Component {
           <PfSpinner />
         </ToolbarGroup>
         <ToolbarGroup>
+          {serverConfig.clusterInfo?.name && (
+            <ToolbarItem>
+              <div style={{ paddingRight: '1em' }}>
+                <Tooltip
+                  entryDelay={0}
+                  position="bottom"
+                  content={<div>Kiali is observing "{serverConfig.clusterInfo.name}" cluster</div>}
+                >
+                  <Label>
+                    <ClusterIcon /> {serverConfig.clusterInfo.name}
+                  </Label>
+                </Tooltip>
+              </div>
+            </ToolbarItem>
+          )}
           <ToolbarItem>
             <IstioStatus />
           </ToolbarItem>

--- a/src/components/Nav/Masthead/Masthead.tsx
+++ b/src/components/Nav/Masthead/Masthead.tsx
@@ -31,7 +31,7 @@ class Masthead extends React.Component {
                 <Tooltip
                   entryDelay={0}
                   position="bottom"
-                  content={<div>Kiali is observing "{serverConfig.clusterInfo.name}" cluster</div>}
+                  content={<div>Kiali home cluster: {serverConfig.clusterInfo.name}</div>}
                 >
                   <Label>
                     <ClusterIcon /> {serverConfig.clusterInfo.name}

--- a/src/components/Nav/Navigation.tsx
+++ b/src/components/Nav/Navigation.tsx
@@ -56,7 +56,12 @@ export class Navigation extends React.Component<PropsType, NavigationState> {
   }
 
   componentDidMount() {
-    document.title = serverConfig.installationTag ? serverConfig.installationTag : 'Kiali Console';
+    let pageTitle = serverConfig.installationTag ? serverConfig.installationTag : 'Kiali';
+    if (serverConfig.clusterInfo?.name) {
+      pageTitle += ` [${serverConfig.clusterInfo.name}]`;
+    }
+
+    document.title = pageTitle;
   }
 
   isGraph = () => {

--- a/src/types/ServerConfig.ts
+++ b/src/types/ServerConfig.ts
@@ -5,6 +5,12 @@ export type IstioLabelKey = 'appLabelName' | 'versionLabelName' | 'injectionLabe
 interface iter8Config {
   enabled: boolean;
 }
+
+interface ClusterInfo {
+  name: string;
+  network: string;
+}
+
 // Kiali addons/extensions specific
 interface Extensions {
   iter8: iter8Config;
@@ -48,6 +54,7 @@ export interface ToleranceConfig {
 */
 
 export interface ServerConfig {
+  clusterInfo?: ClusterInfo;
   extensions?: Extensions;
   healthConfig: HealthConfig;
   installationTag?: string;


### PR DESCRIPTION
Cluster information is shown only if available.

Fixes kiali/kiali#3523
Related back-end PR: kiali/kiali#3580

** Screenshot **

![image](https://user-images.githubusercontent.com/23639005/104499452-c0a47b80-55a2-11eb-92e3-042a004a80ea.png)

