### PR TITLE
Allow custom health configuration to be deployed as annotations

### DIFF
--- a/src/components/Health/__tests__/HealthDetails.test.tsx
+++ b/src/components/Health/__tests__/HealthDetails.test.tsx
@@ -15,7 +15,7 @@ describe('HealthDetails', () => {
     const health = new ServiceHealth(
       'bookinfo',
       'reviews',
-      { inbound: {}, outbound: {} },
+      { inbound: {}, outbound: {}, healthAnnotations: {} },
       { rateInterval: 60, hasSidecar: true }
     );
 
@@ -27,7 +27,7 @@ describe('HealthDetails', () => {
     const health = new ServiceHealth(
       'bookinfo',
       'reviews',
-      { inbound: {}, outbound: {} },
+      { inbound: {}, outbound: {}, healthAnnotations: {} },
       { rateInterval: 60, hasSidecar: true }
     );
 

--- a/src/components/Health/__tests__/HealthDetails.test.tsx
+++ b/src/components/Health/__tests__/HealthDetails.test.tsx
@@ -5,7 +5,7 @@ import { shallowToJson } from 'enzyme-to-json';
 import { HealthDetails } from '../HealthDetails';
 import { ServiceHealth } from '../../../types/Health';
 import { setServerConfig } from '../../../config/ServerConfig';
-import { serverRateConfig } from '../../../types/__testData__/ErrorRateConfig';
+import { serverRateConfig } from '../../../types/ErrorRate/__testData__/ErrorRateConfig';
 
 describe('HealthDetails', () => {
   beforeAll(() => {

--- a/src/components/Health/__tests__/HealthIndicator.test.tsx
+++ b/src/components/Health/__tests__/HealthIndicator.test.tsx
@@ -31,7 +31,7 @@ describe('HealthIndicator', () => {
         { name: 'A', availableReplicas: 1, currentReplicas: 1, desiredReplicas: 1, syncedProxies: 1 },
         { name: 'B', availableReplicas: 2, currentReplicas: 2, desiredReplicas: 2, syncedProxies: 2 }
       ],
-      { inbound: {}, outbound: {} },
+      { inbound: {}, outbound: {}, healthAnnotations: {} },
       { rateInterval: 600, hasSidecar: true }
     );
 
@@ -55,7 +55,7 @@ describe('HealthIndicator', () => {
         { name: 'A', availableReplicas: 1, currentReplicas: 1, desiredReplicas: 10, syncedProxies: 1 },
         { name: 'B', availableReplicas: 2, currentReplicas: 2, desiredReplicas: 2, syncedProxies: 2 }
       ],
-      { inbound: {}, outbound: {} },
+      { inbound: {}, outbound: {}, healthAnnotations: {} },
       { rateInterval: 600, hasSidecar: true }
     );
 
@@ -79,7 +79,7 @@ describe('HealthIndicator', () => {
         { name: 'A', availableReplicas: 0, currentReplicas: 0, desiredReplicas: 0, syncedProxies: 0 },
         { name: 'B', availableReplicas: 2, currentReplicas: 2, desiredReplicas: 2, syncedProxies: 2 }
       ],
-      { inbound: {}, outbound: {} },
+      { inbound: {}, outbound: {}, healthAnnotations: {} },
       { rateInterval: 600, hasSidecar: true }
     );
 
@@ -103,7 +103,7 @@ describe('HealthIndicator', () => {
         { name: 'A', availableReplicas: 0, currentReplicas: 0, desiredReplicas: 0, syncedProxies: 0 },
         { name: 'B', availableReplicas: 0, currentReplicas: 0, desiredReplicas: 0, syncedProxies: 0 }
       ],
-      { inbound: {}, outbound: {} },
+      { inbound: {}, outbound: {}, healthAnnotations: {} },
       { rateInterval: 600, hasSidecar: true }
     );
 
@@ -125,7 +125,8 @@ describe('HealthIndicator', () => {
       [{ name: 'A', availableReplicas: 1, currentReplicas: 1, desiredReplicas: 1, syncedProxies: 1 }],
       {
         inbound: { http: { '200': 0.5, '500': 0.5 } },
-        outbound: { http: { '500': 0.4, '200': 2 } }
+        outbound: { http: { '500': 0.4, '200': 2 } },
+        healthAnnotations: {}
       },
       { rateInterval: 600, hasSidecar: true }
     );
@@ -157,7 +158,7 @@ describe('HealthIndicator', () => {
             syncedProxies: 1
           }
         ],
-        { inbound: {}, outbound: {} },
+        { inbound: {}, outbound: {}, healthAnnotations: {} },
         { rateInterval: 600, hasSidecar: true }
       );
 

--- a/src/components/Health/__tests__/__snapshots__/HealthIndicator.test.tsx.snap
+++ b/src/components/Health/__tests__/__snapshots__/HealthIndicator.test.tsx.snap
@@ -96,6 +96,7 @@ exports[`HealthIndicator proxy status section renders the degraded workloads 1`]
               },
             },
             "requests": Object {
+              "healthAnnotations": Object {},
               "inbound": Object {},
               "outbound": Object {},
             },
@@ -240,6 +241,7 @@ exports[`HealthIndicator proxy status section renders the degraded workloads 2`]
           },
         },
         "requests": Object {
+          "healthAnnotations": Object {},
           "inbound": Object {},
           "outbound": Object {},
         },

--- a/src/components/TrafficList/TrafficDetails.tsx
+++ b/src/components/TrafficList/TrafficDetails.tsx
@@ -19,6 +19,7 @@ import * as TrafficListFilters from './FiltersAndSorts';
 import { KialiAppState } from '../../store/Store';
 import { connect } from 'react-redux';
 import { durationSelector } from '../../store/Selectors';
+import { HealthAnnotationType } from '../../types/HealthAnnotation';
 
 export interface AppNode {
   id: string;
@@ -35,6 +36,7 @@ export interface WorkloadNode {
   namespace: string;
   name: string;
   isInaccessible: boolean;
+  healthAnnotation?: HealthAnnotationType;
 }
 
 export interface ServiceNode {
@@ -45,6 +47,7 @@ export interface ServiceNode {
   isServiceEntry?: string;
   isInaccessible: boolean;
   destServices?: DestService[];
+  healthAnnotation?: HealthAnnotationType;
 }
 
 export type TrafficNode = AppNode | ServiceNode | WorkloadNode;
@@ -196,7 +199,8 @@ class TrafficDetails extends React.Component<TrafficDetailsProps, TrafficDetails
           name: node.service || 'unknown',
           isServiceEntry: node.isServiceEntry,
           isInaccessible: node.isInaccessible || false,
-          destServices: node.destServices
+          destServices: node.destServices,
+          healthAnnotation: node.healthAnnotation
         };
       default:
         return {
@@ -204,7 +208,8 @@ class TrafficDetails extends React.Component<TrafficDetailsProps, TrafficDetails
           type: NodeType.WORKLOAD,
           namespace: node.namespace,
           name: node.workload || 'unknown',
-          isInaccessible: node.isInaccessible || false
+          isInaccessible: node.isInaccessible || false,
+          healthAnnotation: node.healthAnnotation
         };
     }
   };

--- a/src/components/TrafficList/TrafficDetails.tsx
+++ b/src/components/TrafficList/TrafficDetails.tsx
@@ -200,7 +200,7 @@ class TrafficDetails extends React.Component<TrafficDetailsProps, TrafficDetails
           isServiceEntry: node.isServiceEntry,
           isInaccessible: node.isInaccessible || false,
           destServices: node.destServices,
-          healthAnnotation: node.healthAnnotation
+          healthAnnotation: node.hasHealthConfig
         };
       default:
         return {
@@ -209,7 +209,7 @@ class TrafficDetails extends React.Component<TrafficDetailsProps, TrafficDetails
           namespace: node.namespace,
           name: node.workload || 'unknown',
           isInaccessible: node.isInaccessible || false,
-          healthAnnotation: node.healthAnnotation
+          healthAnnotation: node.hasHealthConfig
         };
     }
   };

--- a/src/config/HealthConfig.ts
+++ b/src/config/HealthConfig.ts
@@ -38,3 +38,4 @@ const replaceXCode = (value: string): string => {
 */
 export const allMatchTEST = allMatch;
 export const getExprTEST = getExpr;
+export const replaceXCodeTEST = replaceXCode;

--- a/src/config/HealthConfig.ts
+++ b/src/config/HealthConfig.ts
@@ -2,6 +2,9 @@ import { HealthConfig, RegexConfig } from '../types/ServerConfig';
 
 const allMatch = new RegExp('.*');
 
+/*
+ Parse configuration from backend format to regex expression
+*/
 export const parseHealthConfig = (healthConfig: HealthConfig) => {
   for (let [key, r] of Object.entries(healthConfig.rate)) {
     healthConfig.rate[key].namespace = getExpr(healthConfig.rate[key].namespace);
@@ -16,11 +19,14 @@ export const parseHealthConfig = (healthConfig: HealthConfig) => {
   return healthConfig;
 };
 
-export const getExpr = (value: RegexConfig | undefined, code: boolean = false): RegExp => {
+/*
+  Convert the string to regex, if isCode is true then call to replaceXCode to change the X|x in code expression to \d
+*/
+export const getExpr = (value: RegexConfig | undefined, isCode: boolean = false): RegExp => {
   if (value) {
     if (typeof value === 'string' && value !== '') {
       const v = value.replace('\\\\', '\\');
-      return new RegExp(code ? replaceXCode(v) : v);
+      return new RegExp(isCode ? replaceXCode(v) : v);
     }
     if (typeof value === 'object' && value.toString() !== '/(?:)/') {
       return value;
@@ -29,6 +35,9 @@ export const getExpr = (value: RegexConfig | undefined, code: boolean = false): 
   return allMatch;
 };
 
+/* Replace x|X by the regular expression
+   Example: 4XX or 5XX to 4\d\d 5\d\d
+*/
 const replaceXCode = (value: string): string => {
   return value.replace(/x|X/g, '\\d');
 };

--- a/src/config/HealthConfig.ts
+++ b/src/config/HealthConfig.ts
@@ -8,7 +8,7 @@ export const parseHealthConfig = (healthConfig: HealthConfig) => {
     healthConfig.rate[key].name = getExpr(healthConfig.rate[key].name);
     healthConfig.rate[key].kind = getExpr(healthConfig.rate[key].kind);
     for (let t of Object.values(r.tolerance)) {
-      t.code = getExpr(t.code);
+      t.code = getExpr(t.code, true);
       t.direction = getExpr(t.direction);
       t.protocol = getExpr(t.protocol);
     }
@@ -16,16 +16,21 @@ export const parseHealthConfig = (healthConfig: HealthConfig) => {
   return healthConfig;
 };
 
-export const getExpr = (value: RegexConfig | undefined): RegExp => {
+export const getExpr = (value: RegexConfig | undefined, code: boolean = false): RegExp => {
   if (value) {
     if (typeof value === 'string' && value !== '') {
-      return new RegExp(value.replace('\\\\', '\\'));
+      const v = value.replace('\\\\', '\\');
+      return new RegExp(code ? replaceXCode(v) : v);
     }
     if (typeof value === 'object' && value.toString() !== '/(?:)/') {
       return value;
     }
   }
   return allMatch;
+};
+
+const replaceXCode = (value: string): string => {
+  return value.replace(/x|X/g, '\\d');
 };
 
 /*

--- a/src/config/__tests__/HealthConfig.test.ts
+++ b/src/config/__tests__/HealthConfig.test.ts
@@ -1,4 +1,4 @@
-import { allMatchTEST, getExprTEST } from '../HealthConfig';
+import { allMatchTEST, getExprTEST, replaceXCodeTEST } from '../HealthConfig';
 
 describe('#getExprTEST', () => {
   it('getExprTEST should return allMatch if undefined value', () => {
@@ -23,6 +23,28 @@ describe('#getExprTEST', () => {
 
   it('Check that default backend is converted correctly', () => {
     const backendGo = '^[4-5]\\d\\d$';
-    expect(getExprTEST(backendGo)).toStrictEqual(/^[4-5]\d\d$/);
+    expect(getExprTEST(backendGo, true)).toStrictEqual(/^[4-5]\d\d$/);
+  });
+
+  it('Check that X is converted correctly', () => {
+    const backendGo = '[45]XX';
+    expect(getExprTEST(backendGo, true)).toStrictEqual(/[45]\d\d/);
+  });
+
+  it('Check that x is converted correctly', () => {
+    const backendGo = '[45]xx';
+    const expr = getExprTEST(backendGo, true);
+    expect(expr).toStrictEqual(/[45]\d\d/);
+    expect(expr.test('404')).toBeTruthy();
+    expect(expr.test('501')).toBeTruthy();
+    expect(expr.test('603')).toBeFalsy();
+  });
+
+  it('Check that replaceXCode convert correctly', () => {
+    var backendGo = '[45]XX';
+    expect(replaceXCodeTEST(backendGo)).toStrictEqual('[45]\\d\\d');
+
+    backendGo = '[45]xx';
+    expect(replaceXCodeTEST(backendGo)).toStrictEqual('[45]\\d\\d');
   });
 });

--- a/src/pages/ServiceList/__tests__/ServiceListComponent.test.ts
+++ b/src/pages/ServiceList/__tests__/ServiceListComponent.test.ts
@@ -18,7 +18,7 @@ const makeService = (
   inbound: { [key: string]: { [key: string]: number } },
   outbound: { [key: string]: { [key: string]: number } }
 ): WithServiceHealth<ServiceListItem> => {
-  const reqErrs: RequestHealth = { inbound: inbound, outbound: outbound };
+  const reqErrs: RequestHealth = { inbound: inbound, outbound: outbound, healthAnnotations: {} };
   const health = new ServiceHealth('bookinfo', 'reviews', reqErrs, { rateInterval: 60, hasSidecar: true });
 
   return {

--- a/src/services/GraphDataSource.ts
+++ b/src/services/GraphDataSource.ts
@@ -176,7 +176,7 @@ export default class GraphDataSource {
     }
 
     // Some appenders are expensive so only specify an appender if needed.
-    let appenders: AppenderString = 'deadNode,sidecarsCheck,serviceEntry,istio';
+    let appenders: AppenderString = 'deadNode,sidecarsCheck,serviceEntry,istio,healthConfig';
 
     if (fetchParams.showOperationNodes) {
       appenders += ',aggregateNode';

--- a/src/types/ErrorRate/ErrorRate.ts
+++ b/src/types/ErrorRate/ErrorRate.ts
@@ -53,9 +53,11 @@ export const calculateErrorRate = (
   // Get the first configuration that match with the case
   const rateAnnotation = new RateHealth(requests.healthAnnotations);
   const conf = rateAnnotation.toleranceConfig || getRateHealthConfig(ns, name, kind).tolerance;
+
   // Get aggregate
   let status = getAggregate(requests, conf);
   const globalStatus = calculateStatus(status.global);
+
   if (globalStatus.status.status !== HEALTHY) {
     return {
       errorRatio: {
@@ -87,7 +89,6 @@ export const calculateErrorRate = (
         ? valuesErrorCodes.outbound
         : result.errorRatio.outbound.status.value;
   }
-
   // In that case we want to keep values
   return result;
 };
@@ -110,7 +111,6 @@ export const calculateStatus = (
         reqTol.tolerance && checkExpr(reqTol!.tolerance!.protocol, protocol) ? reqTol.tolerance : undefined;
       // Calculate the status for the tolerance provided
       const auxStatus = getRequestErrorsStatus((rate as Rate).errorRatio, tolerance);
-
       // Check the priority of the status
       if (auxStatus.status.priority > result.status.status.priority) {
         result.status = auxStatus;

--- a/src/types/ErrorRate/GraphEdgeStatus.ts
+++ b/src/types/ErrorRate/GraphEdgeStatus.ts
@@ -96,7 +96,8 @@ export const calculateStatusGraph = (
         unit: '%'
       };
       // Calculate the status
-      const auxStatus = ascendingThresholdCheck(rate as number, thresholds);
+      const errRatio = (rate as number) / getTotalRequest(traffic);
+      const auxStatus = ascendingThresholdCheck(100 * errRatio, thresholds);
       // Check if the status has more priority than the previous one
       if (auxStatus.status.priority > result.status.status.priority) {
         result.status = auxStatus;
@@ -110,4 +111,12 @@ export const calculateStatusGraph = (
     result.status.value = 0;
   }
   return result;
+};
+
+export const getTotalRequest = (traffic: Responses): number => {
+  var reqRate = 0;
+  Object.values(traffic).forEach(item => {
+    Object.values(item.flags).forEach(v => (reqRate += Number(v)));
+  });
+  return reqRate;
 };

--- a/src/types/ErrorRate/GraphEdgeStatus.ts
+++ b/src/types/ErrorRate/GraphEdgeStatus.ts
@@ -14,12 +14,12 @@ export const getEdgeHealth = (
   target: DecoratedGraphNodeData
 ): ThresholdStatus => {
   // We need to check the configuration for item A outbound requests and configuration of B for inbound requests
-  const annotationSource = source.healthAnnotation ? new RateHealth(source.healthAnnotation) : undefined;
+  const annotationSource = source.hasHealthConfig ? new RateHealth(source.hasHealthConfig) : undefined;
   const configSource =
     annotationSource && annotationSource.toleranceConfig
       ? annotationSource.toleranceConfig
       : getRateHealthConfig(source.namespace, source[source.nodeType], source.nodeType).tolerance;
-  const annotationTarget = target.healthAnnotation ? new RateHealth(target.healthAnnotation) : undefined;
+  const annotationTarget = target.hasHealthConfig ? new RateHealth(target.hasHealthConfig) : undefined;
   const configTarget =
     annotationTarget && annotationTarget.toleranceConfig
       ? annotationTarget.toleranceConfig

--- a/src/types/ErrorRate/TrafficHealth.ts
+++ b/src/types/ErrorRate/TrafficHealth.ts
@@ -20,6 +20,7 @@ export const getTrafficHealth = (item: TrafficItem, direction: Direction): Thres
     annotation && annotation.toleranceConfig
       ? annotation.toleranceConfig
       : getRateHealthConfig(item.node.namespace, item.node.name, item.node.type).tolerance;
+
   // Get tolerances of the configuration for the direction provided
   const tolerances = config.filter(tol => checkExpr(tol.direction, direction));
   // Get the responses like a item with traffic

--- a/src/types/ErrorRate/TrafficHealth.ts
+++ b/src/types/ErrorRate/TrafficHealth.ts
@@ -1,18 +1,27 @@
 import { Direction } from '../MetricsOptions';
 import { ThresholdStatus } from '../Health';
-import { ProtocolWithTraffic } from '../Graph';
+import { NodeType, ProtocolWithTraffic } from '../Graph';
 import { aggregate, checkExpr, getRateHealthConfig, transformEdgeResponses } from './utils';
 import { calculateStatusGraph } from './GraphEdgeStatus';
 import { TrafficItem } from 'components/TrafficList/TrafficDetails';
+import { RateHealth } from '../HealthAnnotation';
 
 /*
  Calculate Health for DetailsTraffic
 */
 export const getTrafficHealth = (item: TrafficItem, direction: Direction): ThresholdStatus => {
+  // Get the annotation configuration
+  const annotation =
+    item.node.type !== NodeType.APP && item.node.healthAnnotation
+      ? new RateHealth(item.node.healthAnnotation)
+      : undefined;
   // Get the configuration for the node
-  const config = getRateHealthConfig(item.node.namespace, item.node.name, item.node.type);
+  const config =
+    annotation && annotation.toleranceConfig
+      ? annotation.toleranceConfig
+      : getRateHealthConfig(item.node.namespace, item.node.name, item.node.type).tolerance;
   // Get tolerances of the configuration for the direction provided
-  const tolerances = config?.tolerance.filter(tol => checkExpr(tol.direction, direction));
+  const tolerances = config.filter(tol => checkExpr(tol.direction, direction));
   // Get the responses like a item with traffic
   const traffic = item.traffic as ProtocolWithTraffic;
   // Aggregate the responses and transform them for calculate the status

--- a/src/types/ErrorRate/__testData__/ErrorRateConfig.ts
+++ b/src/types/ErrorRate/__testData__/ErrorRateConfig.ts
@@ -1,6 +1,8 @@
 import { getExpr } from '../../../config/HealthConfig';
 import { RequestHealth, RequestType } from '../../Health';
 import { HealthAnnotationType } from '../../HealthAnnotation';
+import { TrafficItem } from '../../../components/TrafficList/TrafficDetails';
+import { NodeType, Responses } from '../../Graph';
 
 const codes = ['200', '400', '404', '500'];
 export const annotationSample: HealthAnnotationType = { 'health.kiali.io/rate': '4XX,10,20,http,inbound' };
@@ -15,6 +17,41 @@ const randomRequest = (greater: number = 40): RequestType => {
       Math.floor(Math.random() * (100 * precision - greater * precision) + greater * precision) / (1 * precision);
   });
   return result;
+};
+
+export const generateTrafficItem = (
+  requests: { [key: string]: number[] },
+  annotation?: HealthAnnotationType
+): TrafficItem => {
+  var responses: Responses = {};
+
+  Object.keys(requests).forEach(key => {
+    var flags = {};
+    requests[key].forEach((v, i) => (flags[i] = v));
+    responses[key] = {
+      hosts: {},
+      flags
+    };
+  });
+
+  return {
+    direction: 'inbound',
+    node: {
+      id: 'x-server',
+      type: NodeType.SERVICE,
+      namespace: 'alpha',
+      name: 'x-server',
+      isInaccessible: false,
+      healthAnnotation: annotation
+    },
+    traffic: {
+      protocol: 'http',
+      rates: {
+        http: '20'
+      },
+      responses
+    }
+  };
 };
 
 export const generateRequestHealth = (

--- a/src/types/ErrorRate/__testData__/ErrorRateConfig.ts
+++ b/src/types/ErrorRate/__testData__/ErrorRateConfig.ts
@@ -1,4 +1,33 @@
-import { getExpr } from '../../config/HealthConfig';
+import { getExpr } from '../../../config/HealthConfig';
+import { RequestHealth, RequestType } from '../../Health';
+import { HealthAnnotationType } from '../../HealthAnnotation';
+
+const codes = ['200', '400', '404', '500'];
+export const annotationSample: HealthAnnotationType = { 'health.kiali.io/rate': '4XX,10,20,http,inbound' };
+
+const precision = 100; // 2 decimals
+const randomRequest = (greater: number = 40): RequestType => {
+  var result = {
+    http: {}
+  };
+  codes.forEach(code => {
+    result['http'][code] =
+      Math.floor(Math.random() * (100 * precision - greater * precision) + greater * precision) / (1 * precision);
+  });
+  return result;
+};
+
+export const generateRequestHealth = (
+  annotation: HealthAnnotationType,
+  inbound?: RequestType,
+  outbound?: RequestType
+): RequestHealth => {
+  return {
+    inbound: inbound || randomRequest(),
+    outbound: outbound || randomRequest(),
+    healthAnnotations: annotation || {}
+  };
+};
 
 export const serverRateConfig = {
   kialiFeatureFlags: {

--- a/src/types/ErrorRate/__tests__/ErrorRate.test.ts
+++ b/src/types/ErrorRate/__tests__/ErrorRate.test.ts
@@ -1,23 +1,11 @@
-import * as E from '../ErrorRate';
-import { Rate } from '../ErrorRate/types';
-import { serverConfig, setServerConfig } from '../../config/ServerConfig';
+import * as E from '../';
+import { setServerConfig } from '../../../config/ServerConfig';
 import { serverRateConfig } from '../__testData__/ErrorRateConfig';
-import * as H from '../../types/Health';
+import * as H from '../../Health';
 
 describe('getRateHealthConfig', () => {
   beforeAll(() => {
     setServerConfig(serverRateConfig);
-  });
-  describe('getRateHealthConfig', () => {
-    it('should return rate object or undefined', () => {
-      expect(E.getRateHealthConfigTEST('bookinfo', 'reviews', 'app')).toBeDefined();
-      expect(typeof E.getRateHealthConfigTEST('bookinfo', 'reviews', 'app')).toBe('object');
-      expect(E.getRateHealthConfigTEST('bookinfo', 'reviews', 'app')).toBe(serverConfig.healthConfig!.rate[0]);
-
-      expect(E.getRateHealthConfigTEST('bookinfo', 'error-rev-iews', 'app')).toBe(serverConfig.healthConfig!.rate[1]);
-      expect(E.getRateHealthConfigTEST('bookinfo', 'reviews', 'workloadss')).toBe(serverConfig.healthConfig!.rate[1]);
-      expect(E.getRateHealthConfigTEST('istio-system', 'reviews', 'workload')).toBe(serverConfig.healthConfig!.rate[1]);
-    });
   });
   describe('sumRequests', () => {
     it('should aggregate the requests', () => {
@@ -134,61 +122,6 @@ describe('getRateHealthConfig', () => {
         },
         toleranceConfig: requestsPriority0.tolerance
       });
-    });
-  });
-  describe('aggregate', () => {
-    it('should aggregate the requests', () => {
-      const requests = {
-        http: {
-          '501': 3,
-          '404': 2,
-          '200': 4,
-          '100': 1
-        },
-        grpc: {
-          '1': 3,
-          '16': 2
-        }
-      };
-
-      let result = E.aggregateTEST(requests, serverRateConfig.healthConfig.rate[1].tolerance);
-      let requestsResult = result[0].requests;
-      expect((requestsResult['http'] as Rate).requestRate).toBe(10);
-      expect((requestsResult['http'] as Rate).errorRate).toBe(3);
-      requestsResult = result[1].requests;
-      expect((requestsResult['grpc'] as Rate).requestRate).toBe(5);
-      expect((requestsResult['grpc'] as Rate).errorRate).toBe(5);
-
-      result = E.aggregateTEST(requests, [
-        {
-          code: new RegExp('200'),
-          protocol: new RegExp('http'),
-          direction: new RegExp('inbound'),
-          failure: 2,
-          degraded: 1
-        },
-        {
-          code: new RegExp('16'),
-          protocol: new RegExp('grpc'),
-          direction: new RegExp('inbound'),
-          failure: 2,
-          degraded: 1
-        }
-      ]);
-
-      const requestsTolerance1 = result[0].requests;
-
-      expect((requestsTolerance1['http'] as Rate).requestRate).toBe(10);
-      expect((requestsTolerance1['http'] as Rate).errorRate).toBe(4);
-
-      expect(requestsTolerance1['grpc']).toBeUndefined();
-
-      const requestsTolerance2 = result[1].requests;
-
-      expect(requestsTolerance2['http']).toBeUndefined();
-
-      expect((requestsTolerance2['grpc'] as Rate).requestRate).toBe(5);
-      expect((requestsTolerance2['grpc'] as Rate).errorRate).toBe(2);
     });
   });
 });

--- a/src/types/ErrorRate/__tests__/ErrorRateBattery.test.ts
+++ b/src/types/ErrorRate/__tests__/ErrorRateBattery.test.ts
@@ -1,0 +1,28 @@
+import { calculateErrorRate } from '../ErrorRate';
+import { getRateHealthConfig } from '../utils';
+import { setServerConfig } from '../../../config/ServerConfig';
+import { annotationSample, generateRequestHealth, serverRateConfig } from '../__testData__/ErrorRateConfig';
+import { RateHealth } from '../../HealthAnnotation';
+
+describe('getRateHealthConfig', () => {
+  beforeAll(() => {
+    setServerConfig(serverRateConfig);
+  });
+  describe('Be sure that the configuration is used correctly', () => {
+    it('Case Node A has annotation and default configuration ', () => {
+      // Check that there is a default configuration for this node
+      expect(getRateHealthConfig('alpha', 'x-server', 'service')).toBeDefined();
+      const result = calculateErrorRate('alpha', 'x-server', 'service', generateRequestHealth(annotationSample));
+      const rate = new RateHealth(annotationSample);
+      expect(result.config).toEqual(rate.toleranceConfig);
+    });
+
+    it('Case Node A has not annotation', () => {
+      // Check that there is a default configuration for this node
+      const config = getRateHealthConfig('alpha', 'x-server', 'service');
+      expect(config).toBeDefined();
+      const result = calculateErrorRate('alpha', 'x-server', 'service', generateRequestHealth({}));
+      expect(result.config).toEqual(config.tolerance);
+    });
+  });
+});

--- a/src/types/ErrorRate/__tests__/GraphEdgeStatus.test.ts
+++ b/src/types/ErrorRate/__tests__/GraphEdgeStatus.test.ts
@@ -1,0 +1,19 @@
+import { setServerConfig } from '../../../config/ServerConfig';
+import { serverRateConfig } from '../__testData__/ErrorRateConfig';
+import { getTotalRequest } from '../GraphEdgeStatus';
+import { Responses } from '../../Graph';
+
+describe('getRateHealthConfig', () => {
+  beforeAll(() => {
+    setServerConfig(serverRateConfig);
+  });
+
+  it('getTotalRequest', () => {
+    // Check with annotation to set 400
+    const resp: Responses = {
+      '200': { hosts: {}, flags: { '-': '3', XX: '4', YYY: '2' } },
+      '400': { hosts: {}, flags: { '-': '1', XX: '1', YYY: '6' } }
+    };
+    expect(getTotalRequest(resp)).toBe(17);
+  });
+});

--- a/src/types/ErrorRate/__tests__/GraphEdgeStatus.test.ts
+++ b/src/types/ErrorRate/__tests__/GraphEdgeStatus.test.ts
@@ -1,7 +1,26 @@
 import { setServerConfig } from '../../../config/ServerConfig';
 import { serverRateConfig } from '../__testData__/ErrorRateConfig';
-import { getTotalRequest } from '../GraphEdgeStatus';
+import { calculateStatusGraph, generateRateForGraphTolerance, getTotalRequest } from '../GraphEdgeStatus';
 import { Responses } from '../../Graph';
+import { RequestTolerance } from '../types';
+import { ToleranceConfig } from '../../ServerConfig';
+import * as H from '../../Health';
+
+const tolerance400: ToleranceConfig = {
+  code: new RegExp(/400/),
+  degraded: 10,
+  failure: 20,
+  protocol: new RegExp(/http/),
+  direction: new RegExp(/inbound/)
+};
+
+const tolerance500: ToleranceConfig = {
+  code: new RegExp(/500/),
+  degraded: 10,
+  failure: 20,
+  protocol: new RegExp(/http/),
+  direction: new RegExp(/inbound/)
+};
 
 describe('getRateHealthConfig', () => {
   beforeAll(() => {
@@ -15,5 +34,108 @@ describe('getRateHealthConfig', () => {
       '400': { hosts: {}, flags: { '-': '1', XX: '1', YYY: '6' } }
     };
     expect(getTotalRequest(resp)).toBe(17);
+  });
+  describe('calculateStatusGraph', () => {
+    it('case A is FAILURE for 400', () => {
+      const tolerances: RequestTolerance[] = [
+        {
+          tolerance: tolerance400,
+          requests: { http: 8 }
+        }
+      ];
+
+      // Check with annotation to set 400
+      const resp: Responses = {
+        '200': { hosts: {}, flags: { '-': '3', XX: '4', YYY: '2' } },
+        '400': { hosts: {}, flags: { '-': '1', XX: '1', YYY: '6' } }
+      };
+
+      const status = calculateStatusGraph(tolerances, resp);
+      expect(status.toleranceConfig).toBe(tolerances[0].tolerance);
+      expect(status.protocol).toBe('http');
+      expect(status.status.value).toBe((8 / 17) * 100);
+      expect(status.status.status).toBe(H.FAILURE);
+    });
+
+    it('case A is HEALTHY for 500', () => {
+      const tolerances: RequestTolerance[] = [
+        {
+          tolerance: tolerance500,
+          requests: { http: 0 }
+        }
+      ];
+
+      // Check with annotation to set 400
+      const resp: Responses = {
+        '200': { hosts: {}, flags: { '-': '3', XX: '4', YYY: '2' } },
+        '400': { hosts: {}, flags: { '-': '1', XX: '1', YYY: '6' } }
+      };
+
+      const status = calculateStatusGraph(tolerances, resp);
+      expect(status.toleranceConfig).toBe(tolerances[0].tolerance);
+      expect(status.protocol).toBe('http');
+      expect(status.status.value).toBe((0 / 17) * 100);
+      expect(status.status.status).toBe(H.HEALTHY);
+    });
+
+    it('case A is the worst case FAILURE here for multiple tolerances', () => {
+      const tolerances: RequestTolerance[] = [
+        {
+          tolerance: tolerance500,
+          requests: { http: 0 }
+        },
+        {
+          tolerance: tolerance400,
+          requests: { http: 8 }
+        }
+      ];
+
+      // Check with annotation to set 400
+      const resp: Responses = {
+        '200': { hosts: {}, flags: { '-': '3', XX: '4', YYY: '2' } },
+        '400': { hosts: {}, flags: { '-': '1', XX: '1', YYY: '6' } }
+      };
+
+      const status = calculateStatusGraph(tolerances, resp);
+      expect(status.toleranceConfig).toBe(tolerances[1].tolerance);
+      expect(status.protocol).toBe('http');
+      expect(status.status.value).toBe((8 / 17) * 100);
+      expect(status.status.status).toBe(H.FAILURE);
+    });
+  });
+
+  it('generateRateForGraphTolerance', () => {
+    var toleranceFor400: RequestTolerance = {
+      tolerance: tolerance400,
+      requests: {}
+    };
+
+    var toleranceFor400_500: RequestTolerance = {
+      tolerance: {
+        code: new RegExp(/[45]\d\d/),
+        degraded: 10,
+        failure: 20,
+        protocol: new RegExp(/http/),
+        direction: new RegExp(/inbound/)
+      },
+      requests: {}
+    };
+
+    const requests: H.RequestType = {
+      http: {
+        '200': 2,
+        '400': 4,
+        '500': 5
+      },
+      grpc: {
+        '14': 2
+      }
+    };
+
+    generateRateForGraphTolerance(toleranceFor400, requests);
+    generateRateForGraphTolerance(toleranceFor400_500, requests);
+
+    expect(toleranceFor400.requests['http']).toBe(4);
+    expect(toleranceFor400_500.requests['http']).toBe(9);
   });
 });

--- a/src/types/ErrorRate/__tests__/TrafficHealth.test.ts
+++ b/src/types/ErrorRate/__tests__/TrafficHealth.test.ts
@@ -1,0 +1,30 @@
+import { setServerConfig } from '../../../config/ServerConfig';
+import { generateTrafficItem, serverRateConfig } from '../__testData__/ErrorRateConfig';
+import { getTrafficHealth } from '../TrafficHealth';
+import * as H from '../../Health';
+
+describe('getRateHealthConfig', () => {
+  beforeAll(() => {
+    setServerConfig(serverRateConfig);
+  });
+  describe('getTrafficHealth', () => {
+    it('should return the ThresholdStatus for a trafficItem', () => {
+      var itemA = generateTrafficItem({ '200': [2, 3], '400': [1, 2], '500': [5] });
+      const thresholdA = getTrafficHealth(itemA, 'inbound');
+      // Default serverRateConfig for 5XX
+      expect(thresholdA.value).toBe((5 / 13) * 100);
+      expect(thresholdA.status).toBe(H.FAILURE);
+    });
+
+    it('Should use annotation instead configuration', () => {
+      // Check with annotation to set 400
+      const itemB = generateTrafficItem(
+        { '200': [2, 3], '400': [1, 2], '500': [5] },
+        { 'health.kiali.io/rate': '400,10,20,http,inbound' }
+      );
+      const thresholdB = getTrafficHealth(itemB, 'inbound');
+      expect(thresholdB.value).toBe((3 / 13) * 100);
+      expect(thresholdB.status).toBe(H.FAILURE);
+    });
+  });
+});

--- a/src/types/ErrorRate/__tests__/utils.test.ts
+++ b/src/types/ErrorRate/__tests__/utils.test.ts
@@ -1,0 +1,142 @@
+import {
+  aggregate,
+  checkExpr,
+  getErrorCodeRate,
+  getRateHealthConfig,
+  getHealthRateAnnotation,
+  requestsErrorRateCode,
+  transformEdgeResponses
+} from '../utils';
+import { serverConfig, setServerConfig } from '../../../config/ServerConfig';
+import { annotationSample, generateRequestHealth, serverRateConfig } from '../__testData__/ErrorRateConfig';
+import { Rate } from '../types';
+import { Responses } from '../../Graph';
+import { RequestType } from '../../Health';
+import { HealthAnnotationType } from '../../HealthAnnotation';
+
+describe('getRateHealthConfig', () => {
+  beforeAll(() => {
+    setServerConfig(serverRateConfig);
+  });
+  it('requestsErrorRateCode', () => {
+    const req: RequestType = { http: { '200': 40.1, '400': 30.2 } };
+    expect(requestsErrorRateCode(req)).toBe((30.2 / 70.3) * 100);
+
+    // Case no rate
+    expect(requestsErrorRateCode({})).toBe(-1);
+  });
+
+  it('getHealthRateAnnotation', () => {
+    const annotation: HealthAnnotationType = { 'health.kiali.io/rate': '400,10,30,htpp,inbound' };
+    const wrongAnnotation: HealthAnnotationType = { rate: '400,10,30,htpp,inbound' };
+
+    expect(getHealthRateAnnotation(undefined)).toBeUndefined();
+    expect(getHealthRateAnnotation(wrongAnnotation)).toBeUndefined();
+    expect(getHealthRateAnnotation(annotation)).toBe('400,10,30,htpp,inbound');
+  });
+
+  it('getErrorCodeRate', () => {
+    const inbound = { htpp: { '200': 2.3, '400': 1.2 } };
+    const outbound = { htpp: { '200': 1.2, '500': 2 } };
+    const requests = generateRequestHealth(annotationSample, inbound, outbound);
+    const errorCodeRate = getErrorCodeRate(requests);
+
+    expect(errorCodeRate.inbound).toBe(requestsErrorRateCode(inbound));
+    expect(errorCodeRate.outbound).toBe(requestsErrorRateCode(outbound));
+  });
+
+  it('getRateHealthConfig should return rate object or undefined', () => {
+    expect(checkExpr(undefined, 'app')).toBeTruthy();
+    expect(checkExpr(new RegExp(/book/), 'bookinfo')).toBeTruthy();
+    expect(checkExpr(new RegExp(/b(.*)/), 'bookinfo')).toBeTruthy();
+    expect(checkExpr('book', 'bookinfo')).toBeTruthy();
+    expect(checkExpr('b.*', 'bookinfo')).toBeTruthy();
+
+    expect(checkExpr(new RegExp(/book/), 'app')).toBeFalsy();
+    expect(checkExpr(new RegExp(/b(.*)/), 'app')).toBeFalsy();
+    expect(checkExpr('book', 'app')).toBeFalsy();
+    expect(checkExpr('b.*', 'app')).toBeFalsy();
+  });
+
+  it('getRateHealthConfig should return rate object or undefined', () => {
+    expect(getRateHealthConfig('bookinfo', 'reviews', 'app')).toBeDefined();
+    expect(typeof getRateHealthConfig('bookinfo', 'reviews', 'app')).toBe('object');
+    expect(getRateHealthConfig('bookinfo', 'reviews', 'app')).toBe(serverConfig.healthConfig!.rate[0]);
+
+    expect(getRateHealthConfig('bookinfo', 'error-rev-iews', 'app')).toBe(serverConfig.healthConfig!.rate[1]);
+    expect(getRateHealthConfig('bookinfo', 'reviews', 'workloadss')).toBe(serverConfig.healthConfig!.rate[1]);
+    expect(getRateHealthConfig('istio-system', 'reviews', 'workload')).toBe(serverConfig.healthConfig!.rate[1]);
+  });
+
+  it('transformEdgeResponses should return a RequestType from edge response and protocol', () => {
+    const edgeResponse: Responses = {
+      '200': { flags: { '-': '1.2', XXX: '3.1' }, hosts: { 'w-server.alpha.svc.cluster.local': '46.1' } }
+    };
+    const protocol = 'http';
+    const requestType = transformEdgeResponses(edgeResponse, protocol);
+
+    expect(requestType).toBeDefined();
+    expect(requestType[protocol]).toBeDefined();
+    Object.keys(edgeResponse).forEach(code => {
+      expect(requestType[protocol][code]).toBeDefined();
+      const percentRate = Object.values(edgeResponse[code].flags).reduce((acc, value) =>
+        String(Number(acc) + Number(value))
+      );
+      expect(requestType[protocol][code]).toBe(Number(percentRate));
+    });
+  });
+
+  it('aggregate should aggregate the requests', () => {
+    const requests = {
+      http: {
+        '501': 3,
+        '404': 2,
+        '200': 4,
+        '100': 1
+      },
+      grpc: {
+        '1': 3,
+        '16': 2
+      }
+    };
+
+    let result = aggregate(requests, serverRateConfig.healthConfig.rate[1].tolerance);
+    let requestsResult = result[0].requests;
+    expect((requestsResult['http'] as Rate).requestRate).toBe(10);
+    expect((requestsResult['http'] as Rate).errorRate).toBe(3);
+    requestsResult = result[1].requests;
+    expect((requestsResult['grpc'] as Rate).requestRate).toBe(5);
+    expect((requestsResult['grpc'] as Rate).errorRate).toBe(5);
+
+    result = aggregate(requests, [
+      {
+        code: new RegExp('200'),
+        protocol: new RegExp('http'),
+        direction: new RegExp('inbound'),
+        failure: 2,
+        degraded: 1
+      },
+      {
+        code: new RegExp('16'),
+        protocol: new RegExp('grpc'),
+        direction: new RegExp('inbound'),
+        failure: 2,
+        degraded: 1
+      }
+    ]);
+
+    const requestsTolerance1 = result[0].requests;
+
+    expect((requestsTolerance1['http'] as Rate).requestRate).toBe(10);
+    expect((requestsTolerance1['http'] as Rate).errorRate).toBe(4);
+
+    expect(requestsTolerance1['grpc']).toBeUndefined();
+
+    const requestsTolerance2 = result[1].requests;
+
+    expect(requestsTolerance2['http']).toBeUndefined();
+
+    expect((requestsTolerance2['grpc'] as Rate).requestRate).toBe(5);
+    expect((requestsTolerance2['grpc'] as Rate).errorRate).toBe(2);
+  });
+});

--- a/src/types/ErrorRate/utils.ts
+++ b/src/types/ErrorRate/utils.ts
@@ -5,6 +5,7 @@ import { RequestHealth, RequestType } from '../Health';
 import { Rate, RequestTolerance } from './types';
 import { generateRateForTolerance } from './ErrorRate';
 import { generateRateForGraphTolerance } from './GraphEdgeStatus';
+import { HealthAnnotationType, HealthAnnotationConfig } from '../HealthAnnotation';
 
 export const emptyRate = (): Rate => {
   return { requestRate: 0, errorRate: 0, errorRatio: 0 };
@@ -26,6 +27,12 @@ const requestsErrorRateCode = (requests: RequestType): number => {
     }
   }
   return rate.requestRate === 0 ? -1 : (rate.errorRate / rate.requestRate) * 100;
+};
+
+export const getHealthRateAnnotation = (config?: HealthAnnotationType): string | undefined => {
+  return config && HealthAnnotationConfig.HEALTH_RATE in config
+    ? config[HealthAnnotationConfig.HEALTH_RATE]
+    : undefined;
 };
 
 export const getErrorCodeRate = (requests: RequestHealth): { inbound: number; outbound: number } => {

--- a/src/types/ErrorRate/utils.ts
+++ b/src/types/ErrorRate/utils.ts
@@ -16,7 +16,7 @@ export const DEFAULTCONF = {
   grpc: new RegExp('^[1-9]$|^1[0-6]$')
 };
 
-const requestsErrorRateCode = (requests: RequestType): number => {
+export const requestsErrorRateCode = (requests: RequestType): number => {
   const rate: Rate = emptyRate();
   for (let [protocol, req] of Object.entries(requests)) {
     for (let [code, value] of Object.entries(req)) {
@@ -82,10 +82,9 @@ export const transformEdgeResponses = (requests: Responses, protocol: string): R
   const prot: { [key: string]: number } = {};
   const result: RequestType = {};
   result[protocol] = prot;
-
   for (let [code, responseDetail] of Object.entries(requests)) {
-    const percentRate = Object.values((responseDetail as ResponseDetail).flags).reduce(
-      (acc, value) => acc + Number(value)
+    const percentRate = Object.values((responseDetail as ResponseDetail).flags).reduce((acc, value) =>
+      String(Number(acc) + Number(value))
     );
     result[protocol][code] = Number(percentRate);
   }

--- a/src/types/Graph.ts
+++ b/src/types/Graph.ts
@@ -184,7 +184,7 @@ export interface GraphNodeData {
   hasCB?: boolean;
   hasMissingSC?: boolean;
   hasVS?: boolean;
-  healthAnnotation?: HealthAnnotationType;
+  hasHealthConfig?: HealthAnnotationType;
   isBox?: string;
   isDead?: boolean;
   isIdle?: boolean;

--- a/src/types/Graph.ts
+++ b/src/types/Graph.ts
@@ -1,6 +1,7 @@
 import Namespace from './Namespace';
 import { DurationInSeconds, TimeInSeconds } from './Common';
 import { Health } from './Health';
+import { HealthAnnotationType } from './HealthAnnotation';
 
 export interface Layout {
   name: string;
@@ -183,6 +184,7 @@ export interface GraphNodeData {
   hasCB?: boolean;
   hasMissingSC?: boolean;
   hasVS?: boolean;
+  healthAnnotation?: HealthAnnotationType;
   isBox?: string;
   isDead?: boolean;
   isIdle?: boolean;

--- a/src/types/Health.ts
+++ b/src/types/Health.ts
@@ -11,6 +11,7 @@ import { PFAlertColor, PfColors } from 'components/Pf/PfColors';
 import { calculateErrorRate } from './ErrorRate';
 import { ToleranceConfig } from './ServerConfig';
 import { serverConfig } from '../config';
+import { HealthAnnotationType } from './HealthAnnotation';
 
 interface HealthConfig {
   items: HealthItem[];
@@ -64,6 +65,7 @@ export interface RequestType {
 export interface RequestHealth {
   inbound: RequestType;
   outbound: RequestType;
+  healthAnnotations: HealthAnnotationType;
 }
 
 export interface Status {
@@ -508,7 +510,13 @@ export class WorkloadHealth extends Health {
 }
 
 export const healthNotAvailable = (): AppHealth => {
-  return new AppHealth('', '', [], { inbound: {}, outbound: {} }, { rateInterval: 60, hasSidecar: true });
+  return new AppHealth(
+    '',
+    '',
+    [],
+    { inbound: {}, outbound: {}, healthAnnotations: {} },
+    { rateInterval: 60, hasSidecar: true }
+  );
 };
 
 export type NamespaceAppHealth = { [app: string]: AppHealth };

--- a/src/types/HealthAnnotation.ts
+++ b/src/types/HealthAnnotation.ts
@@ -1,0 +1,84 @@
+import { ToleranceConfig } from './ServerConfig';
+
+export enum HealthAnnotationConfig {
+  HEALTH_RATE = 'health.kiali.io/rate'
+}
+
+/*
+Health Annotation
+- Map key-value with annotations related with health configuration
+*/
+export type HealthAnnotationType = { [key: string]: string };
+
+export class HealthAnnotation {
+  healthAnnotations: HealthAnnotationType;
+
+  constructor(annotations: HealthAnnotationType) {
+    this.healthAnnotations = annotations;
+  }
+}
+
+export class RateHealth extends HealthAnnotation {
+  annotation: string;
+  isValid: boolean;
+  toleranceConfig?: ToleranceConfig[];
+
+  constructor(annotations: HealthAnnotationType) {
+    super(annotations);
+    this.annotation = annotations[HealthAnnotationConfig.HEALTH_RATE];
+    if (this.annotation && this.annotation.length > 0) {
+      this.isValid = this.validate();
+      this.toleranceConfig = this.isValid ? this.getToleranceConfig() : undefined;
+    } else {
+      this.isValid = false;
+    }
+  }
+
+  validate = () => {
+    return !this.annotation.split(';').some(annotate => this.isNotValidAnnotation(annotate));
+  };
+
+  isNotValidAnnotation = (annotation: string): boolean => {
+    const splits = annotation.split(',');
+    // Be sure annotation type 4xx,10,20,htpp,inbound
+    if (splits.length !== 5) {
+      return true;
+    }
+    if (splits[0].length !== 3) {
+      return true;
+    }
+    // validate Thresholds are numbers and degraded is lower than failure
+    if (!(isNumeric(splits[1]) && isNumeric(splits[2]))) {
+      return true;
+    }
+    const degraded = Number(splits[1]);
+    const failure = Number(splits[2]);
+    return degraded > failure ? true : false;
+  };
+
+  getToleranceConfig = (): ToleranceConfig[] => {
+    var configs: ToleranceConfig[] = [];
+    this.annotation.split(';').forEach(annotate => {
+      const splits = annotate.split(',');
+      configs.push({
+        code: this.convertRegex(splits[0], true),
+        degraded: Number(splits[1]),
+        failure: Number(splits[2]),
+        protocol: this.convertRegex(splits[3]),
+        direction: this.convertRegex(splits[4])
+      });
+    });
+    return configs;
+  };
+
+  convertRegex = (str: string, code: boolean = false): RegExp => {
+    if (code) {
+      return new RegExp(str.replace(/x|X/g, '\\d'));
+    }
+    return new RegExp(str);
+  };
+}
+
+const isNumeric = (val: string): boolean => {
+  return !isNaN(Number(val));
+};

--- a/src/types/HealthAnnotation.ts
+++ b/src/types/HealthAnnotation.ts
@@ -38,13 +38,34 @@ export class RateHealth extends HealthAnnotation {
     return !this.annotation.split(';').some(annotate => this.isNotValidAnnotation(annotate));
   };
 
-  isNotValidAnnotation = (annotation: string): boolean => {
+  getToleranceConfig = (): ToleranceConfig[] => {
+    var configs: ToleranceConfig[] = [];
+    if (this.isValid) {
+      this.annotation.split(';').forEach(annotate => {
+        const splits = annotate.split(',');
+        configs.push({
+          code: this.convertRegex(splits[0], true),
+          degraded: Number(splits[1]),
+          failure: Number(splits[2]),
+          protocol: this.convertRegex(splits[3]),
+          direction: this.convertRegex(splits[4])
+        });
+      });
+    }
+    return configs;
+  };
+
+  private convertRegex = (str: string, code: boolean = false): RegExp => {
+    if (code) {
+      return new RegExp(str.replace(/x|X/g, '\\d'));
+    }
+    return new RegExp(str);
+  };
+
+  private isNotValidAnnotation = (annotation: string): boolean => {
     const splits = annotation.split(',');
     // Be sure annotation type 4xx,10,20,htpp,inbound
     if (splits.length !== 5) {
-      return true;
-    }
-    if (splits[0].length !== 3) {
       return true;
     }
     // validate Thresholds are numbers and degraded is lower than failure
@@ -54,28 +75,6 @@ export class RateHealth extends HealthAnnotation {
     const degraded = Number(splits[1]);
     const failure = Number(splits[2]);
     return degraded > failure ? true : false;
-  };
-
-  getToleranceConfig = (): ToleranceConfig[] => {
-    var configs: ToleranceConfig[] = [];
-    this.annotation.split(';').forEach(annotate => {
-      const splits = annotate.split(',');
-      configs.push({
-        code: this.convertRegex(splits[0], true),
-        degraded: Number(splits[1]),
-        failure: Number(splits[2]),
-        protocol: this.convertRegex(splits[3]),
-        direction: this.convertRegex(splits[4])
-      });
-    });
-    return configs;
-  };
-
-  convertRegex = (str: string, code: boolean = false): RegExp => {
-    if (code) {
-      return new RegExp(str.replace(/x|X/g, '\\d'));
-    }
-    return new RegExp(str);
   };
 }
 

--- a/src/types/__tests__/Health.test.ts
+++ b/src/types/__tests__/Health.test.ts
@@ -82,7 +82,7 @@ describe('Health', () => {
       'bookinfo',
       'reviews',
       [{ availableReplicas: 0, currentReplicas: 1, desiredReplicas: 1, name: 'a', syncedProxies: 1 }],
-      { inbound: { http: { '500': 1 } }, outbound: { http: { '500': 1 } } },
+      { inbound: { http: { '500': 1 } }, outbound: { http: { '500': 1 } }, healthAnnotations: {} },
       { rateInterval: 60, hasSidecar: true }
     );
     expect(health.getGlobalStatus()).toEqual(H.FAILURE);
@@ -95,7 +95,7 @@ describe('Health', () => {
         { availableReplicas: 1, currentReplicas: 1, desiredReplicas: 1, name: 'a', syncedProxies: 1 },
         { availableReplicas: 2, currentReplicas: 2, desiredReplicas: 2, name: 'b', syncedProxies: 2 }
       ],
-      { inbound: {}, outbound: {} },
+      { inbound: {}, outbound: {}, healthAnnotations: {} },
       { rateInterval: 60, hasSidecar: true }
     );
     expect(health.getGlobalStatus()).toEqual(H.HEALTHY);
@@ -108,7 +108,7 @@ describe('Health', () => {
         { availableReplicas: 1, currentReplicas: 1, desiredReplicas: 1, name: 'a', syncedProxies: 1 },
         { availableReplicas: 1, currentReplicas: 1, desiredReplicas: 2, name: 'b', syncedProxies: 2 }
       ],
-      { inbound: {}, outbound: {} },
+      { inbound: {}, outbound: {}, healthAnnotations: {} },
       { rateInterval: 60, hasSidecar: true }
     );
     expect(health.getGlobalStatus()).toEqual(H.DEGRADED);
@@ -121,7 +121,7 @@ describe('Health', () => {
         { availableReplicas: 1, currentReplicas: 1, desiredReplicas: 1, name: 'a', syncedProxies: 1 },
         { availableReplicas: 2, currentReplicas: 2, desiredReplicas: 2, name: 'b', syncedProxies: 2 }
       ],
-      { inbound: { http: { '200': 1.6, '500': 0.3 } }, outbound: { http: { '500': 0.1 } } },
+      { inbound: { http: { '200': 1.6, '500': 0.3 } }, outbound: { http: { '500': 0.1 } }, healthAnnotations: {} },
       { rateInterval: 60, hasSidecar: true }
     );
     expect(health.getGlobalStatus()).toEqual(H.FAILURE);
@@ -134,7 +134,7 @@ describe('Health', () => {
         { availableReplicas: 0, currentReplicas: 0, desiredReplicas: 0, name: 'a', syncedProxies: 1 },
         { availableReplicas: 0, currentReplicas: 0, desiredReplicas: 0, name: 'b', syncedProxies: 2 }
       ],
-      { inbound: { http: { '200': 1.6, '500': 0.3 } }, outbound: { http: { '500': 0.1 } } },
+      { inbound: { http: { '200': 1.6, '500': 0.3 } }, outbound: { http: { '500': 0.1 } }, healthAnnotations: {} },
       { rateInterval: 60, hasSidecar: true }
     );
     expect(health.getGlobalStatus()).toEqual(H.FAILURE);
@@ -144,7 +144,7 @@ describe('Health', () => {
       'bookinfo',
       'reviews',
       [{ availableReplicas: 1, currentReplicas: 1, desiredReplicas: 1, name: 'a', syncedProxies: 1 }],
-      { inbound: {}, outbound: {} },
+      { inbound: {}, outbound: {}, healthAnnotations: {} },
       { rateInterval: 60, hasSidecar: true }
     );
     expect(health.health.items).toHaveLength(2);
@@ -154,7 +154,7 @@ describe('Health', () => {
       'bookinfo',
       'reviews',
       [{ availableReplicas: 1, currentReplicas: 1, desiredReplicas: 1, name: 'a', syncedProxies: 1 }],
-      { inbound: {}, outbound: {} },
+      { inbound: {}, outbound: {}, healthAnnotations: {} },
       { rateInterval: 60, hasSidecar: false }
     );
     expect(health.health.items).toHaveLength(1);
@@ -174,7 +174,7 @@ describe('Health', () => {
             syncedProxies: 1
           }
         ],
-        { inbound: {}, outbound: {} },
+        { inbound: {}, outbound: {}, healthAnnotations: {} },
         { rateInterval: 60, hasSidecar: true }
       );
       expect(health.health.items).toHaveLength(2);
@@ -210,7 +210,7 @@ describe('Health', () => {
             syncedProxies: 0
           }
         ],
-        { inbound: {}, outbound: {} },
+        { inbound: {}, outbound: {}, healthAnnotations: {} },
         { rateInterval: 60, hasSidecar: true }
       );
       expect(health.health.items).toHaveLength(2);

--- a/src/types/__tests__/HealthAnnotation.test.ts
+++ b/src/types/__tests__/HealthAnnotation.test.ts
@@ -1,0 +1,74 @@
+import * as H from '../../types/HealthAnnotation';
+
+const createHealthAnnotation = (value: string): H.HealthAnnotationType => {
+  const annotations: H.HealthAnnotationType = {};
+  annotations[H.HealthAnnotationConfig.HEALTH_RATE] = value;
+  return annotations;
+};
+
+const correctAnnotations = ['5xx,10,20,http,inbound', '4XX,30,40,http,inbound'];
+
+const wrongAnnotations = [
+  '[45]xx,10,20,http', // Not defined the direction
+  '[45]xx,40,20,http,inbound', // Degraded is greater than Failure
+  '[45]xx,10,sd,http,inbound' // Failure is not numeric
+];
+
+describe('healthAnnotation', () => {
+  describe('RateHealth', () => {
+    describe('Validation', () => {
+      it('should be valid/not valid for a correct/wrong annotation', () => {
+        correctAnnotations.forEach(annotation => {
+          const ratehealth = new H.RateHealth(createHealthAnnotation(annotation));
+          expect(ratehealth.isValid).toBeTruthy();
+        });
+
+        wrongAnnotations.forEach(annotation => {
+          var ratehealth = new H.RateHealth(createHealthAnnotation(annotation));
+          expect(ratehealth.isValid).toBeFalsy();
+        });
+      });
+    });
+
+    describe('Validate multiple annotations', () => {
+      it('should be valid for a multiple annotations', () => {
+        const ratehealth = new H.RateHealth(createHealthAnnotation(correctAnnotations.join(';')));
+        expect(ratehealth.isValid).toBeTruthy();
+      });
+
+      it('should be not valid if there is a wrong annotation', () => {
+        // All wrong
+        var ratehealth = new H.RateHealth(createHealthAnnotation(wrongAnnotations.join(';')));
+        expect(ratehealth.isValid).toBeFalsy();
+
+        // One of them wrong
+        var annotations = [...correctAnnotations];
+        annotations.push(wrongAnnotations[0]);
+        ratehealth = new H.RateHealth(createHealthAnnotation(annotations.join(';')));
+        expect(ratehealth.isValid).toBeFalsy();
+      });
+    });
+
+    describe('Return the configuration for annotations', () => {
+      it('should be empty if there is a worng annotation', () => {
+        const ratehealth = new H.RateHealth(createHealthAnnotation(wrongAnnotations.join(';')));
+        expect(ratehealth.getToleranceConfig().length).toBe(0);
+      });
+
+      it('should be an array of objects', () => {
+        const ratehealth = new H.RateHealth(createHealthAnnotation(correctAnnotations.join(';')));
+        const configs = ratehealth.getToleranceConfig();
+        expect(configs.length).toBe(correctAnnotations.length);
+        correctAnnotations.forEach((annotation, i) => {
+          const annotate = annotation.split(',');
+          const code = annotate[0].replace(/x|X/g, '\\d');
+          expect(configs[i].code).toStrictEqual(new RegExp(code));
+          expect(configs[i].degraded).toBe(Number(annotate[1]));
+          expect(configs[i].failure).toBe(Number(annotate[2]));
+          expect(configs[i].protocol).toStrictEqual(new RegExp(annotate[3]));
+          expect(configs[i].direction).toStrictEqual(new RegExp(annotate[4]));
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Fix https://github.com/kiali/kiali/issues/3332

# Tasks

- [X] Support health views
- [X]  Support for health in graph

For workload and services

Require: https://github.com/kiali/kiali/pull/3362

Step 1 of https://github.com/kiali/kiali/issues/3332