### PR TITLE
Remove prod dep on ssri, it seems unnecessary and there is a CVE

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "reselect": "4.0.0",
     "screenfull": "5.0.2",
     "seedrandom": "3.0.1",
-    "ssri": "6.0.1",
     "tippy.js": "3.4.1",
     "typesafe-actions": "3.2.1",
     "typestyle": "2.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13335,7 +13335,7 @@ sshpk@^1.7.0:
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
 
-ssri@6.0.1, ssri@^6.0.1:
+ssri@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/ssri/-/ssri-6.0.1.tgz#2a3c41b28dd45b62b63676ecb74001265ae9edd8"
   integrity sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==


### PR DESCRIPTION
@israel-hdez Snyk complained about https://snyk.io/vuln/SNYK-JS-SSRI-1085630.  It wanted to update the ssri version but I removed it from the prod deps and it seems maybe we don't even need it.  It is still pulled in by react-scripts, but that is a dev dep.  What do you think, can we just get rid of it?