### PR TITLE
Tracing: disable display toolbar on errors

### DIFF
--- a/src/components/JaegerIntegration/JaegerScatter.tsx
+++ b/src/components/JaegerIntegration/JaegerScatter.tsx
@@ -101,7 +101,7 @@ class JaegerScatter extends React.Component<JaegerScatterProps> {
     };
 
     return this.props.errorFetchTraces && this.props.errorFetchTraces.length > 0 ? (
-      this.renderFetchEmtpy('Error fetching Traces in Tracing tool', this.props.errorFetchTraces![0].msg)
+      this.renderFetchEmtpy('Error fetching traces', this.props.errorFetchTraces![0].msg)
     ) : this.props.traces.length > 0 ? (
       <ChartWithLegend<Datapoint, JaegerLineInfo>
         data={[successTraces, errorTraces]}

--- a/src/components/JaegerIntegration/TracesDisplayOptions.tsx
+++ b/src/components/JaegerIntegration/TracesDisplayOptions.tsx
@@ -23,6 +23,7 @@ export const percentilesOptions: DisplayOptionType[] = [
 ];
 
 interface Props {
+  disabled: boolean;
   onQuerySettingsChanged: (settings: QuerySettings) => void;
   onDisplaySettingsChanged: (settings: DisplaySettings) => void;
   percentilesPromise: Promise<Map<string, number>>;
@@ -88,7 +89,7 @@ export class TracesDisplayOptions extends React.Component<Props, State> {
     return (
       <Dropdown
         toggle={
-          <DropdownToggle id={'traces-display-settings'} onToggle={this.onToggle}>
+          <DropdownToggle id={'traces-display-settings'} isDisabled={this.props.disabled} onToggle={this.onToggle}>
             Display
           </DropdownToggle>
         }

--- a/src/components/JaegerIntegration/TracesFetcher.ts
+++ b/src/components/JaegerIntegration/TracesFetcher.ts
@@ -68,6 +68,7 @@ export class TracesFetcher {
       })
       .catch(error => {
         AlertUtils.addError('Could not fetch traces.', error);
+        this.onErrors([{ msg: String(error) }]);
       });
   };
 


### PR DESCRIPTION
Display toolbar is disabled, and error is written on page, when some
error occurred AND there's no trace currently displayed.

If they're some traces currently displayed, the user may still want to
interact with them.

Fixes https://github.com/kiali/kiali/issues/3698
