### PR TITLE
Fix wrong collapsed state on charts

### DIFF
--- a/src/components/Charts/KChart.tsx
+++ b/src/components/Charts/KChart.tsx
@@ -77,6 +77,15 @@ class KChart<T extends LineInfo> extends React.Component<KChartProps<T>, State> 
     };
   }
 
+  componentDidUpdate(prevProps: KChartProps<T>) {
+    // If it starts collapsed because it's empty, then checks if there is new data to expand
+    if (this.state.collapsed && this.props.data.length !== prevProps.data.length) {
+      this.setState({
+        collapsed: false
+      });
+    }
+  }
+
   render() {
     return (
       <Expandable

--- a/src/components/Charts/KChart.tsx
+++ b/src/components/Charts/KChart.tsx
@@ -78,10 +78,13 @@ class KChart<T extends LineInfo> extends React.Component<KChartProps<T>, State> 
   }
 
   componentDidUpdate(prevProps: KChartProps<T>) {
-    // If it starts collapsed because it's empty, then checks if there is new data to expand
-    if (this.state.collapsed && this.props.data.length !== prevProps.data.length) {
+    // Check when there is a change on empty datapoints on a refresh to draw the chart collapsed the first time
+    // User can change the state after that point
+    const propsIsEmpty = !this.props.data.some(s => s.datapoints.length !== 0);
+    const prevPropsIsEmpty = !prevProps.data.some(s => s.datapoints.length !== 0);
+    if (propsIsEmpty !== prevPropsIsEmpty) {
       this.setState({
-        collapsed: false
+        collapsed: propsIsEmpty
       });
     }
   }


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/3693

How to reproduce:
- Identify a workload with traffic in only one side (Inbound or Outbound):

![image](https://user-images.githubusercontent.com/1662329/110819471-839cf280-828e-11eb-8ae7-12c3a55f28b4.png)

- Click in the tab with no traffic and check that charts are collapsed:

![image](https://user-images.githubusercontent.com/1662329/110819586-9c0d0d00-828e-11eb-9b16-6c892295e6a0.png)

- Click in the tab with traffic and verify that charts are expanded (instead to see them collapsed by default):

![image](https://user-images.githubusercontent.com/1662329/110819654-ae874680-828e-11eb-8a7a-59ca768b3558.png)
