### PR TITLE
Consolidate terminology on inbound/outbound

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeTrace.ts
+++ b/src/components/CytoscapeGraph/CytoscapeTrace.ts
@@ -68,8 +68,8 @@ const showSpanSubtrace = (cy: Cy.Core, graphType: GraphType, span: Span) => {
   }
 
   // Inbound service entry
-  const seSelectionIncoming = getInboundServiceEntry(span, cy);
-  lastSelection = nextHop(span, seSelectionIncoming, lastSelection);
+  const seSelectionInbound = getInboundServiceEntry(span, cy);
+  lastSelection = nextHop(span, seSelectionInbound, lastSelection);
 
   // Main service
   const nsSelector = split.length > 1 ? `[${CyNode.namespace}="${split[1]}"]` : '';

--- a/src/components/CytoscapeGraph/graphs/GraphHighlighter.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphHighlighter.ts
@@ -85,7 +85,7 @@ export class GraphHighlighter {
 
   // Returns the nodes to highlight. Highlighting for a hovered element
   // is limited to its neighborhood.  Highlighting for a selected element
-  // is extended to full incoming and outgoing paths.
+  // is extended to full inbound and outbound paths.
   getHighlighted(): { toHighlight: any; dimOthers: boolean } {
     const isHover = this.selected.summaryType === 'graph';
     const event = isHover ? this.hovered : this.selected;

--- a/src/components/TrafficList/TrafficListComponent.tsx
+++ b/src/components/TrafficList/TrafficListComponent.tsx
@@ -301,7 +301,7 @@ class TrafficListComponent extends FilterComponent.Component<
         // No filters available for workloads. Context switch is mandatory.
 
         // Since this will switch context (i.e. will redirect the user to the workload details page),
-        // user is redirected to the "opposite" metrics. When looking at certain item, if traffic is *incoming*
+        // user is redirected to the "opposite" metrics. When looking at certain item, if traffic is *inbound*
         // from a certain workload, that traffic is reflected in the *outbound* metrics of the workload (and vice-versa).
         const inverseMetricsDirection = item.direction === 'inbound' ? 'out_metrics' : 'in_metrics';
         metrics = `${detail}?tab=${inverseMetricsDirection}`;

--- a/src/pages/Graph/GraphHelpFind.tsx
+++ b/src/pages/Graph/GraphHelpFind.tsx
@@ -166,12 +166,12 @@ export default class GraphHelpFind extends React.Component<GraphHelpFindProps> {
       ['app startswith product', `nodes with app label starting with 'product'`],
       ['app != details and version=v1', `nodes with app label not equal to 'details' and with version equal to 'v1'`],
       ['!sc', `nodes without a sidecar`],
-      ['httpin > 0.5', `nodes with incoming http rate > 0.5 rps`],
-      ['tcpout >= 1000', `nodes with outgoing tcp rates >= 1000 bps`],
+      ['httpin > 0.5', `nodes with inbound http rate > 0.5 rps`],
+      ['tcpout >= 1000', `nodes with outbound tcp rates >= 1000 bps`],
       ['!traffic', 'edges with no traffic'],
       ['http > 0.5', `edges with http rate > 0.5 rps`],
       ['rt > 500', `edges with response time > 500ms. (requires response time edge labels)`],
-      ['%httptraffic >= 50.0', `edges with >= 50% of the outgoing http request traffic of the parent`],
+      ['%httptraffic >= 50.0', `edges with >= 50% of the outbound http request traffic of the parent`],
       ['node = svc and svc startswith det or !traffic', 'service node starting with "det" or edges with no traffic']
     ];
   };
@@ -201,7 +201,7 @@ export default class GraphHelpFind extends React.Component<GraphHelpFindProps> {
       ['outside', 'is outside of requested namespaces'],
       ['sidecar'],
       ['serviceentry'],
-      ['trafficsource', `has only outgoing edges`],
+      ['trafficsource', `has only outbound edges`],
       ['virtualservice']
     ];
   };

--- a/src/pages/Graph/GraphToolbar/GraphSettings.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphSettings.tsx
@@ -177,8 +177,8 @@ class GraphSettings extends React.PureComponent<GraphSettingsProps, GraphSetting
         isChecked: edgeLabelMode === EdgeLabelMode.REQUEST_DISTRIBUTION,
         tooltip: (
           <div style={{ textAlign: 'left' }}>
-            HTTP and GRPC Edges display the percentage of outgoing requests for that edge. For a source node, the sum
-            for outgoing edges should be equal to or near 100%, given rounding. TCP edges are not included in the
+            HTTP and GRPC Edges display the percentage of outbound requests for that edge. For a source node, the sum
+            for outbound edges should be equal to or near 100%, given rounding. TCP edges are not included in the
             distribution because their rates reflect bytes sent, not requests sent.
           </div>
         )

--- a/src/pages/Graph/SummaryPanelAppBox.tsx
+++ b/src/pages/Graph/SummaryPanelAppBox.tsx
@@ -190,7 +190,7 @@ export default class SummaryPanelAppBox extends React.Component<SummaryPanelProp
     const reporter: Reporter = nodeData.isIstio ? 'destination' : 'source';
 
     const promiseOut = getNodeMetrics(nodeMetricType, target, props, filters, 'outbound', reporter);
-    // use dest metrics for incoming
+    // use dest metrics for inbound
     const promiseIn = getNodeMetrics(nodeMetricType, target, props, filters, 'inbound', 'destination');
     this.metricsPromise = makeCancelablePromise(Promise.all([promiseOut, promiseIn]));
 
@@ -261,19 +261,19 @@ export default class SummaryPanelAppBox extends React.Component<SummaryPanelProp
     const validChildren = appBox.children(
       `node[nodeType != "${NodeType.SERVICE}"][nodeType != "${NodeType.AGGREGATE}"]`
     );
-    const incoming = getAccumulatedTrafficRateGrpc(validChildren.incomers('edge'));
-    const outgoing = getAccumulatedTrafficRateGrpc(validChildren.edgesTo('*'));
+    const inbound = getAccumulatedTrafficRateGrpc(validChildren.incomers('edge'));
+    const outbound = getAccumulatedTrafficRateGrpc(validChildren.edgesTo('*'));
 
     return (
       <>
         <InOutRateTableGrpc
           title="GRPC Traffic (requests per second):"
-          inRate={incoming.rate}
-          inRateGrpcErr={incoming.rateGrpcErr}
-          inRateNR={incoming.rateNoResponse}
-          outRate={outgoing.rate}
-          outRateGrpcErr={outgoing.rateGrpcErr}
-          outRateNR={outgoing.rateNoResponse}
+          inRate={inbound.rate}
+          inRateGrpcErr={inbound.rateGrpcErr}
+          inRateNR={inbound.rateNoResponse}
+          outRate={outbound.rate}
+          outRateGrpcErr={outbound.rateGrpcErr}
+          outRateNR={outbound.rateNoResponse}
         />
       </>
     );
@@ -284,23 +284,23 @@ export default class SummaryPanelAppBox extends React.Component<SummaryPanelProp
     const validChildren = appBox.children(
       `node[nodeType != "${NodeType.SERVICE}"][nodeType != "${NodeType.AGGREGATE}"]`
     );
-    const incoming = getAccumulatedTrafficRateHttp(validChildren.incomers('edge'));
-    const outgoing = getAccumulatedTrafficRateHttp(validChildren.edgesTo('*'));
+    const inbound = getAccumulatedTrafficRateHttp(validChildren.incomers('edge'));
+    const outbound = getAccumulatedTrafficRateHttp(validChildren.edgesTo('*'));
 
     return (
       <>
         <InOutRateTableHttp
           title="HTTP (requests per second):"
-          inRate={incoming.rate}
-          inRate3xx={incoming.rate3xx}
-          inRate4xx={incoming.rate4xx}
-          inRate5xx={incoming.rate5xx}
-          inRateNR={incoming.rateNoResponse}
-          outRate={outgoing.rate}
-          outRate3xx={outgoing.rate3xx}
-          outRate4xx={outgoing.rate4xx}
-          outRate5xx={outgoing.rate5xx}
-          outRateNR={outgoing.rateNoResponse}
+          inRate={inbound.rate}
+          inRate3xx={inbound.rate3xx}
+          inRate4xx={inbound.rate4xx}
+          inRate5xx={inbound.rate5xx}
+          inRateNR={inbound.rateNoResponse}
+          outRate={outbound.rate}
+          outRate3xx={outbound.rate3xx}
+          outRate4xx={outbound.rate4xx}
+          outRate5xx={outbound.rate5xx}
+          outRateNR={outbound.rateNoResponse}
         />
       </>
     );

--- a/src/pages/Graph/SummaryPanelClusterBox.tsx
+++ b/src/pages/Graph/SummaryPanelClusterBox.tsx
@@ -52,12 +52,11 @@ export default class SummaryPanelClusterBox extends React.Component<SummaryPanel
     const numWorkloads = boxed.filter(`node[nodeType = "${NodeType.WORKLOAD}"]`).size();
     const { numApps, numVersions } = this.countApps(boxed);
     const numEdges = boxed.connectedEdges().size();
-    // inbound edges are from a different cluster, or from a local root node
-    let inboundEdges = clusterBox.cy().nodes(`[${CyNode.cluster} != "${cluster}"]`).edgesTo(boxed);
-    inboundEdges = inboundEdges.add(boxed.filter(`[?${CyNode.isRoot}]`).edgesTo('*'));
+    // inbound edges are from a different cluster
+    const inboundEdges = clusterBox.cy().nodes(`[${CyNode.cluster} != "${cluster}"]`).edgesTo(boxed);
     // outbound edges are to a different cluster
     const outboundEdges = boxed.edgesTo(`[${CyNode.cluster} != "${cluster}"]`);
-    // total edges are inbound + edges from boxed workload/app/root nodes (i.e. not injected service nodes or box nodes)
+    // total edges are inbound + edges from boxed workload|app|root nodes (i.e. not injected service nodes or box nodes)
     const totalEdges = inboundEdges.add(boxed.filter(`[?${CyNode.workload}]`).edgesTo('*'));
     const totalRateGrpc = getAccumulatedTrafficRateGrpc(totalEdges);
     const totalRateHttp = getAccumulatedTrafficRateHttp(totalEdges);

--- a/src/pages/Graph/SummaryPanelClusterBox.tsx
+++ b/src/pages/Graph/SummaryPanelClusterBox.tsx
@@ -52,19 +52,19 @@ export default class SummaryPanelClusterBox extends React.Component<SummaryPanel
     const numWorkloads = boxed.filter(`node[nodeType = "${NodeType.WORKLOAD}"]`).size();
     const { numApps, numVersions } = this.countApps(boxed);
     const numEdges = boxed.connectedEdges().size();
-    // incoming edges are from a different cluster, or from a local root node
-    let incomingEdges = clusterBox.cy().nodes(`[${CyNode.cluster} != "${cluster}"]`).edgesTo(boxed);
-    incomingEdges = incomingEdges.add(boxed.filter(`[?${CyNode.isRoot}]`).edgesTo('*'));
-    // outgoing edges are to a different cluster
-    const outgoingEdges = boxed.edgesTo(`[${CyNode.cluster} != "${cluster}"]`);
-    // total edges are incoming + edges from boxed workload/app/root nodes (i.e. not injected service nodes or box nodes)
-    const totalEdges = incomingEdges.add(boxed.filter(`[?${CyNode.workload}]`).edgesTo('*'));
+    // inbound edges are from a different cluster, or from a local root node
+    let inboundEdges = clusterBox.cy().nodes(`[${CyNode.cluster} != "${cluster}"]`).edgesTo(boxed);
+    inboundEdges = inboundEdges.add(boxed.filter(`[?${CyNode.isRoot}]`).edgesTo('*'));
+    // outbound edges are to a different cluster
+    const outboundEdges = boxed.edgesTo(`[${CyNode.cluster} != "${cluster}"]`);
+    // total edges are inbound + edges from boxed workload/app/root nodes (i.e. not injected service nodes or box nodes)
+    const totalEdges = inboundEdges.add(boxed.filter(`[?${CyNode.workload}]`).edgesTo('*'));
     const totalRateGrpc = getAccumulatedTrafficRateGrpc(totalEdges);
     const totalRateHttp = getAccumulatedTrafficRateHttp(totalEdges);
-    const incomingRateGrpc = getAccumulatedTrafficRateGrpc(incomingEdges);
-    const incomingRateHttp = getAccumulatedTrafficRateHttp(incomingEdges);
-    const outgoingRateGrpc = getAccumulatedTrafficRateGrpc(outgoingEdges);
-    const outgoingRateHttp = getAccumulatedTrafficRateHttp(outgoingEdges);
+    const inboundRateGrpc = getAccumulatedTrafficRateGrpc(inboundEdges);
+    const inboundRateHttp = getAccumulatedTrafficRateHttp(inboundEdges);
+    const outboundRateGrpc = getAccumulatedTrafficRateGrpc(outboundEdges);
+    const outboundRateHttp = getAccumulatedTrafficRateHttp(outboundEdges);
     return (
       <div className="panel panel-default" style={SummaryPanelClusterBox.panelStyle}>
         <div className="panel-heading" style={summaryHeader}>
@@ -73,29 +73,29 @@ export default class SummaryPanelClusterBox extends React.Component<SummaryPanel
         </div>
         <div className={summaryBodyTabs}>
           <SimpleTabs id="graph_summary_tabs" defaultTab={0} style={{ paddingBottom: '10px' }}>
-            <Tab style={summaryFont} title="Incoming" eventKey={0}>
+            <Tab style={summaryFont} title="Inbound" eventKey={0}>
               <div style={summaryFont}>
-                {incomingRateGrpc.rate === 0 && incomingRateHttp.rate === 0 && (
+                {inboundRateGrpc.rate === 0 && inboundRateHttp.rate === 0 && (
                   <>
-                    <KialiIcon.Info /> No incoming traffic.
+                    <KialiIcon.Info /> No inbound traffic.
                   </>
                 )}
-                {incomingRateGrpc.rate > 0 && (
+                {inboundRateGrpc.rate > 0 && (
                   <RateTableGrpc
                     title="GRPC Traffic (requests per second):"
-                    rate={incomingRateGrpc.rate}
-                    rateGrpcErr={incomingRateGrpc.rateGrpcErr}
-                    rateNR={incomingRateGrpc.rateNoResponse}
+                    rate={inboundRateGrpc.rate}
+                    rateGrpcErr={inboundRateGrpc.rateGrpcErr}
+                    rateNR={inboundRateGrpc.rateNoResponse}
                   />
                 )}
-                {incomingRateHttp.rate > 0 && (
+                {inboundRateHttp.rate > 0 && (
                   <RateTableHttp
                     title="HTTP (requests per second):"
-                    rate={incomingRateHttp.rate}
-                    rate3xx={incomingRateHttp.rate3xx}
-                    rate4xx={incomingRateHttp.rate4xx}
-                    rate5xx={incomingRateHttp.rate5xx}
-                    rateNR={incomingRateHttp.rateNoResponse}
+                    rate={inboundRateHttp.rate}
+                    rate3xx={inboundRateHttp.rate3xx}
+                    rate4xx={inboundRateHttp.rate4xx}
+                    rate5xx={inboundRateHttp.rate5xx}
+                    rateNR={inboundRateHttp.rateNoResponse}
                   />
                 )}
                 {
@@ -104,29 +104,29 @@ export default class SummaryPanelClusterBox extends React.Component<SummaryPanel
                 }
               </div>
             </Tab>
-            <Tab style={summaryFont} title="Outgoing" eventKey={1}>
+            <Tab style={summaryFont} title="Outbound" eventKey={1}>
               <div style={summaryFont}>
-                {outgoingRateGrpc.rate === 0 && outgoingRateHttp.rate === 0 && (
+                {outboundRateGrpc.rate === 0 && outboundRateHttp.rate === 0 && (
                   <>
-                    <KialiIcon.Info /> No outgoing traffic.
+                    <KialiIcon.Info /> No outbound traffic.
                   </>
                 )}
-                {outgoingRateGrpc.rate > 0 && (
+                {outboundRateGrpc.rate > 0 && (
                   <RateTableGrpc
                     title="GRPC Traffic (requests per second):"
-                    rate={outgoingRateGrpc.rate}
-                    rateGrpcErr={outgoingRateGrpc.rateGrpcErr}
-                    rateNR={outgoingRateGrpc.rateNoResponse}
+                    rate={outboundRateGrpc.rate}
+                    rateGrpcErr={outboundRateGrpc.rateGrpcErr}
+                    rateNR={outboundRateGrpc.rateNoResponse}
                   />
                 )}
-                {outgoingRateHttp.rate > 0 && (
+                {outboundRateHttp.rate > 0 && (
                   <RateTableHttp
                     title="HTTP (requests per second):"
-                    rate={outgoingRateHttp.rate}
-                    rate3xx={outgoingRateHttp.rate3xx}
-                    rate4xx={outgoingRateHttp.rate4xx}
-                    rate5xx={outgoingRateHttp.rate5xx}
-                    rateNR={outgoingRateHttp.rateNoResponse}
+                    rate={outboundRateHttp.rate}
+                    rate3xx={outboundRateHttp.rate3xx}
+                    rate4xx={outboundRateHttp.rate4xx}
+                    rate5xx={outboundRateHttp.rate5xx}
+                    rateNR={outboundRateHttp.rateNoResponse}
                   />
                 )}
                 {

--- a/src/pages/Graph/SummaryPanelGraph.tsx
+++ b/src/pages/Graph/SummaryPanelGraph.tsx
@@ -131,12 +131,12 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
     const nonServiceEdges = cy.$(`node[nodeType != "${NodeType.SERVICE}"][!isBox]`).edgesTo('*');
     const totalRateGrpc = getAccumulatedTrafficRateGrpc(nonServiceEdges);
     const totalRateHttp = getAccumulatedTrafficRateHttp(nonServiceEdges);
-    const incomingEdges = cy.$(`node[?${CyNode.isRoot}]`).edgesTo('*');
-    const incomingRateGrpc = getAccumulatedTrafficRateGrpc(incomingEdges);
-    const incomingRateHttp = getAccumulatedTrafficRateHttp(incomingEdges);
-    const outgoingEdges = cy.nodes().leaves(`node[?${CyNode.isOutside}],[?${CyNode.isServiceEntry}]`).connectedEdges();
-    const outgoingRateGrpc = getAccumulatedTrafficRateGrpc(outgoingEdges);
-    const outgoingRateHttp = getAccumulatedTrafficRateHttp(outgoingEdges);
+    const inboundEdges = cy.$(`node[?${CyNode.isRoot}]`).edgesTo('*');
+    const inboundRateGrpc = getAccumulatedTrafficRateGrpc(inboundEdges);
+    const inboundRateHttp = getAccumulatedTrafficRateHttp(inboundEdges);
+    const outboundEdges = cy.nodes().leaves(`node[?${CyNode.isOutside}],[?${CyNode.isServiceEntry}]`).connectedEdges();
+    const outboundRateGrpc = getAccumulatedTrafficRateGrpc(outboundEdges);
+    const outboundRateHttp = getAccumulatedTrafficRateHttp(outboundEdges);
 
     return (
       <div className="panel panel-default" style={SummaryPanelGraph.panelStyle}>
@@ -150,29 +150,29 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
         </div>
         <div className={summaryBodyTabs}>
           <SimpleTabs id="graph_summary_tabs" defaultTab={0} style={{ paddingBottom: '10px' }}>
-            <Tab style={summaryFont} title="Incoming" eventKey={0}>
+            <Tab style={summaryFont} title="Inbound" eventKey={0}>
               <div style={summaryFont}>
-                {incomingRateGrpc.rate === 0 && incomingRateHttp.rate === 0 && (
+                {inboundRateGrpc.rate === 0 && inboundRateHttp.rate === 0 && (
                   <>
-                    <KialiIcon.Info /> No incoming traffic.
+                    <KialiIcon.Info /> No inbound traffic.
                   </>
                 )}
-                {incomingRateGrpc.rate > 0 && (
+                {inboundRateGrpc.rate > 0 && (
                   <RateTableGrpc
                     title="GRPC Traffic (requests per second):"
-                    rate={incomingRateGrpc.rate}
-                    rateGrpcErr={incomingRateGrpc.rateGrpcErr}
-                    rateNR={incomingRateGrpc.rateNoResponse}
+                    rate={inboundRateGrpc.rate}
+                    rateGrpcErr={inboundRateGrpc.rateGrpcErr}
+                    rateNR={inboundRateGrpc.rateNoResponse}
                   />
                 )}
-                {incomingRateHttp.rate > 0 && (
+                {inboundRateHttp.rate > 0 && (
                   <RateTableHttp
                     title="HTTP (requests per second):"
-                    rate={incomingRateHttp.rate}
-                    rate3xx={incomingRateHttp.rate3xx}
-                    rate4xx={incomingRateHttp.rate4xx}
-                    rate5xx={incomingRateHttp.rate5xx}
-                    rateNR={incomingRateHttp.rateNoResponse}
+                    rate={inboundRateHttp.rate}
+                    rate3xx={inboundRateHttp.rate3xx}
+                    rate4xx={inboundRateHttp.rate4xx}
+                    rate5xx={inboundRateHttp.rate5xx}
+                    rateNR={inboundRateHttp.rateNoResponse}
                   />
                 )}
                 {
@@ -181,29 +181,29 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
                 }
               </div>
             </Tab>
-            <Tab style={summaryFont} title="Outgoing" eventKey={1}>
+            <Tab style={summaryFont} title="Outbound" eventKey={1}>
               <div style={summaryFont}>
-                {outgoingRateGrpc.rate === 0 && outgoingRateHttp.rate === 0 && (
+                {outboundRateGrpc.rate === 0 && outboundRateHttp.rate === 0 && (
                   <>
-                    <KialiIcon.Info /> No outgoing traffic.
+                    <KialiIcon.Info /> No outbound traffic.
                   </>
                 )}
-                {outgoingRateGrpc.rate > 0 && (
+                {outboundRateGrpc.rate > 0 && (
                   <RateTableGrpc
                     title="GRPC Traffic (requests per second):"
-                    rate={outgoingRateGrpc.rate}
-                    rateGrpcErr={outgoingRateGrpc.rateGrpcErr}
-                    rateNR={outgoingRateGrpc.rateNoResponse}
+                    rate={outboundRateGrpc.rate}
+                    rateGrpcErr={outboundRateGrpc.rateGrpcErr}
+                    rateNR={outboundRateGrpc.rateNoResponse}
                   />
                 )}
-                {outgoingRateHttp.rate > 0 && (
+                {outboundRateHttp.rate > 0 && (
                   <RateTableHttp
                     title="HTTP (requests per second):"
-                    rate={outgoingRateHttp.rate}
-                    rate3xx={outgoingRateHttp.rate3xx}
-                    rate4xx={outgoingRateHttp.rate4xx}
-                    rate5xx={outgoingRateHttp.rate5xx}
-                    rateNR={outgoingRateHttp.rateNoResponse}
+                    rate={outboundRateHttp.rate}
+                    rate3xx={outboundRateHttp.rate3xx}
+                    rate4xx={outboundRateHttp.rate4xx}
+                    rate5xx={outboundRateHttp.rate5xx}
+                    rateNR={outboundRateHttp.rateNoResponse}
                   />
                 )}
                 {

--- a/src/pages/Graph/SummaryPanelNamespaceBox.tsx
+++ b/src/pages/Graph/SummaryPanelNamespaceBox.tsx
@@ -121,22 +121,22 @@ export default class SummaryPanelNamespaceBox extends React.Component<
     const numWorkloads = boxed.filter(`node[nodeType = "${NodeType.WORKLOAD}"]`).size();
     const { numApps, numVersions } = this.countApps(boxed);
     const numEdges = boxed.connectedEdges().size();
-    // incoming edges are from a different namespace or a different cluster, or from a local root node
-    let incomingEdges = namespaceBox
+    // inbound edges are from a different namespace or a different cluster, or from a local root node
+    let inboundEdges = namespaceBox
       .cy()
       .nodes(`[${CyNode.namespace} != "${namespace}"],[${CyNode.cluster} != "${cluster}"]`)
       .edgesTo(boxed);
-    incomingEdges = incomingEdges.add(boxed.filter(`[?${CyNode.isRoot}]`).edgesTo('*'));
-    // outgoing edges are to a different namespace or a different cluster
-    const outgoingEdges = boxed.edgesTo(`[${CyNode.namespace} != "${namespace}"],[${CyNode.cluster} != "${cluster}"]`);
-    // total edges are incoming + edges from boxed workload/app/root nodes (i.e. not injected service nodes or box nodes)
-    const totalEdges = incomingEdges.add(boxed.filter(`[?${CyNode.workload}]`).edgesTo('*'));
+    inboundEdges = inboundEdges.add(boxed.filter(`[?${CyNode.isRoot}]`).edgesTo('*'));
+    // outbound edges are to a different namespace or a different cluster
+    const outboundEdges = boxed.edgesTo(`[${CyNode.namespace} != "${namespace}"],[${CyNode.cluster} != "${cluster}"]`);
+    // total edges are inbound + edges from boxed workload/app/root nodes (i.e. not injected service nodes or box nodes)
+    const totalEdges = inboundEdges.add(boxed.filter(`[?${CyNode.workload}]`).edgesTo('*'));
     const totalRateGrpc = getAccumulatedTrafficRateGrpc(totalEdges);
     const totalRateHttp = getAccumulatedTrafficRateHttp(totalEdges);
-    const incomingRateGrpc = getAccumulatedTrafficRateGrpc(incomingEdges);
-    const incomingRateHttp = getAccumulatedTrafficRateHttp(incomingEdges);
-    const outgoingRateGrpc = getAccumulatedTrafficRateGrpc(outgoingEdges);
-    const outgoingRateHttp = getAccumulatedTrafficRateHttp(outgoingEdges);
+    const inboundRateGrpc = getAccumulatedTrafficRateGrpc(inboundEdges);
+    const inboundRateHttp = getAccumulatedTrafficRateHttp(inboundEdges);
+    const outboundRateGrpc = getAccumulatedTrafficRateGrpc(outboundEdges);
+    const outboundRateHttp = getAccumulatedTrafficRateHttp(outboundEdges);
 
     return (
       <div className="panel panel-default" style={SummaryPanelNamespaceBox.panelStyle}>
@@ -147,29 +147,29 @@ export default class SummaryPanelNamespaceBox extends React.Component<
         </div>
         <div className={summaryBodyTabs}>
           <SimpleTabs id="graph_summary_tabs" defaultTab={0} style={{ paddingBottom: '10px' }}>
-            <Tab style={summaryFont} title="Incoming" eventKey={0}>
+            <Tab style={summaryFont} title="Inbound" eventKey={0}>
               <div style={summaryFont}>
-                {incomingRateGrpc.rate === 0 && incomingRateHttp.rate === 0 && (
+                {inboundRateGrpc.rate === 0 && inboundRateHttp.rate === 0 && (
                   <>
-                    <KialiIcon.Info /> No incoming traffic.
+                    <KialiIcon.Info /> No inbound traffic.
                   </>
                 )}
-                {incomingRateGrpc.rate > 0 && (
+                {inboundRateGrpc.rate > 0 && (
                   <RateTableGrpc
                     title="GRPC Traffic (requests per second):"
-                    rate={incomingRateGrpc.rate}
-                    rateGrpcErr={incomingRateGrpc.rateGrpcErr}
-                    rateNR={incomingRateGrpc.rateNoResponse}
+                    rate={inboundRateGrpc.rate}
+                    rateGrpcErr={inboundRateGrpc.rateGrpcErr}
+                    rateNR={inboundRateGrpc.rateNoResponse}
                   />
                 )}
-                {incomingRateHttp.rate > 0 && (
+                {inboundRateHttp.rate > 0 && (
                   <RateTableHttp
                     title="HTTP (requests per second):"
-                    rate={incomingRateHttp.rate}
-                    rate3xx={incomingRateHttp.rate3xx}
-                    rate4xx={incomingRateHttp.rate4xx}
-                    rate5xx={incomingRateHttp.rate5xx}
-                    rateNR={incomingRateHttp.rateNoResponse}
+                    rate={inboundRateHttp.rate}
+                    rate3xx={inboundRateHttp.rate3xx}
+                    rate4xx={inboundRateHttp.rate4xx}
+                    rate5xx={inboundRateHttp.rate5xx}
+                    rateNR={inboundRateHttp.rateNoResponse}
                   />
                 )}
                 {
@@ -178,29 +178,29 @@ export default class SummaryPanelNamespaceBox extends React.Component<
                 }
               </div>
             </Tab>
-            <Tab style={summaryFont} title="Outgoing" eventKey={1}>
+            <Tab style={summaryFont} title="Outbound" eventKey={1}>
               <div style={summaryFont}>
-                {outgoingRateGrpc.rate === 0 && outgoingRateHttp.rate === 0 && (
+                {outboundRateGrpc.rate === 0 && outboundRateHttp.rate === 0 && (
                   <>
-                    <KialiIcon.Info /> No outgoing traffic.
+                    <KialiIcon.Info /> No outbound traffic.
                   </>
                 )}
-                {outgoingRateGrpc.rate > 0 && (
+                {outboundRateGrpc.rate > 0 && (
                   <RateTableGrpc
                     title="GRPC Traffic (requests per second):"
-                    rate={outgoingRateGrpc.rate}
-                    rateGrpcErr={outgoingRateGrpc.rateGrpcErr}
-                    rateNR={outgoingRateGrpc.rateNoResponse}
+                    rate={outboundRateGrpc.rate}
+                    rateGrpcErr={outboundRateGrpc.rateGrpcErr}
+                    rateNR={outboundRateGrpc.rateNoResponse}
                   />
                 )}
-                {outgoingRateHttp.rate > 0 && (
+                {outboundRateHttp.rate > 0 && (
                   <RateTableHttp
                     title="HTTP (requests per second):"
-                    rate={outgoingRateHttp.rate}
-                    rate3xx={outgoingRateHttp.rate3xx}
-                    rate4xx={outgoingRateHttp.rate4xx}
-                    rate5xx={outgoingRateHttp.rate5xx}
-                    rateNR={outgoingRateHttp.rateNoResponse}
+                    rate={outboundRateHttp.rate}
+                    rate3xx={outboundRateHttp.rate3xx}
+                    rate4xx={outboundRateHttp.rate4xx}
+                    rate5xx={outboundRateHttp.rate5xx}
+                    rateNR={outboundRateHttp.rateNoResponse}
                   />
                 )}
                 {

--- a/src/pages/Graph/SummaryPanelNamespaceBox.tsx
+++ b/src/pages/Graph/SummaryPanelNamespaceBox.tsx
@@ -121,15 +121,14 @@ export default class SummaryPanelNamespaceBox extends React.Component<
     const numWorkloads = boxed.filter(`node[nodeType = "${NodeType.WORKLOAD}"]`).size();
     const { numApps, numVersions } = this.countApps(boxed);
     const numEdges = boxed.connectedEdges().size();
-    // inbound edges are from a different namespace or a different cluster, or from a local root node
-    let inboundEdges = namespaceBox
+    // inbound edges are from a different namespace or a different cluster
+    const inboundEdges = namespaceBox
       .cy()
       .nodes(`[${CyNode.namespace} != "${namespace}"],[${CyNode.cluster} != "${cluster}"]`)
       .edgesTo(boxed);
-    inboundEdges = inboundEdges.add(boxed.filter(`[?${CyNode.isRoot}]`).edgesTo('*'));
     // outbound edges are to a different namespace or a different cluster
     const outboundEdges = boxed.edgesTo(`[${CyNode.namespace} != "${namespace}"],[${CyNode.cluster} != "${cluster}"]`);
-    // total edges are inbound + edges from boxed workload/app/root nodes (i.e. not injected service nodes or box nodes)
+    // total edges are inbound + edges from boxed workload|app|root nodes (i.e. not injected service nodes or box nodes)
     const totalEdges = inboundEdges.add(boxed.filter(`[?${CyNode.workload}]`).edgesTo('*'));
     const totalRateGrpc = getAccumulatedTrafficRateGrpc(totalEdges);
     const totalRateHttp = getAccumulatedTrafficRateHttp(totalEdges);

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/TrafficControlInfo.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/TrafficControlInfo.tsx
@@ -226,7 +226,7 @@ class TrafficControlInfo extends React.Component<TrafficControlInfoProps, State>
                       position={PopoverPosition.auto}
                       content={
                         <>
-                          Match rules used to filter out incoming traffic. With protocol name as a key, its value is an
+                          Match rules used to filter out inbound traffic. With protocol name as a key, its value is an
                           array of Istio matching clauses. Currently, only http is supported
                         </>
                       }


### PR DESCRIPTION
Consolidate terminology on inbound/outbound by converting instances of incoming/outgoing (both in the UI and the code).

Fixes https://github.com/kiali/kiali/issues/3873

@lucasponce This PR currently covers only the terminology change.  If we feel a need to change the Inbound traffic reporting we can expand the PR (see related comments in the issue). Setting to DNM until we have agreed on the scope.