### PR TITLE
Fix null errorMetrics in CardSpakline

### DIFF
--- a/src/pages/Overview/OverviewCardSparkline.tsx
+++ b/src/pages/Overview/OverviewCardSparkline.tsx
@@ -18,19 +18,16 @@ type Props = {
 
 class OverviewCardSparkline extends React.Component<Props, {}> {
   render() {
-    if (
-      this.props.metrics &&
-      this.props.metrics.length > 0 &&
-      this.props.errorMetrics &&
-      this.props.errorMetrics.length > 0
-    ) {
+    if (this.props.metrics && this.props.metrics.length > 0) {
       let series: VCLine<RichDataPoint>[] = [];
 
       const data = toVCLine(this.props.metrics[0].datapoints, 'Total', PFColors.Blue400);
       series.push(data);
 
-      const dataErrors = toVCLine(this.props.errorMetrics[0].datapoints, '4xx+5xx', PFColors.Danger);
-      series.push(dataErrors);
+      if (this.props.errorMetrics && this.props.errorMetrics.length > 0) {
+        const dataErrors = toVCLine(this.props.errorMetrics[0].datapoints, '4xx+5xx', PFColors.Danger);
+        series.push(dataErrors);
+      }
 
       return (
         <>


### PR DESCRIPTION
Some backend queries can return a valid null in the errorMetrics.

On my example, "travel-portal" namespace had no info in the errorMetrics, but it has info in the non-error:
![image](https://user-images.githubusercontent.com/1662329/136385359-38f619a6-756b-4d0f-ab4d-f31e9ce3ab93.png)

A potential workaround for these cases could be to move the errorCondition inside the main check.