### PR TITLE
Improve handling when adding cluster discriminators to graph node labels

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -7,6 +7,7 @@ import ReactResizeDetector from 'react-resize-detector';
 import { GraphData } from 'pages/Graph/GraphPage';
 import { IntervalInMilliseconds, TimeInMilliseconds } from '../../types/Common';
 import {
+  CLUSTER_DEFAULT,
   CytoscapeBaseEvent,
   CytoscapeClickEvent,
   CytoscapeGlobalScratchData,
@@ -603,7 +604,7 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps>
     const globalScratchData: CytoscapeGlobalScratchData = {
       activeNamespaces: this.props.graphData.fetchParams.namespaces,
       edgeLabelMode: this.props.edgeLabelMode,
-      homeCluster: serverConfig.clusterInfo ? serverConfig.clusterInfo.name : UNKNOWN,
+      homeCluster: serverConfig?.clusterInfo?.name || CLUSTER_DEFAULT,
       graphType: this.props.graphData.fetchParams.graphType,
       showCircuitBreakers: this.props.showCircuitBreakers,
       showMissingSidecars: this.props.showMissingSidecars,

--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -171,7 +171,7 @@ export class GraphStyles {
     return { wheelSensitivity: 0.1, autounselectify: false, autoungrabify: true };
   }
 
-  static htmlLabelForNode(ele: Cy.NodeSingular) {
+  static getNodeLabel(ele: Cy.NodeSingular) {
     const getCyGlobalData = (ele: Cy.NodeSingular): CytoscapeGlobalScratchData => {
       return ele.cy().scratch(CytoscapeGlobalScratchNamespace);
     };
@@ -340,7 +340,7 @@ export class GraphStyles {
         valign: 'bottom',
         halignBox: 'center',
         valignBox: 'bottom',
-        tpl: (data: any) => this.htmlLabelForNode(cy.$id(data.id))
+        tpl: (data: any) => this.getNodeLabel(cy.$id(data.id))
       }
     ];
   }

--- a/src/pages/Graph/SummaryLink.tsx
+++ b/src/pages/Graph/SummaryLink.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { NodeType, GraphNodeData, DestService, BoxByType } from '../../types/Graph';
+import { NodeType, GraphNodeData, DestService, BoxByType, CLUSTER_DEFAULT } from '../../types/Graph';
 import { CyNode, decoratedNodeData } from '../../components/CytoscapeGraph/CytoscapeGraphUtils';
 import { KialiIcon } from 'config/KialiIcon';
 import { Badge, PopoverPosition } from '@patternfly/react-core';
@@ -13,7 +13,8 @@ const getTooltip = (tooltip: React.ReactFragment, nodeData: GraphNodeData): Reac
   const addNamespace = nodeData.isBox !== BoxByType.NAMESPACE;
   const addCluster =
     nodeData.isBox !== BoxByType.CLUSTER &&
-    (!serverConfig.clusterInfo || serverConfig.clusterInfo.name !== nodeData.cluster);
+    nodeData.cluster !== CLUSTER_DEFAULT &&
+    serverConfig?.clusterInfo?.name !== nodeData.cluster;
   return (
     <div style={{ textAlign: 'left' }}>
       <span>{tooltip}</span>

--- a/src/types/Graph.ts
+++ b/src/types/Graph.ts
@@ -60,6 +60,7 @@ export enum NodeType {
   WORKLOAD = 'workload'
 }
 
+export const CLUSTER_DEFAULT = 'Kubernetes'; // Istio default cluster, typically indicates a single-cluster env
 export const UNKNOWN = 'unknown';
 
 export interface NodeParamsType {


### PR DESCRIPTION
Some Istio versions set cluster='Kubernetes' as a default in the telemetry, but do not set it as a default on the control plane itself.

Fixes https://github.com/kiali/kiali/issues/3955
