### PR TITLE
Make request routing icon the leftmost for consistency

### DIFF
--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -225,9 +225,6 @@ export class GraphStyles {
         if (!hasKialiScenario) {
           icons = `<span class="${NodeIconVS} ${iconMargin(icons)}"></span> ${icons}`;
         } else {
-          if (node.hasRequestRouting) {
-            icons = `<span class="${NodeIconRequestRouting} ${iconMargin(icons)}"></span> ${icons}`;
-          }
           if (node.hasFaultInjection) {
             icons = `<span class="${NodeIconFaultInjection} ${iconMargin(icons)}"></span> ${icons}`;
           }
@@ -236,6 +233,9 @@ export class GraphStyles {
           }
           if (node.hasRequestTimeout) {
             icons = `<span class="${NodeIconRequestTimeout} ${iconMargin(icons)}"></span> ${icons}`;
+          }
+          if (node.hasRequestRouting) {
+            icons = `<span class="${NodeIconRequestRouting} ${iconMargin(icons)}"></span> ${icons}`;
           }
         }
       }

--- a/src/components/CytoscapeGraph/graphs/__tests__/GraphStyles.test.ts
+++ b/src/components/CytoscapeGraph/graphs/__tests__/GraphStyles.test.ts
@@ -110,4 +110,14 @@ describe('GraphStyles test', () => {
     const firstSpanEnd = label.search('</span>');
     expect(label.substring(firstSpanBegin, firstSpanEnd)).toContain(icons.istio.root.className);
   });
+
+  it('displays request routing icon before other kiali scenarios', () => {
+    const data = { ...nodeData, hasVS: true, hasTCPTrafficShifting: true, hasRequestRouting: true };
+    const node = setupNode(data);
+    const label = GraphStyles.getNodeLabel(node);
+
+    const firstSpanBegin = label.search('<span');
+    const firstSpanEnd = label.search('</span>');
+    expect(label.substring(firstSpanBegin, firstSpanEnd)).toContain(icons.istio.requestRouting.className);
+  });
 });


### PR DESCRIPTION
Aside from root nodes, this moves the request routing icon to be the leftmost icon for consistency's sake so that the current VS icon always appears as the leftmost one.

![Screenshot from 2021-07-15 14-49-48](https://user-images.githubusercontent.com/6226732/125841509-f54afb08-b81b-4113-83cd-998cb16d6bb2.png)

Relates to kiali/kiali#4090 but is not required and can be merged independently of those changes.

