### PR TITLE
Tweak style SparklineChart

### DIFF
--- a/src/components/Charts/SparklineChart.tsx
+++ b/src/components/Charts/SparklineChart.tsx
@@ -126,7 +126,7 @@ export class SparklineChart extends React.Component<Props, State> {
         {this.props.showYAxis ? (
           <ChartAxis
             label="ops"
-            axisLabelComponent={<ChartLabel y={0} x={15} angle={0} renderInPortal={true} />}
+            axisLabelComponent={<ChartLabel y={-5} x={7} angle={0} renderInPortal={true} />}
             tickCount={2}
             dependentAxis={true}
           />


### PR DESCRIPTION
One-liner tweak to position the "ops" title a little bit better, when there are two ticks it looks better with this position:

![image](https://user-images.githubusercontent.com/1662329/136187236-dbcd58e4-7434-470b-be02-3377056ebda9.png)
