### PR TITLE
Reconciliation status on side panel of Istio configs

### DIFF
--- a/src/components/Validations/ValidationObjectSummary.tsx
+++ b/src/components/Validations/ValidationObjectSummary.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
-import { ObjectValidation, ValidationTypes } from '../../types/IstioObjects';
+import { ObjectValidation, StatusCondition, ValidationTypes } from '../../types/IstioObjects';
 import ValidationSummary from './ValidationSummary';
 import { CSSProperties } from 'react';
 
 interface Props {
   id: string;
   validations: ObjectValidation[];
+  reconciledCondition?: StatusCondition;
   style?: CSSProperties;
 }
 
@@ -27,6 +28,7 @@ export class ValidationObjectSummary extends React.PureComponent<Props> {
         objectCount={1}
         errors={this.numberOfChecks(ValidationTypes.Error)}
         warnings={this.numberOfChecks(ValidationTypes.Warning)}
+        reconciledCondition={this.props.reconciledCondition}
         style={this.props.style}
       />
     );

--- a/src/components/Validations/ValidationSummary.tsx
+++ b/src/components/Validations/ValidationSummary.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { CSSProperties } from 'react';
-import { ValidationTypes } from '../../types/IstioObjects';
+import { StatusCondition, ValidationTypes } from '../../types/IstioObjects';
 import { style } from 'typestyle';
 import { Text, TextVariants, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import Validation from './Validation';
 
 interface Props {
   id: string;
+  reconciledCondition?: StatusCondition;
   errors: number;
   warnings: number;
   objectCount?: number;
@@ -80,6 +81,11 @@ export class ValidationSummary extends React.PureComponent<Props> {
             <div key={cat}>{cat}</div>
           ))}
         </div>
+        {this.props.reconciledCondition?.status && (
+          <Text style={{ textAlign: 'left', textEmphasis: 'strong' }} component={TextVariants.p}>
+            The object is reconciled
+          </Text>
+        )}
       </>
     );
   }

--- a/src/components/VirtualList/Renderers.tsx
+++ b/src/components/VirtualList/Renderers.tsx
@@ -30,6 +30,7 @@ import ValidationSummaryLink from '../Link/ValidationSummaryLink';
 import { ValidationStatus } from '../../types/IstioObjects';
 import { PFBadgeType, PFBadge, PFBadges } from 'components/Pf/PfBadges';
 import MissingLabel from '../MissingLabel/MissingLabel';
+import { getReconciliationCondition } from 'utils/IstioConfigUtils';
 
 // Links
 
@@ -318,12 +319,17 @@ export const istioType: Renderer<IstioConfigItem> = (item: IstioConfigItem) => {
 
 export const istioConfiguration: Renderer<IstioConfigItem> = (item: IstioConfigItem, config: Resource) => {
   const validation = item.validation;
+  const reconciledCondition = getReconciliationCondition(item);
   const linkQuery: string = item['type'] ? 'list=yaml' : '';
   return (
     <td role="gridcell" key={'VirtuaItem_Conf_' + item.namespace + '_' + item.name} style={{ verticalAlign: 'middle' }}>
       {validation ? (
         <Link to={`${getLink(item, config, linkQuery)}`}>
-          <ValidationObjectSummary id={item.name + '-config-validation'} validations={[validation]} />
+          <ValidationObjectSummary
+            id={item.name + '-config-validation'}
+            validations={[validation]}
+            reconciledCondition={reconciledCondition}
+          />
         </Link>
       ) : (
         <>N/A</>

--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -12,7 +12,7 @@ import * as API from '../../services/Api';
 import AceEditor from 'react-ace';
 import 'ace-builds/src-noconflict/mode-yaml';
 import 'ace-builds/src-noconflict/theme-eclipse';
-import { ObjectReference, ObjectValidation, StatusCondition, ValidationMessage } from '../../types/IstioObjects';
+import { ObjectReference, ObjectValidation, ValidationMessage } from '../../types/IstioObjects';
 import { AceValidations, jsYaml, parseKialiValidations, parseYamlValidations } from '../../types/AceValidations';
 import IstioActionDropdown from '../../components/IstioActions/IstioActionsDropdown';
 import { RenderComponentScroll, RenderHeader } from '../../components/Nav/Page';
@@ -21,7 +21,7 @@ import { default as IstioActionButtonsContainer } from '../../components/IstioAc
 import history from '../../app/History';
 import { Paths } from '../../config';
 import { MessageType } from '../../types/MessageCenter';
-import { getIstioObject, mergeJsonPatch } from '../../utils/IstioConfigUtils';
+import { getIstioObject, getReconciliationCondition, mergeJsonPatch } from '../../utils/IstioConfigUtils';
 import { style } from 'typestyle';
 import ParameterizedTabs, { activeTab } from '../../components/Tab/Tabs';
 import {
@@ -376,11 +376,6 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
       : ([] as ValidationMessage[]);
   };
 
-  getReconciliationCondition = (istioConfigDetails?: IstioConfigDetails): StatusCondition | undefined => {
-    const istioObject = getIstioObject(istioConfigDetails);
-    return istioObject?.status?.conditions?.find(condition => condition.type === 'Reconciled');
-  };
-
   // Not all Istio types have an overview card
   hasOverview = (): boolean => {
     return (
@@ -440,7 +435,7 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
   renderEditor = () => {
     const yamlSource = this.fetchYaml();
     const istioStatusMsgs = this.getStatusMessages(this.state.istioObjectDetails);
-    const reconciliationStatus = this.getReconciliationCondition(this.state.istioObjectDetails);
+    const reconciliationStatus = getReconciliationCondition(this.state.istioObjectDetails);
     const objectReferences = this.objectReferences(this.state.istioObjectDetails);
     const refPresent = objectReferences.length > 0;
     const showCards = this.showCards(refPresent, istioStatusMsgs);

--- a/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
+++ b/src/pages/IstioConfigDetails/IstioConfigDetailsPage.tsx
@@ -12,7 +12,7 @@ import * as API from '../../services/Api';
 import AceEditor from 'react-ace';
 import 'ace-builds/src-noconflict/mode-yaml';
 import 'ace-builds/src-noconflict/theme-eclipse';
-import { ObjectReference, ObjectValidation, ValidationMessage } from '../../types/IstioObjects';
+import { ObjectReference, ObjectValidation, StatusCondition, ValidationMessage } from '../../types/IstioObjects';
 import { AceValidations, jsYaml, parseKialiValidations, parseYamlValidations } from '../../types/AceValidations';
 import IstioActionDropdown from '../../components/IstioActions/IstioActionsDropdown';
 import { RenderComponentScroll, RenderHeader } from '../../components/Nav/Page';
@@ -43,6 +43,7 @@ import IstioStatusMessageList from './IstioObjectDetails/IstioStatusMessageList'
 import { Annotation } from 'react-ace/types';
 import ValidationReferences from './ValidationReferences';
 import RefreshButtonContainer from '../../components/Refresh/RefreshButton';
+import IstioReconciliationStatus from './IstioObjectDetails/IstioReconciliationStatus';
 
 // Enables the search box for the ACEeditor
 require('ace-builds/src-noconflict/ext-searchbox');
@@ -375,6 +376,11 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
       : ([] as ValidationMessage[]);
   };
 
+  getReconciliationCondition = (istioConfigDetails?: IstioConfigDetails): StatusCondition | undefined => {
+    const istioObject = getIstioObject(istioConfigDetails);
+    return istioObject?.status?.conditions?.find(condition => condition.type === 'Reconciled');
+  };
+
   // Not all Istio types have an overview card
   hasOverview = (): boolean => {
     return (
@@ -419,7 +425,10 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
   isExpanded = (istioConfigDetails?: IstioConfigDetails) => {
     let isExpanded = false;
     if (istioConfigDetails) {
-      isExpanded = this.showCards(this.objectReferences(istioConfigDetails).length > 0, this.getStatusMessages(istioConfigDetails));
+      isExpanded = this.showCards(
+        this.objectReferences(istioConfigDetails).length > 0,
+        this.getStatusMessages(istioConfigDetails)
+      );
     }
     return isExpanded;
   };
@@ -431,6 +440,7 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
   renderEditor = () => {
     const yamlSource = this.fetchYaml();
     const istioStatusMsgs = this.getStatusMessages(this.state.istioObjectDetails);
+    const reconciliationStatus = this.getReconciliationCondition(this.state.istioObjectDetails);
     const objectReferences = this.objectReferences(this.state.istioObjectDetails);
     const refPresent = objectReferences.length > 0;
     const showCards = this.showCards(refPresent, istioStatusMsgs);
@@ -467,6 +477,7 @@ class IstioConfigDetailsPage extends React.Component<RouteComponentProps<IstioCo
                     namespace={this.state.istioObjectDetails.namespace.name}
                   />
                 )}
+                {reconciliationStatus && <IstioReconciliationStatus condition={reconciliationStatus} />}
                 {istioStatusMsgs && istioStatusMsgs.length > 0 && <IstioStatusMessageList messages={istioStatusMsgs} />}
                 {refPresent && <ValidationReferences objectReferences={objectReferences} />}
               </>

--- a/src/pages/IstioConfigDetails/IstioObjectDetails/IstioReconciliationStatus.tsx
+++ b/src/pages/IstioConfigDetails/IstioObjectDetails/IstioReconciliationStatus.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { Stack, StackItem, Title, TitleLevel, TitleSize } from '@patternfly/react-core';
+import { StatusCondition } from 'types/IstioObjects';
+
+interface Props {
+  condition: StatusCondition;
+}
+
+class IstioReconciliationStatus extends React.Component<Props> {
+  render() {
+    return (
+      <>
+        <Title headingLevel={TitleLevel.h3} size={TitleSize.xl}>
+          Reconciliation Status
+        </Title>
+        <Stack gutter="lg">
+          <StackItem>
+            {this.props.condition.status && <>The object is reconciled.</>}
+            {!this.props.condition.status && <>The object is reconciling.</>}
+          </StackItem>
+          <StackItem>{this.props.condition.message}</StackItem>
+        </Stack>
+      </>
+    );
+  }
+}
+
+export default IstioReconciliationStatus;

--- a/src/types/IstioObjects.ts
+++ b/src/types/IstioObjects.ts
@@ -49,7 +49,7 @@ export interface IstioObject {
 
 export interface IstioStatus {
   validationMessages?: ValidationMessage[];
-  conditions?: any[];
+  conditions?: StatusCondition[];
 }
 
 export interface ValidationMessage {
@@ -57,6 +57,12 @@ export interface ValidationMessage {
   documentationUrl: string;
   level?: string;
   type: ValidationMessageType;
+}
+
+export interface StatusCondition {
+  type: string;
+  status: boolean;
+  message: string;
 }
 
 export interface ValidationMessageType {

--- a/src/utils/IstioConfigUtils.ts
+++ b/src/utils/IstioConfigUtils.ts
@@ -1,6 +1,7 @@
 import { IstioConfigDetails } from '../types/IstioConfigDetails';
-import { ConnectionPoolSettings, IstioObject, OutlierDetection } from '../types/IstioObjects';
+import { ConnectionPoolSettings, IstioObject, OutlierDetection, StatusCondition } from '../types/IstioObjects';
 import _ from 'lodash';
+import { IstioConfigItem } from 'types/IstioConfigList';
 
 export const mergeJsonPatch = (objectModified: object, object?: object): object => {
   if (!object) {
@@ -19,7 +20,7 @@ export const mergeJsonPatch = (objectModified: object, object?: object): object 
   return objectModified;
 };
 
-export const getIstioObject = (istioObjectDetails?: IstioConfigDetails) => {
+export const getIstioObject = (istioObjectDetails?: IstioConfigDetails | IstioConfigItem) => {
   let istioObject: IstioObject | undefined;
   if (istioObjectDetails) {
     if (istioObjectDetails.gateway) {
@@ -156,4 +157,11 @@ export const isValidOutlierDetection = (outlierDetection: OutlierDetection): boo
     return false;
   }
   return true;
+};
+
+export const getReconciliationCondition = (
+  istioConfigDetails?: IstioConfigDetails | IstioConfigItem
+): StatusCondition | undefined => {
+  const istioObject = getIstioObject(istioConfigDetails);
+  return istioObject?.status?.conditions?.find(condition => condition.type === 'Reconciled');
 };


### PR DESCRIPTION
This PR adds the following information when the control plane is configured to set the status field into the resources:

Resolves [#4457](https://github.com/kiali/kiali/issues/4457)

The status condition of type "Reconciled" will be shown in the side panel of Istio configs.

![status-conditions](https://user-images.githubusercontent.com/1286393/143242342-52b1230a-27d1-40f4-8ddc-70212442a1b2.png)

The status condition of type "Reconciled" will be indicated as follows in the config list per entry:

![status-reconciled-2](https://user-images.githubusercontent.com/1286393/143252448-92ee4b61-a748-43ce-a14d-b29b7205a818.png)
