### PR TITLE
Prefix validation message with the now explicit code

### DIFF
--- a/src/components/Validations/GlobalValidation.tsx
+++ b/src/components/Validations/GlobalValidation.tsx
@@ -63,7 +63,7 @@ class GlobalValidation extends React.Component<Props> {
 
   message(): string {
     const checks = this.globalChecks();
-    let message = checks.map(check => check.message).join(',');
+    let message = checks.map(check => (check.code ? check.code + ' ' : '') + check.message).join(',');
 
     if (!message.length && !this.isValid()) {
       message = 'Not all checks passed!';

--- a/src/components/Validations/ValidationList.tsx
+++ b/src/components/Validations/ValidationList.tsx
@@ -12,7 +12,13 @@ type Props = {
 class ValidationList extends React.Component<Props> {
   content() {
     return (this.props.checks || []).map((check, index) => {
-      return <Validation key={'validation-check-' + index} severity={check.severity} message={check.message} />;
+      return (
+        <Validation
+          key={'validation-check-' + index}
+          severity={check.severity}
+          message={(check.code ? check.code + ' ' : '') + check.message}
+        />
+      );
     });
   }
 

--- a/src/components/Validations/ValidationStack.tsx
+++ b/src/components/Validations/ValidationStack.tsx
@@ -18,7 +18,11 @@ class ValidationStack extends React.Component<Props> {
     return (this.props.checks || []).map((check, index) => {
       return (
         <StackItem key={'validation-check-item-' + index} className={colorStyle}>
-          <Validation key={'validation-check-' + index} severity={check.severity} message={check.message} />
+          <Validation
+            key={'validation-check-' + index}
+            severity={check.severity}
+            message={(check.code ? check.code + ' ' : '') + check.message}
+          />
         </StackItem>
       );
     });

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceOverview.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceOverview.tsx
@@ -49,7 +49,7 @@ class VirtualServiceOverview extends React.Component<VirtualServiceProps> {
     const severity = highestSeverity(checks);
 
     return {
-      message: checks.map(check => check.message).join(','),
+      message: checks.map(check => (check.code ? check.code + ' ' : '') + check.message).join(','),
       severity
     };
   }

--- a/src/types/AceValidations.ts
+++ b/src/types/AceValidations.ts
@@ -168,7 +168,7 @@ const parseCheck = (yaml: string, check: ObjectCheck): AceCheck => {
     row: 0,
     column: 0,
     type: severity,
-    text: check.message
+    text: (check.code ? check.code + ' ' : '') + check.message
   };
   let aceMarker = {
     startRow: 0,

--- a/src/types/IstioObjects.ts
+++ b/src/types/IstioObjects.ts
@@ -90,6 +90,7 @@ export interface ObjectValidation {
 }
 
 export interface ObjectCheck {
+  code?: string;
   message: string;
   severity: ValidationTypes;
   path: string;


### PR DESCRIPTION
Part of: https://github.com/kiali/kiali/issues/4197

This goes with PR https://github.com/kiali/kiali/pull/4205 - see that for more details.

I don't like this PR because there should be a common function you can call that takes a "check" object as an input parameter and returns the full message string (which is prefixed with `code` if it is not empty - e.g. `return (check.code ? check.code + ' ' : '') + check.message).` Right now that expression is everywhere that `check.message` was before. Someone enhance this PR so it does that :)