### PR TITLE
Fix sync state on URL on Metrics tab

### DIFF
--- a/src/components/Metrics/CustomMetrics.tsx
+++ b/src/components/Metrics/CustomMetrics.tsx
@@ -252,6 +252,7 @@ class CustomMetrics extends React.Component<Props, MetricsState> {
                 <MetricsSettingsDropdown
                   onChanged={this.onMetricsSettingsChanged}
                   onLabelsFiltersChanged={this.onLabelsFiltersChanged}
+                  direction={this.state.dashboard?.title || 'dashboard'}
                   labelsSettings={this.state.labelsSettings}
                   hasHistograms={hasHistograms}
                 />

--- a/src/components/Metrics/IstioMetrics.tsx
+++ b/src/components/Metrics/IstioMetrics.tsx
@@ -117,6 +117,7 @@ class IstioMetrics extends React.Component<Props, MetricsState> {
       if (this.props.direction !== prevProps.direction) {
         const settings = MetricsHelper.retrieveMetricsSettings();
         this.options = this.initOptions(settings);
+        this.setState({ labelsSettings: settings.labelsSettings });
       }
       this.spanOverlay.reset();
       this.refresh();
@@ -288,6 +289,7 @@ class IstioMetrics extends React.Component<Props, MetricsState> {
               <MetricsSettingsDropdown
                 onChanged={this.onMetricsSettingsChanged}
                 onLabelsFiltersChanged={this.onLabelsFiltersChanged}
+                direction={this.props.direction}
                 labelsSettings={this.state.labelsSettings}
                 hasHistograms={true}
               />

--- a/src/components/MetricsOptions/MetricsSettingsDropdown.tsx
+++ b/src/components/MetricsOptions/MetricsSettingsDropdown.tsx
@@ -39,16 +39,19 @@ export class MetricsSettingsDropdown extends React.Component<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props) {
+    // TODO Move the sync of URL and state to a global place
     const changeDirection = prevProps.direction !== this.props.direction;
-    const stateLabelsSettings = changeDirection ? new Map() : this.state.labelsSettings;
+    const settings = retrieveMetricsSettings();
+    let initLabelSettings = changeDirection ? settings.labelsSettings : new Map();
+    const stateLabelsSettings = changeDirection ? initLabelSettings : this.state.labelsSettings;
     const labelsSettings = combineLabelsSettings(this.props.labelsSettings, stateLabelsSettings);
     if (!isEqual(stateLabelsSettings, labelsSettings) || changeDirection) {
       this.setState(prevState => {
         return {
           labelsSettings: labelsSettings,
-          showQuantiles: changeDirection ? [] : prevState.showQuantiles,
-          showAverage: changeDirection ? true : prevState.showAverage,
-          showSpans: changeDirection ? false : prevState.showSpans
+          showQuantiles: changeDirection ? settings.showQuantiles : prevState.showQuantiles,
+          showAverage: changeDirection ? settings.showAverage : prevState.showAverage,
+          showSpans: changeDirection ? settings.showSpans : prevState.showSpans
         };
       });
     }
@@ -125,7 +128,6 @@ export class MetricsSettingsDropdown extends React.Component<Props, State> {
     if (!hasHistograms && !hasLabels) {
       return null;
     }
-
     return (
       <Dropdown
         toggle={<DropdownToggle onToggle={this.onToggle}>Metrics Settings</DropdownToggle>}

--- a/src/components/MetricsOptions/MetricsSettingsDropdown.tsx
+++ b/src/components/MetricsOptions/MetricsSettingsDropdown.tsx
@@ -17,6 +17,7 @@ import { PromLabel } from 'types/Metrics';
 interface Props {
   onChanged: (state: MetricsSettings) => void;
   onLabelsFiltersChanged: (labelsFilters: LabelsSettings) => void;
+  direction: string;
   hasHistograms: boolean;
   labelsSettings: LabelsSettings;
 }
@@ -37,10 +38,19 @@ export class MetricsSettingsDropdown extends React.Component<Props, State> {
     this.state = { ...settings, isOpen: false };
   }
 
-  componentDidUpdate() {
-    const labelsSettings = combineLabelsSettings(this.props.labelsSettings, this.state.labelsSettings);
-    if (!isEqual(this.state.labelsSettings, labelsSettings)) {
-      this.setState({ labelsSettings: labelsSettings });
+  componentDidUpdate(prevProps: Props) {
+    const changeDirection = prevProps.direction !== this.props.direction;
+    const stateLabelsSettings = changeDirection ? new Map() : this.state.labelsSettings;
+    const labelsSettings = combineLabelsSettings(this.props.labelsSettings, stateLabelsSettings);
+    if (!isEqual(stateLabelsSettings, labelsSettings) || changeDirection) {
+      this.setState(prevState => {
+        return {
+          labelsSettings: labelsSettings,
+          showQuantiles: changeDirection ? [] : prevState.showQuantiles,
+          showAverage: changeDirection ? true : prevState.showAverage,
+          showSpans: changeDirection ? false : prevState.showSpans
+        };
+      });
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/4106

It's a workaround, Kiali should review how state is shared between components and URL and unify it, right now there is some technical debt from the early designs that have a mix of strategies on this.

