### PR TITLE
Upgrade tippy dependency to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "reselect": "4.0.0",
     "screenfull": "5.0.2",
     "seedrandom": "3.0.1",
-    "tippy.js": "3.4.1",
+    "tippy.js": "6.3.1",
     "typesafe-actions": "3.2.1",
     "typestyle": "2.0.4",
     "visibilityjs": "2.0.2"

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "reselect": "4.0.0",
     "screenfull": "5.0.2",
     "seedrandom": "3.0.1",
-    "tippy.js": "5.2.1",
+    "tippy.js": "6.3.1",
     "typesafe-actions": "3.2.1",
     "typestyle": "2.0.4",
     "visibilityjs": "2.0.2"

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "reselect": "4.0.0",
     "screenfull": "5.0.2",
     "seedrandom": "3.0.1",
-    "tippy.js": "6.3.1",
+    "tippy.js": "5.2.1",
     "typesafe-actions": "3.2.1",
     "typestyle": "2.0.4",
     "visibilityjs": "2.0.2"

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -13,7 +13,6 @@ import InitializingScreen from './InitializingScreen';
 import StartupInitializer from './StartupInitializer';
 import LoginPageContainer from '../pages/Login/LoginPage';
 import { LoginActions } from '../actions/LoginActions';
-import 'tippy.js/dist/tippy.css';
 import 'tippy.js/themes/light-border.css';
 import 'react-datepicker/dist/react-datepicker.css';
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -14,7 +14,7 @@ import StartupInitializer from './StartupInitializer';
 import LoginPageContainer from '../pages/Login/LoginPage';
 import { LoginActions } from '../actions/LoginActions';
 import 'tippy.js/dist/tippy.css';
-import 'tippy.js/dist/themes/light-border.css';
+import 'tippy.js/themes/light-border.css';
 import 'react-datepicker/dist/react-datepicker.css';
 
 Visibility.change((_e, state) => {

--- a/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
+++ b/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
@@ -145,7 +145,7 @@ export class NodeContextMenu extends React.PureComponent<Props> {
   }
 
   private onClick = (_e: React.MouseEvent<HTMLAnchorElement>) => {
-    this.props.contextMenu.unmount();
+    this.props.contextMenu.hide(0);
   };
 }
 

--- a/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
+++ b/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
@@ -145,7 +145,7 @@ export class NodeContextMenu extends React.PureComponent<Props> {
   }
 
   private onClick = (_e: React.MouseEvent<HTMLAnchorElement>) => {
-    this.props.contextMenu.hide(0);
+    this.props.contextMenu.unmount();
   };
 }
 

--- a/src/components/CytoscapeGraph/CytoscapeContextMenu.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeContextMenu.tsx
@@ -81,7 +81,7 @@ export class CytoscapeContextMenuWrapper extends React.PureComponent<Props> {
       if (event.target) {
         const currentContextMenu = this.getCurrentContextMenu();
         if (currentContextMenu) {
-          currentContextMenu.unmount();
+          currentContextMenu.hide(0); // hide it in 0ms
         }
 
         let contextMenuComponentType: EdgeContextMenuType | NodeContextMenuType | undefined;
@@ -141,21 +141,28 @@ export class CytoscapeContextMenuWrapper extends React.PureComponent<Props> {
   ) {
     // Prevent the tippy content from picking up the right-click when we are moving it over to the edge/node
     this.addContextMenuEventListener();
+
+    // Creates a dummy element to pass into tippy.
+    // Inspired by: https://github.com/cytoscape/cytoscape.js-popper/blob/v1.0.7/demo-tippy.html#L89
+    const dummyDomElement = document.createElement('div');
     const content = this.contextMenuRef.current;
-    const tippyInstance = tippy(
-      (target as any).popperRef(), // Using an extension, popperRef is not in base definition
-      {
-        content: content as HTMLDivElement,
-        trigger: 'manual',
-        arrow: true,
-        placement: 'bottom',
-        hideOnClick: false,
-        sticky: true,
-        interactive: true,
-        theme: 'light-border',
-        offset: [0, this.tippyDistance(target)]
-      }
-    )[0];
+    const tippyInstance = tippy(dummyDomElement, {
+      content: content as HTMLDivElement,
+      onCreate: function (instance) {
+        instance.popperInstance!.reference = (target as any).popperRef();
+      },
+      lazy: false,
+      trigger: 'manual',
+      arrow: true,
+      placement: 'bottom',
+      hideOnClick: false,
+      multiple: false,
+      sticky: true,
+      interactive: true,
+      theme: 'light-border',
+      distance: this.tippyDistance(target),
+      appendTo: document.body
+    });
 
     const result = (
       <Provider store={store}>

--- a/src/components/CytoscapeGraph/CytoscapeContextMenu.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeContextMenu.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import * as Cy from 'cytoscape';
 import { Router } from 'react-router';
-import tippy, { Instance } from 'tippy.js';
+import tippy, { Instance, sticky } from 'tippy.js';
 import { DecoratedGraphEdgeData, DecoratedGraphNodeData } from '../../types/Graph';
 import { Provider } from 'react-redux';
 import { store } from '../../store/ConfigStore';
@@ -81,7 +81,7 @@ export class CytoscapeContextMenuWrapper extends React.PureComponent<Props> {
       if (event.target) {
         const currentContextMenu = this.getCurrentContextMenu();
         if (currentContextMenu) {
-          currentContextMenu.hide(0); // hide it in 0ms
+          currentContextMenu.unmount();
         }
 
         let contextMenuComponentType: EdgeContextMenuType | NodeContextMenuType | undefined;
@@ -143,25 +143,21 @@ export class CytoscapeContextMenuWrapper extends React.PureComponent<Props> {
     this.addContextMenuEventListener();
 
     // Creates a dummy element to pass into tippy.
-    // Inspired by: https://github.com/cytoscape/cytoscape.js-popper/blob/v1.0.7/demo-tippy.html#L89
     const dummyDomElement = document.createElement('div');
     const content = this.contextMenuRef.current;
     const tippyInstance = tippy(dummyDomElement, {
       content: content as HTMLDivElement,
-      onCreate: function (instance) {
-        instance.popperInstance!.reference = (target as any).popperRef();
-      },
-      lazy: false,
       trigger: 'manual',
+      getReferenceClientRect: (target as any).popperRef().getBoundingClientRect,
       arrow: true,
       placement: 'bottom',
       hideOnClick: false,
-      multiple: false,
       sticky: true,
       interactive: true,
       theme: 'light-border',
-      distance: this.tippyDistance(target),
-      appendTo: document.body
+      offset: [0, this.tippyDistance(target)],
+      appendTo: document.body,
+      plugins: [sticky]
     });
 
     const result = (

--- a/src/components/CytoscapeGraph/CytoscapeContextMenu.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeContextMenu.tsx
@@ -81,7 +81,7 @@ export class CytoscapeContextMenuWrapper extends React.PureComponent<Props> {
       if (event.target) {
         const currentContextMenu = this.getCurrentContextMenu();
         if (currentContextMenu) {
-          currentContextMenu.hide(0); // hide it in 0ms
+          currentContextMenu.unmount();
         }
 
         let contextMenuComponentType: EdgeContextMenuType | NodeContextMenuType | undefined;
@@ -150,14 +150,12 @@ export class CytoscapeContextMenuWrapper extends React.PureComponent<Props> {
         arrow: true,
         placement: 'bottom',
         hideOnClick: false,
-        multiple: false,
         sticky: true,
         interactive: true,
         theme: 'light-border',
-        size: 'large',
-        distance: this.tippyDistance(target)
+        offset: [0, this.tippyDistance(target)]
       }
-    ).instances[0];
+    )[0];
 
     const result = (
       <Provider store={store}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -17486,12 +17486,12 @@ tippy.js@5.1.2:
   dependencies:
     popper.js "^1.16.0"
 
-tippy.js@6.3.1:
-  version "6.3.1"
-  resolved "https://registry.yarnpkg.com/tippy.js/-/tippy.js-6.3.1.tgz#3788a007be7015eee0fd589a66b98fb3f8f10181"
-  integrity sha512-JnFncCq+rF1dTURupoJ4yPie5Cof978inW6/4S6kmWV7LL9YOSEVMifED3KdrVPEG+Z/TFH2CDNJcQEfaeuQww==
+tippy.js@5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/tippy.js/-/tippy.js-5.2.1.tgz#e08d7332c103a15e427124d710d881fca82365d6"
+  integrity sha512-66UT6JRVn3dXNCORE+0UvUK3JZqV/VhLlU6HTDm3FmrweUUFUxUGvT8tUQ7ycMp+uhuLAwQw6dBabyC+iKf/MA==
   dependencies:
-    "@popperjs/core" "^2.8.3"
+    popper.js "^1.16.0"
 
 tmp@0.0.33, tmp@^0.0.33:
   version "0.0.33"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1895,22 +1895,10 @@
   resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-2.8.15.tgz#f62a569213ccb32ecdbd9da8709d6b5a55f8d215"
   integrity sha512-hhxWJ+gHqBxh5kWo6J23B9T5hvaRqwwtK5YoVscvv2skWIS+5XPLetVjhEmMoZ18MEcMHmpKkEri9s9Tj5jtlQ==
 
-<<<<<<< HEAD
 "@pmmmwh/react-refresh-webpack-plugin@^0.4.3":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.4.3.tgz#1eec460596d200c0236bf195b078a5d1df89b766"
   integrity sha512-br5Qwvh8D2OQqSXpd1g/xqXKnK0r+Jz6qVKBbWmpUcrbGOxUrf39V5oZ1876084CGn18uMdR5uvPqBv9UqtBjQ==
-=======
-"@popperjs/core@^2.8.3":
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.2.tgz#adea7b6953cbb34651766b0548468e743c6a2353"
-  integrity sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==
-
-"@snyk/cli-interface@1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@snyk/cli-interface/-/cli-interface-1.5.0.tgz#b9dbe6ebfb86e67ffabf29d4e0d28a52670ac456"
-  integrity sha512-+Qo+IO3YOXWgazlo+CKxOuWFLQQdaNCJ9cSfhFQd687/FuesaIxWdInaAdfpsLScq0c6M1ieZslXgiZELSzxbg==
->>>>>>> a0d57366 (Bump to latest version and fix issues)
   dependencies:
     ansi-html "^0.0.7"
     error-stack-parser "^2.0.6"
@@ -1919,7 +1907,7 @@
     schema-utils "^2.6.5"
     source-map "^0.7.3"
 
-"@popperjs/core@^2.5.4", "@popperjs/core@^2.6.0":
+"@popperjs/core@^2.5.4", "@popperjs/core@^2.6.0", "@popperjs/core@^2.8.3":
   version "2.9.2"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.2.tgz#adea7b6953cbb34651766b0548468e743c6a2353"
   integrity sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==
@@ -13495,7 +13483,7 @@ polished@^4.0.5:
   dependencies:
     "@babel/runtime" "^7.14.0"
 
-popper.js@^1.0.0, popper.js@^1.14.4, popper.js@^1.14.6, popper.js@^1.16.0:
+popper.js@^1.0.0, popper.js@^1.14.4, popper.js@^1.16.0:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
   integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -17479,19 +17479,19 @@ tiny-warning@^1.0.0, tiny-warning@^1.0.3:
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
 
-tippy.js@3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/tippy.js/-/tippy.js-3.4.1.tgz#f0eb3081824ad6c5d364336451ad77ae2f543da8"
-  integrity sha512-ZiyGP9WZyCCcjxKM4G88cm4U1r1ytjeMDGa5FSKPaPzwc/3yZJVZsb1ffcmqUMCpryRp5LNxRNGKLzbs11sb/Q==
-  dependencies:
-    popper.js "^1.14.6"
-
 tippy.js@5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/tippy.js/-/tippy.js-5.1.2.tgz#5ac91233c59ab482ef5988cffe6e08bd26528e66"
   integrity sha512-Qtrv2wqbRbaKMUb6bWWBQWPayvcDKNrGlvihxtsyowhT7RLGEh1STWuy6EMXC6QLkfKPB2MLnf8W2mzql9VDAw==
   dependencies:
     popper.js "^1.16.0"
+
+tippy.js@6.3.1:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/tippy.js/-/tippy.js-6.3.1.tgz#3788a007be7015eee0fd589a66b98fb3f8f10181"
+  integrity sha512-JnFncCq+rF1dTURupoJ4yPie5Cof978inW6/4S6kmWV7LL9YOSEVMifED3KdrVPEG+Z/TFH2CDNJcQEfaeuQww==
+  dependencies:
+    "@popperjs/core" "^2.8.3"
 
 tmp@0.0.33, tmp@^0.0.33:
   version "0.0.33"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1895,10 +1895,22 @@
   resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-2.8.15.tgz#f62a569213ccb32ecdbd9da8709d6b5a55f8d215"
   integrity sha512-hhxWJ+gHqBxh5kWo6J23B9T5hvaRqwwtK5YoVscvv2skWIS+5XPLetVjhEmMoZ18MEcMHmpKkEri9s9Tj5jtlQ==
 
+<<<<<<< HEAD
 "@pmmmwh/react-refresh-webpack-plugin@^0.4.3":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.4.3.tgz#1eec460596d200c0236bf195b078a5d1df89b766"
   integrity sha512-br5Qwvh8D2OQqSXpd1g/xqXKnK0r+Jz6qVKBbWmpUcrbGOxUrf39V5oZ1876084CGn18uMdR5uvPqBv9UqtBjQ==
+=======
+"@popperjs/core@^2.8.3":
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.2.tgz#adea7b6953cbb34651766b0548468e743c6a2353"
+  integrity sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==
+
+"@snyk/cli-interface@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@snyk/cli-interface/-/cli-interface-1.5.0.tgz#b9dbe6ebfb86e67ffabf29d4e0d28a52670ac456"
+  integrity sha512-+Qo+IO3YOXWgazlo+CKxOuWFLQQdaNCJ9cSfhFQd687/FuesaIxWdInaAdfpsLScq0c6M1ieZslXgiZELSzxbg==
+>>>>>>> a0d57366 (Bump to latest version and fix issues)
   dependencies:
     ansi-html "^0.0.7"
     error-stack-parser "^2.0.6"
@@ -17486,12 +17498,12 @@ tippy.js@5.1.2:
   dependencies:
     popper.js "^1.16.0"
 
-tippy.js@5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/tippy.js/-/tippy.js-5.2.1.tgz#e08d7332c103a15e427124d710d881fca82365d6"
-  integrity sha512-66UT6JRVn3dXNCORE+0UvUK3JZqV/VhLlU6HTDm3FmrweUUFUxUGvT8tUQ7ycMp+uhuLAwQw6dBabyC+iKf/MA==
+tippy.js@6.3.1:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/tippy.js/-/tippy.js-6.3.1.tgz#3788a007be7015eee0fd589a66b98fb3f8f10181"
+  integrity sha512-JnFncCq+rF1dTURupoJ4yPie5Cof978inW6/4S6kmWV7LL9YOSEVMifED3KdrVPEG+Z/TFH2CDNJcQEfaeuQww==
   dependencies:
-    popper.js "^1.16.0"
+    "@popperjs/core" "^2.8.3"
 
 tmp@0.0.33, tmp@^0.0.33:
   version "0.0.33"


### PR DESCRIPTION
Upgrades the `tippy.js` dependency to the latest version. There were some breaking API changes between major versions and [this migration guide](https://github.com/atomiks/tippyjs/blob/master/MIGRATION_GUIDE.md) was followed to fix those. The two props the UI was previously using that I am unsure of the exact effects are [multiple](https://github.com/atomiks/tippyjs/blob/master/MIGRATION_GUIDE.md#if-you-were-using-multiple-or-relying-on-its-behavior) and [size](https://github.com/atomiks/tippyjs/blob/master/MIGRATION_GUIDE.md#if-you-were-using-size). I haven't noticed any regressions or changes in behavior but regression tests should be run on this PR to ensure nothing has changed with the version bump.

Fixes https://github.com/kiali/kiali/issues/4035
