### PR TITLE
 Application Traffic - some outbound traffic is not shown

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -180,7 +180,7 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps>
       // pre-select node if provided
       const node = this.props.graphData.fetchParams.node;
       if (node && cy && cy.$(':selected').length === 0) {
-        let selector = "[nodeType = '" + node.nodeType + "']";
+        let selector = `[namespace = "${node.namespace.name}"][nodeType = "${node.nodeType}"]`;
         switch (node.nodeType) {
           case NodeType.AGGREGATE:
             selector =

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -7,6 +7,7 @@ import ReactResizeDetector from 'react-resize-detector';
 import { GraphData } from 'pages/Graph/GraphPage';
 import { IntervalInMilliseconds, TimeInMilliseconds } from '../../types/Common';
 import {
+  BoxByType,
   CLUSTER_DEFAULT,
   CytoscapeBaseEvent,
   CytoscapeClickEvent,
@@ -187,6 +188,7 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps>
             break;
           case NodeType.APP:
           case NodeType.BOX: // we only support app box node graphs, treat like an app node
+            console.log(`preselect nodeType=${node.nodeType}, version=${node.version}`);
             selector = selector + "[app = '" + node.app + "']";
             if (node.version && node.version !== UNKNOWN) {
               selector = selector + "[version = '" + node.version + "']";
@@ -201,7 +203,18 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps>
 
         const eles = cy.nodes(selector);
         if (eles.length > 0) {
-          this.selectTargetAndUpdateSummary(eles[0]);
+          let target = eles[0];
+          // default app to the whole app box, when appropriate
+          if (
+            (node.nodeType === NodeType.APP || node.nodeType === NodeType.BOX) &&
+            !node.version &&
+            target.isChild() &&
+            target.parent()[0].data(CyNode.isBox) === BoxByType.APP
+          ) {
+            target = target.parent()[0];
+          }
+
+          this.selectTargetAndUpdateSummary(target);
         }
       }
 

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -188,7 +188,6 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps>
             break;
           case NodeType.APP:
           case NodeType.BOX: // we only support app box node graphs, treat like an app node
-            console.log(`preselect nodeType=${node.nodeType}, version=${node.version}`);
             selector = selector + "[app = '" + node.app + "']";
             if (node.version && node.version !== UNKNOWN) {
               selector = selector + "[version = '" + node.version + "']";

--- a/src/components/CytoscapeGraph/MiniGraphCard.tsx
+++ b/src/components/CytoscapeGraph/MiniGraphCard.tsx
@@ -13,7 +13,7 @@ import {
 import history from '../../app/History';
 import GraphDataSource from '../../services/GraphDataSource';
 import { DecoratedGraphElements, EdgeLabelMode, GraphType, NodeType } from '../../types/Graph';
-import CytoscapeGraph, { GraphNodeDoubleTapEvent } from './CytoscapeGraph';
+import CytoscapeGraph, { GraphNodeTapEvent } from './CytoscapeGraph';
 import { CytoscapeGraphSelectorBuilder } from './CytoscapeGraphSelector';
 import { DagreGraph } from './graphs/DagreGraph';
 import { GraphUrlParams, makeNodeGraphUrlFromParams } from 'components/Nav/NavUtils';
@@ -125,13 +125,13 @@ export default class MiniGraphCard extends React.Component<MiniGraphCardProps, M
     );
   }
 
-  private handleNodeTap = (e: GraphNodeDoubleTapEvent) => {
+  private handleNodeTap = (e: GraphNodeTapEvent) => {
     // Do nothing on inaccessible nodes or service entry nodes
     if (e.isInaccessible || e.isServiceEntry) {
       return;
     }
 
-    // If we are already on the details page of the double-tapped node, do nothing.
+    // If we are already on the details page of the tapped node, do nothing.
     const displayedNode = this.props.dataSource.fetchParameters.node;
     // Minigraph will consider box nodes as app
     const eNodeType = e.nodeType === 'box' && e.isBox ? e.isBox : e.workload ? 'workload' : e.nodeType;

--- a/src/components/CytoscapeGraph/MiniGraphCard.tsx
+++ b/src/components/CytoscapeGraph/MiniGraphCard.tsx
@@ -36,8 +36,11 @@ type MiniGraphCardState = {
 };
 
 export default class MiniGraphCard extends React.Component<MiniGraphCardProps, MiniGraphCardState> {
+  private cytoscapeGraphRef: any;
+
   constructor(props) {
     super(props);
+    this.cytoscapeGraphRef = React.createRef();
     this.state = { isKebabOpen: false, graphData: props.dataSource.graphData };
   }
 
@@ -108,6 +111,7 @@ export default class MiniGraphCard extends React.Component<MiniGraphCardProps, M
               isMiniGraph={true}
               layout={DagreGraph.getLayout()}
               onNodeTap={this.handleNodeTap}
+              ref={refInstance => this.setCytoscapeGraph(refInstance)}
               refreshInterval={0}
               showCircuitBreakers={true}
               showIdleEdges={false}
@@ -123,6 +127,10 @@ export default class MiniGraphCard extends React.Component<MiniGraphCardProps, M
         </CardBody>
       </Card>
     );
+  }
+
+  private setCytoscapeGraph(cytoscapeGraph: any) {
+    this.cytoscapeGraphRef.current = cytoscapeGraph;
   }
 
   private handleNodeTap = (e: GraphNodeTapEvent) => {
@@ -144,7 +152,13 @@ export default class MiniGraphCard extends React.Component<MiniGraphCardProps, M
       return;
     }
 
-    // Redirect to the details page of the double-tapped node.
+    // unselect the currently selected node
+    const cy = this.cytoscapeGraphRef.current.getCy();
+    if (cy) {
+      cy.$(':selected').selectify().unselect().unselectify();
+    }
+
+    // Redirect to the details page of the tapped node.
     let resource = e[eNodeType];
     let resourceType: string = eNodeType === NodeType.APP ? 'application' : eNodeType;
 

--- a/src/pages/AppDetails/AppInfo.tsx
+++ b/src/pages/AppDetails/AppInfo.tsx
@@ -56,7 +56,7 @@ class AppInfo extends React.Component<AppInfoProps, AppInfoState> {
     if (!this.props.app) {
       return;
     }
-    this.graphDataSource.fetchForApp(this.props.duration, this.props.app.namespace.name, this.props.app.name);
+    this.graphDataSource.fetchForVersionedApp(this.props.duration, this.props.app.namespace.name, this.props.app.name);
     const hasSidecar = this.props.app.workloads.some(w => w.istioSidecar);
     API.getAppHealth(this.props.app.namespace.name, this.props.app.name, this.props.duration, hasSidecar)
       .then(health => this.setState({ health: health }))

--- a/src/pages/Graph/GraphPage.tsx
+++ b/src/pages/Graph/GraphPage.tsx
@@ -577,7 +577,7 @@ export class GraphPage extends React.Component<GraphPageProps, GraphPageState> {
       }
     }
 
-    const targetNode = { ...event, namespace: { name: event.namespace } };
+    const targetNode: NodeParamsType = { ...event, namespace: { name: event.namespace } };
 
     // If, while in the drilled-down graph, the user double clicked the same
     // node as in the main graph, it doesn't make sense to re-load the same view.

--- a/src/pages/Graph/GraphPage.tsx
+++ b/src/pages/Graph/GraphPage.tsx
@@ -348,7 +348,6 @@ export class GraphPage extends React.Component<GraphPageProps, GraphPageState> {
       prev.showIdleNodes !== curr.showIdleNodes ||
       GraphPage.isNodeChanged(prev.node, curr.node)
     ) {
-      console.log(`load@update isInitialLoad=${isInitialLoad}`);
       this.loadGraphDataFromBackend();
     }
 
@@ -460,7 +459,6 @@ export class GraphPage extends React.Component<GraphPageProps, GraphPageState> {
   }
 
   private handleEmptyGraphAction = () => {
-    console.log('load@empty');
     this.loadGraphDataFromBackend();
   };
 
@@ -584,7 +582,6 @@ export class GraphPage extends React.Component<GraphPageProps, GraphPageState> {
     // Instead, assume that the user wants more details for the node and do a
     // redirect to the details page.
     if (sameNode) {
-      console.log('HandleDoubleTap: sameNode');
       this.handleDoubleTapSameNode(targetNode);
       return;
     }
@@ -606,7 +603,6 @@ export class GraphPage extends React.Component<GraphPageProps, GraphPageState> {
     };
 
     // To ensure updated components get the updated URL, update the URL first and then the state
-    console.log(`HandleDoubleTap: ${targetNode.nodeType}:${targetNode.app}`);
     history.push(makeNodeGraphUrlFromParams(urlParams));
   };
 

--- a/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -51,7 +51,11 @@ class ServiceInfo extends React.Component<Props, ServiceInfoState> {
   }
 
   componentDidUpdate(prev: Props) {
-    if (prev.duration !== this.props.duration || prev.lastRefreshAt !== this.props.lastRefreshAt) {
+    if (
+      prev.duration !== this.props.duration ||
+      prev.lastRefreshAt !== this.props.lastRefreshAt ||
+      prev.serviceDetails?.service.name !== this.props.serviceDetails?.service.name
+    ) {
       this.fetchBackend();
     }
   }

--- a/src/pages/WorkloadDetails/WorkloadInfo.tsx
+++ b/src/pages/WorkloadDetails/WorkloadInfo.tsx
@@ -69,7 +69,11 @@ class WorkloadInfo extends React.Component<WorkloadInfoProps, WorkloadInfoState>
 
   componentDidUpdate(prev: WorkloadInfoProps) {
     // Fetch WorkloadInfo backend on duration changes or WorkloadDetailsPage update
-    if (prev.duration !== this.props.duration || prev.lastRefreshAt !== this.props.lastRefreshAt) {
+    if (
+      prev.duration !== this.props.duration ||
+      prev.lastRefreshAt !== this.props.lastRefreshAt ||
+      this.props.workload?.name !== prev.workload?.name
+    ) {
       this.fetchBackend();
     }
   }

--- a/src/services/GraphDataSource.ts
+++ b/src/services/GraphDataSource.ts
@@ -251,6 +251,20 @@ export default class GraphDataSource {
 
   public fetchForAppParams = (duration: DurationInSeconds, namespace: string, app: string): FetchParams => {
     const params = GraphDataSource.defaultFetchParams(duration, namespace);
+    params.graphType = GraphType.APP;
+    params.node!.nodeType = NodeType.APP;
+    params.node!.app = app;
+    return params;
+  };
+
+  public fetchForVersionedApp = (duration: DurationInSeconds, namespace: string, app: string) => {
+    const params = this.fetchForVersionedAppParams(duration, namespace, app);
+    params.showSecurity = true;
+    this.fetchGraphData(params);
+  };
+
+  public fetchForVersionedAppParams = (duration: DurationInSeconds, namespace: string, app: string): FetchParams => {
+    const params = GraphDataSource.defaultFetchParams(duration, namespace);
     params.graphType = GraphType.VERSIONED_APP;
     params.node!.nodeType = NodeType.APP;
     params.node!.app = app;


### PR DESCRIPTION
Fix regression in Application detail's Traffic tab.  The fix maintains the change to a versionedapp graph for application mini-graphs (the cause of the problem) but restores the traffic tab to its original behavior. 

While investigating I ended up fixing a few things that, in the end, did not contribute to the reported problem:
- fix target node selection for application nodes for node detail and application mini-graphs
- fix two double-loading issues for the graph, one related to node graphs and the other related to bookmarked graphs

Fixes https://github.com/kiali/kiali/issues/3974