### PR TITLE
Fix overview filter for Healthy case

### DIFF
--- a/src/pages/Overview/Filters.ts
+++ b/src/pages/Overview/Filters.ts
@@ -113,7 +113,10 @@ export const healthFilter: RunnableFilter<NamespaceInfo> = {
       : ns.status
       ? (showInError && ns.status.inError.length > 0) ||
         (showInWarning && ns.status.inWarning.length > 0) ||
-        (showInSuccess && ns.status.inSuccess.length > 0)
+        (showInSuccess &&
+          ns.status.inSuccess.length > 0 &&
+          ns.status.inError.length === 0 &&
+          ns.status.inWarning.length === 0)
       : false;
   }
 };


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/3719

@hhovsepy let me know if this PR looks good for that use case.

Yes, in highly populated namespaces, probably the delay of the async fetch is visible, but I checked that the "loading" icon is present on those cases.