### PR TITLE
Fix form validation for wildcard and mesh gateway

### DIFF
--- a/src/components/IstioWizards/GatewaySelector.tsx
+++ b/src/components/IstioWizards/GatewaySelector.tsx
@@ -128,24 +128,26 @@ class GatewaySelector extends React.Component<Props, GatewaySelectorState> {
   };
 
   isMeshGatewayValid = (): boolean => {
+    const hasVsWildcard = this.props.vsHosts.some(h => h === '*');
+    const hasGwWildcard = this.state.gwHosts.split(',').some(h => h === '*');
     // Gateway added
     if (this.state.addGateway) {
       // Mesh can't use wildcard in the hosts
       if (this.state.addMesh) {
         if (this.state.newGateway) {
           // If mesh, a new gateway can't use wildcard
-          return !this.state.gwHosts.split(',').some(h => h === '*');
+          return !hasGwWildcard;
         } else {
           // If mesh, a selected gateway can't use wildcard
-          return !this.props.vsHosts.some(h => h === '*');
+          return !hasVsWildcard;
         }
       }
+      return true;
     } else {
       // No gateway means that mesh is used by default
       // Mesh can't use wildcard in the hosts
-      return !this.props.vsHosts.some(h => h === '*');
+      return !hasVsWildcard;
     }
-    return true;
   };
 
   isGatewayValid = (): boolean => {

--- a/src/components/IstioWizards/ServiceWizard.tsx
+++ b/src/components/IstioWizards/ServiceWizard.tsx
@@ -350,19 +350,20 @@ class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWizardSta
   onVsHosts = (valid: boolean, vsHosts: string[]) => {
     this.setState(prevState => {
       prevState.valid.vsHosts = valid;
-      // Sync VS Hosts with GW
-      if (
-        valid &&
-        !prevState.valid.gateway &&
-        vsHosts.every(h => h !== '*') &&
-        prevState.gateway &&
-        prevState.gateway.addMesh
-      ) {
-        prevState.valid.gateway = valid;
-      }
-      // When adding a new Gateway, VirtualService host should be synced with Gateway host
       if (prevState.gateway && prevState.gateway.addGateway && prevState.gateway.newGateway) {
         prevState.gateway.gwHosts = vsHosts.join(',');
+      }
+      // Check if Gateway is valid after a VsHosts check
+      if (valid && !prevState.valid.gateway) {
+        const hasVsWildcard = vsHosts.some(h => h === '*');
+        if (hasVsWildcard) {
+          if (prevState.gateway && !prevState.gateway.addMesh) {
+            prevState.valid.gateway = true;
+          }
+        } else {
+          // If no wildcard Gateway should be ok
+          prevState.valid.gateway = true;
+        }
       }
       return {
         valid: prevState.valid,
@@ -402,11 +403,6 @@ class ServiceWizard extends React.Component<ServiceWizardProps, ServiceWizardSta
   onGateway = (valid: boolean, gateway: GatewaySelectorState) => {
     this.setState(prevState => {
       prevState.valid.gateway = valid;
-      // Sync VS Hosts as when Gateway is valid, it will be valid the VS Hosts
-      if (valid) {
-        prevState.valid.vsHosts = valid;
-      }
-      // When adding a new Gateway, VirtualService host should be synced with Gateway host
       return {
         valid: prevState.valid,
         gateway: gateway,

--- a/src/components/IstioWizards/VirtualServiceHosts.tsx
+++ b/src/components/IstioWizards/VirtualServiceHosts.tsx
@@ -13,16 +13,18 @@ class VirtualServiceHosts extends React.Component<Props> {
       // vsHosts must have a value
       return false;
     }
-    if (this.props.gateway && vsHosts.some(h => h === '*')) {
-      if (!this.props.gateway.addGateway) {
-        // wildcard needs a gateway
-        return false;
-      } else {
+    const hasWildcard = vsHosts.some(h => h === '*');
+    if (this.props.gateway) {
+      if (this.props.gateway.addGateway) {
         if (this.props.gateway.addMesh) {
-          // wildcard needs a non mesh gateway
-          return false;
+          // Mesh needs a non Wilcard
+          return !hasWildcard;
         }
+      } else {
+        return !hasWildcard;
       }
+    } else {
+      return !hasWildcard;
     }
     return true;
   };


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/4416

Added a couple of synced form validations on the VirtualHosts field:

![image](https://user-images.githubusercontent.com/1662329/137877250-8987fd21-ffd2-4776-bda0-98c72764032d.png)

And Gateway "include mesh" field:

![image](https://user-images.githubusercontent.com/1662329/137877343-fbc40034-d22d-4d76-8683-ecfb37b1cec5.png)

