### PR TITLE
[v1.29] Fix graph replay regression

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -109,6 +109,7 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps>
   private focusSelector?: string;
   private graphHighlighter?: GraphHighlighter;
   private namespaceChanged: boolean;
+  private needsInitialLayout: boolean;
   private nodeChanged: boolean;
   private resetSelection: boolean = false;
   private trafficRenderer?: TrafficRender;
@@ -120,6 +121,7 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps>
     this.cytoscapeReactWrapperRef = React.createRef();
     this.focusSelector = props.focusSelector;
     this.namespaceChanged = false;
+    this.needsInitialLayout = false;
     this.nodeChanged = false;
   }
 
@@ -161,12 +163,14 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps>
 
     let updateLayout = false;
     if (
+      this.needsInitialLayout ||
       this.nodeNeedsRelayout() ||
       this.namespaceNeedsRelayout(prevProps.graphData.elements, this.props.graphData.elements) ||
       this.elementsNeedRelayout(prevProps.graphData.elements, this.props.graphData.elements) ||
       this.props.layout.name !== prevProps.layout.name
     ) {
       updateLayout = true;
+      this.needsInitialLayout = false;
     }
 
     this.processGraphUpdate(cy, updateLayout);
@@ -493,6 +497,7 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps>
       if (this.props.onReady) {
         this.props.onReady(evt.cy);
       }
+      this.needsInitialLayout = true;
     });
 
     cy.on('destroy', (_evt: Cy.EventObject) => {


### PR DESCRIPTION
Fix graph replay regression introduced when removing code that was causing duplicate layouts (in what was thought to be all cases). But we still need to ensure an initial layout is performed for any new cy graph, even if the elements are exactly the same as before, which can happen for graph replay (although, the fix is not specific to graph replay just in case there is another scenario not considered). The fix still maintains the initial goal of avoiding duplicate/unnecessary layouts.

v1.29 backport for kiali/kiali#3684