### PR TITLE
Display hostnames in network section of service details

### DIFF
--- a/src/pages/ServiceDetails/ServiceDetailsPage.tsx
+++ b/src/pages/ServiceDetails/ServiceDetailsPage.tsx
@@ -93,13 +93,7 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
             namespaces.map(ns => API.getIstioConfig(ns.name, ['gateways'], false, '', ''))
           )
           .then(responses => {
-            let gateways: Gateway[] = [];
-            responses.forEach(response => {
-              response.data.gateways.forEach(gw => {
-                gateways.push(gw);
-              });
-            });
-            this.setState({ gateways: gateways });
+            this.setState({ gateways: responses.map(response => response.data.gateways).flat() });
           })
           .catch(gwError => {
             AlertUtils.addError('Could not fetch Gateways list.', gwError);
@@ -132,13 +126,7 @@ class ServiceDetails extends React.Component<ServiceDetailsProps, ServiceDetails
   };
 
   private getGatewaysAsList(): string[] {
-    let gatewayList: string[] = [];
-
-    this.state.gateways.forEach(gateway => {
-      gatewayList.push(gateway.metadata.namespace + '/' + gateway.metadata.name);
-    });
-
-    return gatewayList;
+    return this.state.gateways.map(gateway => gateway.metadata.namespace + '/' + gateway.metadata.name);
   }
 
   private renderTabs() {

--- a/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -4,7 +4,7 @@ import { Grid, GridItem, Stack, StackItem } from '@patternfly/react-core';
 import ServiceId from '../../types/ServiceId';
 import ServiceDescription from './ServiceDescription';
 import { ServiceDetailsInfo } from '../../types/ServiceInfo';
-import { ObjectValidation, PeerAuthentication, Validations } from '../../types/IstioObjects';
+import { Gateway, ObjectValidation, PeerAuthentication, Validations } from '../../types/IstioObjects';
 import { RenderComponentScroll } from '../../components/Nav/Page';
 import { PromisesRegistry } from 'utils/CancelablePromises';
 import { DurationInSeconds, TimeInMilliseconds } from 'types/Common';
@@ -24,7 +24,7 @@ interface Props extends ServiceId {
   lastRefreshAt: TimeInMilliseconds;
   mtlsEnabled: boolean;
   serviceDetails?: ServiceDetailsInfo;
-  gateways: string[];
+  gateways: Gateway[];
   peerAuthentications: PeerAuthentication[];
   validations: Validations;
 }
@@ -112,6 +112,7 @@ class ServiceInfo extends React.Component<Props, ServiceInfoState> {
                 {this.props.serviceDetails && (
                   <ServiceNetwork
                     serviceDetails={this.props.serviceDetails}
+                    gateways={this.props.gateways}
                     validations={this.getServiceValidation()}
                   />
                 )}

--- a/src/pages/ServiceDetails/ServiceNetwork.tsx
+++ b/src/pages/ServiceDetails/ServiceNetwork.tsx
@@ -167,8 +167,7 @@ class ServiceNetwork extends React.Component<Props> {
                             position={TooltipPosition.right}
                             content={
                               <div style={{ textAlign: 'left' }}>
-                                Hostname <b>{hostname.hostname}</b> found in {hostname.fromType}{' '}
-                                <b>{hostname.fromName}</b>
+                                {hostname.fromType} {hostname.fromName}: {hostname.hostname}
                               </div>
                             }
                           >

--- a/src/pages/ServiceDetails/ServiceNetwork.tsx
+++ b/src/pages/ServiceDetails/ServiceNetwork.tsx
@@ -153,10 +153,15 @@ class ServiceNetwork extends React.Component<Props> {
               {this.props.serviceDetails.virtualServices.items.length > 0 && (
                 <li>
                   <span>Hostnames</span>
-                  <div style={{ display: 'inline-block' }}>
+                  <div
+                    style={{
+                      display: 'inline-block',
+                      width: '75%'
+                    }}
+                  >
                     {this.getHostnames(this.props.serviceDetails.virtualServices.items).map((hostname, i) => {
                       return (
-                        <div key={'hostname_' + i}>
+                        <div key={'hostname_' + i} style={{ overflow: 'hidden' }}>
                           <Tooltip
                             content={
                               <>
@@ -164,7 +169,14 @@ class ServiceNetwork extends React.Component<Props> {
                               </>
                             }
                           >
-                            <span>
+                            <span
+                              style={{
+                                whiteSpace: 'nowrap',
+                                overflow: 'hidden',
+                                textOverflow: 'ellipsis',
+                                display: 'block'
+                              }}
+                            >
                               {hostname.hostname} <KialiIcon.Info className={infoStyle} />
                             </span>
                           </Tooltip>

--- a/src/pages/ServiceDetails/ServiceNetwork.tsx
+++ b/src/pages/ServiceDetails/ServiceNetwork.tsx
@@ -161,24 +161,29 @@ class ServiceNetwork extends React.Component<Props> {
                   >
                     {this.getHostnames(this.props.serviceDetails.virtualServices.items).map((hostname, i) => {
                       return (
-                        <div key={'hostname_' + i} style={{ overflow: 'hidden' }}>
+                        <div key={'hostname_' + i}>
                           <Tooltip
                             content={
                               <>
-                                From {hostname.fromType}: {hostname.fromName}
+                                Hostname <b>{hostname.hostname}</b> found in {hostname.fromType}{' '}
+                                <b>{hostname.fromName}</b>
                               </>
                             }
                           >
-                            <span
-                              style={{
-                                whiteSpace: 'nowrap',
-                                overflow: 'hidden',
-                                textOverflow: 'ellipsis',
-                                display: 'block'
-                              }}
-                            >
-                              {hostname.hostname} <KialiIcon.Info className={infoStyle} />
-                            </span>
+                            <div style={{ display: 'flex' }}>
+                              <span
+                                style={{
+                                  whiteSpace: 'nowrap',
+                                  overflow: 'hidden',
+                                  textOverflow: 'ellipsis'
+                                }}
+                              >
+                                {hostname.hostname}
+                              </span>
+                              <span>
+                                <KialiIcon.Info className={infoStyle} />
+                              </span>
+                            </div>
                           </Tooltip>
                         </div>
                       );

--- a/src/pages/ServiceDetails/ServiceNetwork.tsx
+++ b/src/pages/ServiceDetails/ServiceNetwork.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Card, CardBody, CardHeader, Title, Tooltip } from '@patternfly/react-core';
+import { Card, CardBody, CardHeader, Title, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { ServiceDetailsInfo } from '../../types/ServiceInfo';
 import { style } from 'typestyle';
 import { Gateway, ObjectCheck, ObjectValidation, VirtualService } from '../../types/IstioObjects';
@@ -117,10 +117,11 @@ class ServiceNetwork extends React.Component<Props> {
                       <div key={'endpoint_' + i + '_address_' + u}>
                         {address.name !== '' ? (
                           <Tooltip
+                            position={TooltipPosition.right}
                             content={
-                              <>
+                              <div style={{ textAlign: 'left' }}>
                                 {address.kind}: {address.name}
-                              </>
+                              </div>
                             }
                           >
                             <span>
@@ -163,11 +164,12 @@ class ServiceNetwork extends React.Component<Props> {
                       return (
                         <div key={'hostname_' + i}>
                           <Tooltip
+                            position={TooltipPosition.right}
                             content={
-                              <>
+                              <div style={{ textAlign: 'left' }}>
                                 Hostname <b>{hostname.hostname}</b> found in {hostname.fromType}{' '}
                                 <b>{hostname.fromName}</b>
-                              </>
+                              </div>
                             }
                           >
                             <div style={{ display: 'flex' }}>


### PR DESCRIPTION
**Description**

This PR enhance the Service Overview page adding a lists of hostnames that can reach the service according to the VirtualServices/Gateways configurations.

**Issue**

[#4067](https://github.com/kiali/kiali/issues/4067)

**Documentation**

If there are VirtualServices related to the Service, the hostnames will be showed as follows:

![ex1p](https://user-images.githubusercontent.com/1286393/123870115-45dcdc00-d908-11eb-833e-7cfedd7f5a55.png)

The configuration is the following:

```yaml
apiVersion: networking.istio.io/v1alpha3
kind: Gateway
metadata:
  name: bookinfo-gateway-1
spec:
  selector:
    istio: ingressgateway
  servers:
  - port:
      number: 80
      name: http
      protocol: HTTP
    hosts:
    - bookinfo.com
---
apiVersion: networking.istio.io/v1alpha3
kind: Gateway
metadata:
  name: bookinfo-gateway-2
spec:
  selector:
    istio: ingressgateway
  servers:
  - port:
      number: 80
      name: http
      protocol: HTTP
    hosts:
    - bookinfo.net
---
apiVersion: networking.istio.io/v1alpha3
kind: VirtualService
metadata:
  name: bookinfo
spec:
  hosts:
  - my.bookinfo.com
  - my.bookinfo.net
  gateways:
  - bookinfo-gateway-1
  - bookinfo-gateway-2
  http:
  - match:
    - uri:
        exact: /productpage
    - uri:
        prefix: /static
    - uri:
        exact: /login
    - uri:
        exact: /logout
    - uri:
        prefix: /api/v1/products
    route:
    - destination:
        host: productpage
        port:
          number: 9080
```

If the VirtualService has a wildcard host (*) then it will try to get hosts from the related gateways:

![ex2p](https://user-images.githubusercontent.com/1286393/123870591-e4693d00-d908-11eb-9a1f-504062fb5999.png)

The configuration is the following:

```yaml
apiVersion: networking.istio.io/v1alpha3
kind: Gateway
metadata:
  name: bookinfo-gateway-1
spec:
  selector:
    istio: ingressgateway
  servers:
  - port:
      number: 80
      name: http
      protocol: HTTP
    hosts:
    - bookinfo.com
---
apiVersion: networking.istio.io/v1alpha3
kind: Gateway
metadata:
  name: bookinfo-gateway-2
spec:
  selector:
    istio: ingressgateway
  servers:
  - port:
      number: 80
      name: http
      protocol: HTTP
    hosts:
    - bookinfo.net
---
apiVersion: networking.istio.io/v1alpha3
kind: VirtualService
metadata:
  name: bookinfo
spec:
  hosts:
  - "*"
  gateways:
  - bookinfo-gateway-1
  - bookinfo-gateway-2
  http:
  - match:
    - uri:
        exact: /productpage
    - uri:
        prefix: /static
    - uri:
        exact: /login
    - uri:
        exact: /logout
    - uri:
        prefix: /api/v1/products
    route:
    - destination:
        host: productpage
        port:
          number: 9080
```

And finally if at least a Gateway has a wildcard host, it will show the wildcard:

![ex3p](https://user-images.githubusercontent.com/1286393/123870799-3e6a0280-d909-11eb-9c90-f0efed797d2f.png)

The configuration is the following:

```yaml
apiVersion: networking.istio.io/v1alpha3
kind: Gateway
metadata:
  name: bookinfo-gateway-1
spec:
  selector:
    istio: ingressgateway
  servers:
  - port:
      number: 80
      name: http
      protocol: HTTP
    hosts:
    - '*'
---
apiVersion: networking.istio.io/v1alpha3
kind: Gateway
metadata:
  name: bookinfo-gateway-2
spec:
  selector:
    istio: ingressgateway
  servers:
  - port:
      number: 80
      name: http
      protocol: HTTP
    hosts:
    - bookinfo.net
---
apiVersion: networking.istio.io/v1alpha3
kind: VirtualService
metadata:
  name: bookinfo
spec:
  hosts:  
  - '*'
  gateways:
  - bookinfo-gateway-1
  - bookinfo-gateway-2
  http:
  - match:
    - uri:
        exact: /productpage
    - uri:
        prefix: /static
    - uri:
        exact: /login
    - uri:
        exact: /logout
    - uri:
        prefix: /api/v1/products
    route:
    - destination:
        host: productpage
        port:
          number: 9080
```