### PR TITLE
Indicate in a different way the reserved word mesh

### DIFF
--- a/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceOverview.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceOverview.tsx
@@ -2,10 +2,21 @@ import * as React from 'react';
 import { checkForPath, highestSeverity } from '../../../types/ServiceInfo';
 import { Host, HTTPRoute, ObjectValidation, TCPRoute, TLSRoute, VirtualService } from '../../../types/IstioObjects';
 import VirtualServiceRoute from './VirtualServiceRoute';
-import { Stack, StackItem, Text, TextVariants, Title, TitleLevel, TitleSize } from '@patternfly/react-core';
+import {
+  Stack,
+  StackItem,
+  Text,
+  TextVariants,
+  Title,
+  TitleLevel,
+  TitleSize,
+  Tooltip,
+  TooltipPosition
+} from '@patternfly/react-core';
 import GlobalValidation from '../../../components/Validations/GlobalValidation';
 import IstioObjectLink from '../../../components/Link/IstioObjectLink';
 import ServiceLink from './ServiceLink';
+import { PFColors } from '../../../components/Pf/PfColors';
 
 interface VirtualServiceProps {
   namespace: string;
@@ -66,7 +77,21 @@ class VirtualServiceOverview extends React.Component<VirtualServiceProps> {
       childrenList.push(
         <li key={'gateway_' + host.service + '_' + j}>
           {host.service === 'mesh' || !isValid ? (
-            host.service
+            <div style={{ color: PFColors.Blue400, textAlign: 'left', cursor: 'pointer' }}>
+              <Tooltip
+                aria-label={host.service}
+                position={TooltipPosition.left}
+                enableFlip={true}
+                distance={5}
+                content={
+                  <p>
+                    The special value <b>mesh</b> allows internal calls from other services in the mesh
+                  </p>
+                }
+              >
+                <p>{host.service}</p>
+              </Tooltip>
+            </div>
           ) : (
             <IstioObjectLink name={host.service} namespace={host.namespace} type={'gateway'}>
               {gateways[key]}

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceOverview.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceOverview.tsx
@@ -89,7 +89,7 @@ class VirtualServiceOverview extends React.Component<VirtualServiceProps> {
               {host.service}
               <Tooltip
                 position={TooltipPosition.right}
-                content="The special value mesh allows internal calls from other services in the mesh"
+                content="The reserved word mesh is used to imply all the sidecars in the mesh"
               >
                 <KialiIcon.Info className={infoStyle} />
               </Tooltip>

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceOverview.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceOverview.tsx
@@ -89,7 +89,11 @@ class VirtualServiceOverview extends React.Component<VirtualServiceProps> {
               {host.service}
               <Tooltip
                 position={TooltipPosition.right}
-                content="The reserved word mesh is used to imply all the sidecars in the mesh"
+                content={
+                  <div style={{ textAlign: 'left' }}>
+                    The reserved word, "mesh", implies all of the sidecars in the mesh
+                  </div>
+                }
               >
                 <KialiIcon.Info className={infoStyle} />
               </Tooltip>

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceOverview.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceOverview.tsx
@@ -11,20 +11,24 @@ import {
   TitleLevel,
   TitleSize,
   Tooltip,
-  TooltipPosition,
-  Button,
-  ButtonVariant
+  TooltipPosition
 } from '@patternfly/react-core';
 import GlobalValidation from '../../../components/Validations/GlobalValidation';
 import IstioObjectLink from '../../../components/Link/IstioObjectLink';
 import ServiceLink from './ServiceLink';
-import { KialiIcon, defaultIconStyle } from 'config/KialiIcon';
+import { KialiIcon } from 'config/KialiIcon';
+import { style } from 'typestyle';
 
 interface VirtualServiceProps {
   namespace: string;
   virtualService: VirtualService;
   validation?: ObjectValidation;
 }
+
+const infoStyle = style({
+  margin: '0px 0px 2px 10px',
+  verticalAlign: '-5px !important'
+});
 
 class VirtualServiceOverview extends React.Component<VirtualServiceProps> {
   validation(): ObjectValidation | undefined {
@@ -82,12 +86,10 @@ class VirtualServiceOverview extends React.Component<VirtualServiceProps> {
             <div>
               {host.service}
               <Tooltip
-                position={TooltipPosition.top}
+                position={TooltipPosition.right}
                 content="The special value mesh allows internal calls from other services in the mesh"
               >
-                <Button variant={ButtonVariant.link} style={{ paddingLeft: '6px' }}>
-                  <KialiIcon.Info className={defaultIconStyle} />
-                </Button>
+                <KialiIcon.Info className={infoStyle} />
               </Tooltip>
             </div>
           ) : (

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceOverview.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceOverview.tsx
@@ -82,7 +82,9 @@ class VirtualServiceOverview extends React.Component<VirtualServiceProps> {
       const host = this.parseHost(gateways[key]);
       childrenList.push(
         <li key={'gateway_' + host.service + '_' + j}>
-          {host.service === 'mesh' || !isValid ? (
+          {!isValid ? (
+            host.service
+          ) : host.service === 'mesh' ? (
             <div>
               {host.service}
               <Tooltip

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceOverview.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceOverview.tsx
@@ -11,12 +11,14 @@ import {
   TitleLevel,
   TitleSize,
   Tooltip,
-  TooltipPosition
+  TooltipPosition,
+  Button,
+  ButtonVariant
 } from '@patternfly/react-core';
 import GlobalValidation from '../../../components/Validations/GlobalValidation';
 import IstioObjectLink from '../../../components/Link/IstioObjectLink';
 import ServiceLink from './ServiceLink';
-import { PFColors } from '../../../components/Pf/PfColors';
+import { KialiIcon, defaultIconStyle } from 'config/KialiIcon';
 
 interface VirtualServiceProps {
   namespace: string;
@@ -77,19 +79,15 @@ class VirtualServiceOverview extends React.Component<VirtualServiceProps> {
       childrenList.push(
         <li key={'gateway_' + host.service + '_' + j}>
           {host.service === 'mesh' || !isValid ? (
-            <div style={{ color: PFColors.Blue400, textAlign: 'left', cursor: 'pointer' }}>
+            <div>
+              {host.service}
               <Tooltip
-                aria-label={host.service}
-                position={TooltipPosition.left}
-                enableFlip={true}
-                distance={5}
-                content={
-                  <p>
-                    The special value <b>mesh</b> allows internal calls from other services in the mesh
-                  </p>
-                }
+                position={TooltipPosition.top}
+                content="The special value mesh allows internal calls from other services in the mesh"
               >
-                <p>{host.service}</p>
+                <Button variant={ButtonVariant.link} style={{ paddingLeft: '6px' }}>
+                  <KialiIcon.Info className={defaultIconStyle} />
+                </Button>
               </Tooltip>
             </div>
           ) : (


### PR DESCRIPTION
**Description**

This PR adds the same styles to the special "mesh" gateway as other gateways have in the VirtualService Overview and it also adds a tooltip with more details about its meaning.

**Issue**

[#1391](https://github.com/kiali/kiali/issues/1391)

**Documentation**

The following is a demo of how the change looks:

![mesh_tooltip](https://user-images.githubusercontent.com/1286393/119180739-0f798a80-ba47-11eb-92bd-eed9cc3c3d67.png)
