### PR TITLE
Display Envoy tab for workloads running Istio Proxy without Sidecar

### DIFF
--- a/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
+++ b/src/pages/WorkloadDetails/WorkloadDetailsPage.tsx
@@ -163,7 +163,6 @@ class WorkloadDetails extends React.Component<WorkloadDetailsPageProps, Workload
         </Tab>
       );
     }
-
     if (this.state.workload && this.hasIstioSidecars(this.state.workload)) {
       const envoyTab = (
         <Tab title="Envoy" eventKey={10} key={'Envoy'}>
@@ -189,10 +188,12 @@ class WorkloadDetails extends React.Component<WorkloadDetailsPageProps, Workload
       workload.pods.forEach(pod => {
         if (pod.istioContainers && pod.istioContainers.length > 0) {
           hasIstioSidecars = true;
+        } else {
+          hasIstioSidecars =
+            hasIstioSidecars || (!!pod.containers && pod.containers.some(cont => cont.name === 'istio-proxy'));
         }
       });
     }
-
     return hasIstioSidecars;
   }
 


### PR DESCRIPTION
Fix https://github.com/kiali/kiali/issues/4165

I was thinking about to add some check in this case to avoid error in envoy tab (check that there is a configDump)

But this is going to increase the consuming and maybe it's not necessary I don't think there are many cases

![Screenshot from 2021-09-01 11-02-44](https://user-images.githubusercontent.com/3019213/131643660-7c922bce-a7f4-46ea-be24-d8a3346ff981.png)
