### PR TITLE
Fix misleading tooltip displayed on chart legends

### DIFF
--- a/src/components/Charts/ChartWithLegend.tsx
+++ b/src/components/Charts/ChartWithLegend.tsx
@@ -43,6 +43,7 @@ const overlayName = 'overlay';
 class ChartWithLegend<T extends RichDataPoint, O extends LineInfo> extends React.Component<Props<T, O>, State> {
   containerRef: React.RefObject<HTMLDivElement>;
   hoveredItem?: VCDataPoint;
+  mouseOnLegend = false;
 
   constructor(props: Props<T, O>) {
     super(props);
@@ -143,7 +144,11 @@ class ChartWithLegend<T extends RichDataPoint, O extends LineInfo> extends React
           width={this.state.width}
           padding={padding}
           events={events}
-          containerComponent={newBrushVoronoiContainer(labelComponent, this.props.brushHandlers)}
+          containerComponent={newBrushVoronoiContainer(
+            labelComponent,
+            this.props.brushHandlers,
+            () => this.mouseOnLegend
+          )}
           scale={{ x: this.props.xAxis === 'series' ? 'linear' : 'time' }}
           // Hack: 1 pxl on Y domain padding to prevent harsh clipping (https://github.com/kiali/kiali/issues/2069)
           domainPadding={{ y: 1, x: this.props.xAxis === 'series' ? 50 : undefined }}
@@ -220,6 +225,8 @@ class ChartWithLegend<T extends RichDataPoint, O extends LineInfo> extends React
               data: { cursor: 'pointer' },
               labels: { cursor: 'pointer' }
             }}
+            borderPadding={{ top: 10 }}
+            symbolSpacer={5}
           />
         </Chart>
       </div>
@@ -312,9 +319,14 @@ class ChartWithLegend<T extends RichDataPoint, O extends LineInfo> extends React
       idx: idx,
       serieID: serieID,
       onMouseOver: props => {
+        this.mouseOnLegend = true;
         return {
           style: { ...props.style, strokeWidth: 4, fillOpacity: 0 }
         };
+      },
+      onMouseOut: () => {
+        this.mouseOnLegend = false;
+        return null;
       },
       onClick: () => {
         if (!this.state.hiddenSeries.delete(serieName)) {

--- a/src/components/Charts/Container.tsx
+++ b/src/components/Charts/Container.tsx
@@ -23,10 +23,14 @@ const formatValue = (label: string, datum: RichDataPoint, value: number) => {
   return label + ': ' + getFormatter(d3Format, datum.unit!)(value / (datum.scaleFactor || 1));
 };
 
-export const newBrushVoronoiContainer = (labelComponent: JSX.Element, handlers?: BrushHandlers) => {
+export const newBrushVoronoiContainer = (
+  labelComponent: JSX.Element,
+  handlers: BrushHandlers | undefined,
+  hideTooltip: () => boolean
+) => {
   const voronoiProps = {
     labels: obj => {
-      if (obj.datum.hideLabel) {
+      if (obj.datum.hideLabel || hideTooltip()) {
         return '';
       }
       if (obj.datum._median !== undefined) {

--- a/src/utils/VictoryEvents.ts
+++ b/src/utils/VictoryEvents.ts
@@ -6,6 +6,7 @@ interface EventItem {
   serieID: string;
   onClick?: (props: RawOrBucket<LineInfo>) => Partial<RawOrBucket<LineInfo>> | null;
   onMouseOver?: (props: RawOrBucket<LineInfo>) => Partial<RawOrBucket<LineInfo>> | null;
+  onMouseOut?: (props: RawOrBucket<LineInfo>) => Partial<RawOrBucket<LineInfo>> | null;
 }
 
 export type VCEvent = {
@@ -64,7 +65,7 @@ export const addLegendEvent = (events: VCEvent[], item: EventItem): void => {
           childName: [item.serieID],
           target: 'data',
           eventKey: 'all',
-          mutation: () => null
+          mutation: props => (item.onMouseOut ? item.onMouseOut(props) : null)
         }
       ];
     };


### PR DESCRIPTION
Tooltip is now hidden while hovering legend items.
Note that I also reduced the gap between the legend symbols and texts,
because the pointer isn't considered on legend while it's on that space;
reducing it makes this issue smaller.

Fixes https://github.com/kiali/kiali/issues/3035
