### PR TITLE
Fix broken query for trace percentiles

### DIFF
--- a/src/components/JaegerIntegration/TracesDisplayOptions.tsx
+++ b/src/components/JaegerIntegration/TracesDisplayOptions.tsx
@@ -25,7 +25,7 @@ export const percentilesOptions: DisplayOptionType[] = [
 interface Props {
   onQuerySettingsChanged: (settings: QuerySettings) => void;
   onDisplaySettingsChanged: (settings: DisplaySettings) => void;
-  percentilesPromise: Promise<Map<string, string>>;
+  percentilesPromise: Promise<Map<string, number>>;
 }
 
 type State = QuerySettings &
@@ -39,7 +39,7 @@ interface DisplayOptionType {
 }
 
 export class TracesDisplayOptions extends React.Component<Props, State> {
-  private computedPercentiles: Map<string, string> | undefined;
+  private computedPercentiles: Map<string, number> | undefined;
 
   constructor(props: Props) {
     super(props);
@@ -118,7 +118,7 @@ export class TracesDisplayOptions extends React.Component<Props, State> {
           if (this.computedPercentiles) {
             const val = this.computedPercentiles!.get(item.id);
             if (val) {
-              label += ` (${val}+)`;
+              label += ` (${val.toFixed(2)}ms+)`;
             }
           }
           return (

--- a/src/components/JaegerIntegration/TracesFetcher.ts
+++ b/src/components/JaegerIntegration/TracesFetcher.ts
@@ -12,7 +12,7 @@ export type FetchOptions = {
   targetKind: TargetKind;
   spanLimit: number;
   tags: string;
-  minDuration?: string;
+  minDuration?: number;
 };
 
 export class TracesFetcher {
@@ -37,7 +37,7 @@ export class TracesFetcher {
       endMicros: range.to,
       tags: o.tags,
       limit: o.spanLimit,
-      minDuration: o.minDuration
+      minDuration: o.minDuration ? Math.floor(1000 * o.minDuration) : undefined
     };
     const apiCall =
       o.targetKind === 'app'

--- a/src/types/Tracing.ts
+++ b/src/types/Tracing.ts
@@ -3,7 +3,7 @@ export type TracingQuery = {
   endMicros?: number;
   tags?: string;
   limit?: number;
-  minDuration?: string;
+  minDuration?: number;
 };
 
 export type Span = {


### PR DESCRIPTION
Since the grpc jaeger client PR, minDuration now has to be passed as an
integer (in microseconds) instead of a string
