### PR TITLE
Common line height for all pod log entries

### DIFF
--- a/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
+++ b/src/pages/WorkloadDetails/WorkloadPodLogs.tsx
@@ -640,11 +640,11 @@ export class WorkloadPodLogs extends React.Component<WorkloadPodLogsProps, Workl
                   }
                   const le = e.logEntry!;
                   return !le.accessLog ? (
-                    <>
+                    <div key={`le-d-${i}`} style={{ height: '22px', lineHeight: '22px' }}>
                       <p key={`le-${i}`} style={{ color: le.color!, fontSize: '12px' }}>
                         {this.entryToString(e)}
                       </p>
-                    </>
+                    </div>
                   ) : (
                     <div key={`al-${i}`} style={{ height: '22px', lineHeight: '22px' }}>
                       {this.state.showTimestamps && (


### PR DESCRIPTION
Ensures all log entries have the same font height/line height. By default `<p>` elements have a 16px bottom margin but that apparently gets overridden by the font-height or line-height properties. Those properties were being set for access logs but not for non-access logs e.g. app container logs or proxy app logs.

Before:
![Screenshot from 2021-10-06 09-45-32](https://user-images.githubusercontent.com/6226732/136215526-6c0a6863-95fe-4efe-b470-7d719bdad468.png)

After:
![Screenshot from 2021-10-06 09-46-28](https://user-images.githubusercontent.com/6226732/136215575-e5e33848-775e-4b07-97c0-3e0f3ca5f077.png)

Relates to: kiali/kiali#4356