### PR TITLE
Fix issue with unknown node label

### DIFF
--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -249,6 +249,9 @@ export class GraphStyles {
       case NodeType.SERVICE:
         label.unshift(service);
         break;
+      case NodeType.UNKNOWN:
+        label.unshift(UNKNOWN);
+        break;
       case NodeType.WORKLOAD:
         label.unshift(workload);
         break;


### PR DESCRIPTION
The unknown node is being labeled as "error".