### PR TITLE
Mesh page - Add column linking remote Kialis

### DIFF
--- a/src/types/Mesh.ts
+++ b/src/types/Mesh.ts
@@ -1,9 +1,18 @@
 export interface MeshCluster {
   apiEndpoint: string;
   isKialiHome: boolean;
+  kialiInstances: KialiInstance[];
   name: string;
   network: string;
   secretName: string;
+}
+
+export interface KialiInstance {
+  serviceName: string;
+  namespace: string;
+  operatorResource: string;
+  url: string;
+  version: string;
 }
 
 export type MeshClusters = MeshCluster[];


### PR DESCRIPTION
This adds a column in "Mesh" page to show the Kiali instances discovered in each listed cluster.

Format of the column is "namespace / service name". If the Kiali service has the "kiali.io/external-url" annotation, the value of that annotation is used to create links and allow the user to jump to those remote Kialis.

This is the result:

![image](https://user-images.githubusercontent.com/23639005/111009503-6b45da00-8359-11eb-9fd6-759cc97d2c9e.png)


Related back-end PR: https://github.com/kiali/kiali/pull/3768
Related operator PR: https://github.com/kiali/kiali-operator/pull/264

Fixes kiali/kiali#3526

