### PR TITLE
Links to Istio Dashboards

### DIFF
--- a/src/components/Metrics/CustomMetrics.tsx
+++ b/src/components/Metrics/CustomMetrics.tsx
@@ -223,7 +223,7 @@ class CustomMetrics extends React.Component<Props, MetricsState> {
             <MetricsRawAggregation onChanged={this.onRawAggregationChanged} />
           </ToolbarItem>
         </ToolbarGroup>
-        <ToolbarGroup>
+        <ToolbarGroup style={{ marginLeft: 'auto', paddingRight: '20px' }}>
           <GrafanaLinks
             links={this.state.grafanaLinks}
             namespace={this.props.namespace}

--- a/src/components/Metrics/IstioMetrics.tsx
+++ b/src/components/Metrics/IstioMetrics.tsx
@@ -277,7 +277,7 @@ class IstioMetrics extends React.Component<Props, MetricsState> {
             <MetricsReporter onChanged={this.onReporterChanged} direction={this.props.direction} />
           </ToolbarItem>
         </ToolbarGroup>
-        <ToolbarGroup>
+        <ToolbarGroup style={{ marginLeft: 'auto', paddingRight: '20px' }}>
           <GrafanaLinks
             links={this.state.grafanaLinks}
             namespace={this.props.namespace}

--- a/src/pages/Overview/OverviewNamespaceActions.tsx
+++ b/src/pages/Overview/OverviewNamespaceActions.tsx
@@ -8,11 +8,13 @@ import {
   Tooltip,
   TooltipPosition
 } from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 export type OverviewNamespaceAction = {
   isGroup: boolean;
   isSeparator: boolean;
   isDisabled: boolean;
+  isExternal?: boolean;
   title?: string;
   children?: OverviewNamespaceAction[];
   action?: (namespace: string) => void;
@@ -97,7 +99,7 @@ export class OverviewNamespaceActions extends React.Component<Props, State> {
             isDisabled={action.isDisabled}
             onClick={() => (action.action ? action.action(this.props.namespace) : undefined)}
           >
-            {action.title}
+            {action.title} {!!action.isExternal ? <ExternalLinkAltIcon /> : undefined}
           </DropdownItem>
         );
         return action.isDisabled

--- a/src/types/GrafanaInfo.ts
+++ b/src/types/GrafanaInfo.ts
@@ -1,5 +1,17 @@
 import { ExternalLink } from './Dashboards';
 
+export const ISTIO_MESH_DASHBOARD = 'Istio Mesh Dashboard';
+export const ISTIO_CONTROL_PLANE_DASHBOARD = 'Istio Control Plane Dashboard';
+export const ISTIO_PERFORMANCE_DASHBOARD = 'Istio Performance Dashboard';
+export const ISTIO_WASM_EXTENSION_DASHBOARD = 'Istio Wasm Extension Dashboard';
+
+export const ISTIO_DASHBOARDS: string[] = [
+  ISTIO_MESH_DASHBOARD,
+  ISTIO_CONTROL_PLANE_DASHBOARD,
+  ISTIO_PERFORMANCE_DASHBOARD,
+  ISTIO_WASM_EXTENSION_DASHBOARD
+];
+
 export interface GrafanaInfo {
   externalLinks: ExternalLink[];
 }


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/2731

This PR introduces a couple of changes in the Overview page.

First, it treats the Istio control plane namespace in a different way for actions (it won't show the Sidecar Injection actions and the security option).

Second, instead if grafana links are present, it should show the links to the external dashboards that are related not to the whole cluster but they refers to the control plane instead, so I thought that would be clean to connect them from the Istio control plane.

How to test:

- From the Kiali config add the dashboards:

```
  grafana:
    in_cluster_url: http://localhost:13000
    url: http://localhost:13000
    dashboards:
      - name: "Istio Service Dashboard"
        variables:
          namespace: "var-namespace"
          service: "var-service"
      - name: "Istio Workload Dashboard"
        variables:
          namespace: "var-namespace"
          workload: "var-workload"
      - name: "Istio Mesh Dashboard"
      - name: "Istio Control Plane Dashboard"
      - name: "Istio Performance Dashboard"
      - name: "Istio Wasm Extension Dashboard"
```      

And then Istio control plane namespace will show the external links:

![image](https://user-images.githubusercontent.com/1662329/110594088-a9d26d80-817c-11eb-9934-b5875a4d4b7b.png)

- If no present, Istio would not show the Sidecar / Traffic Policies actions nor the External Dashboards:

![image](https://user-images.githubusercontent.com/1662329/110594353-f74eda80-817c-11eb-9cb8-6083ce3e005d.png)

Note, that this PR would require that these new grafana dashboards should be updated in kiali operator and helm, but this PR could be tested and merged in an independent way. 

Operator PR can be added later.