### PR TITLE
Fix broken Y axis values when all traffic values are zero

### DIFF
--- a/src/pages/Overview/OverviewCardSparkline.tsx
+++ b/src/pages/Overview/OverviewCardSparkline.tsx
@@ -17,7 +17,8 @@ type Props = {
 };
 
 function showMetrics(metrics: Metric[] | undefined): boolean {
-  if (metrics && metrics.length && metrics[0].datapoints.some(dp => Number(dp[1]) !== 0)) {
+  // show metrics if metrics exists and some values at least are not zero
+  if (metrics && metrics.length > 0 && metrics[0].datapoints.some(dp => Number(dp[1]) !== 0)) {
     return true;
   }
 


### PR DESCRIPTION
Fixes [#4425](https://github.com/kiali/kiali/issues/4425).

The steps to test this fix are the following:

1. Deploy bookinfo application and the Istio resources to use the app
2. Check that traffic appears correctly in the Overview Page
3. Remove the Istio resources
4. Check that eventually, the graph will say "No incoming traffic"
