### PR TITLE
Perform focus animation when returning back from node graph to full graph

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -31,6 +31,7 @@ import { GraphData } from 'pages/Graph/GraphPage';
 import { JaegerTrace } from 'types/JaegerInfo';
 import { showTrace, hideTrace } from './CytoscapeTrace';
 import TrafficRenderer from './TrafficAnimation/TrafficRenderer';
+import { addInfo } from 'utils/AlertUtils';
 
 type CytoscapeGraphProps = {
   boxByCluster: boolean;
@@ -548,12 +549,19 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps>
       return;
     }
 
-    let selected = cy.$(this.focusSelector);
-
     // only perform the focus one time
+    const focusSelector = this.focusSelector;
     this.focusSelector = undefined;
 
+    let selected = cy.$(focusSelector);
+
     if (!selected) {
+      addInfo(
+        'Could not focus on requested node. The node may be idle or hidden.',
+        true,
+        undefined,
+        `${focusSelector}`
+      );
       return;
     }
 

--- a/src/components/CytoscapeGraph/MiniGraphCard.tsx
+++ b/src/components/CytoscapeGraph/MiniGraphCard.tsx
@@ -172,7 +172,7 @@ export default class MiniGraphCard extends React.Component<MiniGraphCardProps, M
         break;
     }
 
-    const graphUrl = `/graph/namespaces?graphType=${graphType}&injectServiceNodes=true&namespaces=${namespace}&idleNodes=true&focusSelector=${encodeURI(
+    const graphUrl = `/graph/namespaces?graphType=${graphType}&injectServiceNodes=true&namespaces=${namespace}&focusSelector=${encodeURI(
       cytoscapeGraph.build()
     )}`;
 

--- a/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
@@ -14,7 +14,7 @@ import {
   replayActiveSelector
 } from '../../../store/Selectors';
 import { GraphToolbarActions } from '../../../actions/GraphToolbarActions';
-import { GraphType, NodeParamsType, EdgeLabelMode } from '../../../types/Graph';
+import { GraphType, NodeParamsType, EdgeLabelMode, SummaryData } from '../../../types/Graph';
 import GraphFindContainer from './GraphFind';
 import GraphSettingsContainer from './GraphSettings';
 import history, { HistoryManager, URLParam } from '../../../app/History';
@@ -28,6 +28,7 @@ import { KialiIcon, defaultIconStyle } from 'config/KialiIcon';
 import ReplayContainer from 'components/Time/Replay';
 import { UserSettingsActions } from 'actions/UserSettingsActions';
 import GraphSecondaryMasthead from './GraphSecondaryMasthead';
+import { CyNode } from 'components/CytoscapeGraph/CytoscapeGraphUtils';
 
 type ReduxProps = {
   activeNamespaces: Namespace[];
@@ -36,6 +37,7 @@ type ReduxProps = {
   node?: NodeParamsType;
   replayActive: boolean;
   showIdleNodes: boolean;
+  summaryData: SummaryData | null;
 
   setActiveNamespaces: (activeNamespaces: Namespace[]) => void;
   setEdgeLabelMode: (edgeLabelMode: EdgeLabelMode) => void;
@@ -145,7 +147,14 @@ export class GraphToolbar extends React.PureComponent<GraphToolbarProps> {
 
   handleNamespaceReturn = () => {
     this.props.setNode(undefined);
-    history.push('/graph/namespaces');
+    if (
+      !this.props.summaryData ||
+      (this.props.summaryData.summaryType !== 'node' && this.props.summaryData.summaryType !== 'box')
+    ) {
+      history.push(`/graph/namespaces`);
+    }
+    const selector = `node[id = "${this.props.summaryData!.summaryTarget.data(CyNode.id)}"]`;
+    history.push(`/graph/namespaces?focusSelector=${encodeURI(selector)}`);
   };
 
   render() {
@@ -198,7 +207,8 @@ const mapStateToProps = (state: KialiAppState) => ({
   graphType: graphTypeSelector(state),
   node: state.graph.node,
   replayActive: replayActiveSelector(state),
-  showIdleNodes: showIdleNodesSelector(state)
+  showIdleNodes: showIdleNodesSelector(state),
+  summaryData: state.graph.summaryData
 });
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<KialiAppState, void, KialiAppAction>) => {

--- a/src/utils/AlertUtils.ts
+++ b/src/utils/AlertUtils.ts
@@ -53,12 +53,16 @@ export const extractAxiosError = (message: string, error: AxiosError): { content
 };
 
 // info level message do not generate a toast notification
-export const addInfo = (content: string, showNotification?: boolean, group?: string) => {
-  store.dispatch(MessageCenterActions.addMessage(content, '', group, MessageType.INFO, showNotification));
+export const addInfo = (content: string, showNotification?: boolean, group?: string, detail?: string) => {
+  store.dispatch(
+    MessageCenterActions.addMessage(content, detail ? detail : '', group, MessageType.INFO, showNotification)
+  );
 };
 
-export const addSuccess = (content: string, showNotification?: boolean, group?: string) => {
-  store.dispatch(MessageCenterActions.addMessage(content, '', group, MessageType.SUCCESS, showNotification));
+export const addSuccess = (content: string, showNotification?: boolean, group?: string, detail?: string) => {
+  store.dispatch(
+    MessageCenterActions.addMessage(content, detail ? detail : '', group, MessageType.SUCCESS, showNotification)
+  );
 };
 
 export const addWarning = (content: string, showNotification?: boolean, group?: string, detail?: string) => {


### PR DESCRIPTION
Perform focus animation when returning back from node graph to full graph
- honors the currently selected node in the node graph (if any)
- Behavioral change: don't enable idle nodes when navigating from mini-graph
  - this was originally done to help ensure focus selection worked even if
    the node was idle. But this wass heavy-handed as it could litter the graph
    with idle nodes and confuse users. Instead, on the off-chance that the
    node does not exist and the focus fails, just provide an informational toast.
- other minor enhancement: allow some message utils to provide detail

Fixes https://github.com/kiali/kiali/issues/2281
