### PR TITLE
Adjust Envoy details

### DIFF
--- a/src/components/Envoy/tables/BaseTable.tsx
+++ b/src/components/Envoy/tables/BaseTable.tsx
@@ -9,6 +9,10 @@ import { FilterSelected, StatefulFilters } from '../../Filters/StatefulFilters';
 import { setFiltersToURL } from '../../FilterList/FilterHelper';
 import { ResourceSorts } from '../EnvoyModal';
 import Namespace from '../../../types/Namespace';
+import ToolbarDropdown from '../../ToolbarDropdown/ToolbarDropdown';
+import { PFBadge, PFBadges } from '../../Pf/PfBadges';
+import { TooltipPosition } from '@patternfly/react-core';
+import { style } from 'typestyle';
 
 export interface SummaryTable {
   head: () => ICell[];
@@ -19,11 +23,19 @@ export interface SummaryTable {
   availableFilters: () => FilterType[];
 }
 
+const iconStyle = style({
+  display: 'inline-block',
+  verticalAlign: '2px !important'
+});
+
 export function SummaryTableRenderer<T extends SummaryTable>() {
   interface SummaryTableProps<T> {
     writer: T;
     sortBy: ISortBy;
     onSort: (resource: string, columnIndex: number, sortByDirection: SortByDirection) => void;
+    pod: string;
+    pods: string[];
+    setPod: (pod: string) => void;
   }
 
   type SummaryTableState = {
@@ -53,7 +65,22 @@ export function SummaryTableRenderer<T extends SummaryTable>() {
           <StatefulFilters
             initialFilters={this.props.writer.availableFilters()}
             onFilterChange={this.onFilterApplied}
-          />
+            childrenFirst={true}
+          >
+            <span>
+              <div key="service-icon" className={iconStyle}>
+                <PFBadge badge={PFBadges.Pod} position={TooltipPosition.top} />
+              </div>
+              <ToolbarDropdown
+                id="envoy_pods_list"
+                tooltip="Display envoy config for the selected pod"
+                handleSelect={key => this.props.setPod(key)}
+                value={this.props.pod}
+                label={this.props.pod}
+                options={this.props.pods.sort()}
+              />
+            </span>
+          </StatefulFilters>
           <Table
             aria-label="Sortable Table"
             cells={this.props.writer.head()}

--- a/src/components/Filters/StatefulFilters.tsx
+++ b/src/components/Filters/StatefulFilters.tsx
@@ -43,6 +43,7 @@ export interface StatefulFiltersProps {
   onFilterChange: (active: ActiveFiltersInfo) => void;
   initialFilters: FilterType[];
   ref?: React.RefObject<StatefulFilters>;
+  childrenFirst?: boolean;
 }
 
 export interface StatefulFiltersState {
@@ -87,7 +88,7 @@ export class FilterSelected {
   };
 }
 
-const filterWithChildrenStyle = style({ borderRight: '1px solid #d1d1d1;', paddingRight: '10px', display: 'inherit' });
+const filterWithChildrenStyle = style({ paddingRight: '10px', display: 'inherit' });
 const dividerStyle = style({ borderRight: '1px solid #d1d1d1;', padding: '10px', display: 'inherit' });
 const paddingStyle = style({ padding: '10px' });
 
@@ -322,7 +323,7 @@ export class StatefulFilters extends React.Component<StatefulFiltersProps, State
   renderChildren = () => {
     return (
       this.props.children && (
-        <ToolbarGroup>
+        <ToolbarGroup style={{ marginRight: '10px' }}>
           {Array.isArray(this.props.children) ? (
             (this.props.children as Array<any>).map(
               (child, index) =>
@@ -358,6 +359,7 @@ export class StatefulFilters extends React.Component<StatefulFiltersProps, State
       <>
         <Toolbar className="pf-l-toolbar pf-u-justify-content-space-between pf-u-mx-xl pf-u-my-md">
           <ToolbarSection aria-label="ToolbarSection">
+            {this.props.childrenFirst && this.renderChildren()}
             <ToolbarGroup style={{ marginRight: '0px' }}>
               <ToolbarItem className={classNames(this.props.children ? filterWithChildrenStyle : '', 'pf-u-mr-xl')}>
                 <FormSelect
@@ -373,7 +375,7 @@ export class StatefulFilters extends React.Component<StatefulFiltersProps, State
                 {this.renderInput()}
               </ToolbarItem>
             </ToolbarGroup>
-            {this.renderChildren()}
+            {!this.props.childrenFirst && this.renderChildren()}
             {(this.state.activeFilters.filters.filter(f => f.id === labelFilter.id).length > 0 ||
               this.state.currentFilterType.filterType === FilterTypes.label) && (
               <ToolbarGroup>


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/3635

It groups Envoy config on tabs using the main Envoy config as a driver:

![image](https://user-images.githubusercontent.com/1662329/116382091-d9fdca80-a815-11eb-8be8-a379c92fad63.png)
![image](https://user-images.githubusercontent.com/1662329/116382120-e08c4200-a815-11eb-9712-35fc684f8a96.png)

Bootstrap and Full Config Dump are still using a yaml editor:

![image](https://user-images.githubusercontent.com/1662329/116382229-fa2d8980-a815-11eb-9b80-3822edf62b78.png)

Minor alignment with badges for pod selector.

cc @xeviknal (but it's a trap, I don't expect you put ANY comment about this PR unless 6 weeks)

cc @oschaaf, Kiali is quite active trying to help in browsing the Envoy config, so any feedback would be more than welcome. This PR is pure UI refactor, but this is an area in development and more high level features will be added into Kiali as well.