### PR TITLE
Support new Iter8Info endpoint

### DIFF
--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCreatePage.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentCreatePage.tsx
@@ -95,8 +95,9 @@ class ExperimentCreatePage extends React.Component<Props, State> {
       iter8Info: {
         enabled: false,
         supportedVersion: false,
-        analyticsImageVersion: '',
-        controllerImageVersion: ''
+        analyticsImgVersion: '',
+        controllerImgVersion: '',
+        namespace: 'iter8'
       },
       experiment: {
         name: '',

--- a/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentDetailsPage.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentDetails/ExperimentDetailsPage.tsx
@@ -73,8 +73,9 @@ class ExperimentDetailsPage extends React.Component<Props, State> {
       iter8Info: {
         enabled: false,
         supportedVersion: false,
-        analyticsImageVersion: '',
-        controllerImageVersion: ''
+        analyticsImgVersion: '',
+        controllerImgVersion: '',
+        namespace: 'iter8'
       },
       experiment: emptyExperimentDetailsInfo,
       canDelete: false,

--- a/src/pages/extensions/iter8/Iter8ExperimentList/ExperimentListPage.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentList/ExperimentListPage.tsx
@@ -116,8 +116,9 @@ class ExperimentListPageComponent extends React.Component<Props, State> {
       iter8Info: {
         enabled: false,
         supportedVersion: false,
-        controllerImageVersion: '',
-        analyticsImageVersion: ''
+        controllerImgVersion: '',
+        analyticsImgVersion: '',
+        namespace: 'iter8'
       },
       experimentLists: [],
       sortBy: {},
@@ -135,9 +136,18 @@ class ExperimentListPageComponent extends React.Component<Props, State> {
         const iter8Info = result.data;
         if (iter8Info.enabled) {
           if (!iter8Info.supportedVersion) {
+            if (iter8Info.analyticsImgVersion !== '' && iter8Info.analyticsImgVersion.startsWith('2')) {
+              AlertUtils.addError(
+                'Iter8 v' +
+                  iter8Info.analyticsImgVersion +
+                  ' support will be available in July 2021 release, please use the supported version  (v1.x).'
+              );
+              return;
+            }
             AlertUtils.addError(
-              'You are running an unsupported Iter8 vresion, please upgrade to supported version  (v0.2+) to take advantage of the full features of Iter8 .'
+              'You are running an unsupported Iter8 version, please upgrade to supported version  (v0.2+) to take advantage of the full features of Iter8 .'
             );
+            return;
           }
           if (namespaces.length > 0) {
             API.getExperiments(namespaces)
@@ -155,7 +165,10 @@ class ExperimentListPageComponent extends React.Component<Props, State> {
               });
           }
         } else {
-          AlertUtils.addError('Kiali has Iter8 extension enabled but it is not detected in the cluster');
+          AlertUtils.addError(
+            'Kiali has Iter8 extension enabled but it is not detected in the cluster under namespace ' +
+              iter8Info.namespace
+          );
         }
       })
       .catch(error => {

--- a/src/pages/extensions/iter8/Iter8ExperimentList/ExperimentListPage.tsx
+++ b/src/pages/extensions/iter8/Iter8ExperimentList/ExperimentListPage.tsx
@@ -140,7 +140,7 @@ class ExperimentListPageComponent extends React.Component<Props, State> {
               AlertUtils.addError(
                 'Iter8 v' +
                   iter8Info.analyticsImgVersion +
-                  ' support will be available in July 2021 release, please use the supported version  (v1.x).'
+                  ' is not supported, please use the supported version (v1.x).'
               );
               return;
             }

--- a/src/types/Iter8.ts
+++ b/src/types/Iter8.ts
@@ -3,8 +3,9 @@ import { ResourcePermissions } from './Permissions';
 export interface Iter8Info {
   enabled: boolean;
   supportedVersion: boolean;
-  controllerImageVersion: string;
-  analyticsImageVersion: string;
+  controllerImgVersion: string;
+  analyticsImgVersion: string;
+  namespace: string;
 }
 
 export interface Iter8CandidateStatus {


### PR DESCRIPTION
Output detail error message if Iter8 v2.x was installed and using the new Iter8Info endpoint in pull request [#4028](https://github.com/kiali/kiali/pull/4028)


** Screenshot **

<img width="415" alt="Screen Shot 2021-05-18 at 7 18 21 PM" src="https://user-images.githubusercontent.com/4615187/118735915-5ed57600-b80f-11eb-8ed5-77dfa7862b17.png">

