### PR TITLE
Fix the traffic animation issue

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import ReactResizeDetector from 'react-resize-detector';
 import Namespace from '../../types/Namespace';
 import { GraphHighlighter } from './graphs/GraphHighlighter';
-import TrafficRender from './TrafficAnimation/TrafficRenderer';
 import EmptyGraphLayout from './EmptyGraphLayout';
 import { CytoscapeReactWrapper } from './CytoscapeReactWrapper';
 import * as CytoscapeGraphUtils from './CytoscapeGraphUtils';
@@ -31,6 +30,7 @@ import { Core } from 'cytoscape';
 import { GraphData } from 'pages/Graph/GraphPage';
 import { JaegerTrace } from 'types/JaegerInfo';
 import { showTrace, hideTrace } from './CytoscapeTrace';
+import TrafficRenderer from './TrafficAnimation/TrafficRenderer';
 
 type CytoscapeGraphProps = {
   boxByCluster: boolean;
@@ -112,7 +112,7 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps>
   private needsInitialLayout: boolean;
   private nodeChanged: boolean;
   private resetSelection: boolean = false;
-  private trafficRenderer?: TrafficRender;
+  private trafficRenderer?: TrafficRenderer;
   private userBoxSelected?: Cy.Collection;
 
   constructor(props: CytoscapeGraphProps) {
@@ -174,41 +174,42 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps>
       this.needsInitialLayout = false;
     }
 
-    this.processGraphUpdate(cy, updateLayout);
+    this.processGraphUpdate(cy, updateLayout).then(_response => {
+      // pre-select node if provided
+      const node = this.props.graphData.fetchParams.node;
+      if (node && cy && cy.$(':selected').length === 0) {
+        let selector = "[nodeType = '" + node.nodeType + "']";
+        switch (node.nodeType) {
+          case NodeType.AGGREGATE:
+            selector =
+              selector + "[aggregate = '" + node.aggregate! + "'][aggregateValue = '" + node.aggregateValue! + "']";
+            break;
+          case NodeType.APP:
+          case NodeType.BOX: // we only support app box node graphs, treat like an app node
+            selector = selector + "[app = '" + node.app + "']";
+            if (node.version && node.version !== UNKNOWN) {
+              selector = selector + "[version = '" + node.version + "']";
+            }
+            break;
+          case NodeType.SERVICE:
+            selector = selector + "[service = '" + node.service + "']";
+            break;
+          default:
+            selector = selector + "[workload = '" + node.workload + "']";
+        }
 
-    // pre-select node if provided
-    const node = this.props.graphData.fetchParams.node;
-    if (node && cy && cy.$(':selected').length === 0) {
-      let selector = "[nodeType = '" + node.nodeType + "']";
-      switch (node.nodeType) {
-        case NodeType.AGGREGATE:
-          selector =
-            selector + "[aggregate = '" + node.aggregate! + "'][aggregateValue = '" + node.aggregateValue! + "']";
-          break;
-        case NodeType.APP:
-        case NodeType.BOX: // we only support app box node graphs, treat like an app node
-          selector = selector + "[app = '" + node.app + "']";
-          if (node.version && node.version !== UNKNOWN) {
-            selector = selector + "[version = '" + node.version + "']";
-          }
-          break;
-        case NodeType.SERVICE:
-          selector = selector + "[service = '" + node.service + "']";
-          break;
-        default:
-          selector = selector + "[workload = '" + node.workload + "']";
+        const eles = cy.nodes(selector);
+        if (eles.length > 0) {
+          this.selectTargetAndUpdateSummary(eles[0]);
+        }
       }
-      const eles = cy.nodes(selector);
-      if (eles.length > 0) {
-        this.selectTargetAndUpdateSummary(eles[0]);
-      }
-    }
 
-    if (this.props.trace) {
-      showTrace(cy, this.props.graphData.fetchParams.graphType, this.props.trace);
-    } else if (!this.props.trace && prevProps.trace) {
-      hideTrace(cy);
-    }
+      if (this.props.trace) {
+        showTrace(cy, this.props.graphData.fetchParams.graphType, this.props.trace);
+      } else if (!this.props.trace && prevProps.trace) {
+        hideTrace(cy);
+      }
+    });
   }
 
   render() {
@@ -298,7 +299,7 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps>
     this.contextMenuRef!.current!.connectCy(this.cy);
 
     this.graphHighlighter = new GraphHighlighter(cy);
-    this.trafficRenderer = new TrafficRender(cy, cy.edges());
+    this.trafficRenderer = new TrafficRenderer(cy);
 
     const getCytoscapeBaseEvent = (event: Cy.EventObject): CytoscapeBaseEvent | null => {
       const target = event.target;
@@ -534,6 +535,7 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps>
 
     cy.on('destroy', (_evt: Cy.EventObject) => {
       this.trafficRenderer!.stop();
+      this.trafficRenderer = undefined;
       this.cy = undefined;
       if (this.props.updateSummary) {
         this.props.updateSummary({ summaryType: 'graph', summaryTarget: undefined });
@@ -579,8 +581,8 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps>
     CytoscapeGraphUtils.safeFit(cy);
   }
 
-  private processGraphUpdate(cy: Cy.Core, updateLayout: boolean) {
-    this.trafficRenderer!.stop();
+  private processGraphUpdate(cy: Cy.Core, updateLayout: boolean): Promise<void> {
+    this.trafficRenderer!.pause();
 
     const isTheGraphSelected = cy.$(':selected').length === 0;
     if (this.resetSelection) {
@@ -620,11 +622,22 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps>
 
     cy.endBatch();
 
-    // Run layout and fit outside of the batch operation for it to take effect on the new nodes
+    // Run layout outside of the batch operation for it to take effect on the new nodes,
+    // Layouts can run async so wait until it completes to finish the graph update.
     if (updateLayout) {
-      CytoscapeGraphUtils.runLayout(cy, this.props.layout);
+      return new Promise((resolve, _reject) => {
+        CytoscapeGraphUtils.runLayout(cy, this.props.layout).then(_response => {
+          this.finishGraphUpdate(cy, isTheGraphSelected);
+          resolve();
+        });
+      });
+    } else {
+      this.finishGraphUpdate(cy, isTheGraphSelected);
+      return Promise.resolve();
     }
+  }
 
+  private finishGraphUpdate(cy: Cy.Core, isTheGraphSelected: boolean) {
     // We opt-in for manual selection to be able to control when to select a node/edge
     // https://github.com/cytoscape/cytoscape.js/issues/1145#issuecomment-153083828
     cy.nodes().unselectify();
@@ -635,10 +648,8 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps>
       this.handleTap({ summaryType: 'graph', summaryTarget: cy });
     }
 
-    // Update TrafficRenderer
-    this.trafficRenderer!.setEdges(cy.edges());
     if (this.props.showTrafficAnimation) {
-      this.trafficRenderer!.start();
+      this.trafficRenderer!.start(cy.edges());
     }
 
     // notify that the graph has been updated

--- a/src/components/CytoscapeGraph/CytoscapeGraphUtils.ts
+++ b/src/components/CytoscapeGraph/CytoscapeGraphUtils.ts
@@ -101,11 +101,10 @@ export const runLayout = (cy: Cy.Core, layout: Layout): Promise<any> => {
       appBoxLayout: 'dagre',
       defaultLayout: layout.name
     });
-    promise = cyLayout.promiseOn('boxlayoutstop');
   } else {
     cyLayout = cy.layout(layoutOptions);
-    promise = cyLayout.promiseOn('layoutstop');
   }
+  promise = cyLayout.promiseOn('layoutstop');
   cyLayout.run();
   return promise;
 };

--- a/src/components/CytoscapeGraph/CytoscapeGraphUtils.ts
+++ b/src/components/CytoscapeGraph/CytoscapeGraphUtils.ts
@@ -86,22 +86,28 @@ export const safeFit = (cy: Cy.Core, centerElements?: Cy.Collection) => {
   cy.emit('fit');
 };
 
-export const runLayout = (cy: Cy.Core, layout: Layout) => {
+export const runLayout = (cy: Cy.Core, layout: Layout): Promise<any> => {
   // Using an extension
   (cy as any).nodeHtmlLabel().updateNodeLabel(cy.nodes());
 
   const layoutOptions = LayoutDictionary.getLayout(layout);
+  let promise: Promise<any>;
+  let cyLayout: Cy.Layouts;
   if (cy.nodes('$node > node').length > 0) {
     // if there is any parent (i.e. box) node, run the box-layout
-    cy.layout({
+    cyLayout = cy.layout({
       ...layoutOptions,
       name: 'box-layout',
       appBoxLayout: 'dagre',
       defaultLayout: layout.name
-    }).run();
+    });
+    promise = cyLayout.promiseOn('boxlayoutstop');
   } else {
-    cy.layout(layoutOptions).run();
+    cyLayout = cy.layout(layoutOptions);
+    promise = cyLayout.promiseOn('layoutstop');
   }
+  cyLayout.run();
+  return promise;
 };
 
 export const decoratedEdgeData = (ele: Cy.EdgeSingular): DecoratedGraphEdgeData => {

--- a/src/components/CytoscapeGraph/FocusAnimation.ts
+++ b/src/components/CytoscapeGraph/FocusAnimation.ts
@@ -54,10 +54,10 @@ export default class FocusAnimation {
   // "this".
   processStep = () => {
     try {
-      if (this.startTimestamp === undefined) {
-        this.startTimestamp = Date.now();
-      }
       const current = Date.now();
+      if (this.startTimestamp === undefined) {
+        this.startTimestamp = current;
+      }
       const step = (current - this.startTimestamp) / ANIMATION_DURATION;
       this.layer.clear(this.context);
       this.layer.setTransform(this.context);

--- a/src/components/CytoscapeGraph/Layout/BoxLayout.ts
+++ b/src/components/CytoscapeGraph/Layout/BoxLayout.ts
@@ -130,6 +130,10 @@ export default class BoxLayout {
     this.runAsync();
   }
 
+  emit(events) {
+    this.emit(events);
+  }
+
   // Discrete layouts (dagre) always stop before layout.run() returns. Continuous layouts (cose,cola)
   // are started by layout.run() but may stop after run() returns. Because outer boxes require the inner
   // box layouts to complete, we need to force discrete behavior regardless of layout, and that is why
@@ -208,6 +212,8 @@ export default class BoxLayout {
         boxNode.removeScratch(STYLES_KEY);
         boxNode.removeScratch(PARENT_POSITION_KEY);
       });
+
+      this.emit('boxlayoutstop');
     });
 
     layout.run();

--- a/src/components/CytoscapeGraph/Layout/BoxLayout.ts
+++ b/src/components/CytoscapeGraph/Layout/BoxLayout.ts
@@ -130,8 +130,12 @@ export default class BoxLayout {
     this.runAsync();
   }
 
-  emit(events) {
-    this.emit(events);
+  /**
+   * This is a stub required by cytoscape to allow the layout impl to emit events
+   * @param _events space separated string of event names
+   */
+  emit(_events) {
+    // intentionally empty
   }
 
   // Discrete layouts (dagre) always stop before layout.run() returns. Continuous layouts (cose,cola)
@@ -213,7 +217,7 @@ export default class BoxLayout {
         boxNode.removeScratch(PARENT_POSITION_KEY);
       });
 
-      this.emit('boxlayoutstop');
+      this.emit('layoutstop');
     });
 
     layout.run();
@@ -292,9 +296,6 @@ export default class BoxLayout {
         const boxedNodes = boxNodes.children();
         for (const boxedNode of boxedNodes) {
           for (const edge of boxedNode.connectedEdges()) {
-            if (edge.source().id() === edge.target().parent().id()) {
-              console.log(`${edge.source().id()} === ${edge.target().parent().id()}`);
-            }
             const syntheticEdge = this.syntheticEdgeGenerator.getEdge(boxByType, edge.source(), edge.target());
             if (syntheticEdge) {
               syntheticEdges = syntheticEdges.add(this.cy.add(syntheticEdge));

--- a/src/components/CytoscapeGraph/TrafficAnimation/TrafficRenderer.ts
+++ b/src/components/CytoscapeGraph/TrafficAnimation/TrafficRenderer.ts
@@ -254,42 +254,42 @@ export default class TrafficRenderer {
   private trafficEdges: TrafficEdgeHash = {};
 
   private readonly layer;
-  private readonly canvas;
   private readonly context;
 
-  constructor(cy: any, edges: any) {
+  constructor(cy: any) {
     this.layer = cy.cyCanvas();
-    this.canvas = this.layer.getCanvas();
-    this.canvas.style['pointer-events'] = 'none';
-    this.context = this.canvas.getContext('2d');
-    this.setEdges(edges);
+    const canvas = this.layer.getCanvas();
+    canvas.style['pointer-events'] = 'none';
+    this.context = canvas.getContext('2d');
   }
 
   /**
    * Starts the rendering loop, discards any other rendering loop that was started
    */
-  start() {
-    this.stop();
+  start(edges: any) {
+    this.pause();
+    this.trafficEdges = this.processEdges(edges);
     this.animationTimer = window.setInterval(this.processStep, FRAME_RATE * 1000);
   }
 
   /**
    * Stops the rendering loop if any
    */
-  stop() {
-    if (this.animationTimer) {
+  pause() {
+    if (this.animationTimer !== undefined) {
       window.clearInterval(this.animationTimer);
+      this.layer.clear(this.context);
       this.animationTimer = undefined;
-      this.clear();
+      this.previousTimestamp = undefined;
     }
   }
 
-  setEdges(edges: any) {
-    this.trafficEdges = this.processEdges(edges);
-  }
-
-  clear() {
-    this.layer.clear(this.context);
+  /**
+   * Stops the rendering loop if any
+   */
+  stop() {
+    this.pause();
+    this.trafficEdges = {};
   }
 
   /**
@@ -298,10 +298,10 @@ export default class TrafficRenderer {
    */
   processStep = () => {
     try {
-      if (this.previousTimestamp === undefined) {
-        this.previousTimestamp = Date.now();
-      }
       const nextTimestamp = Date.now();
+      if (!this.previousTimestamp) {
+        this.previousTimestamp = nextTimestamp;
+      }
       const step = this.currentStep(nextTimestamp);
       this.layer.clear(this.context);
       this.layer.setTransform(this.context);

--- a/src/pages/Graph/GraphLegendData.ts
+++ b/src/pages/Graph/GraphLegendData.ts
@@ -62,8 +62,8 @@ const legendData: GraphLegendItem[] = [
   {
     title: 'Node Background',
     data: [
-      { label: 'External Namespace', icon: externalNamespaceImage },
-      { label: 'Restricted Namespace', icon: restrictedNamespaceImage }
+      { label: 'Unselected Namespace', icon: externalNamespaceImage },
+      { label: 'Restricted / External', icon: restrictedNamespaceImage }
     ]
   },
   {

--- a/src/pages/Graph/GraphToolbar/__tests__/__snapshots__/GraphLegend.test.tsx.snap
+++ b/src/pages/Graph/GraphToolbar/__tests__/__snapshots__/GraphLegend.test.tsx.snap
@@ -237,14 +237,14 @@ exports[`GraphLegend test should render correctly 1`] = `
           >
             <span>
               <img
-                alt="External Namespace"
+                alt="Unselected Namespace"
                 src="external-namespace.svg"
               />
             </span>
             <span
               className="f1hob5wc"
             >
-              External Namespace
+              Unselected Namespace
             </span>
           </div>
           <div
@@ -253,14 +253,14 @@ exports[`GraphLegend test should render correctly 1`] = `
           >
             <span>
               <img
-                alt="Restricted Namespace"
+                alt="Restricted / External"
                 src="restricted-namespace.svg"
               />
             </span>
             <span
               className="f1hob5wc"
             >
-              Restricted Namespace
+              Restricted / External
             </span>
           </div>
         </div>


### PR DESCRIPTION
Fix the traffic animation issue, which turned out to just be a symptom of a deeper problem.  It happened only when animation was enabled and the user enabled boxing, changed to an "app" graph type, or navigated to a graph with boxing (and yes, this took a long time to realize :)). The root cause was the fact that boxLayouts finish in an async fashion, and animation was started prior to the layout completing. Theoretically it could also happen without any boxing, but just using cola or cose-bilkent
layouts, which can also run async.

The solution is to introduce some promise logic to ensure we don't complete a graph update before a layout is complete.

* unrelated but included, a small change to legend labels based on some confusion reported by a community member.

Fixes https://github.com/kiali/kiali/issues/3755