### PR TITLE
Support Wizards with one workload without version label

### DIFF
--- a/src/components/IstioWizards/ServiceWizardDropdown.tsx
+++ b/src/components/IstioWizards/ServiceWizardDropdown.tsx
@@ -163,7 +163,12 @@ class ServiceWizardDropdown extends React.Component<Props, State> {
 
   getValidWorkloads = (): WorkloadOverview[] => {
     return this.props.workloads.filter(workload => {
-      return workload.labels && workload.labels[this.appLabelName] && workload.labels[this.versionLabelName];
+      // A workload could skip the version label on this check only when there is a single workload list
+      return (
+        workload.labels &&
+        workload.labels[this.appLabelName] &&
+        (workload.labels[this.versionLabelName] || this.props.workloads.length === 1)
+      );
     });
   };
 


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/3483

Kiali Wizards expect workloads labeled with "app" and "version" labels.

![image](https://user-images.githubusercontent.com/1662329/104609224-1cdecc80-5683-11eb-90cf-98ba7c271a9e.png)

It seems that "version" label tends to not be used in scenarios where there is a single workload for a service, then Fault Injection or Request Timeout scenarios can't be used.

This PR enables that use case.

For QE:
- Test potential regression in Service -> Actions scenario.
- Check that a Workload with "app" but NO "version" can be supported.

Thanks !
