### PR TITLE
Better CSS fix for the ACE editor

### DIFF
--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.scss
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.scss
@@ -8,6 +8,7 @@
   position: relative;
   min-height: 200px;
   border: 1px solid #8b8d8f;
+  font-size: 16px !important;
 }
 
 .istio-validation-error {

--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.scss
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.scss
@@ -8,7 +8,7 @@
   position: relative;
   min-height: 200px;
   border: 1px solid #8b8d8f;
-  font-size: 16px !important;
+  font-size: 14px !important;
 }
 
 .istio-validation-error {

--- a/src/types/IstioConfigDetails.ts
+++ b/src/types/IstioConfigDetails.ts
@@ -40,8 +40,7 @@ export interface IstioConfigDetails {
 
 export const aceOptions: AceOptions = {
   showPrintMargin: false,
-  autoScrollEditorIntoView: true,
-  fontSize: '16px'
+  autoScrollEditorIntoView: true
 };
 
 export const safeDumpOptions = {


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali-ui/pull/2154

Moved the fontSize from the ace builtint properties to the scss file.
