### PR TITLE
Fix wrong render of workload list

### DIFF
--- a/src/components/Details/DetailDescription.tsx
+++ b/src/components/Details/DetailDescription.tsx
@@ -100,7 +100,8 @@ class DetailDescription extends React.PureComponent<Props> {
     let workload: AppWorkload | undefined = undefined;
     if (this.props.workloads && this.props.workloads.length > 0) {
       for (let i = 0; i < this.props.workloads.length; i++) {
-        if (sub.text.startsWith(this.props.workloads[i].workloadName)) {
+        const hWorkload = sub.text.substr(0, sub.text.indexOf(':'));
+        if (hWorkload === this.props.workloads[i].workloadName) {
           workload = this.props.workloads[i];
           break;
         }


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/3973

The list of workloads is matched with the list of workloads provided by health data, so there was a bug in the match code.