### PR TITLE
Deprecate publishing to NPM (front-end)

### DIFF
--- a/.env.downstream
+++ b/.env.downstream
@@ -4,7 +4,7 @@
 #     KIALI_ENV=production yarn build
 #
 #  These variables are written to the directly to the resulting js code and can be
-#  used by calling e.g. process.env.REACT_APP_RCUE
+#  used by calling e.g. process.env.REACT_APP_KIALI_DOC_URL
 #  They are always strings, so we need to decode them depending the use case.
 #  All the envs need to start with REACT_APP or they won't be available within the
 #  app.
@@ -13,5 +13,4 @@
 ######################################################################################
 
 REACT_APP_IS_UPSTREAM=false
-REACT_APP_RCUE=true
 REACT_APP_KIALI_DOC_URL='https://www.kiali.io/documentation/'

--- a/.env.upstream
+++ b/.env.upstream
@@ -4,7 +4,7 @@
 #     KIALI_ENV="" yarn build
 #
 #  These variables are written to the directly to the resulting js code and can be
-#  used by calling e.g. process.env.REACT_APP_RCUE
+#  used by calling e.g. process.env.REACT_APP_KIALI_DOC_URL
 #  They are always strings, so we need to decode them depending the use case.
 #  All the envs need to start with REACT_APP or they won't be available within the
 #  app.
@@ -12,5 +12,4 @@
 #
 ######################################################################################
 REACT_APP_IS_UPSTREAM=true
-REACT_APP_RCUE=false
 REACT_APP_KIALI_DOC_URL='https://www.kiali.io/documentation/'

--- a/Makefile.jenkins
+++ b/Makefile.jenkins
@@ -18,7 +18,6 @@ UI_VERSION_BRANCH ?= $(shell jq -r '.version' package.json | sed 's/\.[[:digit:]
 # BUILD_TAG is an environment variable from Jenkins
 BUILD_TAG ?= prepare-next-version
 BUMP_BRANCH_ID ?= $(BUILD_TAG)
-NPM_DRY_RUN ?= n
 
 # For minors and majors, the version currently stored in package.json
 # is the version to publish. All other kind of releases require
@@ -30,11 +29,6 @@ endif
 # Block edge releases on github
 ifneq ($(RELEASE_TYPE),edge)
   PUSH_GITHUB_TAG = y
-endif
-
-# Block edge releases on npm
-ifneq ($(RELEASE_TYPE),edge)
-  PUSH_TO_NPM = y
 endif
 
 # For "minor" releases, the "master" branch must be
@@ -65,7 +59,7 @@ endif
 
 # Start definition of the recipes
 
-.PHONY: all ui-build ui-test ui-npm-publish
+.PHONY: all ui-build ui-test
 .PHONY: ui-push-version-tag ui-prepare-next-version release
 .PHONY: ui-fix-version ui-check-clean-workspace
 .PHONY: ui-prepare-next-patch-version ui-prepare-master-next-version
@@ -99,22 +93,6 @@ ui-build:
 
 ui-test:
 	CI=true yarn test --maxWorkers=4
-
-ui-npm-publish:
-ifeq ($(PUSH_TO_NPM), y)
-ifdef NPM_TOKEN
-	@echo '//registry.npmjs.org/:_authToken=$(NPM_TOKEN)' > .npmrc
-endif
-ifeq ($(NPM_DRY_RUN), y)
-	npm publish --dry-run
-else
-	# To publish, use always the NPM registry
-	npm publish --registry https://registry.npmjs.org
-endif
-ifdef NPM_TOKEN
-	rm .npmrc
-endif
-endif
 
 ui-push-version-tag:
 ifeq ($(PUSH_GITHUB_TAG),y)
@@ -177,4 +155,4 @@ endif
 ui-prepare-next-version: ui-prepare-next-patch-version ui-prepare-master-next-version
 
 release: ui-check-clean-workspace ui-fix-version ui-build ui-test
-release: ui-npm-publish ui-push-version-tag ui-prepare-next-version
+release: ui-push-version-tag ui-prepare-next-version

--- a/README.adoc
+++ b/README.adoc
@@ -8,10 +8,6 @@ toc::[]
 
 A UI for the Kiali Istio Observability Project
 
-== Technologies
-* React.js
-* Redux
-
 == Quick Start
 [source,shell]
 ----
@@ -50,6 +46,8 @@ reloads any changes to the browser for rapid development.
 * `src/utils`: Various Utilities
 
 == Developing
+
+The Kiali UI is a React application written in Typescript.
 
 We use `yarn` as the package manager, if adding dependencies to `package.json`
 make sure you install them with `yarn` and commit the `yarn.lock` file.
@@ -106,21 +104,6 @@ yarn build-css
 
 Note:
 Only static assets which are `import` 'ed into your application will be included in your resulting build output.
-
-=== RCUE Styling
-To use the https://redhat-rcue.github.io/[RCUE] styled css instead of normal Patternfly
-
-For development run:
-[source,shell]
-----
-env REACT_APP_RCUE=true yarn start
-----
-
-For production build run:
-[source,shell]
-----
-env REACT_APP_RCUE=true yarn build
-----
 
 === Style Code Guide
 

--- a/README.adoc
+++ b/README.adoc
@@ -11,8 +11,17 @@ A UI for the Kiali Istio Observability Project
 == Quick Start
 [source,shell]
 ----
+# Get the kiali-ui sources
+git clone https://github.com/kiali/kiali-ui.git
+cd kiali-ui
+
+# Install Yarn
 npm install -g yarn
+
+# Install kiali-ui dependencies
 yarn
+
+# Start a development server
 yarn start
 ----
 
@@ -20,8 +29,8 @@ yarn start
 On some platforms, `yarn start` may fail with an error like `Error: ENOSPC: System limit for number of file watchers reached`. To fix this, you need to increase the limit of file watchers on your system. The command may vary depending on the platform, please refer to link:https://github.com/guard/listen/wiki/Increasing-the-amount-of-inotify-watchers[these instructions].
 
 A new browser window should automatically open.
-But, if it doesn't then use:
-`http://localhost:3000`
+But, if it doesn't then use: `http://localhost:3000`
+(or whatever address is told by the `yarn start` command).
 
 This launches a development environment that instantly
 reloads any changes to the browser for rapid development.
@@ -33,15 +42,16 @@ reloads any changes to the browser for rapid development.
 * `src/actions`:  Redux actions
 * `src/app`: React top level component
 * `src/assets`: Images and other assets
-* `src/config`: Configuration
-* `src/containers`: [.line-through]#Redux connected containers# _Deprecated_
 * `src/components`: React Components
+* `src/config`: Configuration
 * `src/fonts`:  Fonts
-* `src/images`:  Patternfly Images
+* `src/helpers`:  Utility functions and components
+* `src/img`:  Patternfly Images
 * `src/pages`: Top level pages and nested components
 * `src/reducers`: Redux reducers
 * `src/services`: Api services
 * `src/store`:  Redux store definitions
+* `src/styles`:  Application wide styles
 * `src/types`: Typescript definitions for all kinds of types
 * `src/utils`: Various Utilities
 

--- a/RELEASING.adoc
+++ b/RELEASING.adoc
@@ -4,27 +4,6 @@ Kiali is released using a Jenkins Pipeline. The main document covering
 the release process can be found
 link:https://github.com/kiali/kiali/blob/master/RELEASING.adoc[here].
 
-== Versioning scheme
-
-The versioning scheme that we are following is similar to
-link:http://semver.org[semver], but not as strict, given both that we are not
-1.0 yet and that we are the end product, in the sense that nothing should
-depend on us to do anything. For now, and that might change in the future, our
-API is private and we make no guarantees that compatibility is going to be
-maintaned.
-
-For our versioning scheme, the `major` part means a major release, and that's
-decided in advance by the team. The `minor` means new features are included
-with the release, and the `patch` version covers only bugfixes.
-
-The UI and the core might be out of sync in `patch` versions, but they should
-be in sync for `minor`. That means that, if the UI is 0.5.10, then any core
-version on 0.5.X should work with it, but that are no guarantees that it will
-work with core 0.4.X or core 0.6.X.
-
-Of course, that's a soft limitation, and your mileage may vary. Sometimes it
-might work just fine, we just don't give any guarantees that it will.
-
 == Running the release process locally
 
 If you don't have access to the Jenkins instance or the release process
@@ -36,8 +15,7 @@ This guide covers releasing only kiali-ui.
 === Requirements
 
 You must have write permissions to the kiali-ui public GitHub repository in
-order to be able to push the tags. You will also need an NPM account that
-is able to publish to the NPM @kiali organization.
+order to be able to push the tags.
 
 You will need a working dev environment for kiali-ui (git, npm, yarn, etc).
 You will also need the following tools available in your $PATH:
@@ -57,8 +35,6 @@ kiali-ui repository.
 
 === Making the release
 
-. Login to NPM using the user with write access to the NPM @kiali organization:
-** `npm login`
 . Checkout the code that you want to release:
 ** `git checkout branch_to_release` (usually, you should release "master")
 ** Be advised that the release process will commit changes locally.
@@ -96,6 +72,3 @@ don't change the version in `package.json`).
   name of the branch is _prepare_next_version_. If you want to customize the
   name of the branch:
 ** `BUMP_BRANCH_ID={branch_name} make -f Makefile.jenkins release`
-* If your NPM account don't have write privileges to the @kiali organization but
-  you have a token with the required privileges, you can use that token:
-** `NPM_TOKEN="{your_token}" make -f Makefile.jenkins release`

--- a/RELEASING.adoc
+++ b/RELEASING.adoc
@@ -1,74 +1,12 @@
 = Releasing Kiali UI
 
-Kiali is released using a Jenkins Pipeline. The main document covering
-the release process can be found
-link:https://github.com/kiali/kiali/blob/master/RELEASING.adoc[here].
+Since Kiali v1.35, the kiali-ui is no longer released to NPM. The UI is now
+only being packaged together with the back-end in a container image that
+is published in link:https://quay.io/repository/kiali/kiali?tab=tags[Kiali's Quay.io repository].
 
-== Running the release process locally
+Packaging the front-end and the back-end together has been the way to release
+Kiali for a long time. It's only the NPM artifact that is no longer being published.
 
-If you don't have access to the Jenkins instance or the release process
-through Jenkins doesn't suit your needs, you may want to run the release
-process _locally_.
-
-This guide covers releasing only kiali-ui.
-
-=== Requirements
-
-You must have write permissions to the kiali-ui public GitHub repository in
-order to be able to push the tags.
-
-You will need a working dev environment for kiali-ui (git, npm, yarn, etc).
-You will also need the following tools available in your $PATH:
-
-* https://stedolan.github.io/jq/[jq] - a JSON processor used to update the
-  package.json file
-* https://github.com/fsaintjacques/semver-tool[semver] shell utility - used
-  to update version numbers
-* make - to run the release process
-* curl - because the release process places PRs using the GitHub API
-
-If you want the release process to push a PR for you to prepare the code for
-the next release, you will need a GitHub Token for your account.
-
-It's assumed that you are running the release process in your fork of the
-kiali-ui repository.
-
-=== Making the release
-
-. Checkout the code that you want to release:
-** `git checkout branch_to_release` (usually, you should release "master")
-** Be advised that the release process will commit changes locally.
-. The release process may need to create a PR to prepare the code for the next
-  version. A GitHub token is required to create the PR:
-** `export GH_TOKEN={your_github_token}`
-** This is optional. If a token is not provided, a branch is created in your
-   fork of the code, if needed. Then, you can place the PR manually.
-. Run the release process:
-** `make -f Makefile.jenkins release`
-
-By default, it's assumed that you are doing a _minor_ release.
-If want to do another type of release, you can run the release process specifying
-the RELEASE_TYPE variable. Valid values are "major", "minor", "patch", "edge" and
-"snapshot._X_". For example:
-
-* `RELEASE_TYPE="snapshot.1" make -f Makefile.jenkins release`
-
-*Note*: The process will adjust the version string as needed, according to
-the type of release. Please, don't try to adjust the version string (i.e.
-don't change the version in `package.json`).
-
-=== Available options
-
-* If you want to make a "dry-run" of the release:
-** `NPM_DRY_RUN=y make -f Makefile.jenkins release`
-* In _minor_ or _patch_ mode, the release process updates or creates
-  a version branch in the kiali-ui repository (the branch name is like
-  "vMAJOR.MINOR"). You can omit this:
-** `OMIT_VERSION_BRANCH=y make -f Makefile.jenkins release`
-* In _minor_ or _patch_ mode, the release
-  process may create a branch in your fork of the repository with
-  the required changes to prepare the code for the next release. The branch is
-  created if it isn't possible to push to the kiali-ui repository. By default, the
-  name of the branch is _prepare_next_version_. If you want to customize the
-  name of the branch:
-** `BUMP_BRANCH_ID={branch_name} make -f Makefile.jenkins release`
+If you want to learn more, See the
+link:https://github.com/kiali/kiali/blob/master/RELEASING.adoc[RELEASING.adoc document
+in the back-end repository].

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "license": "Apache-2.0",
   "author": "Red Hat",
   "main": "index.js",
+  "private": true,
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
No longer publish the Kiali-UI to NPM.

Back-end PR: https://github.com/kiali/kiali/pull/3986
Related issue kiali/kiali#3891
