### PR TITLE
Show list of configured hostnames for egress nodes

### DIFF
--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -281,6 +281,10 @@ export class GraphStyles {
         icons = `<span class='${NodeIconGateway} ${iconMargin(icons)}'></span> ${icons}`;
       }
       icons = `<span class='${NodeIconRoot} ${iconMargin(icons)}'></span> ${icons}`;
+    } else {
+      if (node.isGateway?.egressInfo?.hostnames?.length !== undefined) {
+        icons = `<span class='${NodeIconGateway} ${iconMargin(icons)}'></span> ${icons}`;
+      }
     }
 
     const hasIcon = icons.length > 0;
@@ -402,6 +406,7 @@ export class GraphStyles {
     let hosts: string[] = [];
     node.hasVS?.hostnames?.forEach(h => hosts.push(h === '*' ? '* (all hosts)' : h));
     node.isGateway?.ingressInfo?.hostnames?.forEach(h => hosts.push(h === '*' ? '* (all hosts)' : h));
+    node.isGateway?.egressInfo?.hostnames?.forEach(h => hosts.push(h === '*' ? '* (all hosts)' : h));
 
     let htmlHosts = '';
     if (hosts.length !== 0) {

--- a/src/pages/Graph/SummaryPanelNode.tsx
+++ b/src/pages/Graph/SummaryPanelNode.tsx
@@ -177,7 +177,15 @@ export class SummaryPanelNode extends React.Component<SummaryPanelNodeProps, Sum
   };
 
   private renderGatewayHostnames = (nodeData: DecoratedGraphNodeData) => {
-    return this.renderHostnamesSection(nodeData.isGateway?.ingressInfo?.hostnames!);
+    if (nodeData.isGateway?.ingressInfo?.hostnames && nodeData.isGateway?.ingressInfo?.hostnames.length > 0) {
+      return this.renderHostnamesSection(nodeData.isGateway?.ingressInfo?.hostnames);
+    }
+
+    if (nodeData.isGateway?.egressInfo?.hostnames && nodeData.isGateway?.egressInfo?.hostnames.length > 0) {
+      return this.renderHostnamesSection(nodeData.isGateway?.egressInfo?.hostnames);
+    }
+
+    return null;
   };
 
   private renderVsHostnames = (nodeData: DecoratedGraphNodeData) => {
@@ -255,7 +263,8 @@ export class SummaryPanelNode extends React.Component<SummaryPanelNodeProps, Sum
       hasTCPTrafficShifting ||
       hasRequestTimeout;
     const shouldRenderGatewayHostnames =
-      nodeData.isGateway?.ingressInfo?.hostnames !== undefined && nodeData.isGateway.ingressInfo.hostnames.length !== 0;
+      (nodeData.isGateway?.ingressInfo?.hostnames !== undefined && nodeData.isGateway.ingressInfo.hostnames.length !== 0) ||
+      (nodeData.isGateway?.egressInfo?.hostnames !== undefined && nodeData.isGateway.egressInfo.hostnames.length !== 0);
     const shouldRenderVsHostnames = nodeData.hasVS?.hostnames !== undefined && nodeData.hasVS?.hostnames.length !== 0;
     return (
       <div style={{ marginTop: '10px', marginBottom: '10px' }}>

--- a/src/types/Graph.ts
+++ b/src/types/Graph.ts
@@ -325,6 +325,9 @@ export interface GraphNodeData {
     ingressInfo?: {
       hostnames?: string[];
     };
+    egressInfo?: {
+      hostnames?: string[];
+    };
   };
   isMisconfigured?: string;
   isOutside?: boolean;


### PR DESCRIPTION
Also, the side panel should show the full list of configured hosts for the cases where the graph truncates the list.

![image](https://user-images.githubusercontent.com/23639005/140193123-91525a02-141a-4d92-81bc-f832191d0122.png)


Fixes kiali/kiali#3765
