### PR TITLE
In Metrics spans disappear in mouseOver

### DIFF
--- a/src/components/Charts/ChartWithLegend.tsx
+++ b/src/components/Charts/ChartWithLegend.tsx
@@ -322,9 +322,11 @@ class ChartWithLegend<T extends RichDataPoint, O extends LineInfo> extends React
       serieID: serieID,
       onMouseOver: props => {
         this.mouseOnLegend = true;
-        return {
-          style: { ...props.style, strokeWidth: 4, fillOpacity: 0 }
-        };
+        return serieName === 'overlay'
+          ? null
+          : {
+              style: { ...props.style, strokeWidth: 4, fillOpacity: 0 }
+            };
       },
       onMouseOut: () => {
         this.mouseOnLegend = false;


### PR DESCRIPTION
Fix https://github.com/kiali/kiali/issues/3844

# Reproduce
## Before

1 - Enable spans filter in legend
2 - Wait refresh metrics or force it
3 - Now OnMouseOver in Span duration legend Item the spans disappear

## Now 

Fixed