### PR TITLE
Introduce Find/Hide presets

### DIFF
--- a/src/pages/Graph/GraphHelpFind.tsx
+++ b/src/pages/Graph/GraphHelpFind.tsx
@@ -37,15 +37,16 @@ export default class GraphHelpFind extends React.Component<GraphHelpFindProps> {
       color: '#fff',
       backgroundColor: '#003145',
       width: contentWidth,
-      height: '71px',
+      height: '80px',
       padding: '5px',
       resize: 'none',
       overflowY: 'hidden'
     });
     const preface =
       'You can use the Find and Hide fields to highlight or hide graph edges and nodes. Each field accepts ' +
-      'expressions using the language described below. Hide takes precedence when using Find and Hide ' +
-      'together. Uncheck the "Compress Hidden" display option for hidden elements to retain their space.';
+      'expressions using the language described below. Preset expressions are available via the dropdown. ' +
+      'Hide takes precedence when using Find and Hide together. Uncheck the "Compressed Hide" Display ' +
+      'option for hidden elements to retain their space.';
 
     return (
       <>
@@ -72,29 +73,18 @@ export default class GraphHelpFind extends React.Component<GraphHelpFindProps> {
             <>
               <textarea className={`${prefaceStyle}`} readOnly={true} value={preface} />
               <SimpleTabs id="graph_find_help_tabs" defaultTab={0} style={{ width: contentWidth }}>
-                <Tab style={tabFont} eventKey={0} title="Usage Notes">
+                <Tab style={tabFont} eventKey={0} title="Examples">
                   <Table
                     header={<></>}
                     variant={TableVariant.compact}
-                    cells={this.noteColumns()}
-                    rows={this.noteRows()}
+                    cells={this.exampleColumns()}
+                    rows={this.exampleRows()}
                   >
                     <TableHeader />
                     <TableBody />
                   </Table>
                 </Tab>
-                <Tab style={tabFont} eventKey={1} title="Operators">
-                  <Table
-                    header={<></>}
-                    variant={TableVariant.compact}
-                    cells={this.operatorColumns()}
-                    rows={this.operatorRows()}
-                  >
-                    <TableHeader />
-                    <TableBody />
-                  </Table>
-                </Tab>
-                <Tab style={tabFont} eventKey={2} title="Nodes">
+                <Tab style={tabFont} eventKey={1} title="Nodes">
                   <Table
                     header={<></>}
                     variant={TableVariant.compact}
@@ -105,7 +95,7 @@ export default class GraphHelpFind extends React.Component<GraphHelpFindProps> {
                     <TableBody />
                   </Table>
                 </Tab>
-                <Tab style={tabFont} eventKey={3} title="Edges">
+                <Tab style={tabFont} eventKey={2} title="Edges">
                   <Table
                     header={<></>}
                     variant={TableVariant.compact}
@@ -116,12 +106,23 @@ export default class GraphHelpFind extends React.Component<GraphHelpFindProps> {
                     <TableBody />
                   </Table>
                 </Tab>
-                <Tab style={tabFont} eventKey={4} title="Examples">
+                <Tab style={tabFont} eventKey={3} title="Operators">
                   <Table
                     header={<></>}
                     variant={TableVariant.compact}
-                    cells={this.exampleColumns()}
-                    rows={this.exampleRows()}
+                    cells={this.operatorColumns()}
+                    rows={this.operatorRows()}
+                  >
+                    <TableHeader />
+                    <TableBody />
+                  </Table>
+                </Tab>
+                <Tab style={tabFont} eventKey={4} title="Usage Notes">
+                  <Table
+                    header={<></>}
+                    variant={TableVariant.compact}
+                    cells={this.noteColumns()}
+                    rows={this.noteRows()}
                   >
                     <TableHeader />
                     <TableBody />

--- a/src/pages/Graph/GraphHelpFind.tsx
+++ b/src/pages/Graph/GraphHelpFind.tsx
@@ -188,6 +188,7 @@ export default class GraphHelpFind extends React.Component<GraphHelpFindProps> {
       ['httpin <op> <number>', 'unit: requests per second'],
       ['httpout <op> <number>', 'unit: requests per second'],
       ['app <op> <appName>'],
+      ['cluster <op> <clusterName>'],
       ['name <op> <string>', 'tests against app label, operation, service and workload names'],
       ['namespace <op> <namespaceName>'],
       ['node <op> <nodeType>', 'nodeType: app | operation | service | workload | unknown'],

--- a/src/pages/Graph/GraphHelpTour.ts
+++ b/src/pages/Graph/GraphHelpTour.ts
@@ -16,7 +16,8 @@ export const GraphTourStops: { [name: string]: TourStopInfo } = {
   },
   Find: {
     name: 'Find and Hide',
-    description: 'Highlight or Hide graph elements via typed expressions. Click the Find/Hide help icon for details.',
+    description:
+      'Highlight or Hide graph elements via typed expressions. Click the dropdown for preset Find or Hide expressions. Click the Find/Hide help icon for details on the expression language.',
     position: PopoverPosition.bottom
   },
   Graph: {

--- a/src/pages/Graph/GraphToolbar/GraphFind.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphFind.tsx
@@ -19,6 +19,7 @@ import { GraphTourStops } from 'pages/Graph/GraphHelpTour';
 import { TimeInMilliseconds } from 'types/Common';
 import { AutoComplete } from 'utils/AutoComplete';
 import { HEALTHY } from 'types/Health';
+import { GraphFindOptions } from './GraphFindOptions';
 
 type ReduxProps = {
   compressOnHide: boolean;
@@ -195,9 +196,10 @@ export class GraphFind extends React.Component<GraphFindProps, GraphFindState> {
               onKeyDownCapture={this.checkSpecialKeyFind}
               placeholder="Find..."
             />
+            <GraphFindOptions onSelect={this.updateFindOption} />
             {this.props.findValue && (
               <Tooltip key="ot_clear_find" position="top" content="Clear Find...">
-                <Button variant={ButtonVariant.control} onClick={this.clearFind}>
+                <Button style={{ bottom: '1px' }} variant={ButtonVariant.control} onClick={() => this.setFind('')}>
                   <KialiIcon.Close />
                 </Button>
               </Tooltip>
@@ -249,34 +251,6 @@ export class GraphFind extends React.Component<GraphFindProps, GraphFindState> {
     this.props.toggleFindHelp();
   };
 
-  private updateFind = val => {
-    if ('' === val) {
-      this.clearFind();
-    } else {
-      const diff = Math.abs(val.length - this.state.findInputValue.length);
-      this.findAutoComplete.setInput(val, [' ', '!']);
-      this.setState({ findInputValue: val, findError: undefined });
-      // submit if length change is greater than a single key, assume browser suggestion clicked or user paste
-      if (diff > 1) {
-        this.props.setFindValue(val);
-      }
-    }
-  };
-
-  private updateHide = val => {
-    if ('' === val) {
-      this.clearHide();
-    } else {
-      const diff = Math.abs(val.length - this.state.hideInputValue.length);
-      this.hideAutoComplete.setInput(val, [' ', '!']);
-      this.setState({ hideInputValue: val, hideError: undefined });
-      // submit if length change is greater than a single key, assume browser suggestion clicked or user paste
-      if (diff > 1) {
-        this.props.setHideValue(val);
-      }
-    }
-  };
-
   private checkSpecialKeyFind = event => {
     const keyCode = event.keyCode ? event.keyCode : event.which;
     switch (keyCode) {
@@ -295,6 +269,43 @@ export class GraphFind extends React.Component<GraphFindProps, GraphFindState> {
         break;
       default:
         break;
+    }
+  };
+
+  private updateFindOption = key => {
+    console.log(`Option=${key}`);
+    this.setFind(key);
+  };
+
+  private updateFind = val => {
+    if ('' === val) {
+      this.setFind('');
+    } else {
+      const diff = Math.abs(val.length - this.state.findInputValue.length);
+      this.findAutoComplete.setInput(val, [' ', '!']);
+      this.setState({ findInputValue: val, findError: undefined });
+      // submit if length change is greater than a single key, assume browser suggestion clicked or user paste
+      if (diff > 1) {
+        this.props.setFindValue(val);
+      }
+    }
+  };
+
+  private setFind = val => {
+    // TODO: when TextInput refs are fixed in PF4 then use the ref and remove the direct HTMLElement usage
+    this.findInputRef.value = val;
+    const htmlInputElement: HTMLInputElement = document.getElementById('graph_find') as HTMLInputElement;
+    if (htmlInputElement !== null) {
+      htmlInputElement.value = val;
+    }
+    this.findAutoComplete.setInput(val);
+    this.setState({ findInputValue: val, findError: undefined });
+    this.props.setFindValue(val);
+  };
+
+  private submitFind = () => {
+    if (this.props.findValue !== this.state.findInputValue) {
+      this.props.setFindValue(this.state.findInputValue);
     }
   };
 
@@ -319,9 +330,17 @@ export class GraphFind extends React.Component<GraphFindProps, GraphFindState> {
     }
   };
 
-  private submitFind = () => {
-    if (this.props.findValue !== this.state.findInputValue) {
-      this.props.setFindValue(this.state.findInputValue);
+  private updateHide = val => {
+    if ('' === val) {
+      this.clearHide();
+    } else {
+      const diff = Math.abs(val.length - this.state.hideInputValue.length);
+      this.hideAutoComplete.setInput(val, [' ', '!']);
+      this.setState({ hideInputValue: val, hideError: undefined });
+      // submit if length change is greater than a single key, assume browser suggestion clicked or user paste
+      if (diff > 1) {
+        this.props.setHideValue(val);
+      }
     }
   };
 
@@ -329,18 +348,6 @@ export class GraphFind extends React.Component<GraphFindProps, GraphFindState> {
     if (this.props.hideValue !== this.state.hideInputValue) {
       this.props.setHideValue(this.state.hideInputValue);
     }
-  };
-
-  private clearFind = () => {
-    // TODO: when TextInput refs are fixed in PF4 then use the ref and remove the direct HTMLElement usage
-    this.findInputRef.value = '';
-    const htmlInputElement: HTMLInputElement = document.getElementById('graph_find') as HTMLInputElement;
-    if (htmlInputElement !== null) {
-      htmlInputElement.value = '';
-    }
-    this.findAutoComplete.setInput('');
-    this.setState({ findInputValue: '', findError: undefined });
-    this.props.setFindValue('');
   };
 
   private clearHide = () => {

--- a/src/pages/Graph/GraphToolbar/GraphFind.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphFind.tsx
@@ -729,7 +729,7 @@ export class GraphFind extends React.Component<GraphFindProps, GraphFindState> {
       case '>=':
       case '<=':
         if (isNaN(val)) {
-          return this.setError(`Invalid value [${val}]. Expected a numeric value (use . for decimals)`, isFind);
+          return this.setError(`Invalid value [${val}]. Expected a numeric value (use '.' for decimals)`, isFind);
         }
         return `[${field} ${op} ${val}]`;
       case '=':

--- a/src/pages/Graph/GraphToolbar/GraphFind.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphFind.tsx
@@ -223,13 +223,13 @@ export class GraphFind extends React.Component<GraphFindProps, GraphFindState> {
               onKeyDownCapture={this.checkSpecialKeyHide}
               placeholder="Hide..."
             />
-            <GraphFindOptions kind="hide" onSelect={this.updateFindOption} />
+            <GraphFindOptions kind="hide" onSelect={this.updateHideOption} />
             {this.props.hideValue && (
               <Tooltip key="ot_clear_hide" position="top" content="Clear Hide...">
                 <Button
                   style={{ minWidth: '20px', width: '20px', paddingLeft: '5px', paddingRight: '5px', bottom: '1px' }}
                   variant={ButtonVariant.control}
-                  onClick={this.clearHide}
+                  onClick={() => this.setHide('')}
                 >
                   <KialiIcon.Close />
                 </Button>
@@ -282,7 +282,6 @@ export class GraphFind extends React.Component<GraphFindProps, GraphFindState> {
   };
 
   private updateFindOption = key => {
-    console.log(`Option=${key}`);
     this.setFind(key);
   };
 
@@ -339,9 +338,13 @@ export class GraphFind extends React.Component<GraphFindProps, GraphFindState> {
     }
   };
 
+  private updateHideOption = key => {
+    this.setHide(key);
+  };
+
   private updateHide = val => {
     if ('' === val) {
-      this.clearHide();
+      this.setHide('');
     } else {
       const diff = Math.abs(val.length - this.state.hideInputValue.length);
       this.hideAutoComplete.setInput(val, [' ', '!']);
@@ -359,16 +362,16 @@ export class GraphFind extends React.Component<GraphFindProps, GraphFindState> {
     }
   };
 
-  private clearHide = () => {
+  private setHide = val => {
     // TODO: when TextInput refs are fixed in PF4 then use the ref and remove the direct HTMLElement usage
-    this.hideInputRef.value = '';
+    this.hideInputRef.value = val;
     const htmlInputElement: HTMLInputElement = document.getElementById('graph_hide') as HTMLInputElement;
     if (htmlInputElement !== null) {
-      htmlInputElement.value = '';
+      htmlInputElement.value = val;
     }
-    this.hideAutoComplete.setInput('');
-    this.setState({ hideInputValue: '', hideError: undefined });
-    this.props.setHideValue('');
+    this.hideAutoComplete.setInput(val);
+    this.setState({ hideInputValue: val, hideError: undefined });
+    this.props.setHideValue(val);
   };
 
   private handleHide = (cy: any, hideChanged: boolean, graphChanged: boolean, compressOnHideChanged: boolean) => {

--- a/src/pages/Graph/GraphToolbar/GraphFind.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphFind.tsx
@@ -18,7 +18,7 @@ import TourStopContainer from 'components/Tour/TourStop';
 import { GraphTourStops } from 'pages/Graph/GraphHelpTour';
 import { TimeInMilliseconds } from 'types/Common';
 import { AutoComplete } from 'utils/AutoComplete';
-import { HEALTHY } from 'types/Health';
+import { DEGRADED, FAILURE, HEALTHY } from 'types/Health';
 import { GraphFindOptions } from './GraphFindOptions';
 
 type ReduxProps = {
@@ -763,7 +763,7 @@ export class GraphFind extends React.Component<GraphFindProps, GraphFindState> {
         return {
           target: 'node',
           selector: isNegation
-            ? `[${CyNode.healthStatus} != "${HEALTHY.name}"]`
+            ? `[${CyNode.healthStatus} = "${FAILURE.name}"],[${CyNode.healthStatus} = "${DEGRADED.name}"]`
             : `[${CyNode.healthStatus} = "${HEALTHY.name}"]`
         };
       case 'idle':

--- a/src/pages/Graph/GraphToolbar/GraphFind.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphFind.tsx
@@ -57,7 +57,7 @@ type ParsedExpression = {
 };
 
 const inputWidth = {
-  width: '10em'
+  width: 'var(--graph-find-input--width)'
 };
 
 // reduce toolbar padding from 20px to 10px to save space

--- a/src/pages/Graph/GraphToolbar/GraphFind.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphFind.tsx
@@ -196,10 +196,14 @@ export class GraphFind extends React.Component<GraphFindProps, GraphFindState> {
               onKeyDownCapture={this.checkSpecialKeyFind}
               placeholder="Find..."
             />
-            <GraphFindOptions onSelect={this.updateFindOption} />
+            <GraphFindOptions kind="find" onSelect={this.updateFindOption} />
             {this.props.findValue && (
               <Tooltip key="ot_clear_find" position="top" content="Clear Find...">
-                <Button style={{ bottom: '1px' }} variant={ButtonVariant.control} onClick={() => this.setFind('')}>
+                <Button
+                  style={{ minWidth: '20px', width: '20px', paddingLeft: '5px', paddingRight: '5px', bottom: '1px' }}
+                  variant={ButtonVariant.control}
+                  onClick={() => this.setFind('')}
+                >
                   <KialiIcon.Close />
                 </Button>
               </Tooltip>
@@ -219,9 +223,14 @@ export class GraphFind extends React.Component<GraphFindProps, GraphFindState> {
               onKeyDownCapture={this.checkSpecialKeyHide}
               placeholder="Hide..."
             />
+            <GraphFindOptions kind="hide" onSelect={this.updateFindOption} />
             {this.props.hideValue && (
               <Tooltip key="ot_clear_hide" position="top" content="Clear Hide...">
-                <Button variant={ButtonVariant.control} onClick={this.clearHide}>
+                <Button
+                  style={{ minWidth: '20px', width: '20px', paddingLeft: '5px', paddingRight: '5px', bottom: '1px' }}
+                  variant={ButtonVariant.control}
+                  onClick={this.clearHide}
+                >
                   <KialiIcon.Close />
                 </Button>
               </Tooltip>

--- a/src/pages/Graph/GraphToolbar/GraphFind.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphFind.tsx
@@ -73,6 +73,7 @@ const operands: string[] = [
   '%httptraffic',
   'app',
   'circuitbreaker',
+  'cluster',
   'destprincipal',
   'grpc',
   'grpcerr',
@@ -572,6 +573,8 @@ export class GraphFind extends React.Component<GraphFindProps, GraphFindState> {
       //
       case 'app':
         return { target: 'node', selector: `[${CyNode.app} ${op} "${val}"]` };
+      case 'cluster':
+        return { target: 'node', selector: `[${CyNode.cluster} ${op} "${val}"]` };
       case 'grpcin': {
         const s = this.getNumericSelector(CyNode.grpcIn, op, val, expression, isFind);
         return s ? { target: 'node', selector: s } : undefined;

--- a/src/pages/Graph/GraphToolbar/GraphFindOptions.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphFindOptions.tsx
@@ -1,0 +1,59 @@
+import { Dropdown, DropdownToggle, DropdownItem } from '@patternfly/react-core';
+import * as React from 'react';
+import { KialiIcon } from 'config/KialiIcon';
+
+type ReduxProps = {};
+
+type GraphFindOptionsProps = ReduxProps & {
+  onSelect: (expression) => void;
+};
+
+type GraphFindOptionsState = { isOpen: boolean };
+
+export class GraphFindOptions extends React.PureComponent<GraphFindOptionsProps, GraphFindOptionsState> {
+  constructor(props: GraphFindOptionsProps) {
+    super(props);
+    this.state = {
+      isOpen: false
+    };
+  }
+
+  private onToggle = isOpen => {
+    this.setState({
+      isOpen
+    });
+  };
+
+  componentDidUpdate(_prevProps: GraphFindOptionsProps) {}
+
+  render() {
+    const options = [
+      <DropdownItem key="protocol=http" onClick={() => this.props.onSelect('protocol=http')}>
+        HTTP Traffic
+      </DropdownItem>
+    ];
+    return (
+      <Dropdown
+        toggle={
+          <DropdownToggle
+            style={{ minWidth: '20px', width: '20px', paddingLeft: '5px', paddingRight: 0, bottom: '1px' }}
+            id="graphfind-options"
+            iconComponent={null}
+            onToggle={this.onToggle}
+          >
+            <KialiIcon.AngleDown />
+          </DropdownToggle>
+        }
+        isOpen={this.state.isOpen}
+        dropdownItems={options}
+        onSelect={this.close}
+      ></Dropdown>
+    );
+  }
+
+  private close = () => {
+    this.setState({
+      isOpen: false
+    });
+  };
+}

--- a/src/pages/Graph/GraphToolbar/GraphFindOptions.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphFindOptions.tsx
@@ -37,13 +37,10 @@ export class GraphFindOptions extends React.PureComponent<GraphFindOptionsProps,
   render() {
     return (
       <Dropdown
+        key={`graph-${this.props.kind}-presets`}
+        id="graph-findhide-presets"
         toggle={
-          <DropdownToggle
-            className={dropdown}
-            id={`graph${this.props.kind}-options`}
-            iconComponent={null}
-            onToggle={this.onToggle}
-          >
+          <DropdownToggle className={dropdown} iconComponent={null} onToggle={this.onToggle}>
             <KialiIcon.AngleDown />
           </DropdownToggle>
         }
@@ -67,7 +64,7 @@ export class GraphFindOptions extends React.PureComponent<GraphFindOptionsProps,
         : serverConfig.kialiFeatureFlags.uiDefaults!.graph.hideOptions;
     return options.map(o => {
       return (
-        <DropdownItem key="protocol=http" onClick={() => this.props.onSelect(o.expression)}>
+        <DropdownItem key={o.description} onClick={() => this.props.onSelect(o.expression)}>
           {o.description}
         </DropdownItem>
       );

--- a/src/pages/Graph/GraphToolbar/GraphFindOptions.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphFindOptions.tsx
@@ -5,6 +5,7 @@ import { KialiIcon } from 'config/KialiIcon';
 type ReduxProps = {};
 
 type GraphFindOptionsProps = ReduxProps & {
+  kind: 'find' | 'hide';
   onSelect: (expression) => void;
 };
 

--- a/src/pages/Graph/GraphToolbar/GraphFindOptions.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphFindOptions.tsx
@@ -1,44 +1,46 @@
 import { Dropdown, DropdownToggle, DropdownItem } from '@patternfly/react-core';
 import * as React from 'react';
 import { KialiIcon } from 'config/KialiIcon';
+import { serverConfig } from 'config';
+import { style } from 'typestyle';
 
-type ReduxProps = {};
+type FindKind = 'find' | 'hide';
 
-type GraphFindOptionsProps = ReduxProps & {
-  kind: 'find' | 'hide';
+type GraphFindOptionsProps = {
+  kind: FindKind;
   onSelect: (expression) => void;
 };
 
 type GraphFindOptionsState = { isOpen: boolean };
 
+const dropdown = style({
+  minWidth: '20px',
+  width: '20px',
+  paddingLeft: '5px',
+  paddingRight: 0,
+  bottom: '1px'
+});
+
 export class GraphFindOptions extends React.PureComponent<GraphFindOptionsProps, GraphFindOptionsState> {
+  options: React.ReactFragment[];
+
   constructor(props: GraphFindOptionsProps) {
     super(props);
+
+    this.options = this.getOptionItems(props.kind);
+
     this.state = {
       isOpen: false
     };
   }
 
-  private onToggle = isOpen => {
-    this.setState({
-      isOpen
-    });
-  };
-
-  componentDidUpdate(_prevProps: GraphFindOptionsProps) {}
-
   render() {
-    const options = [
-      <DropdownItem key="protocol=http" onClick={() => this.props.onSelect('protocol=http')}>
-        HTTP Traffic
-      </DropdownItem>
-    ];
     return (
       <Dropdown
         toggle={
           <DropdownToggle
-            style={{ minWidth: '20px', width: '20px', paddingLeft: '5px', paddingRight: 0, bottom: '1px' }}
-            id="graphfind-options"
+            className={dropdown}
+            id={`graph${this.props.kind}-options`}
             iconComponent={null}
             onToggle={this.onToggle}
           >
@@ -46,7 +48,7 @@ export class GraphFindOptions extends React.PureComponent<GraphFindOptionsProps,
           </DropdownToggle>
         }
         isOpen={this.state.isOpen}
-        dropdownItems={options}
+        dropdownItems={this.options}
         onSelect={this.close}
       ></Dropdown>
     );
@@ -55,6 +57,26 @@ export class GraphFindOptions extends React.PureComponent<GraphFindOptionsProps,
   private close = () => {
     this.setState({
       isOpen: false
+    });
+  };
+
+  private getOptionItems = (kind: FindKind): React.ReactFragment[] => {
+    const options =
+      kind === 'find'
+        ? serverConfig.kialiFeatureFlags.uiDefaults!.graph.findOptions
+        : serverConfig.kialiFeatureFlags.uiDefaults!.graph.hideOptions;
+    return options.map(o => {
+      return (
+        <DropdownItem key="protocol=http" onClick={() => this.props.onSelect(o.expression)}>
+          {o.description}
+        </DropdownItem>
+      );
+    });
+  };
+
+  private onToggle = isOpen => {
+    this.setState({
+      isOpen
     });
   };
 }

--- a/src/pages/Graph/GraphToolbar/GraphSettings.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphSettings.tsx
@@ -105,15 +105,14 @@ class GraphSettings extends React.PureComponent<GraphSettingsProps, GraphSetting
   }
 
   render() {
-    const { isOpen } = this.state;
     return (
       <Dropdown
         toggle={
-          <DropdownToggle id={'display-settings'} onToggle={this.onToggle}>
+          <DropdownToggle id="display-settings" onToggle={this.onToggle}>
             Display
           </DropdownToggle>
         }
-        isOpen={isOpen}
+        isOpen={this.state.isOpen}
       >
         {this.getPopoverContent()}
       </Dropdown>

--- a/src/pages/Graph/_Graph.scss
+++ b/src/pages/Graph/_Graph.scss
@@ -1,19 +1,13 @@
 :root {
+  --graph-find-input--width: 10em;
   --graph-side-panel--font-size: 12px;
   --graph-side-panel--font-size-px: 12;
 }
 
-#summary-graph-actions .pf-c-dropdown__toggle {
+#summary-appbox-actions .pf-c-dropdown__toggle {
   font-size: var(--graph-side-panel--font-size);
 }
-#summary-graph-actions .pf-c-dropdown__menu-item {
-  font-size: var(--graph-side-panel--font-size);
-}
-
-#summary-group-actions .pf-c-dropdown__toggle {
-  font-size: var(--graph-side-panel--font-size);
-}
-#summary-group-actions .pf-c-dropdown__menu-item {
+#summary-appbox-actions .pf-c-dropdown__menu-item {
   font-size: var(--graph-side-panel--font-size);
 }
 
@@ -50,4 +44,10 @@
   border-bottom: 1px solid transparent;
   border-top-left-radius: 0;
   border-top-right-radius: 0;
+}
+
+// Override to Dropdown's internal style for Find/Hide presets
+
+#graph-findhide-presets .pf-c-dropdown__menu {
+  left: calc(-1 * var(--graph-find-input--width));
 }

--- a/src/types/ServerConfig.ts
+++ b/src/types/ServerConfig.ts
@@ -22,8 +22,8 @@ interface IstioAnnotations {
 }
 
 interface GraphFindOption {
-  expression: string;
   description: string;
+  expression: string;
 }
 
 interface GraphUIDefaults {

--- a/src/types/ServerConfig.ts
+++ b/src/types/ServerConfig.ts
@@ -21,7 +21,18 @@ interface IstioAnnotations {
   istioInjectionAnnotation: string;
 }
 
+interface GraphFindOption {
+  expression: string;
+  description: string;
+}
+
+interface GraphUIDefaults {
+  findOptions: GraphFindOption[];
+  hideOptions: GraphFindOption[];
+}
+
 interface UIDefaults {
+  graph: GraphUIDefaults;
   metricsPerRefresh?: string;
   namespaces?: string[];
   refreshInterval?: string;


### PR DESCRIPTION
Graph Find/Hide now offers preset expressions via new dropdowns on each input.  The preset expressions are supplied via the UIDefaults supplied by the server, and so can be configured by users via the CR.

Fixes https://github.com/kiali/kiali/issues/3708

SERVER PR:  https://github.com/kiali/kiali/pull/4020
Operator PR: https://github.com/kiali/kiali-operator/pull/315