### PR TITLE
UI support for UI defaults

### DIFF
--- a/src/app/AuthenticationController.tsx
+++ b/src/app/AuthenticationController.tsx
@@ -14,7 +14,7 @@ import { ServerStatus } from '../types/ServerStatus';
 import InitializingScreen from './InitializingScreen';
 import { isKioskMode } from '../utils/SearchParamUtils';
 import * as AlertUtils from '../utils/AlertUtils';
-import { setServerConfig } from '../config/ServerConfig';
+import { setServerConfig, serverConfig, humanDurations } from '../config/ServerConfig';
 import { TLSStatus } from '../types/TLSStatus';
 import { MeshTlsActions } from '../actions/MeshTlsActions';
 import { AuthStrategy } from '../types/Auth';
@@ -23,16 +23,23 @@ import { LoginActions } from '../actions/LoginActions';
 import history from './History';
 import { NamespaceActions } from 'actions/NamespaceAction';
 import Namespace from 'types/Namespace';
+import { UserSettingsActions } from 'actions/UserSettingsActions';
+import { DurationInSeconds, IntervalInMilliseconds } from 'types/Common';
+import { config } from 'config';
+import { store } from 'store/ConfigStore';
 
 interface AuthenticationControllerReduxProps {
   authenticated: boolean;
   checkCredentials: () => void;
   isLoginError: boolean;
   landingRoute?: string;
+  setActiveNamespaces: (namespaces: Namespace[]) => void;
+  setDuration: (duration: DurationInSeconds) => void;
   setJaegerInfo: (jaegerInfo: JaegerInfo | null) => void;
   setLandingRoute: (route: string | undefined) => void;
   setMeshTlsStatus: (meshStatus: TLSStatus) => void;
   setNamespaces: (namespaces: Namespace[], receivedAt: Date) => void;
+  setRefreshInterval: (interval: IntervalInMilliseconds) => void;
   setServerStatus: (serverStatus: ServerStatus) => void;
 }
 
@@ -175,6 +182,7 @@ class AuthenticationController extends React.Component<AuthenticationControllerP
       ]);
       this.props.setNamespaces(configs[0].data, new Date());
       setServerConfig(configs[1].data);
+      this.applyUIDefaults();
 
       if (this.props.landingRoute) {
         history.replace(this.props.landingRoute);
@@ -186,6 +194,68 @@ class AuthenticationController extends React.Component<AuthenticationControllerP
       this.setState({ isPostLoginError: true });
     }
   };
+
+  private applyUIDefaults() {
+    const uiDefaults = serverConfig.kialiFeatureFlags.uiDefaults;
+    if (uiDefaults) {
+      // Duration (aka metricsPerRefresh)
+      if (uiDefaults.metricsPerRefresh) {
+        const validDurations = humanDurations(serverConfig, '', '');
+        let metricsPerRefresh = 0;
+        for (const [key, value] of Object.entries(validDurations)) {
+          if (value === uiDefaults.metricsPerRefresh) {
+            metricsPerRefresh = Number(key);
+            break;
+          }
+        }
+        if (metricsPerRefresh > 0) {
+          this.props.setDuration(metricsPerRefresh);
+          console.debug(
+            `Setting UI Default: metricsPerRefresh [${uiDefaults.metricsPerRefresh}=${metricsPerRefresh}s]`
+          );
+        } else {
+          console.debug(`Ignoring invalid UI Default: metricsPerRefresh [${uiDefaults.metricsPerRefresh}]`);
+        }
+      }
+
+      // Refresh Interval
+      let refreshInterval = -1;
+      if (uiDefaults.refreshInterval) {
+        for (const [key, value] of Object.entries(config.toolbar.refreshInterval)) {
+          if (value.toLowerCase().endsWith(uiDefaults.refreshInterval.toLowerCase())) {
+            refreshInterval = Number(key);
+            break;
+          }
+        }
+        if (refreshInterval >= 0) {
+          this.props.setRefreshInterval(refreshInterval);
+          console.debug(`Setting UI Default: refreshInterval [${uiDefaults.refreshInterval}=${refreshInterval}ms]`);
+        } else {
+          console.debug(`Ignoring invalid UI Default: refreshInterval [${uiDefaults.refreshInterval}]`);
+        }
+      }
+
+      // Selected Namespaces
+      if (uiDefaults.namespaces && uiDefaults.namespaces.length > 0) {
+        // use store directly, we don't want to update on redux state change
+        const namespaces = store.getState().namespaces.items;
+        const namespaceNames: string[] = namespaces ? namespaces.map(ns => ns.name) : [];
+        const activeNamespaces: Namespace[] = [];
+
+        for (const name of uiDefaults.namespaces) {
+          if (namespaceNames.includes(name)) {
+            activeNamespaces.push({ name: name } as Namespace);
+          } else {
+            console.debug(`Ignoring invalid UI Default: namespace [${name}]`);
+          }
+        }
+        if (activeNamespaces.length > 0) {
+          this.props.setActiveNamespaces(activeNamespaces);
+          console.debug(`Setting UI Default: namespaces ${JSON.stringify(activeNamespaces.map(ns => ns.name))}`);
+        }
+      }
+    }
+  }
 
   private setDocLayout = () => {
     if (document.documentElement) {
@@ -212,10 +282,13 @@ const mapStateToProps = (state: KialiAppState) => ({
 
 const mapDispatchToProps = (dispatch: KialiDispatch) => ({
   checkCredentials: () => dispatch(LoginThunkActions.checkCredentials()),
+  setActiveNamespaces: bindActionCreators(NamespaceActions.setActiveNamespaces, dispatch),
+  setDuration: bindActionCreators(UserSettingsActions.setDuration, dispatch),
   setJaegerInfo: bindActionCreators(JaegerActions.setInfo, dispatch),
   setLandingRoute: bindActionCreators(LoginActions.setLandingRoute, dispatch),
   setMeshTlsStatus: bindActionCreators(MeshTlsActions.setinfo, dispatch),
   setNamespaces: bindActionCreators(NamespaceActions.receiveList, dispatch),
+  setRefreshInterval: bindActionCreators(UserSettingsActions.setRefreshInterval, dispatch),
   setServerStatus: (serverStatus: ServerStatus) => processServerStatus(dispatch, serverStatus)
 });
 

--- a/src/app/AuthenticationController.tsx
+++ b/src/app/AuthenticationController.tsx
@@ -21,6 +21,8 @@ import { AuthStrategy } from '../types/Auth';
 import { JaegerInfo } from '../types/JaegerInfo';
 import { LoginActions } from '../actions/LoginActions';
 import history from './History';
+import { NamespaceActions } from 'actions/NamespaceAction';
+import Namespace from 'types/Namespace';
 
 interface AuthenticationControllerReduxProps {
   authenticated: boolean;
@@ -30,6 +32,7 @@ interface AuthenticationControllerReduxProps {
   setJaegerInfo: (jaegerInfo: JaegerInfo | null) => void;
   setLandingRoute: (route: string | undefined) => void;
   setMeshTlsStatus: (meshStatus: TLSStatus) => void;
+  setNamespaces: (namespaces: Namespace[], receivedAt: Date) => void;
   setServerStatus: (serverStatus: ServerStatus) => void;
 }
 
@@ -164,8 +167,14 @@ class AuthenticationController extends React.Component<AuthenticationControllerP
           );
         });
 
-      const configs = await Promise.all([API.getServerConfig(), getStatusPromise, getJaegerInfoPromise]);
-      setServerConfig(configs[0].data);
+      const configs = await Promise.all([
+        API.getNamespaces(),
+        API.getServerConfig(),
+        getStatusPromise,
+        getJaegerInfoPromise
+      ]);
+      this.props.setNamespaces(configs[0].data, new Date());
+      setServerConfig(configs[1].data);
 
       if (this.props.landingRoute) {
         history.replace(this.props.landingRoute);
@@ -206,6 +215,7 @@ const mapDispatchToProps = (dispatch: KialiDispatch) => ({
   setJaegerInfo: bindActionCreators(JaegerActions.setInfo, dispatch),
   setLandingRoute: bindActionCreators(LoginActions.setLandingRoute, dispatch),
   setMeshTlsStatus: bindActionCreators(MeshTlsActions.setinfo, dispatch),
+  setNamespaces: bindActionCreators(NamespaceActions.receiveList, dispatch),
   setServerStatus: (serverStatus: ServerStatus) => processServerStatus(dispatch, serverStatus)
 });
 

--- a/src/components/NamespaceDropdown.tsx
+++ b/src/components/NamespaceDropdown.tsx
@@ -34,7 +34,7 @@ type ReduxProps = {
   namespaces: Namespace[];
   refresh: () => void;
   setFilter: (filter: string) => void;
-  setNamespaces: (namespaces: Namespace[]) => void;
+  setActiveNamespaces: (namespaces: Namespace[]) => void;
 };
 
 type NamespaceDropdownProps = ReduxProps & {
@@ -96,7 +96,7 @@ export class NamespaceDropdown extends React.PureComponent<NamespaceDropdownProp
     ) {
       // We must change the props of namespaces
       const items = urlNamespaces.map(ns => ({ name: ns } as Namespace));
-      this.props.setNamespaces(items);
+      this.props.setActiveNamespaces(items);
     } else if (urlNamespaces.length === 0 && this.props.activeNamespaces.length !== 0) {
       HistoryManager.setParam(URLParam.NAMESPACES, this.props.activeNamespaces.map(item => item.name).join(','));
     }
@@ -240,7 +240,7 @@ export class NamespaceDropdown extends React.PureComponent<NamespaceDropdownProp
     if (isOpen) {
       this.props.refresh();
     } else {
-      this.props.setNamespaces(this.state.selectedNamespaces);
+      this.props.setActiveNamespaces(this.state.selectedNamespaces);
       this.clearFilter();
     }
     this.setState({
@@ -301,7 +301,7 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<KialiAppState, void, KialiAp
     clearAll: () => {
       dispatch(NamespaceActions.setActiveNamespaces([]));
     },
-    setNamespaces: (namespaces: Namespace[]) => {
+    setActiveNamespaces: (namespaces: Namespace[]) => {
       dispatch(NamespaceActions.setActiveNamespaces(namespaces));
     },
     setFilter: (filter: string) => {

--- a/src/config/ServerConfig.ts
+++ b/src/config/ServerConfig.ts
@@ -1,12 +1,6 @@
 import _ from 'lodash';
-
 import { ServerConfig } from '../types/ServerConfig';
 import { parseHealthConfig } from './HealthConfig';
-import { store } from 'store/ConfigStore';
-import { UserSettingsActions } from 'actions/UserSettingsActions';
-import { config } from 'config';
-import Namespace from 'types/Namespace';
-import { NamespaceActions } from 'actions/NamespaceAction';
 
 export type Durations = { [key: number]: string };
 
@@ -14,8 +8,8 @@ export type ComputedServerConfig = ServerConfig & {
   durations: Durations;
 };
 
-export const humanDurations = (config: ComputedServerConfig, prefix?: string, suffix?: string) =>
-  _.mapValues(config.durations, v => _.reject([prefix, v, suffix], _.isEmpty).join(' '));
+export const humanDurations = (cfg: ComputedServerConfig, prefix?: string, suffix?: string) =>
+  _.mapValues(cfg.durations, v => _.reject([prefix, v, suffix], _.isEmpty).join(' '));
 
 const toDurations = (tupleArray: [number, string][]): Durations => {
   const obj = {};
@@ -96,74 +90,14 @@ export const toValidDuration = (duration: number): number => {
   return durationsTuples[0][0];
 };
 
-export const setServerConfig = (svcConfig: ServerConfig) => {
+export const setServerConfig = (cfg: ServerConfig) => {
   serverConfig = {
-    ...svcConfig,
+    ...cfg,
     durations: {}
   };
-  serverConfig.healthConfig = svcConfig.healthConfig
-    ? parseHealthConfig(svcConfig.healthConfig)
-    : serverConfig.healthConfig;
+  serverConfig.healthConfig = cfg.healthConfig ? parseHealthConfig(cfg.healthConfig) : serverConfig.healthConfig;
 
   computeValidDurations(serverConfig);
-
-  // apply configured UI Defaults
-  const uiDefaults = serverConfig.kialiFeatureFlags.uiDefaults;
-  if (uiDefaults) {
-    // Duration (aka metricsPerRefresh)
-    if (uiDefaults.metricsPerRefresh) {
-      const validDurations = humanDurations(serverConfig, '', '');
-      let metricsPerRefresh = 0;
-      for (const [key, value] of Object.entries(validDurations)) {
-        if (value === uiDefaults.metricsPerRefresh) {
-          metricsPerRefresh = Number(key);
-          break;
-        }
-      }
-      if (metricsPerRefresh > 0) {
-        store.dispatch(UserSettingsActions.setDuration(metricsPerRefresh));
-        console.debug(`Setting UI Default: metricsPerRefresh [${uiDefaults.metricsPerRefresh}=${metricsPerRefresh}s]`);
-      } else {
-        console.debug(`Ignoring invalid UI Default: metricsPerRefresh [${uiDefaults.metricsPerRefresh}]`);
-      }
-    }
-
-    // Refresh Interval
-    let refreshInterval = -1;
-    if (uiDefaults.refreshInterval) {
-      for (const [key, value] of Object.entries(config.toolbar.refreshInterval)) {
-        if (value.endsWith(uiDefaults.refreshInterval)) {
-          refreshInterval = Number(key);
-          break;
-        }
-      }
-      if (refreshInterval >= 0) {
-        store.dispatch(UserSettingsActions.setRefreshInterval(refreshInterval));
-        console.debug(`Setting UI Default: refreshInterval [${uiDefaults.refreshInterval}=${refreshInterval}ms]`);
-      } else {
-        console.debug(`Ignoring invalid UI Default: refreshInterval [${uiDefaults.refreshInterval}]`);
-      }
-    }
-
-    // Selected Namespaces
-    if (uiDefaults.namespaces && uiDefaults.namespaces.length > 0) {
-      const namespaces = store.getState().namespaces.items;
-      const namespaceNames: string[] = namespaces ? namespaces.map(ns => ns.name) : [];
-      const activeNamespaces: Namespace[] = [];
-
-      for (const name of uiDefaults.namespaces) {
-        if (namespaceNames.includes(name)) {
-          activeNamespaces.push({ name: name } as Namespace);
-        } else {
-          console.debug(`Ignoring invalid UI Default: namespace [${name}]`);
-        }
-      }
-      if (activeNamespaces.length > 0) {
-        store.dispatch(NamespaceActions.setActiveNamespaces(activeNamespaces));
-        console.log(`Setting UI Default: namespaces ${JSON.stringify(activeNamespaces.map(ns => ns.name))}`);
-      }
-    }
-  }
 };
 
 export const isIstioNamespace = (namespace: string): boolean => {

--- a/src/types/ServerConfig.ts
+++ b/src/types/ServerConfig.ts
@@ -20,8 +20,15 @@ interface IstioAnnotations {
   istioInjectionAnnotation: string;
 }
 
+interface UIDefaults {
+  metricsPerRefresh?: string;
+  namespaces?: string[];
+  refreshInterval?: string;
+}
+
 interface KialiFeatureFlags {
   istioInjectionAction: boolean;
+  uiDefaults?: UIDefaults;
 }
 
 /*


### PR DESCRIPTION
Apply UI Defaults as soon as the user successfully authenticates. We immediately update the Redux store with the user-configured defaults.  Note that they can be overwritten almost immediately by anything set/bookmarked in the URL.
These defaults apply only for "vanilla" URLs.

Notes:
- We needed to now fetch the namespaces at auth time, before applying the
  defaults, to ensure that any default namespaces were valid.
- Small unrelated change to NamespaceDropdown for clarity, just renaming a method.

Fixes https://github.com/kiali/kiali/issues/3371

Requires Server PR: https://github.com/kiali/kiali/pull/3688

TESTING NOTE
When testing this remember that the UI Defaults are set in the Kiali CR.  And changes won't take effect until the Kiali pod restarts.  Furthermore, the configured UI defaults have less priority than URL settings, so you need to test with vanilla URLs, I suggest a vanilla bookmark that you then open an incognito window.
