### PR TITLE
Added the default 'mesh' and appropriate tooltip in gateway section of VirtualService overview, when no gateway is set.

### DIFF
--- a/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceOverview.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceOverview.tsx
@@ -115,6 +115,32 @@ class VirtualServiceOverview extends React.Component<VirtualServiceProps> {
     );
   }
 
+  generateEmptyGateways() {
+    return (
+      <>
+        <Text component={TextVariants.h3}>Gateways</Text>
+        <ul className={'details'}>
+          <li key={'gateway_mesh'}>
+            <div>
+              mesh
+              <Tooltip
+                position={TooltipPosition.right}
+                content={
+                  <div style={{ textAlign: 'left' }}>
+                    When this field is omitted, the default gateway (mesh) will be used, which would apply the rule to
+                    all sidecars in the mesh
+                  </div>
+                }
+              >
+                <KialiIcon.Info className={infoStyle} />
+              </Tooltip>
+            </div>
+          </li>
+        </ul>
+      </>
+    );
+  }
+
   generateServiceList(routes: HTTPRoute[] | TLSRoute[] | TCPRoute[], isValid: boolean) {
     const hosts: string[] = [];
     routes.forEach(route => {
@@ -155,6 +181,9 @@ class VirtualServiceOverview extends React.Component<VirtualServiceProps> {
         <Stack>
           {virtualService.spec.gateways && virtualService.spec.gateways.length > 0 && (
             <StackItem id={'gateways'}>{this.generateGatewaysList(virtualService.spec.gateways, isValid)}</StackItem>
+          )}
+          {(!virtualService.spec.gateways || virtualService.spec.gateways.length === 0) && (
+            <StackItem id={'gateways'}>{this.generateEmptyGateways()}</StackItem>
           )}
           {protocols.map((protocol, i) => {
             const { name, object } = protocol;

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceOverview.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/VirtualServiceOverview.tsx
@@ -127,8 +127,8 @@ class VirtualServiceOverview extends React.Component<VirtualServiceProps> {
                 position={TooltipPosition.right}
                 content={
                   <div style={{ textAlign: 'left' }}>
-                    When this field is omitted, the default gateway (mesh) will be used, which would apply the rule to
-                    all sidecars in the mesh
+                    When the gateways field is omitted, the default gateway (mesh) will be used, which would apply the
+                    rule to all sidecars in the mesh
                   </div>
                 }
               >


### PR DESCRIPTION
Fix for RFE: https://github.com/kiali/kiali/issues/1440