### PR TITLE
IstioConfig New Form fixes and refactoring

### DIFF
--- a/src/components/DefaultSecondaryMasthead/DefaultSecondaryMasthead.tsx
+++ b/src/components/DefaultSecondaryMasthead/DefaultSecondaryMasthead.tsx
@@ -43,11 +43,13 @@ export default class DefaultSecondaryMasthead extends React.Component<Props> {
   showTitle() {
     let path = window.location.pathname;
     path = path.substr(path.lastIndexOf('/console') + '/console'.length + 1);
-    if (titles.includes(path)) {
+    if (titles.some(t => path.startsWith(t))) {
       let title = path.charAt(0).toUpperCase() + path.slice(1);
       let disabled = false;
-      if (path === 'istio/new') {
-        title = 'Create New Istio Config';
+      if (path.startsWith('istio/new/')) {
+        // 'istio/new/'.length() == 10
+        const objectType = path.substring(10);
+        title = 'Create ' + objectType;
       } else if (path === 'istio') {
         title = 'Istio Config';
       } else if (path === 'extensions/iter8') {

--- a/src/components/IstioActions/IstioActionsNamespaceDropdown.tsx
+++ b/src/components/IstioActions/IstioActionsNamespaceDropdown.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { Dropdown, DropdownItem, DropdownPosition, DropdownToggle } from '@patternfly/react-core';
+import { Dropdown, DropdownGroup, DropdownItem, DropdownPosition, DropdownToggle } from '@patternfly/react-core';
 import history from '../../app/History';
+import { NEW_ISTIO_RESOURCE } from '../../pages/IstioConfigNew/IstioConfigNewPage';
 
 type Props = {};
 
@@ -28,15 +29,22 @@ class IstioActionsNamespaceDropdown extends React.Component<Props, State> {
     });
   };
 
-  onClickCreate = () => {
-    history.push('/istio/new');
+  onClickCreate = (type: string) => {
+    history.push('/istio/new/' + type);
   };
 
   render() {
     const dropdownItems = [
-      <DropdownItem key="createIstioConfig" onClick={this.onClickCreate}>
-        Create New Istio Config
-      </DropdownItem>
+      <DropdownGroup
+        key={'group_create'}
+        label={'Create'}
+        className="kiali-group-menu"
+        children={NEW_ISTIO_RESOURCE.map(r => (
+          <DropdownItem key={'createIstioConfig_' + r.value} onClick={() => this.onClickCreate(r.value)}>
+            {r.label}
+          </DropdownItem>
+        ))}
+      />
     ];
     return (
       <Dropdown

--- a/src/components/IstioWizards/WizardActions.ts
+++ b/src/components/IstioWizards/WizardActions.ts
@@ -1230,12 +1230,9 @@ export const buildGateway = (name: string, namespace: string, state: GatewayStat
       // Default for istio scenarios, user may change it editing YAML
       selector: {},
       servers: state.gatewayServers.map(s => ({
-        port: {
-          number: +s.portNumber,
-          protocol: s.portProtocol,
-          name: s.portName
-        },
-        hosts: s.hosts
+        port: s.port,
+        hosts: s.hosts,
+        tls: s.tls
       }))
     }
   };

--- a/src/components/IstioWizards/WizardActions.ts
+++ b/src/components/IstioWizards/WizardActions.ts
@@ -22,6 +22,7 @@ import {
   PeerAuthenticationWorkloadSelector,
   RequestAuthentication,
   RouteDestination,
+  ServiceEntry,
   Sidecar,
   Source,
   StringMatch,
@@ -43,6 +44,7 @@ import { Workload } from '../../types/Workload';
 import { FaultInjectionRoute } from './FaultInjection';
 import { TimeoutRetryRoute } from './RequestTimeouts';
 import { GraphDefinition, NodeType } from '../../types/Graph';
+import { ServiceEntryState } from '../../pages/IstioConfigNew/ServiceEntryForm';
 
 export const WIZARD_TRAFFIC_SHIFTING = 'traffic_shifting';
 export const WIZARD_TCP_TRAFFIC_SHIFTING = 'tcp_traffic_shifting';
@@ -1334,6 +1336,20 @@ export const buildRequestAuthentication = (
     ra.spec.jwtRules = state.jwtRules;
   }
   return ra;
+};
+
+export const buildServiceEntry = (name: string, namespace: string, state: ServiceEntryState): ServiceEntry => {
+  const se: ServiceEntry = {
+    metadata: {
+      name: name,
+      namespace: namespace,
+      labels: {
+        [KIALI_WIZARD_LABEL]: 'ServiceEntry'
+      }
+    },
+    spec: state.serviceEntry
+  };
+  return se;
 };
 
 export const buildSidecar = (name: string, namespace: string, state: SidecarState): Sidecar => {

--- a/src/components/IstioWizards/WizardActions.ts
+++ b/src/components/IstioWizards/WizardActions.ts
@@ -1239,7 +1239,7 @@ export const buildGateway = (name: string, namespace: string, state: GatewayStat
       }))
     }
   };
-  state.selectorLabels
+  state.workloadSelectorLabels
     .trim()
     .split(',')
     .forEach(split => {

--- a/src/components/IstioWizards/WizardActions.ts
+++ b/src/components/IstioWizards/WizardActions.ts
@@ -1228,9 +1228,7 @@ export const buildGateway = (name: string, namespace: string, state: GatewayStat
     },
     spec: {
       // Default for istio scenarios, user may change it editing YAML
-      selector: {
-        istio: 'ingressgateway'
-      },
+      selector: {},
       servers: state.gatewayServers.map(s => ({
         port: {
           number: +s.portNumber,
@@ -1241,6 +1239,16 @@ export const buildGateway = (name: string, namespace: string, state: GatewayStat
       }))
     }
   };
+  state.selectorLabels
+    .trim()
+    .split(',')
+    .forEach(split => {
+      const labels = split.trim().split('=');
+      // It should be already validated with workloadSelectorValid, but just to add extra safe check
+      if (gw.spec.selector && labels.length === 2) {
+        gw.spec.selector[labels[0].trim()] = labels[1].trim();
+      }
+    });
   return gw;
 };
 

--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -231,8 +231,7 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
     return (
       this.props.match.params.namespace === prevProps.match.params.namespace &&
       this.props.match.params.object === prevProps.match.params.object &&
-      this.props.match.params.objectType === prevProps.match.params.objectType &&
-      this.props.match.params.objectSubtype === prevProps.match.params.objectSubtype
+      this.props.match.params.objectType === prevProps.match.params.objectType
     );
   }
 
@@ -284,9 +283,7 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
           const targetMessage =
             this.props.match.params.namespace +
             ' / ' +
-            (this.props.match.params.objectSubtype
-              ? this.props.match.params.objectSubtype
-              : this.props.match.params.objectType) +
+            this.props.match.params.objectType +
             ' / ' +
             this.props.match.params.object;
           AlertUtils.add('Changes applied on ' + targetMessage, 'default', MessageType.SUCCESS);

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm.tsx
@@ -215,7 +215,9 @@ class AuthorizationPolicyForm extends React.Component<Props, AuthorizationPolicy
         )}
         {this.state.policy === RULES && <RuleBuilder onAddRule={this.onAddRule} />}
         {this.state.policy === RULES && (
-          <RuleList action={this.state.action} ruleList={this.state.rules} onRemoveRule={this.onRemoveRule} />
+          <FormGroup label="Rule list" fieldId="apRuleList">
+            <RuleList action={this.state.action} ruleList={this.state.rules} onRemoveRule={this.onRemoveRule} />
+          </FormGroup>
         )}
       </>
     );

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm.tsx
@@ -176,7 +176,7 @@ class AuthorizationPolicyForm extends React.Component<Props, AuthorizationPolicy
           </FormSelect>
         </FormGroup>
         {this.state.policy === RULES && (
-          <FormGroup label="Add Workload Selector" fieldId="workloadSelectorSwitch">
+          <FormGroup label="Workload Selector" fieldId="workloadSelectorSwitch">
             <Switch
               id="workloadSelectorSwitch"
               label={' '}
@@ -215,7 +215,7 @@ class AuthorizationPolicyForm extends React.Component<Props, AuthorizationPolicy
         )}
         {this.state.policy === RULES && <RuleBuilder onAddRule={this.onAddRule} />}
         {this.state.policy === RULES && (
-          <FormGroup label="Rule list" fieldId="apRuleList">
+          <FormGroup label="Rule List" fieldId="apRuleList">
             <RuleList action={this.state.action} ruleList={this.state.rules} onRemoveRule={this.onRemoveRule} />
           </FormGroup>
         )}

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm.tsx
@@ -190,8 +190,8 @@ class AuthorizationPolicyForm extends React.Component<Props, AuthorizationPolicy
           <FormGroup
             fieldId="workloadLabels"
             label="Labels"
-            helperText="One or more labels to select a workload where AuthorizationPolicy is applied. Enter a label in the format <label>=<value>. Enter one or multiple labels separated by comma."
-            helperTextInvalid="Invalid labels format: One or more labels to select a workload where AuthorizationPolicy is applied. Enter a label in the format <label>=<value>. Enter one or multiple labels separated by comma."
+            helperText="One or more labels to select a workload where the AuthorizationPolicy is applied."
+            helperTextInvalid="Enter a label in the format <label>=<value>. Enter one or multiple labels separated by comma."
             isValid={this.state.workloadSelectorValid}
           >
             <TextInput

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/RuleBuilder.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/RuleBuilder.tsx
@@ -8,6 +8,7 @@ import ConditionBuilder, { Condition } from './When/ConditionBuilder';
 import ConditionList from './When/ConditionList';
 import { style } from 'typestyle';
 import { PfColors } from '../../../components/Pf/PfColors';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 
 type Props = {
   onAddRule: (rule: Rule) => void;
@@ -32,6 +33,11 @@ const warningStyle = style({
   marginLeft: 25,
   color: PfColors.Red100,
   textAlign: 'center'
+});
+
+const addRuleStyle = style({
+  marginLeft: 0,
+  paddingLeft: 0
 });
 
 class RuleBuilder extends React.Component<Props, State> {
@@ -127,7 +133,7 @@ class RuleBuilder extends React.Component<Props, State> {
   render() {
     return (
       <>
-        <FormGroup label="Add From" fieldId="addFromSwitch">
+        <FormGroup label="From" fieldId="addFromSwitch">
           <Switch
             id="addFromSwitch"
             label={' '}
@@ -150,7 +156,7 @@ class RuleBuilder extends React.Component<Props, State> {
             </FormGroup>
           </>
         )}
-        <FormGroup label="Add To" fieldId="addToSwitch">
+        <FormGroup label="To" fieldId="addToSwitch">
           <Switch
             id="addToSwitch"
             label={' '}
@@ -173,7 +179,7 @@ class RuleBuilder extends React.Component<Props, State> {
             </FormGroup>
           </>
         )}
-        <FormGroup label="Add When" fieldId="addWhenSwitch">
+        <FormGroup label="When" fieldId="addWhenSwitch">
           <Switch
             id="addWhenSwitch"
             label={' '}
@@ -197,13 +203,17 @@ class RuleBuilder extends React.Component<Props, State> {
           </>
         )}
         <FormGroup fieldId="addRule">
-          <Button variant="secondary" onClick={this.onAddRule} isDisabled={!this.canAddRule()}>
-            Add Rule
+          <Button
+            variant="link"
+            icon={<PlusCircleIcon />}
+            onClick={this.onAddRule}
+            isDisabled={!this.canAddRule()}
+            className={addRuleStyle}
+          >
+            Add Rule to Rule List
           </Button>
           {!this.canAddRule() && (
-            <span className={warningStyle}>
-              A Rule needs at least an item in "Add From", "Add To" or "Add When" sections
-            </span>
+            <span className={warningStyle}>A Rule needs at least an item in "From", "To" or "When" sections</span>
           )}
         </FormGroup>
       </>

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/RuleList.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/RuleList.tsx
@@ -12,8 +12,18 @@ type Props = {
 
 const headerCells: ICell[] = [
   {
-    title: 'Rules to match the request',
-    transforms: [cellWidth(100) as any],
+    title: 'From',
+    transforms: [cellWidth(40) as any],
+    props: {}
+  },
+  {
+    title: 'To',
+    transforms: [cellWidth(40) as any],
+    props: {}
+  },
+  {
+    title: 'When',
+    transforms: [cellWidth(40) as any],
     props: {}
   },
   {
@@ -42,7 +52,6 @@ class RuleList extends React.Component<Props> {
           <>
             {rule.from.length > 0 && (
               <>
-                <b>From:</b>
                 <>
                   {rule.from.map((fromItem, i) => {
                     const keys = Object.keys(fromItem);
@@ -62,9 +71,10 @@ class RuleList extends React.Component<Props> {
                 </>
               </>
             )}
+          </>,
+          <>
             {rule.to.length > 0 && (
               <>
-                <b>To:</b>
                 {rule.to.map((toItem, i) => {
                   const keys = Object.keys(toItem);
                   return (
@@ -82,9 +92,10 @@ class RuleList extends React.Component<Props> {
                 })}
               </>
             )}
+          </>,
+          <>
             {rule.when.length > 0 && (
               <>
-                <b>When:</b>
                 {rule.when.map((whenItem, i) => {
                   return (
                     <div id={'when' + i} className={rulesPadding}>

--- a/src/pages/IstioConfigNew/AuthorizationPolicyForm/RuleList.tsx
+++ b/src/pages/IstioConfigNew/AuthorizationPolicyForm/RuleList.tsx
@@ -27,6 +27,7 @@ const rulesPadding = style({
 });
 
 const noRulesStyle = style({
+  marginTop: 10,
   color: PfColors.Red100,
   textAlign: 'center',
   width: '100%'

--- a/src/pages/IstioConfigNew/GatewayForm/ServerBuilder.tsx
+++ b/src/pages/IstioConfigNew/GatewayForm/ServerBuilder.tsx
@@ -1,8 +1,11 @@
 import * as React from 'react';
 import { GatewayServer } from '../GatewayForm';
-import { FormGroup, FormSelect, FormSelectOption } from '@patternfly/react-core';
+import { Button, FormGroup, FormSelect, FormSelectOption } from '@patternfly/react-core';
 import { TextInputBase as TextInput } from '@patternfly/react-core/dist/js/components/TextInput/TextInput';
 import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
+import { style } from 'typestyle';
+import { PfColors } from '../../../components/Pf/PfColors';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 
 type Props = {
   onAddServer: (server: GatewayServer) => void;
@@ -15,6 +18,17 @@ type State = {
   newPortName: string;
   newPortProtocol: string;
 };
+
+const warningStyle = style({
+  marginLeft: 25,
+  color: PfColors.Red100,
+  textAlign: 'center'
+});
+
+const addServerStyle = style({
+  marginLeft: 0,
+  paddingLeft: 0
+});
 
 const portHeader: ICell[] = [
   {
@@ -48,6 +62,11 @@ class ServerBuilder extends React.Component<Props, State> {
     };
   }
 
+  canAddServer = (): boolean => {
+    console.log('TODELETE canAddServer');
+    return false;
+  };
+
   onAddHosts = (value: string, _) => {
     console.log('TODELETE onAddHosts ' + value);
   };
@@ -62,6 +81,10 @@ class ServerBuilder extends React.Component<Props, State> {
 
   onAddPortProtocol = (value: string, _) => {
     console.log('TODELETE onAddPortProtocol ' + value);
+  };
+
+  onAddServer = () => {
+    console.log('TODELETE onAddServer');
   };
 
   portRows() {
@@ -112,7 +135,7 @@ class ServerBuilder extends React.Component<Props, State> {
     return (
       <>
         <FormGroup
-          label="Add Hosts"
+          label="Hosts"
           isRequired={true}
           fieldId="gateway-selector"
           helperText="One or more hosts exposed by this gateway. Enter one or hosts separated by comma."
@@ -130,11 +153,23 @@ class ServerBuilder extends React.Component<Props, State> {
             isValid={this.state.isHostsValid}
           />
         </FormGroup>
-        <FormGroup label="Add Port" isRequired={true} fieldId="server-port">
+        <FormGroup label="Port" isRequired={true} fieldId="server-port">
           <Table aria-label="Port Level MTLS" cells={portHeader} rows={this.portRows()}>
             <TableHeader />
             <TableBody />
           </Table>
+        </FormGroup>
+        <FormGroup fieldId="addRule">
+          <Button
+            variant="link"
+            icon={<PlusCircleIcon />}
+            onClick={this.onAddServer}
+            isDisabled={!this.canAddServer()}
+            className={addServerStyle}
+          >
+            Add Server to Server List
+          </Button>
+          {!this.canAddServer() && <span className={warningStyle}>A Server needs Hosts and Port sections defined</span>}
         </FormGroup>
       </>
     );

--- a/src/pages/IstioConfigNew/GatewayForm/ServerBuilder.tsx
+++ b/src/pages/IstioConfigNew/GatewayForm/ServerBuilder.tsx
@@ -313,7 +313,7 @@ class ServerBuilder extends React.Component<Props, State> {
         )}
         {showTls && this.state.newTlsMode === 'MUTUAL' && (
           <FormGroup
-            label="CA Cert"
+            label="CA Certificate"
             isRequired={true}
             fieldId="ca-certificate"
             isValid={this.state.newTlsCaCertificate.length > 0}

--- a/src/pages/IstioConfigNew/GatewayForm/ServerBuilder.tsx
+++ b/src/pages/IstioConfigNew/GatewayForm/ServerBuilder.tsx
@@ -1,14 +1,15 @@
 import * as React from 'react';
-import { GatewayServer } from '../GatewayForm';
 import { Button, FormGroup, FormSelect, FormSelectOption } from '@patternfly/react-core';
 import { TextInputBase as TextInput } from '@patternfly/react-core/dist/js/components/TextInput/TextInput';
 import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
 import { style } from 'typestyle';
 import { PfColors } from '../../../components/Pf/PfColors';
 import { PlusCircleIcon } from '@patternfly/react-icons';
+import { isGatewayHostValid } from '../../../utils/IstioConfigUtils';
+import { Server } from '../../../types/IstioObjects';
 
 type Props = {
-  onAddServer: (server: GatewayServer) => void;
+  onAddServer: (server: Server) => void;
 };
 
 type State = {
@@ -17,6 +18,10 @@ type State = {
   newPortNumber: string;
   newPortName: string;
   newPortProtocol: string;
+  newTlsMode: string;
+  newTlsServerCertificate: string;
+  newTlsPrivateKey: string;
+  newTlsCaCertificate: string;
 };
 
 const warningStyle = style({
@@ -50,6 +55,8 @@ const portHeader: ICell[] = [
 
 const protocols = ['HTTP', 'HTTPS', 'GRPC', 'HTTP2', 'MONGO', 'TCP', 'TLS'];
 
+const tlsModes = ['PASSTHROUGH', 'SIMPLE', 'MUTUAL', 'AUTO_PASSTHROUGH', 'ISTIO_MUTUAL'];
+
 class ServerBuilder extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
@@ -58,33 +65,128 @@ class ServerBuilder extends React.Component<Props, State> {
       isHostsValid: false,
       newPortNumber: '',
       newPortName: '',
-      newPortProtocol: protocols[0]
+      newPortProtocol: protocols[0],
+      newTlsMode: tlsModes[1], // SIMPLE
+      newTlsServerCertificate: '',
+      newTlsPrivateKey: '',
+      newTlsCaCertificate: ''
     };
   }
 
   canAddServer = (): boolean => {
-    console.log('TODELETE canAddServer');
-    return false;
+    const hostValid = this.state.isHostsValid;
+    const portNumberValid = this.state.newPortNumber.length > 0 && !isNaN(Number(this.state.newPortNumber));
+    const portNameValid = this.state.newPortName.length > 0;
+    const tlsRequired = this.state.newPortProtocol === 'HTTPS' || this.state.newPortProtocol === 'TLS';
+    const tlsCertsValid = tlsRequired
+      ? (this.state.newTlsMode === 'SIMPLE' || this.state.newTlsMode === 'MUTUAL') &&
+        this.state.newTlsServerCertificate.length > 0 &&
+        this.state.newTlsPrivateKey.length > 0
+      : true;
+    const tlsCaValid =
+      tlsRequired && this.state.newTlsMode === 'MUTUAL' ? this.state.newTlsCaCertificate.length > 0 : true;
+    return hostValid && portNumberValid && portNameValid && tlsCertsValid && tlsCaValid;
+  };
+
+  areValidHosts = (hosts: string[]): boolean => {
+    if (hosts.length === 0) {
+      return false;
+    }
+    let isValid = true;
+    for (let i = 0; i < hosts.length; i++) {
+      if (!isGatewayHostValid(hosts[i])) {
+        isValid = false;
+        break;
+      }
+    }
+    return isValid;
   };
 
   onAddHosts = (value: string, _) => {
-    console.log('TODELETE onAddHosts ' + value);
+    const hosts = value.trim().length === 0 ? [] : value.split(',').map(host => host.trim());
+    this.setState({
+      newHosts: hosts,
+      isHostsValid: this.areValidHosts(hosts)
+    });
   };
 
   onAddPortNumber = (value: string, _) => {
-    console.log('TODELETE onAddPortNumber ' + value);
+    this.setState({
+      newPortNumber: value.trim()
+    });
   };
 
   onAddPortName = (value: string, _) => {
-    console.log('TODELETE onAddPortName ' + value);
+    this.setState({
+      newPortName: value.trim()
+    });
   };
 
   onAddPortProtocol = (value: string, _) => {
-    console.log('TODELETE onAddPortProtocol ' + value);
+    this.setState({
+      newPortProtocol: value
+    });
   };
 
   onAddServer = () => {
-    console.log('TODELETE onAddServer');
+    const newServer: Server = {
+      hosts: this.state.newHosts,
+      port: {
+        number: +this.state.newPortNumber,
+        name: this.state.newPortName,
+        protocol: this.state.newPortProtocol
+      }
+    };
+    if (this.state.newPortProtocol === 'HTTPS' || this.state.newPortProtocol === 'TLS') {
+      newServer.tls = {
+        mode: this.state.newTlsMode
+      };
+      if (this.state.newTlsMode === 'SIMPLE' || this.state.newTlsMode === 'MUTUAL') {
+        newServer.tls.privateKey = this.state.newTlsPrivateKey;
+        newServer.tls.serverCertificate = this.state.newTlsServerCertificate;
+      }
+      if (this.state.newTlsMode === 'MUTUAL') {
+        newServer.tls.caCertificates = this.state.newTlsCaCertificate;
+      }
+    }
+    this.setState(
+      {
+        newHosts: [],
+        isHostsValid: false,
+        newPortNumber: '',
+        newPortName: '',
+        newPortProtocol: protocols[0],
+        newTlsMode: tlsModes[1], // SIMPLE
+        newTlsServerCertificate: '',
+        newTlsPrivateKey: '',
+        newTlsCaCertificate: ''
+      },
+      () => this.props.onAddServer(newServer)
+    );
+  };
+
+  onAddTlsMode = (value: string, _) => {
+    this.setState({
+      newTlsMode: value
+    });
+  };
+
+  onAddTlsServerCertificate = (value: string, _) => {
+    this.setState({
+      newTlsServerCertificate: value
+    });
+  };
+
+  onAddTlsPrivateKey = (value: string, _) => {
+    this.setState({
+      newTlsPrivateKey: value
+    });
+  };
+
+  onAddTlsCaCertificate = (value: string, _) => {
+    this.setState({
+      newTlsCaCertificate: value
+    });
   };
 
   portRows() {
@@ -95,7 +197,7 @@ class ServerBuilder extends React.Component<Props, State> {
           <>
             <TextInput
               value={this.state.newPortNumber}
-              type="number"
+              type="text"
               id="addPortNumber"
               aria-describedby="add port number"
               name="addPortNumber"
@@ -132,14 +234,15 @@ class ServerBuilder extends React.Component<Props, State> {
   }
 
   render() {
+    const showTls = this.state.newPortProtocol === 'HTTPS' || this.state.newPortProtocol === 'TLS';
     return (
       <>
         <FormGroup
           label="Hosts"
           isRequired={true}
           fieldId="gateway-selector"
-          helperText="One or more hosts exposed by this gateway. Enter one or hosts separated by comma."
-          helperTextInvalid="Invalid hosts for this gateway. Enter one or hosts separated by comma."
+          helperText="One or more hosts exposed by this Gateway."
+          helperTextInvalid="Invalid hosts for this Gateway. Enter one or hosts separated by comma."
           isValid={this.state.isHostsValid}
         >
           <TextInput
@@ -159,6 +262,77 @@ class ServerBuilder extends React.Component<Props, State> {
             <TableBody />
           </Table>
         </FormGroup>
+        {showTls && (
+          <FormGroup label="TLS Mode" isRequired={true} fieldId="addTlsMode">
+            <FormSelect value={this.state.newTlsMode} id="addTlsMode" name="addTlsMode" onChange={this.onAddTlsMode}>
+              {tlsModes.map((option, index) => (
+                <FormSelectOption isDisabled={false} key={'p' + index} value={option} label={option} />
+              ))}
+            </FormSelect>
+          </FormGroup>
+        )}
+        {showTls && (this.state.newTlsMode === 'SIMPLE' || this.state.newTlsMode === 'MUTUAL') && (
+          <>
+            <FormGroup
+              label="Server Cert"
+              isRequired={true}
+              fieldId="server-certificate"
+              isValid={this.state.newTlsServerCertificate.length > 0}
+              helperTextInvalid={'The path to the file holding the server-side TLS certificate to use.'}
+            >
+              <TextInput
+                value={this.state.newTlsServerCertificate}
+                isRequired={true}
+                type="text"
+                id="server-certificate"
+                aria-describedby="server-certificate"
+                name="server-certificate"
+                onChange={this.onAddTlsServerCertificate}
+                isValid={this.state.newTlsServerCertificate.length > 0}
+              />
+            </FormGroup>
+            <FormGroup
+              label="Private Key"
+              isRequired={true}
+              fieldId="private-key"
+              isValid={this.state.newTlsPrivateKey.length > 0}
+              helperTextInvalid={'The path to the file holding the server’s private key.'}
+            >
+              <TextInput
+                value={this.state.newTlsPrivateKey}
+                isRequired={true}
+                type="text"
+                id="private-key"
+                aria-describedby="private-key"
+                name="private-key"
+                onChange={this.onAddTlsPrivateKey}
+                isValid={this.state.newTlsPrivateKey.length > 0}
+              />
+            </FormGroup>
+          </>
+        )}
+        {showTls && this.state.newTlsMode === 'MUTUAL' && (
+          <FormGroup
+            label="CA Cert"
+            isRequired={true}
+            fieldId="ca-certificate"
+            isValid={this.state.newTlsCaCertificate.length > 0}
+            helperTextInvalid={
+              'The path to a file containing certificate authority certificates to use in verifying a presented client side certificate.'
+            }
+          >
+            <TextInput
+              value={this.state.newTlsCaCertificate}
+              isRequired={true}
+              type="text"
+              id="ca-certificate"
+              aria-describedby="ca-certificate"
+              name="ca-certificate"
+              onChange={this.onAddTlsCaCertificate}
+              isValid={this.state.newTlsCaCertificate.length > 0}
+            />
+          </FormGroup>
+        )}
         <FormGroup fieldId="addRule">
           <Button
             variant="link"

--- a/src/pages/IstioConfigNew/GatewayForm/ServerBuilder.tsx
+++ b/src/pages/IstioConfigNew/GatewayForm/ServerBuilder.tsx
@@ -1,0 +1,144 @@
+import * as React from 'react';
+import { GatewayServer } from '../GatewayForm';
+import { FormGroup, FormSelect, FormSelectOption } from '@patternfly/react-core';
+import { TextInputBase as TextInput } from '@patternfly/react-core/dist/js/components/TextInput/TextInput';
+import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
+
+type Props = {
+  onAddServer: (server: GatewayServer) => void;
+};
+
+type State = {
+  newHosts: string[];
+  isHostsValid: boolean;
+  newPortNumber: string;
+  newPortName: string;
+  newPortProtocol: string;
+};
+
+const portHeader: ICell[] = [
+  {
+    title: 'Port Number',
+    transforms: [cellWidth(20) as any],
+    props: {}
+  },
+  {
+    title: 'Port Name',
+    transforms: [cellWidth(20) as any],
+    props: {}
+  },
+  {
+    title: 'Protocol',
+    transforms: [cellWidth(20) as any],
+    props: {}
+  }
+];
+
+const protocols = ['HTTP', 'HTTPS', 'GRPC', 'HTTP2', 'MONGO', 'TCP', 'TLS'];
+
+class ServerBuilder extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      newHosts: [],
+      isHostsValid: false,
+      newPortNumber: '',
+      newPortName: '',
+      newPortProtocol: protocols[0]
+    };
+  }
+
+  onAddHosts = (value: string, _) => {
+    console.log('TODELETE onAddHosts ' + value);
+  };
+
+  onAddPortNumber = (value: string, _) => {
+    console.log('TODELETE onAddPortNumber ' + value);
+  };
+
+  onAddPortName = (value: string, _) => {
+    console.log('TODELETE onAddPortName ' + value);
+  };
+
+  onAddPortProtocol = (value: string, _) => {
+    console.log('TODELETE onAddPortProtocol ' + value);
+  };
+
+  portRows() {
+    return [
+      {
+        keys: 'gatewayPortNew',
+        cells: [
+          <>
+            <TextInput
+              value={this.state.newPortNumber}
+              type="number"
+              id="addPortNumber"
+              aria-describedby="add port number"
+              name="addPortNumber"
+              onChange={this.onAddPortNumber}
+              isValid={this.state.newPortNumber.length > 0 && !isNaN(Number(this.state.newPortNumber))}
+            />
+          </>,
+          <>
+            <TextInput
+              value={this.state.newPortName}
+              type="text"
+              id="addPortName"
+              aria-describedby="add port name"
+              name="addPortName"
+              onChange={this.onAddPortName}
+              isValid={this.state.newPortName.length > 0}
+            />
+          </>,
+          <>
+            <FormSelect
+              value={this.state.newPortProtocol}
+              id="addPortProtocol"
+              name="addPortProtocol"
+              onChange={this.onAddPortProtocol}
+            >
+              {protocols.map((option, index) => (
+                <FormSelectOption isDisabled={false} key={'p' + index} value={option} label={option} />
+              ))}
+            </FormSelect>
+          </>
+        ]
+      }
+    ];
+  }
+
+  render() {
+    return (
+      <>
+        <FormGroup
+          label="Add Hosts"
+          isRequired={true}
+          fieldId="gateway-selector"
+          helperText="One or more hosts exposed by this gateway. Enter one or hosts separated by comma."
+          helperTextInvalid="Invalid hosts for this gateway. Enter one or hosts separated by comma."
+          isValid={this.state.isHostsValid}
+        >
+          <TextInput
+            value={this.state.newHosts.join(',')}
+            isRequired={true}
+            type="text"
+            id="hosts"
+            aria-describedby="hosts"
+            name="hosts"
+            onChange={this.onAddHosts}
+            isValid={this.state.isHostsValid}
+          />
+        </FormGroup>
+        <FormGroup label="Add Port" isRequired={true} fieldId="server-port">
+          <Table aria-label="Port Level MTLS" cells={portHeader} rows={this.portRows()}>
+            <TableHeader />
+            <TableBody />
+          </Table>
+        </FormGroup>
+      </>
+    );
+  }
+}
+
+export default ServerBuilder;

--- a/src/pages/IstioConfigNew/GatewayForm/ServerBuilder.tsx
+++ b/src/pages/IstioConfigNew/GatewayForm/ServerBuilder.tsx
@@ -79,9 +79,9 @@ class ServerBuilder extends React.Component<Props, State> {
     const portNameValid = this.state.newPortName.length > 0;
     const tlsRequired = this.state.newPortProtocol === 'HTTPS' || this.state.newPortProtocol === 'TLS';
     const tlsCertsValid = tlsRequired
-      ? (this.state.newTlsMode === 'SIMPLE' || this.state.newTlsMode === 'MUTUAL') &&
-        this.state.newTlsServerCertificate.length > 0 &&
-        this.state.newTlsPrivateKey.length > 0
+      ? this.state.newTlsMode === 'SIMPLE' || this.state.newTlsMode === 'MUTUAL'
+        ? this.state.newTlsServerCertificate.length > 0 && this.state.newTlsPrivateKey.length > 0
+        : true
       : true;
     const tlsCaValid =
       tlsRequired && this.state.newTlsMode === 'MUTUAL' ? this.state.newTlsCaCertificate.length > 0 : true;
@@ -274,7 +274,7 @@ class ServerBuilder extends React.Component<Props, State> {
         {showTls && (this.state.newTlsMode === 'SIMPLE' || this.state.newTlsMode === 'MUTUAL') && (
           <>
             <FormGroup
-              label="Server Cert"
+              label="Server Certificate"
               isRequired={true}
               fieldId="server-certificate"
               isValid={this.state.newTlsServerCertificate.length > 0}

--- a/src/pages/IstioConfigNew/GatewayForm/ServerList.tsx
+++ b/src/pages/IstioConfigNew/GatewayForm/ServerList.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { GatewayServer } from '../GatewayForm';
+
+type Props = {
+  serverList: GatewayServer[];
+  onRemoveServer: (index: number) => void;
+};
+
+class ServerList extends React.Component<Props> {
+  render() {
+    return <>The Gateway Server List</>;
+  }
+}
+
+export default ServerList;

--- a/src/pages/IstioConfigNew/GatewayForm/ServerList.tsx
+++ b/src/pages/IstioConfigNew/GatewayForm/ServerList.tsx
@@ -18,7 +18,17 @@ const noServerStyle = style({
 
 const headerCells: ICell[] = [
   {
-    title: 'Gateway Servers',
+    title: 'Server Hosts',
+    transforms: [cellWidth(100) as any],
+    props: {}
+  },
+  {
+    title: 'Port',
+    transforms: [cellWidth(20) as any],
+    props: {}
+  },
+  {
+    title: 'TLS',
     transforms: [cellWidth(100) as any],
     props: {}
   },
@@ -35,16 +45,31 @@ class ServerList extends React.Component<Props> {
         key: 'server_' + i,
         cells: [
           <>
+            {server.hosts.map(host => (
+              <div>{host}</div>
+            ))}
+          </>,
+          <>
+            <div>{server.port.name}</div>
             <div>
-              <span>
-                <b>Hosts:</b> [{server.hosts.join(',')}]
-              </span>
+              [{server.port.number}, {server.port.protocol}]
             </div>
-            <div>
-              <span>
-                <b>Port:</b> [{server.port.name}, {server.port.number}, {server.port.protocol}]
-              </span>
-            </div>
+          </>,
+          <>
+            {server.tls ? (
+              <>
+                <div>{server.tls.mode}</div>
+                {server.tls.serverCertificate && server.tls.serverCertificate.length > 0 ? (
+                  <div>[{server.tls.serverCertificate}]</div>
+                ) : undefined}
+                {server.tls.privateKey && server.tls.privateKey.length > 0 ? (
+                  <div>[{server.tls.privateKey}]</div>
+                ) : undefined}
+                {server.tls.caCertificates && server.tls.caCertificates.length > 0 ? (
+                  <div>[{server.tls.caCertificates}]</div>
+                ) : undefined}
+              </>
+            ) : undefined}
           </>,
           <></>
         ]

--- a/src/pages/IstioConfigNew/GatewayForm/ServerList.tsx
+++ b/src/pages/IstioConfigNew/GatewayForm/ServerList.tsx
@@ -1,14 +1,85 @@
 import * as React from 'react';
-import { GatewayServer } from '../GatewayForm';
+import { Server } from '../../../types/IstioObjects';
+import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
+import { style } from 'typestyle';
+import { PfColors } from '../../../components/Pf/PfColors';
 
 type Props = {
-  serverList: GatewayServer[];
+  serverList: Server[];
   onRemoveServer: (index: number) => void;
 };
 
+const noServerStyle = style({
+  marginTop: 10,
+  color: PfColors.Red100,
+  textAlign: 'center',
+  width: '100%'
+});
+
+const headerCells: ICell[] = [
+  {
+    title: 'Gateway Servers',
+    transforms: [cellWidth(100) as any],
+    props: {}
+  },
+  {
+    title: '',
+    props: {}
+  }
+];
+
 class ServerList extends React.Component<Props> {
+  rows = () => {
+    return this.props.serverList.map((server, i) => {
+      return {
+        key: 'server_' + i,
+        cells: [
+          <>
+            <div>
+              <span>
+                <b>Hosts:</b> [{server.hosts.join(',')}]
+              </span>
+            </div>
+            <div>
+              <span>
+                <b>Port:</b> [{server.port.name}, {server.port.number}, {server.port.protocol}]
+              </span>
+            </div>
+          </>,
+          <></>
+        ]
+      };
+    });
+  };
+
+  // @ts-ignore
+  actionResolver = (rowData, { rowIndex }) => {
+    const removeAction = {
+      title: 'Remove Rule',
+      // @ts-ignore
+      onClick: (event, rowIndex, rowData, extraData) => {
+        this.props.onRemoveServer(rowIndex);
+      }
+    };
+    return [removeAction];
+  };
+
   render() {
-    return <>The Gateway Server List</>;
+    return (
+      <>
+        <Table
+          aria-label="Server List"
+          cells={headerCells}
+          rows={this.rows()}
+          // @ts-ignore
+          actionResolver={this.actionResolver}
+        >
+          <TableHeader />
+          <TableBody />
+        </Table>
+        {this.props.serverList.length === 0 && <div className={noServerStyle}>No Servers defined</div>}
+      </>
+    );
   }
 }
 

--- a/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
+++ b/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
@@ -19,6 +19,7 @@ import {
   buildGateway,
   buildPeerAuthentication,
   buildRequestAuthentication,
+  buildServiceEntry,
   buildSidecar
 } from '../../components/IstioWizards/WizardActions';
 import { MessageType } from '../../types/MessageCenter';
@@ -47,6 +48,13 @@ import { isValidK8SName } from '../../helpers/ValidationHelpers';
 import DefaultSecondaryMasthead from '../../components/DefaultSecondaryMasthead/DefaultSecondaryMasthead';
 import { RouteComponentProps } from 'react-router-dom';
 import { PfColors } from '../../components/Pf/PfColors';
+import ServiceEntryForm, {
+  initServiceEntry,
+  isServiceEntryValid,
+  SERVICE_ENTRIES,
+  SERVICE_ENTRY,
+  ServiceEntryState
+} from './ServiceEntryForm';
 
 export interface IstioConfigNewPageId {
   objectType: string;
@@ -63,6 +71,7 @@ type State = {
   gateway: GatewayState;
   peerAuthentication: PeerAuthenticationState;
   requestAuthentication: RequestAuthenticationState;
+  serviceEntry: ServiceEntryState;
   sidecar: SidecarState;
 };
 
@@ -80,6 +89,7 @@ const DIC = {
   Gateway: GATEWAYS,
   PeerAuthentication: PEER_AUTHENTICATIONS,
   RequestAuthentication: REQUEST_AUTHENTICATIONS,
+  ServiceEntry: SERVICE_ENTRIES,
   Sidecar: SIDECARS
 };
 
@@ -89,6 +99,7 @@ export const NEW_ISTIO_RESOURCE = [
   { value: GATEWAY, label: GATEWAY, disabled: false },
   { value: PEER_AUTHENTICATION, label: PEER_AUTHENTICATION, disabled: false },
   { value: REQUEST_AUTHENTICATION, label: REQUEST_AUTHENTICATION, disabled: false },
+  { value: SERVICE_ENTRY, label: SERVICE_ENTRY, disabled: false },
   { value: SIDECAR, label: SIDECAR, disabled: false }
 ];
 
@@ -99,6 +110,7 @@ const initState = (): State => ({
   gateway: initGateway(),
   peerAuthentication: initPeerAuthentication(),
   requestAuthentication: initRequestAuthentication(),
+  serviceEntry: initServiceEntry(),
   // Init with the istio-system/* for sidecar
   sidecar: initSidecar(serverConfig.istioNamespace + '/*')
 });
@@ -196,6 +208,12 @@ class IstioConfigNewPage extends React.Component<Props, State> {
             json: JSON.stringify(buildRequestAuthentication(this.state.name, ns.name, this.state.requestAuthentication))
           });
           break;
+        case SERVICE_ENTRY:
+          jsonIstioObjects.push({
+            namespace: ns.name,
+            json: JSON.stringify(buildServiceEntry(this.state.name, ns.name, this.state.serviceEntry))
+          });
+          break;
         case SIDECAR:
           jsonIstioObjects.push({
             namespace: ns.name,
@@ -240,6 +258,8 @@ class IstioConfigNewPage extends React.Component<Props, State> {
         return isPeerAuthenticationStateValid(this.state.peerAuthentication);
       case REQUEST_AUTHENTICATION:
         return isRequestAuthenticationStateValid(this.state.requestAuthentication);
+      case SERVICE_ENTRY:
+        return isServiceEntryValid(this.state.serviceEntry);
       case SIDECAR:
         return isSidecarStateValid(this.state.sidecar);
       default:
@@ -285,6 +305,15 @@ class IstioConfigNewPage extends React.Component<Props, State> {
       );
       return {
         requestAuthentication: prevState.requestAuthentication
+      };
+    });
+  };
+
+  onChangeServiceEntry = (serviceEntry: ServiceEntryState) => {
+    this.setState(prevState => {
+      Object.keys(prevState.serviceEntry).forEach(key => (prevState.serviceEntry[key] = serviceEntry[key]));
+      return {
+        serviceEntry: prevState.serviceEntry
       };
     });
   };
@@ -348,6 +377,9 @@ class IstioConfigNewPage extends React.Component<Props, State> {
                 requestAuthentication={this.state.requestAuthentication}
                 onChange={this.onChangeRequestAuthentication}
               />
+            )}
+            {this.props.match.params.objectType === SERVICE_ENTRY && (
+              <ServiceEntryForm serviceEntry={this.state.serviceEntry} onChange={this.onChangeServiceEntry} />
             )}
             {this.props.match.params.objectType === SIDECAR && (
               <SidecarForm sidecar={this.state.sidecar} onChange={this.onChangeSidecar} />

--- a/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
+++ b/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
@@ -314,7 +314,6 @@ class IstioConfigNewPage extends React.Component<Props, State> {
               label="Name"
               isRequired={true}
               fieldId="name"
-              helperText={this.props.match.params.objectType + ' name'}
               helperTextInvalid={'A valid ' + this.props.match.params.objectType + ' name is required'}
               isValid={isNameValid}
             >

--- a/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
+++ b/src/pages/IstioConfigNew/IstioConfigNewPage.tsx
@@ -46,6 +46,7 @@ import RequestAuthenticationForm, {
 import { isValidK8SName } from '../../helpers/ValidationHelpers';
 import DefaultSecondaryMasthead from '../../components/DefaultSecondaryMasthead/DefaultSecondaryMasthead';
 import { RouteComponentProps } from 'react-router-dom';
+import { PfColors } from '../../components/Pf/PfColors';
 
 export interface IstioConfigNewPageId {
   objectType: string;
@@ -66,6 +67,13 @@ type State = {
 };
 
 const formPadding = style({ padding: '30px 20px 30px 20px' });
+
+const warningStyle = style({
+  marginLeft: 15,
+  paddingTop: 5,
+  color: PfColors.Red100,
+  textAlign: 'center'
+});
 
 const DIC = {
   AuthorizationPolicy: AUTHORIZATION_POLICIES,
@@ -303,25 +311,6 @@ class IstioConfigNewPage extends React.Component<Props, State> {
         <RenderContent>
           <Form className={formPadding} isHorizontal={true}>
             <FormGroup
-              label="Namespaces"
-              isRequired={true}
-              fieldId="namespaces"
-              helperText={'Select namespace(s) where this configuration will be applied'}
-              helperTextInvalid={'At least one namespace should be selected'}
-              isValid={isNamespacesValid}
-            >
-              <TextInput
-                value={this.props.activeNamespaces.map(n => n.name).join(',')}
-                isRequired={true}
-                type="text"
-                id="namespaces"
-                aria-describedby="namespaces"
-                name="namespaces"
-                isDisabled={true}
-                isValid={isNamespacesValid}
-              />
-            </FormGroup>
-            <FormGroup
               label="Name"
               isRequired={true}
               fieldId="name"
@@ -371,6 +360,9 @@ class IstioConfigNewPage extends React.Component<Props, State> {
               <Button variant="secondary" onClick={() => this.backToList()}>
                 Cancel
               </Button>
+              {!isNamespacesValid && (
+                <span className={warningStyle}>An Istio Config resource needs at least a namespace selected</span>
+              )}
             </ActionGroup>
           </Form>
         </RenderContent>

--- a/src/pages/IstioConfigNew/PeerAuthenticationForm.tsx
+++ b/src/pages/IstioConfigNew/PeerAuthenticationForm.tsx
@@ -306,8 +306,8 @@ class PeerAuthenticationForm extends React.Component<Props, PeerAuthenticationSt
           <FormGroup
             fieldId="workloadLabels"
             label="Labels"
-            helperText="One or more labels to select a workload where PeerAuthentication is applied. Enter a label in the format <label>=<value>. Enter one or multiple labels separated by comma."
-            helperTextInvalid="Invalid labels format: One or more labels to select a workload where AuthorizationPolicy is applied. Enter a label in the format <label>=<value>. Enter one or multiple labels separated by comma."
+            helperText="One or more labels to select a workload where the PeerAuthentication is applied."
+            helperTextInvalid="Enter a label in the format <label>=<value>. Enter one or multiple labels separated by comma."
             isValid={this.state.workloadSelectorValid}
           >
             <TextInput
@@ -352,7 +352,7 @@ class PeerAuthenticationForm extends React.Component<Props, PeerAuthenticationSt
               <div className={noPortMtlsStyle}>PeerAuthentication has no Port Mutual TLS defined</div>
             )}
             {!this.state.addWorkloadSelector && (
-              <div className={noPortMtlsStyle}>Ports Mutual TLS requires a Workload Selector</div>
+              <div className={noPortMtlsStyle}>Port Mutual TLS requires a Workload Selector</div>
             )}
           </FormGroup>
         )}

--- a/src/pages/IstioConfigNew/PeerAuthenticationForm.tsx
+++ b/src/pages/IstioConfigNew/PeerAuthenticationForm.tsx
@@ -5,6 +5,7 @@ import { PeerAuthenticationMutualTLSMode } from '../../types/IstioObjects';
 import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
 import { style } from 'typestyle';
 import { PfColors } from '../../components/Pf/PfColors';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 
 const noPortMtlsStyle = style({
   marginTop: 15,
@@ -276,14 +277,13 @@ class PeerAuthenticationForm extends React.Component<Props, PeerAuthenticationSt
             <>
               <Button
                 id="addServerBtn"
-                variant="secondary"
+                variant="link"
+                icon={<PlusCircleIcon />}
                 isDisabled={
                   this.state.addNewPortMtls.port.length === 0 || isNaN(Number(this.state.addNewPortMtls.port))
                 }
                 onClick={this.onAddPortMtls}
-              >
-                Add Port MTLS
-              </Button>
+              />
             </>
           ]
         }
@@ -293,7 +293,7 @@ class PeerAuthenticationForm extends React.Component<Props, PeerAuthenticationSt
   render() {
     return (
       <>
-        <FormGroup label="Add Workload Selector" fieldId="workloadSelectorSwitch">
+        <FormGroup label="Workload Selector" fieldId="workloadSelectorSwitch">
           <Switch
             id="workloadSelectorSwitch"
             label={' '}
@@ -327,7 +327,7 @@ class PeerAuthenticationForm extends React.Component<Props, PeerAuthenticationSt
             ))}
           </FormSelect>
         </FormGroup>
-        <FormGroup label="Add Port MTLS" fieldId="addPortMtls">
+        <FormGroup label="Port Mutual TLS" fieldId="addPortMtls">
           <Switch
             id="addPortMtls"
             label={' '}
@@ -349,10 +349,10 @@ class PeerAuthenticationForm extends React.Component<Props, PeerAuthenticationSt
               <TableBody />
             </Table>
             {this.props.peerAuthentication.portLevelMtls.length === 0 && (
-              <div className={noPortMtlsStyle}>PeerAuthentication has no Ports MTLS defined</div>
+              <div className={noPortMtlsStyle}>PeerAuthentication has no Port Mutual TLS defined</div>
             )}
             {!this.state.addWorkloadSelector && (
-              <div className={noPortMtlsStyle}>Ports MTLS require a Workload Selector</div>
+              <div className={noPortMtlsStyle}>Ports Mutual TLS requires a Workload Selector</div>
             )}
           </FormGroup>
         )}

--- a/src/pages/IstioConfigNew/RequestAuthenticationForm.tsx
+++ b/src/pages/IstioConfigNew/RequestAuthenticationForm.tsx
@@ -158,8 +158,8 @@ class RequestAuthenticationForm extends React.Component<Props, RequestAuthentica
           <FormGroup
             fieldId="workloadLabels"
             label="Labels"
-            helperText="One or more labels to select a workload where RequestAuthentication is applied. Enter a label in the format <label>=<value>. Enter one or multiple labels separated by comma."
-            helperTextInvalid="Invalid labels format: One or more labels to select a workload where AuthorizationPolicy is applied. Enter a label in the format <label>=<value>. Enter one or multiple labels separated by comma."
+            helperText="One or more labels to select a workload where the RequestAuthentication is applied."
+            helperTextInvalid="Enter a label in the format <label>=<value>. Enter one or multiple labels separated by comma."
             isValid={this.state.workloadSelectorValid}
           >
             <TextInput

--- a/src/pages/IstioConfigNew/RequestAuthenticationForm.tsx
+++ b/src/pages/IstioConfigNew/RequestAuthenticationForm.tsx
@@ -145,7 +145,7 @@ class RequestAuthenticationForm extends React.Component<Props, RequestAuthentica
   render() {
     return (
       <>
-        <FormGroup label="Add Workload Selector" fieldId="workloadSelectorSwitch">
+        <FormGroup label="Workload Selector" fieldId="workloadSelectorSwitch">
           <Switch
             id="workloadSelectorSwitch"
             label={' '}
@@ -172,7 +172,7 @@ class RequestAuthenticationForm extends React.Component<Props, RequestAuthentica
             />
           </FormGroup>
         )}
-        <FormGroup label="Add JWT Rules" fieldId="addJWTRules">
+        <FormGroup label="JWT Rules" fieldId="addJWTRules">
           <Switch
             id="addJWTRules"
             label={' '}

--- a/src/pages/IstioConfigNew/ServiceEntryForm.tsx
+++ b/src/pages/IstioConfigNew/ServiceEntryForm.tsx
@@ -1,0 +1,366 @@
+import * as React from 'react';
+import { Port, ServiceEntrySpec } from '../../types/IstioObjects';
+import { Button, FormGroup, FormSelect, FormSelectOption } from '@patternfly/react-core';
+import { TextInputBase as TextInput } from '@patternfly/react-core/dist/js/components/TextInput/TextInput';
+import { isGatewayHostValid } from '../../utils/IstioConfigUtils';
+import { cellWidth, ICell, Table, TableBody, TableHeader } from '@patternfly/react-table';
+import { PlusCircleIcon } from '@patternfly/react-icons';
+import { style } from 'typestyle';
+import { PfColors } from '../../components/Pf/PfColors';
+
+export const SERVICE_ENTRY = 'ServiceEntry';
+export const SERVICE_ENTRIES = 'serviceentries';
+
+const MESH_EXTERNAL = 'MESH_EXTERNAL';
+const MESH_INTERNAL = 'MESH_INTERNAL';
+
+const location = [MESH_EXTERNAL, MESH_INTERNAL];
+
+const NONE = 'NONE';
+const STATIC = 'STATIC';
+const DNS = 'DNS';
+
+const resolution = [NONE, STATIC, DNS];
+
+const protocols = ['HTTP', 'HTTPS', 'GRPC', 'HTTP2', 'MONGO', 'TCP', 'TLS'];
+
+const headerCells: ICell[] = [
+  {
+    title: 'Port Number',
+    transforms: [cellWidth(20) as any],
+    props: {}
+  },
+  {
+    title: 'Port Name',
+    transforms: [cellWidth(20) as any],
+    props: {}
+  },
+  {
+    title: 'Protocol',
+    transforms: [cellWidth(20) as any],
+    props: {}
+  },
+  {
+    title: 'Target Protocol',
+    transforms: [cellWidth(20) as any],
+    props: {}
+  },
+  {
+    title: '',
+    props: {}
+  }
+];
+
+const noPortsStyle = style({
+  marginTop: 15,
+  color: PfColors.Red100
+});
+
+type Props = {
+  serviceEntry: ServiceEntryState;
+  onChange: (serviceEntry: ServiceEntryState) => void;
+};
+
+export type ServiceEntryState = {
+  serviceEntry: ServiceEntrySpec;
+  validHosts: boolean;
+  addNewPortNumber: string;
+  addNewPortName: string;
+  addNewPortProtocol: string;
+  addNewTargetPort: string;
+};
+
+export const initServiceEntry = (): ServiceEntryState => ({
+  serviceEntry: {
+    location: location[0], // MESH_EXTERNAL
+    resolution: resolution[0] // NONE
+  },
+  validHosts: false,
+  addNewPortNumber: '80',
+  addNewPortName: '',
+  addNewPortProtocol: protocols[0],
+  addNewTargetPort: ''
+});
+
+export const isServiceEntryValid = (se: ServiceEntryState): boolean => {
+  return se.validHosts && se.serviceEntry.ports !== undefined && se.serviceEntry.ports.length > 0;
+};
+
+class ServiceEntryForm extends React.Component<Props, ServiceEntryState> {
+  constructor(props: Props) {
+    super(props);
+    this.state = initServiceEntry();
+  }
+
+  // @ts-ignore
+  actionResolver = (rowData, { rowIndex }) => {
+    const removeAction = {
+      title: 'Remove Port',
+      // @ts-ignore
+      onClick: (event, rowIndex, rowData, extraData) => {
+        this.setState(
+          prevState => {
+            prevState.serviceEntry.ports?.splice(rowIndex, 1);
+            return {
+              serviceEntry: prevState.serviceEntry
+            };
+          },
+          () => this.props.onChange(this.state)
+        );
+      }
+    };
+    if (this.state.serviceEntry.ports && rowIndex < this.state.serviceEntry.ports.length) {
+      return [removeAction];
+    }
+    return [];
+  };
+
+  areValidHosts = (hosts: string[]): boolean => {
+    if (hosts.length === 0) {
+      return false;
+    }
+    let isValid = true;
+    for (let i = 0; i < hosts.length; i++) {
+      if (!isGatewayHostValid(hosts[i])) {
+        isValid = false;
+        break;
+      }
+    }
+    return isValid;
+  };
+
+  isValidPort = () => {
+    const validPortNumber = this.state.addNewPortNumber.length > 0 && !isNaN(Number(this.state.addNewPortNumber));
+    const validPortName = this.state.addNewPortName.length > 0;
+    const validTargetPort =
+      this.state.addNewTargetPort.length === 0 ||
+      (this.state.addNewTargetPort.length > 0 && !isNaN(Number(this.state.addNewTargetPort)));
+    return validPortNumber && validPortName && validTargetPort;
+  };
+
+  onAddHosts = (value: string, _) => {
+    const hosts = value.trim().length === 0 ? [] : value.split(',').map(host => host.trim());
+    this.setState(
+      prevState => {
+        prevState.serviceEntry.hosts = hosts;
+        return {
+          serviceEntry: prevState.serviceEntry,
+          validHosts: this.areValidHosts(hosts)
+        };
+      },
+      () => this.props.onChange(this.state)
+    );
+  };
+
+  onAddLocation = (value: string, _) => {
+    this.setState(
+      prevState => {
+        prevState.serviceEntry.location = value;
+        return {
+          serviceEntry: prevState.serviceEntry
+        };
+      },
+      () => this.props.onChange(this.state)
+    );
+  };
+
+  onAddResolution = (value: string, _) => {
+    this.setState(
+      prevState => {
+        prevState.serviceEntry.resolution = value;
+        return {
+          serviceEntry: prevState.serviceEntry
+        };
+      },
+      () => this.props.onChange(this.state)
+    );
+  };
+
+  onAddPortNumber = (value: string, _) => {
+    this.setState({
+      addNewPortNumber: value
+    });
+  };
+
+  onAddPortName = (value: string, _) => {
+    this.setState({
+      addNewPortName: value
+    });
+  };
+
+  onAddPortProtocol = (value: string, _) => {
+    this.setState({
+      addNewPortProtocol: value
+    });
+  };
+
+  onAddTargetPort = (value: string, _) => {
+    this.setState({
+      addNewTargetPort: value
+    });
+  };
+
+  onAddNewPort = () => {
+    // @ts-ignore
+    this.setState(
+      prevState => {
+        const newPort: Port = {
+          number: +this.state.addNewPortNumber,
+          name: this.state.addNewPortName,
+          protocol: this.state.addNewPortProtocol
+        };
+        if (this.state.addNewTargetPort.length > 0) {
+          newPort.targetPort = +this.state.addNewTargetPort;
+        }
+        if (!prevState.serviceEntry.ports) {
+          prevState.serviceEntry.ports = [];
+        }
+        prevState.serviceEntry.ports.push(newPort);
+        return {
+          serviceEntry: prevState.serviceEntry,
+          addNewPortNumber: '80',
+          addNewPortName: '',
+          addNewPortProtocol: protocols[0],
+          addNewTargetPort: ''
+        };
+      },
+      () => this.props.onChange(this.state)
+    );
+  };
+
+  rows() {
+    return (this.state.serviceEntry.ports || [])
+      .map((p, i) => ({
+        key: 'port_' + i,
+        cells: [<>{p.number}</>, <>{p.name}</>, <>{p.protocol}</>, <>{p.targetPort}</>, '']
+      }))
+      .concat([
+        {
+          key: 'portNew',
+          cells: [
+            <>
+              <TextInput
+                value={this.state.addNewPortNumber}
+                id="addPortNumber"
+                aria-describedby="add port number"
+                name="addPortNumber"
+                onChange={this.onAddPortNumber}
+                isValid={this.state.addNewPortNumber.length > 0 && !isNaN(Number(this.state.addNewPortNumber))}
+              />
+            </>,
+            <>
+              <TextInput
+                value={this.state.addNewPortName}
+                id="addPortName"
+                aria-describedby="add port name"
+                name="addPortName"
+                onChange={this.onAddPortName}
+                isValid={this.state.addNewPortName.length > 0}
+              />
+            </>,
+            <>
+              <FormSelect
+                value={this.state.addNewPortProtocol}
+                id="addPortProtocol"
+                name="addPortProtocol"
+                onChange={this.onAddPortProtocol}
+              >
+                {protocols.map((option, index) => (
+                  <FormSelectOption key={'p' + index} value={option} label={option} />
+                ))}
+              </FormSelect>
+            </>,
+            <>
+              <TextInput
+                value={this.state.addNewTargetPort}
+                id="addTargetPort"
+                aria-describedby="add target port"
+                name="addTargetPort"
+                onChange={this.onAddTargetPort}
+                isValid={
+                  this.state.addNewTargetPort.length === 0 ||
+                  (this.state.addNewTargetPort.length > 0 && !isNaN(Number(this.state.addNewTargetPort)))
+                }
+              />
+            </>,
+            <>
+              <Button
+                id="addServerBtn"
+                variant="link"
+                icon={<PlusCircleIcon />}
+                isDisabled={!this.isValidPort()}
+                onClick={this.onAddNewPort}
+              />
+            </>
+          ]
+        }
+      ]);
+  }
+
+  render() {
+    return (
+      <>
+        <FormGroup
+          label="Hosts"
+          isRequired={true}
+          fieldId="hosts"
+          helperText="The hosts associated with the ServiceEntry."
+          helperTextInvalid="Invalid hosts for this ServiceEntry. Enter one or hosts separated by comma."
+          isValid={this.state.validHosts}
+        >
+          <TextInput
+            value={this.state.serviceEntry.hosts?.join(',')}
+            isRequired={true}
+            type="text"
+            id="hosts"
+            aria-describedby="hosts"
+            name="hosts"
+            onChange={this.onAddHosts}
+            isValid={this.state.validHosts}
+          />
+        </FormGroup>
+        <FormGroup label="Location" isRequired={true} fieldId="location">
+          <FormSelect
+            value={this.state.serviceEntry.location}
+            id="location"
+            name="location"
+            onChange={this.onAddLocation}
+          >
+            {location.map((option, index) => (
+              <FormSelectOption isDisabled={false} key={'p' + index} value={option} label={option} />
+            ))}
+          </FormSelect>
+        </FormGroup>
+        <FormGroup label="Ports" fieldId="ports">
+          <Table
+            aria-label="Ports"
+            cells={headerCells}
+            rows={this.rows()}
+            // @ts-ignore
+            actionResolver={this.actionResolver}
+          >
+            <TableHeader />
+            <TableBody />
+          </Table>
+          {(!this.state.serviceEntry.ports || this.state.serviceEntry.ports.length === 0) && (
+            <div className={noPortsStyle}>ServiceEntry has no Ports defined</div>
+          )}
+        </FormGroup>
+        <FormGroup label="Resolution" isRequired={true} fieldId="resolution">
+          <FormSelect
+            value={this.state.serviceEntry.resolution}
+            id="resolution"
+            name="resolution"
+            onChange={this.onAddResolution}
+          >
+            {resolution.map((option, index) => (
+              <FormSelectOption isDisabled={false} key={'p' + index} value={option} label={option} />
+            ))}
+          </FormSelect>
+        </FormGroup>
+      </>
+    );
+  }
+}
+
+export default ServiceEntryForm;

--- a/src/pages/IstioConfigNew/SidecarForm.tsx
+++ b/src/pages/IstioConfigNew/SidecarForm.tsx
@@ -230,8 +230,8 @@ class SidecarForm extends React.Component<Props, SidecarState> {
           <FormGroup
             fieldId="workloadLabels"
             label="Labels"
-            helperText="One or more labels to select a workload where Sidecar is applied. Enter a label in the format <label>=<value>. Enter one or multiple labels separated by comma."
-            helperTextInvalid="Invalid labels format: One or more labels to select a workload where Sidecar is applied. Enter a label in the format <label>=<value>. Enter one or multiple labels separated by comma."
+            helperText="One or more labels to select a workload where the Sidecar is applied."
+            helperTextInvalid="Enter a label in the format <label>=<value>. Enter one or multiple labels separated by comma."
             isValid={this.state.workloadSelectorValid}
           >
             <TextInput

--- a/src/pages/IstioConfigNew/SidecarForm.tsx
+++ b/src/pages/IstioConfigNew/SidecarForm.tsx
@@ -5,6 +5,7 @@ import { PfColors } from '../../components/Pf/PfColors';
 // Use TextInputBase like workaround while PF4 team work in https://github.com/patternfly/patternfly-react/issues/4072
 import { Button, FormGroup, Switch, TextInputBase as TextInput } from '@patternfly/react-core';
 import { isSidecarHostValid } from '../../utils/IstioConfigUtils';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 
 const headerCells: ICell[] = [
   {
@@ -194,9 +195,12 @@ class SidecarForm extends React.Component<Props, SidecarState> {
               )}
             </>,
             <>
-              <Button variant="secondary" isDisabled={!this.state.validEgressHost} onClick={this.onAddEgressHost}>
-                Add Egress Host
-              </Button>
+              <Button
+                variant="link"
+                icon={<PlusCircleIcon />}
+                isDisabled={!this.state.validEgressHost}
+                onClick={this.onAddEgressHost}
+              />
             </>
           ]
         }
@@ -206,18 +210,7 @@ class SidecarForm extends React.Component<Props, SidecarState> {
   render() {
     return (
       <>
-        Egress hosts defined:
-        <Table
-          aria-label="Egress Hosts"
-          cells={headerCells}
-          rows={this.rows()}
-          // @ts-ignore
-          actionResolver={this.actionResolver}
-        >
-          <TableHeader />
-          <TableBody />
-        </Table>
-        <FormGroup label="Add Workload Selector" fieldId="workloadSelectorSwitch">
+        <FormGroup label="Workload Selector" fieldId="workloadSelectorSwitch">
           <Switch
             id="workloadSelectorSwitch"
             label={' '}
@@ -251,9 +244,21 @@ class SidecarForm extends React.Component<Props, SidecarState> {
             />
           </FormGroup>
         )}
-        {this.state.egressHosts.length === 0 && (
-          <div className={noEgressHostsStyle}>Sidecar has no Egress Hosts Defined</div>
-        )}
+        <FormGroup label="Egress" fieldId="egressHostTable">
+          <Table
+            aria-label="Egress Hosts"
+            cells={headerCells}
+            rows={this.rows()}
+            // @ts-ignore
+            actionResolver={this.actionResolver}
+          >
+            <TableHeader />
+            <TableBody />
+          </Table>
+          {this.state.egressHosts.length === 0 && (
+            <div className={noEgressHostsStyle}>Sidecar has no Egress Hosts Defined</div>
+          )}
+        </FormGroup>
       </>
     );
   }

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -50,7 +50,7 @@ const navItems: MenuItem[] = [
   {
     title: 'Istio Config',
     to: '/' + Paths.ISTIO,
-    pathsActive: [new RegExp('^/namespaces/(.*)/' + Paths.ISTIO + '/(.*)'), new RegExp('/' + Paths.ISTIO + '/new')]
+    pathsActive: [new RegExp('^/namespaces/(.*)/' + Paths.ISTIO + '/(.*)'), new RegExp('/' + Paths.ISTIO + '/new/(.*)')]
   },
   {
     title: 'Distributed Tracing',
@@ -105,11 +105,6 @@ const pathRoutes: Path[] = [
     path: '/namespaces/:namespace/' + Paths.SERVICES + '/:service',
     component: ServiceDetailsPageContainer
   },
-  // NOTE that order on routes is important
-  {
-    path: '/namespaces/:namespace/' + Paths.ISTIO + '/:objectType/:objectSubtype/:object',
-    component: IstioConfigDetailsPage
-  },
   {
     path: '/namespaces/:namespace/' + Paths.ISTIO + '/:objectType/:object',
     component: IstioConfigDetailsPage
@@ -135,7 +130,7 @@ const pathRoutes: Path[] = [
     component: WorkloadDetailsPage
   },
   {
-    path: '/' + Paths.ISTIO + '/new',
+    path: '/' + Paths.ISTIO + '/new/:objectType',
     component: IstioConfigNewPageContainer
   },
   {

--- a/src/types/IstioConfigDetails.ts
+++ b/src/types/IstioConfigDetails.ts
@@ -19,7 +19,6 @@ import { AceOptions } from 'react-ace/types';
 export interface IstioConfigId {
   namespace: string;
   objectType: string;
-  objectSubtype: string;
   object: string;
 }
 

--- a/src/types/IstioObjects.ts
+++ b/src/types/IstioObjects.ts
@@ -121,6 +121,7 @@ export interface Port {
   number: number;
   protocol: string;
   name: string;
+  targetPort?: number;
 }
 
 export interface Pod {


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/3761
Fixes https://github.com/kiali/kiali/issues/3763

This PR provides fixes and refactoring in several areas of the IstioConfig New Forms.

Use same "Create" group for "Actions" dropdown and allow to select the type of object in a first step:

![image](https://user-images.githubusercontent.com/1662329/112240643-f8860a00-8c48-11eb-8032-876c1ca41e3b.png)

Present the Istio Config resource on the title, and eliminate redundant fields for type and namespaces:

![image](https://user-images.githubusercontent.com/1662329/112240752-2ec38980-8c49-11eb-9d54-62990a459b80.png)

Namespace validation is moved to the "Create/Cancel" button similar as others used:

![image](https://user-images.githubusercontent.com/1662329/112240786-4733a400-8c49-11eb-8cab-00fbdb98efca.png)

Review all forms (AuthorizationPolicy, Gateway, PeerAuthentication, RequestAuthentication, Sidecar) and unify criteria.
No changes in feature, just use same wording for messages, minor changes to adjust the style and use same icons/buttons for same patterns (in terms of implementations, it follows the Builder/List pattern for sections on big forms).

For the Gateway case, it add supports for HTTPS/TLS and allow to define certificates on SIMPLE/MUTUAL cases:

![image](https://user-images.githubusercontent.com/1662329/112241144-f7091180-8c49-11eb-964b-6b75a0f1bfbd.png)

![image](https://user-images.githubusercontent.com/1662329/112241301-451e1500-8c4a-11eb-99dc-af730cea8b93.png)

For testing:

- Gateways Servers with HTTPS/TLS ports should show mandatory TLS section.
- SIMPLE TLS mode should ask server certificate and private key.
- MUTUAL TLS should add CA Certificate as well.
- Generated Gateway can be selected from a Service Wizard.
- Regression when creating new AuthorizationPolicy, PeerAuthentication, RequestAuthentication and Sidecar objects.

Update:

As requested on https://github.com/kiali/kiali/issues/3763#issuecomment-805601598 added an additional fix to cover the ServiceEntry case.

Please @lautou we will be happy if you help us to test it.

So, ServiceEntry is added into to the IstioConfig Actions Menu:

![image](https://user-images.githubusercontent.com/1662329/112349920-6eca5100-8cc9-11eb-9935-4ba204d7ba5a.png)

And it will provide a basic layout for most common / basic ServiceEntry cases:

![image](https://user-images.githubusercontent.com/1662329/112349982-7ee23080-8cc9-11eb-9d70-db3f34bb7cff.png)

As this forms are for creation, it happens as other resources, once created it can be edited via YAML as usual










