### PR TITLE
[WIP] Server-side UI Defaults

### DIFF
--- a/src/actions/NamespaceThunkActions.ts
+++ b/src/actions/NamespaceThunkActions.ts
@@ -3,6 +3,8 @@ import { KialiAppState } from '../store/Store';
 import * as Api from '../services/Api';
 import { KialiAppAction } from './KialiAppAction';
 import { NamespaceActions } from './NamespaceAction';
+import { serverConfig } from 'config';
+import Namespace from 'types/Namespace';
 
 const shouldFetchNamespaces = (state: KialiAppState) => {
   if (!state) {
@@ -16,6 +18,7 @@ const NamespaceThunkActions = {
   asyncFetchNamespaces: () => {
     return (dispatch: ThunkDispatch<KialiAppState, void, KialiAppAction>) => {
       dispatch(NamespaceActions.requestStarted());
+
       return Api.getNamespaces()
         .then(response => response.data)
         .then(data => {
@@ -23,6 +26,20 @@ const NamespaceThunkActions = {
         })
         .catch(() => dispatch(NamespaceActions.requestFailed()));
     };
+  },
+
+  defaultToServerNamespaces: () => (
+    dispatch: ThunkDispatch<KialiAppState, void, KialiAppAction>,
+    getState: () => KialiAppState
+  ) => {
+    const state = getState();
+    const serverNamespaces = serverConfig.kialiFeatureFlags.uiDefaults.namespaces.map(x => ({ name: x } as Namespace));
+
+    // In general we are only using this on component creation, but if for some
+    // reason it is called twice, we try to avoid replacing user input.
+    if (state.namespaces.activeNamespaces.length === 0 && serverNamespaces.length > 0) {
+      dispatch(NamespaceActions.setActiveNamespaces(serverNamespaces));
+    }
   },
 
   fetchNamespacesIfNeeded: () => {

--- a/src/components/DurationDropdown/DurationDropdown.tsx
+++ b/src/components/DurationDropdown/DurationDropdown.tsx
@@ -1,5 +1,5 @@
 import ToolbarDropdown from '../ToolbarDropdown/ToolbarDropdown';
-import { serverConfig, humanDurations } from '../../config/ServerConfig';
+import { serverConfig, humanDurations, durationsMap } from '../../config/ServerConfig';
 import * as React from 'react';
 import { DurationInSeconds } from '../../types/Common';
 import { KialiAppState } from '../../store/Store';
@@ -77,6 +77,21 @@ export const withURLAwareness = DurationDropdownComponent => {
   };
 };
 
+export const withServerDefault = DurationDropdownComponent => {
+  return class extends React.Component<DurationDropdownProps> {
+    componentDidMount() {
+      console.log(durationsMap);
+      console.log(serverConfig.kialiFeatureFlags.uiDefaults.metricsPerRefresh);
+      console.log(durationsMap[serverConfig.kialiFeatureFlags.uiDefaults.metricsPerRefresh]);
+      this.props.setDuration(durationsMap[serverConfig.kialiFeatureFlags.uiDefaults.metricsPerRefresh]);
+    }
+
+    render() {
+      return <DurationDropdownComponent {...this.props} />;
+    }
+  };
+};
+
 const mapStateToProps = (state: KialiAppState) => ({
   duration: durationSelector(state)
 });
@@ -90,4 +105,4 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<KialiAppState, void, KialiAp
 export const DurationDropdownContainer = connect(
   mapStateToProps,
   mapDispatchToProps
-)(withURLAwareness(withDurations(DurationDropdown)));
+)(withServerDefault(withURLAwareness(withDurations(DurationDropdown))));

--- a/src/components/NamespaceDropdown.tsx
+++ b/src/components/NamespaceDropdown.tsx
@@ -35,6 +35,7 @@ type ReduxProps = {
   refresh: () => void;
   setFilter: (filter: string) => void;
   setNamespaces: (namespaces: Namespace[]) => void;
+  getServerDefaults: () => void;
 };
 
 type NamespaceDropdownProps = ReduxProps & {
@@ -80,6 +81,7 @@ export class NamespaceDropdown extends React.PureComponent<NamespaceDropdownProp
   }
 
   componentDidMount() {
+    this.props.getServerDefaults();
     this.props.refresh();
     this.syncNamespacesURLParam();
   }
@@ -295,6 +297,9 @@ const mapStateToProps = (state: KialiAppState) => {
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<KialiAppState, void, KialiAppAction>) => {
   return {
+    getServerDefaults: () => {
+      dispatch(NamespaceThunkActions.defaultToServerNamespaces());
+    },
     refresh: () => {
       dispatch(NamespaceThunkActions.fetchNamespacesIfNeeded());
     },

--- a/src/components/Refresh/Refresh.tsx
+++ b/src/components/Refresh/Refresh.tsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { ThunkDispatch } from 'redux-thunk';
 import { KialiAppState } from '../../store/Store';
 import { refreshIntervalSelector } from '../../store/Selectors';
-import { config } from '../../config';
+import { config, serverConfig } from '../../config';
 import { IntervalInMilliseconds, TimeInMilliseconds } from '../../types/Common';
 import { UserSettingsActions } from '../../actions/UserSettingsActions';
 import { KialiAppAction } from '../../actions/KialiAppAction';
@@ -25,6 +25,7 @@ type ComponentProps = {
   manageURL?: boolean;
 
   handleRefresh?: () => void;
+  defaultToServerRefreshInterval: () => void;
 };
 
 type Props = ComponentProps & ReduxProps;
@@ -34,6 +35,7 @@ type State = {
 };
 
 const REFRESH_INTERVALS = config.toolbar.refreshInterval;
+const SERVER_REFRESH_INTERVALS = config.toolbar.serverRefreshIntervals;
 
 class Refresh extends React.PureComponent<Props, State> {
   constructor(props: Props) {
@@ -57,6 +59,7 @@ class Refresh extends React.PureComponent<Props, State> {
   }
 
   componentDidMount() {
+    this.props.defaultToServerRefreshInterval();
     this.updateRefresher();
   }
 
@@ -129,6 +132,10 @@ const mapStateToProps = (state: KialiAppState) => ({
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<KialiAppState, void, KialiAppAction>) => {
   return {
+    defaultToServerRefreshInterval: () => {
+      const interval = serverConfig.kialiFeatureFlags.uiDefaults.autoRefreshInterval;
+      dispatch(UserSettingsActions.setRefreshInterval(SERVER_REFRESH_INTERVALS[interval]));
+    },
     setRefreshInterval: (refresh: IntervalInMilliseconds) => {
       dispatch(UserSettingsActions.setRefreshInterval(refresh));
     },

--- a/src/components/Refresh/Refresh.tsx
+++ b/src/components/Refresh/Refresh.tsx
@@ -133,7 +133,7 @@ const mapStateToProps = (state: KialiAppState) => ({
 const mapDispatchToProps = (dispatch: ThunkDispatch<KialiAppState, void, KialiAppAction>) => {
   return {
     defaultToServerRefreshInterval: () => {
-      const interval = serverConfig.kialiFeatureFlags.uiDefaults.autoRefreshInterval;
+      const interval = serverConfig.kialiFeatureFlags.uiDefaults.refreshInterval;
       dispatch(UserSettingsActions.setRefreshInterval(SERVER_REFRESH_INTERVALS[interval]));
     },
     setRefreshInterval: (refresh: IntervalInMilliseconds) => {

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -30,6 +30,17 @@ const conf = {
       300000: 'Every 5m',
       900000: 'Every 15m'
     },
+    /** Matches the refresh intervals from the server to ones that we can use **/
+    serverRefreshIntervals: {
+      '': 0,
+      pause: 0,
+      '10s': 10000,
+      '15s': 15000,
+      '30s': 30000,
+      '1m': 60000,
+      '5m': 300000,
+      '15m': 900000
+    },
     /** Graphs layouts types */
     graphLayouts: {
       cola: 'Cola',

--- a/src/config/ServerConfig.ts
+++ b/src/config/ServerConfig.ts
@@ -74,7 +74,7 @@ let serverConfig: ComputedServerConfig = {
     uiDefaults: {
       namespaces: [],
       metricsPerRefresh: '1m',
-      autoRefreshInterval: ''
+      refreshInterval: ''
     }
   },
   prometheus: {

--- a/src/config/ServerConfig.ts
+++ b/src/config/ServerConfig.ts
@@ -33,6 +33,10 @@ const durationsTuples: [number, string][] = [
   [604800, '7d'],
   [2592000, '30d']
 ];
+export const durationsMap = durationsTuples.reduce((accum, [duration, human]) => {
+  accum[human] = duration;
+  return accum;
+}, {});
 
 const computeValidDurations = (cfg: ComputedServerConfig) => {
   let filtered = durationsTuples;
@@ -66,7 +70,12 @@ let serverConfig: ComputedServerConfig = {
     versionLabelName: 'version'
   },
   kialiFeatureFlags: {
-    istioInjectionAction: true
+    istioInjectionAction: true,
+    uiDefaults: {
+      namespaces: [],
+      metricsPerRefresh: '1m',
+      autoRefreshInterval: ''
+    }
   },
   prometheus: {
     globalScrapeInterval: 15,

--- a/src/types/ServerConfig.ts
+++ b/src/types/ServerConfig.ts
@@ -23,7 +23,7 @@ interface IstioAnnotations {
 interface UIDefaults {
   namespaces: string[];
   metricsPerRefresh: string;
-  autoRefreshInterval: string;
+  refreshInterval: string;
 }
 
 interface KialiFeatureFlags {

--- a/src/types/ServerConfig.ts
+++ b/src/types/ServerConfig.ts
@@ -20,8 +20,15 @@ interface IstioAnnotations {
   istioInjectionAnnotation: string;
 }
 
+interface UIDefaults {
+  namespaces: string[];
+  metricsPerRefresh: string;
+  autoRefreshInterval: string;
+}
+
 interface KialiFeatureFlags {
   istioInjectionAction: boolean;
+  uiDefaults: UIDefaults;
 }
 
 /*


### PR DESCRIPTION
Part of https://github.com/kiali/kiali/issues/3371.

This PR implements some UI defaults coming from the server CR configuration. Currently, this supports:

- [x] Namespace selector on the graph
- [ ] Time range for traffic metrics per refresh
- [ ] Graph automatic refresh duration