### PR TITLE
Fix BoxLayout issue

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeGraphUtils.ts
+++ b/src/components/CytoscapeGraph/CytoscapeGraphUtils.ts
@@ -1,6 +1,5 @@
 import * as LayoutDictionary from './graphs/LayoutDictionary';
 import { DecoratedGraphEdgeData, DecoratedGraphNodeData, Layout } from '../../types/Graph';
-import { DagreGraph } from './graphs/DagreGraph';
 import * as Cy from 'cytoscape';
 
 export const CyEdge = {
@@ -97,8 +96,8 @@ export const runLayout = (cy: Cy.Core, layout: Layout) => {
     cy.layout({
       ...layoutOptions,
       name: 'box-layout',
-      appBoxLayout: LayoutDictionary.getLayout(DagreGraph.getLayout()),
-      defaultLayout: layout
+      appBoxLayout: 'dagre',
+      defaultLayout: layout.name
     }).run();
   } else {
     cy.layout(layoutOptions).run();


### PR DESCRIPTION
Fix BoxLayout issue with synthetic edge generation. It can no longer assume the box type of a parent node.

Also, some minor cleanup and ensure that all layout type props are applied at all times.

fixes https://github.com/kiali/kiali/issues/3623
