### PR TITLE
Show editor sidepanel when there are only validation references

### DIFF
--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -368,8 +368,8 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
     return istioObject ? jsYaml.safeDump(istioObject, safeDumpOptions) : '';
   };
 
-  getStatusMessages = (): ValidationMessage[] => {
-    const istioObject = getIstioObject(this.state.istioObjectDetails);
+  getStatusMessages = (istioConfigDetails?: IstioConfigDetails): ValidationMessage[] => {
+    const istioObject = getIstioObject(istioConfigDetails);
     return istioObject && istioObject.status && istioObject.status.validationMessages
       ? istioObject.status.validationMessages
       : ([] as ValidationMessage[]);
@@ -383,8 +383,9 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
     );
   };
 
-  objectReferences = (): ObjectReference[] => {
-    const istioValidations: ObjectValidation = this.state.istioValidations || ({} as ObjectValidation);
+  objectReferences = (istioConfigDetails?: IstioConfigDetails): ObjectReference[] => {
+    const details: IstioConfigDetails = istioConfigDetails || ({} as IstioConfigDetails);
+    const istioValidations: ObjectValidation = details.validation || ({} as ObjectValidation);
     return istioValidations.references || ([] as ObjectReference[]);
   };
 
@@ -418,7 +419,7 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
   isExpanded = (istioConfigDetails?: IstioConfigDetails) => {
     let isExpanded = false;
     if (istioConfigDetails) {
-      isExpanded = this.showCards(this.objectReferences().length > 0, this.getStatusMessages());
+      isExpanded = this.showCards(this.objectReferences(istioConfigDetails).length > 0, this.getStatusMessages(istioConfigDetails));
     }
     return isExpanded;
   };
@@ -429,8 +430,8 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
 
   renderEditor = () => {
     const yamlSource = this.fetchYaml();
-    const istioStatusMsgs = this.getStatusMessages();
-    const objectReferences = this.objectReferences();
+    const istioStatusMsgs = this.getStatusMessages(this.state.istioObjectDetails);
+    const objectReferences = this.objectReferences(this.state.istioObjectDetails);
     const refPresent = objectReferences.length > 0;
     const showCards = this.showCards(refPresent, istioStatusMsgs);
     let editorValidations: AceValidations = {


### PR DESCRIPTION
**Bug**:
1. When one istio config has validations
2. When the validation has a referenced resource
3. The istioConfig details page doesn't show the side panel and therefore the references are not visible
4. By default, the side panel should be visible when there are references or messages.

![Screenshot of Kiali Console (14)](https://user-images.githubusercontent.com/613814/126505672-93182459-f10f-466a-a1a3-3fc6bf03f3ee.png)

**Fixed issue**:
By default the side panel is present when at least one reference is present.
![Screenshot of Kiali Console (15)](https://user-images.githubusercontent.com/613814/126505813-a04b2a03-f09a-4cf2-b8e0-30b291b009df.png)

** Steps to reproduce **:
One validation that has references is [KIA0003](https://kiali.io/documentation/latest/validations/#_kia0003_more_than_one_object_applied_to_the_same_workload)

```yaml
k apply -n bookinfo -f - <<EOF
kind: Sidecar
apiVersion: networking.istio.io/v1alpha3
metadata:
  name: test-1
  namespace: bookinfo
spec:
  workloadSelector:
    labels:
      app: reviews
  ingress: ~
  egress:
    - hosts:
        - istio-system/*
        - istio-system/reviews.bookinfo.svc.cluster.local
  outboundTrafficPolicy: ~
  localhost: ~
---
kind: Sidecar
apiVersion: networking.istio.io/v1alpha3
metadata:
  name: test-2
  namespace: bookinfo
spec:
  workloadSelector:
    labels:
      app: reviews
  ingress: ~
  egress:
    - hosts:
        - istio-system/*
        - bookinfo/review.bookinfo
  outboundTrafficPolicy: ~
  localhost: ~
EOF
```