### PR TITLE
Upgrade namespace in overview page to newer installed Istio.

### DIFF
--- a/src/components/IstioWizards/WizardActions.ts
+++ b/src/components/IstioWizards/WizardActions.ts
@@ -1387,9 +1387,15 @@ export const buildSidecar = (name: string, namespace: string, state: SidecarStat
   return sc;
 };
 
-export const buildNamespaceInjectionPatch = (enable: boolean, remove: boolean): string => {
+export const buildNamespaceInjectionPatch = (enable: boolean, remove: boolean, revision: string | null): string => {
   const labels = {};
-  labels[serverConfig.istioLabels.injectionLabelName] = remove ? null : enable ? 'enabled' : 'disabled';
+  if (revision) {
+    labels[serverConfig.istioLabels.injectionLabelName] = null;
+    labels[serverConfig.istioLabels.injectionLabelRev] = revision;
+  } else {
+    labels[serverConfig.istioLabels.injectionLabelName] = remove ? null : enable ? 'enabled' : 'disabled';
+    labels[serverConfig.istioLabels.injectionLabelRev] = null;
+  }
   const patch = {
     metadata: {
       labels: labels

--- a/src/config/ServerConfig.ts
+++ b/src/config/ServerConfig.ts
@@ -58,15 +58,21 @@ const defaultServerConfig: ComputedServerConfig = {
   istioAnnotations: {
     istioInjectionAnnotation: 'sidecar.istio.io/inject'
   },
+  istioCanaryRevision: {
+    current: '',
+    upgrade: ''
+  },
   istioIdentityDomain: 'svc.cluster.local',
   istioNamespace: 'istio-system',
   istioLabels: {
     appLabelName: 'app',
     injectionLabelName: 'istio-injection',
+    injectionLabelRev: 'istio.io/rev',
     versionLabelName: 'version'
   },
   kialiFeatureFlags: {
-    istioInjectionAction: true
+    istioInjectionAction: true,
+    istioUpgradeAction: false
   },
   prometheus: {
     globalScrapeInterval: 15,

--- a/src/types/ErrorRate/__testData__/ErrorRateConfig.ts
+++ b/src/types/ErrorRate/__testData__/ErrorRateConfig.ts
@@ -69,7 +69,8 @@ export const generateRequestHealth = (
 export const serverRateConfig = {
   clusters: {},
   kialiFeatureFlags: {
-    istioInjectionAction: true
+    istioInjectionAction: true,
+    istioUpgradeAction: false
   },
   healthConfig: {
     rate: [
@@ -114,11 +115,16 @@ export const serverRateConfig = {
   istioAnnotations: {
     istioInjectionAnnotation: ''
   },
+  istioCanaryRevision: {
+    current: '',
+    upgrade: ''
+  },
   istioIdentityDomain: 'svc.cluster.local',
   istioNamespace: 'istio-system',
   istioLabels: {
     appLabelName: 'app',
     injectionLabelName: 'istio-injection',
+    injectionLabelRev: 'istio.io/rev',
     versionLabelName: 'version'
   },
   prometheus: {

--- a/src/types/ServerConfig.ts
+++ b/src/types/ServerConfig.ts
@@ -1,7 +1,7 @@
 import { DurationInSeconds } from './Common';
 import { MeshCluster } from './Mesh';
 
-export type IstioLabelKey = 'appLabelName' | 'versionLabelName' | 'injectionLabelName';
+export type IstioLabelKey = 'appLabelName' | 'versionLabelName' | 'injectionLabelName' | 'injectionLabelRev';
 
 interface iter8Config {
   enabled: boolean;
@@ -40,7 +40,13 @@ interface UIDefaults {
 
 interface KialiFeatureFlags {
   istioInjectionAction: boolean;
+  istioUpgradeAction: boolean;
   uiDefaults?: UIDefaults;
+}
+
+interface IstioCanaryRevision {
+  current: string;
+  upgrade: string;
 }
 
 /*
@@ -79,6 +85,7 @@ export interface ServerConfig {
   healthConfig: HealthConfig;
   installationTag?: string;
   istioAnnotations: IstioAnnotations;
+  istioCanaryRevision: IstioCanaryRevision;
   istioIdentityDomain: string;
   istioNamespace: string;
   istioLabels: { [key in IstioLabelKey]: string };

--- a/src/types/__testData__/HealthConfig.ts
+++ b/src/types/__testData__/HealthConfig.ts
@@ -3,7 +3,8 @@ import { getExpr } from '../../config/HealthConfig';
 export const healthConfig = {
   clusters: {},
   kialiFeatureFlags: {
-    istioInjectionAction: true
+    istioInjectionAction: true,
+    istioUpgradeAction: false
   },
   healthConfig: {
     rate: [
@@ -34,11 +35,16 @@ export const healthConfig = {
   istioAnnotations: {
     istioInjectionAnnotation: ''
   },
+  istioCanaryRevision: {
+    current: '',
+    upgrade: ''
+  },
   istioIdentityDomain: 'svc.cluster.local',
   istioNamespace: 'istio-system',
   istioLabels: {
     appLabelName: 'app',
     injectionLabelName: 'istio-injection',
+    injectionLabelRev: 'istio.io/rev',
     versionLabelName: 'version'
   },
   prometheus: {


### PR DESCRIPTION
Fix for issue https://github.com/kiali/kiali/issues/3988

Requires backend: https://github.com/kiali/kiali/pull/4122

This PR contains a feature for executing Upgrade/Downgrade To Istio on Namespace action in Overview page.

When Kiali CR is configured "IstioUpgradeAction" and appropriate current and newer Istio revisions: "IstioCurrentRevision" and "IstioUpgradeRevision". Then Kiali allows user to upgrade to the newest Istio by setting the 'istio.io/rev' label to namespace.
Then all workload's pods are restared in that namespace to inject the newest Istio Envoy.