### PR TITLE
Fix the graph tour by adding support for multiple stops at one place

### DIFF
--- a/src/pages/Graph/GraphHelpTour.ts
+++ b/src/pages/Graph/GraphHelpTour.ts
@@ -2,6 +2,13 @@ import { PopoverPosition } from '@patternfly/react-core';
 import { TourStopInfo, TourInfo } from 'components/Tour/TourStop';
 
 export const GraphTourStops: { [name: string]: TourStopInfo } = {
+  ContextualMenu: {
+    name: 'Contextual Menu',
+    description:
+      'Right-click a node or an edge to see the contextual menu with links to details, traffic and inbound/outbound metrics for the node or edge.',
+    position: PopoverPosition.left,
+    offset: '0, 250'
+  },
   Display: {
     name: 'Display',
     description:
@@ -15,16 +22,9 @@ export const GraphTourStops: { [name: string]: TourStopInfo } = {
   Graph: {
     name: 'Graph',
     description:
-      "Click on a node to see its summary and emphasize its end-to-end paths. Double-click a node to see a graph focused on that node.\nDouble-click an 'external namespace' node to navigate directly to the namespace in the node's text label.",
-    position: PopoverPosition.auto,
-    offset: '0, -350'
-  },
-  ContextualMenu: {
-    name: 'Contextual Menu',
-    description:
-      'Right-click a node or an edge to see the contextual menu with links to details, traffic and inbound/outbound metrics for the node or edge.',
-    position: PopoverPosition.auto,
-    offset: '0, -350'
+      "Click on a node or edge to see its summary and emphasize its end-to-end paths. Double-click a node to see a graph focused on that node.\nDouble-click an 'external namespace' node to navigate directly to the namespace in the node's text label. Shift-Drag to quickly zoom in.",
+    position: PopoverPosition.left,
+    offset: '0, 250'
   },
   GraphType: {
     name: 'Graph Type',
@@ -47,6 +47,11 @@ export const GraphTourStops: { [name: string]: TourStopInfo } = {
     description: 'Select the namespaces you want to see in the graph.',
     position: PopoverPosition.bottom
   },
+  SidePanel: {
+    name: 'Side Panel',
+    description: 'The Side Panel shows details about the currently selected node or edge, otherwise the whole graph.',
+    position: PopoverPosition.left
+  },
   TimeRange: {
     name: 'Time Range & Replay',
     description:
@@ -65,6 +70,7 @@ const GraphTour: TourInfo = {
     GraphTourStops.TimeRange,
     GraphTourStops.Graph,
     GraphTourStops.ContextualMenu,
+    GraphTourStops.SidePanel,
     GraphTourStops.Layout,
     GraphTourStops.Legend
   ]

--- a/src/pages/Graph/GraphPage.tsx
+++ b/src/pages/Graph/GraphPage.tsx
@@ -62,8 +62,8 @@ import { NamespaceActions } from '../../actions/NamespaceAction';
 import GraphThunkActions from '../../actions/GraphThunkActions';
 import { JaegerTrace } from 'types/JaegerInfo';
 import { JaegerThunkActions } from 'actions/JaegerThunkActions';
-import GraphTour, { GraphTourStops } from 'pages/Graph/GraphHelpTour';
-import TourStopContainer, { getNextTourStop, TourInfo } from 'components/Tour/TourStop';
+import GraphTour from 'pages/Graph/GraphHelpTour';
+import { getNextTourStop, TourInfo } from 'components/Tour/TourStop';
 
 // GraphURLPathProps holds path variable values.  Currenly all path variables are relevant only to a node graph
 type GraphURLPathProps = {
@@ -451,18 +451,16 @@ export class GraphPage extends React.Component<GraphPageProps, GraphPageState> {
               )}
             </ErrorBoundary>
             {this.props.summaryData && (
-              <TourStopContainer info={[GraphTourStops.Graph, GraphTourStops.ContextualMenu, GraphTourStops.SidePanel]}>
-                <SummaryPanel
-                  data={this.props.summaryData}
-                  namespaces={this.props.activeNamespaces}
-                  graphType={this.props.graphType}
-                  injectServiceNodes={this.props.showServiceNodes}
-                  queryTime={this.state.graphData.timestamp / 1000}
-                  duration={this.state.graphData.fetchParams.duration}
-                  isPageVisible={this.props.isPageVisible}
-                  {...computePrometheusRateParams(this.props.duration, NUMBER_OF_DATAPOINTS)}
-                />
-              </TourStopContainer>
+              <SummaryPanel
+                data={this.props.summaryData}
+                namespaces={this.props.activeNamespaces}
+                graphType={this.props.graphType}
+                injectServiceNodes={this.props.showServiceNodes}
+                queryTime={this.state.graphData.timestamp / 1000}
+                duration={this.state.graphData.fetchParams.duration}
+                isPageVisible={this.props.isPageVisible}
+                {...computePrometheusRateParams(this.props.duration, NUMBER_OF_DATAPOINTS)}
+              />
             )}
           </FlexView>
         </FlexView>

--- a/src/pages/Graph/GraphPage.tsx
+++ b/src/pages/Graph/GraphPage.tsx
@@ -52,10 +52,8 @@ import { GraphToolbarActions } from '../../actions/GraphToolbarActions';
 import { NodeContextMenuContainer } from '../../components/CytoscapeGraph/ContextMenu/NodeContextMenu';
 import { PfColors, PFKialiColor } from 'components/Pf/PfColors';
 import { TourActions } from 'actions/TourActions';
-import TourStopContainer, { getNextTourStop, TourInfo } from 'components/Tour/TourStop';
 import { arrayEquals } from 'utils/Common';
 import { isKioskMode, getFocusSelector, unsetFocusSelector, getTraceId } from 'utils/SearchParamUtils';
-import GraphTour, { GraphTourStops } from './GraphHelpTour';
 import { Badge, Chip } from '@patternfly/react-core';
 import { toRangeString } from 'components/Time/Utils';
 import { replayBorder } from 'components/Time/Replay';
@@ -64,6 +62,8 @@ import { NamespaceActions } from '../../actions/NamespaceAction';
 import GraphThunkActions from '../../actions/GraphThunkActions';
 import { JaegerTrace } from 'types/JaegerInfo';
 import { JaegerThunkActions } from 'actions/JaegerThunkActions';
+import GraphTour, { GraphTourStops } from 'pages/Graph/GraphHelpTour';
+import TourStopContainer, { getNextTourStop, TourInfo } from 'components/Tour/TourStop';
 
 // GraphURLPathProps holds path variable values.  Currenly all path variables are relevant only to a node graph
 type GraphURLPathProps = {
@@ -431,22 +431,18 @@ export class GraphPage extends React.Component<GraphPageProps, GraphPageState> {
                 </Chip>
               )}
               {(!this.props.replayActive || isReplayReady) && (
-                <TourStopContainer info={GraphTourStops.Graph}>
-                  <TourStopContainer info={GraphTourStops.ContextualMenu}>
-                    <CytoscapeGraph
-                      containerClassName={cytoscapeGraphContainerStyle}
-                      contextMenuGroupComponent={NodeContextMenuContainer}
-                      contextMenuNodeComponent={NodeContextMenuContainer}
-                      focusSelector={this.focusSelector}
-                      graphData={this.state.graphData}
-                      isMTLSEnabled={this.props.mtlsEnabled}
-                      onEmptyGraphAction={this.handleEmptyGraphAction}
-                      onNodeDoubleTap={this.handleDoubleTap}
-                      ref={refInstance => this.setCytoscapeGraph(refInstance)}
-                      {...this.props}
-                    />
-                  </TourStopContainer>
-                </TourStopContainer>
+                <CytoscapeGraph
+                  containerClassName={cytoscapeGraphContainerStyle}
+                  contextMenuGroupComponent={NodeContextMenuContainer}
+                  contextMenuNodeComponent={NodeContextMenuContainer}
+                  focusSelector={this.focusSelector}
+                  graphData={this.state.graphData}
+                  isMTLSEnabled={this.props.mtlsEnabled}
+                  onEmptyGraphAction={this.handleEmptyGraphAction}
+                  onNodeDoubleTap={this.handleDoubleTap}
+                  ref={refInstance => this.setCytoscapeGraph(refInstance)}
+                  {...this.props}
+                />
               )}
               {isReady && (
                 <div className={cytoscapeToolbarWrapperDivStyle}>
@@ -455,16 +451,18 @@ export class GraphPage extends React.Component<GraphPageProps, GraphPageState> {
               )}
             </ErrorBoundary>
             {this.props.summaryData && (
-              <SummaryPanel
-                data={this.props.summaryData}
-                namespaces={this.props.activeNamespaces}
-                graphType={this.props.graphType}
-                injectServiceNodes={this.props.showServiceNodes}
-                queryTime={this.state.graphData.timestamp / 1000}
-                duration={this.state.graphData.fetchParams.duration}
-                isPageVisible={this.props.isPageVisible}
-                {...computePrometheusRateParams(this.props.duration, NUMBER_OF_DATAPOINTS)}
-              />
+              <TourStopContainer info={[GraphTourStops.Graph, GraphTourStops.ContextualMenu, GraphTourStops.SidePanel]}>
+                <SummaryPanel
+                  data={this.props.summaryData}
+                  namespaces={this.props.activeNamespaces}
+                  graphType={this.props.graphType}
+                  injectServiceNodes={this.props.showServiceNodes}
+                  queryTime={this.state.graphData.timestamp / 1000}
+                  duration={this.state.graphData.fetchParams.duration}
+                  isPageVisible={this.props.isPageVisible}
+                  {...computePrometheusRateParams(this.props.duration, NUMBER_OF_DATAPOINTS)}
+                />
+              </TourStopContainer>
             )}
           </FlexView>
         </FlexView>

--- a/src/pages/Graph/SummaryPanel.tsx
+++ b/src/pages/Graph/SummaryPanel.tsx
@@ -13,6 +13,8 @@ import { KialiAppState } from 'store/Store';
 import SummaryPanelClusterBox from './SummaryPanelClusterBox';
 import SummaryPanelNamespaceBox from './SummaryPanelNamespaceBox';
 import { CyNode } from 'components/CytoscapeGraph/CytoscapeGraphUtils';
+import { GraphTourStops } from 'pages/Graph/GraphHelpTour';
+import TourStopContainer from 'components/Tour/TourStop';
 
 type SummaryPanelState = {
   isVisible: boolean;
@@ -90,94 +92,96 @@ class SummaryPanel extends React.Component<MainSummaryPanelPropType, SummaryPane
         : expandedStyle
       : collapsedStyle;
     return (
-      <div id="graph-side-panel" className={mainStyle}>
-        <div className={mainTopStyle}>
-          <div className={toggleSidePanelStyle} onClick={this.togglePanel}>
-            {this.state.isVisible ? (
-              <>
-                <KialiIcon.AngleDoubleDown /> Hide
-              </>
-            ) : (
-              <>
-                <KialiIcon.AngleDoubleUp /> Show
-              </>
+      <TourStopContainer info={[GraphTourStops.Graph, GraphTourStops.ContextualMenu, GraphTourStops.SidePanel]}>
+        <div id="graph-side-panel" className={mainStyle}>
+          <div className={mainTopStyle}>
+            <div className={toggleSidePanelStyle} onClick={this.togglePanel}>
+              {this.state.isVisible ? (
+                <>
+                  <KialiIcon.AngleDoubleDown /> Hide
+                </>
+              ) : (
+                <>
+                  <KialiIcon.AngleDoubleUp /> Show
+                </>
+              )}
+            </div>
+            {summaryType === 'box' && boxType === 'app' && (
+              <SummaryPanelAppBox
+                data={this.props.data}
+                namespaces={this.props.data.summaryTarget.namespaces}
+                graphType={this.props.graphType}
+                injectServiceNodes={this.props.injectServiceNodes}
+                queryTime={this.props.queryTime}
+                duration={this.props.duration}
+                step={this.props.step}
+                rateInterval={this.props.rateInterval}
+              />
+            )}
+            {summaryType === 'box' && boxType === 'cluster' && (
+              <SummaryPanelClusterBox
+                data={this.props.data}
+                namespaces={this.props.data.summaryTarget.namespaces}
+                graphType={this.props.graphType}
+                injectServiceNodes={this.props.injectServiceNodes}
+                queryTime={this.props.queryTime}
+                duration={this.props.duration}
+                step={this.props.step}
+                rateInterval={this.props.rateInterval}
+              />
+            )}
+            {summaryType === 'box' && boxType === 'namespace' && (
+              <SummaryPanelNamespaceBox
+                data={this.props.data}
+                namespaces={this.props.data.summaryTarget.namespaces}
+                graphType={this.props.graphType}
+                injectServiceNodes={this.props.injectServiceNodes}
+                queryTime={this.props.queryTime}
+                duration={this.props.duration}
+                step={this.props.step}
+                rateInterval={this.props.rateInterval}
+              />
+            )}
+            {summaryType === 'edge' && <SummaryPanelEdge {...this.props} />}
+            {summaryType === 'graph' && (
+              <SummaryPanelGraph
+                data={this.props.data}
+                namespaces={this.props.namespaces}
+                graphType={this.props.graphType}
+                injectServiceNodes={this.props.injectServiceNodes}
+                queryTime={this.props.queryTime}
+                duration={this.props.duration}
+                step={this.props.step}
+                rateInterval={this.props.rateInterval}
+              />
+            )}
+            {this.props.data.summaryType === 'node' && (
+              <SummaryPanelNodeContainer
+                data={this.props.data}
+                queryTime={this.props.queryTime}
+                namespaces={this.props.namespaces}
+                graphType={this.props.graphType}
+                injectServiceNodes={this.props.injectServiceNodes}
+                duration={this.props.duration}
+                step={this.props.step}
+                rateInterval={this.props.rateInterval}
+              />
             )}
           </div>
-          {summaryType === 'box' && boxType === 'app' && (
-            <SummaryPanelAppBox
-              data={this.props.data}
-              namespaces={this.props.data.summaryTarget.namespaces}
-              graphType={this.props.graphType}
-              injectServiceNodes={this.props.injectServiceNodes}
-              queryTime={this.props.queryTime}
-              duration={this.props.duration}
-              step={this.props.step}
-              rateInterval={this.props.rateInterval}
-            />
-          )}
-          {summaryType === 'box' && boxType === 'cluster' && (
-            <SummaryPanelClusterBox
-              data={this.props.data}
-              namespaces={this.props.data.summaryTarget.namespaces}
-              graphType={this.props.graphType}
-              injectServiceNodes={this.props.injectServiceNodes}
-              queryTime={this.props.queryTime}
-              duration={this.props.duration}
-              step={this.props.step}
-              rateInterval={this.props.rateInterval}
-            />
-          )}
-          {summaryType === 'box' && boxType === 'namespace' && (
-            <SummaryPanelNamespaceBox
-              data={this.props.data}
-              namespaces={this.props.data.summaryTarget.namespaces}
-              graphType={this.props.graphType}
-              injectServiceNodes={this.props.injectServiceNodes}
-              queryTime={this.props.queryTime}
-              duration={this.props.duration}
-              step={this.props.step}
-              rateInterval={this.props.rateInterval}
-            />
-          )}
-          {summaryType === 'edge' && <SummaryPanelEdge {...this.props} />}
-          {summaryType === 'graph' && (
-            <SummaryPanelGraph
-              data={this.props.data}
-              namespaces={this.props.namespaces}
-              graphType={this.props.graphType}
-              injectServiceNodes={this.props.injectServiceNodes}
-              queryTime={this.props.queryTime}
-              duration={this.props.duration}
-              step={this.props.step}
-              rateInterval={this.props.rateInterval}
-            />
-          )}
-          {this.props.data.summaryType === 'node' && (
-            <SummaryPanelNodeContainer
-              data={this.props.data}
-              queryTime={this.props.queryTime}
-              namespaces={this.props.namespaces}
-              graphType={this.props.graphType}
-              injectServiceNodes={this.props.injectServiceNodes}
-              duration={this.props.duration}
-              step={this.props.step}
-              rateInterval={this.props.rateInterval}
-            />
+          {this.props.jaegerState.selectedTrace && this.state.isVisible && (
+            <div className={`panel panel-default ${summaryPanelBottomSplit}`}>
+              <div className="panel-body">
+                <SummaryPanelTraceDetailsContainer
+                  trace={this.props.jaegerState.selectedTrace}
+                  node={this.props.data.summaryTarget}
+                  graphType={this.props.graphType}
+                  jaegerURL={this.props.jaegerState.info?.url}
+                />
+              </div>
+            </div>
           )}
         </div>
-        {this.props.jaegerState.selectedTrace && this.state.isVisible && (
-          <div className={`panel panel-default ${summaryPanelBottomSplit}`}>
-            <div className="panel-body">
-              <SummaryPanelTraceDetailsContainer
-                trace={this.props.jaegerState.selectedTrace}
-                node={this.props.data.summaryTarget}
-                graphType={this.props.graphType}
-                jaegerURL={this.props.jaegerState.info?.url}
-              />
-            </div>
-          </div>
-        )}
-      </div>
+      </TourStopContainer>
     );
   }
 


### PR DESCRIPTION
Fix the graph tour by adding support for multiple stops at one place (i.e. wrapping the same children elements).
also
- re-acnchor the "graph" stops on the side panel
- add a stop for the side-panel
- add text to the "graph" stop mentioning the new Shift-Drag zoom feature

Fixes https://github.com/kiali/kiali/issues/3683