### PR TITLE
Always show locks in graph

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -597,7 +597,6 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps>
       boxByNamespace: this.props.boxByNamespace,
       edgeLabelMode: this.props.edgeLabelMode,
       graphType: this.props.graphData.fetchParams.graphType,
-      mtlsEnabled: this.props.isMTLSEnabled,
       showCircuitBreakers: this.props.showCircuitBreakers,
       showMissingSidecars: this.props.showMissingSidecars,
       showSecurity: this.props.showSecurity,

--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -35,7 +35,6 @@ let EdgeColorDegraded: PFColorVal;
 let EdgeColorFailure: PFColorVal;
 const EdgeColorTCPWithTraffic = PfColors.Blue600;
 const EdgeIconMTLS = icons.istio.mtls.ascii; // lock
-const EdgeIconDisabledMTLS = icons.istio.disabledMtls.ascii; // broken lock
 const EdgeTextOutlineColor = PfColors.White;
 const EdgeTextOutlineWidth = '1px';
 const EdgeTextFont = 'Verdana,Arial,Helvetica,sans-serif,pficon';
@@ -379,14 +378,8 @@ export class GraphStyles {
 
       const mtlsPercentage = edgeData.isMTLS;
       if (cyGlobal.showSecurity && edgeData.hasTraffic) {
-        if (cyGlobal.mtlsEnabled) {
-          if (!mtlsPercentage || mtlsPercentage < 100) {
-            content = `${EdgeIconDisabledMTLS} ${content}`;
-          }
-        } else {
-          if (mtlsPercentage && mtlsPercentage > 0) {
-            content = `${EdgeIconMTLS} ${content}`;
-          }
+        if (mtlsPercentage && mtlsPercentage > 0) {
+          content = `${EdgeIconMTLS} ${content}`;
         }
       }
 

--- a/src/types/Graph.ts
+++ b/src/types/Graph.ts
@@ -83,7 +83,6 @@ export type CytoscapeGlobalScratchData = {
   boxByNamespace: boolean;
   edgeLabelMode: EdgeLabelMode;
   graphType: GraphType;
-  mtlsEnabled: boolean;
   showCircuitBreakers: boolean;
   showMissingSidecars: boolean;
   showSecurity: boolean;


### PR DESCRIPTION
fix https://github.com/kiali/kiali/issues/3707

1. When mTLS is STRICTLY enabled at mesh-level, locks are present:

1.1 All connections use mTLS:
![Screenshot of Kiali (10)](https://user-images.githubusercontent.com/613814/111779583-9a5acf00-88b6-11eb-90d7-5c31c446da76.png)

1.2 Only details/ratings has mTLS disabled:
![Screenshot of Kiali (13)](https://user-images.githubusercontent.com/613814/111782991-00952100-88ba-11eb-9878-84b2f61579de.png)


When mTLS is not strictly enabled at mesh-level, lock are present too:

1.1 All connections use mTLS:
![Screenshot of Kiali (11)](https://user-images.githubusercontent.com/613814/111779935-0806fb00-88b7-11eb-90a7-ac2900280538.png)

1.2 Only details/ratings has mTLS:
When mTLS is not strictly enabled, but only details and ratings has mtls:
![Screenshot of Kiali (12)](https://user-images.githubusercontent.com/613814/111782149-fb83a200-88b8-11eb-9f2e-da8401fae04e.png)

