### PR TITLE
Sort sublists details pages

### DIFF
--- a/src/components/Details/DetailDescription.tsx
+++ b/src/components/Details/DetailDescription.tsx
@@ -5,9 +5,9 @@ import { style } from 'typestyle';
 import { Link } from 'react-router-dom';
 import MissingSidecar from '../MissingSidecar/MissingSidecar';
 import * as H from '../../types/Health';
+import { HealthSubItem } from '../../types/Health';
 import { renderTrafficStatus } from '../Health/HealthDetails';
 import { createIcon } from '../Health/Helper';
-import { HealthSubItem } from '../../types/Health';
 import { PFBadge, PFBadges } from '../Pf/PfBadges';
 
 type Props = {
@@ -67,7 +67,9 @@ class DetailDescription extends React.PureComponent<Props> {
   private appList() {
     const applicationList =
       this.props.apps && this.props.apps.length > 0
-        ? this.props.apps.map(name => this.renderAppItem(this.props.namespace, name))
+        ? this.props.apps
+            .sort((a1: string, a2: string) => (a1 < a2 ? -1 : 1))
+            .map(name => this.renderAppItem(this.props.namespace, name))
         : this.renderEmptyItem('applications');
 
     return [
@@ -159,9 +161,11 @@ class DetailDescription extends React.PureComponent<Props> {
           <div>
             <ul id="workload-list" style={{ listStyleType: 'none' }}>
               {this.props.workloads
-                ? this.props.workloads.map((wkd, subIdx) => {
-                    return <li key={subIdx}>{this.renderWorkloadItem(wkd)}</li>;
-                  })
+                ? this.props.workloads
+                    .sort((w1: AppWorkload, w2: AppWorkload) => (w1.workloadName < w2.workloadName ? -1 : 1))
+                    .map((wkd, subIdx) => {
+                      return <li key={subIdx}>{this.renderWorkloadItem(wkd)}</li>;
+                    })
                 : undefined}
             </ul>
           </div>
@@ -178,7 +182,9 @@ class DetailDescription extends React.PureComponent<Props> {
   private serviceList() {
     const serviceList =
       this.props.services && this.props.services.length > 0
-        ? this.props.services.map(name => this.renderServiceItem(this.props.namespace, name))
+        ? this.props.services
+            .sort((s1: string, s2: string) => (s1 < s2 ? -1 : 1))
+            .map(name => this.renderServiceItem(this.props.namespace, name))
         : this.renderEmptyItem('services');
 
     return [

--- a/src/components/IstioConfigCard/IstioConfigCard.tsx
+++ b/src/components/IstioConfigCard/IstioConfigCard.tsx
@@ -64,30 +64,32 @@ class IstioConfigCard extends React.Component<Props> {
       return this.noIstioConfig();
     }
     let rows: IRow[] = [];
-    this.props.items.map((item, itemIdx) => {
-      rows.push({
-        cells: [
-          {
-            title: (
-              <span>
-                <PFBadge badge={IstioTypes[item.type].badge} position={TooltipPosition.top} />
-                {this.overviewLink(item)}
-              </span>
-            )
-          },
-          {
-            title: (
-              <ValidationObjectSummary
-                id={itemIdx + '-config-validation'}
-                validations={item.validation ? [item.validation] : []}
-                style={{ verticalAlign: '-0.5em' }}
-              />
-            )
-          }
-        ]
+    this.props.items
+      .sort((a: IstioConfigItem, b: IstioConfigItem) => (a.type < b.type ? -1 : a.name < b.name ? -1 : 1))
+      .map((item, itemIdx) => {
+        rows.push({
+          cells: [
+            {
+              title: (
+                <span>
+                  <PFBadge badge={IstioTypes[item.type].badge} position={TooltipPosition.top} />
+                  {this.overviewLink(item)}
+                </span>
+              )
+            },
+            {
+              title: (
+                <ValidationObjectSummary
+                  id={itemIdx + '-config-validation'}
+                  validations={item.validation ? [item.validation] : []}
+                  style={{ verticalAlign: '-0.5em' }}
+                />
+              )
+            }
+          ]
+        });
+        return rows;
       });
-      return rows;
-    });
 
     return rows;
   }

--- a/src/components/IstioConfigCard/IstioConfigCard.tsx
+++ b/src/components/IstioConfigCard/IstioConfigCard.tsx
@@ -65,7 +65,15 @@ class IstioConfigCard extends React.Component<Props> {
     }
     let rows: IRow[] = [];
     this.props.items
-      .sort((a: IstioConfigItem, b: IstioConfigItem) => (a.type < b.type ? -1 : a.name < b.name ? -1 : 1))
+      .sort((a: IstioConfigItem, b: IstioConfigItem) => {
+        if (a.type < b.type) {
+          return -1;
+        } else if (a.type > b.type) {
+          return 1;
+        } else {
+          return a.name < b.name ? -1 : 1;
+        }
+      })
       .map((item, itemIdx) => {
         rows.push({
           cells: [

--- a/src/components/IstioConfigCard/__tests__/IstioConfigCard.test.tsx
+++ b/src/components/IstioConfigCard/__tests__/IstioConfigCard.test.tsx
@@ -1,0 +1,112 @@
+import * as React from 'react';
+import { mount, shallow } from 'enzyme';
+import { IstioConfigItem } from '../../../types/IstioConfigList';
+import IstioConfigCard from '../IstioConfigCard';
+import { shallowToJson } from 'enzyme-to-json';
+import IstioObjectLink from '../../Link/IstioObjectLink';
+
+import { store } from '../../../store/ConfigStore';
+import { Provider } from 'react-redux';
+import { MemoryRouter, Route } from 'react-router';
+
+const mockComponent = (name: string, items: IstioConfigItem[]) => {
+  return <IstioConfigCard name={name} items={items} />;
+};
+
+const mountComponent = (name: string, items: IstioConfigItem[]) => {
+  return mount(
+    <Provider store={store}>
+      <MemoryRouter>
+        <Route render={() => mockComponent(name, items)} />
+      </MemoryRouter>
+    </Provider>
+  );
+};
+
+describe('IstioConfigCard', () => {
+  it('shows empty state when no items', () => {
+    const card = mockComponent('reviews', []);
+
+    expect(mount(card).text()).toContain('No Istio Config found for reviews');
+    expect(shallowToJson(shallow(card))).toMatchSnapshot();
+  });
+
+  it('sort by type and name', () => {
+    const name = 'reviews';
+    const items = [
+      { type: 'virtualservice', name: 'reviews-v9', namespace: 'bookinfo' },
+      { type: 'sidecar', name: 'reviews-v9', namespace: 'bookinfo' },
+      { type: 'destinationrule', name: 'reviews-v2', namespace: 'bookinfo' },
+      { type: 'sidecar', name: 'reviews-v1', namespace: 'bookinfo' },
+      { type: 'virtualservice', name: 'reviews-v8', namespace: 'bookinfo' },
+      { type: 'sidecar', name: 'reviews-v3', namespace: 'bookinfo' },
+      { type: 'destinationrule', name: 'reviews-v9', namespace: 'bookinfo' },
+      { type: 'destinationrule', name: 'reviews-v8', namespace: 'bookinfo' },
+      { type: 'virtualservice', name: 'reviews-v5', namespace: 'bookinfo' }
+    ];
+
+    const card = mockComponent(name, items);
+    const shallowed = shallow(card);
+    expect(shallowToJson(shallowed)).toMatchSnapshot();
+
+    const mounted = mountComponent(name, items);
+    const links = mounted.find(IstioObjectLink);
+
+    expect(links.at(0).props()).toEqual({
+      type: 'destinationrule',
+      name: 'reviews-v2',
+      namespace: 'bookinfo',
+      children: 'reviews-v2'
+    });
+    expect(links.at(1).props()).toEqual({
+      type: 'destinationrule',
+      name: 'reviews-v8',
+      namespace: 'bookinfo',
+      children: 'reviews-v8'
+    });
+    expect(links.at(2).props()).toEqual({
+      type: 'destinationrule',
+      name: 'reviews-v9',
+      namespace: 'bookinfo',
+      children: 'reviews-v9'
+    });
+    expect(links.at(3).props()).toEqual({
+      type: 'sidecar',
+      name: 'reviews-v1',
+      namespace: 'bookinfo',
+      children: 'reviews-v1'
+    });
+    expect(links.at(4).props()).toEqual({
+      type: 'sidecar',
+      name: 'reviews-v3',
+      namespace: 'bookinfo',
+      children: 'reviews-v3'
+    });
+    expect(links.at(5).props()).toEqual({
+      type: 'sidecar',
+      name: 'reviews-v9',
+      namespace: 'bookinfo',
+      children: 'reviews-v9'
+    });
+    expect(links.at(6).props()).toEqual({
+      type: 'virtualservice',
+      name: 'reviews-v5',
+      namespace: 'bookinfo',
+      children: 'reviews-v5'
+    });
+    expect(links.at(7).props()).toEqual({
+      type: 'virtualservice',
+      name: 'reviews-v8',
+      namespace: 'bookinfo',
+      children: 'reviews-v8'
+    });
+    expect(links.at(8).props()).toEqual({
+      type: 'virtualservice',
+      name: 'reviews-v9',
+      namespace: 'bookinfo',
+      children: 'reviews-v9'
+    });
+
+    expect(links).toHaveLength(9);
+  });
+});

--- a/src/components/IstioConfigCard/__tests__/__snapshots__/IstioConfigCard.test.tsx.snap
+++ b/src/components/IstioConfigCard/__tests__/__snapshots__/IstioConfigCard.test.tsx.snap
@@ -1,0 +1,438 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`IstioConfigCard shows empty state when no items 1`] = `
+<Card
+  id="IstioConfigCard"
+  isCompact={true}
+>
+  <CardHead>
+    <CardActions />
+    <CardHeader>
+      <Title
+        headingLevel="h5"
+        size="lg"
+        style={
+          Object {
+            "float": "left",
+          }
+        }
+      >
+        Istio Config
+      </Title>
+    </CardHeader>
+  </CardHead>
+  <CardBody>
+    <Component
+      aria-label="list_istio_config"
+      cells={
+        Array [
+          Object {
+            "title": "Name",
+          },
+          Object {
+            "title": "Status",
+            "transforms": Array [
+              [Function],
+            ],
+          },
+        ]
+      }
+      className="table"
+      rows={
+        Array [
+          Object {
+            "cells": Array [
+              Object {
+                "props": Object {
+                  "colSpan": 2,
+                },
+                "title": <EmptyState
+                  className="fvhz1n5"
+                  variant="small"
+                >
+                  <EmptyStateBody
+                    className="fvhz1n5"
+                  >
+                    No Istio Config found for 
+                    reviews
+                  </EmptyStateBody>
+                </EmptyState>,
+              },
+            ],
+          },
+        ]
+      }
+      variant="compact"
+    >
+      <TableHeader />
+      <TableBody />
+    </Component>
+  </CardBody>
+</Card>
+`;
+
+exports[`IstioConfigCard sort by type and name 1`] = `
+<Card
+  id="IstioConfigCard"
+  isCompact={true}
+>
+  <CardHead>
+    <CardActions />
+    <CardHeader>
+      <Title
+        headingLevel="h5"
+        size="lg"
+        style={
+          Object {
+            "float": "left",
+          }
+        }
+      >
+        Istio Config
+      </Title>
+    </CardHeader>
+  </CardHead>
+  <CardBody>
+    <Component
+      aria-label="list_istio_config"
+      cells={
+        Array [
+          Object {
+            "title": "Name",
+          },
+          Object {
+            "title": "Status",
+            "transforms": Array [
+              [Function],
+            ],
+          },
+        ]
+      }
+      className="table"
+      rows={
+        Array [
+          Object {
+            "cells": Array [
+              Object {
+                "title": <span>
+                  <PFBadge
+                    badge={
+                      Object {
+                        "badge": "DR",
+                        "tt": "Destination Rule",
+                      }
+                    }
+                    position="top"
+                  />
+                  <IstioObjectLink
+                    name="reviews-v2"
+                    namespace="bookinfo"
+                    type="destinationrule"
+                  >
+                    reviews-v2
+                  </IstioObjectLink>
+                </span>,
+              },
+              Object {
+                "title": <ValidationObjectSummary
+                  id="0-config-validation"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.5em",
+                    }
+                  }
+                  validations={Array []}
+                />,
+              },
+            ],
+          },
+          Object {
+            "cells": Array [
+              Object {
+                "title": <span>
+                  <PFBadge
+                    badge={
+                      Object {
+                        "badge": "DR",
+                        "tt": "Destination Rule",
+                      }
+                    }
+                    position="top"
+                  />
+                  <IstioObjectLink
+                    name="reviews-v8"
+                    namespace="bookinfo"
+                    type="destinationrule"
+                  >
+                    reviews-v8
+                  </IstioObjectLink>
+                </span>,
+              },
+              Object {
+                "title": <ValidationObjectSummary
+                  id="1-config-validation"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.5em",
+                    }
+                  }
+                  validations={Array []}
+                />,
+              },
+            ],
+          },
+          Object {
+            "cells": Array [
+              Object {
+                "title": <span>
+                  <PFBadge
+                    badge={
+                      Object {
+                        "badge": "DR",
+                        "tt": "Destination Rule",
+                      }
+                    }
+                    position="top"
+                  />
+                  <IstioObjectLink
+                    name="reviews-v9"
+                    namespace="bookinfo"
+                    type="destinationrule"
+                  >
+                    reviews-v9
+                  </IstioObjectLink>
+                </span>,
+              },
+              Object {
+                "title": <ValidationObjectSummary
+                  id="2-config-validation"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.5em",
+                    }
+                  }
+                  validations={Array []}
+                />,
+              },
+            ],
+          },
+          Object {
+            "cells": Array [
+              Object {
+                "title": <span>
+                  <PFBadge
+                    badge={
+                      Object {
+                        "badge": "SC",
+                        "tt": "Istio Sidecar Proxy",
+                      }
+                    }
+                    position="top"
+                  />
+                  <IstioObjectLink
+                    name="reviews-v1"
+                    namespace="bookinfo"
+                    type="sidecar"
+                  >
+                    reviews-v1
+                  </IstioObjectLink>
+                </span>,
+              },
+              Object {
+                "title": <ValidationObjectSummary
+                  id="3-config-validation"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.5em",
+                    }
+                  }
+                  validations={Array []}
+                />,
+              },
+            ],
+          },
+          Object {
+            "cells": Array [
+              Object {
+                "title": <span>
+                  <PFBadge
+                    badge={
+                      Object {
+                        "badge": "SC",
+                        "tt": "Istio Sidecar Proxy",
+                      }
+                    }
+                    position="top"
+                  />
+                  <IstioObjectLink
+                    name="reviews-v3"
+                    namespace="bookinfo"
+                    type="sidecar"
+                  >
+                    reviews-v3
+                  </IstioObjectLink>
+                </span>,
+              },
+              Object {
+                "title": <ValidationObjectSummary
+                  id="4-config-validation"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.5em",
+                    }
+                  }
+                  validations={Array []}
+                />,
+              },
+            ],
+          },
+          Object {
+            "cells": Array [
+              Object {
+                "title": <span>
+                  <PFBadge
+                    badge={
+                      Object {
+                        "badge": "SC",
+                        "tt": "Istio Sidecar Proxy",
+                      }
+                    }
+                    position="top"
+                  />
+                  <IstioObjectLink
+                    name="reviews-v9"
+                    namespace="bookinfo"
+                    type="sidecar"
+                  >
+                    reviews-v9
+                  </IstioObjectLink>
+                </span>,
+              },
+              Object {
+                "title": <ValidationObjectSummary
+                  id="5-config-validation"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.5em",
+                    }
+                  }
+                  validations={Array []}
+                />,
+              },
+            ],
+          },
+          Object {
+            "cells": Array [
+              Object {
+                "title": <span>
+                  <PFBadge
+                    badge={
+                      Object {
+                        "badge": "VS",
+                        "tt": "Virtual Service",
+                      }
+                    }
+                    position="top"
+                  />
+                  <IstioObjectLink
+                    name="reviews-v5"
+                    namespace="bookinfo"
+                    type="virtualservice"
+                  >
+                    reviews-v5
+                  </IstioObjectLink>
+                </span>,
+              },
+              Object {
+                "title": <ValidationObjectSummary
+                  id="6-config-validation"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.5em",
+                    }
+                  }
+                  validations={Array []}
+                />,
+              },
+            ],
+          },
+          Object {
+            "cells": Array [
+              Object {
+                "title": <span>
+                  <PFBadge
+                    badge={
+                      Object {
+                        "badge": "VS",
+                        "tt": "Virtual Service",
+                      }
+                    }
+                    position="top"
+                  />
+                  <IstioObjectLink
+                    name="reviews-v8"
+                    namespace="bookinfo"
+                    type="virtualservice"
+                  >
+                    reviews-v8
+                  </IstioObjectLink>
+                </span>,
+              },
+              Object {
+                "title": <ValidationObjectSummary
+                  id="7-config-validation"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.5em",
+                    }
+                  }
+                  validations={Array []}
+                />,
+              },
+            ],
+          },
+          Object {
+            "cells": Array [
+              Object {
+                "title": <span>
+                  <PFBadge
+                    badge={
+                      Object {
+                        "badge": "VS",
+                        "tt": "Virtual Service",
+                      }
+                    }
+                    position="top"
+                  />
+                  <IstioObjectLink
+                    name="reviews-v9"
+                    namespace="bookinfo"
+                    type="virtualservice"
+                  >
+                    reviews-v9
+                  </IstioObjectLink>
+                </span>,
+              },
+              Object {
+                "title": <ValidationObjectSummary
+                  id="8-config-validation"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.5em",
+                    }
+                  }
+                  validations={Array []}
+                />,
+              },
+            ],
+          },
+        ]
+      }
+      variant="compact"
+    >
+      <TableHeader />
+      <TableBody />
+    </Component>
+  </CardBody>
+</Card>
+`;

--- a/src/pages/ServiceDetails/ServiceDescription.tsx
+++ b/src/pages/ServiceDetails/ServiceDescription.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Card, CardBody, CardHeader, Title, Tooltip, TooltipPosition } from '@patternfly/react-core';
-import { ServiceDetailsInfo } from '../../types/ServiceInfo';
+import { ServiceDetailsInfo, WorkloadOverview } from '../../types/ServiceInfo';
 import DetailDescription from '../../components/Details/DetailDescription';
 import { AppWorkload } from '../../types/App';
 import { serverConfig } from '../../config';
@@ -69,18 +69,20 @@ class ServiceDescription extends React.Component<ServiceInfoDescriptionProps, St
     const workloads: AppWorkload[] = [];
     if (this.props.serviceDetails) {
       if (this.props.serviceDetails.workloads) {
-        this.props.serviceDetails.workloads.forEach(wk => {
-          if (wk.labels) {
-            const appName = wk.labels[serverConfig.istioLabels.appLabelName];
-            if (!apps.includes(appName)) {
-              apps.push(appName);
+        this.props.serviceDetails.workloads
+          .sort((w1: WorkloadOverview, w2: WorkloadOverview) => (w1.name > w2.name ? -1 : 1))
+          .forEach(wk => {
+            if (wk.labels) {
+              const appName = wk.labels[serverConfig.istioLabels.appLabelName];
+              if (!apps.includes(appName)) {
+                apps.push(appName);
+              }
             }
-          }
-          workloads.push({
-            workloadName: wk.name,
-            istioSidecar: wk.istioSidecar
+            workloads.push({
+              workloadName: wk.name,
+              istioSidecar: wk.istioSidecar
+            });
           });
-        });
       }
     }
     // We will show service labels only when there is some label that is not present in the selector

--- a/src/pages/ServiceDetails/ServiceDescription.tsx
+++ b/src/pages/ServiceDetails/ServiceDescription.tsx
@@ -70,7 +70,7 @@ class ServiceDescription extends React.Component<ServiceInfoDescriptionProps, St
     if (this.props.serviceDetails) {
       if (this.props.serviceDetails.workloads) {
         this.props.serviceDetails.workloads
-          .sort((w1: WorkloadOverview, w2: WorkloadOverview) => (w1.name > w2.name ? -1 : 1))
+          .sort((w1: WorkloadOverview, w2: WorkloadOverview) => (w1.name < w2.name ? -1 : 1))
           .forEach(wk => {
             if (wk.labels) {
               const appName = wk.labels[serverConfig.istioLabels.appLabelName];

--- a/src/pages/WorkloadDetails/WorkloadPods.tsx
+++ b/src/pages/WorkloadDetails/WorkloadPods.tsx
@@ -80,79 +80,81 @@ class WorkloadPods extends React.Component<WorkloadPodsProps> {
     }
 
     let rows: IRow[] = [];
-    (this.props.pods || []).map((pod, _podIdx) => {
-      let validation: ObjectValidation = {} as ObjectValidation;
-      if (this.props.validations[pod.name]) {
-        validation = this.props.validations[pod.name];
-      }
-      const podProperties = (
-        <div key="properties-list" className={resourceListStyle}>
-          <ul style={{ listStyleType: 'none' }}>
-            <li>
-              <span>Created</span>
-              <div style={{ display: 'inline-block' }}>
-                <LocalTime time={pod.createdAt} />
-              </div>
-            </li>
-            <li>
-              <span>Created By</span>
-              <div style={{ display: 'inline-block' }}>
-                {pod.createdBy && pod.createdBy.length > 0
-                  ? pod.createdBy.map(ref => ref.name + ' (' + ref.kind + ')').join(', ')
-                  : 'Not found'}
-              </div>
-            </li>
-            <li>
-              <span>Istio Init Container</span>
-              <div style={{ display: 'inline-block' }}>
-                {pod.istioInitContainers ? pod.istioInitContainers.map(c => `${c.image}`).join(', ') : 'Not found'}
-              </div>
-            </li>
-            <li>
-              <span>Istio Container</span>
-              <div style={{ display: 'inline-block' }}>
-                {pod.istioContainers ? pod.istioContainers.map(c => `${c.image}`).join(', ') : 'Not found'}
-              </div>
-            </li>
-            <li>
-              <span>Labels</span>
-              <div style={{ display: 'inline-block' }}>
-                <Labels labels={pod.labels} expanded={true} />
-              </div>
-            </li>
-          </ul>
-        </div>
-      );
-
-      rows.push({
-        cells: [
-          {
-            title: (
-              <span>
-                <div key="service-icon" className={iconStyle}>
-                  <PFBadge badge={PFBadges.Pod} position={TooltipPosition.top} />
+    (this.props.pods || [])
+      .sort((p1: Pod, p2: Pod) => (p1.name < p2.name ? -1 : 1))
+      .map((pod, _podIdx) => {
+        let validation: ObjectValidation = {} as ObjectValidation;
+        if (this.props.validations[pod.name]) {
+          validation = this.props.validations[pod.name];
+        }
+        const podProperties = (
+          <div key="properties-list" className={resourceListStyle}>
+            <ul style={{ listStyleType: 'none' }}>
+              <li>
+                <span>Created</span>
+                <div style={{ display: 'inline-block' }}>
+                  <LocalTime time={pod.createdAt} />
                 </div>
-                {pod.name}
-                <Tooltip
-                  position={TooltipPosition.right}
-                  content={<div style={{ textAlign: 'left' }}>{podProperties}</div>}
-                >
-                  <KialiIcon.Info className={infoStyle} />
-                </Tooltip>
-              </span>
-            )
-          },
-          {
-            title: (
-              <>
-                <PodStatus proxyStatus={pod.proxyStatus} checks={validation.checks} />
-              </>
-            )
-          }
-        ]
+              </li>
+              <li>
+                <span>Created By</span>
+                <div style={{ display: 'inline-block' }}>
+                  {pod.createdBy && pod.createdBy.length > 0
+                    ? pod.createdBy.map(ref => ref.name + ' (' + ref.kind + ')').join(', ')
+                    : 'Not found'}
+                </div>
+              </li>
+              <li>
+                <span>Istio Init Container</span>
+                <div style={{ display: 'inline-block' }}>
+                  {pod.istioInitContainers ? pod.istioInitContainers.map(c => `${c.image}`).join(', ') : 'Not found'}
+                </div>
+              </li>
+              <li>
+                <span>Istio Container</span>
+                <div style={{ display: 'inline-block' }}>
+                  {pod.istioContainers ? pod.istioContainers.map(c => `${c.image}`).join(', ') : 'Not found'}
+                </div>
+              </li>
+              <li>
+                <span>Labels</span>
+                <div style={{ display: 'inline-block' }}>
+                  <Labels labels={pod.labels} expanded={true} />
+                </div>
+              </li>
+            </ul>
+          </div>
+        );
+
+        rows.push({
+          cells: [
+            {
+              title: (
+                <span>
+                  <div key="service-icon" className={iconStyle}>
+                    <PFBadge badge={PFBadges.Pod} position={TooltipPosition.top} />
+                  </div>
+                  {pod.name}
+                  <Tooltip
+                    position={TooltipPosition.right}
+                    content={<div style={{ textAlign: 'left' }}>{podProperties}</div>}
+                  >
+                    <KialiIcon.Info className={infoStyle} />
+                  </Tooltip>
+                </span>
+              )
+            },
+            {
+              title: (
+                <>
+                  <PodStatus proxyStatus={pod.proxyStatus} checks={validation.checks} />
+                </>
+              )
+            }
+          ]
+        });
+        return rows;
       });
-      return rows;
-    });
 
     return rows;
   }


### PR DESCRIPTION
the details description component didn't apply any sorting for both apps, workloads and services (nor in backend/frontend). Therefore, some refreshing of the page made some of the list change the order all the time despite of there wasn't any information change. It was just a sorting change. It bugged me a little bit and distracted me from putting attention on other sections of the detail pages.

Same thing happens with the pod list and the istio config section.

![list-glitch](https://user-images.githubusercontent.com/613814/122775349-53f88000-d2aa-11eb-88ee-5ba783d81295.gif)


