### PR TITLE
Improve match builder

### DIFF
--- a/src/components/IstioWizards/RequestRouting.tsx
+++ b/src/components/IstioWizards/RequestRouting.tsx
@@ -28,9 +28,17 @@ type State = {
   validationMsg: string;
 };
 
-const MSG_SAME_MATCHING = 'A Rule with same matching criteria is already added.';
-const MSG_HEADER_NAME_NON_EMPTY = 'Header name must be non empty';
-const MSG_HEADER_VALUE_NON_EMPTY = 'Header value must be non empty';
+export const MSG_SAME_MATCHING = 'A Rule with same matching criteria is already added.';
+export const MSG_HEADER_NAME_NON_EMPTY = 'Header name must be non empty';
+export const MSG_HEADER_VALUE_NON_EMPTY = 'Header value must be non empty';
+
+export function isMatchesIncluded(rules: Rule[], newRule: Rule) {
+  return rules.some(rule => {
+    return (
+      rule.matches.length === newRule.matches.length && rule.matches.every(match => newRule.matches.includes(match))
+    );
+  });
+}
 
 class RequestRouting extends React.Component<Props, State> {
   constructor(props: Props) {
@@ -78,21 +86,6 @@ class RequestRouting extends React.Component<Props, State> {
       validationMsg: ''
     };
   }
-
-  isMatchesIncluded = (rules: Rule[], rule: Rule) => {
-    let found = false;
-    for (let i = 0; i < rules.length; i++) {
-      const item = rules[i];
-      if (item.matches.length !== rule.matches.length) {
-        continue;
-      }
-      found = item.matches.every(value => rule.matches.includes(value));
-      if (found) {
-        break;
-      }
-    }
-    return found;
-  };
 
   isValid = (rules: Rule[]): boolean => {
     // Corner case, an empty rules shouldn't be a valid scenario to create a VS/DR
@@ -163,7 +156,7 @@ class RequestRouting extends React.Component<Props, State> {
         if (prevState.timeoutRetryRoute.isRetry && prevState.timeoutRetryRoute.isValidRetry) {
           newRule.retries = prevState.timeoutRetryRoute.retries;
         }
-        if (!this.isMatchesIncluded(prevState.rules, newRule)) {
+        if (!isMatchesIncluded(prevState.rules, newRule)) {
           prevState.rules.push(newRule);
           return {
             matches: prevState.matches,

--- a/src/components/IstioWizards/RequestRouting/MatchBuilder.tsx
+++ b/src/components/IstioWizards/RequestRouting/MatchBuilder.tsx
@@ -56,7 +56,7 @@ class MatchBuilder extends React.Component<Props, State> {
     };
   }
 
-  onMathOptionsToggle = () => {
+  onMatchOptionsToggle = () => {
     this.setState({
       isMatchDropdown: !this.state.isMatchDropdown
     });
@@ -72,7 +72,7 @@ class MatchBuilder extends React.Component<Props, State> {
     return (
       <InputGroup>
         <Dropdown
-          toggle={<DropdownToggle onToggle={this.onMathOptionsToggle}>{this.props.category}</DropdownToggle>}
+          toggle={<DropdownToggle onToggle={this.onMatchOptionsToggle}>{this.props.category}</DropdownToggle>}
           isOpen={this.state.isMatchDropdown}
           dropdownItems={this.props.matchOptions.map((mode, index) => (
             <DropdownItem
@@ -81,7 +81,7 @@ class MatchBuilder extends React.Component<Props, State> {
               component="button"
               onClick={() => {
                 this.props.onSelectCategory(mode);
-                this.onMathOptionsToggle();
+                this.onMatchOptionsToggle();
               }}
             >
               {mode}

--- a/src/components/IstioWizards/RequestRouting/MatchBuilder.tsx
+++ b/src/components/IstioWizards/RequestRouting/MatchBuilder.tsx
@@ -7,6 +7,8 @@ type Props = {
   headerName: string;
   matchValue: string;
   isValid: boolean;
+  matchOptions: string[];
+  opOptions: string[];
   onSelectCategory: (category: string) => void;
   onHeaderNameChange: (headerName: string) => void;
   onSelectOperator: (operator: string) => void;
@@ -19,23 +21,23 @@ type State = {
   isOperatorDropdown: boolean;
 };
 
+// Match options
 export const HEADERS = 'headers';
 export const URI = 'uri';
 export const SCHEME = 'scheme';
 export const METHOD = 'method';
 export const AUTHORITY = 'authority';
 
-const matchOptions: string[] = [HEADERS, URI, SCHEME, METHOD, AUTHORITY];
-
+// Operators
 export const EXACT = 'exact';
 export const PREFIX = 'prefix';
 export const REGEX = 'regex';
 
+export const opOptions: string[] = [EXACT, PREFIX, REGEX];
+
 // Pseudo operator
 export const PRESENCE = 'is present';
 export const ANYTHING = '^.*$';
-
-const opOptions: string[] = [EXACT, PREFIX, REGEX];
 
 const placeholderText = {
   [HEADERS]: 'Header value...',
@@ -67,13 +69,12 @@ class MatchBuilder extends React.Component<Props, State> {
   };
 
   render() {
-    const renderOpOptions: string[] = this.props.category === HEADERS ? [PRESENCE, ...opOptions] : opOptions;
     return (
       <InputGroup>
         <Dropdown
           toggle={<DropdownToggle onToggle={this.onMathOptionsToggle}>{this.props.category}</DropdownToggle>}
           isOpen={this.state.isMatchDropdown}
-          dropdownItems={matchOptions.map((mode, index) => (
+          dropdownItems={this.props.matchOptions.map((mode, index) => (
             <DropdownItem
               key={mode + '_' + index}
               value={mode}
@@ -98,7 +99,7 @@ class MatchBuilder extends React.Component<Props, State> {
         <Dropdown
           toggle={<DropdownToggle onToggle={this.onOperatorToggle}>{this.props.operator}</DropdownToggle>}
           isOpen={this.state.isOperatorDropdown}
-          dropdownItems={renderOpOptions.map((op, index) => (
+          dropdownItems={this.props.opOptions.map((op, index) => (
             <DropdownItem
               key={op + '_' + index}
               value={op}

--- a/src/components/IstioWizards/RequestRouting/RuleBuilder.tsx
+++ b/src/components/IstioWizards/RequestRouting/RuleBuilder.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Button, Tabs, Tab } from '@patternfly/react-core';
-import MatchBuilder from './MatchBuilder';
+import MatchBuilder, { HEADERS, URI, SCHEME, METHOD, AUTHORITY, PRESENCE, opOptions } from './MatchBuilder';
 import Matches from './Matches';
 import { style } from 'typestyle';
 import { WorkloadOverview } from '../../../types/ServiceInfo';
@@ -84,7 +84,11 @@ class RuleBuilder extends React.Component<Props, State> {
         <Tabs isFilled={true} activeKey={this.state.ruleTabKey} onSelect={this.ruleHandleTabClick}>
           <Tab eventKey={0} title={'Request Matching'}>
             <div style={{ marginTop: '20px' }}>
-              <MatchBuilder {...this.props} />
+              <MatchBuilder
+                {...this.props}
+                matchOptions={[HEADERS, URI, SCHEME, METHOD, AUTHORITY]}
+                opOptions={this.props.category === HEADERS ? [PRESENCE, ...opOptions] : opOptions}
+              />
               <Matches {...this.props} />
             </div>
           </Tab>


### PR DESCRIPTION
** Describe the change **

Exposing a function and constants as well as changing the `MatchBuilder` component to be more reusable.

** Issue reference **

I am working on this [issue](https://github.com/iter8-tools/kiali-ui/issues/34).

Lucas mentioned in this [comment](https://github.com/kiali/kiali-ui/pull/2015#issuecomment-736032444) that we should consider components. 

Unfortunately, we could not use all of the components out of the box. Specifically, we needed more control over the `MatchBuilder` component. In our use case, we only want to a subset of the match options (i.e. only `URI` and `HEADERS`) and we do not want the operator options to change in the case of `HEADERS`. In this PR, we made the match and operator options properties so that we can provide our own.

In addition, we also export some constants and pulled out another function that we would like to reuse.

** Backwards compatible? **

[Yes] Is your pull-request introducing changes in behavior?

** Screenshot **

There are no UI changes.

** Documentation **

There is no need for documentation changes.
