### PR TITLE
Fix Health broken

### DIFF
--- a/src/components/FilterList/__tests__/OverviewPageHelper.test.ts
+++ b/src/components/FilterList/__tests__/OverviewPageHelper.test.ts
@@ -1,0 +1,105 @@
+import * as FilterHelper from '../FilterHelper';
+import NamespaceInfo from '../../../pages/Overview/NamespaceInfo';
+import * as Filters from '../../../pages/Overview/Filters';
+import { FilterSelected } from '../../Filters/StatefulFilters';
+
+const allNamespaces: NamespaceInfo[] = [
+  {
+    name: 'a',
+    status: {
+      inNotReady: [],
+      inError: [],
+      inWarning: ['a-tres'],
+      inSuccess: ['a-uno', 'a-dos'],
+      notAvailable: []
+    }
+  },
+  {
+    name: 'b',
+    status: {
+      inNotReady: [],
+      inError: ['b-tres'],
+      inWarning: ['b-dos'],
+      inSuccess: ['b-uno'],
+      notAvailable: []
+    }
+  },
+  {
+    name: 'c',
+    status: {
+      inNotReady: [],
+      inError: [],
+      inWarning: [],
+      inSuccess: ['c-uno', 'c-dos', 'c-tres'],
+      notAvailable: []
+    }
+  }
+];
+
+describe('Overview Page', () => {
+  it('filters Healthy namespaces', () => {
+    FilterSelected.setSelected({
+      filters: [
+        {
+          id: 'health',
+          title: 'Health',
+          value: 'Healthy'
+        }
+      ],
+      op: 'or'
+    });
+    const filteredNamespaces = FilterHelper.runFilters(
+      allNamespaces,
+      Filters.availableFilters,
+      FilterSelected.getSelected()
+    );
+
+    expect(filteredNamespaces.length).toEqual(1);
+    expect(filteredNamespaces[0].name).toEqual('c');
+  });
+
+  it('filters Warning namespaces', () => {
+    FilterSelected.setSelected({
+      filters: [
+        {
+          id: 'health',
+          title: 'Health',
+          value: 'Degraded'
+        }
+      ],
+      op: 'or'
+    });
+
+    const filteredNamespaces = FilterHelper.runFilters(
+      allNamespaces,
+      Filters.availableFilters,
+      FilterSelected.getSelected()
+    );
+
+    expect(filteredNamespaces.length).toEqual(2);
+    expect(filteredNamespaces[0].name).toEqual('a');
+    expect(filteredNamespaces[1].name).toEqual('b');
+  });
+
+  it('filters Failure namespaces', () => {
+    FilterSelected.setSelected({
+      filters: [
+        {
+          id: 'health',
+          title: 'Health',
+          value: 'Failure'
+        }
+      ],
+      op: 'or'
+    });
+
+    const filteredNamespaces = FilterHelper.runFilters(
+      allNamespaces,
+      Filters.availableFilters,
+      FilterSelected.getSelected()
+    );
+
+    expect(filteredNamespaces.length).toEqual(1);
+    expect(filteredNamespaces[0].name).toEqual('b');
+  });
+});

--- a/src/components/Link/IstioConfigListLink.tsx
+++ b/src/components/Link/IstioConfigListLink.tsx
@@ -39,8 +39,11 @@ class IstioConfigListLink extends React.Component<Props> {
     return params;
   };
 
-  render() {
+  cleanFilters = () => {
     FilterSelected.resetFilters();
+  };
+
+  render() {
     let params: string = this.namespacesToParams();
     const validationParams: string = this.validationToParams();
     if (params !== '' && validationParams !== '') {
@@ -48,7 +51,11 @@ class IstioConfigListLink extends React.Component<Props> {
     }
     params += validationParams;
 
-    return <Link to={`/${Paths.ISTIO}?${params}`}>{this.props.children}</Link>;
+    return (
+      <Link to={`/${Paths.ISTIO}?${params}`} onClick={this.cleanFilters}>
+        {this.props.children}
+      </Link>
+    );
   }
 }
 

--- a/src/components/Link/__tests__/__snapshots__/IstioConfigListLink.tsx.snap
+++ b/src/components/Link/__tests__/__snapshots__/IstioConfigListLink.tsx.snap
@@ -2,30 +2,35 @@
 
 exports[`Link with only namespaces and more than one renders the link with only one namespace 1`] = `
 <Link
+  onClick={[Function]}
   to="/istio?namespaces=bookinfo,istio-system,runtimes"
 />
 `;
 
 exports[`Link with only namespaces but only one namespace renders the link with only one namespace 1`] = `
 <Link
+  onClick={[Function]}
   to="/istio?namespaces=bookinfo"
 />
 `;
 
 exports[`Link with validation filters and both errors and warnings renders link with namespaces and only errors filters 1`] = `
 <Link
+  onClick={[Function]}
   to="/istio?namespaces=bookinfo,runtimes&configvalidation=Warning&configvalidation=Not+Valid"
 />
 `;
 
 exports[`Link with validation filters and only errors renders link with namespaces and only errors filters 1`] = `
 <Link
+  onClick={[Function]}
   to="/istio?namespaces=bookinfo,runtimes&configvalidation=Not+Valid"
 />
 `;
 
 exports[`Link with validation filters and only warnings renders link with namespaces and only warning filters 1`] = `
 <Link
+  onClick={[Function]}
   to="/istio?namespaces=bookinfo&configvalidation=Warning"
 />
 `;

--- a/src/components/VirtualList/Renderers.tsx
+++ b/src/components/VirtualList/Renderers.tsx
@@ -26,6 +26,7 @@ import { GetIstioObjectUrl } from '../Link/IstioObjectLink';
 import { labelFilter } from 'components/Filters/CommonFilters';
 import { labelFilter as NsLabelFilter } from '../../pages/Overview/Filters';
 import ValidationSummaryLink from '../Link/ValidationSummaryLink';
+import { ValidationStatus } from '../../types/IstioObjects';
 
 // Links
 
@@ -107,22 +108,27 @@ export const tls: Renderer<NamespaceInfo> = (ns: NamespaceInfo) => {
 };
 
 export const istioConfig: Renderer<NamespaceInfo> = (ns: NamespaceInfo) => {
-  let status: any = <small style={{ fontSize: '65%', marginLeft: '5px' }}>N/A</small>;
-  if (ns.validations) {
-    status = (
-      <td role="gridcell" key={'VirtuaItem_IstioConfig_' + ns.name} style={{ verticalAlign: 'middle' }}>
-        <ValidationSummaryLink namespace={ns.name} warnings={ns.validations.warnings} errors={ns.validations.errors}>
-          <ValidationSummary
-            id={'ns-val-' + ns.name}
-            errors={ns.validations.errors}
-            warnings={ns.validations.warnings}
-            objectCount={ns.validations.objectCount}
-            style={{ marginLeft: '5px' }}
-          />
-        </ValidationSummaryLink>
-      </td>
-    );
+  let validations: ValidationStatus = { objectCount: 0, errors: 0, warnings: 0 };
+  if (!!ns.validations) {
+    validations = ns.validations;
   }
+  const status = (
+    <td role="gridcell" key={'VirtuaItem_IstioConfig_' + ns.name} style={{ verticalAlign: 'middle' }}>
+      <ValidationSummaryLink
+        namespace={ns.name}
+        objectCount={validations.objectCount}
+        errors={validations.errors}
+        warnings={validations.warnings}
+      >
+        <ValidationSummary
+          id={'ns-val-' + ns.name}
+          errors={validations.errors}
+          warnings={validations.warnings}
+          objectCount={validations.objectCount}
+        />
+      </ValidationSummaryLink>
+    </td>
+  );
   return status;
 };
 

--- a/src/pages/Overview/Sorts.ts
+++ b/src/pages/Overview/Sorts.ts
@@ -60,16 +60,23 @@ export const sortFields: SortField<NamespaceInfo>[] = [
       if (a.validations && b.validations) {
         if (a.validations.errors === b.validations.errors) {
           if (a.validations.warnings === b.validations.warnings) {
-            return a.name.localeCompare(b.name);
-          } else if (a.validations.warnings > b.validations.warnings) {
-            return -1;
+            if (a.validations.objectCount && b.validations.objectCount) {
+              if (a.validations.objectCount === b.validations.objectCount) {
+                // If all equal, use name for sorting
+                return a.name.localeCompare(b.name);
+              } else {
+                return a.validations.objectCount > b.validations.objectCount ? -1 : 1;
+              }
+            } else if (a.validations.objectCount) {
+              return -1;
+            } else if (b.validations.objectCount) {
+              return 1;
+            }
           } else {
-            return 1;
+            return a.validations.warnings > b.validations.warnings ? -1 : 1;
           }
-        } else if (a.validations.errors > b.validations.errors) {
-          return -1;
         } else {
-          return 1;
+          return a.validations.errors > b.validations.errors ? -1 : 1;
         }
       } else if (a.validations) {
         return -1;

--- a/src/pages/Overview/__tests__/OverviewSort.test.ts
+++ b/src/pages/Overview/__tests__/OverviewSort.test.ts
@@ -1,0 +1,111 @@
+import NamespaceInfo from '../NamespaceInfo';
+import { sortFields, sortFunc } from '../Sorts';
+
+const allNamespaces: NamespaceInfo[] = [
+  {
+    name: 'alpha',
+    validations: {
+      objectCount: 0,
+      errors: 0,
+      warnings: 0
+    }
+  },
+  {
+    name: 'beta',
+    validations: {
+      objectCount: 0,
+      errors: 0,
+      warnings: 0
+    }
+  },
+  {
+    name: 'default',
+    validations: {
+      objectCount: 2,
+      errors: 0,
+      warnings: 0
+    }
+  },
+  {
+    name: 'electronic-shop',
+    validations: {
+      objectCount: 2,
+      errors: 0,
+      warnings: 0
+    }
+  },
+  {
+    name: 'fraud-detection',
+    validations: {
+      objectCount: 0,
+      errors: 0,
+      warnings: 0
+    }
+  },
+  {
+    name: 'istio-system',
+    validations: {
+      objectCount: 0,
+      errors: 0,
+      warnings: 0
+    }
+  },
+  {
+    name: 'travel-agency',
+    validations: {
+      objectCount: 0,
+      errors: 0,
+      warnings: 0
+    }
+  },
+  {
+    name: 'travel-control',
+    validations: {
+      objectCount: 0,
+      errors: 0,
+      warnings: 0
+    }
+  },
+  {
+    name: 'travel-portal',
+    validations: {
+      objectCount: 0,
+      errors: 0,
+      warnings: 0
+    }
+  }
+];
+
+const configSortField = sortFields[3];
+
+describe('Overview Page ', () => {
+  it('sorts config asc', () => {
+    const sortedNamespaces = sortFunc(allNamespaces, configSortField, true);
+    expect(sortedNamespaces.map(n => n.name)).toEqual([
+      'default',
+      'electronic-shop',
+      'alpha',
+      'beta',
+      'fraud-detection',
+      'istio-system',
+      'travel-agency',
+      'travel-control',
+      'travel-portal'
+    ]);
+  });
+
+  it('sorts config desc', () => {
+    const sortedNamespaces = sortFunc(allNamespaces, configSortField, false);
+    expect(sortedNamespaces.map(n => n.name)).toEqual([
+      'travel-portal',
+      'travel-control',
+      'travel-agency',
+      'istio-system',
+      'fraud-detection',
+      'beta',
+      'alpha',
+      'electronic-shop',
+      'default'
+    ]);
+  });
+});


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/3757
Fixes https://github.com/kiali/kiali/issues/3756

In short, as filters are stateful, they shouldn't be reset on render but on an action, otherwise it may have side effects.

This scenario was similar as this old one:

https://github.com/kiali/kiali-ui/blob/master/src/components/BreadcrumbView/BreadcrumbView.tsx#L120

I fixed and also added more tests on the filter case as I was not sure at first time if the problem was with some changes I did there.