### PR TITLE
Metrics page: more details & links from spans

### DIFF
--- a/src/app/History.ts
+++ b/src/app/History.ts
@@ -32,6 +32,7 @@ export enum URLParam {
   JAEGER_PERCENTILE = 'percentile',
   JAEGER_SHOW_SPANS_AVG = 'showSpansAvg',
   JAEGER_TRACE_ID = 'traceId',
+  JAEGER_SPAN_ID = 'spanId',
   NAMESPACES = 'namespaces',
   OPERATION_NODES = 'operationNodes',
   OVERVIEW_TYPE = 'otype',

--- a/src/components/JaegerIntegration/TracesComponent.tsx
+++ b/src/components/JaegerIntegration/TracesComponent.tsx
@@ -29,6 +29,7 @@ import { getTimeRangeMicros } from 'utils/tracing/TracingHelper';
 import { TracesDisplayOptions, QuerySettings, DisplaySettings, percentilesOptions } from './TracesDisplayOptions';
 import { Direction, genStatsKey, MetricsStatsQuery } from 'types/MetricsOptions';
 import { MetricsStatsResult } from 'types/Metrics';
+import { getSpanId } from 'utils/SearchParamUtils';
 
 interface TracesProps {
   namespace: string;
@@ -74,7 +75,7 @@ class TracesComponent extends React.Component<TracesProps, TracesState> {
       traces: [],
       jaegerErrors: [],
       targetApp: targetApp,
-      activeTab: traceDetailsTab,
+      activeTab: getSpanId() ? spansDetailsTab : traceDetailsTab,
       toolbarDisabled: false
     };
     this.fetcher = new TracesFetcher(this.onTracesUpdated, errors => {

--- a/src/components/Metrics/CustomMetrics.tsx
+++ b/src/components/Metrics/CustomMetrics.tsx
@@ -154,8 +154,9 @@ class CustomMetrics extends React.Component<Props, MetricsState> {
       this.onDomainChange([datum.start as Date, datum.end as Date]);
     } else if ('traceId' in datum) {
       const traceId = datum.traceId;
+      const spanId = datum.spanId;
       history.push(
-        `/namespaces/${this.props.namespace}/applications/${this.props.app}?tab=traces&${URLParam.JAEGER_TRACE_ID}=${traceId}`
+        `/namespaces/${this.props.namespace}/applications/${this.props.app}?tab=traces&${URLParam.JAEGER_TRACE_ID}=${traceId}&${URLParam.JAEGER_SPAN_ID}=${spanId}`
       );
     }
   };

--- a/src/components/Metrics/IstioMetrics.tsx
+++ b/src/components/Metrics/IstioMetrics.tsx
@@ -203,6 +203,7 @@ class IstioMetrics extends React.Component<Props, MetricsState> {
       this.onDomainChange([datum.start as Date, datum.end as Date]);
     } else if ('traceId' in datum) {
       const traceId = datum.traceId;
+      const spanId = datum.spanId;
       const domain =
         this.props.objectType === MetricsObjectTypes.APP
           ? 'applications'
@@ -210,7 +211,7 @@ class IstioMetrics extends React.Component<Props, MetricsState> {
           ? 'services'
           : 'workloads';
       history.push(
-        `/namespaces/${this.props.namespace}/${domain}/${this.props.object}?tab=traces&${URLParam.JAEGER_TRACE_ID}=${traceId}`
+        `/namespaces/${this.props.namespace}/${domain}/${this.props.object}?tab=traces&${URLParam.JAEGER_TRACE_ID}=${traceId}&${URLParam.JAEGER_SPAN_ID}=${spanId}`
       );
     }
   };

--- a/src/components/Metrics/SpanOverlay.ts
+++ b/src/components/Metrics/SpanOverlay.ts
@@ -10,7 +10,7 @@ import { Overlay, OverlayInfo } from 'types/Overlay';
 import { toOverlay } from 'utils/VictoryChartsUtils';
 import { defaultMetricsDuration } from './Helper';
 
-export type JaegerLineInfo = LineInfo & { traceId?: string };
+export type JaegerLineInfo = LineInfo & { traceId?: string; spanId?: string };
 
 type FetchOptions = {
   namespace: string;
@@ -80,14 +80,17 @@ export class SpanOverlay {
       };
       const dps = this.spans.map(span => {
         const hasError = span.tags.some(tag => tag.key === 'error' && tag.value);
+        const methodTags = span.tags.filter(tag => tag.key === 'http.method');
+        const method = methodTags.length > 0 ? methodTags[0].value : undefined;
         return {
-          name: span.operationName,
+          name: `${method && `[${method}] `}${span.operationName}`,
           x: new Date(span.startTime / 1000),
           y: Number(span.duration / 1000000),
           error: hasError,
           color: hasError ? PFAlertColor.Danger : PfColors.Cyan300,
           size: 4,
-          traceId: span.traceID
+          traceId: span.traceID,
+          spanId: span.spanID
         };
       });
       return toOverlay(info, dps);

--- a/src/pages/Graph/SummaryPanelTraceDetails.tsx
+++ b/src/pages/Graph/SummaryPanelTraceDetails.tsx
@@ -190,7 +190,21 @@ class SummaryPanelTraceDetails extends React.Component<Props, State> {
     );
   }
 
+  private spanViewLink(span: RichSpanData): string | undefined {
+    const node = decoratedNodeData(this.props.node);
+    return node.namespace
+      ? `/namespaces/${node.namespace}` +
+          (node.workload
+            ? `/workloads/${node.workload}`
+            : node.service
+            ? `/services/${node.service}`
+            : `/applications/${node.app!}`) +
+          `?tab=traces&${URLParam.JAEGER_TRACE_ID}=${this.props.trace.traceID}&${URLParam.JAEGER_SPAN_ID}=${span.spanID}`
+      : undefined;
+  }
+
   private renderSpan(span: RichSpanData) {
+    const spanURL = this.spanViewLink(span);
     return (
       <>
         <div>
@@ -207,6 +221,11 @@ class SummaryPanelTraceDetails extends React.Component<Props, State> {
           <strong>Related: </strong>
           {this.renderRelatedSpans(span)}
         </div>
+        {spanURL && (
+          <div>
+            <Link to={spanURL}>Show span</Link>
+          </div>
+        )}
       </>
     );
   }

--- a/src/utils/SearchParamUtils.ts
+++ b/src/utils/SearchParamUtils.ts
@@ -25,6 +25,10 @@ export const hasExperimentalFlag = (flag: string): boolean => {
   return getExperimentalFlags().includes(flag);
 };
 
+export const getSpanId = () => {
+  return new URLSearchParams(window.location.search).get(URLParam.JAEGER_SPAN_ID) || undefined;
+};
+
 export const getTraceId = () => {
   return new URLSearchParams(window.location.search).get(URLParam.JAEGER_TRACE_ID) || undefined;
 };


### PR DESCRIPTION
# New proprosal

Add to the tooltip the method of the span

![Screenshot from 2021-03-24 11-21-05](https://user-images.githubusercontent.com/3019213/112294446-3019a400-8c93-11eb-8c53-a362789f7f86.png)

When we click the span this redirect us to the traces tab with the span selected. This span will be expanded with a blue border on the right
![Screenshot from 2021-03-24 11-20-31](https://user-images.githubusercontent.com/3019213/112294462-30b23a80-8c93-11eb-832b-695489f0ce78.png)
