### PR TITLE
Improve graph node labels and PF badging

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -32,10 +32,9 @@ import EmptyGraphLayout from './EmptyGraphLayout';
 import FocusAnimation from './FocusAnimation';
 import { GraphHighlighter } from './graphs/GraphHighlighter';
 import TrafficRenderer from './TrafficAnimation/TrafficRenderer';
+import { serverConfig } from 'config';
 
 type CytoscapeGraphProps = {
-  boxByCluster: boolean;
-  boxByNamespace: boolean;
   compressOnHide: boolean;
   containerClassName?: string;
   contextMenuEdgeComponent?: EdgeContextMenuType;
@@ -603,9 +602,8 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps>
 
     const globalScratchData: CytoscapeGlobalScratchData = {
       activeNamespaces: this.props.graphData.fetchParams.namespaces,
-      boxByCluster: this.props.boxByCluster,
-      boxByNamespace: this.props.boxByNamespace,
       edgeLabelMode: this.props.edgeLabelMode,
+      homeCluster: serverConfig.clusterInfo ? serverConfig.clusterInfo.name : UNKNOWN,
       graphType: this.props.graphData.fetchParams.graphType,
       showCircuitBreakers: this.props.showCircuitBreakers,
       showMissingSidecars: this.props.showMissingSidecars,

--- a/src/components/CytoscapeGraph/MiniGraphCard.tsx
+++ b/src/components/CytoscapeGraph/MiniGraphCard.tsx
@@ -82,8 +82,6 @@ export default class MiniGraphCard extends React.Component<MiniGraphCardProps, M
         <CardBody>
           <div style={{ height: '100%' }}>
             <CytoscapeGraph
-              boxByCluster={false}
-              boxByNamespace={false}
               compressOnHide={true}
               containerClassName={miniGraphContainerStyle}
               graphData={{

--- a/src/components/CytoscapeGraph/__tests__/CytoscapeGraph.test.tsx
+++ b/src/components/CytoscapeGraph/__tests__/CytoscapeGraph.test.tsx
@@ -47,8 +47,6 @@ describe('CytoscapeGraph component test', () => {
     dataSource.on('fetchSuccess', () => {
       const wrapper = shallow(
         <CytoscapeGraph
-          boxByCluster={false}
-          boxByNamespace={false}
           compressOnHide={true}
           edgeLabelMode={myEdgeLabelMode}
           graphData={{

--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -17,6 +17,7 @@ import { decoratedEdgeData, decoratedNodeData, CyNode } from '../CytoscapeGraphU
 import _ from 'lodash';
 import * as Cy from 'cytoscape';
 import { getEdgeHealth } from '../../../types/ErrorRate';
+import { PFBadges } from 'components/Pf/PfBadges';
 export const DimClass = 'mousedim';
 export const HighlightClass = 'mousehighlight';
 export const HoveredClass = 'mousehover';
@@ -68,11 +69,11 @@ const NodeTextFontSizeHover = '11px';
 const NodeTextFontSizeHoverBox = '13px';
 const NodeWidth = NodeHeight;
 
-const badgeMargin = style({
+const iconMargin = style({
   marginLeft: '1px'
 });
 
-const badgesDefault = style({
+const iconsDefault = style({
   alignItems: 'center',
   backgroundColor: NodeBadgeBackgroundColor,
   borderTopLeftRadius: '3px',
@@ -176,35 +177,48 @@ export class GraphStyles {
     };
 
     const cyGlobal = getCyGlobalData(ele);
-    const data = decoratedNodeData(ele);
-    const app = data.app || '';
-    const isBox = data.isBox;
-    const isBoxed = data.parent;
-    const isBoxedBy = isBoxed ? ele.parent()[0].data().isBox : undefined;
+    const node = decoratedNodeData(ele);
+    const app = node.app || '';
+    const cluster = node.cluster;
+    const namespace = node.namespace;
+    const nodeType = node.nodeType;
+    const service = node.service || '';
+    const version = node.version || '';
+    const workload = node.workload || '';
+    const isBox = node.isBox;
+    const isBoxed = node.parent;
+    const box1 = isBoxed ? ele.parent()[0] : undefined;
+    const box1Type = box1 ? box1.data().isBox : undefined;
+    const box2 = box1 && box1.parent() ? box1.parent()[0] : undefined;
+    const box2Type = box2 ? box2.data().isBox : undefined;
+    const box3 = box2 && box2.parent() ? box2.parent()[0] : undefined;
+    const box3Type = box3 ? box3.data().isBox : undefined;
+    const isAppBoxed = box1Type === BoxByType.APP;
+    const isNamespaceBoxed = box1Type === BoxByType.NAMESPACE || box2Type === BoxByType.NAMESPACE;
+    const isClusterBoxed =
+      box1Type === BoxByType.CLUSTER || box2Type === BoxByType.CLUSTER || box3Type === BoxByType.CLUSTER;
     const isMultiNamespace = cyGlobal.activeNamespaces.length > 1;
-    const isOutside = data.isOutside;
-    const namespace = data.namespace;
-    const nodeType = data.nodeType;
-    const service = data.service || '';
-    const version = data.version || '';
-    const workload = data.workload || '';
+    const isOutside = node.isOutside;
 
-    let badges = '';
-    if (data.isRoot) {
-      badges = `<span class="${NodeIconRoot} ${badgeMargin}"></span> ${badges}`;
+    console.log(
+      `[app=${node.app}] isAppBoxed=${isAppBoxed}, isNSBoxed=${isNamespaceBoxed}, isCLBoxed=${isClusterBoxed}`
+    );
+    let icons = '';
+    if (node.isRoot) {
+      icons = `<span class="${NodeIconRoot} ${iconMargin}"></span> ${icons}`;
     }
-    if (cyGlobal.showMissingSidecars && data.hasMissingSC) {
-      badges = `<span class="${NodeIconMS} ${badgeMargin}"></span> ${badges}`;
+    if (cyGlobal.showMissingSidecars && node.hasMissingSC) {
+      icons = `<span class="${NodeIconMS} ${iconMargin}"></span> ${icons}`;
     }
-    if (cyGlobal.showCircuitBreakers && data.hasCB) {
-      badges = `<span class="${NodeIconCB} ${badgeMargin}"></span> ${badges}`;
+    if (cyGlobal.showCircuitBreakers && node.hasCB) {
+      icons = `<span class="${NodeIconCB} ${iconMargin}"></span> ${icons}`;
     }
-    if (cyGlobal.showVirtualServices && data.hasVS) {
-      badges = `<span class="${NodeIconVS} ${badgeMargin}"></span> ${badges}`;
+    if (cyGlobal.showVirtualServices && node.hasVS) {
+      icons = `<span class="${NodeIconVS} ${iconMargin}"></span> ${icons}`;
     }
-    const hasBadge = badges.length > 0;
-    if (hasBadge) {
-      badges = `<div class=${badgesDefault}>${badges}</div>`;
+    const hasIcon = icons.length > 0;
+    if (hasIcon) {
+      icons = `<div class=${iconsDefault}>${icons}</div>`;
     }
 
     let labelStyle = '';
@@ -222,23 +236,36 @@ export class GraphStyles {
     }
 
     const content: string[] = [];
+
+    // append namespace if necessary
     if (
       (isMultiNamespace || isOutside) &&
-      !cyGlobal.boxByNamespace &&
+      !!namespace &&
       namespace !== UNKNOWN &&
-      nodeType !== NodeType.UNKNOWN &&
-      isBox !== BoxByType.CLUSTER &&
+      !isAppBoxed &&
+      !isNamespaceBoxed &&
       isBox !== BoxByType.NAMESPACE
     ) {
       content.push(`(${namespace})`);
     }
 
+    // append cluster if necessary
+    if (
+      !!cluster &&
+      cluster !== UNKNOWN &&
+      cluster !== cyGlobal.homeCluster &&
+      !isBoxed &&
+      isBox !== BoxByType.CLUSTER
+    ) {
+      content.push(`(${cluster})`);
+    }
+
     switch (nodeType) {
       case NodeType.AGGREGATE:
-        content.unshift(data.aggregateValue!);
+        content.unshift(node.aggregateValue!);
         break;
       case NodeType.APP:
-        if (isBoxed && isBoxedBy === BoxByType.APP) {
+        if (isAppBoxed) {
           if (cyGlobal.graphType === GraphType.APP) {
             content.unshift(app);
           } else if (version && version !== UNKNOWN) {
@@ -261,13 +288,10 @@ export class GraphStyles {
             content.unshift(app);
             break;
           case BoxByType.CLUSTER:
-            content.unshift(data.cluster);
+            content.unshift(node.cluster);
             break;
           case BoxByType.NAMESPACE:
-            content.unshift(data.namespace);
-            if (!cyGlobal.boxByCluster && data.cluster !== UNKNOWN) {
-              content.push(`(${data.cluster})`);
-            }
+            content.unshift(node.namespace);
             break;
         }
         break;
@@ -285,31 +309,31 @@ export class GraphStyles {
     }
 
     const contentText = content.join('<br/>');
-    const contentClasses = hasBadge ? `${contentDefault} ${contentWithBadges}` : `${contentDefault}`;
+    const contentClasses = hasIcon ? `${contentDefault} ${contentWithBadges}` : `${contentDefault}`;
     let appBoxStyle = '';
     if (isBox) {
-      let letter = '';
+      let badge = '';
       switch (isBox) {
         case BoxByType.APP:
-          letter = 'A';
+          badge = PFBadges.App.badge;
           appBoxStyle += `font-size: ${NodeTextFontSize};`;
           break;
         case BoxByType.CLUSTER:
-          letter = 'CL';
+          badge = PFBadges.Cluster.badge;
           break;
         case BoxByType.NAMESPACE:
-          letter = 'NS';
+          badge = PFBadges.Namespace.badge;
           break;
         default:
           console.warn(`GraphSyles: Unexpected box [${isBox}] `);
       }
-      const contentBadge = `<span class="pf-c-badge pf-m-unread ${contentBoxPfBadge}" style="${appBoxStyle}">${letter}</span>`;
+      const contentBadge = `<span class="pf-c-badge pf-m-unread ${contentBoxPfBadge}" style="${appBoxStyle}">${badge}</span>`;
       const contentSpan = `<span class="${contentClasses} ${contentBox}" style=" ${appBoxStyle}${contentStyle}">${contentBadge}${contentText}</span>`;
-      return `<div class="${labelDefault} ${labelBox}" style="${labelStyle}">${badges}${contentSpan}</div>`;
+      return `<div class="${labelDefault} ${labelBox}" style="${labelStyle}">${icons}${contentSpan}</div>`;
     }
 
     const contentSpan = `<div class="${contentClasses}" style="${contentStyle}">${contentText}</div>`;
-    return `<div class="${labelDefault}" style="${labelStyle}">${badges}${contentSpan}</div>`;
+    return `<div class="${labelDefault}" style="${labelStyle}">${icons}${contentSpan}</div>`;
   }
 
   static htmlNodeLabels(cy: Cy.Core) {

--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -191,18 +191,14 @@ export class GraphStyles {
     const box1Type = box1 ? box1.data().isBox : undefined;
     const box2 = box1 && box1.parent() ? box1.parent()[0] : undefined;
     const box2Type = box2 ? box2.data().isBox : undefined;
-    const box3 = box2 && box2.parent() ? box2.parent()[0] : undefined;
-    const box3Type = box3 ? box3.data().isBox : undefined;
+    // const box3 = box2 && box2.parent() ? box2.parent()[0] : undefined;
+    // const box3Type = box3 ? box3.data().isBox : undefined;
     const isAppBoxed = box1Type === BoxByType.APP;
     const isNamespaceBoxed = box1Type === BoxByType.NAMESPACE || box2Type === BoxByType.NAMESPACE;
-    const isClusterBoxed =
-      box1Type === BoxByType.CLUSTER || box2Type === BoxByType.CLUSTER || box3Type === BoxByType.CLUSTER;
+    // const isClusterBoxed = box1Type === BoxByType.CLUSTER || box2Type === BoxByType.CLUSTER || box3Type === BoxByType.CLUSTER;
     const isMultiNamespace = cyGlobal.activeNamespaces.length > 1;
     const isOutside = node.isOutside;
 
-    console.log(
-      `[app=${node.app}] isAppBoxed=${isAppBoxed}, isNSBoxed=${isNamespaceBoxed}, isCLBoxed=${isClusterBoxed}`
-    );
     let icons = '';
     if (node.isRoot) {
       icons = `<span class="${NodeIconRoot} ${iconMargin}"></span> ${icons}`;

--- a/src/components/IstioWizards/RequestRouting/Rules.tsx
+++ b/src/components/IstioWizards/RequestRouting/Rules.tsx
@@ -13,6 +13,7 @@ import {
 } from '@patternfly/react-core';
 import { WorkloadWeight } from '../TrafficShifting';
 import { Abort, Delay, HTTPRetry } from '../../../types/IstioObjects';
+import { pfBadge, PFBadges } from 'components/Pf/PfBadges';
 
 export enum MOVE_TYPE {
   UP,
@@ -137,9 +138,7 @@ class Rules extends React.Component<Props> {
                       .map((wk, i) => {
                         return (
                           <div key={'wk_' + order + '_' + wk.name + '_' + i}>
-                            <Tooltip position={TooltipPosition.top} content={<>Workload</>}>
-                              <Badge className={'virtualitem_badge_definition'}>WS</Badge>
-                            </Tooltip>
+                            {pfBadge(PFBadges.Workload, TooltipPosition.top)}
                             {wk.name} ({wk.weight}% routed traffic)
                           </div>
                         );

--- a/src/components/IstioWizards/RequestRouting/Rules.tsx
+++ b/src/components/IstioWizards/RequestRouting/Rules.tsx
@@ -13,7 +13,7 @@ import {
 } from '@patternfly/react-core';
 import { WorkloadWeight } from '../TrafficShifting';
 import { Abort, Delay, HTTPRetry } from '../../../types/IstioObjects';
-import { pfBadge, PFBadges } from 'components/Pf/PfBadges';
+import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
 
 export enum MOVE_TYPE {
   UP,
@@ -138,7 +138,7 @@ class Rules extends React.Component<Props> {
                       .map((wk, i) => {
                         return (
                           <div key={'wk_' + order + '_' + wk.name + '_' + i}>
-                            {pfBadge(PFBadges.Workload, TooltipPosition.top)}
+                            <PFBadge badge={PFBadges.Workload} position={TooltipPosition.top} />
                             {wk.name} ({wk.weight}% routed traffic)
                           </div>
                         );

--- a/src/components/IstioWizards/TrafficShifting.tsx
+++ b/src/components/IstioWizards/TrafficShifting.tsx
@@ -7,6 +7,7 @@ import { PFColors } from '../Pf/PfColors';
 import { Badge, Button, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { EqualizerIcon } from '@patternfly/react-icons';
 import { getDefaultWeights } from './WizardActions';
+import { pfBadge, PFBadges } from 'components/Pf/PfBadges';
 
 type Props = {
   workloads: WorkloadOverview[];
@@ -217,9 +218,7 @@ class TrafficShifting extends React.Component<Props, State> {
           cells: [
             <>
               <div>
-                <Tooltip key={'tooltip_' + workload.name} position={TooltipPosition.top} content={<>Workload</>}>
-                  <Badge className={'virtualitem_badge_definition'}>WS</Badge>
-                </Tooltip>
+                {pfBadge(PFBadges.Workload, TooltipPosition.top)}
                 {workload.name}
               </div>
             </>,

--- a/src/components/IstioWizards/TrafficShifting.tsx
+++ b/src/components/IstioWizards/TrafficShifting.tsx
@@ -7,7 +7,7 @@ import { PFColors } from '../Pf/PfColors';
 import { Badge, Button, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { EqualizerIcon } from '@patternfly/react-icons';
 import { getDefaultWeights } from './WizardActions';
-import { pfBadge, PFBadges } from 'components/Pf/PfBadges';
+import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
 
 type Props = {
   workloads: WorkloadOverview[];
@@ -218,7 +218,7 @@ class TrafficShifting extends React.Component<Props, State> {
           cells: [
             <>
               <div>
-                {pfBadge(PFBadges.Workload, TooltipPosition.top)}
+                <PFBadge badge={PFBadges.Workload} position={TooltipPosition.top} />
                 {workload.name}
               </div>
             </>,

--- a/src/components/Link/IstioObjectLink.tsx
+++ b/src/components/Link/IstioObjectLink.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { Paths } from '../../config';
 import { Link } from 'react-router-dom';
-import { Badge, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { IstioTypes } from '../VirtualList/Config';
+import { pfBadge } from 'components/Pf/PfBadges';
 
 interface Props {
   name: string;
@@ -32,9 +32,7 @@ export class ReferenceIstioObjectLink extends React.Component<Props> {
 
     return (
       <>
-        <Tooltip position={TooltipPosition.top} content={<>{istioType.name}</>}>
-          <Badge className={'virtualitem_badge_definition'}>{istioType.icon}</Badge>
-        </Tooltip>
+        {pfBadge(istioType.badge)}
         <IstioObjectLink name={name} namespace={namespace} type={type} subType={subType}>
           {namespace}/{name}
         </IstioObjectLink>

--- a/src/components/Link/IstioObjectLink.tsx
+++ b/src/components/Link/IstioObjectLink.tsx
@@ -2,7 +2,8 @@ import * as React from 'react';
 import { Paths } from '../../config';
 import { Link } from 'react-router-dom';
 import { IstioTypes } from '../VirtualList/Config';
-import { pfBadge } from 'components/Pf/PfBadges';
+import { PFBadge } from 'components/Pf/PfBadges';
+import { TooltipPosition } from '@patternfly/react-core';
 
 interface Props {
   name: string;
@@ -32,7 +33,7 @@ export class ReferenceIstioObjectLink extends React.Component<Props> {
 
     return (
       <>
-        {pfBadge(istioType.badge)}
+        <PFBadge badge={istioType.badge} position={TooltipPosition.top} />
         <IstioObjectLink name={name} namespace={namespace} type={type} subType={subType}>
           {namespace}/{name}
         </IstioObjectLink>

--- a/src/components/Pf/PfBadges.tsx
+++ b/src/components/Pf/PfBadges.tsx
@@ -1,0 +1,105 @@
+import { Badge, Tooltip, TooltipPosition } from '@patternfly/react-core';
+import React, { CSSProperties } from 'react';
+import { style } from 'typestyle';
+import { PFColors } from './PfColors';
+
+export type PFBadge = {
+  badge: string;
+  tt: string;
+};
+
+// PF Badges used by Kiali, keep alphabetized
+// avoid duplicate badge letters, especially if they may appear on the same page
+export const PFBadges = Object.freeze({
+  App: { badge: 'A', tt: 'Application' } as PFBadge,
+  Adapter: { badge: 'A', tt: 'Adapter' } as PFBadge,
+  AttributeManifest: { badge: 'AM', tt: 'Attribute Manifest' } as PFBadge,
+  AuthorizationPolicy: { badge: 'AP', tt: 'Authorization Policy' } as PFBadge,
+  Cluster: { badge: 'CL', tt: 'Cluster' } as PFBadge,
+  ClusterRBACConfig: { badge: 'CRC', tt: 'Cluster RBAC Configuration' } as PFBadge,
+  Container: { badge: 'C', tt: 'Container' } as PFBadge,
+  DestinationRule: { badge: 'DR', tt: 'Destination Rule' } as PFBadge,
+  EnvoyFilter: { badge: 'EF', tt: 'Envoy Filter' } as PFBadge,
+  Gateway: { badge: 'G', tt: 'Gateway' } as PFBadge,
+  Handler: { badge: 'H', tt: 'Handler' },
+  Host: { badge: 'H', tt: 'Host' },
+  Instance: { badge: 'I', tt: 'Instance' },
+  Iter8: { badge: 'IT8', tt: 'Iter8 Experiment' },
+  MeshPolicy: { badge: 'MP', tt: 'Mesh Policy' } as PFBadge,
+  Namespace: { badge: 'NS', tt: 'Namespace' } as PFBadge,
+  Operation: { badge: 'O', tt: 'Operation' } as PFBadge,
+  PeerAuthentication: { badge: 'PA', tt: 'Peer Authentication' } as PFBadge,
+  Pod: { badge: 'P', tt: 'Pod' } as PFBadge,
+  Policy: { badge: 'P', tt: 'Policy' } as PFBadge,
+  RBACConfig: { badge: 'RC', tt: 'RBAC Configuration' } as PFBadge,
+  RequestAuthentication: { badge: 'RA', tt: 'Request Authentication' } as PFBadge,
+  Rule: { badge: 'R', tt: 'Rule' } as PFBadge,
+  Service: { badge: 'S', tt: 'Service' } as PFBadge,
+  ServiceEntry: { badge: 'SE', tt: 'Service Entry' } as PFBadge,
+  ServiceRole: { badge: 'SR', tt: 'Service Role' } as PFBadge,
+  ServiceRoleBinding: { badge: 'SRB', tt: 'Service Role Binding' } as PFBadge,
+  Sidecar: { badge: 'SC', tt: 'Istio Sidecar Proxy' } as PFBadge,
+  Template: { badge: 'T', tt: 'Template' } as PFBadge,
+  Unknown: { badge: 'U', tt: 'Unknown' } as PFBadge,
+  VirtualService: { badge: 'VS', tt: 'Virtual Service' } as PFBadge,
+  Workload: { badge: 'W', tt: 'Workload' } as PFBadge,
+  WorkloadEntry: { badge: 'WE', tt: 'Workload Entry' } as PFBadge
+});
+
+export const kialiBadge = style({
+  backgroundColor: PFColors.Blue200,
+  borderRadius: '30em',
+  marginRight: '10px'
+});
+
+export const pfBadge = (
+  badge: PFBadge,
+  position?: TooltipPosition,
+  key?: string,
+  style?: CSSProperties
+): React.ReactFragment => {
+  return (
+    <Tooltip
+      key={key || `pfbadge-${badge.badge}`}
+      position={position || TooltipPosition.auto}
+      content={<>{badge.tt}</>}
+    >
+      <Badge className={kialiBadge} style={style}>
+        {badge.badge}
+      </Badge>
+    </Tooltip>
+  );
+};
+
+export const pfAdHocBadge = (
+  badge: string,
+  tooltip?: string,
+  position?: TooltipPosition,
+  key?: string,
+  style?: CSSProperties,
+  isRead?: boolean
+): React.ReactFragment => {
+  const badgeElem = (
+    <Badge className={kialiBadge} style={style} isRead={!!isRead}>
+      {badge}
+    </Badge>
+  );
+  return tooltip ? (
+    <Tooltip key={key || `pfbadge-${badge}`} position={position || TooltipPosition.auto} content={<>{tooltip}</>}>
+      {badgeElem}
+    </Tooltip>
+  ) : (
+    badgeElem
+  );
+};
+
+// convenience method: same as pfAdHocBadge with ReadOnly styling
+export const pfAdHocBadgeRO = (
+  badge: string,
+  tooltip?: string,
+  position?: TooltipPosition,
+  key?: string,
+  style?: CSSProperties
+): React.ReactFragment => {
+  return pfAdHocBadge(badge, tooltip, position, key, style, true);
+};

--- a/src/components/Pf/PfBadges.tsx
+++ b/src/components/Pf/PfBadges.tsx
@@ -3,47 +3,47 @@ import React, { CSSProperties } from 'react';
 import { style } from 'typestyle';
 import { PFColors } from './PfColors';
 
-export type PFBadge = {
+export type PFBadgeType = {
   badge: string;
-  tt: string;
+  tt?: React.ReactFragment;
 };
 
 // PF Badges used by Kiali, keep alphabetized
 // avoid duplicate badge letters, especially if they may appear on the same page
 export const PFBadges = Object.freeze({
-  App: { badge: 'A', tt: 'Application' } as PFBadge,
-  Adapter: { badge: 'A', tt: 'Adapter' } as PFBadge,
-  AttributeManifest: { badge: 'AM', tt: 'Attribute Manifest' } as PFBadge,
-  AuthorizationPolicy: { badge: 'AP', tt: 'Authorization Policy' } as PFBadge,
-  Cluster: { badge: 'CL', tt: 'Cluster' } as PFBadge,
-  ClusterRBACConfig: { badge: 'CRC', tt: 'Cluster RBAC Configuration' } as PFBadge,
-  Container: { badge: 'C', tt: 'Container' } as PFBadge,
-  DestinationRule: { badge: 'DR', tt: 'Destination Rule' } as PFBadge,
-  EnvoyFilter: { badge: 'EF', tt: 'Envoy Filter' } as PFBadge,
-  Gateway: { badge: 'G', tt: 'Gateway' } as PFBadge,
+  App: { badge: 'A', tt: 'Application' } as PFBadgeType,
+  Adapter: { badge: 'A', tt: 'Adapter' } as PFBadgeType,
+  AttributeManifest: { badge: 'AM', tt: 'Attribute Manifest' } as PFBadgeType,
+  AuthorizationPolicy: { badge: 'AP', tt: 'Authorization Policy' } as PFBadgeType,
+  Cluster: { badge: 'CL', tt: 'Cluster' } as PFBadgeType,
+  ClusterRBACConfig: { badge: 'CRC', tt: 'Cluster RBAC Configuration' } as PFBadgeType,
+  Container: { badge: 'C', tt: 'Container' } as PFBadgeType,
+  DestinationRule: { badge: 'DR', tt: 'Destination Rule' } as PFBadgeType,
+  EnvoyFilter: { badge: 'EF', tt: 'Envoy Filter' } as PFBadgeType,
+  Gateway: { badge: 'G', tt: 'Gateway' } as PFBadgeType,
   Handler: { badge: 'H', tt: 'Handler' },
   Host: { badge: 'H', tt: 'Host' },
   Instance: { badge: 'I', tt: 'Instance' },
   Iter8: { badge: 'IT8', tt: 'Iter8 Experiment' },
-  MeshPolicy: { badge: 'MP', tt: 'Mesh Policy' } as PFBadge,
-  Namespace: { badge: 'NS', tt: 'Namespace' } as PFBadge,
-  Operation: { badge: 'O', tt: 'Operation' } as PFBadge,
-  PeerAuthentication: { badge: 'PA', tt: 'Peer Authentication' } as PFBadge,
-  Pod: { badge: 'P', tt: 'Pod' } as PFBadge,
-  Policy: { badge: 'P', tt: 'Policy' } as PFBadge,
-  RBACConfig: { badge: 'RC', tt: 'RBAC Configuration' } as PFBadge,
-  RequestAuthentication: { badge: 'RA', tt: 'Request Authentication' } as PFBadge,
-  Rule: { badge: 'R', tt: 'Rule' } as PFBadge,
-  Service: { badge: 'S', tt: 'Service' } as PFBadge,
-  ServiceEntry: { badge: 'SE', tt: 'Service Entry' } as PFBadge,
-  ServiceRole: { badge: 'SR', tt: 'Service Role' } as PFBadge,
-  ServiceRoleBinding: { badge: 'SRB', tt: 'Service Role Binding' } as PFBadge,
-  Sidecar: { badge: 'SC', tt: 'Istio Sidecar Proxy' } as PFBadge,
-  Template: { badge: 'T', tt: 'Template' } as PFBadge,
-  Unknown: { badge: 'U', tt: 'Unknown' } as PFBadge,
-  VirtualService: { badge: 'VS', tt: 'Virtual Service' } as PFBadge,
-  Workload: { badge: 'W', tt: 'Workload' } as PFBadge,
-  WorkloadEntry: { badge: 'WE', tt: 'Workload Entry' } as PFBadge
+  MeshPolicy: { badge: 'MP', tt: 'Mesh Policy' } as PFBadgeType,
+  Namespace: { badge: 'NS', tt: 'Namespace' } as PFBadgeType,
+  Operation: { badge: 'O', tt: 'Operation' } as PFBadgeType,
+  PeerAuthentication: { badge: 'PA', tt: 'Peer Authentication' } as PFBadgeType,
+  Pod: { badge: 'P', tt: 'Pod' } as PFBadgeType,
+  Policy: { badge: 'P', tt: 'Policy' } as PFBadgeType,
+  RBACConfig: { badge: 'RC', tt: 'RBAC Configuration' } as PFBadgeType,
+  RequestAuthentication: { badge: 'RA', tt: 'Request Authentication' } as PFBadgeType,
+  Rule: { badge: 'R', tt: 'Rule' } as PFBadgeType,
+  Service: { badge: 'S', tt: 'Service' } as PFBadgeType,
+  ServiceEntry: { badge: 'SE', tt: 'Service Entry' } as PFBadgeType,
+  ServiceRole: { badge: 'SR', tt: 'Service Role' } as PFBadgeType,
+  ServiceRoleBinding: { badge: 'SRB', tt: 'Service Role Binding' } as PFBadgeType,
+  Sidecar: { badge: 'SC', tt: 'Istio Sidecar Proxy' } as PFBadgeType,
+  Template: { badge: 'T', tt: 'Template' } as PFBadgeType,
+  Unknown: { badge: 'U', tt: 'Unknown' } as PFBadgeType,
+  VirtualService: { badge: 'VS', tt: 'Virtual Service' } as PFBadgeType,
+  Workload: { badge: 'W', tt: 'Workload' } as PFBadgeType,
+  WorkloadEntry: { badge: 'WE', tt: 'Workload Entry' } as PFBadgeType
 });
 
 export const kialiBadge = style({
@@ -52,54 +52,46 @@ export const kialiBadge = style({
   marginRight: '10px'
 });
 
-export const pfBadge = (
-  badge: PFBadge,
-  position?: TooltipPosition,
-  key?: string,
-  style?: CSSProperties
-): React.ReactFragment => {
-  return (
-    <Tooltip
-      key={key || `pfbadge-${badge.badge}`}
-      position={position || TooltipPosition.auto}
-      content={<>{badge.tt}</>}
-    >
-      <Badge className={kialiBadge} style={style}>
-        {badge.badge}
+type PFBadgeProps = {
+  badge: PFBadgeType;
+  className?: string; // default=kialiBadge
+  id?: string;
+  isRead?: boolean;
+  key?: string;
+  position?: TooltipPosition; // default=auto
+  style?: CSSProperties;
+};
+
+export class PFBadge extends React.PureComponent<PFBadgeProps> {
+  render() {
+    const key = `pfbadge-${this.props.badge.badge}`;
+    const badge = (
+      <Badge
+        className={this.props.className || kialiBadge}
+        id={this.props.id || key}
+        isRead={this.props.isRead || false}
+        key={this.props.key || key}
+        style={this.props.style}
+      >
+        {this.props.badge.badge}
       </Badge>
-    </Tooltip>
-  );
-};
+    );
 
-export const pfAdHocBadge = (
-  badge: string,
-  tooltip?: React.ReactFragment,
-  position?: TooltipPosition,
-  key?: string,
-  style?: CSSProperties,
-  isRead?: boolean
-): React.ReactFragment => {
-  const badgeElem = (
-    <Badge className={kialiBadge} style={style} isRead={!!isRead}>
-      {badge}
-    </Badge>
-  );
-  return tooltip ? (
-    <Tooltip key={key || `pfbadge-${badge}`} position={position || TooltipPosition.auto} content={tooltip}>
-      {badgeElem}
-    </Tooltip>
-  ) : (
-    badgeElem
-  );
-};
+    return !this.props.badge.tt ? (
+      badge
+    ) : (
+      <Tooltip
+        content={<>{this.props.badge.tt}</>}
+        id={`tt-${this.props.id || key}`}
+        key={`tt-${this.props.key || key}`}
+        position={this.props.position || TooltipPosition.auto}
+      >
+        {badge}
+      </Tooltip>
+    );
+  }
+}
 
-// convenience method: same as pfAdHocBadge with ReadOnly styling
-export const pfAdHocBadgeRO = (
-  badge: string,
-  tooltip?: string,
-  position?: TooltipPosition,
-  key?: string,
-  style?: CSSProperties
-): React.ReactFragment => {
-  return pfAdHocBadge(badge, tooltip, position, key, style, true);
+export const getPFBadge = (badge: string, tt?: React.ReactFragment): React.ReactFragment => {
+  return <PFBadge badge={{ badge: badge, tt: tt }} />;
 };

--- a/src/components/Pf/PfBadges.tsx
+++ b/src/components/Pf/PfBadges.tsx
@@ -47,7 +47,7 @@ export const PFBadges = Object.freeze({
 });
 
 export const kialiBadge = style({
-  backgroundColor: PFColors.Blue200,
+  backgroundColor: PFColors.Badge,
   borderRadius: '30em',
   marginRight: '10px'
 });
@@ -73,7 +73,7 @@ export const pfBadge = (
 
 export const pfAdHocBadge = (
   badge: string,
-  tooltip?: string,
+  tooltip?: React.ReactFragment,
   position?: TooltipPosition,
   key?: string,
   style?: CSSProperties,
@@ -85,7 +85,7 @@ export const pfAdHocBadge = (
     </Badge>
   );
   return tooltip ? (
-    <Tooltip key={key || `pfbadge-${badge}`} position={position || TooltipPosition.auto} content={<>{tooltip}</>}>
+    <Tooltip key={key || `pfbadge-${badge}`} position={position || TooltipPosition.auto} content={tooltip}>
       {badgeElem}
     </Tooltip>
   ) : (

--- a/src/components/Pf/PfColors.tsx
+++ b/src/components/Pf/PfColors.tsx
@@ -38,7 +38,7 @@ export enum PFColors {
   // semantic kiali colors
   Active = 'var(--pf-global--active-color--400)',
   ActiveText = 'var(--pf-global--primary-color--200)',
-  Badge = 'var(--pf-global--palette--blue-200)', // UX-assigned badge background. also, see dep in _VirtualList.scss
+  Badge = 'var(--pf-global--palette--blue-200)', // UX-assigned badge background
   Replay = 'var(--pf-global--active-color--300)', // also, see dep in _Time.scss
 
   // Health/Alert colors https://www.patternfly.org/v4/design-guidelines/styles/colors

--- a/src/components/TrafficList/TrafficListComponent.tsx
+++ b/src/components/TrafficList/TrafficListComponent.tsx
@@ -12,12 +12,12 @@ import history, { URLParam } from 'app/History';
 import { createIcon } from 'components/Health/Helper';
 import { sortFields } from './FiltersAndSorts';
 import { SortField } from 'types/SortFilters';
-import { pfBadge, PFBadge, PFBadges } from 'components/Pf/PfBadges';
+import { PFBadgeType, PFBadge, PFBadges } from 'components/Pf/PfBadges';
 
 export interface TrafficListItem {
   direction: TrafficDirection;
   healthStatus: ThresholdStatus;
-  badge: PFBadge;
+  badge: PFBadgeType;
   node: TrafficNode;
   protocol: string;
   trafficRate: string;
@@ -152,7 +152,7 @@ class TrafficListComponent extends FilterComponent.Component<
 
   trafficToListItems(trafficItems: TrafficItem[]) {
     const listItems = trafficItems.map(ti => {
-      let badge: PFBadge;
+      let badge: PFBadgeType;
       switch (ti.node.type) {
         case NodeType.APP:
           badge = PFBadges.App;
@@ -232,7 +232,7 @@ class TrafficListComponent extends FilterComponent.Component<
               </Tooltip>
             </>,
             <>
-              {pfBadge(item.badge, TooltipPosition.top, `tt_badge_${i}`)}
+              <PFBadge badge={item.badge} position={TooltipPosition.top} key={`tt_badge_${i}`} />
               {!!links.detail ? (
                 <Link key={`link_d_${item.badge}_${name}`} to={links.detail} className={'virtualitem_definition_link'}>
                   {name}

--- a/src/components/TrafficList/TrafficListComponent.tsx
+++ b/src/components/TrafficList/TrafficListComponent.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Badge, Title, Tooltip, TooltipPosition } from '@patternfly/react-core';
+import { Title, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { style } from 'typestyle';
 import { IRow, sortable, SortByDirection, Table, TableBody, TableHeader, cellWidth } from '@patternfly/react-table';
 import { Link } from 'react-router-dom';
@@ -12,11 +12,12 @@ import history, { URLParam } from 'app/History';
 import { createIcon } from 'components/Health/Helper';
 import { sortFields } from './FiltersAndSorts';
 import { SortField } from 'types/SortFilters';
+import { pfBadge, PFBadge, PFBadges } from 'components/Pf/PfBadges';
 
 export interface TrafficListItem {
   direction: TrafficDirection;
   healthStatus: ThresholdStatus;
-  icon: string;
+  badge: PFBadge;
   node: TrafficNode;
   protocol: string;
   trafficRate: string;
@@ -151,20 +152,20 @@ class TrafficListComponent extends FilterComponent.Component<
 
   trafficToListItems(trafficItems: TrafficItem[]) {
     const listItems = trafficItems.map(ti => {
-      let icon: string;
+      let badge: PFBadge;
       switch (ti.node.type) {
         case NodeType.APP:
-          icon = 'A';
+          badge = PFBadges.App;
           break;
         case NodeType.SERVICE:
-          icon = 'S';
+          badge = PFBadges.Service;
           break;
         default:
-          icon = 'W';
+          badge = PFBadges.Workload;
       }
       const item: TrafficListItem = {
         direction: ti.direction,
-        icon: icon,
+        badge: badge,
         node: ti.node,
         protocol: (ti.traffic.protocol || 'N/A').toUpperCase(),
         healthStatus: this.getHealthStatus(ti),
@@ -231,15 +232,9 @@ class TrafficListComponent extends FilterComponent.Component<
               </Tooltip>
             </>,
             <>
-              <Tooltip
-                key={`tt_badge_${i}`}
-                position={TooltipPosition.top}
-                content={<>{this.nodeTypeToType(item.node.type)}</>}
-              >
-                <Badge className={'virtualitem_badge_definition'}>{item.icon}</Badge>
-              </Tooltip>
+              {pfBadge(item.badge, TooltipPosition.top, `tt_badge_${i}`)}
               {!!links.detail ? (
-                <Link key={`link_d_${item.icon}_${name}`} to={links.detail} className={'virtualitem_definition_link'}>
+                <Link key={`link_d_${item.badge}_${name}`} to={links.detail} className={'virtualitem_definition_link'}>
                   {name}
                 </Link>
               ) : (
@@ -251,7 +246,7 @@ class TrafficListComponent extends FilterComponent.Component<
             <>{item.protocol}</>,
             <>
               {!!links.metrics && (
-                <Link key={`link_m_${item.icon}_${name}`} to={links.metrics} className={'virtualitem_definition_link'}>
+                <Link key={`link_m_${item.badge}_${name}`} to={links.metrics} className={'virtualitem_definition_link'}>
                   View metrics
                 </Link>
               )}

--- a/src/components/VirtualList/Config.ts
+++ b/src/components/VirtualList/Config.ts
@@ -11,6 +11,7 @@ import { isIstioNamespace } from 'config/ServerConfig';
 import NamespaceInfo from '../../pages/Overview/NamespaceInfo';
 import * as React from 'react';
 import { StatefulFilters } from '../Filters/StatefulFilters';
+import { PFBadge, PFBadges } from '../../components/Pf/PfBadges';
 
 export type SortResource = AppListItem | WorkloadListItem | ServiceListItem;
 export type TResource = SortResource | IstioConfigItem;
@@ -18,7 +19,7 @@ export type RenderResource = TResource | NamespaceInfo;
 export type Renderer<R extends RenderResource> = (
   item: R,
   config: Resource,
-  icon: string,
+  badge: PFBadge,
   health?: Health,
   statefulFilter?: React.RefObject<StatefulFilters>
 ) => JSX.Element | undefined;
@@ -156,64 +157,94 @@ const istioType: ResourceType<IstioConfigItem> = {
   renderer: Renderers.istioType
 };
 
+type istioConfigType = {
+  name: string;
+  url: string;
+  badge: PFBadge;
+};
+
 export const IstioTypes = {
-  gateway: { name: 'Gateway', url: 'gateways', icon: 'G' },
-  virtualservice: { name: 'VirtualService', url: 'virtualservices', icon: 'VS' },
-  destinationrule: { name: 'DestinationRule', url: 'destinationrules', icon: 'DR' },
-  serviceentry: { name: 'ServiceEntry', url: 'serviceentries', icon: 'SE' },
-  rule: { name: 'Rule', url: 'rules', icon: 'R' },
-  adapter: { name: 'Adapter', url: 'adapters', icon: 'A' },
-  template: { name: 'Template', url: 'templates', icon: 'T' },
-  instance: { name: 'Instance', url: 'instances', icon: 'I' },
-  handler: { name: 'Handler', url: 'handlers', icon: 'H' },
-  quotaspec: { name: 'QuotaSpec', url: 'quotaspecs', icon: 'QS' },
-  quotaspecbinding: { name: 'QuotaSpecBinding', url: 'quotaspecbindings', icon: 'QSB' },
-  policy: { name: 'Policy', url: 'policies', icon: 'P' },
-  meshpolicy: { name: 'MeshPolicy', url: 'meshpolicies', icon: 'MP' },
-  clusterrbacconfig: { name: 'ClusterRbacConfig', url: 'clusterrbacconfigs', icon: 'CRC' },
-  rbacconfig: { name: 'RbacConfig', url: 'rbacconfigs', icon: 'RC' },
-  authorizationpolicy: { name: 'AuthorizationPolicy', url: 'authorizationpolicies', icon: 'AP' },
-  sidecar: { name: 'Sidecar', url: 'sidecars', icon: 'S' },
-  servicerole: { name: 'ServiceRole', url: 'serviceroles', icon: 'SR' },
-  servicerolebinding: { name: 'ServiceRoleBinding', url: 'servicerolebindings', icon: 'SRB' },
-  peerauthentication: { name: 'PeerAuthentication', url: 'peerauthentications', icon: 'PA' },
-  requestauthentication: { name: 'RequestAuthentication', url: 'requestauthentications', icon: 'RA' },
-  workloadentry: { name: 'WorkloadEntry', url: 'workloadentries', icon: 'WE' },
-  envoyfilter: { name: 'EnvoyFilter', url: 'envoyfilters', icon: 'EF' },
-  attributemanifest: { name: 'AttributeManifest', url: 'attributemanifests', icon: 'AM' },
-  httpapispec: { name: 'HTTPAPISpec', url: 'httpapispecs', icon: 'HA' },
-  httpapispecbinding: { name: 'HTTPAPISpecBinding', url: 'httpapispecbindings', icon: 'HAB' }
+  gateway: { name: 'Gateway', url: 'gateways', badge: PFBadges.Gateway } as istioConfigType,
+  virtualservice: { name: 'VirtualService', url: 'virtualservices', badge: PFBadges.VirtualService } as istioConfigType,
+  destinationrule: {
+    name: 'DestinationRule',
+    url: 'destinationrules',
+    badge: PFBadges.DestinationRule
+  } as istioConfigType,
+  serviceentry: { name: 'ServiceEntry', url: 'serviceentries', badge: PFBadges.ServiceEntry } as istioConfigType,
+  rule: { name: 'Rule', url: 'rules', badge: PFBadges.Rule } as istioConfigType,
+  adapter: { name: 'Adapter', url: 'adapters', badge: PFBadges.Adapter } as istioConfigType,
+  template: { name: 'Template', url: 'templates', badge: PFBadges.Template } as istioConfigType,
+  instance: { name: 'Instance', url: 'instances', badge: PFBadges.Instance } as istioConfigType,
+  handler: { name: 'Handler', url: 'handlers', badge: PFBadges.Handler } as istioConfigType,
+  policy: { name: 'Policy', url: 'policies', badge: PFBadges.Policy } as istioConfigType,
+  meshpolicy: { name: 'MeshPolicy', url: 'meshpolicies', badge: PFBadges.MeshPolicy } as istioConfigType,
+  clusterrbacconfig: {
+    name: 'ClusterRbacConfig',
+    url: 'clusterrbacconfigs',
+    badge: PFBadges.ClusterRBACConfig
+  } as istioConfigType,
+  rbacconfig: { name: 'RbacConfig', url: 'rbacconfigs', badge: PFBadges.RBACConfig } as istioConfigType,
+  authorizationpolicy: {
+    name: 'AuthorizationPolicy',
+    url: 'authorizationpolicies',
+    badge: PFBadges.AuthorizationPolicy
+  } as istioConfigType,
+  sidecar: { name: 'Sidecar', url: 'sidecars', badge: PFBadges.Sidecar } as istioConfigType,
+  servicerole: { name: 'ServiceRole', url: 'serviceroles', icon: PFBadges.ServiceRole },
+  servicerolebinding: {
+    name: 'ServiceRoleBinding',
+    url: 'servicerolebindings',
+    badge: PFBadges.ServiceRoleBinding
+  } as istioConfigType,
+  peerauthentication: {
+    name: 'PeerAuthentication',
+    url: 'peerauthentications',
+    badge: PFBadges.PeerAuthentication
+  } as istioConfigType,
+  requestauthentication: {
+    name: 'RequestAuthentication',
+    url: 'requestauthentications',
+    badge: PFBadges.RequestAuthentication
+  } as istioConfigType,
+  workloadentry: { name: 'WorkloadEntry', url: 'workloadentries', badge: PFBadges.WorkloadEntry } as istioConfigType,
+  envoyfilter: { name: 'EnvoyFilter', url: 'envoyfilters', badge: PFBadges.EnvoyFilter } as istioConfigType,
+  attributemanifest: {
+    name: 'AttributeManifest',
+    url: 'attributemanifests',
+    badge: PFBadges.AttributeManifest
+  } as istioConfigType
 };
 
 export type Resource = {
   name: string;
   columns: ResourceType<any>[];
   caption?: string;
-  icon?: string;
+  badge?: PFBadge;
 };
 
 const namespaces: Resource = {
   name: 'namespaces',
   columns: [tlsStatus, nsItem, istioConfiguration, labels, status],
-  icon: 'NS'
+  badge: PFBadges.Namespace
 };
 
 const workloads: Resource = {
   name: 'workloads',
   columns: [item, namespace, workloadType, labels, health, details],
-  icon: 'W'
+  badge: PFBadges.Workload
 };
 
 const applications: Resource = {
   name: 'applications',
   columns: [item, namespace, labels, health, details],
-  icon: 'A'
+  badge: PFBadges.App
 };
 
 const services: Resource = {
   name: 'services',
   columns: [serviceItem, namespace, labels, health, configuration, details],
-  icon: 'S'
+  badge: PFBadges.Service
 };
 
 const istio: Resource = {

--- a/src/components/VirtualList/Config.ts
+++ b/src/components/VirtualList/Config.ts
@@ -11,7 +11,7 @@ import { isIstioNamespace } from 'config/ServerConfig';
 import NamespaceInfo from '../../pages/Overview/NamespaceInfo';
 import * as React from 'react';
 import { StatefulFilters } from '../Filters/StatefulFilters';
-import { PFBadge, PFBadges } from '../../components/Pf/PfBadges';
+import { PFBadges, PFBadgeType } from '../../components/Pf/PfBadges';
 
 export type SortResource = AppListItem | WorkloadListItem | ServiceListItem;
 export type TResource = SortResource | IstioConfigItem;
@@ -19,7 +19,7 @@ export type RenderResource = TResource | NamespaceInfo;
 export type Renderer<R extends RenderResource> = (
   item: R,
   config: Resource,
-  badge: PFBadge,
+  badge: PFBadgeType,
   health?: Health,
   statefulFilter?: React.RefObject<StatefulFilters>
 ) => JSX.Element | undefined;
@@ -160,7 +160,7 @@ const istioType: ResourceType<IstioConfigItem> = {
 type istioConfigType = {
   name: string;
   url: string;
-  badge: PFBadge;
+  badge: PFBadgeType;
 };
 
 export const IstioTypes = {
@@ -220,7 +220,7 @@ export type Resource = {
   name: string;
   columns: ResourceType<any>[];
   caption?: string;
-  badge?: PFBadge;
+  badge?: PFBadgeType;
 };
 
 const namespaces: Resource = {

--- a/src/components/VirtualList/Renderers.tsx
+++ b/src/components/VirtualList/Renderers.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { Badge, Tooltip, TooltipPosition } from '@patternfly/react-core';
+import { Badge, Tooltip } from '@patternfly/react-core';
 import * as FilterHelper from '../FilterList/FilterHelper';
 import { appLabelFilter, versionLabelFilter } from '../../pages/WorkloadList/FiltersAndSorts';
 
@@ -27,6 +27,7 @@ import { labelFilter } from 'components/Filters/CommonFilters';
 import { labelFilter as NsLabelFilter } from '../../pages/Overview/Filters';
 import ValidationSummaryLink from '../Link/ValidationSummaryLink';
 import { ValidationStatus } from '../../types/IstioObjects';
+import { pfAdHocBadgeRO, pfBadge, PFBadge, PFBadges } from 'components/Pf/PfBadges';
 
 // Links
 
@@ -72,24 +73,8 @@ export const details: Renderer<AppListItem | WorkloadListItem | ServiceListItem>
             <MissingSidecar namespace={item.namespace} />
           </li>
         )}
-        {isWorkload && hasMissingApp && (
-          <li>
-            Missing{' '}
-            <Badge isRead={true} className={'virtualitem_badge_definition'}>
-              app
-            </Badge>
-            label
-          </li>
-        )}
-        {isWorkload && hasMissingVersion && (
-          <li>
-            Missing{' '}
-            <Badge isRead={true} className={'virtualitem_badge_definition'}>
-              version
-            </Badge>
-            label
-          </li>
-        )}
+        {isWorkload && hasMissingApp && <li>Missing {pfAdHocBadgeRO('app')} label</li>}
+        {isWorkload && hasMissingVersion && <li>Missing {pfAdHocBadgeRO('version')} label</li>}
         {spacer && ' '}
         {additionalDetails && additionalDetails.icon && (
           <li>{renderAPILogo(additionalDetails.icon, additionalDetails.title, 0)}</li>
@@ -155,26 +140,20 @@ export const status: Renderer<NamespaceInfo> = (ns: NamespaceInfo) => {
   return <td role="gridcell" key={'VirtuaItem_Status_' + ns.name} />;
 };
 
-export const nsItem: Renderer<NamespaceInfo> = (ns: NamespaceInfo, _config: Resource, icon: string) => {
+export const nsItem: Renderer<NamespaceInfo> = (ns: NamespaceInfo, _config: Resource, badge: PFBadge) => {
   return (
     <td role="gridcell" key={'VirtuaItem_NamespaceItem_' + ns.name} style={{ verticalAlign: 'middle' }}>
-      <Badge className={'virtualitem_badge_definition'}>{icon}</Badge>
+      {pfBadge(badge)}
       {ns.name}
     </td>
   );
 };
 
-export const item: Renderer<TResource> = (item: TResource, config: Resource, icon: string) => {
+export const item: Renderer<TResource> = (item: TResource, config: Resource, badge: PFBadge) => {
   const key = 'link_definition_' + config.name + '_' + item.namespace + '_' + item.name;
-  let itemName = config.name.charAt(0).toUpperCase() + config.name.slice(1);
-  if (config.name === 'istio') {
-    itemName = IstioTypes[item['type']].name;
-  }
   return (
     <td role="gridcell" key={'VirtuaItem_Item_' + item.namespace + '_' + item.name} style={{ verticalAlign: 'middle' }}>
-      <Tooltip position={TooltipPosition.top} content={<>{itemName}</>}>
-        <Badge className={'virtualitem_badge_definition'}>{icon}</Badge>
-      </Tooltip>
+      {pfBadge(badge)}
       <Link key={key} to={getLink(item, config)} className={'virtualitem_definition_link'}>
         {item.name}
       </Link>
@@ -189,9 +168,7 @@ export const namespace: Renderer<TResource> = (item: TResource) => {
       key={'VirtuaItem_Namespace_' + item.namespace + '_' + item.name}
       style={{ verticalAlign: 'middle' }}
     >
-      <Tooltip position={TooltipPosition.top} content={<>Namespace</>}>
-        <Badge className={'virtualitem_badge_definition'}>NS</Badge>
-      </Tooltip>
+      {pfBadge(PFBadges.Namespace)}
       {item.namespace}
     </td>
   );
@@ -220,7 +197,7 @@ const labelActivate = (filters: ActiveFilter[], key: string, value: string, id: 
 export const labels: Renderer<SortResource | NamespaceInfo> = (
   item: SortResource | NamespaceInfo,
   _: Resource,
-  __: string,
+  __: PFBadge,
   ___?: Health,
   statefulFilter?: React.RefObject<StatefulFilters>
 ) => {
@@ -285,7 +262,7 @@ export const labels: Renderer<SortResource | NamespaceInfo> = (
     </td>
   );
 };
-export const health: Renderer<TResource> = (item: TResource, __: Resource, _: string, health?: Health) => {
+export const health: Renderer<TResource> = (item: TResource, __: Resource, _: PFBadge, health?: Health) => {
   return (
     <td
       role="gridcell"

--- a/src/components/VirtualList/Renderers.tsx
+++ b/src/components/VirtualList/Renderers.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { Badge, Tooltip } from '@patternfly/react-core';
+import { Badge, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import * as FilterHelper from '../FilterList/FilterHelper';
 import { appLabelFilter, versionLabelFilter } from '../../pages/WorkloadList/FiltersAndSorts';
 
@@ -27,7 +27,7 @@ import { labelFilter } from 'components/Filters/CommonFilters';
 import { labelFilter as NsLabelFilter } from '../../pages/Overview/Filters';
 import ValidationSummaryLink from '../Link/ValidationSummaryLink';
 import { ValidationStatus } from '../../types/IstioObjects';
-import { pfAdHocBadgeRO, pfBadge, PFBadge, PFBadges } from 'components/Pf/PfBadges';
+import { PFBadgeType, PFBadge, PFBadges } from 'components/Pf/PfBadges';
 
 // Links
 
@@ -73,8 +73,16 @@ export const details: Renderer<AppListItem | WorkloadListItem | ServiceListItem>
             <MissingSidecar namespace={item.namespace} />
           </li>
         )}
-        {isWorkload && hasMissingApp && <li>Missing {pfAdHocBadgeRO('app')} label</li>}
-        {isWorkload && hasMissingVersion && <li>Missing {pfAdHocBadgeRO('version')} label</li>}
+        {isWorkload && hasMissingApp && (
+          <li>
+            Missing <PFBadge badge={{ badge: 'app' }} isRead={true} /> label
+          </li>
+        )}
+        {isWorkload && hasMissingVersion && (
+          <li>
+            Missing <PFBadge badge={{ badge: 'version' }} isRead={true} /> label
+          </li>
+        )}
         {spacer && ' '}
         {additionalDetails && additionalDetails.icon && (
           <li>{renderAPILogo(additionalDetails.icon, additionalDetails.title, 0)}</li>
@@ -140,20 +148,20 @@ export const status: Renderer<NamespaceInfo> = (ns: NamespaceInfo) => {
   return <td role="gridcell" key={'VirtuaItem_Status_' + ns.name} />;
 };
 
-export const nsItem: Renderer<NamespaceInfo> = (ns: NamespaceInfo, _config: Resource, badge: PFBadge) => {
+export const nsItem: Renderer<NamespaceInfo> = (ns: NamespaceInfo, _config: Resource, badge: PFBadgeType) => {
   return (
     <td role="gridcell" key={'VirtuaItem_NamespaceItem_' + ns.name} style={{ verticalAlign: 'middle' }}>
-      {pfBadge(badge)}
+      <PFBadge badge={badge} />
       {ns.name}
     </td>
   );
 };
 
-export const item: Renderer<TResource> = (item: TResource, config: Resource, badge: PFBadge) => {
+export const item: Renderer<TResource> = (item: TResource, config: Resource, badge: PFBadgeType) => {
   const key = 'link_definition_' + config.name + '_' + item.namespace + '_' + item.name;
   return (
     <td role="gridcell" key={'VirtuaItem_Item_' + item.namespace + '_' + item.name} style={{ verticalAlign: 'middle' }}>
-      {pfBadge(badge)}
+      <PFBadge badge={badge} position={TooltipPosition.top} />
       <Link key={key} to={getLink(item, config)} className={'virtualitem_definition_link'}>
         {item.name}
       </Link>
@@ -168,7 +176,7 @@ export const namespace: Renderer<TResource> = (item: TResource) => {
       key={'VirtuaItem_Namespace_' + item.namespace + '_' + item.name}
       style={{ verticalAlign: 'middle' }}
     >
-      {pfBadge(PFBadges.Namespace)}
+      <PFBadge badge={PFBadges.Namespace} position={TooltipPosition.top} />
       {item.namespace}
     </td>
   );
@@ -197,7 +205,7 @@ const labelActivate = (filters: ActiveFilter[], key: string, value: string, id: 
 export const labels: Renderer<SortResource | NamespaceInfo> = (
   item: SortResource | NamespaceInfo,
   _: Resource,
-  __: PFBadge,
+  __: PFBadgeType,
   ___?: Health,
   statefulFilter?: React.RefObject<StatefulFilters>
 ) => {
@@ -223,7 +231,7 @@ export const labels: Renderer<SortResource | NamespaceInfo> = (
               key={`labelbadge_${key}_${value}_${item.name}`}
               isRead={true}
               style={{
-                backgroundColor: labelAct ? PFColors.Blue200 : undefined,
+                backgroundColor: labelAct ? PFColors.Badge : undefined,
                 cursor: isExactlyLabelFilter || !labelAct ? 'pointer' : 'not-allowed'
               }}
               onClick={() =>
@@ -262,7 +270,7 @@ export const labels: Renderer<SortResource | NamespaceInfo> = (
     </td>
   );
 };
-export const health: Renderer<TResource> = (item: TResource, __: Resource, _: PFBadge, health?: Health) => {
+export const health: Renderer<TResource> = (item: TResource, __: Resource, _: PFBadgeType, health?: Health) => {
   return (
     <td
       role="gridcell"

--- a/src/components/VirtualList/VirtualItem.tsx
+++ b/src/components/VirtualList/VirtualItem.tsx
@@ -59,18 +59,13 @@ export default class VirtualItem extends React.Component<VirtualItemProps, Virtu
   };
 
   renderDetails = (item: RenderResource, health?: Health) => {
-    const icon = this.getIcon();
     return this.props.config.columns.map(object =>
-      object.renderer(item, this.props.config, icon, health, this.props.statefulFilterProps)
+      object.renderer(item, this.props.config, this.getBadge(), health, this.props.statefulFilterProps)
     );
   };
 
-  getIcon = () => {
-    if (this.props.config.name !== 'istio') {
-      return this.props.config.icon;
-    } else {
-      return IstioTypes[this.props.item['type']].icon;
-    }
+  getBadge = () => {
+    return this.props.config.name !== 'istio' ? this.props.config.badge : IstioTypes[this.props.item['type']].badge;
   };
 
   render() {

--- a/src/components/VirtualList/_VirtualList.scss
+++ b/src/components/VirtualList/_VirtualList.scss
@@ -50,12 +50,6 @@
   position: relative;
 }
 
-.virtualitem_badge_definition {
-  background-color: var(--pf-global--palette--blue-200); //should match PFColors.Badge
-  border-radius: 30em;
-  margin-right: 10px;
-}
-
 .faultinjection_badge_definition {
   background-color: #703fec;
   border-radius: 30em;

--- a/src/pages/Graph/SummaryLink.tsx
+++ b/src/pages/Graph/SummaryLink.tsx
@@ -7,21 +7,36 @@ import { Health } from 'types/Health';
 import { HealthIndicator, DisplayMode } from 'components/Health/HealthIndicator';
 import { pfAdHocBadge, pfBadge, PFBadges } from 'components/Pf/PfBadges';
 import KialiPageLink from 'components/Link/KialiPageLink';
+import { serverConfig } from 'config';
+
+const getTooltip = (tooltip: string, nodeData: GraphNodeData): React.ReactFragment => {
+  const addNamespace = nodeData.isBox !== BoxByType.NAMESPACE;
+  const addCluster =
+    nodeData.isBox !== BoxByType.CLUSTER &&
+    (!serverConfig.clusterInfo || serverConfig.clusterInfo.name !== nodeData.cluster);
+  return (
+    <div style={{ textAlign: 'left' }}>
+      <span>{tooltip}</span>
+      {addNamespace && <div>{`Namespace: ${nodeData.namespace}`}</div>}
+      {addCluster && <div>{`Cluster: ${nodeData.cluster}`}</div>}
+    </div>
+  );
+};
 
 const getBadge = (nodeData: GraphNodeData, nodeType?: NodeType) => {
   switch (nodeType || nodeData.nodeType) {
     case NodeType.AGGREGATE:
-      return pfAdHocBadge(PFBadges.Operation.badge, `Operation: ${nodeData.aggregate!}`);
+      return pfAdHocBadge(PFBadges.Operation.badge, getTooltip(`Operation: ${nodeData.aggregate!}`, nodeData));
     case NodeType.APP:
-      return pfBadge(PFBadges.App);
+      return pfAdHocBadge(PFBadges.App.badge, getTooltip(PFBadges.App.tt, nodeData));
     case NodeType.BOX:
       switch (nodeData.isBox) {
         case BoxByType.APP:
-          return pfBadge(PFBadges.App);
+          return pfAdHocBadge(PFBadges.App.badge, getTooltip(PFBadges.App.tt, nodeData));
         case BoxByType.CLUSTER:
-          return pfBadge(PFBadges.Cluster);
+          return pfAdHocBadge(PFBadges.Cluster.badge, getTooltip(PFBadges.Cluster.tt, nodeData));
         case BoxByType.NAMESPACE:
-          return pfBadge(PFBadges.Namespace);
+          return pfAdHocBadge(PFBadges.Namespace.badge, getTooltip(PFBadges.Namespace.tt, nodeData));
         default:
           return pfBadge(PFBadges.Unknown);
       }
@@ -29,11 +44,16 @@ const getBadge = (nodeData: GraphNodeData, nodeType?: NodeType) => {
       return !!nodeData.isServiceEntry
         ? pfAdHocBadge(
             PFBadges.ServiceEntry.badge,
-            nodeData.isServiceEntry.location === 'MESH_EXTERNAL' ? 'External Service Entry' : 'Internal Service Entry'
+            getTooltip(
+              nodeData.isServiceEntry.location === 'MESH_EXTERNAL'
+                ? 'External Service Entry'
+                : 'Internal Service Entry',
+              nodeData
+            )
           )
-        : pfBadge(PFBadges.Service);
+        : pfAdHocBadge(PFBadges.Service.badge, getTooltip(PFBadges.Service.tt, nodeData));
     case NodeType.WORKLOAD:
-      return pfBadge(PFBadges.Workload);
+      return pfAdHocBadge(PFBadges.Workload.badge, getTooltip(PFBadges.Workload.tt, nodeData));
     default:
       return pfBadge(PFBadges.Unknown);
   }

--- a/src/pages/Graph/SummaryLink.tsx
+++ b/src/pages/Graph/SummaryLink.tsx
@@ -5,11 +5,11 @@ import { KialiIcon } from 'config/KialiIcon';
 import { Badge, PopoverPosition } from '@patternfly/react-core';
 import { Health } from 'types/Health';
 import { HealthIndicator, DisplayMode } from 'components/Health/HealthIndicator';
-import { pfAdHocBadge, pfBadge, PFBadges } from 'components/Pf/PfBadges';
+import { getPFBadge, PFBadge, PFBadges } from 'components/Pf/PfBadges';
 import KialiPageLink from 'components/Link/KialiPageLink';
 import { serverConfig } from 'config';
 
-const getTooltip = (tooltip: string, nodeData: GraphNodeData): React.ReactFragment => {
+const getTooltip = (tooltip: React.ReactFragment, nodeData: GraphNodeData): React.ReactFragment => {
   const addNamespace = nodeData.isBox !== BoxByType.NAMESPACE;
   const addCluster =
     nodeData.isBox !== BoxByType.CLUSTER &&
@@ -26,23 +26,23 @@ const getTooltip = (tooltip: string, nodeData: GraphNodeData): React.ReactFragme
 const getBadge = (nodeData: GraphNodeData, nodeType?: NodeType) => {
   switch (nodeType || nodeData.nodeType) {
     case NodeType.AGGREGATE:
-      return pfAdHocBadge(PFBadges.Operation.badge, getTooltip(`Operation: ${nodeData.aggregate!}`, nodeData));
+      return getPFBadge(PFBadges.Operation.badge, getTooltip(`Operation: ${nodeData.aggregate!}`, nodeData));
     case NodeType.APP:
-      return pfAdHocBadge(PFBadges.App.badge, getTooltip(PFBadges.App.tt, nodeData));
+      return getPFBadge(PFBadges.App.badge, getTooltip(PFBadges.App.tt!, nodeData));
     case NodeType.BOX:
       switch (nodeData.isBox) {
         case BoxByType.APP:
-          return pfAdHocBadge(PFBadges.App.badge, getTooltip(PFBadges.App.tt, nodeData));
+          return getPFBadge(PFBadges.App.badge, getTooltip(PFBadges.App.tt!, nodeData));
         case BoxByType.CLUSTER:
-          return pfAdHocBadge(PFBadges.Cluster.badge, getTooltip(PFBadges.Cluster.tt, nodeData));
+          return getPFBadge(PFBadges.Cluster.badge, getTooltip(PFBadges.Cluster.tt!, nodeData));
         case BoxByType.NAMESPACE:
-          return pfAdHocBadge(PFBadges.Namespace.badge, getTooltip(PFBadges.Namespace.tt, nodeData));
+          return getPFBadge(PFBadges.Namespace.badge, getTooltip(PFBadges.Namespace.tt!, nodeData));
         default:
-          return pfBadge(PFBadges.Unknown);
+          return <PFBadge badge={PFBadges.Unknown} />;
       }
     case NodeType.SERVICE:
       return !!nodeData.isServiceEntry
-        ? pfAdHocBadge(
+        ? getPFBadge(
             PFBadges.ServiceEntry.badge,
             getTooltip(
               nodeData.isServiceEntry.location === 'MESH_EXTERNAL'
@@ -51,11 +51,11 @@ const getBadge = (nodeData: GraphNodeData, nodeType?: NodeType) => {
               nodeData
             )
           )
-        : pfAdHocBadge(PFBadges.Service.badge, getTooltip(PFBadges.Service.tt, nodeData));
+        : getPFBadge(PFBadges.Service.badge, getTooltip(PFBadges.Service.tt!, nodeData));
     case NodeType.WORKLOAD:
-      return pfAdHocBadge(PFBadges.Workload.badge, getTooltip(PFBadges.Workload.tt, nodeData));
+      return getPFBadge(PFBadges.Workload.badge, getTooltip(PFBadges.Workload.tt!, nodeData));
     default:
-      return pfBadge(PFBadges.Unknown);
+      return <PFBadge badge={PFBadges.Unknown} />;
   }
 };
 
@@ -125,7 +125,7 @@ const getLink = (nodeData: GraphNodeData, nodeType?: NodeType) => {
 export const renderBadgedHost = (host: string) => {
   return (
     <span>
-      {pfBadge(PFBadges.Host)}
+      <PFBadge badge={PFBadges.Host} />
       {host}
     </span>
   );

--- a/src/pages/Graph/SummaryLink.tsx
+++ b/src/pages/Graph/SummaryLink.tsx
@@ -1,84 +1,41 @@
 import * as React from 'react';
-import { Tooltip, Badge, PopoverPosition, TooltipPosition } from '@patternfly/react-core';
-import { CyNode, decoratedNodeData } from 'components/CytoscapeGraph/CytoscapeGraphUtils';
-import { HealthIndicator, DisplayMode } from 'components/Health/HealthIndicator';
-import KialiPageLink from 'components/Link/KialiPageLink';
+import { NodeType, GraphNodeData, DestService, BoxByType } from '../../types/Graph';
+import { CyNode, decoratedNodeData } from '../../components/CytoscapeGraph/CytoscapeGraphUtils';
 import { KialiIcon } from 'config/KialiIcon';
-import { NodeType, GraphNodeData, DestService, BoxByType } from 'types/Graph';
+import { Badge, PopoverPosition } from '@patternfly/react-core';
 import { Health } from 'types/Health';
+import { HealthIndicator, DisplayMode } from 'components/Health/HealthIndicator';
+import { pfAdHocBadge, pfBadge, PFBadges } from 'components/Pf/PfBadges';
+import KialiPageLink from 'components/Link/KialiPageLink';
 
 const getBadge = (nodeData: GraphNodeData, nodeType?: NodeType) => {
   switch (nodeType || nodeData.nodeType) {
     case NodeType.AGGREGATE:
-      return (
-        <Tooltip position={TooltipPosition.auto} content={<>Operation: {nodeData.aggregate!}</>}>
-          <Badge className="virtualitem_badge_definition">O</Badge>
-        </Tooltip>
-      );
+      return pfAdHocBadge(PFBadges.Operation.badge, `Operation: ${nodeData.aggregate!}`);
     case NodeType.APP:
-      return (
-        <Tooltip position={TooltipPosition.auto} content={<>Application</>}>
-          <Badge className="virtualitem_badge_definition">A</Badge>
-        </Tooltip>
-      );
+      return pfBadge(PFBadges.App);
     case NodeType.BOX:
       switch (nodeData.isBox) {
         case BoxByType.APP:
-          return (
-            <Tooltip position={TooltipPosition.auto} content={<>Application</>}>
-              <Badge className="virtualitem_badge_definition">A</Badge>
-            </Tooltip>
-          );
+          return pfBadge(PFBadges.App);
         case BoxByType.CLUSTER:
-          return (
-            <Tooltip position={TooltipPosition.auto} content={<>Cluster</>}>
-              <Badge className="virtualitem_badge_definition">CL</Badge>
-            </Tooltip>
-          );
+          return pfBadge(PFBadges.Cluster);
         case BoxByType.NAMESPACE:
-          return (
-            <Tooltip position={TooltipPosition.auto} content={<>Namespace</>}>
-              <Badge className="virtualitem_badge_definition">NS</Badge>
-            </Tooltip>
-          );
+          return pfBadge(PFBadges.Namespace);
         default:
-          return (
-            <Tooltip position={TooltipPosition.auto} content={<>Unknown</>}>
-              <Badge className="virtualitem_badge_definition">U</Badge>
-            </Tooltip>
-          );
+          return pfBadge(PFBadges.Unknown);
       }
     case NodeType.SERVICE:
-      return !!nodeData.isServiceEntry ? (
-        <Tooltip
-          position={TooltipPosition.auto}
-          content={
-            <>
-              {nodeData.isServiceEntry.location === 'MESH_EXTERNAL'
-                ? 'External Service Entry'
-                : 'Internal Service Entry'}
-            </>
-          }
-        >
-          <Badge className="virtualitem_badge_definition">SE</Badge>
-        </Tooltip>
-      ) : (
-        <Tooltip position={TooltipPosition.auto} content={<>Service</>}>
-          <Badge className="virtualitem_badge_definition">S</Badge>
-        </Tooltip>
-      );
+      return !!nodeData.isServiceEntry
+        ? pfAdHocBadge(
+            PFBadges.ServiceEntry.badge,
+            nodeData.isServiceEntry.location === 'MESH_EXTERNAL' ? 'External Service Entry' : 'Internal Service Entry'
+          )
+        : pfBadge(PFBadges.Service);
     case NodeType.WORKLOAD:
-      return (
-        <Tooltip position={TooltipPosition.auto} content={<>Workload</>}>
-          <Badge className="virtualitem_badge_definition">W</Badge>
-        </Tooltip>
-      );
+      return pfBadge(PFBadges.Workload);
     default:
-      return (
-        <Tooltip position={TooltipPosition.auto} content={<>Unknown</>}>
-          <Badge className="virtualitem_badge_definition">U</Badge>
-        </Tooltip>
-      );
+      return pfBadge(PFBadges.Unknown);
   }
 };
 
@@ -139,7 +96,7 @@ const getLink = (nodeData: GraphNodeData, nodeType?: NodeType) => {
       <KialiPageLink key={key} href={link} cluster={cluster}>
         {displayName}
       </KialiPageLink>
-    )
+    );
   }
 
   return <span key={key}>{displayName}</span>;
@@ -148,9 +105,7 @@ const getLink = (nodeData: GraphNodeData, nodeType?: NodeType) => {
 export const renderBadgedHost = (host: string) => {
   return (
     <span>
-      <Tooltip content={<>Host</>}>
-        <Badge className="virtualitem_badge_definition">H</Badge>
-      </Tooltip>
+      {pfBadge(PFBadges.Host)}
       {host}
     </span>
   );

--- a/src/pages/Graph/SummaryPanelClusterBox.tsx
+++ b/src/pages/Graph/SummaryPanelClusterBox.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Tab, Tooltip, TooltipPosition, Badge } from '@patternfly/react-core';
+import { Tab } from '@patternfly/react-core';
 import { style } from 'typestyle';
 import { summaryFont, summaryHeader, summaryBodyTabs } from './SummaryPanelCommon';
 import { CyNode } from 'components/CytoscapeGraph/CytoscapeGraphUtils';
@@ -10,6 +10,7 @@ import { PFColors } from 'components/Pf/PfColors';
 import { KialiIcon } from 'config/KialiIcon';
 import { SummaryPanelPropType, NodeType } from 'types/Graph';
 import { getAccumulatedTrafficRateGrpc, getAccumulatedTrafficRateHttp } from 'utils/TrafficRate';
+import { pfBadge, PFBadges } from 'components/Pf/PfBadges';
 
 type SummaryPanelClusterBoxState = {
   clusterBox: any;
@@ -192,12 +193,10 @@ export default class SummaryPanelClusterBox extends React.Component<SummaryPanel
     return (
       <React.Fragment key={cluster}>
         <span>
-          <Tooltip position={TooltipPosition.auto} content={<>Cluster</>}>
-            <Badge className="virtualitem_badge_definition" style={{ marginBottom: '2px' }}>
-              CL
-            </Badge>
-          </Tooltip>
-          <KialiPageLink href="/" cluster={cluster}>{cluster}</KialiPageLink>{' '}
+          {pfBadge(PFBadges.Cluster, undefined, undefined, { marginBottom: '2px' })}
+          <KialiPageLink href="/" cluster={cluster}>
+            {cluster}
+          </KialiPageLink>{' '}
         </span>
         <br />
       </React.Fragment>

--- a/src/pages/Graph/SummaryPanelClusterBox.tsx
+++ b/src/pages/Graph/SummaryPanelClusterBox.tsx
@@ -10,7 +10,7 @@ import { PFColors } from 'components/Pf/PfColors';
 import { KialiIcon } from 'config/KialiIcon';
 import { SummaryPanelPropType, NodeType } from 'types/Graph';
 import { getAccumulatedTrafficRateGrpc, getAccumulatedTrafficRateHttp } from 'utils/TrafficRate';
-import { pfBadge, PFBadges } from 'components/Pf/PfBadges';
+import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
 
 type SummaryPanelClusterBoxState = {
   clusterBox: any;
@@ -193,7 +193,7 @@ export default class SummaryPanelClusterBox extends React.Component<SummaryPanel
     return (
       <React.Fragment key={cluster}>
         <span>
-          {pfBadge(PFBadges.Cluster, undefined, undefined, { marginBottom: '2px' })}
+          <PFBadge badge={PFBadges.Cluster} style={{ marginBottom: '2px' }} />
           <KialiPageLink href="/" cluster={cluster}>
             {cluster}
           </KialiPageLink>{' '}

--- a/src/pages/Graph/SummaryPanelGraph.tsx
+++ b/src/pages/Graph/SummaryPanelGraph.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Badge, Tab, Tooltip, TooltipPosition } from '@patternfly/react-core';
+import { Tab } from '@patternfly/react-core';
 import { style } from 'typestyle';
 import _ from 'lodash';
 import { RateTableGrpc, RateTableHttp } from '../../components/SummaryPanel/RateTable';
@@ -28,6 +28,7 @@ import Namespace from 'types/Namespace';
 import ValidationSummary from 'components/Validations/ValidationSummary';
 import { PFColors } from '../../components/Pf/PfColors';
 import ValidationSummaryLink from '../../components/Link/ValidationSummaryLink';
+import { pfBadge, PFBadges } from 'components/Pf/PfBadges';
 
 type SummaryPanelGraphMetricsState = {
   reqRates: Datapoint[];
@@ -301,11 +302,7 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
     return (
       <React.Fragment key={ns}>
         <span>
-          <Tooltip position={TooltipPosition.auto} content={<>Namespace</>}>
-            <Badge className="virtualitem_badge_definition" style={{ marginBottom: '2px' }}>
-              NS
-            </Badge>
-          </Tooltip>
+          {pfBadge(PFBadges.Namespace, undefined, undefined, { marginBottom: '2px' })}
           {ns} {this.renderValidations(ns)}
         </span>
         <br />

--- a/src/pages/Graph/SummaryPanelGraph.tsx
+++ b/src/pages/Graph/SummaryPanelGraph.tsx
@@ -28,7 +28,7 @@ import Namespace from 'types/Namespace';
 import ValidationSummary from 'components/Validations/ValidationSummary';
 import { PFColors } from '../../components/Pf/PfColors';
 import ValidationSummaryLink from '../../components/Link/ValidationSummaryLink';
-import { pfBadge, PFBadges } from 'components/Pf/PfBadges';
+import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
 
 type SummaryPanelGraphMetricsState = {
   reqRates: Datapoint[];
@@ -302,7 +302,7 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
     return (
       <React.Fragment key={ns}>
         <span>
-          {pfBadge(PFBadges.Namespace, undefined, undefined, { marginBottom: '2px' })}
+          <PFBadge badge={PFBadges.Namespace} style={{ marginBottom: '2px' }} />
           {ns} {this.renderValidations(ns)}
         </span>
         <br />

--- a/src/pages/Graph/SummaryPanelNamespaceBox.tsx
+++ b/src/pages/Graph/SummaryPanelNamespaceBox.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Tab, Tooltip, TooltipPosition, Badge } from '@patternfly/react-core';
+import { Tab } from '@patternfly/react-core';
 import { style } from 'typestyle';
 import { RateTableGrpc, RateTableHttp } from '../../components/SummaryPanel/RateTable';
 import { RpsChart, TcpChart } from '../../components/SummaryPanel/RpsChart';
@@ -26,6 +26,7 @@ import { ValidationStatus } from 'types/IstioObjects';
 import { PFColors } from '../../components/Pf/PfColors';
 import ValidationSummary from 'components/Validations/ValidationSummary';
 import ValidationSummaryLink from '../../components/Link/ValidationSummaryLink';
+import { pfBadge, PFBadges } from 'components/Pf/PfBadges';
 
 type SummaryPanelNamespaceBoxMetricsState = {
   errRates: Datapoint[];
@@ -270,11 +271,7 @@ export default class SummaryPanelNamespaceBox extends React.Component<
     return (
       <React.Fragment key={ns}>
         <span>
-          <Tooltip position={TooltipPosition.auto} content={<>Namespace</>}>
-            <Badge className="virtualitem_badge_definition" style={{ marginBottom: '2px' }}>
-              NS
-            </Badge>
-          </Tooltip>
+          {pfBadge(PFBadges.Namespace, undefined, undefined, { marginBottom: '2px' })}
           {ns}{' '}
           {!!validation && (
             <ValidationSummaryLink

--- a/src/pages/Graph/SummaryPanelNamespaceBox.tsx
+++ b/src/pages/Graph/SummaryPanelNamespaceBox.tsx
@@ -26,7 +26,7 @@ import { ValidationStatus } from 'types/IstioObjects';
 import { PFColors } from '../../components/Pf/PfColors';
 import ValidationSummary from 'components/Validations/ValidationSummary';
 import ValidationSummaryLink from '../../components/Link/ValidationSummaryLink';
-import { pfBadge, PFBadges } from 'components/Pf/PfBadges';
+import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
 
 type SummaryPanelNamespaceBoxMetricsState = {
   errRates: Datapoint[];
@@ -271,7 +271,7 @@ export default class SummaryPanelNamespaceBox extends React.Component<
     return (
       <React.Fragment key={ns}>
         <span>
-          {pfBadge(PFBadges.Namespace, undefined, undefined, { marginBottom: '2px' })}
+          <PFBadge badge={PFBadges.Namespace} style={{ marginBottom: '2px' }} />
           {ns}{' '}
           {!!validation && (
             <ValidationSummaryLink

--- a/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
+++ b/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
@@ -34,7 +34,7 @@ import { connect } from 'react-redux';
 import { timeRangeSelector } from '../../store/Selectors';
 import { PFColors, PFColorVal } from 'components/Pf/PfColors';
 import AccessLogModal from 'components/Envoy/AccessLogModal';
-import { pfAdHocBadge, pfBadge, PFBadges } from 'components/Pf/PfBadges';
+import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
 
 const appContainerColors = [PFColors.White, PFColors.LightGreen400, PFColors.LightBlue400, PFColors.Purple100];
 const proxyContainerColor = PFColors.Gold400;
@@ -257,7 +257,7 @@ class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, WorkloadPodL
                     {this.state.showToolbar && (
                       <Toolbar className={toolbar}>
                         <ToolbarGroup>
-                          {pfBadge(PFBadges.Pod)}
+                          <PFBadge badge={PFBadges.Pod} position={TooltipPosition.top} />
                           <ToolbarItem className={displayFlex}>
                             <ToolbarDropdown
                               id={'wpl_pods'}
@@ -356,7 +356,11 @@ class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, WorkloadPodL
     return (
       <Form>
         <FormGroup fieldId="container-log-selection" isInline>
-          {pfAdHocBadge(PFBadges.Container.badge, 'Containers', undefined, undefined, { marginRight: '10px' })}
+          <PFBadge
+            badge={{ badge: PFBadges.Container.badge, tt: 'Containers' }}
+            style={{ marginRight: '10px' }}
+            position={TooltipPosition.top}
+          />
           {this.state.containers!.map((c, i) => {
             return (
               <div key={`c-d-${i}`} className="pf-c-check">

--- a/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
+++ b/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
@@ -12,7 +12,6 @@ import {
   ToolbarItem,
   Tooltip,
   TooltipPosition,
-  Badge,
   Form,
   FormGroup,
   Dropdown,
@@ -35,6 +34,7 @@ import { connect } from 'react-redux';
 import { timeRangeSelector } from '../../store/Selectors';
 import { PFColors, PFColorVal } from 'components/Pf/PfColors';
 import AccessLogModal from 'components/Envoy/AccessLogModal';
+import { pfAdHocBadge, pfBadge, PFBadges } from 'components/Pf/PfBadges';
 
 const appContainerColors = [PFColors.White, PFColors.LightGreen400, PFColors.LightBlue400, PFColors.Purple100];
 const proxyContainerColor = PFColors.Gold400;
@@ -257,9 +257,7 @@ class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, WorkloadPodL
                     {this.state.showToolbar && (
                       <Toolbar className={toolbar}>
                         <ToolbarGroup>
-                          <Tooltip position={TooltipPosition.top} content={<>Pod</>}>
-                            <Badge className="virtualitem_badge_definition">P</Badge>
-                          </Tooltip>
+                          {pfBadge(PFBadges.Pod)}
                           <ToolbarItem className={displayFlex}>
                             <ToolbarDropdown
                               id={'wpl_pods'}
@@ -358,11 +356,7 @@ class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, WorkloadPodL
     return (
       <Form>
         <FormGroup fieldId="container-log-selection" isInline>
-          <Tooltip position={TooltipPosition.top} content={<>Containers</>}>
-            <Badge className="virtualitem_badge_definition" style={{ marginRight: '10px' }}>
-              C
-            </Badge>
-          </Tooltip>
+          {pfAdHocBadge(PFBadges.Container.badge, 'Containers', undefined, undefined, { marginRight: '10px' })}
           {this.state.containers!.map((c, i) => {
             return (
               <div key={`c-d-${i}`} className="pf-c-check">

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentInfoDescription.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentInfoDescription.tsx
@@ -43,7 +43,7 @@ import equal from 'fast-deep-equal';
 import TrafficControlInfo from './TrafficControlInfo';
 import ErrorBoundaryWithMessage from '../../../../components/ErrorBoundary/ErrorBoundaryWithMessage';
 import { PFColors } from '../../../../components/Pf/PfColors';
-import { pfAdHocBadge } from 'components/Pf/PfBadges';
+import { PFBadge } from 'components/Pf/PfBadges';
 
 interface ExperimentInfoDescriptionProps {
   target: string;
@@ -79,7 +79,7 @@ class ExperimentInfoDescription extends React.Component<ExperimentInfoDescriptio
   serviceInfo() {
     return [
       <DataListCell key="service-icon" isIcon={true}>
-        {pfAdHocBadge('S')}
+        <PFBadge badge={{ badge: 'S' }} />
       </DataListCell>,
       <DataListCell key="targetService">
         <Text component={TextVariants.h3}>Service</Text>
@@ -114,7 +114,7 @@ class ExperimentInfoDescription extends React.Component<ExperimentInfoDescriptio
     let badgeKind = kind === 'Deployment' ? 'W' : 'S';
     return [
       <DataListCell key="workload-icon" isIcon={true}>
-        {pfAdHocBadge(badgeKind)}
+        <PFBadge badge={{ badge: badgeKind }} />
       </DataListCell>,
       <DataListCell key={bname}>
         <Text component={TextVariants.h3}>{bname}</Text>
@@ -149,7 +149,7 @@ class ExperimentInfoDescription extends React.Component<ExperimentInfoDescriptio
     let linkTo = '/namespaces/' + namespace + '/istio/gateways/' + gatewayname;
     return [
       <DataListCell key="workload-icon" isIcon={true}>
-        {pfAdHocBadge(badgeKind)}
+        <PFBadge badge={{ badge: badgeKind }} />
       </DataListCell>,
       <DataListCell key="gateway">
         <Text>Gateway</Text>
@@ -213,7 +213,7 @@ class ExperimentInfoDescription extends React.Component<ExperimentInfoDescriptio
         </CardActions>
         <CardHeader>
           <Title style={{ float: 'left' }} headingLevel="h3" size="2xl">
-            {pfAdHocBadge(this.props.experimentDetails.experimentType)}
+            <PFBadge badge={{ badge: this.props.experimentDetails.experimentType }} />
             &nbsp;&nbsp;
             {this.props.experimentDetails.experimentItem.name}
           </Title>

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentInfoDescription.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentInfoDescription.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import {
-  Badge,
   Card,
   CardActions,
   CardBody,
@@ -44,6 +43,7 @@ import equal from 'fast-deep-equal';
 import TrafficControlInfo from './TrafficControlInfo';
 import ErrorBoundaryWithMessage from '../../../../components/ErrorBoundary/ErrorBoundaryWithMessage';
 import { PFColors } from '../../../../components/Pf/PfColors';
+import { pfAdHocBadge } from 'components/Pf/PfBadges';
 
 interface ExperimentInfoDescriptionProps {
   target: string;
@@ -79,7 +79,7 @@ class ExperimentInfoDescription extends React.Component<ExperimentInfoDescriptio
   serviceInfo() {
     return [
       <DataListCell key="service-icon" isIcon={true}>
-        <Badge className={'virtualitem_badge_definition'}>S</Badge>
+        {pfAdHocBadge('S')}
       </DataListCell>,
       <DataListCell key="targetService">
         <Text component={TextVariants.h3}>Service</Text>
@@ -114,7 +114,7 @@ class ExperimentInfoDescription extends React.Component<ExperimentInfoDescriptio
     let badgeKind = kind === 'Deployment' ? 'W' : 'S';
     return [
       <DataListCell key="workload-icon" isIcon={true}>
-        <Badge className={'virtualitem_badge_definition'}>{badgeKind}</Badge>
+        {pfAdHocBadge(badgeKind)}
       </DataListCell>,
       <DataListCell key={bname}>
         <Text component={TextVariants.h3}>{bname}</Text>
@@ -149,7 +149,7 @@ class ExperimentInfoDescription extends React.Component<ExperimentInfoDescriptio
     let linkTo = '/namespaces/' + namespace + '/istio/gateways/' + gatewayname;
     return [
       <DataListCell key="workload-icon" isIcon={true}>
-        <Badge className={'virtualitem_badge_definition'}>{badgeKind}</Badge>
+        {pfAdHocBadge(badgeKind)}
       </DataListCell>,
       <DataListCell key="gateway">
         <Text>Gateway</Text>
@@ -213,7 +213,7 @@ class ExperimentInfoDescription extends React.Component<ExperimentInfoDescriptio
         </CardActions>
         <CardHeader>
           <Title style={{ float: 'left' }} headingLevel="h3" size="2xl">
-            <Badge className={'virtualitem_badge_definition'}>{this.props.experimentDetails.experimentType}</Badge>
+            {pfAdHocBadge(this.props.experimentDetails.experimentType)}
             &nbsp;&nbsp;
             {this.props.experimentDetails.experimentItem.name}
           </Title>

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentRules.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentRules.tsx
@@ -7,7 +7,7 @@ import { PFColors } from './../../../../components/Pf/PfColors';
 import { Badge, EmptyState, EmptyStateVariant, Title, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { WorkloadWeight } from './../../../../components/IstioWizards/TrafficShifting';
 import { Abort, Delay, HTTPRetry } from './../../../../types/IstioObjects';
-import { pfBadge, PFBadges } from 'components/Pf/PfBadges';
+import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
 
 export enum MOVE_TYPE {
   UP,
@@ -125,7 +125,7 @@ class ExperimentRules extends React.Component<Props> {
                       .map((wk, i) => {
                         return (
                           <div key={'wk_' + order + '_' + wk.name + '_' + i}>
-                            {pfBadge(PFBadges.Workload, TooltipPosition.top)}
+                            <PFBadge badge={PFBadges.Workload} position={TooltipPosition.top} />
                             {wk.name} ({wk.weight}% routed traffic)
                           </div>
                         );

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentRules.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentRules.tsx
@@ -7,6 +7,7 @@ import { PFColors } from './../../../../components/Pf/PfColors';
 import { Badge, EmptyState, EmptyStateVariant, Title, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { WorkloadWeight } from './../../../../components/IstioWizards/TrafficShifting';
 import { Abort, Delay, HTTPRetry } from './../../../../types/IstioObjects';
+import { pfBadge, PFBadges } from 'components/Pf/PfBadges';
 
 export enum MOVE_TYPE {
   UP,
@@ -124,9 +125,7 @@ class ExperimentRules extends React.Component<Props> {
                       .map((wk, i) => {
                         return (
                           <div key={'wk_' + order + '_' + wk.name + '_' + i}>
-                            <Tooltip position={TooltipPosition.top} content={<>Workload</>}>
-                              <Badge className={'virtualitem_badge_definition'}>WS</Badge>
-                            </Tooltip>
+                            {pfBadge(PFBadges.Workload, TooltipPosition.top)}
                             {wk.name} ({wk.weight}% routed traffic)
                           </div>
                         );

--- a/src/pages/extensions/iter8/Iter8ExperimentList/ExperimentListPage.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentList/ExperimentListPage.tsx
@@ -24,7 +24,6 @@ import { FilterSelected, StatefulFilters } from '../../../../components/Filters/
 import { namespaceEquals } from '../../../../utils/Common';
 import history from '../../../../app/History';
 import {
-  Badge,
   Dropdown,
   DropdownItem,
   DropdownPosition,
@@ -49,6 +48,7 @@ import { activeNamespacesSelector, durationSelector } from '../../../../store/Se
 import { connect } from 'react-redux';
 import DefaultSecondaryMasthead from '../../../../components/DefaultSecondaryMasthead/DefaultSecondaryMasthead';
 import RefreshContainer from '../../../../components/Refresh/Refresh';
+import { pfAdHocBadge, pfBadge, PFBadges } from 'components/Pf/PfBadges';
 
 // Style constants
 const containerPadding = style({ padding: '20px 20px 20px 20px' });
@@ -432,7 +432,7 @@ class ExperimentListPageComponent extends React.Component<Props, State> {
       let linkTo = '/namespaces/' + namespace + '/workloads/' + name;
       return (
         <>
-          <Badge className={'virtualitem_badge_definition'}>W</Badge>
+          {pfAdHocBadge('W')}
           <Link to={linkTo}>{name}</Link>
         </>
       );
@@ -441,7 +441,7 @@ class ExperimentListPageComponent extends React.Component<Props, State> {
         let linkTo = '/namespaces/' + namespace + '/services/' + name;
         return (
           <>
-            <Badge className={'virtualitem_badge_definition'}>S</Badge>
+            {pfAdHocBadge('S')}
             <Link to={linkTo}>{name}</Link>
           </>
         );
@@ -462,14 +462,8 @@ class ExperimentListPageComponent extends React.Component<Props, State> {
       return {
         cells: [
           <>
-            <Tooltip
-              key={'TooltipExtensionIter8Name_' + h.name}
-              position={TooltipPosition.top}
-              content={<>Iter8 Experiment</>}
-            >
-              <Badge className={'virtualitem_badge_definition'}>IT8</Badge>
-            </Tooltip>
-            <Badge className={'virtualitem_badge_definition'}>{h.experimentKind}</Badge>
+            {pfBadge(PFBadges.Iter8, TooltipPosition.top, `TooltipExtensionIter8Name_${h.name}`)}
+            {pfAdHocBadge(h.experimentKind)}
             <Link
               to={`/extensions/namespaces/${h.namespace}/iter8/${h.name}?target=${h.targetService}&startTime=${h.startTime}&endTime=${h.endTime}&baseline=${h.baseline.name}&candidates=${candidates}`}
               key={'Experiment_' + h.namespace + '_' + h.namespace}
@@ -478,13 +472,7 @@ class ExperimentListPageComponent extends React.Component<Props, State> {
             </Link>
           </>,
           <>
-            <Tooltip
-              key={'TooltipExtensionNamespace_' + h.namespace}
-              position={TooltipPosition.top}
-              content={<>Namespace</>}
-            >
-              <Badge className={'virtualitem_badge_definition'}>NS</Badge>
-            </Tooltip>
+            {pfBadge(PFBadges.Namespace, TooltipPosition.top, `TooltipExtensionNamespace_${h.namespace}`)}
             {h.namespace}
           </>,
           <>

--- a/src/pages/extensions/iter8/Iter8ExperimentList/ExperimentListPage.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentList/ExperimentListPage.tsx
@@ -48,7 +48,7 @@ import { activeNamespacesSelector, durationSelector } from '../../../../store/Se
 import { connect } from 'react-redux';
 import DefaultSecondaryMasthead from '../../../../components/DefaultSecondaryMasthead/DefaultSecondaryMasthead';
 import RefreshContainer from '../../../../components/Refresh/Refresh';
-import { pfAdHocBadge, pfBadge, PFBadges } from 'components/Pf/PfBadges';
+import { PFBadges, PFBadge } from 'components/Pf/PfBadges';
 
 // Style constants
 const containerPadding = style({ padding: '20px 20px 20px 20px' });
@@ -432,7 +432,7 @@ class ExperimentListPageComponent extends React.Component<Props, State> {
       let linkTo = '/namespaces/' + namespace + '/workloads/' + name;
       return (
         <>
-          {pfAdHocBadge('W')}
+          <PFBadge badge={{ badge: 'W' }} />
           <Link to={linkTo}>{name}</Link>
         </>
       );
@@ -441,7 +441,7 @@ class ExperimentListPageComponent extends React.Component<Props, State> {
         let linkTo = '/namespaces/' + namespace + '/services/' + name;
         return (
           <>
-            {pfAdHocBadge('S')}
+            <PFBadge badge={{ badge: 'S' }} />
             <Link to={linkTo}>{name}</Link>
           </>
         );
@@ -462,8 +462,12 @@ class ExperimentListPageComponent extends React.Component<Props, State> {
       return {
         cells: [
           <>
-            {pfBadge(PFBadges.Iter8, TooltipPosition.top, `TooltipExtensionIter8Name_${h.name}`)}
-            {pfAdHocBadge(h.experimentKind)}
+            <PFBadge
+              key={`TooltipExtensionIter8Name_${h.name}`}
+              badge={PFBadges.Iter8}
+              position={TooltipPosition.top}
+            />
+            <PFBadge badge={{ badge: h.experimentKind }} />
             <Link
               to={`/extensions/namespaces/${h.namespace}/iter8/${h.name}?target=${h.targetService}&startTime=${h.startTime}&endTime=${h.endTime}&baseline=${h.baseline.name}&candidates=${candidates}`}
               key={'Experiment_' + h.namespace + '_' + h.namespace}
@@ -472,7 +476,11 @@ class ExperimentListPageComponent extends React.Component<Props, State> {
             </Link>
           </>,
           <>
-            {pfBadge(PFBadges.Namespace, TooltipPosition.top, `TooltipExtensionNamespace_${h.namespace}`)}
+            <PFBadge
+              key={`TooltipExtensionNamespace_${h.namespace}`}
+              badge={PFBadges.Namespace}
+              position={TooltipPosition.top}
+            />
             {h.namespace}
           </>,
           <>

--- a/src/types/Graph.ts
+++ b/src/types/Graph.ts
@@ -79,8 +79,7 @@ export interface NodeParamsType {
 export const CytoscapeGlobalScratchNamespace = '_global';
 export type CytoscapeGlobalScratchData = {
   activeNamespaces: Namespace[];
-  boxByCluster: boolean;
-  boxByNamespace: boolean;
+  homeCluster: string;
   edgeLabelMode: EdgeLabelMode;
   graphType: GraphType;
   showCircuitBreakers: boolean;


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/3879

Improve graph badging, ensure namespace and/or cluster information is provided where needed for discrimination, and not provided when it's not.
- remove boxByCluster and boxByNamespace booleans from cy's global scratch data, no longer needed
- add homeCluster to Cy's global scratch data
- beef up side panel badge tooltips with cluster+namespace discriminators, this avoids having to display a lot more badges/values in the side panel
- This PR includes and associated refactor that touches files that apply PF badges:
  - Consolidate PF Badging in a way sort of analogous to PfColors...
  - Basically put all all of our used PF Badges in one place for easy reference, add some stronger typing, and provide some utilities for consistent use and styling.  Update current PF badges to use the new approach.
  - This refactor should not affect the styling of existing PF badges, but it makes it easier to ensure consistent styling going forward, and to easy see our currently defined badges and their associated abbreviations and default tooltips.
