### PR TITLE
fix text selection when copying envoy config dump to clipboard

### DIFF
--- a/src/components/Envoy/EnvoyDetails.tsx
+++ b/src/components/Envoy/EnvoyDetails.tsx
@@ -16,6 +16,7 @@ import {
   GridItem,
   Tab,
   Tabs,
+  Tooltip,
   TooltipPosition
 } from '@patternfly/react-core';
 import { SummaryTableBuilder } from './tables/BaseTable';
@@ -200,7 +201,7 @@ class EnvoyDetails extends React.Component<EnvoyDetailsProps, EnvoyDetailsState>
   onCopyToClipboard = (_text: string, _result: boolean) => {
     const editor = this.aceEditorRef.current!['editor'];
     if (editor) {
-      editor.selectconfig();
+      editor.selectAll();
     }
   };
 
@@ -277,13 +278,17 @@ class EnvoyDetails extends React.Component<EnvoyDetailsProps, EnvoyDetailsState>
                       label={this.state.pod.name}
                       options={this.props.workload.pods.map((pod: Pod) => pod.name).sort()}
                     />
-                    <span style={{ float: 'right' }}>
-                      <CopyToClipboard onCopy={this.onCopyToClipboard} text={this.editorContent()}>
+                    <Tooltip key="copy_config" position="top" content="Copy config dump to clipboard">
+                      <CopyToClipboard
+                        style={{ float: 'right', marginTop: '15px' }}
+                        onCopy={this.onCopyToClipboard}
+                        text={this.editorContent()}
+                      >
                         <Button variant={ButtonVariant.link} isInline>
                           <KialiIcon.Copy className={defaultIconStyle} />
                         </Button>
                       </CopyToClipboard>
-                    </span>
+                    </Tooltip>
                   </div>
                   <AceEditor
                     ref={this.aceEditorRef}


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/4445

Also:
- remove unnecessary span
- position copy icon closer to editor
- add tooltip to be more helpful, and consistent with logs page.

To be honest, I'm not sure it's necessary to select the text when clicking the copy icon.  But I'm fairly selecting the text is what the errant code was trying to do.

@lucasponce , do whatever you like with this if you want to move it along while I'm on PTO.