### PR TITLE
Ensure that Health calculations for graph use correct time period

### DIFF
--- a/src/pages/Overview/OverviewPage.tsx
+++ b/src/pages/Overview/OverviewPage.tsx
@@ -302,7 +302,7 @@ export class OverviewPage extends React.Component<OverviewProps, State> {
       });
   }
 
-  fetchHealthChunk(chunk: NamespaceInfo[], duration: number, type: OverviewType) {
+  fetchHealthChunk(chunk: NamespaceInfo[], duration: DurationInSeconds, type: OverviewType) {
     const apiFunc = switchType(
       type,
       API.getNamespaceAppHealth,

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -6,7 +6,7 @@ import { LoginSession } from '../store/Store';
 import { App } from '../types/App';
 import { AppList } from '../types/AppList';
 import { AuthInfo } from '../types/Auth';
-import { DurationInSeconds, HTTP_VERBS, Password, UserName } from '../types/Common';
+import { DurationInSeconds, HTTP_VERBS, Password, TimeInSeconds, UserName } from '../types/Common';
 import { DashboardModel } from 'types/Dashboards';
 import { GrafanaInfo } from '../types/GrafanaInfo';
 import { GraphDefinition, NodeParamsType, NodeType } from '../types/Graph';
@@ -255,24 +255,24 @@ export const getCustomDashboard = (ns: string, tpl: string, params: DashboardQue
 export const getServiceHealth = (
   namespace: string,
   service: string,
-  durationSec: number,
+  duration: DurationInSeconds,
   hasSidecar: boolean
 ): Promise<ServiceHealth> => {
-  const params = durationSec ? { rateInterval: String(durationSec) + 's' } : {};
+  const params = duration ? { rateInterval: String(duration) + 's' } : {};
   return newRequest(HTTP_VERBS.GET, urls.serviceHealth(namespace, service), params, {}).then(response =>
-    ServiceHealth.fromJson(namespace, service, response.data, { rateInterval: durationSec, hasSidecar: hasSidecar })
+    ServiceHealth.fromJson(namespace, service, response.data, { rateInterval: duration, hasSidecar: hasSidecar })
   );
 };
 
 export const getAppHealth = (
   namespace: string,
   app: string,
-  durationSec: number,
+  duration: DurationInSeconds,
   hasSidecar: boolean
 ): Promise<AppHealth> => {
-  const params = durationSec ? { rateInterval: String(durationSec) + 's' } : {};
+  const params = duration ? { rateInterval: String(duration) + 's' } : {};
   return newRequest(HTTP_VERBS.GET, urls.appHealth(namespace, app), params, {}).then(response =>
-    AppHealth.fromJson(namespace, app, response.data, { rateInterval: durationSec, hasSidecar: hasSidecar })
+    AppHealth.fromJson(namespace, app, response.data, { rateInterval: duration, hasSidecar: hasSidecar })
   );
 };
 
@@ -290,35 +290,49 @@ export const getWorkloadHealth = (
   );
 };
 
-export const getNamespaceAppHealth = (namespace: string, durationSec: number): Promise<NamespaceAppHealth> => {
+export const getNamespaceAppHealth = (
+  namespace: string,
+  duration: DurationInSeconds,
+  queryTime?: TimeInSeconds
+): Promise<NamespaceAppHealth> => {
   const params: any = {
     type: 'app'
   };
-  if (durationSec) {
-    params.rateInterval = String(durationSec) + 's';
+  if (duration) {
+    params.rateInterval = String(duration) + 's';
+  }
+  if (queryTime) {
+    params.queryTime = String(queryTime);
   }
   return newRequest<NamespaceAppHealth>(HTTP_VERBS.GET, urls.namespaceHealth(namespace), params, {}).then(response => {
     const ret: NamespaceAppHealth = {};
     Object.keys(response.data).forEach(k => {
-      ret[k] = AppHealth.fromJson(namespace, k, response.data[k], { rateInterval: durationSec, hasSidecar: true });
+      ret[k] = AppHealth.fromJson(namespace, k, response.data[k], { rateInterval: duration, hasSidecar: true });
     });
     return ret;
   });
 };
 
-export const getNamespaceServiceHealth = (namespace: string, durationSec: number): Promise<NamespaceServiceHealth> => {
+export const getNamespaceServiceHealth = (
+  namespace: string,
+  duration: DurationInSeconds,
+  queryTime?: TimeInSeconds
+): Promise<NamespaceServiceHealth> => {
   const params: any = {
     type: 'service'
   };
-  if (durationSec) {
-    params.rateInterval = String(durationSec) + 's';
+  if (duration) {
+    params.rateInterval = String(duration) + 's';
+  }
+  if (queryTime) {
+    params.queryTime = String(queryTime);
   }
   return newRequest<NamespaceServiceHealth>(HTTP_VERBS.GET, urls.namespaceHealth(namespace), params, {}).then(
     response => {
       const ret: NamespaceServiceHealth = {};
       Object.keys(response.data).forEach(k => {
         ret[k] = ServiceHealth.fromJson(namespace, k, response.data[k], {
-          rateInterval: durationSec,
+          rateInterval: duration,
           hasSidecar: true
         });
       });
@@ -329,20 +343,24 @@ export const getNamespaceServiceHealth = (namespace: string, durationSec: number
 
 export const getNamespaceWorkloadHealth = (
   namespace: string,
-  durationSec: number
+  duration: DurationInSeconds,
+  queryTime?: TimeInSeconds
 ): Promise<NamespaceWorkloadHealth> => {
   const params: any = {
     type: 'workload'
   };
-  if (durationSec) {
-    params.rateInterval = String(durationSec) + 's';
+  if (duration) {
+    params.rateInterval = String(duration) + 's';
+  }
+  if (queryTime) {
+    params.queryTime = String(queryTime);
   }
   return newRequest<NamespaceWorkloadHealth>(HTTP_VERBS.GET, urls.namespaceHealth(namespace), params, {}).then(
     response => {
       const ret: NamespaceWorkloadHealth = {};
       Object.keys(response.data).forEach(k => {
         ret[k] = WorkloadHealth.fromJson(namespace, k, response.data[k], {
-          rateInterval: durationSec,
+          rateInterval: duration,
           hasSidecar: true
         });
       });

--- a/src/services/GraphDataSource.ts
+++ b/src/services/GraphDataSource.ts
@@ -423,7 +423,8 @@ export default class GraphDataSource {
       return;
     }
 
-    const duration = this.fetchParameters.duration;
+    const duration = this.graphDuration;
+    const queryTime = this.graphTimestamp;
     const appNamespacePromises = new Map<string, Promise<NamespaceAppHealth>>();
     const serviceNamespacePromises = new Map<string, Promise<NamespaceServiceHealth>>();
     const workloadNamespacePromises = new Map<string, Promise<NamespaceWorkloadHealth>>();
@@ -448,7 +449,7 @@ export default class GraphDataSource {
         let promise = workloadNamespacePromises.get(namespace);
         const nodeHealth = { node: node, key: node.data.workload! };
         if (!promise) {
-          promise = API.getNamespaceWorkloadHealth(namespace, duration);
+          promise = API.getNamespaceWorkloadHealth(namespace, duration, queryTime);
           workloadNamespacePromises.set(namespace, promise);
           promiseToNode.set(promise, [nodeHealth]);
         } else {
@@ -461,7 +462,7 @@ export default class GraphDataSource {
             let promise = appNamespacePromises.get(namespace);
             const nodeHealth = { node: node, key: node.data.app! };
             if (!promise) {
-              promise = API.getNamespaceAppHealth(namespace, duration);
+              promise = API.getNamespaceAppHealth(namespace, duration, queryTime);
               appNamespacePromises.set(namespace, promise);
               promiseToNode.set(promise, [nodeHealth]);
             } else {
@@ -475,7 +476,7 @@ export default class GraphDataSource {
               let promise = appNamespacePromises.get(namespace);
               const nodeHealth = { node: node, key: node.data.app! };
               if (!promise) {
-                promise = API.getNamespaceAppHealth(namespace, duration);
+                promise = API.getNamespaceAppHealth(namespace, duration, queryTime);
                 appNamespacePromises.set(namespace, promise);
                 promiseToNode.set(promise, [nodeHealth]);
               } else {
@@ -489,7 +490,7 @@ export default class GraphDataSource {
             let promise = serviceNamespacePromises.get(namespace);
             const nodeHealth = { node: node, key: node.data.service! };
             if (!promise) {
-              promise = API.getNamespaceServiceHealth(namespace, duration);
+              promise = API.getNamespaceServiceHealth(namespace, duration, queryTime);
               serviceNamespacePromises.set(namespace, promise);
               promiseToNode.set(promise, [nodeHealth]);
             } else {


### PR DESCRIPTION
Ensure that Health calculations for graph nodes use the same time period as that used for the graph generation itself.

Fixes https://github.com/kiali/kiali/issues/4058

**SERVER PR** https://github.com/kiali/kiali/pull/4065

To test:
0. Start by deploying master to see the "before"  (or, you can deploy only the server PR at this point)
1. Deploy an app (bookinfo, travel, whatever) and generate "green" traffic for a few minutes.
2. Use the Kiali wizard to introduce a 100% fault injection for one of the intermediate services.
3. Wait for the traffic to go "red"
4. start graph replay before the introduction of the FI

You should see that the health of the chosen service is "red" even before the FI is introduced

5. deploy the PRs and repeat the test

You should properly see "green" for the chosen service health, until the FI is introduced, when it should go "red"

