### PR TITLE
Align labels validation icons

### DIFF
--- a/src/components/MissingLabel/MissingLabel.tsx
+++ b/src/components/MissingLabel/MissingLabel.tsx
@@ -26,22 +26,22 @@ class MissingLabel extends React.Component<MissingLabelProps, {}> {
     const tooltipContent = (
       <div style={{ textAlign: 'left' }}>
         {this.props.missingApp && (
-          <div>
+          <>
             <div>
               <PFBadge badge={{ badge: appLabel }} isRead={true} style={{ marginRight: '0px' }} /> label is missing.{' '}
               <br />
             </div>
             <div>This workload won't be linked with an application.</div>
-          </div>
+          </>
         )}
         {this.props.missingVersion && (
-          <div>
+          <>
             <div>
               <PFBadge badge={{ badge: versionLabel }} isRead={true} style={{ marginRight: '0px' }} /> label is missing.{' '}
               <br />
             </div>
             <div>This workload won't have Istio routing capabilities.</div>
-          </div>
+          </>
         )}
         <div>Missing labels will impact in the telemetry collected by the Istio proxy.</div>
       </div>

--- a/src/components/MissingLabel/MissingLabel.tsx
+++ b/src/components/MissingLabel/MissingLabel.tsx
@@ -60,7 +60,7 @@ class MissingLabel extends React.Component<MissingLabelProps, {}> {
       </span>
     );
     return this.props.tooltip ? (
-      <Tooltip key={`tooltip_missing_label`} position={TooltipPosition.top} content={tooltipContent}>
+      <Tooltip key={`tooltip_missing_label`} position={TooltipPosition.right} content={tooltipContent}>
         {iconComponent}
       </Tooltip>
     ) : (

--- a/src/components/MissingLabel/MissingLabel.tsx
+++ b/src/components/MissingLabel/MissingLabel.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react';
+import { Tooltip, TooltipPosition } from '@patternfly/react-core';
+import { icons, serverConfig } from '../../config';
+import { KialiIcon } from '../../config/KialiIcon';
+import { style } from 'typestyle';
+import { PFBadge } from '../Pf/PfBadges';
+
+type MissingLabelProps = {
+  missingApp: boolean;
+  missingVersion: boolean;
+  tooltip: boolean;
+  style?: React.CSSProperties;
+};
+
+const infoStyle = style({
+  margin: '0px 5px 2px 4px',
+  verticalAlign: '-5px !important'
+});
+
+class MissingLabel extends React.Component<MissingLabelProps, {}> {
+  render() {
+    const appLabel = serverConfig.istioLabels.appLabelName;
+    const versionLabel = serverConfig.istioLabels.versionLabelName;
+    const icon = icons.istio.missingLabel.icon;
+    const color = icons.istio.missingLabel.color;
+    const tooltipContent = (
+      <div style={{ textAlign: 'left' }}>
+        {this.props.missingApp && (
+          <div>
+            <div>
+              <PFBadge badge={{ badge: appLabel }} isRead={true} style={{ marginRight: '0px' }} /> label is missing.{' '}
+              <br />
+            </div>
+            <div>This workload won't be linked with an application.</div>
+          </div>
+        )}
+        {this.props.missingVersion && (
+          <div>
+            <div>
+              <PFBadge badge={{ badge: versionLabel }} isRead={true} style={{ marginRight: '0px' }} /> label is missing.{' '}
+              <br />
+            </div>
+            <div>This workload won't have Istio routing capabilities.</div>
+          </div>
+        )}
+        <div>Missing labels will impact in the telemetry collected by the Istio proxy.</div>
+      </div>
+    );
+    const iconComponent = (
+      <span style={this.props.style}>
+        {React.createElement(icon, { style: { color: color, verticalAlign: '-2px' } })}
+        {!this.props.tooltip && (
+          <span style={{ marginLeft: '8px' }}>
+            Missing {this.props.missingApp ? 'App' : this.props.missingVersion ? 'Version' : 'Label'}
+            <Tooltip key={`tooltip_missing_label`} position={TooltipPosition.top} content={tooltipContent}>
+              <KialiIcon.Info className={infoStyle} />
+            </Tooltip>
+          </span>
+        )}
+      </span>
+    );
+    return this.props.tooltip ? (
+      <Tooltip key={`tooltip_missing_label`} position={TooltipPosition.top} content={tooltipContent}>
+        {iconComponent}
+      </Tooltip>
+    ) : (
+      iconComponent
+    );
+  }
+}
+
+export default MissingLabel;

--- a/src/components/VirtualList/Renderers.tsx
+++ b/src/components/VirtualList/Renderers.tsx
@@ -28,6 +28,7 @@ import { labelFilter as NsLabelFilter } from '../../pages/Overview/Filters';
 import ValidationSummaryLink from '../Link/ValidationSummaryLink';
 import { ValidationStatus } from '../../types/IstioObjects';
 import { PFBadgeType, PFBadge, PFBadges } from 'components/Pf/PfBadges';
+import MissingLabel from '../MissingLabel/MissingLabel';
 
 // Links
 
@@ -73,15 +74,8 @@ export const details: Renderer<AppListItem | WorkloadListItem | ServiceListItem>
             <MissingSidecar namespace={item.namespace} />
           </li>
         )}
-        {isWorkload && hasMissingApp && (
-          <li>
-            Missing <PFBadge badge={{ badge: 'app' }} isRead={true} style={{ marginRight: '0px' }} /> label
-          </li>
-        )}
-        {isWorkload && hasMissingVersion && (
-          <li>
-            Missing <PFBadge badge={{ badge: 'version' }} isRead={true} style={{ marginRight: '0px' }} /> label
-          </li>
+        {isWorkload && (hasMissingApp || hasMissingVersion) && (
+          <MissingLabel missingApp={hasMissingApp} missingVersion={hasMissingVersion} tooltip={false} />
         )}
         {spacer && ' '}
         {additionalDetails && additionalDetails.icon && (

--- a/src/config/Icons.ts
+++ b/src/config/Icons.ts
@@ -2,13 +2,21 @@ import deepFreeze from 'deep-freeze';
 
 import solidPinIcon from '../assets/img/solid-pin.png';
 import hollowPinIcon from '../assets/img/hollow-pin.png';
-import { BlueprintIcon } from '@patternfly/react-icons';
+import { BlueprintIcon, WrenchIcon } from '@patternfly/react-icons';
 
 export { solidPinIcon, hollowPinIcon };
 
 const mutIcons = {
   istio: {
     circuitBreaker: { className: 'fa fa-bolt', type: 'fa', name: 'bolt', ascii: '\uf0e7 ' },
+    missingLabel: {
+      icon: WrenchIcon,
+      className: 'fa fa-wrench',
+      type: 'fa',
+      name: 'wrench',
+      ascii: '\uE932',
+      color: 'red'
+    },
     missingSidecar: {
       icon: BlueprintIcon,
       className: 'pf-icon pf-icon-blueprint',

--- a/src/pages/WorkloadDetails/WorkloadDescription.tsx
+++ b/src/pages/WorkloadDetails/WorkloadDescription.tsx
@@ -13,6 +13,7 @@ import { HealthIndicator } from '../../components/Health/HealthIndicator';
 import { serverConfig } from '../../config';
 import MissingSidecar from '../../components/MissingSidecar/MissingSidecar';
 import { PFBadge, PFBadges } from '../../components/Pf/PfBadges';
+import MissingLabel from '../../components/MissingLabel/MissingLabel';
 
 type WorkloadDescriptionProps = {
   workload?: Workload;
@@ -142,6 +143,14 @@ class WorkloadDescription extends React.Component<WorkloadDescriptionProps> {
                 tooltip={true}
                 style={{ marginLeft: '10px' }}
                 text={''}
+              />
+            ) : undefined}
+            {this.props.workload && (!this.props.workload.appLabel || !this.props.workload.versionLabel) ? (
+              <MissingLabel
+                missingApp={!this.props.workload.appLabel}
+                missingVersion={!this.props.workload.versionLabel}
+                style={{ marginLeft: '10px' }}
+                tooltip={true}
               />
             ) : undefined}
           </Title>

--- a/src/pages/WorkloadDetails/WorkloadDescription.tsx
+++ b/src/pages/WorkloadDetails/WorkloadDescription.tsx
@@ -137,22 +137,22 @@ class WorkloadDescription extends React.Component<WorkloadDescriptionProps> {
             <span className={healthIconStyle}>
               <HealthIndicator id={workload.name} health={this.props.health} />
             </span>
-            {this.props.workload && !this.props.workload.istioSidecar ? (
+            {this.props.workload && !this.props.workload.istioSidecar && (
               <MissingSidecar
                 namespace={this.props.namespace}
                 tooltip={true}
                 style={{ marginLeft: '10px' }}
                 text={''}
               />
-            ) : undefined}
-            {this.props.workload && (!this.props.workload.appLabel || !this.props.workload.versionLabel) ? (
+            )}
+            {this.props.workload && (!this.props.workload.appLabel || !this.props.workload.versionLabel) && (
               <MissingLabel
                 missingApp={!this.props.workload.appLabel}
                 missingVersion={!this.props.workload.versionLabel}
                 style={{ marginLeft: '10px' }}
                 tooltip={true}
               />
-            ) : undefined}
+            )}
           </Title>
         </CardHeader>
         <CardBody>


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/1404

This PR aligns the "missing" validations (sidecar, app and version) used in the context of Istio.

This is a UI improvement, the original https://github.com/kiali/kiali/issues/1404 issue has a bigger scope which can be discussed later (all validations will follow same convention as other istio resources validations, and for this particular, we'll keep focusing on the Istio labels, not a generic check for presence of any label), but this will provide a consistent UI in the meantime.

So, "Missing Sidecar, "Missing App" or "Missing Version" will look in the list:

![image](https://user-images.githubusercontent.com/1662329/119492033-e87cca80-bd5e-11eb-9f78-225391eefa30.png)

With additional tooltips as the uniform way to add details:

![image](https://user-images.githubusercontent.com/1662329/119492461-6640d600-bd5f-11eb-9a49-442605b49088.png)

Note that there will be only a single message, "Missing App" or "Missing Version", being "App" more important, in the tooltip the user will have a note if both labels are missing.

Also similar pattern will be used for the details, to be aligned with the "Missing Sidecar" icon:

![image](https://user-images.githubusercontent.com/1662329/119493016-0434a080-bd60-11eb-9f6e-b71ef9a523ba.png)


