### PR TITLE
Adding a Select all option to metrics settings filter

### DIFF
--- a/src/components/MetricsOptions/MetricsSettingsDropdown.tsx
+++ b/src/components/MetricsOptions/MetricsSettingsDropdown.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Dropdown, DropdownToggle, Radio } from '@patternfly/react-core';
+import { Divider, Dropdown, DropdownToggle, DropdownToggleCheckbox, Radio } from '@patternfly/react-core';
 import { style } from 'typestyle';
 import isEqual from 'lodash/isEqual';
 
@@ -24,8 +24,10 @@ interface Props {
 
 type State = MetricsSettings & {
   isOpen: boolean;
+  allSelected: boolean;
 };
 
+const checkboxLabelStyle = style({ marginLeft: '0.5em' });
 const checkboxStyle = style({ marginLeft: 10 });
 const secondLevelStyle = style({ marginLeft: 18 });
 const spacerStyle = style({ height: '1em' });
@@ -35,8 +37,25 @@ export class MetricsSettingsDropdown extends React.Component<Props, State> {
     super(props);
     const settings = retrieveMetricsSettings();
     settings.labelsSettings = combineLabelsSettings(props.labelsSettings, settings.labelsSettings);
-    this.state = { ...settings, isOpen: false };
+    this.state = { ...settings, isOpen: false, allSelected: false };
   }
+
+  checkSelected = () => {
+    let allSelected = true;
+    this.props.labelsSettings.forEach(lblSetting => {
+      if (lblSetting.checked === false) {
+        allSelected = false;
+      } else {
+        Object.keys(lblSetting.values).forEach(value => {
+          if (lblSetting.values[value] === false) {
+            allSelected = false;
+          }
+        });
+      }
+    });
+
+    this.setState({ allSelected: allSelected });
+  };
 
   componentDidUpdate(prevProps: Props) {
     // TODO Move the sync of URL and state to a global place
@@ -53,7 +72,7 @@ export class MetricsSettingsDropdown extends React.Component<Props, State> {
           showAverage: changeDirection ? settings.showAverage : prevState.showAverage,
           showSpans: changeDirection ? settings.showSpans : prevState.showSpans
         };
-      });
+      }, this.checkSelected);
     }
   }
 
@@ -73,14 +92,20 @@ export class MetricsSettingsDropdown extends React.Component<Props, State> {
       {
         labelsSettings: new Map(this.state.labelsSettings)
       },
-      () => this.props.onChanged(this.state)
+      () => {
+        this.props.onChanged(this.state);
+        this.checkSelected();
+      }
     );
   };
 
   onLabelsFiltersChanged = (label: PromLabel, value: string, checked: boolean, singleSelection: boolean) => {
     const newValues = mergeLabelFilter(this.state.labelsSettings, label, value, checked, singleSelection);
     this.updateLabelsSettingsURL(newValues);
-    this.setState({ labelsSettings: newValues }, () => this.props.onLabelsFiltersChanged(newValues));
+    this.setState({ labelsSettings: newValues }, () => {
+      this.props.onLabelsFiltersChanged(newValues);
+      this.checkSelected();
+    });
   };
 
   updateLabelsSettingsURL = (labelsSettings: LabelsSettings) => {
@@ -122,6 +147,37 @@ export class MetricsSettingsDropdown extends React.Component<Props, State> {
     this.setState({ showQuantiles: newQuantiles }, () => this.props.onChanged(this.state));
   };
 
+  bulkUpdate = (selected: boolean): void => {
+    this.state.labelsSettings.forEach(lblSetting => {
+      lblSetting.checked = selected;
+
+      Object.keys(lblSetting.values).forEach(value => {
+        lblSetting.values[value] = selected;
+      });
+    });
+
+    this.updateLabelsSettingsURL(this.state.labelsSettings);
+
+    this.setState(
+      {
+        labelsSettings: new Map(this.state.labelsSettings)
+      },
+      () => {
+        this.props.onChanged(this.state);
+      }
+    );
+  };
+
+  onBulkAll = () => {
+    this.bulkUpdate(true);
+    this.setState({ allSelected: true });
+  };
+
+  onBulkNone = () => {
+    this.bulkUpdate(false);
+    this.setState({ allSelected: false });
+  };
+
   render() {
     const hasHistograms = this.props.hasHistograms;
     const hasLabels = this.state.labelsSettings.size > 0;
@@ -136,10 +192,33 @@ export class MetricsSettingsDropdown extends React.Component<Props, State> {
         {/* TODO: Remove the class="pf-c-dropdown__menu-item" attribute which is fixing a sizing issue in PF.
          * https://github.com/patternfly/patternfly-react/issues/3156 */}
         <div style={{ paddingLeft: '10px', backgroundColor: PFColors.White }} className="pf-c-dropdown__menu-item">
+          {hasLabels && this.renderBulkSelector()}
           {hasLabels && this.renderLabelOptions()}
           {hasHistograms && this.renderHistogramOptions()}
         </div>
       </Dropdown>
+    );
+  }
+
+  renderBulkSelector(): JSX.Element {
+    return (
+      <div>
+        <DropdownToggleCheckbox
+          id="bulk-select-id"
+          key="bulk-select-key"
+          aria-label="Select all metrics"
+          isChecked={this.state.allSelected}
+          onClick={() => {
+            if (this.state.allSelected) {
+              this.onBulkNone();
+            } else {
+              this.onBulkAll();
+            }
+          }}
+        ></DropdownToggleCheckbox>
+        <span className={checkboxLabelStyle}>Select all metrics</span>
+        <Divider style={{ paddingTop: '5px' }} />
+      </div>
     );
   }
 

--- a/src/components/MetricsOptions/MetricsSettingsDropdown.tsx
+++ b/src/components/MetricsOptions/MetricsSettingsDropdown.tsx
@@ -207,7 +207,7 @@ export class MetricsSettingsDropdown extends React.Component<Props, State> {
         <DropdownToggleCheckbox
           id="bulk-select-id"
           key="bulk-select-key"
-          aria-label="Select all metrics and labels"
+          aria-label="Select all metric/label filters"
           isChecked={this.state.allSelected}
           onClick={() => {
             if (this.state.allSelected) {
@@ -217,7 +217,7 @@ export class MetricsSettingsDropdown extends React.Component<Props, State> {
             }
           }}
         ></DropdownToggleCheckbox>
-        <span className={checkboxSelectAllStyle}>Select all metrics and labels</span>
+        <span className={checkboxSelectAllStyle}>Select all metric/label filters</span>
         <Divider style={{ paddingTop: '5px' }} />
       </div>
     );

--- a/src/components/MetricsOptions/MetricsSettingsDropdown.tsx
+++ b/src/components/MetricsOptions/MetricsSettingsDropdown.tsx
@@ -27,7 +27,7 @@ type State = MetricsSettings & {
   allSelected: boolean;
 };
 
-const checkboxLabelStyle = style({ marginLeft: '0.5em' });
+const checkboxSelectAllStyle = style({ marginLeft: 10, fontWeight: 700 });
 const checkboxStyle = style({ marginLeft: 10 });
 const secondLevelStyle = style({ marginLeft: 18 });
 const spacerStyle = style({ height: '1em' });
@@ -42,7 +42,7 @@ export class MetricsSettingsDropdown extends React.Component<Props, State> {
 
   checkSelected = () => {
     let allSelected = true;
-    this.props.labelsSettings.forEach(lblSetting => {
+    this.state.labelsSettings.forEach(lblSetting => {
       if (lblSetting.checked === false) {
         allSelected = false;
       } else {
@@ -74,6 +74,7 @@ export class MetricsSettingsDropdown extends React.Component<Props, State> {
         };
       }, this.checkSelected);
     }
+    console.log(this.state.allSelected);
   }
 
   private onToggle = isOpen => {
@@ -206,7 +207,7 @@ export class MetricsSettingsDropdown extends React.Component<Props, State> {
         <DropdownToggleCheckbox
           id="bulk-select-id"
           key="bulk-select-key"
-          aria-label="Select all metrics"
+          aria-label="Select all metrics and labels"
           isChecked={this.state.allSelected}
           onClick={() => {
             if (this.state.allSelected) {
@@ -216,7 +217,7 @@ export class MetricsSettingsDropdown extends React.Component<Props, State> {
             }
           }}
         ></DropdownToggleCheckbox>
-        <span className={checkboxLabelStyle}>Select all metrics</span>
+        <span className={checkboxSelectAllStyle}>Select all metrics and labels</span>
         <Divider style={{ paddingTop: '5px' }} />
       </div>
     );


### PR DESCRIPTION
**Description**

This PR adds an option to select all the labels in the Metrics settings filter.

**Issue**

[#3596](https://github.com/kiali/kiali/issues/3596)

**Documentation**

![metrics_filter_1](https://user-images.githubusercontent.com/1286393/123319485-d8dfd580-d506-11eb-8caf-47f58cd2cbb8.png)
![metrics_filter_2](https://user-images.githubusercontent.com/1286393/123319498-dbdac600-d506-11eb-9acc-4a7e748e627d.png)
![metrics_filter_3](https://user-images.githubusercontent.com/1286393/123319508-ded5b680-d506-11eb-89e4-8feefc78c646.png)


