### PR TITLE
Add sourceprincipal and destprincipal operands to Graph Find/Hide.

### DIFF
--- a/src/pages/Graph/GraphHelpFind.tsx
+++ b/src/pages/Graph/GraphHelpFind.tsx
@@ -142,6 +142,7 @@ export default class GraphHelpFind extends React.Component<GraphHelpFindProps> {
   };
   private edgeRows = (): string[][] => {
     return [
+      ['destprincipal <op> <principal>'],
       ['grpc <op> <number>', 'unit: requests per second'],
       ['%grpcerr <op> <number>', 'range: [0..100]'],
       ['%grpctraffic <op> <number>', 'range: [0..100]'],
@@ -150,6 +151,7 @@ export default class GraphHelpFind extends React.Component<GraphHelpFindProps> {
       ['%httptraffic <op> <number>', 'range: [0..100]'],
       ['protocol <op> <protocol>', 'grpc, http, tcp, etc..'],
       ['responsetime <op> <number>', `unit: millis, will auto-enable 'response time' edge labels`],
+      ['sourceprincipal <op> <principal>'],
       ['tcp <op> <number>', 'unit: requests per second'],
       ['mtls', `will auto-enable 'security' display option`],
       ['traffic', 'any traffic for any protocol']
@@ -221,7 +223,7 @@ export default class GraphHelpFind extends React.Component<GraphHelpFindProps> {
       ['Abbrevations: circuitbreaker|cb, responsetime|rt, serviceentry->se, sidecar|sc, virtualservice|vs'],
       ['Hiding nodes will automatically hide connected edges.'],
       ['Hiding edges will automatically hide nodes left with no visible edges.'],
-      ['Hiding "healthy"ss nodes may still leave valid, healthy edges in the graph.']
+      ['Hiding "healthy" nodes may still leave valid, healthy edges in the graph.']
     ];
   };
 

--- a/src/pages/Graph/GraphToolbar/GraphFind.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphFind.tsx
@@ -72,6 +72,7 @@ const operands: string[] = [
   '%httptraffic',
   'app',
   'circuitbreaker',
+  'destprincipal',
   'grpc',
   'grpcerr',
   'grpcin',
@@ -92,6 +93,7 @@ const operands: string[] = [
   'service',
   'serviceentry',
   'sidecar',
+  'sourceprincipal',
   'tcp',
   'traffic',
   'trafficsource',
@@ -633,6 +635,12 @@ export class GraphFind extends React.Component<GraphFindProps, GraphFindState> {
       //
       // edges..
       //
+      case 'destprincipal':
+        if (!this.props.showSecurity) {
+          AlertUtils.addSuccess('Enabling "security" display option for graph find/hide expression');
+          this.props.toggleGraphSecurity();
+        }
+        return { target: 'edge', selector: `[${CyEdge.destPrincipal} ${op} "${val}"]` };
       case 'grpc': {
         const s = this.getNumericSelector(CyEdge.grpc, op, val, expression, isFind);
         return s ? { target: 'edge', selector: s } : undefined;
@@ -671,6 +679,12 @@ export class GraphFind extends React.Component<GraphFindProps, GraphFindState> {
         const s = this.getNumericSelector(CyEdge.responseTime, op, val, expression, isFind);
         return s ? { target: 'edge', selector: s } : undefined;
       }
+      case 'sourceprincipal':
+        if (!this.props.showSecurity) {
+          AlertUtils.addSuccess('Enabling "security" display option for graph find/hide expression');
+          this.props.toggleGraphSecurity();
+        }
+        return { target: 'edge', selector: `[${CyEdge.sourcePrincipal} ${op} "${val}"]` };
       case 'tcp': {
         const s = this.getNumericSelector(CyEdge.tcp, op, val, expression, isFind);
         return s ? { target: 'edge', selector: s } : undefined;

--- a/src/pages/Graph/GraphToolbar/__tests__/GraphFind.test.tsx
+++ b/src/pages/Graph/GraphToolbar/__tests__/GraphFind.test.tsx
@@ -101,6 +101,8 @@ describe('Parse find value test', () => {
 
     // check coverage of edge operands
     // @ts-ignore
+    expect(instance.parseValue('destprincipal contains spiffe')).toEqual('edge[destPrincipal *= "spiffe"]');
+    // @ts-ignore
     expect(instance.parseValue('grpc > 5.0')).toEqual('edge[grpc > 5.0]');
     // @ts-ignore
     expect(instance.parseValue('%grpcerror > 50')).toEqual('edge[grpcPercentErr > 50]');
@@ -117,9 +119,13 @@ describe('Parse find value test', () => {
     // @ts-ignore
     expect(instance.parseValue('%httptraffic > 50')).toEqual('edge[httpPercentReq > 50]');
     // @ts-ignore
+    expect(instance.parseValue('protocol = http')).toEqual('edge[protocol = "http"]');
+    // @ts-ignore
     expect(instance.parseValue('responseTime > 5.0')).toEqual('edge[responseTime > 5.0]');
     // @ts-ignore
     expect(instance.parseValue('rt > 5.0')).toEqual('edge[responseTime > 5.0]');
+    // @ts-ignore
+    expect(instance.parseValue('sourceprincipal contains spiffe')).toEqual('edge[sourcePrincipal *= "spiffe"]');
     // @ts-ignore
     expect(instance.parseValue('tcp > 5.0')).toEqual('edge[tcp > 5.0]');
 


### PR DESCRIPTION
Note that use of these operands will auto-enable the Security Display option as it is required for populating the principal fields.

Closes https://github.com/kiali/kiali/issues/4000
