### PR TITLE
Add Trendlines to Metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "redux-persist": "5.10.0",
     "redux-persist-transform-filter": "0.0.18",
     "redux-thunk": "2.3.0",
+    "regression": "^2.0.1",
     "reselect": "4.0.0",
     "screenfull": "5.0.2",
     "seedrandom": "3.0.1",

--- a/src/app/History.ts
+++ b/src/app/History.ts
@@ -55,6 +55,7 @@ export enum URLParam {
   REPORTER = 'reporter',
   SHOW_AVERAGE = 'avg',
   SHOW_SPANS = 'spans',
+  SHOW_TRENDLINES = 'trendlines',
   SORT = 'sort',
   TO = 'to',
   EXPERIMENTAL_FLAGS = 'xflags'

--- a/src/components/Charts/ChartWithLegend.tsx
+++ b/src/components/Charts/ChartWithLegend.tsx
@@ -13,6 +13,7 @@ import { CustomTooltip } from './CustomTooltip';
 import { INTERPOTALION_STRATEGY } from './SparklineChart';
 import { KialiIcon } from '../../config/KialiIcon';
 import { Button, ButtonVariant, Tooltip, TooltipPosition } from '@patternfly/react-core';
+import regression from 'regression';
 import { style } from 'typestyle';
 
 type Props<T extends RichDataPoint, O extends LineInfo> = {
@@ -23,6 +24,7 @@ type Props<T extends RichDataPoint, O extends LineInfo> = {
   stroke?: boolean;
   fill?: boolean;
   showSpans?: boolean;
+  showTrendline?: boolean;
   isMaximized?: boolean;
   groupOffset?: number;
   sizeRatio?: number;
@@ -150,13 +152,13 @@ class ChartWithLegend<T extends RichDataPoint, O extends LineInfo> extends React
         }
       });
     }
-    this.props.data.forEach((s, idx) => this.registerEvents(events, idx, 'serie-' + idx, s.legendItem.name));
+    this.props.data.forEach((s, idx) => this.registerEvents(events, idx, ['serie-' + idx, 'serie-reg-' + idx], s.legendItem.name));
     let useSecondAxis = showOverlay;
     let normalizedOverlay: RawOrBucket<O>[] = [];
     let overlayFactor = 1.0;
     const mainMax = Math.max(...this.props.data.map(line => Math.max(...line.datapoints.map(d => d.y))));
     if (this.props.overlay) {
-      this.registerEvents(events, overlayIdx, overlayName, overlayName);
+      this.registerEvents(events, overlayIdx, [overlayName], overlayName);
       // Normalization for y-axis display to match y-axis domain of the main data
       // (see https://formidable.com/open-source/victory/gallery/multiple-dependent-axes/)
       const overlayMax = Math.max(...this.props.overlay.vcLine.datapoints.map(d => d.y));
@@ -399,7 +401,7 @@ class ChartWithLegend<T extends RichDataPoint, O extends LineInfo> extends React
           if (this.state.hiddenSeries.has(serie.legendItem.name)) {
             return undefined;
           }
-          return React.cloneElement(
+          const plot = React.cloneElement(
             this.props.seriesComponent,
             this.withStyle(
               {
@@ -411,7 +413,36 @@ class ChartWithLegend<T extends RichDataPoint, O extends LineInfo> extends React
               serie.color
             )
           );
-        })}
+
+          if (this.props.showTrendline === true) {
+            const first_dpx = (serie.datapoints[0].x as Date).getTime() / 1000;
+            const datapoints = serie.datapoints.map(d => [((d.x as Date).getTime()/1000 - first_dpx) / 10000, parseFloat(d.y.toString())]);
+            const linearRegression = regression.linear(datapoints, { precision: 10 });
+
+            let regressionDatapoints = serie.datapoints.map(d => ({
+              ...d,
+              y: linearRegression.predict(((d.x as Date).getTime()/1000 - first_dpx) / 10000)[1]
+            }));
+
+            const regressionPlot = React.cloneElement(
+              this.props.seriesComponent,
+              this.withStyle(
+                {
+                  key: 'serie-reg-' + idx,
+                  name: 'serie-reg-' + idx,
+                  data: regressionDatapoints,
+                  interpolation: INTERPOTALION_STRATEGY
+                },
+                serie.color,
+                true
+              )
+            );
+
+            return [plot, regressionPlot];
+          }
+
+          return [plot];
+        }).flat()}
       </ChartGroup>
     );
   };
@@ -440,12 +471,12 @@ class ChartWithLegend<T extends RichDataPoint, O extends LineInfo> extends React
   };
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private withStyle = (props: any, color?: string) => {
+  private withStyle = (props: any, color?: string, strokeDasharray?: boolean) => {
     return this.props.overrideSeriesComponentStyle === false
       ? props
       : {
           ...props,
-          style: { data: { fill: this.props.fill ? color : undefined, stroke: this.props.stroke ? color : undefined } }
+          style: { data: { fill: this.props.fill ? color : undefined, stroke: this.props.stroke ? color : undefined, strokeDasharray: strokeDasharray === true ? "3 5" : undefined } }
         };
   };
 
@@ -485,7 +516,7 @@ class ChartWithLegend<T extends RichDataPoint, O extends LineInfo> extends React
     return filtered;
   }
 
-  private registerEvents(events: VCEvent[], idx: number, serieID: string, serieName: string) {
+  private registerEvents(events: VCEvent[], idx: number, serieID: string[], serieName: string) {
     addLegendEvent(events, {
       legendName: 'serie-legend',
       idx: idx,

--- a/src/components/Charts/Dashboard.tsx
+++ b/src/components/Charts/Dashboard.tsx
@@ -22,6 +22,7 @@ export type Props<T extends LineInfo> = {
   template?: string;
   dashboardHeight: number;
   showSpans: boolean;
+  showTrendlines?: boolean;
   customMetric?: boolean;
   overlay?: Overlay<T>;
   timeWindow?: [Date, Date];
@@ -89,6 +90,7 @@ export class Dashboard<T extends LineInfo> extends React.Component<Props<T>, Sta
         chartHeight={this.getChartHeight()}
         chart={chart}
         showSpans={this.props.showSpans}
+        showTrendline={this.props.showTrendlines}
         data={dataSupplier()}
         onToggleMaximized={() => this.onToggleMaximized(chart.name)}
         isMaximized={this.state.maximizedChart !== undefined}

--- a/src/components/Charts/KChart.tsx
+++ b/src/components/Charts/KChart.tsx
@@ -26,6 +26,7 @@ type KChartProps<T extends LineInfo> = {
   onToggleMaximized: () => void;
   onClick?: (datum: RawOrBucket<T>) => void;
   showSpans: boolean;
+  showTrendline?: boolean;
   brushHandlers?: BrushHandlers;
   overlay?: Overlay<T>;
   timeWindow?: [Date, Date];
@@ -186,6 +187,7 @@ class KChart<T extends LineInfo> extends React.Component<KChartProps<T>, State> 
         fill={typeData.fill}
         stroke={typeData.stroke}
         showSpans={this.props.showSpans}
+        showTrendline={this.props.showTrendline}
         groupOffset={typeData.groupOffset}
         sizeRatio={typeData.sizeRatio}
         overlay={this.props.overlay}

--- a/src/components/Charts/SparklineChart.tsx
+++ b/src/components/Charts/SparklineChart.tsx
@@ -80,7 +80,7 @@ export class SparklineChart extends React.Component<Props, State> {
         addLegendEvent(events, {
           legendName: this.props.name + '-legend',
           idx: idx,
-          serieID: this.props.name + '-area-' + idx,
+          serieID: [this.props.name + '-area-' + idx],
           onClick: () => {
             if (!this.state.hiddenSeries.delete(idx)) {
               // Was not already hidden => add to set

--- a/src/components/Metrics/Helper.ts
+++ b/src/components/Metrics/Helper.ts
@@ -148,6 +148,7 @@ export const retrieveMetricsSettings = (): MetricsSettings => {
   const urlParams = new URLSearchParams(history.location.search);
   const settings: MetricsSettings = {
     showSpans: false,
+    showTrendlines: false,
     showAverage: true,
     showQuantiles: [],
     labelsSettings: new Map()
@@ -159,6 +160,10 @@ export const retrieveMetricsSettings = (): MetricsSettings => {
   const spans = urlParams.get(URLParam.SHOW_SPANS);
   if (spans !== null) {
     settings.showSpans = spans === 'true';
+  }
+  const trendlines = urlParams.get(URLParam.SHOW_TRENDLINES);
+  if (trendlines !== null) {
+    settings.showTrendlines = trendlines === 'true';
   }
   const quantiles = urlParams.get(URLParam.QUANTILES);
   if (quantiles !== null) {

--- a/src/components/Metrics/IstioMetrics.tsx
+++ b/src/components/Metrics/IstioMetrics.tsx
@@ -37,6 +37,7 @@ type MetricsState = {
   spanOverlay?: Overlay<JaegerLineInfo>;
   tabHeight: number;
   showSpans: boolean;
+  showTrendlines: boolean;
 };
 
 type ObjectId = {
@@ -82,7 +83,8 @@ class IstioMetrics extends React.Component<Props, MetricsState> {
       labelsSettings: settings.labelsSettings,
       grafanaLinks: [],
       tabHeight: 300,
-      showSpans: settings.showSpans
+      showSpans: settings.showSpans,
+      showTrendlines: settings.showTrendlines
     };
     this.spanOverlay = new SpanOverlay(changed => this.setState({ spanOverlay: changed }));
   }
@@ -262,6 +264,7 @@ class IstioMetrics extends React.Component<Props, MetricsState> {
                 labelPrettifier={MetricsHelper.prettyLabelValues}
                 overlay={this.state.spanOverlay}
                 showSpans={this.state.showSpans}
+                showTrendlines={this.state.showTrendlines}
                 dashboardHeight={dashboardHeight}
                 timeWindow={evalTimeRange(this.props.timeRange)}
                 brushHandlers={{ onDomainChangeEnd: (_, props) => this.onDomainChange(props.currentDomain.x) }}
@@ -278,6 +281,13 @@ class IstioMetrics extends React.Component<Props, MetricsState> {
     urlParams.set(URLParam.SHOW_SPANS, String(checked));
     history.replace(history.location.pathname + '?' + urlParams.toString());
     this.setState({ showSpans: !this.state.showSpans });
+  };
+
+  private onTrendlines = (checked: boolean) => {
+    const urlParams = new URLSearchParams(history.location.search);
+    urlParams.set(URLParam.SHOW_TRENDLINES, String(checked));
+    history.replace(history.location.pathname + '?' + urlParams.toString());
+    this.setState({ showTrendlines: !this.state.showTrendlines });
   };
 
   private renderOptionsBar() {
@@ -303,15 +313,6 @@ class IstioMetrics extends React.Component<Props, MetricsState> {
           <ToolbarGroup>
             <ToolbarItem className={displayFlex}>
               <div style={maximizeButtonStyle} className="pf-c-check">
-                <input
-                  key={`spans-show-chart`}
-                  id={`spans-show-`}
-                  className="pf-c-check__input"
-                  style={{ marginBottom: '3px' }}
-                  type="checkbox"
-                  checked={this.state.showSpans}
-                  onChange={event => this.onSpans(event.target.checked)}
-                />
                 <label
                   className="pf-c-check__label"
                   style={{
@@ -319,7 +320,38 @@ class IstioMetrics extends React.Component<Props, MetricsState> {
                     paddingRight: '5px'
                   }}
                 >
+                  <input
+                    key={`spans-show-chart`}
+                    id={`spans-show-`}
+                    className="pf-c-check__input"
+                    type="checkbox"
+                    checked={this.state.showSpans}
+                    onChange={event => this.onSpans(event.target.checked)}
+                  />
+                  &nbsp;
                   Spans
+                </label>
+              </div>
+            </ToolbarItem>
+            <ToolbarItem className={displayFlex}>
+              <div style={maximizeButtonStyle} className="pf-c-check">
+                <label
+                  className="pf-c-check__label"
+                  style={{
+                    paddingLeft: '5px',
+                    paddingRight: '5px'
+                  }}
+                >
+                  <input
+                    key={`trendlines-show-chart`}
+                    id={`trendlines-show-`}
+                    className="pf-c-check__input"
+                    type="checkbox"
+                    checked={this.state.showTrendlines}
+                    onChange={event => this.onTrendlines(event.target.checked)}
+                  />
+                  &nbsp;
+                  Trendlines
                 </label>
               </div>
             </ToolbarItem>

--- a/src/components/MetricsOptions/MetricsSettings.ts
+++ b/src/components/MetricsOptions/MetricsSettings.ts
@@ -16,5 +16,6 @@ export interface MetricsSettings {
   labelsSettings: LabelsSettings;
   showAverage: boolean;
   showSpans: boolean;
+  showTrendlines: boolean;
   showQuantiles: Quantiles[];
 }

--- a/src/components/SummaryPanel/RateChart.tsx
+++ b/src/components/SummaryPanel/RateChart.tsx
@@ -41,7 +41,7 @@ export class RateChart extends React.Component<Props, State> {
       addLegendEvent(events, {
         legendName: this.props.baseName + '-legend',
         idx: idx,
-        serieID: this.props.baseName + '-bars-' + idx,
+        serieID: [this.props.baseName + '-bars-' + idx],
         onClick: __ => {
           // Same event can be fired for several targets, so make sure we only apply it once
           if (!this.state.hiddenSeries.delete(idx)) {

--- a/src/utils/VictoryEvents.ts
+++ b/src/utils/VictoryEvents.ts
@@ -3,7 +3,7 @@ import { RawOrBucket, LineInfo } from '../types/VictoryChartInfo';
 interface EventItem {
   legendName: string;
   idx: number;
-  serieID: string;
+  serieID: string[];
   onClick?: (props: RawOrBucket<LineInfo>) => Partial<RawOrBucket<LineInfo>> | null;
   onMouseOver?: (props: RawOrBucket<LineInfo>) => Partial<RawOrBucket<LineInfo>> | null;
   onMouseOut?: (props: RawOrBucket<LineInfo>) => Partial<RawOrBucket<LineInfo>> | null;
@@ -35,12 +35,12 @@ export const addLegendEvent = (events: VCEvent[], item: EventItem): void => {
       e.stopPropagation();
       return [
         {
-          childName: [item.serieID],
+          childName: [item.serieID[0]],
           target: 'data',
           mutation: props => item.onClick!(props)
         },
         {
-          childName: [item.serieID],
+          childName: [item.serieID[0]],
           target: 'data',
           eventKey: 'all',
           mutation: () => null
@@ -52,7 +52,7 @@ export const addLegendEvent = (events: VCEvent[], item: EventItem): void => {
     eventHandlers.onMouseOver = () => {
       return [
         {
-          childName: [item.serieID],
+          childName: item.serieID,
           target: 'data',
           eventKey: 'all',
           mutation: props => item.onMouseOver!(props)
@@ -62,7 +62,7 @@ export const addLegendEvent = (events: VCEvent[], item: EventItem): void => {
     eventHandlers.onMouseOut = () => {
       return [
         {
-          childName: [item.serieID],
+          childName: item.serieID,
           target: 'data',
           eventKey: 'all',
           mutation: props => (item.onMouseOut ? item.onMouseOut(props) : null)

--- a/yarn.lock
+++ b/yarn.lock
@@ -15381,6 +15381,11 @@ regjsparser@^0.6.4:
   dependencies:
     jsesc "~0.5.0"
 
+regression@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/regression/-/regression-2.0.1.tgz#8d29c3e8224a10850c35e337e85a8b2fac3b0c87"
+  integrity sha1-jSnD6CJKEIUMNeM36FqLL6w7DIc=
+
 relateurl@^0.2.7:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"


### PR DESCRIPTION
* Adding regression-js as a helper library for the linear regression algorithm
* Add a "Trendlines" option in the inbound/outbound metric tabs.
* Trendlines are dashed lines.
* Trendlines are shown and hidden together with its associated serie when the corresponding label is clicked on the legend.
* Trendlines are highlighted together with its associated serie when the mouse cursor is over the corresponding label on the legend.

** Animation **

Related #2997.

cc @jotak
