### PR TITLE
Add ability to set proxy log level for workload pod

### DIFF
--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -155,6 +155,7 @@ const conf = {
       pod: (namespace: string, pod: string) => `api/namespaces/${namespace}/pods/${pod}`,
       podLogs: (namespace: string, pod: string) => `api/namespaces/${namespace}/pods/${pod}/logs`,
       podEnvoyProxy: (namespace: string, pod: string) => `api/namespaces/${namespace}/pods/${pod}/config_dump`,
+      podEnvoyProxyLogging: (namespace: string, pod: string) => `api/namespaces/${namespace}/pods/${pod}/logging`,
       podEnvoyProxyResourceEntries: (namespace: string, pod: string, resource: string) =>
         `api/namespaces/${namespace}/pods/${pod}/config_dump/${resource}`,
       serverConfig: `api/config`,

--- a/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
+++ b/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
@@ -6,7 +6,6 @@ import {
   CardBody,
   Grid,
   GridItem,
-  Popover,
   TextInput,
   Toolbar,
   ToolbarGroup,
@@ -43,6 +42,7 @@ import { TracingQuery, Span } from 'types/Tracing';
 import { AxiosResponse } from 'axios';
 import moment from 'moment';
 import { formatDuration } from 'utils/tracing/TracingHelper';
+import { infoStyle } from 'styles/DropdownStyles';
 
 const appContainerColors = [PFColors.White, PFColors.LightGreen400, PFColors.Purple100, PFColors.LightBlue400];
 const proxyContainerColor = PFColors.Gold400;
@@ -482,6 +482,7 @@ export class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, Workl
   };
 
   private getLogsDiv = () => {
+    const hasProxyContainer = this.state.containerOptions?.some(opt => opt.isProxy);
     const logDropDowns = Object.keys(LogLevel).map(level => {
       return (
         <DropdownItem
@@ -496,23 +497,25 @@ export class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, Workl
     });
     const dropdownGroupLabel = (
       // nowrap is needed for the info icon to appear on same line as the label text
-      <Popover
-        headerContent="Setting Proxy Logger Level"
-        bodyContent={
-          <span>
-            This action configures the <b>application</b> log level for the proxy but will not affect the <b>access</b>{' '}
-            logs. Setting the log level to 'off' will <b>not</b> disable access logging. To hide all proxy logging from
-            the logs view, un-check the 'istio-proxy' container.
-          </span>
-        }
-      >
-        <div style={{ whiteSpace: 'nowrap' }}>
-          Set Proxy Log Level
-          <Button variant={ButtonVariant.link} style={{ paddingLeft: '6px' }}>
-            <KialiIcon.Info className={defaultIconStyle} />
-          </Button>
-        </div>
-      </Popover>
+      <div style={{ whiteSpace: 'nowrap' }}>
+        Set Proxy Log Level
+        <Tooltip
+          position={TooltipPosition.right}
+          content={
+            <div style={{ textAlign: 'left' }}>
+              <div>
+                This action configures the proxy logger level but does not affect the proxy <b>access</b> logs. Setting
+                the log level to 'off' disables the proxy loggers but does <b>not</b> disable access logging. To hide
+                all proxy logging from the logs view, including access logs, un-check the proxy container. <br />
+                <br />
+                This option is disabled for pods with no proxy container.
+              </div>
+            </div>
+          }
+        >
+          <KialiIcon.Info className={infoStyle} />
+        </Tooltip>
+      </div>
     );
 
     const kebabActions = [
@@ -527,7 +530,7 @@ export class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, Workl
       </DropdownItem>,
       <DropdownSeparator key="logLevelSeparator" />,
       <DropdownGroup label={dropdownGroupLabel} key="setLogLevels">
-        {logDropDowns}
+        {hasProxyContainer && logDropDowns}
       </DropdownGroup>
     ];
 

--- a/src/pages/WorkloadDetails/__tests__/WorkloadPodLogs.test.tsx
+++ b/src/pages/WorkloadDetails/__tests__/WorkloadPodLogs.test.tsx
@@ -1,0 +1,77 @@
+import * as React from 'react';
+import { mount, shallow } from 'enzyme';
+import screenfull, { Screenfull } from 'screenfull';
+import { setPodEnvoyProxyLogLevel } from '../../../services/Api';
+import { WorkloadPodLogs } from '../WorkloadPodLogs';
+import { Dropdown, DropdownItem, KebabToggle } from '@patternfly/react-core';
+
+jest.mock('screenfull');
+jest.mock('../../../services/Api', () => {
+  const originalModule = (jest as any).requireActual('../../../services/Api');
+
+  return {
+    __esModule: true,
+    ...originalModule,
+    setPodEnvoyProxyLogLevel: jest.fn(() => Promise.resolve(undefined))
+  };
+});
+
+let defaultProps = {
+  lastRefreshAt: 200,
+  timeRange: {},
+  namespace: 'namespace',
+  pods: [],
+  workload: 'workload'
+};
+
+describe('WorkloadPodLogs', () => {
+  beforeEach(() => {
+    (screenfull as Screenfull).onchange = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders', () => {
+    const wrapper = shallow(<WorkloadPodLogs {...defaultProps} />);
+    expect(wrapper.exists()).toBeTruthy();
+  });
+
+  const props = {
+    ...defaultProps,
+    pods: [
+      { name: 'testingpod', createdAt: 'anytime', createdBy: [], status: 'any', appLabel: false, versionLabel: false }
+    ]
+  };
+  it('renders a kebab toggle dropdown', () => {
+    const wrapper = shallow(<WorkloadPodLogs {...props} />);
+    const kebabDropdownWrapper = wrapper
+      .find(Dropdown)
+      .findWhere(n => n.prop('toggle') && n.prop('toggle').type === KebabToggle);
+    expect(wrapper.find(Dropdown).exists()).toBeTruthy();
+    expect(kebabDropdownWrapper.exists()).toBeTruthy();
+  });
+
+  it('renders a log level action in the kebab', () => {
+    // using 'mount' since the dropdowns are children of the kebab
+    const wrapper = mount(<WorkloadPodLogs {...props} />);
+    wrapper.setState({ kebabOpen: true });
+    expect(
+      wrapper
+        .find(DropdownItem)
+        .findWhere(n => n.key() === 'setLogLevelDebug')
+        .exists()
+    ).toBeTruthy();
+  });
+
+  it('calls set log level when action selected', () => {
+    const wrapper = mount(<WorkloadPodLogs {...props} />);
+    wrapper.setState({ kebabOpen: true });
+    wrapper
+      .find(DropdownItem)
+      .findWhere(n => n.key() === 'setLogLevelDebug')
+      .simulate('click');
+    expect(setPodEnvoyProxyLogLevel as jest.Mock).toHaveBeenCalled();
+  });
+});

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -528,6 +528,13 @@ export const getPodLogs = (
   return newRequest<PodLogs>(HTTP_VERBS.GET, urls.podLogs(namespace, name), params, {});
 };
 
+export const setPodEnvoyProxyLogLevel = (namespace: string, name: string, level: string) => {
+  const params: any = {};
+  params.level = level;
+
+  return newRequest<undefined>(HTTP_VERBS.POST, urls.podEnvoyProxyLogging(namespace, name), params, {});
+};
+
 export const getPodEnvoyProxy = (namespace: string, pod: string) => {
   return newRequest<EnvoyProxyDump>(HTTP_VERBS.GET, urls.podEnvoyProxy(namespace, pod), {}, {});
 };


### PR DESCRIPTION
Adds a way to set a workload pod's proxy log level from the kebab dropdown.

Any error that occurs when setting the log level will result in an error notification/alert.

![Screenshot from 2021-09-08 14-15-33](https://user-images.githubusercontent.com/6226732/132564137-300461a9-7bcb-4a0a-8484-ccd4148c4d73.png)

On error:
![Screenshot from 2021-09-07 14-13-30](https://user-images.githubusercontent.com/6226732/132564237-8023d382-04c3-40a0-9652-9dd20d1d193b.png)

Relates to: kiali/kiali#1525
Server side PR: kiali/kiali#4312
