### PR TITLE
Change Smooth chart properties

### DIFF
--- a/src/components/Charts/ChartWithLegend.tsx
+++ b/src/components/Charts/ChartWithLegend.tsx
@@ -11,6 +11,7 @@ import { buildLegendInfo, toBuckets } from 'utils/VictoryChartsUtils';
 import { VCEvent, addLegendEvent } from 'utils/VictoryEvents';
 import { XAxisType } from 'types/Dashboards';
 import { CustomTooltip } from './CustomTooltip';
+import { INTERPOTALION_STRATEGY } from './SparklineChart';
 
 type Props<T extends RichDataPoint, O extends LineInfo> = {
   chartHeight?: number;
@@ -247,7 +248,8 @@ class ChartWithLegend<T extends RichDataPoint, O extends LineInfo> extends React
               {
                 key: 'serie-' + idx,
                 name: 'serie-' + idx,
-                data: serie.datapoints
+                data: serie.datapoints,
+                interpolation: INTERPOTALION_STRATEGY
               },
               serie.color
             )

--- a/src/components/Charts/SparklineChart.tsx
+++ b/src/components/Charts/SparklineChart.tsx
@@ -18,6 +18,8 @@ type State = {
   hiddenSeries: Set<number>;
 };
 
+export const INTERPOTALION_STRATEGY = 'monotoneX';
+
 export class SparklineChart extends React.Component<Props, State> {
   containerRef?: React.RefObject<HTMLDivElement>;
 
@@ -144,6 +146,7 @@ export class SparklineChart extends React.Component<Props, State> {
                   strokeWidth: 2
                 }
               }}
+              interpolation={INTERPOTALION_STRATEGY}
             />
           );
         })}


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/2060

It's a one-liner PR to smooth the charts curves.

I've used monotoneX as other strategies have more visualization cornercases when reaching the limits of the chart, I think this looks better.

![image](https://user-images.githubusercontent.com/1662329/110311431-11b17880-8004-11eb-8590-496ea9fa996e.png)

![image](https://user-images.githubusercontent.com/1662329/110311470-1c6c0d80-8004-11eb-9d4b-66139311a21d.png)

![image](https://user-images.githubusercontent.com/1662329/110311512-2c83ed00-8004-11eb-909f-c77917540fe1.png)

![image](https://user-images.githubusercontent.com/1662329/110311561-3efe2680-8004-11eb-966f-b79c88840a65.png)
