### PR TITLE
Show Istio configuration linked with Services and Workloads (and Applications) on list pages

### DIFF
--- a/src/components/Filters/CommonFilters.ts
+++ b/src/components/Filters/CommonFilters.ts
@@ -68,6 +68,24 @@ export const labelFilter: FilterType = {
   filterValues: []
 };
 
+export const virtualServicesFilter: FilterType = {
+  id: 'virtualServices',
+  title: 'Virtual Services',
+  placeholder: 'Has VirtualService',
+  filterType: FilterTypes.select,
+  action: FILTER_ACTION_APPEND,
+  filterValues: presenceValues
+};
+
+export const destinationRulesFilter: FilterType = {
+  id: 'destinationRules',
+  title: 'Destination Rules',
+  placeholder: 'Has DestinationRule',
+  filterType: FilterTypes.select,
+  action: FILTER_ACTION_APPEND,
+  filterValues: presenceValues
+};
+
 export const getFilterSelectedValues = (filter: FilterType, activeFilters: ActiveFiltersInfo): string[] => {
   const selected: string[] = activeFilters.filters
     .filter(activeFilter => activeFilter.id === filter.id)

--- a/src/components/Filters/CommonFilters.ts
+++ b/src/components/Filters/CommonFilters.ts
@@ -68,24 +68,6 @@ export const labelFilter: FilterType = {
   filterValues: []
 };
 
-export const virtualServicesFilter: FilterType = {
-  id: 'virtualServices',
-  title: 'Virtual Services',
-  placeholder: 'Has VirtualService',
-  filterType: FilterTypes.select,
-  action: FILTER_ACTION_APPEND,
-  filterValues: presenceValues
-};
-
-export const destinationRulesFilter: FilterType = {
-  id: 'destinationRules',
-  title: 'Destination Rules',
-  placeholder: 'Has DestinationRule',
-  filterType: FilterTypes.select,
-  action: FILTER_ACTION_APPEND,
-  filterValues: presenceValues
-};
-
 export const getFilterSelectedValues = (filter: FilterType, activeFilters: ActiveFiltersInfo): string[] => {
   const selected: string[] = activeFilters.filters
     .filter(activeFilter => activeFilter.id === filter.id)

--- a/src/components/VirtualList/Renderers.tsx
+++ b/src/components/VirtualList/Renderers.tsx
@@ -62,14 +62,6 @@ export const details: Renderer<AppListItem | WorkloadListItem | ServiceListItem>
   const hasMissingVersion = isWorkload && !item['versionLabel'];
   const additionalDetails = (item as WorkloadListItem | ServiceListItem).additionalDetailSample;
   const spacer = hasMissingSC && additionalDetails && additionalDetails.icon;
-  const virtualServices = (item as ServiceListItem).virtualServices;
-  const destinationRules = (item as ServiceListItem).destinationRules;
-  const gateways = (item as WorkloadListItem).gateways;
-  const authorizationPolicies = (item as WorkloadListItem).authorizationPolicies;
-  const peerAuthentications = (item as WorkloadListItem).peerAuthentications;
-  const sidecars = (item as WorkloadListItem).sidecars;
-  const requestAuthentications = (item as WorkloadListItem).requestAuthentications;
-  const envoyFilters = (item as WorkloadListItem).envoyFilters;
 
   return (
     <td
@@ -90,83 +82,13 @@ export const details: Renderer<AppListItem | WorkloadListItem | ServiceListItem>
         {additionalDetails && additionalDetails.icon && (
           <li>{renderAPILogo(additionalDetails.icon, additionalDetails.title, 0)}</li>
         )}
-        {virtualServices &&
-          virtualServices.length > 0 &&
-          virtualServices.map(vs => (
+        {item.istioReferences &&
+          item.istioReferences.length > 0 &&
+          item.istioReferences.map(ir => (
             <li>
-              <PFBadge badge={PFBadges.VirtualService} position={TooltipPosition.top} />
-              <IstioObjectLink name={vs} namespace={item.namespace || ''} type={'virtualservice'}>
-                {vs}
-              </IstioObjectLink>
-            </li>
-          ))}
-        {destinationRules &&
-          destinationRules.length > 0 &&
-          destinationRules.map(dr => (
-            <li>
-              <PFBadge badge={PFBadges.DestinationRule} position={TooltipPosition.top} />
-              <IstioObjectLink name={dr} namespace={item.namespace || ''} type={'destinationrule'}>
-                {dr}
-              </IstioObjectLink>
-            </li>
-          ))}
-        {gateways &&
-          gateways.length > 0 &&
-          gateways.map(dr => (
-            <li>
-              <PFBadge badge={PFBadges.DestinationRule} position={TooltipPosition.top} />
-              <IstioObjectLink name={dr} namespace={item.namespace || ''} type={'destinationrule'}>
-                {dr}
-              </IstioObjectLink>
-            </li>
-          ))}
-        {authorizationPolicies &&
-          authorizationPolicies.length > 0 &&
-          authorizationPolicies.map(ap => (
-            <li>
-              <PFBadge badge={PFBadges.AuthorizationPolicy} position={TooltipPosition.top} />
-              <IstioObjectLink name={ap} namespace={item.namespace || ''} type={'authorizationpolicy'}>
-                {ap}
-              </IstioObjectLink>
-            </li>
-          ))}
-        {peerAuthentications &&
-          peerAuthentications.length > 0 &&
-          peerAuthentications.map(pa => (
-            <li>
-              <PFBadge badge={PFBadges.PeerAuthentication} position={TooltipPosition.top} />
-              <IstioObjectLink name={pa} namespace={item.namespace || ''} type={'peerauthentication'}>
-                {pa}
-              </IstioObjectLink>
-            </li>
-          ))}
-        {sidecars &&
-          sidecars.length > 0 &&
-          sidecars.map(sc => (
-            <li>
-              <PFBadge badge={PFBadges.Sidecar} position={TooltipPosition.top} />
-              <IstioObjectLink name={sc} namespace={item.namespace || ''} type={'sidecar'}>
-                {sc}
-              </IstioObjectLink>
-            </li>
-          ))}
-        {requestAuthentications &&
-          requestAuthentications.length > 0 &&
-          requestAuthentications.map(ra => (
-            <li>
-              <PFBadge badge={PFBadges.RequestAuthentication} position={TooltipPosition.top} />
-              <IstioObjectLink name={ra} namespace={item.namespace || ''} type={'requestauthentication'}>
-                {ra}
-              </IstioObjectLink>
-            </li>
-          ))}
-        {envoyFilters &&
-          envoyFilters.length > 0 &&
-          envoyFilters.map(ef => (
-            <li>
-              <PFBadge badge={PFBadges.EnvoyFilter} position={TooltipPosition.top} />
-              <IstioObjectLink name={ef} namespace={item.namespace || ''} type={'envoyfilter'}>
-                {ef}
+              <PFBadge badge={PFBadges[ir.objectType]} position={TooltipPosition.top} />
+              <IstioObjectLink name={ir.name} namespace={item.namespace || ''} type={ir.objectType.toLowerCase()}>
+                {ir.name}
               </IstioObjectLink>
             </li>
           ))}

--- a/src/components/VirtualList/Renderers.tsx
+++ b/src/components/VirtualList/Renderers.tsx
@@ -62,6 +62,9 @@ export const details: Renderer<AppListItem | WorkloadListItem | ServiceListItem>
   const hasMissingVersion = isWorkload && !item['versionLabel'];
   const additionalDetails = (item as WorkloadListItem | ServiceListItem).additionalDetailSample;
   const spacer = hasMissingSC && additionalDetails && additionalDetails.icon;
+  const hasVirtualService = (item as ServiceListItem).virtualService;
+  const hasDestinationRule = (item as ServiceListItem).destinationRule;
+  const kialiWizard = (item as ServiceListItem).kialiWizard;
   return (
     <td
       role="gridcell"
@@ -80,6 +83,12 @@ export const details: Renderer<AppListItem | WorkloadListItem | ServiceListItem>
         {spacer && ' '}
         {additionalDetails && additionalDetails.icon && (
           <li>{renderAPILogo(additionalDetails.icon, additionalDetails.title, 0)}</li>
+        )}
+        {(hasVirtualService || hasDestinationRule || kialiWizard) && (
+          <li>
+            {hasVirtualService && <PFBadge badge={PFBadges.VirtualService} position={TooltipPosition.top} />}
+            {hasDestinationRule && <PFBadge badge={PFBadges.DestinationRule} position={TooltipPosition.top} />}
+          </li>
         )}
       </ul>
     </td>

--- a/src/components/VirtualList/Renderers.tsx
+++ b/src/components/VirtualList/Renderers.tsx
@@ -22,7 +22,7 @@ import ValidationSummary from '../Validations/ValidationSummary';
 import OverviewCardContentExpanded from '../../pages/Overview/OverviewCardContentExpanded';
 import { OverviewToolbar } from '../../pages/Overview/OverviewToolbar';
 import { StatefulFilters } from '../Filters/StatefulFilters';
-import { GetIstioObjectUrl } from '../Link/IstioObjectLink';
+import IstioObjectLink, { GetIstioObjectUrl } from '../Link/IstioObjectLink';
 import { labelFilter } from 'components/Filters/CommonFilters';
 import { labelFilter as NsLabelFilter } from '../../pages/Overview/Filters';
 import ValidationSummaryLink from '../Link/ValidationSummaryLink';
@@ -62,9 +62,8 @@ export const details: Renderer<AppListItem | WorkloadListItem | ServiceListItem>
   const hasMissingVersion = isWorkload && !item['versionLabel'];
   const additionalDetails = (item as WorkloadListItem | ServiceListItem).additionalDetailSample;
   const spacer = hasMissingSC && additionalDetails && additionalDetails.icon;
-  const hasVirtualService = (item as ServiceListItem).virtualService;
-  const hasDestinationRule = (item as ServiceListItem).destinationRule;
-  const kialiWizard = (item as ServiceListItem).kialiWizard;
+  const virtualServices = (item as ServiceListItem).virtualServices;
+  const destinationRules = (item as ServiceListItem).destinationRules;
   return (
     <td
       role="gridcell"
@@ -84,12 +83,26 @@ export const details: Renderer<AppListItem | WorkloadListItem | ServiceListItem>
         {additionalDetails && additionalDetails.icon && (
           <li>{renderAPILogo(additionalDetails.icon, additionalDetails.title, 0)}</li>
         )}
-        {(hasVirtualService || hasDestinationRule || kialiWizard) && (
-          <li>
-            {hasVirtualService && <PFBadge badge={PFBadges.VirtualService} position={TooltipPosition.top} />}
-            {hasDestinationRule && <PFBadge badge={PFBadges.DestinationRule} position={TooltipPosition.top} />}
-          </li>
-        )}
+        {virtualServices &&
+          virtualServices.length > 0 &&
+          virtualServices.map(vs => (
+            <li>
+              <PFBadge badge={PFBadges.VirtualService} position={TooltipPosition.top} />
+              <IstioObjectLink name={vs} namespace={item.namespace || ''} type={'virtualservice'}>
+                {vs}
+              </IstioObjectLink>
+            </li>
+          ))}
+        {destinationRules &&
+          destinationRules.length > 0 &&
+          destinationRules.map(dr => (
+            <li>
+              <PFBadge badge={PFBadges.DestinationRule} position={TooltipPosition.top} />
+              <IstioObjectLink name={dr} namespace={item.namespace || ''} type={'destinationrule'}>
+                {dr}
+              </IstioObjectLink>
+            </li>
+          ))}
       </ul>
     </td>
   );

--- a/src/components/VirtualList/Renderers.tsx
+++ b/src/components/VirtualList/Renderers.tsx
@@ -64,6 +64,13 @@ export const details: Renderer<AppListItem | WorkloadListItem | ServiceListItem>
   const spacer = hasMissingSC && additionalDetails && additionalDetails.icon;
   const virtualServices = (item as ServiceListItem).virtualServices;
   const destinationRules = (item as ServiceListItem).destinationRules;
+  const gateways = (item as WorkloadListItem).gateways;
+  const authorizationPolicies = (item as WorkloadListItem).authorizationPolicies;
+  const peerAuthentications = (item as WorkloadListItem).peerAuthentications;
+  const sidecars = (item as WorkloadListItem).sidecars;
+  const requestAuthentications = (item as WorkloadListItem).requestAuthentications;
+  const envoyFilters = (item as WorkloadListItem).envoyFilters;
+
   return (
     <td
       role="gridcell"
@@ -100,6 +107,66 @@ export const details: Renderer<AppListItem | WorkloadListItem | ServiceListItem>
               <PFBadge badge={PFBadges.DestinationRule} position={TooltipPosition.top} />
               <IstioObjectLink name={dr} namespace={item.namespace || ''} type={'destinationrule'}>
                 {dr}
+              </IstioObjectLink>
+            </li>
+          ))}
+        {gateways &&
+          gateways.length > 0 &&
+          gateways.map(dr => (
+            <li>
+              <PFBadge badge={PFBadges.DestinationRule} position={TooltipPosition.top} />
+              <IstioObjectLink name={dr} namespace={item.namespace || ''} type={'destinationrule'}>
+                {dr}
+              </IstioObjectLink>
+            </li>
+          ))}
+        {authorizationPolicies &&
+          authorizationPolicies.length > 0 &&
+          authorizationPolicies.map(ap => (
+            <li>
+              <PFBadge badge={PFBadges.AuthorizationPolicy} position={TooltipPosition.top} />
+              <IstioObjectLink name={ap} namespace={item.namespace || ''} type={'authorizationpolicy'}>
+                {ap}
+              </IstioObjectLink>
+            </li>
+          ))}
+        {peerAuthentications &&
+          peerAuthentications.length > 0 &&
+          peerAuthentications.map(pa => (
+            <li>
+              <PFBadge badge={PFBadges.PeerAuthentication} position={TooltipPosition.top} />
+              <IstioObjectLink name={pa} namespace={item.namespace || ''} type={'peerauthentication'}>
+                {pa}
+              </IstioObjectLink>
+            </li>
+          ))}
+        {sidecars &&
+          sidecars.length > 0 &&
+          sidecars.map(sc => (
+            <li>
+              <PFBadge badge={PFBadges.Sidecar} position={TooltipPosition.top} />
+              <IstioObjectLink name={sc} namespace={item.namespace || ''} type={'sidecar'}>
+                {sc}
+              </IstioObjectLink>
+            </li>
+          ))}
+        {requestAuthentications &&
+          requestAuthentications.length > 0 &&
+          requestAuthentications.map(ra => (
+            <li>
+              <PFBadge badge={PFBadges.RequestAuthentication} position={TooltipPosition.top} />
+              <IstioObjectLink name={ra} namespace={item.namespace || ''} type={'requestauthentication'}>
+                {ra}
+              </IstioObjectLink>
+            </li>
+          ))}
+        {envoyFilters &&
+          envoyFilters.length > 0 &&
+          envoyFilters.map(ef => (
+            <li>
+              <PFBadge badge={PFBadges.EnvoyFilter} position={TooltipPosition.top} />
+              <IstioObjectLink name={ef} namespace={item.namespace || ''} type={'envoyfilter'}>
+                {ef}
               </IstioObjectLink>
             </li>
           ))}

--- a/src/helpers/__tests__/LabelFilterHelper.test.ts
+++ b/src/helpers/__tests__/LabelFilterHelper.test.ts
@@ -10,14 +10,7 @@ const appList: AppListItem[] = [
     name: 'ratings',
     istioSidecar: false,
     labels: { app: 'ratings', service: 'ratings', version: 'v1' },
-    virtualServices: [],
-    destinationRules: [],
-    gateways: [],
-    authorizationPolicies: [],
-    peerAuthentications: [],
-    sidecars: [],
-    requestAuthentications: [],
-    envoyFilters: []
+    istioReferences: []
   },
   {
     namespace: 'bookinfo',
@@ -25,14 +18,7 @@ const appList: AppListItem[] = [
     name: 'productpage',
     istioSidecar: false,
     labels: { app: 'productpage', service: 'productpage', version: 'v1' },
-    virtualServices: [],
-    destinationRules: [],
-    gateways: [],
-    authorizationPolicies: [],
-    peerAuthentications: [],
-    sidecars: [],
-    requestAuthentications: [],
-    envoyFilters: []
+    istioReferences: []
   },
   {
     namespace: 'bookinfo',
@@ -40,14 +26,7 @@ const appList: AppListItem[] = [
     name: 'details',
     istioSidecar: false,
     labels: { app: 'details', service: 'details', version: 'v1' },
-    virtualServices: [],
-    destinationRules: [],
-    gateways: [],
-    authorizationPolicies: [],
-    peerAuthentications: [],
-    sidecars: [],
-    requestAuthentications: [],
-    envoyFilters: []
+    istioReferences: []
   },
   {
     namespace: 'bookinfo',
@@ -55,14 +34,7 @@ const appList: AppListItem[] = [
     name: 'reviews',
     istioSidecar: false,
     labels: { app: 'reviews', service: 'reviews', version: 'v1,v2,v3' },
-    virtualServices: [],
-    destinationRules: [],
-    gateways: [],
-    authorizationPolicies: [],
-    peerAuthentications: [],
-    sidecars: [],
-    requestAuthentications: [],
-    envoyFilters: []
+    istioReferences: []
   }
 ];
 
@@ -76,12 +48,7 @@ const workloadList: WorkloadListItem[] = [
     labels: { app: 'details', version: 'v1' },
     appLabel: true,
     versionLabel: true,
-    gateways: [],
-    authorizationPolicies: [],
-    peerAuthentications: [],
-    sidecars: [],
-    requestAuthentications: [],
-    envoyFilters: []
+    istioReferences: []
   },
   {
     namespace: 'bookinfo',
@@ -92,12 +59,7 @@ const workloadList: WorkloadListItem[] = [
     labels: { app: 'productpage', version: 'v1' },
     appLabel: true,
     versionLabel: true,
-    gateways: [],
-    authorizationPolicies: [],
-    peerAuthentications: [],
-    sidecars: [],
-    requestAuthentications: [],
-    envoyFilters: []
+    istioReferences: []
   },
   {
     namespace: 'bookinfo',
@@ -108,12 +70,7 @@ const workloadList: WorkloadListItem[] = [
     labels: { app: 'ratings', version: 'v1' },
     appLabel: true,
     versionLabel: true,
-    gateways: [],
-    authorizationPolicies: [],
-    peerAuthentications: [],
-    sidecars: [],
-    requestAuthentications: [],
-    envoyFilters: []
+    istioReferences: []
   },
   {
     namespace: 'bookinfo',
@@ -124,12 +81,7 @@ const workloadList: WorkloadListItem[] = [
     labels: { app: 'reviews', version: 'v1' },
     appLabel: true,
     versionLabel: true,
-    gateways: [],
-    authorizationPolicies: [],
-    peerAuthentications: [],
-    sidecars: [],
-    requestAuthentications: [],
-    envoyFilters: []
+    istioReferences: []
   },
   {
     namespace: 'bookinfo',
@@ -140,12 +92,7 @@ const workloadList: WorkloadListItem[] = [
     labels: { app: 'reviews', version: 'v2' },
     appLabel: true,
     versionLabel: true,
-    gateways: [],
-    authorizationPolicies: [],
-    peerAuthentications: [],
-    sidecars: [],
-    requestAuthentications: [],
-    envoyFilters: []
+    istioReferences: []
   },
   {
     namespace: 'bookinfo',
@@ -156,12 +103,7 @@ const workloadList: WorkloadListItem[] = [
     labels: { app: 'reviews', version: 'v3' },
     appLabel: true,
     versionLabel: true,
-    gateways: [],
-    authorizationPolicies: [],
-    peerAuthentications: [],
-    sidecars: [],
-    requestAuthentications: [],
-    envoyFilters: []
+    istioReferences: []
   }
 ];
 
@@ -173,8 +115,7 @@ const serviceList: ServiceListItem[] = [
     istioSidecar: false,
     labels: { app: 'details', service: 'details' },
     validation: { name: 'details', objectType: 'service', valid: true, checks: [] },
-    virtualServices: [],
-    destinationRules: [],
+    istioReferences: [],
     kialiWizard: ''
   },
   {
@@ -184,8 +125,7 @@ const serviceList: ServiceListItem[] = [
     istioSidecar: false,
     labels: { app: 'reviews', service: 'reviews' },
     validation: { name: 'reviews', objectType: 'service', valid: true, checks: [] },
-    virtualServices: [],
-    destinationRules: [],
+    istioReferences: [],
     kialiWizard: ''
   },
   {
@@ -195,8 +135,7 @@ const serviceList: ServiceListItem[] = [
     istioSidecar: false,
     labels: { app: 'ratings', service: 'ratings' },
     validation: { name: 'ratings', objectType: 'service', valid: true, checks: [] },
-    virtualServices: [],
-    destinationRules: [],
+    istioReferences: [],
     kialiWizard: ''
   },
   {
@@ -206,8 +145,7 @@ const serviceList: ServiceListItem[] = [
     istioSidecar: false,
     labels: { app: 'productpage', service: 'productpage' },
     validation: { name: 'productpage', objectType: 'service', valid: true, checks: [] },
-    virtualServices: [],
-    destinationRules: [],
+    istioReferences: [],
     kialiWizard: ''
   }
 ];
@@ -227,14 +165,7 @@ describe('LabelFilter', () => {
         name: 'details',
         istioSidecar: false,
         labels: { app: 'details', service: 'details', version: 'v1' },
-        virtualServices: [],
-        destinationRules: [],
-        gateways: [],
-        authorizationPolicies: [],
-        peerAuthentications: [],
-        sidecars: [],
-        requestAuthentications: [],
-        envoyFilters: []
+        istioReferences: []
       }
     ]);
   });
@@ -248,14 +179,7 @@ describe('LabelFilter', () => {
         name: 'reviews',
         istioSidecar: false,
         labels: { app: 'reviews', service: 'reviews', version: 'v1,v2,v3' },
-        virtualServices: [],
-        destinationRules: [],
-        gateways: [],
-        authorizationPolicies: [],
-        peerAuthentications: [],
-        sidecars: [],
-        requestAuthentications: [],
-        envoyFilters: []
+        istioReferences: []
       }
     ]);
   });
@@ -277,12 +201,7 @@ describe('LabelFilter', () => {
         labels: { app: 'reviews', version: 'v1' },
         appLabel: true,
         versionLabel: true,
-        gateways: [],
-        authorizationPolicies: [],
-        peerAuthentications: [],
-        sidecars: [],
-        requestAuthentications: [],
-        envoyFilters: []
+        istioReferences: []
       },
       {
         namespace: 'bookinfo',
@@ -293,12 +212,7 @@ describe('LabelFilter', () => {
         labels: { app: 'reviews', version: 'v2' },
         appLabel: true,
         versionLabel: true,
-        gateways: [],
-        authorizationPolicies: [],
-        peerAuthentications: [],
-        sidecars: [],
-        requestAuthentications: [],
-        envoyFilters: []
+        istioReferences: []
       },
       {
         namespace: 'bookinfo',
@@ -309,12 +223,7 @@ describe('LabelFilter', () => {
         labels: { app: 'reviews', version: 'v3' },
         appLabel: true,
         versionLabel: true,
-        gateways: [],
-        authorizationPolicies: [],
-        peerAuthentications: [],
-        sidecars: [],
-        requestAuthentications: [],
-        envoyFilters: []
+        istioReferences: []
       }
     ]);
   });
@@ -334,8 +243,7 @@ describe('LabelFilter', () => {
         istioSidecar: false,
         labels: { app: 'details', service: 'details' },
         validation: { name: 'details', objectType: 'service', valid: true, checks: [] },
-        virtualServices: [],
-        destinationRules: [],
+        istioReferences: [],
         kialiWizard: ''
       }
     ]);

--- a/src/helpers/__tests__/LabelFilterHelper.test.ts
+++ b/src/helpers/__tests__/LabelFilterHelper.test.ts
@@ -9,28 +9,60 @@ const appList: AppListItem[] = [
     healthPromise: new Promise(() => {}),
     name: 'ratings',
     istioSidecar: false,
-    labels: { app: 'ratings', service: 'ratings', version: 'v1' }
+    labels: { app: 'ratings', service: 'ratings', version: 'v1' },
+    virtualServices: [],
+    destinationRules: [],
+    gateways: [],
+    authorizationPolicies: [],
+    peerAuthentications: [],
+    sidecars: [],
+    requestAuthentications: [],
+    envoyFilters: []
   },
   {
     namespace: 'bookinfo',
     healthPromise: new Promise(() => {}),
     name: 'productpage',
     istioSidecar: false,
-    labels: { app: 'productpage', service: 'productpage', version: 'v1' }
+    labels: { app: 'productpage', service: 'productpage', version: 'v1' },
+    virtualServices: [],
+    destinationRules: [],
+    gateways: [],
+    authorizationPolicies: [],
+    peerAuthentications: [],
+    sidecars: [],
+    requestAuthentications: [],
+    envoyFilters: []
   },
   {
     namespace: 'bookinfo',
     healthPromise: new Promise(() => {}),
     name: 'details',
     istioSidecar: false,
-    labels: { app: 'details', service: 'details', version: 'v1' }
+    labels: { app: 'details', service: 'details', version: 'v1' },
+    virtualServices: [],
+    destinationRules: [],
+    gateways: [],
+    authorizationPolicies: [],
+    peerAuthentications: [],
+    sidecars: [],
+    requestAuthentications: [],
+    envoyFilters: []
   },
   {
     namespace: 'bookinfo',
     healthPromise: new Promise(() => {}),
     name: 'reviews',
     istioSidecar: false,
-    labels: { app: 'reviews', service: 'reviews', version: 'v1,v2,v3' }
+    labels: { app: 'reviews', service: 'reviews', version: 'v1,v2,v3' },
+    virtualServices: [],
+    destinationRules: [],
+    gateways: [],
+    authorizationPolicies: [],
+    peerAuthentications: [],
+    sidecars: [],
+    requestAuthentications: [],
+    envoyFilters: []
   }
 ];
 
@@ -43,7 +75,13 @@ const workloadList: WorkloadListItem[] = [
     istioSidecar: false,
     labels: { app: 'details', version: 'v1' },
     appLabel: true,
-    versionLabel: true
+    versionLabel: true,
+    gateways: [],
+    authorizationPolicies: [],
+    peerAuthentications: [],
+    sidecars: [],
+    requestAuthentications: [],
+    envoyFilters: []
   },
   {
     namespace: 'bookinfo',
@@ -53,7 +91,13 @@ const workloadList: WorkloadListItem[] = [
     istioSidecar: false,
     labels: { app: 'productpage', version: 'v1' },
     appLabel: true,
-    versionLabel: true
+    versionLabel: true,
+    gateways: [],
+    authorizationPolicies: [],
+    peerAuthentications: [],
+    sidecars: [],
+    requestAuthentications: [],
+    envoyFilters: []
   },
   {
     namespace: 'bookinfo',
@@ -63,7 +107,13 @@ const workloadList: WorkloadListItem[] = [
     istioSidecar: false,
     labels: { app: 'ratings', version: 'v1' },
     appLabel: true,
-    versionLabel: true
+    versionLabel: true,
+    gateways: [],
+    authorizationPolicies: [],
+    peerAuthentications: [],
+    sidecars: [],
+    requestAuthentications: [],
+    envoyFilters: []
   },
   {
     namespace: 'bookinfo',
@@ -73,7 +123,13 @@ const workloadList: WorkloadListItem[] = [
     istioSidecar: false,
     labels: { app: 'reviews', version: 'v1' },
     appLabel: true,
-    versionLabel: true
+    versionLabel: true,
+    gateways: [],
+    authorizationPolicies: [],
+    peerAuthentications: [],
+    sidecars: [],
+    requestAuthentications: [],
+    envoyFilters: []
   },
   {
     namespace: 'bookinfo',
@@ -83,7 +139,13 @@ const workloadList: WorkloadListItem[] = [
     istioSidecar: false,
     labels: { app: 'reviews', version: 'v2' },
     appLabel: true,
-    versionLabel: true
+    versionLabel: true,
+    gateways: [],
+    authorizationPolicies: [],
+    peerAuthentications: [],
+    sidecars: [],
+    requestAuthentications: [],
+    envoyFilters: []
   },
   {
     namespace: 'bookinfo',
@@ -93,7 +155,13 @@ const workloadList: WorkloadListItem[] = [
     istioSidecar: false,
     labels: { app: 'reviews', version: 'v3' },
     appLabel: true,
-    versionLabel: true
+    versionLabel: true,
+    gateways: [],
+    authorizationPolicies: [],
+    peerAuthentications: [],
+    sidecars: [],
+    requestAuthentications: [],
+    envoyFilters: []
   }
 ];
 
@@ -104,7 +172,10 @@ const serviceList: ServiceListItem[] = [
     name: 'details',
     istioSidecar: false,
     labels: { app: 'details', service: 'details' },
-    validation: { name: 'details', objectType: 'service', valid: true, checks: [] }
+    validation: { name: 'details', objectType: 'service', valid: true, checks: [] },
+    virtualServices: [],
+    destinationRules: [],
+    kialiWizard: ''
   },
   {
     namespace: 'bookinfo',
@@ -112,7 +183,10 @@ const serviceList: ServiceListItem[] = [
     name: 'reviews',
     istioSidecar: false,
     labels: { app: 'reviews', service: 'reviews' },
-    validation: { name: 'reviews', objectType: 'service', valid: true, checks: [] }
+    validation: { name: 'reviews', objectType: 'service', valid: true, checks: [] },
+    virtualServices: [],
+    destinationRules: [],
+    kialiWizard: ''
   },
   {
     namespace: 'bookinfo',
@@ -120,7 +194,10 @@ const serviceList: ServiceListItem[] = [
     name: 'ratings',
     istioSidecar: false,
     labels: { app: 'ratings', service: 'ratings' },
-    validation: { name: 'ratings', objectType: 'service', valid: true, checks: [] }
+    validation: { name: 'ratings', objectType: 'service', valid: true, checks: [] },
+    virtualServices: [],
+    destinationRules: [],
+    kialiWizard: ''
   },
   {
     namespace: 'bookinfo',
@@ -128,7 +205,10 @@ const serviceList: ServiceListItem[] = [
     name: 'productpage',
     istioSidecar: false,
     labels: { app: 'productpage', service: 'productpage' },
-    validation: { name: 'productpage', objectType: 'service', valid: true, checks: [] }
+    validation: { name: 'productpage', objectType: 'service', valid: true, checks: [] },
+    virtualServices: [],
+    destinationRules: [],
+    kialiWizard: ''
   }
 ];
 
@@ -146,7 +226,15 @@ describe('LabelFilter', () => {
         healthPromise: new Promise(() => {}),
         name: 'details',
         istioSidecar: false,
-        labels: { app: 'details', service: 'details', version: 'v1' }
+        labels: { app: 'details', service: 'details', version: 'v1' },
+        virtualServices: [],
+        destinationRules: [],
+        gateways: [],
+        authorizationPolicies: [],
+        peerAuthentications: [],
+        sidecars: [],
+        requestAuthentications: [],
+        envoyFilters: []
       }
     ]);
   });
@@ -159,7 +247,15 @@ describe('LabelFilter', () => {
         healthPromise: new Promise(() => {}),
         name: 'reviews',
         istioSidecar: false,
-        labels: { app: 'reviews', service: 'reviews', version: 'v1,v2,v3' }
+        labels: { app: 'reviews', service: 'reviews', version: 'v1,v2,v3' },
+        virtualServices: [],
+        destinationRules: [],
+        gateways: [],
+        authorizationPolicies: [],
+        peerAuthentications: [],
+        sidecars: [],
+        requestAuthentications: [],
+        envoyFilters: []
       }
     ]);
   });
@@ -180,7 +276,13 @@ describe('LabelFilter', () => {
         istioSidecar: false,
         labels: { app: 'reviews', version: 'v1' },
         appLabel: true,
-        versionLabel: true
+        versionLabel: true,
+        gateways: [],
+        authorizationPolicies: [],
+        peerAuthentications: [],
+        sidecars: [],
+        requestAuthentications: [],
+        envoyFilters: []
       },
       {
         namespace: 'bookinfo',
@@ -190,7 +292,13 @@ describe('LabelFilter', () => {
         istioSidecar: false,
         labels: { app: 'reviews', version: 'v2' },
         appLabel: true,
-        versionLabel: true
+        versionLabel: true,
+        gateways: [],
+        authorizationPolicies: [],
+        peerAuthentications: [],
+        sidecars: [],
+        requestAuthentications: [],
+        envoyFilters: []
       },
       {
         namespace: 'bookinfo',
@@ -200,7 +308,13 @@ describe('LabelFilter', () => {
         istioSidecar: false,
         labels: { app: 'reviews', version: 'v3' },
         appLabel: true,
-        versionLabel: true
+        versionLabel: true,
+        gateways: [],
+        authorizationPolicies: [],
+        peerAuthentications: [],
+        sidecars: [],
+        requestAuthentications: [],
+        envoyFilters: []
       }
     ]);
   });
@@ -219,7 +333,10 @@ describe('LabelFilter', () => {
         name: 'details',
         istioSidecar: false,
         labels: { app: 'details', service: 'details' },
-        validation: { name: 'details', objectType: 'service', valid: true, checks: [] }
+        validation: { name: 'details', objectType: 'service', valid: true, checks: [] },
+        virtualServices: [],
+        destinationRules: [],
+        kialiWizard: ''
       }
     ]);
   });

--- a/src/pages/AppList/AppListClass.tsx
+++ b/src/pages/AppList/AppListClass.tsx
@@ -8,7 +8,15 @@ export const getAppItems = (data: AppList, rateInterval: number): AppListItem[] 
       name: app.name,
       istioSidecar: app.istioSidecar,
       healthPromise: API.getAppHealth(data.namespace.name, app.name, rateInterval, app.istioSidecar),
-      labels: app.labels
+      labels: app.labels,
+      virtualServices: app.virtualServices,
+      destinationRules: app.destinationRules,
+      gateways: app.gateways,
+      authorizationPolicies: app.authorizationPolicies,
+      peerAuthentications: app.peerAuthentications,
+      sidecars: app.sidecars,
+      requestAuthentications: app.requestAuthentications,
+      envoyFilters: app.envoyFilters
     }));
   }
   return [];

--- a/src/pages/AppList/AppListClass.tsx
+++ b/src/pages/AppList/AppListClass.tsx
@@ -1,5 +1,6 @@
 import { AppList, AppListItem } from '../../types/AppList';
 import * as API from '../../services/Api';
+import { sortIstioReferences } from './FiltersAndSorts';
 
 export const getAppItems = (data: AppList, rateInterval: number): AppListItem[] => {
   if (data.applications) {
@@ -9,14 +10,7 @@ export const getAppItems = (data: AppList, rateInterval: number): AppListItem[] 
       istioSidecar: app.istioSidecar,
       healthPromise: API.getAppHealth(data.namespace.name, app.name, rateInterval, app.istioSidecar),
       labels: app.labels,
-      virtualServices: app.virtualServices,
-      destinationRules: app.destinationRules,
-      gateways: app.gateways,
-      authorizationPolicies: app.authorizationPolicies,
-      peerAuthentications: app.peerAuthentications,
-      sidecars: app.sidecars,
-      requestAuthentications: app.requestAuthentications,
-      envoyFilters: app.envoyFilters
+      istioReferences: sortIstioReferences(app.istioReferences, true)
     }));
   }
   return [];

--- a/src/pages/ServiceList/ServiceListPage.tsx
+++ b/src/pages/ServiceList/ServiceListPage.tsx
@@ -19,6 +19,7 @@ import { activeNamespacesSelector, durationSelector } from '../../store/Selector
 import DefaultSecondaryMasthead from '../../components/DefaultSecondaryMasthead/DefaultSecondaryMasthead';
 import { connect } from 'react-redux';
 import TimeDurationContainer from '../../components/Time/TimeDurationComponent';
+import { sortIstioReferences } from '../AppList/FiltersAndSorts';
 
 type ServiceListPageState = FilterComponent.State<ServiceListItem>;
 
@@ -103,8 +104,7 @@ class ServiceListPageComponent extends FilterComponent.Component<
         validation: this.getServiceValidation(service.name, data.validations),
         additionalDetailSample: service.additionalDetailSample,
         labels: service.labels || {},
-        virtualServices: service.virtualServices,
-        destinationRules: service.destinationRules,
+        istioReferences: sortIstioReferences(service.istioReferences, true),
         kialiWizard: service.kialiWizard
       }));
     }

--- a/src/pages/ServiceList/ServiceListPage.tsx
+++ b/src/pages/ServiceList/ServiceListPage.tsx
@@ -102,7 +102,10 @@ class ServiceListPageComponent extends FilterComponent.Component<
         healthPromise: API.getServiceHealth(data.namespace.name, service.name, rateInterval, service.istioSidecar),
         validation: this.getServiceValidation(service.name, data.validations),
         additionalDetailSample: service.additionalDetailSample,
-        labels: service.labels || {}
+        labels: service.labels || {},
+        virtualService: service.virtualService,
+        destinationRule: service.destinationRule,
+        kialiWizard: service.kialiWizard
       }));
     }
     return [];

--- a/src/pages/ServiceList/ServiceListPage.tsx
+++ b/src/pages/ServiceList/ServiceListPage.tsx
@@ -103,8 +103,8 @@ class ServiceListPageComponent extends FilterComponent.Component<
         validation: this.getServiceValidation(service.name, data.validations),
         additionalDetailSample: service.additionalDetailSample,
         labels: service.labels || {},
-        virtualService: service.virtualService,
-        destinationRule: service.destinationRule,
+        virtualServices: service.virtualServices,
+        destinationRules: service.destinationRules,
         kialiWizard: service.kialiWizard
       }));
     }

--- a/src/pages/WorkloadList/WorkloadListPage.tsx
+++ b/src/pages/WorkloadList/WorkloadListPage.tsx
@@ -107,7 +107,13 @@ class WorkloadListPageComponent extends FilterComponent.Component<
           this.props.duration,
           deployment.istioSidecar
         ),
-        labels: deployment.labels
+        labels: deployment.labels,
+        gateways: deployment.gateways,
+        authorizationPolicies: deployment.authorizationPolicies,
+        peerAuthentications: deployment.peerAuthentications,
+        sidecars: deployment.sidecars,
+        requestAuthentications: deployment.requestAuthentications,
+        envoyFilters: deployment.envoyFilters
       }));
     }
     return [];

--- a/src/pages/WorkloadList/WorkloadListPage.tsx
+++ b/src/pages/WorkloadList/WorkloadListPage.tsx
@@ -18,6 +18,7 @@ import { activeNamespacesSelector, durationSelector } from '../../store/Selector
 import { connect } from 'react-redux';
 import DefaultSecondaryMasthead from '../../components/DefaultSecondaryMasthead/DefaultSecondaryMasthead';
 import TimeDurationContainer from '../../components/Time/TimeDurationComponent';
+import { sortIstioReferences } from '../AppList/FiltersAndSorts';
 
 type WorkloadListPageState = FilterComponent.State<WorkloadListItem>;
 
@@ -108,12 +109,7 @@ class WorkloadListPageComponent extends FilterComponent.Component<
           deployment.istioSidecar
         ),
         labels: deployment.labels,
-        gateways: deployment.gateways,
-        authorizationPolicies: deployment.authorizationPolicies,
-        peerAuthentications: deployment.peerAuthentications,
-        sidecars: deployment.sidecars,
-        requestAuthentications: deployment.requestAuthentications,
-        envoyFilters: deployment.envoyFilters
+        istioReferences: sortIstioReferences(deployment.istioReferences, true)
       }));
     }
     return [];

--- a/src/types/AppList.ts
+++ b/src/types/AppList.ts
@@ -1,5 +1,6 @@
 import Namespace from './Namespace';
 import { AppHealth } from './Health';
+import { ObjectReference } from './IstioObjects';
 
 export interface AppList {
   namespace: Namespace;
@@ -10,14 +11,7 @@ export interface AppOverview {
   name: string;
   istioSidecar: boolean;
   labels: { [key: string]: string };
-  virtualServices: string[];
-  destinationRules: string[];
-  gateways: string[];
-  authorizationPolicies: string[];
-  peerAuthentications: string[];
-  sidecars: string[];
-  requestAuthentications: string[];
-  envoyFilters: string[];
+  istioReferences: ObjectReference[];
 }
 
 export interface AppListItem extends AppOverview {

--- a/src/types/AppList.ts
+++ b/src/types/AppList.ts
@@ -10,6 +10,14 @@ export interface AppOverview {
   name: string;
   istioSidecar: boolean;
   labels: { [key: string]: string };
+  virtualServices: string[];
+  destinationRules: string[];
+  gateways: string[];
+  authorizationPolicies: string[];
+  peerAuthentications: string[];
+  sidecars: string[];
+  requestAuthentications: string[];
+  envoyFilters: string[];
 }
 
 export interface AppListItem extends AppOverview {

--- a/src/types/ServiceList.ts
+++ b/src/types/ServiceList.ts
@@ -14,8 +14,8 @@ export interface ServiceOverview {
   istioSidecar: boolean;
   additionalDetailSample?: AdditionalItem;
   labels: { [key: string]: string };
-  virtualService: boolean;
-  destinationRule: boolean;
+  virtualServices: string[];
+  destinationRules: string[];
   kialiWizard: boolean;
 }
 

--- a/src/types/ServiceList.ts
+++ b/src/types/ServiceList.ts
@@ -1,6 +1,6 @@
 import Namespace from './Namespace';
 import { ServiceHealth } from './Health';
-import { Validations, ObjectValidation } from './IstioObjects';
+import { Validations, ObjectValidation, ObjectReference } from './IstioObjects';
 import { AdditionalItem } from './Workload';
 
 export interface ServiceList {
@@ -14,8 +14,7 @@ export interface ServiceOverview {
   istioSidecar: boolean;
   additionalDetailSample?: AdditionalItem;
   labels: { [key: string]: string };
-  virtualServices: string[];
-  destinationRules: string[];
+  istioReferences: ObjectReference[];
   kialiWizard: string;
 }
 

--- a/src/types/ServiceList.ts
+++ b/src/types/ServiceList.ts
@@ -16,7 +16,7 @@ export interface ServiceOverview {
   labels: { [key: string]: string };
   virtualServices: string[];
   destinationRules: string[];
-  kialiWizard: boolean;
+  kialiWizard: string;
 }
 
 export interface ServiceListItem extends ServiceOverview {

--- a/src/types/ServiceList.ts
+++ b/src/types/ServiceList.ts
@@ -14,6 +14,9 @@ export interface ServiceOverview {
   istioSidecar: boolean;
   additionalDetailSample?: AdditionalItem;
   labels: { [key: string]: string };
+  virtualService: boolean;
+  destinationRule: boolean;
+  kialiWizard: boolean;
 }
 
 export interface ServiceListItem extends ServiceOverview {

--- a/src/types/Workload.ts
+++ b/src/types/Workload.ts
@@ -62,6 +62,12 @@ export interface WorkloadOverview {
   appLabel: boolean;
   versionLabel: boolean;
   labels: { [key: string]: string };
+  gateways: string[];
+  authorizationPolicies: string[];
+  peerAuthentications: string[];
+  sidecars: string[];
+  requestAuthentications: string[];
+  envoyFilters: string[];
 }
 
 export interface WorkloadListItem extends WorkloadOverview {

--- a/src/types/Workload.ts
+++ b/src/types/Workload.ts
@@ -1,6 +1,6 @@
 import Namespace from './Namespace';
 import { WorkloadHealth } from './Health';
-import { Pod, Service } from './IstioObjects';
+import { ObjectReference, Pod, Service } from './IstioObjects';
 
 export interface WorkloadId {
   namespace: string;
@@ -62,12 +62,7 @@ export interface WorkloadOverview {
   appLabel: boolean;
   versionLabel: boolean;
   labels: { [key: string]: string };
-  gateways: string[];
-  authorizationPolicies: string[];
-  peerAuthentications: string[];
-  sidecars: string[];
-  requestAuthentications: string[];
-  envoyFilters: string[];
+  istioReferences: ObjectReference[];
 }
 
 export interface WorkloadListItem extends WorkloadOverview {


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/1446

This PR adds Istio config used in Services and Workloads in the list pages, allowing to browser in multi-namespace list which services have Istio config. Sorting and filtering are supported on this.
![image](https://user-images.githubusercontent.com/1662329/124274551-b1f65480-db41-11eb-96e2-a0ae5a846f5e.png)
![image](https://user-images.githubusercontent.com/1662329/124274579-bae72600-db41-11eb-9a7c-bd82808af80b.png)

Similar for workloads:
![image](https://user-images.githubusercontent.com/1662329/124274610-c5092480-db41-11eb-8ac6-cbb91dba2ce6.png)
![image](https://user-images.githubusercontent.com/1662329/124274633-cd615f80-db41-11eb-9f73-82259c1d6c53.png)

Also, adding this info into the applications as a join view of services and workloads:
![image](https://user-images.githubusercontent.com/1662329/124274726-e66a1080-db41-11eb-8c66-10fe8fea89fc.png)

This issue was filled some time ago but it was not implemented as Kiali didn't support caching all resources.
Now all extra queries are fetched from memory, so it wouldn't add a significant impact on the request.
