### PR TITLE
Refine message for remote Kiali

### DIFF
--- a/src/app/AuthenticationController.tsx
+++ b/src/app/AuthenticationController.tsx
@@ -19,6 +19,7 @@ import { TLSStatus } from '../types/TLSStatus';
 import { MeshTlsActions } from '../actions/MeshTlsActions';
 import { AuthStrategy } from '../types/Auth';
 import { JaegerInfo } from '../types/JaegerInfo';
+import { ServerConfig } from '../types/ServerConfig';
 import { LoginActions } from '../actions/LoginActions';
 import history from './History';
 import { NamespaceActions } from 'actions/NamespaceAction';
@@ -183,6 +184,7 @@ class AuthenticationController extends React.Component<AuthenticationControllerP
       this.props.setNamespaces(configs[0].data, new Date());
       setServerConfig(configs[1].data);
       this.applyUIDefaults();
+      this.checkConfiguredRemoteKialis(configs[1].data);
 
       if (this.props.landingRoute) {
         history.replace(this.props.landingRoute);
@@ -253,6 +255,30 @@ class AuthenticationController extends React.Component<AuthenticationControllerP
           this.props.setActiveNamespaces(activeNamespaces);
           console.debug(`Setting UI Default: namespaces ${JSON.stringify(activeNamespaces.map(ns => ns.name))}`);
         }
+      }
+    }
+  }
+
+  // Check which clusters does not have an accessible Kiali instance.
+  // Emit a warning telling that for those clusters, no cross-links will be available.
+  private checkConfiguredRemoteKialis(backendConfigs: ServerConfig) {
+    if (backendConfigs.clusters) {
+      const clustersWithoutKialis = [] as string[];
+      for (let cluster in backendConfigs.clusters) {
+        if (backendConfigs.clusters.hasOwnProperty(cluster)) {
+          const kialiInstance = backendConfigs.clusters[cluster].kialiInstances?.find(instance => instance.url.length !== 0);
+          if (!kialiInstance) {
+            clustersWithoutKialis.push(cluster);
+          }
+        }
+      }
+
+      if (clustersWithoutKialis.length > 0) {
+        AlertUtils.addWarning(
+          "Not all remote clusters have reachable Kiali instances.",
+          undefined, undefined,
+          "Context menus are diasabled for remote cluster nodes without a discovered Kiali or if it is not configured for remote links."
+        );
       }
     }
   }

--- a/src/app/AuthenticationController.tsx
+++ b/src/app/AuthenticationController.tsx
@@ -277,7 +277,7 @@ class AuthenticationController extends React.Component<AuthenticationControllerP
         AlertUtils.addWarning(
           "Not all remote clusters have reachable Kiali instances.",
           undefined, undefined,
-          "Context menus are diasabled for remote cluster nodes without a discovered Kiali or if it is not configured for remote links."
+          "Context menus are disabled for remote cluster nodes if a Kiali instance is not discovered, or if the remote Kiali is not configured with an external URL."
         );
       }
     }

--- a/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
+++ b/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
@@ -121,34 +121,18 @@ export class NodeContextMenu extends React.PureComponent<Props> {
       return null;
     }
 
-    let buildMenu = false;
-    let menuOptions: React.ReactNode = null;
-    // use local links if this is the home cluster, or if there is no configured home cluster
-    if (!serverConfig.clusterInfo?.name || linkParams.cluster === serverConfig.clusterInfo.name) {
-      buildMenu = true;
-    } else {
-      // Check if the remote Kiali is configured with a url. If so, build the menu; else, put a note.
-      const cluster = serverConfig.clusters[linkParams.cluster];
-      if (cluster && cluster.kialiInstances?.some(instance => instance.url.length !== 0)) {
-        buildMenu = true;
-      } else {
-        menuOptions = (
-          <p>
-            No remote links, Kiali is not available on the <strong>{linkParams.cluster}</strong> cluster.
-          </p>
-        );
-      }
-    }
-
-    if (buildMenu) {
-      const options: ContextMenuOption[] = getOptionsFromLinkParams(linkParams, this.props.jaegerInfo);
-      menuOptions = (
-        <>
-          <div className={graphContextMenuSubTitleStyle}>Show</div>
-          {options.map(o => this.createMenuItem(o.url, o.text, o.target, o.external))}
-        </>
-      );
-    }
+    // The getOptionsFromLinkParams function can potentially return a blank list if the
+    // node associated to the context menu is for a remote cluster with no accessible Kialis.
+    // That would lead to an empty menu. Here, we assume that whoever is the host/parent component,
+    // that component won't render this context menu in case this menu would be blank. So, here
+    // it's simply assumed that the context menu will look good.
+    const options: ContextMenuOption[] = getOptionsFromLinkParams(linkParams, this.props.jaegerInfo);
+    const menuOptions = (
+      <>
+        <div className={graphContextMenuSubTitleStyle}>Show</div>
+        {options.map(o => this.createMenuItem(o.url, o.text, o.target, o.external))}
+      </>
+    );
 
     return (
       <div className={graphContextMenuContainerStyle}>

--- a/src/components/CytoscapeGraph/CytoscapeContextMenu.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeContextMenu.tsx
@@ -7,6 +7,7 @@ import { DecoratedGraphEdgeData, DecoratedGraphNodeData } from '../../types/Grap
 import { Provider } from 'react-redux';
 import { store } from '../../store/ConfigStore';
 import history from '../../app/History';
+import { getOptions } from './ContextMenu/NodeContextMenu';
 
 type Props = {
   groupContextMenuContent?: NodeContextMenuType;
@@ -95,7 +96,7 @@ export class CytoscapeContextMenuWrapper extends React.PureComponent<Props> {
           contextMenuComponentType = this.props.edgeContextMenuContent;
         }
 
-        if (contextMenuComponentType) {
+        if (contextMenuComponentType && getOptions({ ...event.target.data() }).length > 0) {
           this.makeContextMenu(contextMenuComponentType, event.target);
         }
       }

--- a/src/pages/Graph/GraphPage.tsx
+++ b/src/pages/Graph/GraphPage.tsx
@@ -59,7 +59,6 @@ import { replayBorder } from 'components/Time/Replay';
 import GraphDataSource, { FetchParams, EMPTY_GRAPH_DATA } from '../../services/GraphDataSource';
 import { NamespaceActions } from '../../actions/NamespaceAction';
 import GraphThunkActions from '../../actions/GraphThunkActions';
-import { serverConfig } from '../../config';
 import { JaegerTrace } from 'types/JaegerInfo';
 import { JaegerThunkActions } from 'actions/JaegerThunkActions';
 import GraphTour from 'pages/Graph/GraphHelpTour';
@@ -328,28 +327,6 @@ export class GraphPage extends React.Component<GraphPageProps, GraphPageState> {
 
     // start the initial graph generation
     this.loadGraphDataFromBackend();
-
-    // Check which clusters does not have an accessible Kiali instance.
-    // Emit a warning telling that for those clusters, no cross-links will be available.
-    if (serverConfig.clusters) {
-      const clustersWithoutKialis = [] as string[];
-      for (let cluster in serverConfig.clusters) {
-        if (serverConfig.clusters.hasOwnProperty(cluster)) {
-          const kialiInstance = serverConfig.clusters[cluster].kialiInstances?.find(instance => instance.url.length !== 0);
-          if (!kialiInstance) {
-            clustersWithoutKialis.push(cluster);
-          }
-        }
-      }
-
-      if (clustersWithoutKialis.length > 0) {
-        if (clustersWithoutKialis.length === 1) {
-          AlertUtils.addWarning(`Cannot find a reachable Kiali instance in cluster ${clustersWithoutKialis[0]}. Turning off links for objects living in this cluster.`);
-        } else {
-          AlertUtils.addWarning(`Cannot find a reachable Kiali instance in the following clusters: ${clustersWithoutKialis.join(', ')}. Turning off links for objects living in these clusters.`);
-        }
-      }
-    }
   }
 
   componentDidUpdate(prev: GraphPageProps) {

--- a/src/pages/Graph/GraphPage.tsx
+++ b/src/pages/Graph/GraphPage.tsx
@@ -59,6 +59,7 @@ import { replayBorder } from 'components/Time/Replay';
 import GraphDataSource, { FetchParams, EMPTY_GRAPH_DATA } from '../../services/GraphDataSource';
 import { NamespaceActions } from '../../actions/NamespaceAction';
 import GraphThunkActions from '../../actions/GraphThunkActions';
+import { serverConfig } from '../../config';
 import { JaegerTrace } from 'types/JaegerInfo';
 import { JaegerThunkActions } from 'actions/JaegerThunkActions';
 import GraphTour from 'pages/Graph/GraphHelpTour';
@@ -327,6 +328,28 @@ export class GraphPage extends React.Component<GraphPageProps, GraphPageState> {
 
     // start the initial graph generation
     this.loadGraphDataFromBackend();
+
+    // Check which clusters does not have an accessible Kiali instance.
+    // Emit a warning telling that for those clusters, no cross-links will be available.
+    if (serverConfig.clusters) {
+      const clustersWithoutKialis = [] as string[];
+      for (let cluster in serverConfig.clusters) {
+        if (serverConfig.clusters.hasOwnProperty(cluster)) {
+          const kialiInstance = serverConfig.clusters[cluster].kialiInstances?.find(instance => instance.url.length !== 0);
+          if (!kialiInstance) {
+            clustersWithoutKialis.push(cluster);
+          }
+        }
+      }
+
+      if (clustersWithoutKialis.length > 0) {
+        if (clustersWithoutKialis.length === 1) {
+          AlertUtils.addWarning(`Cannot find a reachable Kiali instance in cluster ${clustersWithoutKialis[0]}. Turning off links for objects living in this cluster.`);
+        } else {
+          AlertUtils.addWarning(`Cannot find a reachable Kiali instance in the following clusters: ${clustersWithoutKialis.join(', ')}. Turning off links for objects living in these clusters.`);
+        }
+      }
+    }
   }
 
   componentDidUpdate(prev: GraphPageProps) {


### PR DESCRIPTION
This standardizes the behavior of the graph context menu when there are no available options to show. Concretely, no options because of a node living in a remote cluster where an accessible Kiali instance couldn't be found.

When Kiali UI boots, it will check which clusters does NOT have accessible Kialis. A message will be logged in the message center telling about this fact and that no links to these clusters will be available. In the graph, context menus for relevant nodes won't be present.

![image](https://user-images.githubusercontent.com/23639005/117068832-6108e200-acf1-11eb-9002-8d2c03a5c05a.png)

Fixes kiali/kiali#3907
