### PR TITLE
Show Mesh nav entry only when needed

### DIFF
--- a/src/components/Nav/Menu.tsx
+++ b/src/components/Nav/Menu.tsx
@@ -55,6 +55,8 @@ class Menu extends React.Component<MenuProps, MenuState> {
         // Extensions Nav Menu Items are conditionally rendered
         if (item.title === 'Iter8 Experiments') {
           return serverConfig.extensions!.iter8!.enabled;
+        } else if (item.title === 'Mesh') {
+          return serverConfig.clusterInfo !== undefined && serverConfig.clusterInfo !== null;
         }
         return true;
       })


### PR DESCRIPTION
The back-end config endpoint should be reporting cluster information only when multi-cluster is enabled in Istio. Since the "Mesh" nav entry is a page related with multi-cluster, this should show it only when needed.

Related to kiali/kiali#3592
Back-end PR: kiali/kiali#3607