### PR TITLE
Graph shorcuts in Graph Tour

### DIFF
--- a/src/components/Tour/TourStop.tsx
+++ b/src/components/Tour/TourStop.tsx
@@ -13,7 +13,8 @@ import { PFColors } from 'components/Pf/PfColors';
 
 export interface TourStopInfo {
   name: string; // displayed in the tour stop header.
-  description: string; // displayed as the tour stop body
+  description?: string; // displayed as the tour stop body
+  htmlDescription?: JSX.Element;
   position?: PopoverPosition;
   offset?: string; // tippy prop: 'xOffset, yOffset'
   isValid?: boolean; // internal use, leave unset
@@ -185,7 +186,7 @@ class TourStop extends React.PureComponent<TourStopProps> {
                   <span>{info.name}</span>
                 </div>
               }
-              bodyContent={info.description}
+              bodyContent={info.description ? info.description : info.htmlDescription}
               footerContent={
                 <div>
                   {this.backButton()}

--- a/src/pages/Graph/GraphHelpTour.tsx
+++ b/src/pages/Graph/GraphHelpTour.tsx
@@ -1,21 +1,7 @@
 import * as React from 'react';
-import { Chip, Grid, GridItem, PopoverPosition } from '@patternfly/react-core';
+import { PopoverPosition } from '@patternfly/react-core';
 import { TourStopInfo, TourInfo } from 'components/Tour/TourStop';
-
-const shortcuts = (): JSX.Element => {
-  return (
-    <Grid gutter={'md'}>
-      <GridItem span={5}>
-        <Chip isReadOnly>Mouse Wheel</Chip>
-      </GridItem>
-      <GridItem span={7}>Zoom in and out</GridItem>
-      <GridItem span={5}>
-        <Chip isReadOnly>Shift + Drag</Chip>
-      </GridItem>
-      <GridItem span={7}>Select and zoom</GridItem>
-    </Grid>
-  );
-};
+import GraphShortcuts from './GraphToolbar/GraphShortcuts';
 
 export const GraphTourStops: { [name: string]: TourStopInfo } = {
   ContextualMenu: {
@@ -72,7 +58,7 @@ export const GraphTourStops: { [name: string]: TourStopInfo } = {
   },
   Shortcuts: {
     name: 'Shortcuts',
-    htmlDescription: shortcuts(),
+    htmlDescription: <GraphShortcuts />,
     position: PopoverPosition.left
   },
   SidePanel: {

--- a/src/pages/Graph/GraphHelpTour.tsx
+++ b/src/pages/Graph/GraphHelpTour.tsx
@@ -1,5 +1,21 @@
-import { PopoverPosition } from '@patternfly/react-core';
+import * as React from 'react';
+import { Chip, Grid, GridItem, PopoverPosition } from '@patternfly/react-core';
 import { TourStopInfo, TourInfo } from 'components/Tour/TourStop';
+
+const shortcuts = (): JSX.Element => {
+  return (
+    <Grid gutter={'md'}>
+      <GridItem span={5}>
+        <Chip isReadOnly>Mouse Wheel</Chip>
+      </GridItem>
+      <GridItem span={7}>Zoom in and out</GridItem>
+      <GridItem span={5}>
+        <Chip isReadOnly>Shift + Drag</Chip>
+      </GridItem>
+      <GridItem span={7}>Select and zoom</GridItem>
+    </Grid>
+  );
+};
 
 export const GraphTourStops: { [name: string]: TourStopInfo } = {
   ContextualMenu: {
@@ -54,6 +70,11 @@ export const GraphTourStops: { [name: string]: TourStopInfo } = {
     description: 'Select the namespaces you want to see in the graph.',
     position: PopoverPosition.bottom
   },
+  Shortcuts: {
+    name: 'Shortcuts',
+    htmlDescription: shortcuts(),
+    position: PopoverPosition.left
+  },
   SidePanel: {
     name: 'Side Panel',
     description: 'The Side Panel shows details about the currently selected node or edge, otherwise the whole graph.',
@@ -70,6 +91,7 @@ export const GraphTourStops: { [name: string]: TourStopInfo } = {
 const GraphTour: TourInfo = {
   name: 'GraphTour',
   stops: [
+    GraphTourStops.Shortcuts,
     GraphTourStops.Namespaces,
     GraphTourStops.GraphTraffic,
     GraphTourStops.GraphType,

--- a/src/pages/Graph/GraphToolbar/GraphShortcuts.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphShortcuts.tsx
@@ -17,28 +17,24 @@ const shortcuts: Shortcut[] = [
 
 const makeShortcut = (shortcut: Shortcut): JSX.Element => {
   return (
-    <tr>
-      <td>
-        <div style={{ marginLeft: '10px', marginBottom: '10px' }}>
-          <Chip isReadOnly>{shortcut.shortcut}</Chip>
-        </div>
-      </td>
-      <td style={{ marginLeft: '10px' }}>
-        <div style={{ marginLeft: '10px', marginBottom: '10px' }}>{shortcut.description}</div>
-      </td>
-    </tr>
+    <div style={{ display: 'flex', marginLeft: '10px', marginBottom: '10px' }}>
+      <div style={{ flex: '40%' }}>
+        <Chip isReadOnly>{shortcut.shortcut}</Chip>
+      </div>
+      <div style={{ flex: '60%' }}>{shortcut.description}</div>
+    </div>
   );
 };
 
 const GraphShortcuts = (): JSX.Element => (
   <>
-    <table style={{ margin: '10px' }}>
+    <div style={{ margin: '10px' }}>
       {shortcuts.map(
         (s: Shortcut): JSX.Element => {
           return makeShortcut(s);
         }
       )}
-    </table>
+    </div>
   </>
 );
 

--- a/src/pages/Graph/GraphToolbar/GraphShortcuts.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphShortcuts.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Chip, Grid, GridItem } from '@patternfly/react-core';
+import { Chip } from '@patternfly/react-core';
 
 interface Shortcut {
   shortcut: string;
@@ -17,26 +17,28 @@ const shortcuts: Shortcut[] = [
 
 const makeShortcut = (shortcut: Shortcut): JSX.Element => {
   return (
-    <>
-      <GridItem span={5}>
-        <Chip isReadOnly>{shortcut.shortcut}</Chip>
-      </GridItem>
-      <GridItem span={7}>
-        <p>{shortcut.description}</p>
-      </GridItem>
-    </>
+    <tr>
+      <td>
+        <div style={{ marginLeft: '10px', marginBottom: '10px' }}>
+          <Chip isReadOnly>{shortcut.shortcut}</Chip>
+        </div>
+      </td>
+      <td style={{ marginLeft: '10px' }}>
+        <div style={{ marginLeft: '10px', marginBottom: '10px' }}>{shortcut.description}</div>
+      </td>
+    </tr>
   );
 };
 
 const GraphShortcuts = (): JSX.Element => (
   <>
-    <Grid gutter={'md'}>
+    <table style={{ margin: '10px' }}>
       {shortcuts.map(
         (s: Shortcut): JSX.Element => {
           return makeShortcut(s);
         }
       )}
-    </Grid>
+    </table>
   </>
 );
 

--- a/src/pages/Graph/GraphToolbar/GraphShortcuts.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphShortcuts.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Chip, Grid, GridItem } from '@patternfly/react-core';
+
+interface Shortcut {
+  shortcut: string;
+  description: string;
+}
+
+const shortcuts: Shortcut[] = [
+  { shortcut: 'Mouse wheel', description: 'Zoom' },
+  { shortcut: 'Click + Drag', description: 'Panning' },
+  { shortcut: 'Shift + Drag', description: 'Select zoom area' },
+  { shortcut: 'Right click', description: 'Contextual menu on nodes' },
+  { shortcut: 'Single click', description: 'Details in side panel on nodes and edges' },
+  { shortcut: 'Double click', description: 'Drill into a node details graph' }
+];
+
+const makeShortcut = (shortcut: Shortcut): JSX.Element => {
+  return (
+    <>
+      <GridItem span={5}>
+        <Chip isReadOnly>{shortcut.shortcut}</Chip>
+      </GridItem>
+      <GridItem span={7}>
+        <p>{shortcut.description}</p>
+      </GridItem>
+    </>
+  );
+};
+
+const GraphShortcuts = (): JSX.Element => (
+  <>
+    <Grid gutter={'md'}>
+      {shortcuts.map(
+        (s: Shortcut): JSX.Element => {
+          return makeShortcut(s);
+        }
+      )}
+    </Grid>
+  </>
+);
+
+export default GraphShortcuts;

--- a/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
@@ -185,9 +185,9 @@ export class GraphToolbar extends React.PureComponent<GraphToolbarProps> {
           </div>
           <GraphFindContainer cy={this.props.cy} />
 
-          <ToolbarGroup className={rightToolbarStyle} aria-label="graph_refresh_toolbar">
-            <Tooltip key={'graph-tour-help-ot'} position={TooltipPosition.right} content="Graph help tour...">
-              <TourStopContainer info={GraphTourStops.Shortcuts}>
+          <TourStopContainer info={GraphTourStops.Shortcuts}>
+            <ToolbarGroup className={rightToolbarStyle} aria-label="graph_refresh_toolbar">
+              <Tooltip key={'graph-tour-help-ot'} position={TooltipPosition.right} content="Shortcuts and tips...">
                 <Button
                   className={rightToolbarStyle}
                   variant="link"
@@ -195,12 +195,11 @@ export class GraphToolbar extends React.PureComponent<GraphToolbarProps> {
                   onClick={this.props.onToggleHelp}
                 >
                   <KialiIcon.Help className={defaultIconStyle} />
-                  {' Graph tour'}
                 </Button>
-              </TourStopContainer>
-            </Tooltip>
-            <GraphResetContainer />
-          </ToolbarGroup>
+              </Tooltip>
+              <GraphResetContainer />
+            </ToolbarGroup>
+          </TourStopContainer>
         </Toolbar>
         {this.props.replayActive && <ReplayContainer id="time-range-replay" />}
       </>

--- a/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
@@ -187,15 +187,17 @@ export class GraphToolbar extends React.PureComponent<GraphToolbarProps> {
 
           <ToolbarGroup className={rightToolbarStyle} aria-label="graph_refresh_toolbar">
             <Tooltip key={'graph-tour-help-ot'} position={TooltipPosition.right} content="Graph help tour...">
-              <Button
-                className={rightToolbarStyle}
-                variant="link"
-                style={{ paddingLeft: '6px', paddingRight: '0px' }}
-                onClick={this.props.onToggleHelp}
-              >
-                <KialiIcon.Help className={defaultIconStyle} />
-                {' Graph tour'}
-              </Button>
+              <TourStopContainer info={GraphTourStops.Shortcuts}>
+                <Button
+                  className={rightToolbarStyle}
+                  variant="link"
+                  style={{ paddingLeft: '6px', paddingRight: '0px' }}
+                  onClick={this.props.onToggleHelp}
+                >
+                  <KialiIcon.Help className={defaultIconStyle} />
+                  {' Graph tour'}
+                </Button>
+              </TourStopContainer>
             </Tooltip>
             <GraphResetContainer />
           </ToolbarGroup>


### PR DESCRIPTION
This PR adds a new stop in the graph tour to show the shortcuts available in the graph.

This is a work in progress draft PR to get feedback:

![shortcuts](https://user-images.githubusercontent.com/1286393/134524459-c25386c0-234c-4c20-aec9-66ca33472a2f.png)

Resolves [#4133](https://github.com/kiali/kiali/issues/4133)