### PR TITLE
Convention for redux props usage into props components types

### DIFF
--- a/STYLE_GUIDE.adoc
+++ b/STYLE_GUIDE.adoc
@@ -91,29 +91,26 @@ of the rules needed:
 The declaration of the properties of a component connected to Redux should clearly indicate whether each property comes from Redux or are strictly from the component.
 This convention should help developers easily see which properties comes from the Redux state management without the need to be either versed with the whole Redux catalog or the component itself.
 
-The convention is to
-* Declare a type A which only contains the Redux properties.
-* Declare a type B which only contains the properties from the component.
-* Intersect type A into type B.
-* Use type B for the component declaration.
+The convention is consist in:
+
+* Declaring a type `ReduxProps` which only contains the Redux properties, sorted alphabetically.
+* Declaring a type `<ClassName>Props` which only contains the properties from the component, sorted alphabetically.
+* Intersecting type `ReduxProps` into type `<ClassName>Props`.
+* Using `<ClassName>Props` type for the component declaration.
 
 See an example:
 
 [source, typescript]
 ----
 type ReduxProps = {
- setLastRefreshAt: (lastRefreshAt: TimeInMilliseconds) => void;
+ // just the Redux props, alphabetical
 };
 
-type Props = ReduxProps & {
- objectName: string;
- readOnly: boolean;
- canUpdate: boolean;
- showOverview: boolean;
- overview: boolean;
-}
+type <ClassName>Props = ReduxProps & {
+ // non-Redux props, alphabetical
+};
 
-class StyleComponent extends React.Component<Props> {
+class <ClassName>Component extends React.Component<Props> {
 ...
 }
 ----

--- a/STYLE_GUIDE.adoc
+++ b/STYLE_GUIDE.adoc
@@ -65,13 +65,15 @@ createItem = () => {
 }
 ----
 
-= Redux and Type-safe Use
+= Redux
+
+== Type-safe usage
 
 For additional type safety in our Redux Actions/Reducers, we use the library:
 https://github.com/piotrwitek/typesafe-actions
 Please refer to this site for instructions on how to use typescript with Redux.
 
-= Redux and URL Consistency
+== URL Consistency
 
 Every application page should strive to have it's state in Redux so that
 we have a reproducible application state contained in Redux.
@@ -83,3 +85,35 @@ of the rules needed:
 * On component construction let URL param values override any existing redux state values.
 * On component construction set (via replace) any unset URL params to reflect the redux state value. This gives us a full bookmark at all times.
 * After construction update URL (via replace) as necessary to reflect redux state changes. This is typically done in _componentDidUpdate_. This maintains the full bookmark.
+
+== Redux props usage
+
+The declaration of the properties of a component connected to Redux should clearly indicate whether each property comes from Redux or are strictly from the component.
+This convention should help developers easily see which properties comes from the Redux state management without the need to be either versed with the whole Redux catalog or the component itself.
+
+The convention is to
+* Declare a type A which only contains the Redux properties.
+* Declare a type B which only contains the properties from the component.
+* Intersect type A into type B.
+* Use type B for the component declaration.
+
+See an example:
+
+[source, typescript]
+----
+type ReduxProps = {
+ setLastRefreshAt: (lastRefreshAt: TimeInMilliseconds) => void;
+};
+
+type Props = ReduxProps & {
+ objectName: string;
+ readOnly: boolean;
+ canUpdate: boolean;
+ showOverview: boolean;
+ overview: boolean;
+}
+
+class StyleComponent extends React.Component<Props> {
+...
+}
+----


### PR DESCRIPTION
I had the conception that we were using the following convention for specifying redux props:

https://github.com/kiali/kiali-ui/blob/ff87e9a66894ef0f13c01a7b8f086c7a282a9aa4/src/components/IstioActions/IstioActionsButtons.tsx#L10-L24

@lucasponce proof me wrong here, which I thank for it.
https://github.com/kiali/kiali-ui/pull/2212/files#r694932209

So I thought that we could kind of agree on a way to go altogether.
I propose to use the way as linked right above.

What do you think?