### PR TITLE
Fix bad axios import

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@patternfly/react-table": "2.28.51",
     "@patternfly/react-tokens": "2.8.15",
     "@webcomponents/custom-elements": "1.2.4",
-    "axios": "0.21.2",
+    "axios": "0.21.4",
     "bootstrap-slider-without-jquery": "10.0.0",
     "csstips": "0.3.0",
     "csx": "9.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4552,7 +4552,14 @@ axios-mock-adapter@1.16.0:
   dependencies:
     deep-equal "^1.0.1"
 
-axios@0.21.2, axios@^0.21.1:
+axios@0.21.4:
+  version "0.21.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
+  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
+  dependencies:
+    follow-redirects "^1.14.0"
+
+axios@^0.21.1:
   version "0.21.2"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.2.tgz#21297d5084b2aeeb422f5d38e7be4fbb82239017"
   integrity sha512-87otirqUw3e8CzHTMO+/9kh/FSgXt/eVDvipijwDtEuwbkySWZ9SBm6VEubmJ/kLKEoLQV/POhxXFb66bfekfg==


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/4363

The axios "0.21.2" lib has a bug and response interceptor is not invoked [1].
That provokes the error in the loading icon in Kiali masthead.

[1] https://github.com/kiali/kiali-ui/blob/master/src/app/App.tsx#L60

