### PR TITLE
Allow nav from detail view mini-graph to graph page node graph.

### DIFF
--- a/src/components/CytoscapeGraph/MiniGraphCard.tsx
+++ b/src/components/CytoscapeGraph/MiniGraphCard.tsx
@@ -17,6 +17,8 @@ import { DecoratedGraphElements, EdgeLabelMode, GraphType, NodeType } from '../.
 import CytoscapeGraph, { GraphNodeDoubleTapEvent } from './CytoscapeGraph';
 import { CytoscapeGraphSelectorBuilder } from './CytoscapeGraphSelector';
 import { DagreGraph } from './graphs/DagreGraph';
+import { GraphUrlParams, makeNodeGraphUrlFromParams } from 'components/Nav/NavUtils';
+import { store } from 'store/ConfigStore';
 
 const miniGraphContainerStyle = style({ height: '300px' });
 
@@ -51,8 +53,11 @@ export default class MiniGraphCard extends React.Component<MiniGraphCardProps, M
 
   render() {
     const graphCardActions = [
-      <DropdownItem key="viewGraph" onClick={this.onViewGraph}>
+      <DropdownItem key="viewFullGraph" onClick={this.onViewFullGraph}>
         Show full graph
+      </DropdownItem>,
+      <DropdownItem key="viewNodeGraph" onClick={this.onViewNodeGraph}>
+        Show node graph
       </DropdownItem>
     ];
 
@@ -142,7 +147,7 @@ export default class MiniGraphCard extends React.Component<MiniGraphCardProps, M
     });
   };
 
-  private onViewGraph = () => {
+  private onViewFullGraph = () => {
     const namespace = this.props.dataSource.fetchParameters.namespaces[0].name;
     let cytoscapeGraph = new CytoscapeGraphSelectorBuilder().namespace(namespace);
     let graphType: GraphType = GraphType.APP;
@@ -177,5 +182,37 @@ export default class MiniGraphCard extends React.Component<MiniGraphCardProps, M
     )}`;
 
     history.push(graphUrl);
+  };
+
+  private onViewNodeGraph = () => {
+    let graphType = this.props.dataSource.fetchParameters.graphType;
+    switch (this.props.dataSource.fetchParameters.node!.nodeType) {
+      case NodeType.APP:
+        graphType = GraphType.APP;
+        break;
+      case NodeType.SERVICE:
+        graphType = GraphType.SERVICE;
+        break;
+      case NodeType.WORKLOAD:
+        graphType = GraphType.WORKLOAD;
+        break;
+    }
+
+    const urlParams: GraphUrlParams = {
+      activeNamespaces: this.props.dataSource.fetchParameters.namespaces,
+      duration: this.props.dataSource.fetchParameters.duration,
+      edgeLabelMode: this.props.dataSource.fetchParameters.edgeLabelMode,
+      graphLayout: store.getState().graph.layout,
+      graphType: graphType,
+      node: this.props.dataSource.fetchParameters.node!,
+      refreshInterval: store.getState().userSettings.refreshInterval,
+      showIdleEdges: this.props.dataSource.fetchParameters.showIdleEdges,
+      showIdleNodes: this.props.dataSource.fetchParameters.showIdleNodes,
+      showOperationNodes: this.props.dataSource.fetchParameters.showOperationNodes,
+      showServiceNodes: true
+    };
+
+    // To ensure updated components get the updated URL, update the URL first and then the state
+    history.push(makeNodeGraphUrlFromParams(urlParams));
   };
 }

--- a/src/pages/Graph/GraphToolbar/GraphSecondaryMasthead.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphSecondaryMasthead.tsx
@@ -12,6 +12,7 @@ import TimeDurationContainer from '../../../components/Time/TimeDurationComponen
 type GraphSecondaryMastheadProps = {
   disabled: boolean;
   graphType: GraphType;
+  isNodeGraph: boolean;
 
   onToggleHelp: () => void;
   onGraphTypeChange: (graphType: GraphType) => void;
@@ -52,7 +53,7 @@ export default class GraphSecondaryMasthead extends React.PureComponent<GraphSec
     return (
       <SecondaryMasthead title={false}>
         <div className={mastheadStyle}>
-          <NamespaceDropdownContainer disabled={false} />
+          <NamespaceDropdownContainer disabled={this.props.isNodeGraph} />
           <span className={vrStyle} />
           <TourStopContainer info={GraphTourStops.GraphType}>
             <span className={leftSpacerStyle}>

--- a/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
@@ -146,7 +146,6 @@ export class GraphToolbar extends React.PureComponent<GraphToolbarProps> {
   };
 
   handleNamespaceReturn = () => {
-    this.props.setNode(undefined);
     if (
       !this.props.summaryData ||
       (this.props.summaryData.summaryType !== 'node' && this.props.summaryData.summaryType !== 'box')
@@ -154,6 +153,7 @@ export class GraphToolbar extends React.PureComponent<GraphToolbarProps> {
       history.push(`/graph/namespaces`);
     }
     const selector = `node[id = "${this.props.summaryData!.summaryTarget.data(CyNode.id)}"]`;
+    this.props.setNode(undefined);
     history.push(`/graph/namespaces?focusSelector=${encodeURI(selector)}`);
   };
 
@@ -163,6 +163,7 @@ export class GraphToolbar extends React.PureComponent<GraphToolbarProps> {
         <GraphSecondaryMasthead
           disabled={this.props.disabled}
           graphType={this.props.graphType}
+          isNodeGraph={!!this.props.node}
           onToggleHelp={this.props.onToggleHelp}
           onGraphTypeChange={this.props.setGraphType}
           onHandleRefresh={this.handleRefresh}


### PR DESCRIPTION
A couple of other minor fixes:
- include aggregate nodes when checking for node change
- disable namespace selector in node graph view
- avoid race condition when unsetting node on return to main graph

Closes https://github.com/kiali/kiali/issues/3696

