### PR TITLE
Fix ACE editor font size

### DIFF
--- a/src/types/IstioConfigDetails.ts
+++ b/src/types/IstioConfigDetails.ts
@@ -40,7 +40,8 @@ export interface IstioConfigDetails {
 
 export const aceOptions: AceOptions = {
   showPrintMargin: false,
-  autoScrollEditorIntoView: true
+  autoScrollEditorIntoView: true,
+  fontSize: '16px'
 };
 
 export const safeDumpOptions = {


### PR DESCRIPTION
Trivial. 
At some point a minor regression was introduced in the ACE editor and font size was not aligned with font size of rest of the details pages.

Before:
![image](https://user-images.githubusercontent.com/1662329/117807091-746cfd80-b25b-11eb-9ff2-870c6618a83c.png)

After:
![image](https://user-images.githubusercontent.com/1662329/117807151-851d7380-b25b-11eb-9b24-c529c0a89476.png)

In terms of code is tricky, ACE editor is a third party component with some built-in styles that are modified via CSS but it also offers a generic options in the component to change this internally, which was the method used for this fix.