### PR TITLE
Show CB badge even when no VS present

### DIFF
--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -207,33 +207,34 @@ export class GraphStyles {
     if (cyGlobal.showMissingSidecars && node.hasMissingSC) {
       icons = `<span class="${NodeIconMS} ${iconMargin(icons)}"></span> ${icons}`;
     }
-    if (cyGlobal.showVirtualServices && node.hasVS) {
+    if (cyGlobal.showVirtualServices) {
+      if (node.hasCB) {
+        icons = `<span class="${NodeIconCB} ${iconMargin(icons)}"></span> ${icons}`;
+      }
       // If there's an additional traffic scenario present then it's assumed
       // that there is a VS present so the VS badge is omitted.
-      const hasKialiScenario =
-        node.hasCB ||
-        node.hasFaultInjection ||
-        node.hasRequestRouting ||
-        node.hasRequestTimeout ||
-        node.hasTCPTrafficShifting ||
-        node.hasTrafficShifting;
-      if (!hasKialiScenario) {
-        icons = `<span class="${NodeIconVS} ${iconMargin(icons)}"></span> ${icons}`;
-      } else {
-        if (node.hasRequestRouting) {
-          icons = `<span class="${NodeIconRequestRouting} ${iconMargin(icons)}"></span> ${icons}`;
-        }
-        if (node.hasFaultInjection) {
-          icons = `<span class="${NodeIconFaultInjection} ${iconMargin(icons)}"></span> ${icons}`;
-        }
-        if (node.hasTrafficShifting || node.hasTCPTrafficShifting) {
-          icons = `<span class="${NodeIconTrafficShifting} ${iconMargin(icons)}"></span> ${icons}`;
-        }
-        if (node.hasRequestTimeout) {
-          icons = `<span class="${NodeIconRequestTimeout} ${iconMargin(icons)}"></span> ${icons}`;
-        }
-        if (node.hasCB) {
-          icons = `<span class="${NodeIconCB} ${iconMargin(icons)}"></span> ${icons}`;
+      if (node.hasVS) {
+        const hasKialiScenario =
+          node.hasFaultInjection ||
+          node.hasRequestRouting ||
+          node.hasRequestTimeout ||
+          node.hasTCPTrafficShifting ||
+          node.hasTrafficShifting;
+        if (!hasKialiScenario) {
+          icons = `<span class="${NodeIconVS} ${iconMargin(icons)}"></span> ${icons}`;
+        } else {
+          if (node.hasRequestRouting) {
+            icons = `<span class="${NodeIconRequestRouting} ${iconMargin(icons)}"></span> ${icons}`;
+          }
+          if (node.hasFaultInjection) {
+            icons = `<span class="${NodeIconFaultInjection} ${iconMargin(icons)}"></span> ${icons}`;
+          }
+          if (node.hasTrafficShifting || node.hasTCPTrafficShifting) {
+            icons = `<span class="${NodeIconTrafficShifting} ${iconMargin(icons)}"></span> ${icons}`;
+          }
+          if (node.hasRequestTimeout) {
+            icons = `<span class="${NodeIconRequestTimeout} ${iconMargin(icons)}"></span> ${icons}`;
+          }
         }
       }
     }

--- a/src/components/CytoscapeGraph/graphs/__tests__/GraphStyles.test.ts
+++ b/src/components/CytoscapeGraph/graphs/__tests__/GraphStyles.test.ts
@@ -14,7 +14,7 @@ const nodeData = {
   nodeType: NodeType.APP
 };
 
-function setupNode(nodeData: any) {
+function setupNode(nodeData: any, cyData?: any) {
   const data = cytoscape({
     elements: {
       nodes: [{ data: nodeData }],
@@ -24,7 +24,8 @@ function setupNode(nodeData: any) {
   const node = data.nodes()[0];
   node.cy().scratch(CytoscapeGlobalScratchNamespace, {
     activeNamespaces: ['TEST'],
-    showVirtualServices: true
+    showVirtualServices: true,
+    ...cyData
   });
   return node;
 }
@@ -42,6 +43,20 @@ describe('GraphStyles test', () => {
     const node = setupNode(data);
     const label = GraphStyles.getNodeLabel(node);
     expect(label).toContain(icons.istio.circuitBreaker.className);
+  });
+
+  it('has icon for circuit breaker even when no VS', () => {
+    const data = { ...nodeData, hasCB: true };
+    const node = setupNode(data);
+    const label = GraphStyles.getNodeLabel(node);
+    expect(label).toContain(icons.istio.circuitBreaker.className);
+  });
+
+  it('hides circuit breaker icon when showVirtualServices is false', () => {
+    const data = { ...nodeData, hasVS: true, hasCB: true };
+    const node = setupNode(data, { showVirtualServices: false });
+    const label = GraphStyles.getNodeLabel(node);
+    expect(label.includes(icons.istio.circuitBreaker.className)).toBe(false);
   });
 
   it('has icon for fault injection', () => {


### PR DESCRIPTION
Displays the Circuit Breaker badge on the graph even if a Virtual Service is not present.

Fixes kiali/kiali#4076
