### PR TITLE
Relax matching on breadcrumb paths

### DIFF
--- a/src/components/BreadcrumbView/BreadcrumbView.tsx
+++ b/src/components/BreadcrumbView/BreadcrumbView.tsx
@@ -31,8 +31,8 @@ const ItemNames = {
 
 const IstioName = 'Istio Config';
 const Iter8Name = 'Iter8 Experiments';
-const namespaceRegex = /namespaces\/([a-z0-9-]+)\/([a-z0-9-]+)\/([a-z0-9-]+)(\/([a-z0-9-.]+))?(\/([a-z0-9-]+))?/;
-const extNamespaceRegex = /extensions\/namespaces\/([a-z0-9-]+)\/([a-z0-9-]+)\/([a-z0-9-]+)(\/([a-z0-9-.]+))?(\/([a-z0-9-]+))?/;
+const namespaceRegex = /namespaces\/([a-z0-9-]+)\/([\w-.]+)\/([\w-.]+)(\/([\w-.]+))?(\/([\w-.]+))?/;
+const extNamespaceRegex = /extensions\/namespaces\/([a-z0-9-]+)\/([\w-.]+)\/([\w-.]+)(\/([\w-.]+))?(\/([\w-.]+))?/;
 
 export class BreadcrumbView extends React.Component<BreadCumbViewProps, BreadCumbViewState> {
   static capitalize = (str: string) => {


### PR DESCRIPTION
Don't hold all parts of the breadcrumb path to valid k8s namespace value restrictions.  Let other parts conform to valid label value restrictions (see https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set)

Fixes https://github.com/kiali/kiali/issues/3776
