### PR TITLE
Generate link to istio config for workload entries

### DIFF
--- a/src/pages/Graph/SummaryLink.tsx
+++ b/src/pages/Graph/SummaryLink.tsx
@@ -9,6 +9,12 @@ import { getPFBadge, PFBadge, PFBadges } from 'components/Pf/PfBadges';
 import KialiPageLink from 'components/Link/KialiPageLink';
 import { serverConfig } from 'config';
 
+interface linkInfo {
+  link: string;
+  displayName: string;
+  key: string;
+}
+
 const getTooltip = (tooltip: React.ReactFragment, nodeData: GraphNodeData): React.ReactFragment => {
   const addNamespace = nodeData.isBox !== BoxByType.NAMESPACE;
   const addCluster =
@@ -62,7 +68,7 @@ const getBadge = (nodeData: GraphNodeData, nodeType?: NodeType) => {
   }
 };
 
-const getLink = (nodeData: GraphNodeData, nodeType?: NodeType) => {
+const getLink = (nodeData: GraphNodeData, nodeType?: NodeType, linkGenerator?: () => linkInfo) => {
   const { app, cluster, namespace, service, workload } = nodeData;
   if (!nodeType || nodeData.nodeType === NodeType.UNKNOWN) {
     nodeType = nodeData.nodeType;
@@ -71,51 +77,53 @@ const getLink = (nodeData: GraphNodeData, nodeType?: NodeType) => {
   let link: string | undefined;
   let key: string | undefined;
 
-  switch (nodeType) {
-    case NodeType.AGGREGATE:
-      displayName = nodeData.aggregateValue!;
-      break;
-    case NodeType.APP:
-      link = `/namespaces/${encodeURIComponent(namespace)}/applications/${encodeURIComponent(app!)}`;
-      key = `${namespace}.app.${app}`;
-      displayName = app!;
-      break;
-    case NodeType.BOX:
-      switch (nodeData.isBox) {
-        case BoxByType.APP:
-          link = `/namespaces/${encodeURIComponent(namespace)}/applications/${encodeURIComponent(app!)}`;
-          key = `${namespace}.app.${app}`;
-          displayName = app!;
-          break;
-        case BoxByType.CLUSTER:
-          displayName = cluster;
-          break;
-        case BoxByType.NAMESPACE:
-          displayName = namespace;
-          break;
-      }
-      break;
-    case NodeType.SERVICE:
-      if (nodeData.isServiceEntry) {
-        link = `/namespaces/${encodeURIComponent(
-          nodeData.isServiceEntry.namespace
-        )}/istio/serviceentries/${encodeURIComponent(service!)}`;
-      } else {
-        link = `/namespaces/${encodeURIComponent(namespace)}/services/${encodeURIComponent(service!)}`;
-      }
-      key = `${namespace}.svc.${service}`;
-      displayName = service!;
-      break;
-    case NodeType.WORKLOAD:
-      link = nodeData.hasWorkloadEntry
-        ? `/namespaces/${encodeURIComponent(namespace)}/istio/workloadentries/${encodeURIComponent(workload!)}`
-        : `/namespaces/${encodeURIComponent(namespace)}/workloads/${encodeURIComponent(workload!)}`;
-      key = `${namespace}.wl.${workload}`;
-      displayName = workload!;
-      break;
-    default:
-      // NOOP
-      break;
+  if (linkGenerator) {
+    ({ displayName, link, key } = linkGenerator());
+  } else {
+    switch (nodeType) {
+      case NodeType.AGGREGATE:
+        displayName = nodeData.aggregateValue!;
+        break;
+      case NodeType.APP:
+        link = `/namespaces/${encodeURIComponent(namespace)}/applications/${encodeURIComponent(app!)}`;
+        key = `${namespace}.app.${app}`;
+        displayName = app!;
+        break;
+      case NodeType.BOX:
+        switch (nodeData.isBox) {
+          case BoxByType.APP:
+            link = `/namespaces/${encodeURIComponent(namespace)}/applications/${encodeURIComponent(app!)}`;
+            key = `${namespace}.app.${app}`;
+            displayName = app!;
+            break;
+          case BoxByType.CLUSTER:
+            displayName = cluster;
+            break;
+          case BoxByType.NAMESPACE:
+            displayName = namespace;
+            break;
+        }
+        break;
+      case NodeType.SERVICE:
+        if (nodeData.isServiceEntry) {
+          link = `/namespaces/${encodeURIComponent(
+            nodeData.isServiceEntry.namespace
+          )}/istio/serviceentries/${encodeURIComponent(service!)}`;
+        } else {
+          link = `/namespaces/${encodeURIComponent(namespace)}/services/${encodeURIComponent(service!)}`;
+        }
+        key = `${namespace}.svc.${service}`;
+        displayName = service!;
+        break;
+      case NodeType.WORKLOAD:
+        link = `/namespaces/${encodeURIComponent(namespace)}/workloads/${encodeURIComponent(workload!)}`;
+        key = `${namespace}.wl.${workload}`;
+        displayName = workload!;
+        break;
+      default:
+        // NOOP
+        break;
+    }
   }
 
   if (link && !nodeData.isInaccessible) {
@@ -138,9 +146,15 @@ export const renderBadgedHost = (host: string) => {
   );
 };
 
-export const renderBadgedLink = (nodeData: GraphNodeData, nodeType?: NodeType, label?: string) => {
-  const link = getLink(nodeData, nodeType);
+export const renderBadgedLink = (
+  nodeData: GraphNodeData,
+  nodeType?: NodeType,
+  label?: string,
+  linkGenerator?: () => linkInfo
+) => {
+  const link = getLink(nodeData, nodeType, linkGenerator);
 
+  // Render multiple links for
   return (
     <>
       <span style={{ marginRight: '1em', marginBottom: '3px', display: 'inline-block' }}>

--- a/src/pages/Graph/SummaryLink.tsx
+++ b/src/pages/Graph/SummaryLink.tsx
@@ -9,7 +9,7 @@ import { getPFBadge, PFBadge, PFBadges } from 'components/Pf/PfBadges';
 import KialiPageLink from 'components/Link/KialiPageLink';
 import { serverConfig } from 'config';
 
-interface linkInfo {
+interface LinkInfo {
   link: string;
   displayName: string;
   key: string;
@@ -68,7 +68,7 @@ const getBadge = (nodeData: GraphNodeData, nodeType?: NodeType) => {
   }
 };
 
-const getLink = (nodeData: GraphNodeData, nodeType?: NodeType, linkGenerator?: () => linkInfo) => {
+const getLink = (nodeData: GraphNodeData, nodeType?: NodeType, linkGenerator?: () => LinkInfo) => {
   const { app, cluster, namespace, service, workload } = nodeData;
   if (!nodeType || nodeData.nodeType === NodeType.UNKNOWN) {
     nodeType = nodeData.nodeType;
@@ -150,11 +150,10 @@ export const renderBadgedLink = (
   nodeData: GraphNodeData,
   nodeType?: NodeType,
   label?: string,
-  linkGenerator?: () => linkInfo
+  linkGenerator?: () => LinkInfo
 ) => {
   const link = getLink(nodeData, nodeType, linkGenerator);
 
-  // Render multiple links for
   return (
     <>
       <span style={{ marginRight: '1em', marginBottom: '3px', display: 'inline-block' }}>

--- a/src/pages/Graph/SummaryLink.tsx
+++ b/src/pages/Graph/SummaryLink.tsx
@@ -54,7 +54,9 @@ const getBadge = (nodeData: GraphNodeData, nodeType?: NodeType) => {
           )
         : getPFBadge(PFBadges.Service.badge, getTooltip(PFBadges.Service.tt!, nodeData));
     case NodeType.WORKLOAD:
-      return getPFBadge(PFBadges.Workload.badge, getTooltip(PFBadges.Workload.tt!, nodeData));
+      return nodeData.hasWorkloadEntry
+        ? getPFBadge(PFBadges.WorkloadEntry.badge, getTooltip(PFBadges.WorkloadEntry.tt!, nodeData))
+        : getPFBadge(PFBadges.Workload.badge, getTooltip(PFBadges.Workload.tt!, nodeData));
     default:
       return <PFBadge badge={PFBadges.Unknown} />;
   }
@@ -105,7 +107,9 @@ const getLink = (nodeData: GraphNodeData, nodeType?: NodeType) => {
       displayName = service!;
       break;
     case NodeType.WORKLOAD:
-      link = `/namespaces/${encodeURIComponent(namespace)}/workloads/${encodeURIComponent(workload!)}`;
+      link = nodeData.hasWorkloadEntry
+        ? `/namespaces/${encodeURIComponent(namespace)}/istio/workloadentries/${encodeURIComponent(workload!)}`
+        : `/namespaces/${encodeURIComponent(namespace)}/workloads/${encodeURIComponent(workload!)}`;
       key = `${namespace}.wl.${workload}`;
       displayName = workload!;
       break;
@@ -129,7 +133,7 @@ export const renderBadgedHost = (host: string) => {
   return (
     <div>
       <PFBadge badge={PFBadges.Host} />
-      {host === "*" ? "* (all hosts)" : host}
+      {host === '*' ? '* (all hosts)' : host}
     </div>
   );
 };

--- a/src/pages/Graph/SummaryLink.tsx
+++ b/src/pages/Graph/SummaryLink.tsx
@@ -30,7 +30,7 @@ const getTooltip = (tooltip: React.ReactFragment, nodeData: GraphNodeData): Reac
   );
 };
 
-const getBadge = (nodeData: GraphNodeData, nodeType?: NodeType) => {
+export const getBadge = (nodeData: GraphNodeData, nodeType?: NodeType) => {
   switch (nodeType || nodeData.nodeType) {
     case NodeType.AGGREGATE:
       return getPFBadge(PFBadges.Operation.badge, getTooltip(`Operation: ${nodeData.aggregate!}`, nodeData));
@@ -68,7 +68,7 @@ const getBadge = (nodeData: GraphNodeData, nodeType?: NodeType) => {
   }
 };
 
-const getLink = (nodeData: GraphNodeData, nodeType?: NodeType, linkGenerator?: () => LinkInfo) => {
+export const getLink = (nodeData: GraphNodeData, nodeType?: NodeType, linkGenerator?: () => LinkInfo) => {
   const { app, cluster, namespace, service, workload } = nodeData;
   if (!nodeType || nodeData.nodeType === NodeType.UNKNOWN) {
     nodeType = nodeData.nodeType;

--- a/src/pages/Graph/SummaryPanelNode.tsx
+++ b/src/pages/Graph/SummaryPanelNode.tsx
@@ -35,7 +35,7 @@ type ReduxProps = {
   jaegerState: JaegerState;
 };
 
-type SummaryPanelNodeProps = ReduxProps & SummaryPanelPropType;
+export type SummaryPanelNodeProps = ReduxProps & SummaryPanelPropType;
 
 const expandableSectionStyle = style({
   fontSize: 'var(--graph-side-panel--font-size)',
@@ -101,7 +101,6 @@ export class SummaryPanelNode extends React.Component<SummaryPanelNodeProps, Sum
     const actions =
       options.length > 0 ? [<DropdownGroup label="Show" className="kiali-group-menu" children={options} />] : undefined;
 
-    // TODO: Summary Panel node tests
     let workloadLinks;
     if (nodeData.hasWorkloadEntry) {
       nodeData.hasWorkloadEntry.forEach(we => {
@@ -149,7 +148,6 @@ export class SummaryPanelNode extends React.Component<SummaryPanelNodeProps, Sum
             {shouldRenderService && <div>{renderBadgedLink(nodeData, NodeType.SERVICE)}</div>}
             {shouldRenderApp && <div>{renderBadgedLink(nodeData, NodeType.APP)}</div>}
             {shouldRenderWorkload && workloadLinks}
-            {/* Add case for WE entries and rendering each workload entry */}
           </div>
         </div>
         {shouldRenderTraces ? this.renderWithTabs(nodeData) : this.renderTrafficOnly()}

--- a/src/pages/Graph/SummaryPanelNode.tsx
+++ b/src/pages/Graph/SummaryPanelNode.tsx
@@ -61,6 +61,8 @@ const expandableSectionStyle = style({
   }
 });
 
+const workloadExpandableSectionStyle = classes(expandableSectionStyle, style({ display: 'inline' }));
+
 export class SummaryPanelNode extends React.Component<SummaryPanelNodeProps, SummaryPanelNodeState> {
   private readonly mainDivRef: React.RefObject<HTMLDivElement>;
 
@@ -166,9 +168,9 @@ export class SummaryPanelNode extends React.Component<SummaryPanelNodeProps, Sum
               ? '1 workload entry'
               : `${nodeData.hasWorkloadEntry.length} workload entries`
           }
-          className={classes(expandableSectionStyle, style({ display: 'inline' }))}
+          className={workloadExpandableSectionStyle}
         >
-          <div style={{ marginLeft: '3em' }}>{workloadEntryLinks}</div>
+          <div style={{ marginLeft: '3.5em' }}>{workloadEntryLinks}</div>
         </Expandable>
       </>
     );

--- a/src/pages/Graph/SummaryPanelNode.tsx
+++ b/src/pages/Graph/SummaryPanelNode.tsx
@@ -1,7 +1,14 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
-import { renderDestServicesLinks, renderBadgedLink, renderHealth, renderBadgedHost } from './SummaryLink';
+import {
+  getBadge,
+  getLink,
+  renderBadgedHost,
+  renderBadgedLink,
+  renderDestServicesLinks,
+  renderHealth
+} from './SummaryLink';
 import { NodeType, SummaryPanelPropType, DecoratedGraphNodeData, DestService } from '../../types/Graph';
 import { summaryHeader, summaryPanel, summaryBodyTabs, summaryFont } from './SummaryPanelCommon';
 import { decoratedNodeData } from '../../components/CytoscapeGraph/CytoscapeGraphUtils';
@@ -21,7 +28,7 @@ import { SummaryPanelNodeTraffic } from './SummaryPanelNodeTraffic';
 import SummaryPanelNodeTraces from './SummaryPanelNodeTraces';
 import SimpleTabs from 'components/Tab/SimpleTabs';
 import { JaegerState } from 'reducers/JaegerState';
-import { style } from 'typestyle';
+import { classes, style } from 'typestyle';
 
 type SummaryPanelNodeState = {
   isActionOpen: boolean;
@@ -101,28 +108,6 @@ export class SummaryPanelNode extends React.Component<SummaryPanelNodeProps, Sum
     const actions =
       options.length > 0 ? [<DropdownGroup label="Show" className="kiali-group-menu" children={options} />] : undefined;
 
-    let workloadLinks;
-    if (nodeData.hasWorkloadEntry) {
-      nodeData.hasWorkloadEntry.forEach(we => {
-        if (!workloadLinks) {
-          workloadLinks = [];
-        }
-        const generateWorkloadEntryLink = () => ({
-          link: `/namespaces/${encodeURIComponent(nodeData.namespace)}/istio/workloadentries/${encodeURIComponent(
-            we.name
-          )}`,
-          displayName: we.name,
-          key: `${nodeData.namespace}.wle.${we.name}`
-        });
-
-        workloadLinks.push(
-          <div>{renderBadgedLink(nodeData, NodeType.WORKLOAD, undefined, generateWorkloadEntryLink)}</div>
-        );
-      });
-    } else {
-      workloadLinks = <div>{renderBadgedLink(nodeData, NodeType.WORKLOAD)}</div>;
-    }
-
     return (
       <div ref={this.mainDivRef} className={`panel panel-default ${summaryPanel}`}>
         <div className="panel-heading" style={summaryHeader}>
@@ -147,13 +132,47 @@ export class SummaryPanelNode extends React.Component<SummaryPanelNodeProps, Sum
             {shouldRenderSvcList && <div>{servicesList}</div>}
             {shouldRenderService && <div>{renderBadgedLink(nodeData, NodeType.SERVICE)}</div>}
             {shouldRenderApp && <div>{renderBadgedLink(nodeData, NodeType.APP)}</div>}
-            {shouldRenderWorkload && workloadLinks}
+            {shouldRenderWorkload && this.renderWorkloadSection(nodeData)}
           </div>
         </div>
         {shouldRenderTraces ? this.renderWithTabs(nodeData) : this.renderTrafficOnly()}
       </div>
     );
   }
+
+  private renderWorkloadSection = (nodeData: DecoratedGraphNodeData) => {
+    if (!nodeData.hasWorkloadEntry) {
+      return <div>{renderBadgedLink(nodeData, NodeType.WORKLOAD)}</div>;
+    }
+
+    const workloadEntryLinks = nodeData.hasWorkloadEntry.map(we => (
+      <div>
+        {getLink(nodeData, NodeType.WORKLOAD, () => ({
+          link: `/namespaces/${encodeURIComponent(nodeData.namespace)}/istio/workloadentries/${encodeURIComponent(
+            we.name
+          )}`,
+          displayName: we.name,
+          key: `${nodeData.namespace}.wle.${we.name}`
+        }))}
+      </div>
+    ));
+
+    return (
+      <>
+        {getBadge(nodeData, NodeType.WORKLOAD)}
+        <Expandable
+          toggleText={
+            nodeData.hasWorkloadEntry.length === 1
+              ? '1 workload entry'
+              : `${nodeData.hasWorkloadEntry.length} workload entries`
+          }
+          className={classes(expandableSectionStyle, style({ display: 'inline' }))}
+        >
+          <div style={{ marginLeft: '3em' }}>{workloadEntryLinks}</div>
+        </Expandable>
+      </>
+    );
+  };
 
   private renderGatewayHostnames = (nodeData: DecoratedGraphNodeData) => {
     return this.renderHostnamesSection(nodeData.isGateway?.ingressInfo?.hostnames!);

--- a/src/pages/Graph/__tests__/SummaryLink.test.tsx
+++ b/src/pages/Graph/__tests__/SummaryLink.test.tsx
@@ -17,21 +17,6 @@ describe('renderBadgedLink', () => {
     };
   });
 
-  it('should generate a link to istio config and badge for workload entries', () => {
-    const node = { ...defaultGraphData, workload: 'details-v1', hasWorkloadEntry: true };
-    const expectedLink = `/namespaces/${encodeURIComponent(node.namespace)}/istio/workloadentries/${encodeURIComponent(
-      node.workload!
-    )}`;
-    const wrapper = mount(<MemoryRouter>{renderBadgedLink(node)}</MemoryRouter>);
-    expect(wrapper.find('a').filter(`[href="${expectedLink}"]`).exists()).toBeTruthy();
-    expect(
-      wrapper
-        .find(PFBadge)
-        .filterWhere(badge => badge.prop('badge').badge === PFBadges.WorkloadEntry.badge)
-        .exists()
-    ).toBeTruthy();
-  });
-
   it('should generate a link to workload page and badge', () => {
     const node = { ...defaultGraphData, workload: 'details-v1' };
     const expectedLink = `/namespaces/${encodeURIComponent(node.namespace)}/workloads/${encodeURIComponent(
@@ -39,6 +24,25 @@ describe('renderBadgedLink', () => {
     )}`;
     const wrapper = mount(<MemoryRouter>{renderBadgedLink(node)}</MemoryRouter>);
     expect(wrapper.find('a').filter(`[href="${expectedLink}"]`).exists()).toBeTruthy();
+    expect(
+      wrapper
+        .find(PFBadge)
+        .filterWhere(badge => badge.prop('badge').badge === PFBadges.Workload.badge)
+        .exists()
+    ).toBeTruthy();
+  });
+
+  it('should generate link with link generator', () => {
+    const node: GraphNodeData = {
+      ...defaultGraphData,
+      workload: 'details-v1'
+    };
+    const linkInfo = { link: '/custom/link/to/url', displayName: 'customDisplay', key: 'key-1-2' };
+
+    const wrapper = mount(<MemoryRouter>{renderBadgedLink(node, undefined, undefined, () => linkInfo)}</MemoryRouter>);
+    const linkNode = wrapper.find('a').filter(`[href="${linkInfo.link}"]`);
+    expect(linkNode.exists()).toBeTruthy();
+    expect(linkNode.text()).toContain(linkInfo.displayName);
     expect(
       wrapper
         .find(PFBadge)

--- a/src/pages/Graph/__tests__/SummaryLink.test.tsx
+++ b/src/pages/Graph/__tests__/SummaryLink.test.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { renderBadgedLink } from '../SummaryLink';
+import { GraphNodeData, NodeType } from '../../../types/Graph';
+import { PFBadge, PFBadges } from '../../../components/Pf/PfBadges';
+import { mount } from 'enzyme';
+import { MemoryRouter } from 'react-router-dom';
+
+let defaultGraphData: GraphNodeData;
+
+describe('renderBadgedLink', () => {
+  beforeEach(() => {
+    defaultGraphData = {
+      id: 'testingID',
+      nodeType: NodeType.WORKLOAD,
+      cluster: 'default-cluster',
+      namespace: 'bookinfo'
+    };
+  });
+
+  it('should generate a link to istio config and badge for workload entries', () => {
+    const node = { ...defaultGraphData, workload: 'details-v1', hasWorkloadEntry: true };
+    const expectedLink = `/namespaces/${encodeURIComponent(node.namespace)}/istio/workloadentries/${encodeURIComponent(
+      node.workload!
+    )}`;
+    const wrapper = mount(<MemoryRouter>{renderBadgedLink(node)}</MemoryRouter>);
+    expect(wrapper.find('a').filter(`[href="${expectedLink}"]`).exists()).toBeTruthy();
+    expect(
+      wrapper
+        .find(PFBadge)
+        .filterWhere(badge => badge.prop('badge').badge === PFBadges.WorkloadEntry.badge)
+        .exists()
+    ).toBeTruthy();
+  });
+
+  it('should generate a link to workload page and badge', () => {
+    const node = { ...defaultGraphData, workload: 'details-v1' };
+    const expectedLink = `/namespaces/${encodeURIComponent(node.namespace)}/workloads/${encodeURIComponent(
+      node.workload!
+    )}`;
+    const wrapper = mount(<MemoryRouter>{renderBadgedLink(node)}</MemoryRouter>);
+    expect(wrapper.find('a').filter(`[href="${expectedLink}"]`).exists()).toBeTruthy();
+    expect(
+      wrapper
+        .find(PFBadge)
+        .filterWhere(badge => badge.prop('badge').badge === PFBadges.Workload.badge)
+        .exists()
+    ).toBeTruthy();
+  });
+});

--- a/src/pages/Graph/__tests__/SummaryPanelNode.test.tsx
+++ b/src/pages/Graph/__tests__/SummaryPanelNode.test.tsx
@@ -3,6 +3,7 @@ import { GraphNodeData, GraphType, NodeType } from '../../../types/Graph';
 import { mount } from 'enzyme';
 import { SummaryPanelNode, SummaryPanelNodeProps } from '../SummaryPanelNode';
 import { MemoryRouter } from 'react-router-dom';
+import { Expandable } from '@patternfly/react-core';
 
 let defaultProps: SummaryPanelNodeProps;
 let nodeData: GraphNodeData;
@@ -56,5 +57,35 @@ describe('SummaryPanelNode', () => {
     const weLinks = wrapper.find('a').findWhere(a => a.prop('href') && a.prop('href').includes('workloadentries'));
     expect(weLinks.exists()).toBeTruthy();
     expect(weLinks.length).toEqual(2);
+  });
+
+  it('renders expandable dropdown for workload entries', () => {
+    nodeData = { ...nodeData, workload: 'ratings-v1', hasWorkloadEntry: [{ name: 'first_we' }, { name: 'second_we' }] };
+    const wrapper = mount(
+      <MemoryRouter>
+        <SummaryPanelNode {...defaultProps}></SummaryPanelNode>
+      </MemoryRouter>
+    );
+    const expandable = wrapper.find(Expandable);
+    expect(expandable.exists()).toBeTruthy();
+    expect(
+      expandable
+        .children()
+        .find('a')
+        .findWhere(a => a.prop('href') && a.prop('href').includes('workloadentries'))
+        .exists()
+    ).toBeTruthy();
+  });
+
+  it('renders a single link to workload', () => {
+    nodeData = { ...nodeData, workload: 'ratings-v1' };
+    const wrapper = mount(
+      <MemoryRouter>
+        <SummaryPanelNode {...defaultProps}></SummaryPanelNode>
+      </MemoryRouter>
+    );
+    const weLinks = wrapper.find('a').findWhere(a => a.prop('href') && a.prop('href').includes('workload'));
+    expect(weLinks.exists()).toBeTruthy();
+    expect(weLinks.length).toEqual(1);
   });
 });

--- a/src/pages/Graph/__tests__/SummaryPanelNode.test.tsx
+++ b/src/pages/Graph/__tests__/SummaryPanelNode.test.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import { GraphNodeData, GraphType, NodeType } from '../../../types/Graph';
+import { mount } from 'enzyme';
+import { SummaryPanelNode, SummaryPanelNodeProps } from '../SummaryPanelNode';
+import { MemoryRouter } from 'react-router-dom';
+
+let defaultProps: SummaryPanelNodeProps;
+let nodeData: GraphNodeData;
+
+describe('SummaryPanelNode', () => {
+  beforeEach(() => {
+    nodeData = {
+      id: '1234',
+      app: 'ratings',
+      cluster: 'Kubernetes',
+      nodeType: NodeType.APP,
+      namespace: 'bookinfo',
+      destServices: []
+    };
+    const target = {
+      data: (destServices?) => (destServices ? [] : nodeData)
+    };
+    defaultProps = {
+      jaegerState: {},
+      data: {
+        summaryType: 'node',
+        summaryTarget: target
+      },
+      duration: 15,
+      graphType: GraphType.VERSIONED_APP,
+      injectServiceNodes: false,
+      namespaces: [],
+      queryTime: 20,
+      rateInterval: '30s',
+      step: 15,
+      trafficRates: []
+    };
+  });
+
+  it('renders', () => {
+    const wrapper = mount(
+      <MemoryRouter>
+        <SummaryPanelNode {...defaultProps}></SummaryPanelNode>
+      </MemoryRouter>
+    );
+    expect(wrapper.exists()).toBeTruthy();
+  });
+
+  it('renders workload entry links', () => {
+    nodeData = { ...nodeData, workload: 'ratings-v1', hasWorkloadEntry: [{ name: 'first_we' }, { name: 'second_we' }] };
+    const wrapper = mount(
+      <MemoryRouter>
+        <SummaryPanelNode {...defaultProps}></SummaryPanelNode>
+      </MemoryRouter>
+    );
+    const weLinks = wrapper.find('a').findWhere(a => a.prop('href') && a.prop('href').includes('workloadentries'));
+    expect(weLinks.exists()).toBeTruthy();
+    expect(weLinks.length).toEqual(2);
+  });
+});

--- a/src/types/Graph.ts
+++ b/src/types/Graph.ts
@@ -285,6 +285,10 @@ export interface SEInfo {
   namespace: string; // namespace represents where the ServiceEntry object is defined and not necessarily the namespace of the node.
 }
 
+export interface WEInfo {
+  name: string;
+}
+
 // Node data expected from server
 export interface GraphNodeData {
   id: string;
@@ -311,7 +315,7 @@ export interface GraphNodeData {
   hasVS?: {
     hostnames?: string[];
   };
-  hasWorkloadEntry?: boolean;
+  hasWorkloadEntry?: WEInfo[];
   isBox?: string;
   isDead?: boolean;
   isIdle?: boolean;


### PR DESCRIPTION
In the graph node summary panel for workloads with workload entries, the link now links to the istio config page for the workload entry instead of the workloads page.

Fixes kiali/kiali#4219
Back-end changes: kiali/kiali#4372