### PR TITLE
ServiceDetails page, Istio Config section: added support of listing Gateways linked in VirtualServices.

### DIFF
--- a/src/pages/ServiceDetails/ServiceInfo.tsx
+++ b/src/pages/ServiceDetails/ServiceInfo.tsx
@@ -9,7 +9,7 @@ import { RenderComponentScroll } from '../../components/Nav/Page';
 import { PromisesRegistry } from 'utils/CancelablePromises';
 import { DurationInSeconds, TimeInMilliseconds } from 'types/Common';
 import GraphDataSource from 'services/GraphDataSource';
-import { drToIstioItems, vsToIstioItems } from '../../types/IstioConfigList';
+import { drToIstioItems, vsToIstioItems, gwToIstioItems } from '../../types/IstioConfigList';
 import { KialiAppState } from '../../store/Store';
 import { connect } from 'react-redux';
 import { durationSelector, meshWideMTLSEnabledSelector } from '../../store/Selectors';
@@ -92,7 +92,15 @@ class ServiceInfo extends React.Component<Props, ServiceInfoState> {
     const drIstioConfigItems = this.props.serviceDetails?.destinationRules
       ? drToIstioItems(this.props.serviceDetails.destinationRules.items, this.props.serviceDetails.validations)
       : [];
-    const istioConfigItems = vsIstioConfigItems.concat(drIstioConfigItems);
+    const gwIstioConfigItems =
+      this.props?.gateways && this.props.serviceDetails?.virtualServices
+        ? gwToIstioItems(
+            this.props?.gateways,
+            this.props.serviceDetails.virtualServices.items,
+            this.props.serviceDetails.validations
+          )
+        : [];
+    const istioConfigItems = gwIstioConfigItems.concat(vsIstioConfigItems.concat(drIstioConfigItems));
 
     // RenderComponentScroll handles height to provide an inner scroll combined with tabs
     // This height needs to be propagated to minigraph to proper resize in height


### PR DESCRIPTION
RFE https://github.com/kiali/kiali/issues/4326

When VirtualService have linked Gateways, then these Gateways are listed in Istio Config section of ServiceDetails page.

Gateways can be linked for instance while creating Routing via Wizard.

![Screenshot from 2021-09-29 09-01-21](https://user-images.githubusercontent.com/604313/135220533-18a85c87-e2b1-4bef-aa41-0ea8b972c6a7.png)
![Screenshot from 2021-09-29 09-01-50](https://user-images.githubusercontent.com/604313/135220538-ffa7fdcf-1c10-4c12-aabc-78019f5d12ab.png)
