### PR TITLE
Fix ServiceEntry graph links

### DIFF
--- a/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
+++ b/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
@@ -56,7 +56,7 @@ type LinkParams = { cluster: string; namespace: string; name: string; type: stri
 export class NodeContextMenu extends React.PureComponent<Props> {
   static derivedValuesFromProps(node: DecoratedGraphNodeData): LinkParams | undefined {
     const cluster: string = node.cluster;
-    const namespace: string = node.namespace;
+    const namespace: string = node.isServiceEntry ? node.isServiceEntry.namespace : node.namespace;
     let name: string | undefined = undefined;
     let type: string | undefined = undefined;
     switch (node.nodeType) {

--- a/src/pages/Graph/SummaryLink.tsx
+++ b/src/pages/Graph/SummaryLink.tsx
@@ -95,7 +95,9 @@ const getLink = (nodeData: GraphNodeData, nodeType?: NodeType) => {
       break;
     case NodeType.SERVICE:
       if (nodeData.isServiceEntry) {
-        link = `/namespaces/${encodeURIComponent(namespace)}/istio/serviceentries/${encodeURIComponent(service!)}`;
+        link = `/namespaces/${encodeURIComponent(
+          nodeData.isServiceEntry.namespace
+        )}/istio/serviceentries/${encodeURIComponent(service!)}`;
       } else {
         link = `/namespaces/${encodeURIComponent(namespace)}/services/${encodeURIComponent(service!)}`;
       }
@@ -186,7 +188,7 @@ export const renderDestServicesLinks = (node: any) => {
       isOutside: nodeData.isOutside,
       isRoot: nodeData.isRoot,
       isServiceEntry: nodeData.isServiceEntry,
-      namespace: ds.namespace,
+      namespace: nodeData.isServiceEntry ? nodeData.isServiceEntry.namespace : nodeData.namespace,
       nodeType: NodeType.SERVICE,
       service: ds.name,
       version: '',

--- a/src/types/Graph.ts
+++ b/src/types/Graph.ts
@@ -166,8 +166,9 @@ export interface DestService {
 }
 
 export interface SEInfo {
-  location: string;
   hosts: string[];
+  location: string;
+  namespace: string; // namespace represents where the ServiceEntry object is defined and not necessarily the namespace of the node.
 }
 
 // Node data expected from server


### PR DESCRIPTION
ServiceEntries should link to the namespace where they are defined which isn't always the node namespace.

Relates to: https://github.com/kiali/kiali/issues/3798
Requires backend changes: https://github.com/kiali/kiali/pull/3980

These ServiceEntry links were broken before when the ServiceEntry definition was outside of the graph node's namespace but should now properly direct to the Istio Config of the Service Entry.

![LinkDetailsScreenshot](https://user-images.githubusercontent.com/6226732/117502625-c527e200-af4d-11eb-883a-06f44fbbedcd.png)

![NodeSummaryDetailsLink](https://user-images.githubusercontent.com/6226732/117502829-159f3f80-af4e-11eb-9146-d41d533dfc69.png)
