### PR TITLE
Use the typescript way to check undefined

### DIFF
--- a/src/components/Details/DetailObject.tsx
+++ b/src/components/Details/DetailObject.tsx
@@ -96,7 +96,7 @@ class DetailObject extends React.Component<DetailObjectProps> {
   }
 
   render() {
-    const findLabels = typeof this.props.labels !== 'undefined' && this.props.labels.length > 0;
+    const findLabels = this.props.labels !== undefined && this.props.labels.length > 0;
 
     const objectList = this.buildList(this.props.name, this.props.detail, findLabels, 0);
     return <div>{objectList}</div>;

--- a/src/components/Validations/ValidationSummary.tsx
+++ b/src/components/Validations/ValidationSummary.tsx
@@ -85,7 +85,7 @@ export class ValidationSummary extends React.PureComponent<Props> {
   }
 
   tooltipContent() {
-    if (typeof this.props.objectCount !== undefined) {
+    if (this.props.objectCount !== undefined) {
       if (this.props.objectCount === 0) {
         return this.tooltipNA();
       } else {
@@ -97,7 +97,7 @@ export class ValidationSummary extends React.PureComponent<Props> {
   }
 
   tooltipBase() {
-    return typeof this.props.objectCount === 'undefined' || this.props.objectCount > 0 ? (
+    return this.props.objectCount === undefined || this.props.objectCount > 0 ? (
       <Validation iconStyle={this.props.style} severity={this.severity()} />
     ) : (
       <div style={{ display: 'inline-block', marginLeft: '5px' }}>N/A</div>


### PR DESCRIPTION
Replacing vanilla js undefined checks to use typescript native way.
Although the vanilla js check works fine, it is worth tho move it to typescript.

cc/ @jshaughn @israel-hdez @mtho11 