### PR TITLE
Idle -> Not Ready for Workloads scaled to 0

### DIFF
--- a/src/components/Filters/CommonFilters.ts
+++ b/src/components/Filters/CommonFilters.ts
@@ -6,7 +6,7 @@ import {
   ActiveFiltersInfo,
   FilterTypes
 } from '../../types/Filters';
-import { HEALTHY, DEGRADED, FAILURE, NA, Health } from '../../types/Health';
+import { HEALTHY, DEGRADED, FAILURE, NA, NOT_READY, Health } from '../../types/Health';
 import { removeDuplicatesArray } from '../../utils/Common';
 
 export const presenceValues: FilterValue[] = [
@@ -47,6 +47,10 @@ export const healthFilter: FilterType = {
     {
       id: FAILURE.name,
       title: FAILURE.name
+    },
+    {
+      id: NOT_READY.name,
+      title: NOT_READY.name
     },
     {
       id: 'na',

--- a/src/components/Health/__tests__/HealthIndicator.test.tsx
+++ b/src/components/Health/__tests__/HealthIndicator.test.tsx
@@ -4,7 +4,7 @@ import { shallowToJson } from 'enzyme-to-json';
 
 import { HealthIndicator, DisplayMode } from '../HealthIndicator';
 import { createIcon } from '../../../components/Health/Helper';
-import { AppHealth, DEGRADED, FAILURE, HEALTHY, IDLE } from '../../../types/Health';
+import { AppHealth, DEGRADED, FAILURE, HEALTHY, NOT_READY } from '../../../types/Health';
 import { PFAlertColor } from 'components/Pf/PfColors';
 import { setServerConfig } from '../../../config/ServerConfig';
 import { healthConfig } from '../../../types/__testData__/HealthConfig';
@@ -86,7 +86,7 @@ describe('HealthIndicator', () => {
     // SMALL
     let wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.SMALL} />);
     let html = wrapper.html();
-    expect(html).toContain(shallow(createIcon(IDLE, 'sm')).html());
+    expect(html).toContain(shallow(createIcon(NOT_READY, 'sm')).html());
 
     // LARGE
     wrapper = shallow(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} />);
@@ -110,7 +110,7 @@ describe('HealthIndicator', () => {
     // SMALL
     let wrapper = mount(<HealthIndicator id="svc" health={health} mode={DisplayMode.SMALL} />);
     let html = wrapper.html();
-    expect(html).toContain(mount(createIcon(IDLE, 'sm')).html());
+    expect(html).toContain(mount(createIcon(NOT_READY, 'sm')).html());
 
     // LARGE
     wrapper = mount(<HealthIndicator id="svc" health={health} mode={DisplayMode.LARGE} />);

--- a/src/pages/Overview/Filters.ts
+++ b/src/pages/Overview/Filters.ts
@@ -1,5 +1,5 @@
 import { ActiveFiltersInfo, FILTER_ACTION_APPEND, FilterTypes, RunnableFilter, FilterValue } from '../../types/Filters';
-import { DEGRADED, FAILURE, HEALTHY } from '../../types/Health';
+import { DEGRADED, FAILURE, HEALTHY, NOT_READY } from '../../types/Health';
 import { NamespaceInfo } from './NamespaceInfo';
 import { MTLSStatuses } from '../../types/TLSStatus';
 import { TextInputTypes } from '@patternfly/react-core';
@@ -60,6 +60,7 @@ export const labelFilter: RunnableFilter<NamespaceInfo> = {
 };
 
 const healthValues: FilterValue[] = [
+  { id: NOT_READY.name, title: NOT_READY.name },
   { id: FAILURE.name, title: FAILURE.name },
   { id: DEGRADED.name, title: DEGRADED.name },
   { id: HEALTHY.name, title: HEALTHY.name }
@@ -69,16 +70,21 @@ const summarizeHealthFilters = (healthFilters: ActiveFiltersInfo) => {
   if (healthFilters.filters.length === 0) {
     return {
       noFilter: true,
+      showInNotReady: true,
       showInError: true,
       showInWarning: true,
       showInSuccess: true
     };
   }
-  let showInError = false,
+  let showInNotReady = false,
+    showInError = false,
     showInWarning = false,
     showInSuccess = false;
   healthFilters.filters.forEach(f => {
     switch (f.value) {
+      case NOT_READY.name:
+        showInNotReady = true;
+        break;
       case FAILURE.name:
         showInError = true;
         break;
@@ -93,6 +99,7 @@ const summarizeHealthFilters = (healthFilters: ActiveFiltersInfo) => {
   });
   return {
     noFilter: false,
+    showInNotReady: showInNotReady,
     showInError: showInError,
     showInWarning: showInWarning,
     showInSuccess: showInSuccess
@@ -107,11 +114,12 @@ export const healthFilter: RunnableFilter<NamespaceInfo> = {
   action: FILTER_ACTION_APPEND,
   filterValues: healthValues,
   run: (ns: NamespaceInfo, filters: ActiveFiltersInfo) => {
-    const { showInError, showInWarning, showInSuccess, noFilter } = summarizeHealthFilters(filters);
+    const { showInNotReady, showInError, showInWarning, showInSuccess, noFilter } = summarizeHealthFilters(filters);
     return noFilter
       ? true
       : ns.status
-      ? (showInError && ns.status.inError.length > 0) ||
+      ? (showInNotReady && ns.status.inNotReady.length > 0) ||
+        (showInError && ns.status.inError.length > 0) ||
         (showInWarning && ns.status.inWarning.length > 0) ||
         (showInSuccess && ns.status.inSuccess.length > 0)
       : false;

--- a/src/pages/Overview/NamespaceInfo.ts
+++ b/src/pages/Overview/NamespaceInfo.ts
@@ -14,7 +14,7 @@ export type NamespaceInfo = {
 };
 
 export type NamespaceStatus = {
-  inIdle: string[];
+  inNotReady: string[];
   inError: string[];
   inWarning: string[];
   inSuccess: string[];

--- a/src/pages/Overview/OverviewCardContentCompact.tsx
+++ b/src/pages/Overview/OverviewCardContentCompact.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DEGRADED, FAILURE, HEALTHY, IDLE } from '../../types/Health';
+import { DEGRADED, FAILURE, HEALTHY, NOT_READY } from '../../types/Health';
 import OverviewStatus from './OverviewStatus';
 import { OverviewType } from './OverviewToolbar';
 import { NamespaceStatus } from './NamespaceInfo';
@@ -22,7 +22,7 @@ class OverviewCardContentCompact extends React.Component<Props> {
       status.inWarning.length +
       status.inSuccess.length +
       status.notAvailable.length +
-      status.inIdle.length;
+      status.inNotReady.length;
     let text: string;
     if (nbItems === 1) {
       text = switchType(this.props.type, '1 Application', '1 Service', '1 Workload');
@@ -35,12 +35,12 @@ class OverviewCardContentCompact extends React.Component<Props> {
           <span>
             <div style={{ display: 'inline-block', width: '125px' }}>{text}</div>
             <div style={{ display: 'inline-block' }}>
-              {status.inIdle.length > 0 && (
+              {status.inNotReady.length > 0 && (
                 <OverviewStatus
-                  id={name + '-iddle'}
+                  id={name + '-not-ready'}
                   namespace={name}
-                  status={IDLE}
-                  items={status.inIdle}
+                  status={NOT_READY}
+                  items={status.inNotReady}
                   targetPage={targetPage}
                 />
               )}

--- a/src/pages/Overview/OverviewCardContentExpanded.tsx
+++ b/src/pages/Overview/OverviewCardContentExpanded.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DEGRADED, FAILURE, HEALTHY, IDLE } from '../../types/Health';
+import { DEGRADED, FAILURE, HEALTHY, NOT_READY } from '../../types/Health';
 import OverviewStatus from './OverviewStatus';
 import { OverviewType } from './OverviewToolbar';
 import { NamespaceStatus } from './NamespaceInfo';
@@ -44,7 +44,7 @@ class OverviewCardContentExpanded extends React.Component<Props> {
       status.inWarning.length +
       status.inSuccess.length +
       status.notAvailable.length +
-      status.inIdle.length;
+      status.inNotReady.length;
     let text: string;
     if (nbItems === 1) {
       text = switchType(this.props.type, '1 Application', '1 Service', '1 Workload');
@@ -68,12 +68,12 @@ class OverviewCardContentExpanded extends React.Component<Props> {
           <span>
             {mainLink}
             <div style={{ display: 'inline-block' }}>
-              {status.inIdle.length > 0 && (
+              {status.inNotReady.length > 0 && (
                 <OverviewStatus
-                  id={name + '-iddle'}
+                  id={name + '-not-ready'}
                   namespace={name}
-                  status={IDLE}
-                  items={status.inIdle}
+                  status={NOT_READY}
+                  items={status.inNotReady}
                   targetPage={targetPage}
                 />
               )}

--- a/src/pages/Overview/OverviewPage.tsx
+++ b/src/pages/Overview/OverviewPage.tsx
@@ -27,7 +27,7 @@ import {
   FAILURE,
   Health,
   HEALTHY,
-  IDLE,
+  NOT_READY,
   NamespaceAppHealth,
   NamespaceServiceHealth,
   NamespaceWorkloadHealth
@@ -284,7 +284,7 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
       .then(results => {
         results.forEach(result => {
           const nsStatus: NamespaceStatus = {
-            inIdle: [],
+            inNotReady: [],
             inError: [],
             inWarning: [],
             inSuccess: [],
@@ -299,8 +299,8 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
               nsStatus.inWarning.push(item);
             } else if (status === HEALTHY) {
               nsStatus.inSuccess.push(item);
-            } else if (status === IDLE) {
-              nsStatus.inIdle.push(item);
+            } else if (status === NOT_READY) {
+              nsStatus.inNotReady.push(item);
             } else {
               nsStatus.notAvailable.push(item);
             }

--- a/src/types/Health.ts
+++ b/src/types/Health.ts
@@ -97,8 +97,8 @@ export const DEGRADED: Status = {
   icon: ExclamationTriangleIcon,
   class: 'icon-degraded'
 };
-export const IDLE: Status = {
-  name: 'Idle',
+export const NOT_READY: Status = {
+  name: 'Not Ready',
   color: PFAlertColor.InfoBackground,
   priority: 2,
   icon: MinusCircleIcon,
@@ -143,11 +143,11 @@ export const ratioCheck = (
   syncedProxies: number
 ): Status => {
   /*
-    IDLE STATE
+    NOT READY STATE
  */
   // User has scaled down a workload, then desired replicas will be 0 and it's not an error condition
   if (desiredReplicas === 0) {
-    return IDLE;
+    return NOT_READY;
   }
 
   /*

--- a/src/types/__tests__/Health.test.ts
+++ b/src/types/__tests__/Health.test.ts
@@ -24,7 +24,7 @@ describe('Health', () => {
     expect(H.ratioCheck(3, 3, 3, 3)).toEqual(H.HEALTHY);
   });
   it('should check ratio with no item', () => {
-    expect(H.ratioCheck(0, 0, 0, 0)).toEqual(H.IDLE);
+    expect(H.ratioCheck(0, 0, 0, 0)).toEqual(H.NOT_READY);
   });
   it('should check ratio pending Pods', () => {
     // 3 Pods with problems


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/3576

As discussed in https://github.com/kiali/kiali/issues/3576#issuecomment-760241754 we have a clash with same term for two different states.

This PR just renames the "Idle" status in Apps and Workloads for a better alignment with the terminology.

Idle is reserved for no traffic situations.

It's just a rename but it touches several areas so a close review and regression tests would help to confirm that nothing is missed.
