### PR TITLE
Graph zoom-aware labeling and scale-usability enhancements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "proxy": "http://localhost:20001/kiali",
   "name": "@kiali/kiali-ui",
   "version": "1.45.0",
   "description": "React UI for [Kiali](https://github.com/kiali/kiali).",
@@ -66,7 +67,7 @@
     "csstips": "0.3.0",
     "csx": "9.1.0",
     "cy-node-html-label": "2.0.0",
-    "cytoscape": "3.15.1",
+    "cytoscape": "3.20.0",
     "cytoscape-canvas": "3.0.1",
     "cytoscape-cola": "2.3.1",
     "cytoscape-cose-bilkent": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-  "proxy": "http://localhost:20001/kiali",
   "name": "@kiali/kiali-ui",
   "version": "1.45.0",
   "description": "React UI for [Kiali](https://github.com/kiali/kiali).",
@@ -67,7 +66,7 @@
     "csstips": "0.3.0",
     "csx": "9.1.0",
     "cy-node-html-label": "2.0.0",
-    "cytoscape": "3.20.0",
+    "cytoscape": "3.15.5",
     "cytoscape-canvas": "3.0.1",
     "cytoscape-cola": "2.3.1",
     "cytoscape-cose-bilkent": "4.1.0",

--- a/src/actions/GraphActions.ts
+++ b/src/actions/GraphActions.ts
@@ -1,5 +1,5 @@
 import { ActionType, createAction, createStandardAction } from 'typesafe-actions';
-import { CytoscapeClickEvent, GraphDefinition, Layout, NodeParamsType, RankResult } from '../types/Graph';
+import { CytoscapeEvent, GraphDefinition, Layout, NodeParamsType, RankResult } from '../types/Graph';
 import { ActionKeys } from './ActionKeys';
 import { TimeInMilliseconds } from 'types/Common';
 
@@ -10,7 +10,7 @@ export const GraphActions = {
   setNode: createStandardAction(ActionKeys.GRAPH_SET_NODE)<NodeParamsType | undefined>(),
   setRankResult: createStandardAction(ActionKeys.GRAPH_SET_RANK_RESULT)<RankResult>(),
   setUpdateTime: createStandardAction(ActionKeys.GRAPH_SET_UPDATE_TIME)<TimeInMilliseconds>(),
-  updateSummary: createStandardAction(ActionKeys.GRAPH_UPDATE_SUMMARY)<CytoscapeClickEvent>()
+  updateSummary: createStandardAction(ActionKeys.GRAPH_UPDATE_SUMMARY)<CytoscapeEvent>()
 };
 
 export type GraphAction = ActionType<typeof GraphActions>;

--- a/src/components/CytoscapeGraph/ContextMenu/EdgeContextMenu.tsx
+++ b/src/components/CytoscapeGraph/ContextMenu/EdgeContextMenu.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { style } from 'typestyle';
+import { prettyProtocol } from 'types/Graph';
+import { EdgeContextMenuProps } from '../CytoscapeContextMenu';
+import { getTitle } from 'pages/Graph/SummaryPanelCommon';
+import { renderBadgedName } from 'pages/Graph/SummaryLink';
+import { decoratedNodeData } from '../CytoscapeGraphUtils';
+import { EdgeSingular } from 'cytoscape';
+
+const contextMenu = style({
+  fontSize: 'var(--graph-side-panel--font-size)',
+  textAlign: 'left'
+});
+
+export class EdgeContextMenu extends React.PureComponent<EdgeContextMenuProps> {
+  render() {
+    return (
+      <div className={contextMenu}>
+        {getTitle(`Edge (${prettyProtocol(this.props.protocol)})`)}
+        {renderBadgedName(decoratedNodeData((this.props.element as EdgeSingular).source()), 'From:  ')}
+        {renderBadgedName(decoratedNodeData((this.props.element as EdgeSingular).target()), 'To:        ')}
+      </div>
+    );
+  }
+}

--- a/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
+++ b/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
@@ -62,7 +62,8 @@ export class NodeContextMenu extends React.PureComponent<Props> {
       case NodeType.APP:
       case NodeType.BOX:
         // only app boxes have full context menus
-        if (node.isBox === BoxByType.APP) {
+        const isBox = node.isBox;
+        if (!isBox || isBox === BoxByType.APP) {
           // Prefer workload links
           if (node.workload && node.parent) {
             name = node.workload;

--- a/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
+++ b/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
@@ -19,6 +19,7 @@ type ReduxProps = {
   jaegerInfo?: JaegerInfo;
 };
 
+// Note, in the below styles we assign colors to be consistent with PF Dropdown
 const contextMenu = style({
   fontSize: 'var(--graph-side-panel--font-size)',
   textAlign: 'left'
@@ -46,7 +47,7 @@ const contextMenuItem = style({
 });
 
 const contextMenuItemLink = style({
-  color: PFColors.Black600
+  color: PFColors.Black900
 });
 
 type Props = NodeContextMenuProps & ReduxProps;

--- a/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
+++ b/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
@@ -13,48 +13,40 @@ import { NodeContextMenuProps } from '../CytoscapeContextMenu';
 import { getTitle } from 'pages/Graph/SummaryPanelCommon';
 import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
 import { renderBadgedName } from 'pages/Graph/SummaryLink';
+import { PFColors } from 'components/Pf/PfColors';
 
 type ReduxProps = {
   jaegerInfo?: JaegerInfo;
 };
 
-const graphContextMenuContainerStyle = style({
-  fontSize: 'var(--graph-side-panel--font-size)'
-  // textAlign: 'left'
+const contextMenu = style({
+  fontSize: 'var(--graph-side-panel--font-size)',
+  textAlign: 'left'
 });
 
-/*
-const graphContextMenuTitleStyle = style({
-  textAlign: 'left',
-  fontSize: '16px',
-  borderBottom: '1px solid black'
+const contextMenuHeader = style({
+  marginBottom: '2px'
 });
-*/
 
-const graphContextMenuSubTitleStyle = style({
-  // borderTop: '1px solid black',
-  textAlign: 'left',
-  // fontSize: '14px',
-  color: '#737679',
+const contextMenuSubTitle = style({
+  color: PFColors.Black600,
   fontWeight: 700,
   paddingTop: 2,
   paddingBottom: 4
 });
 
-const graphContextMenuItemStyle = style({
-  textAlign: 'left',
-  // fontSize: '12px',
+const contextMenuItem = style({
   textDecoration: 'none',
   $nest: {
     '&:hover': {
-      backgroundColor: '#def3ff',
-      color: '#4d5258'
+      backgroundColor: PFColors.Black200,
+      color: PFColors.Blue400
     }
   }
 });
 
-const graphContextMenuItemLinkStyle = style({
-  color: '#363636'
+const contextMenuItemLink = style({
+  color: PFColors.Black600
 });
 
 type Props = NodeContextMenuProps & ReduxProps;
@@ -93,7 +85,7 @@ export class NodeContextMenu extends React.PureComponent<Props> {
 
   createMenuItem(href: string, title: string, target: string = '_self', external: boolean = false) {
     const commonLinkProps = {
-      className: graphContextMenuItemLinkStyle,
+      className: contextMenuItemLink,
       children: title,
       onClick: this.onClick,
       target
@@ -113,7 +105,7 @@ export class NodeContextMenu extends React.PureComponent<Props> {
     }
 
     return (
-      <div key={title} className={graphContextMenuItemStyle}>
+      <div key={title} className={contextMenuItem}>
         {item}
       </div>
     );
@@ -136,15 +128,15 @@ export class NodeContextMenu extends React.PureComponent<Props> {
     const options: ContextMenuOption[] = getOptionsFromLinkParams(linkParams, this.props.jaegerInfo);
     const menuOptions = (
       <>
-        <div className={graphContextMenuSubTitleStyle}>Show</div>
+        <div className={contextMenuSubTitle}>Show</div>
         {options.map(o => this.createMenuItem(o.url, o.text, o.target, o.external))}
       </>
     );
 
     return (
-      <div className={graphContextMenuContainerStyle}>
+      <div className={contextMenu}>
         {getTitle(this.props.nodeType)}
-        <div style={{ marginBottom: '2px', textAlign: 'left' }}>
+        <div className={contextMenuHeader}>
           <PFBadge badge={PFBadges.Namespace} style={{ marginBottom: '2px' }} />
           {this.props.namespace}
           {renderBadgedName(this.props)}

--- a/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
+++ b/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
@@ -10,24 +10,31 @@ import { JaegerInfo } from 'types/JaegerInfo';
 import { KialiAppState } from 'store/Store';
 import { Paths, serverConfig } from 'config';
 import { NodeContextMenuProps } from '../CytoscapeContextMenu';
+import { getTitle } from 'pages/Graph/SummaryPanelCommon';
+import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
+import { renderBadgedName } from 'pages/Graph/SummaryLink';
 
 type ReduxProps = {
   jaegerInfo?: JaegerInfo;
 };
 
 const graphContextMenuContainerStyle = style({
-  textAlign: 'left'
+  fontSize: 'var(--graph-side-panel--font-size)'
+  // textAlign: 'left'
 });
 
+/*
 const graphContextMenuTitleStyle = style({
   textAlign: 'left',
   fontSize: '16px',
   borderBottom: '1px solid black'
 });
+*/
 
 const graphContextMenuSubTitleStyle = style({
+  // borderTop: '1px solid black',
   textAlign: 'left',
-  fontSize: '14px',
+  // fontSize: '14px',
   color: '#737679',
   fontWeight: 700,
   paddingTop: 2,
@@ -36,7 +43,7 @@ const graphContextMenuSubTitleStyle = style({
 
 const graphContextMenuItemStyle = style({
   textAlign: 'left',
-  fontSize: '12px',
+  // fontSize: '12px',
   textDecoration: 'none',
   $nest: {
     '&:hover': {
@@ -136,9 +143,13 @@ export class NodeContextMenu extends React.PureComponent<Props> {
 
     return (
       <div className={graphContextMenuContainerStyle}>
-        <div className={graphContextMenuTitleStyle}>
-          <strong>{linkParams.name}</strong>
+        {getTitle(this.props.nodeType)}
+        <div style={{ marginBottom: '2px', textAlign: 'left' }}>
+          <PFBadge badge={PFBadges.Namespace} style={{ marginBottom: '2px' }} />
+          {this.props.namespace}
+          {renderBadgedName(this.props)}
         </div>
+        <hr />
         {menuOptions}
       </div>
     );

--- a/src/components/CytoscapeGraph/CytoscapeContextMenu.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeContextMenu.tsx
@@ -16,7 +16,6 @@ export type NodeContextMenuComponentType = React.ComponentType<NodeContextMenuPr
 export type ContextMenuComponentType = EdgeContextMenuComponentType | NodeContextMenuComponentType;
 
 type Props = {
-  contextMenuBoxComponent?: NodeContextMenuComponentType;
   contextMenuEdgeComponent?: EdgeContextMenuComponentType;
   contextMenuNodeComponent?: NodeContextMenuComponentType;
 };
@@ -72,13 +71,7 @@ export class CytoscapeContextMenuWrapper extends React.PureComponent<Props> {
 
   // Connects cy to this component
   handleContextMenu(elem: Cy.NodeSingular | Cy.EdgeSingular, isHover: boolean) {
-    let contextMenuType: ContextMenuComponentType | undefined;
-
-    if (elem.isNode()) {
-      contextMenuType = elem.isParent() ? this.props.contextMenuBoxComponent : this.props.contextMenuNodeComponent;
-    } else {
-      contextMenuType = this.props.contextMenuEdgeComponent;
-    }
+    const contextMenuType = elem.isNode() ? this.props.contextMenuNodeComponent : this.props.contextMenuEdgeComponent;
 
     if (contextMenuType) {
       this.makeContextMenu(contextMenuType, elem, isHover);

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -115,7 +115,7 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps,
   };
 
   // for hover support
-  static hoverMs = 500;
+  static hoverMs = 250;
   static mouseInTarget: any;
   static mouseInTimeout: any;
   static mouseOutTimeout: any;

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -488,19 +488,21 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps>
         const newZoom = cy.zoom();
         this.zoom = newZoom;
 
-        this.zoomThresholds!.some(zoomThresh => {
-          if (
+        const thresholdCrossed = this.zoomThresholds!.some(zoomThresh => {
+          return (
             (newZoom < zoomThresh && (!oldZoom || oldZoom >= zoomThresh)) ||
             (newZoom >= zoomThresh && oldZoom && oldZoom < zoomThresh)
-          ) {
-            console.log(`changeLabels onzoom=${this.zoom}`);
-            CytoscapeGraphUtils.runLayout(cy, this.props.layout);
-            return true;
-          } else {
-            console.log(`zoom=${this.zoom}`);
-            return false;
-          }
+          );
         });
+
+        if (thresholdCrossed) {
+          console.log(`changeLabels onzoom=${this.zoom}`);
+          // this ensure that if html labels changed that we re-layout to potentially condense the graph
+          // CytoscapeGraphUtils.runLayout(cy, this.props.layout);
+          this.forceUpdate();
+        } else {
+          console.log(`zoom=${this.zoom}`);
+        }
       }
     });
 
@@ -598,6 +600,7 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps>
         this.props.onReady(evt.cy);
       }
       this.needsInitialLayout = true;
+      this.zoom = evt.cy.zoom();
     });
 
     cy.on('destroy', (_evt: Cy.EventObject) => {

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -812,13 +812,6 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps,
     if (updateLayout) {
       return new Promise((resolve, _reject) => {
         CytoscapeGraphUtils.runLayout(cy, this.props.layout).then(_response => {
-          // During a layout styles can be applied using an intermediate zoom value.  Because we
-          // have zoom-influence styling, we force an cy-update to the whole graph. There doesn't
-          // seem to a be a better way to do this than to remove and add the elements.
-          cy.startBatch();
-          cy.add(cy.elements().remove());
-          cy.endBatch();
-
           this.finishGraphUpdate(cy, isTheGraphSelected);
           resolve();
         });

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -489,14 +489,8 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps,
               this.userBoxSelected = this.userBoxSelected?.add(elements);
             }
           });
-          this.zoomIgnore = true;
           CytoscapeGraphUtils.safeFit(cy, this.userBoxSelected);
           this.customViewport = true;
-          // We'd prefer to do this once, after all of the 'box' events, but because cy doesn't seem to give
-          // us an event for this, we force an update here to ensure labels are updated, if the box event has
-          // cause a zoom threshold to be changed.
-          this.forceUpdate();
-          this.zoomIgnore = false;
         }
       }
     });

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -153,7 +153,7 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps,
     this.nodeChanged = false;
     this.zoom = 1; // 1 is the default cy zoom
     this.zoomIgnore = true; // ignore zoom events prior to the first rendering
-    const thresholds = serverConfig.kialiFeatureFlags.uiDefaults!.graph.thresholds;
+    const thresholds = serverConfig.kialiFeatureFlags.uiDefaults.graph.thresholds;
     this.zoomThresholds = Array.from(new Set([thresholds.zoomLabel, thresholds.zoomBadge]));
 
     this.state = { zoomThresholdTime: 0 };

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -202,7 +202,6 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps,
     let needsLayout = false;
     if (
       this.needsInitialLayout ||
-      // this.state.zoomThresholdTime !== prevState.zoomThresholdTime ||
       this.nodeNeedsRelayout() ||
       this.namespaceNeedsRelayout(prevProps.graphData.elements, this.props.graphData.elements) ||
       this.elementsNeedRelayout(prevProps.graphData.elements, this.props.graphData.elements) ||
@@ -593,7 +592,7 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps,
       });
 
       if (thresholdCrossed) {
-        // Update state to force an update with layout, to account for the label changes.
+        // Update state to re-render with the label changes.
         console.log(`zoom thresh crossed ${oldZoom} -> ${newZoom}`);
         // start a zoomIgnore which will end after the layout (this.processGraphUpdate()) completes.
         this.zoomIgnore = true;

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -568,14 +568,9 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps,
     });
 
     // Crossing a zoom threshold can affect labeling, and so we need an update to re-render the labels.
-    // But the label addition/removal/change can also affect spacing, so we also need to run the layout.
     // Some cy 'zoom' events need to be ignored, typically while a layout or drag-zoom 'box' event is
-    // in progress, as cy can generate unwanted 'intermediate' values.
-    //
-    // Note that cy 3.19.0 introduces 'scrollzoom' events, which are generated only on mousewheel zoom.
-    // That, in addition to us emitting some custom events (like a kiali-zoom) on things like cytoscape
-    // toolbar zooming, could be cleaner. But, 3.16.0 introduced a behavior/regression that currently affects
-    // us negatively (see https://github.com/cytoscape/cytoscape.js/issues/2956) and is holding us as 3.15.*.
+    // in progress, as cy can generate unwanted 'intermediate' values.  So we set zoomIgnore=true, it will
+    // be set false after the update.
     cy.on('zoom', (evt: Cy.EventObject) => {
       const cytoscapeEvent = getCytoscapeBaseEvent(evt);
       if (!cytoscapeEvent || this.zoomIgnore) {
@@ -824,9 +819,10 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps,
 
   private finishGraphUpdate(cy: Cy.Core, isTheGraphSelected: boolean) {
     // For reasons unknown, box label positions can be wrong after a graph update.
-    // Actually, It seems like only outer nested compound nodes. It seems like a cy bug to me,
-    // But maybe it has to do with either the html node-label extension, or our BoxLayout.
-    // Anyway, refreshing them here seems to fix the positioning.
+    // It seems limited to outer nested compound nodes and looks like a cy bug to me,
+    // but maybe it has to do with either the html node-label extension, or our BoxLayout.
+    // Anyway, refreshing them here seems to fix the positioning (for now, kust refresh
+    // box nodes, but we may find the need to do all nodes).
     (cy as any).nodeHtmlLabel().updateNodeLabel(cy.nodes(':parent'));
 
     // We opt-in for manual selection to be able to control when to select a node/edge

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -24,7 +24,11 @@ import { JaegerTrace } from 'types/JaegerInfo';
 import Namespace from '../../types/Namespace';
 import { addInfo } from 'utils/AlertUtils';
 import { angleBetweenVectors, squaredDistance, normalize } from '../../utils/MathUtils';
-import { CytoscapeContextMenuWrapper, NodeContextMenuType, EdgeContextMenuType } from './CytoscapeContextMenu';
+import {
+  CytoscapeContextMenuWrapper,
+  NodeContextMenuComponentType,
+  EdgeContextMenuComponentType
+} from './CytoscapeContextMenu';
 import * as CytoscapeGraphUtils from './CytoscapeGraphUtils';
 import { CyNode, isCore, isEdge, isNode } from './CytoscapeGraphUtils';
 import { CytoscapeReactWrapper } from './CytoscapeReactWrapper';
@@ -40,9 +44,9 @@ import { scoreNodes, ScoringCriteria } from './GraphScore';
 type CytoscapeGraphProps = {
   compressOnHide: boolean;
   containerClassName?: string;
-  contextMenuEdgeComponent?: EdgeContextMenuType;
-  contextMenuGroupComponent?: NodeContextMenuType;
-  contextMenuNodeComponent?: NodeContextMenuType;
+  contextMenuEdgeComponent?: EdgeContextMenuComponentType;
+  contextMenuBoxComponent?: NodeContextMenuComponentType;
+  contextMenuNodeComponent?: NodeContextMenuComponentType;
   edgeLabels: EdgeLabelMode[];
   graphData: GraphData;
   focusSelector?: string;
@@ -292,7 +296,7 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps,
             ref={this.contextMenuRef}
             edgeContextMenuContent={this.props.contextMenuEdgeComponent}
             nodeContextMenuContent={this.props.contextMenuNodeComponent}
-            groupContextMenuContent={this.props.contextMenuGroupComponent}
+            boxContextMenuContent={this.props.contextMenuBoxComponent}
           />
           <CytoscapeReactWrapper ref={e => this.setCytoscapeReactWrapperRef(e)} />
         </EmptyGraphLayout>

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -120,7 +120,7 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps,
   };
 
   // for hover support
-  static hoverInMs = 300;
+  static hoverInMs = 260;
   static hoverOutMs = 100;
   static mouseInTarget: any;
   static mouseInTimeout: any;
@@ -516,9 +516,6 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps,
       if (!cytoscapeEvent) {
         return;
       }
-      if (!cy.elements(':selected').empty()) {
-        return;
-      }
 
       // cancel any active mouseOut timer
       if (CytoscapeGraph.mouseOutTimeout) {
@@ -538,9 +535,6 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps,
       const cytoscapeEvent = getCytoscapeBaseEvent(evt);
 
       if (!cytoscapeEvent) {
-        return;
-      }
-      if (!cy.elements(':selected').empty()) {
         return;
       }
 

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -45,7 +45,6 @@ type CytoscapeGraphProps = {
   compressOnHide: boolean;
   containerClassName?: string;
   contextMenuEdgeComponent?: EdgeContextMenuComponentType;
-  contextMenuBoxComponent?: NodeContextMenuComponentType;
   contextMenuNodeComponent?: NodeContextMenuComponentType;
   edgeLabels: EdgeLabelMode[];
   graphData: GraphData;
@@ -295,7 +294,6 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps,
         >
           <CytoscapeContextMenuWrapper
             ref={this.contextMenuRef}
-            contextMenuBoxComponent={this.props.contextMenuBoxComponent}
             contextMenuEdgeComponent={this.props.contextMenuEdgeComponent}
             contextMenuNodeComponent={this.props.contextMenuNodeComponent}
           />

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -430,7 +430,7 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps,
         clearTimeout(CytoscapeGraph.tapTimeout);
         CytoscapeGraph.tapTimeout = null;
 
-        // cancel any hover timers in progress
+        // cancel any active hover timers
         if (CytoscapeGraph.mouseInTimeout) {
           clearTimeout(CytoscapeGraph.mouseInTimeout);
           CytoscapeGraph.mouseInTimeout = null;
@@ -469,12 +469,11 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps,
             // if clicking the same target, then unselect it (by re-selecting the graph)
             if (
               this.props.summaryData &&
-              !this.props.summaryData.isHover &&
               cytoscapeEvent.summaryType !== 'graph' &&
               cytoscapeEvent.summaryType === this.props.summaryData.summaryType &&
               cytoscapeEvent.summaryTarget === this.props.summaryData.summaryTarget
             ) {
-              this.handleTap({ isHover: false, summaryType: 'graph', summaryTarget: cy } as SummaryData);
+              this.handleTap({ summaryType: 'graph', summaryTarget: cy } as SummaryData);
               this.selectTarget(cy);
             } else {
               this.handleTap(cytoscapeEvent);
@@ -523,7 +522,7 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps,
         return;
       }
 
-      // cancel any mouseOut timer in progress
+      // cancel any active mouseOut timer
       if (CytoscapeGraph.mouseOutTimeout) {
         clearTimeout(CytoscapeGraph.mouseOutTimeout);
         CytoscapeGraph.mouseOutTimeout = null;
@@ -531,18 +530,9 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps,
 
       // start mouseIn timer
       CytoscapeGraph.mouseInTimeout = setTimeout(() => {
-        // timer expired without a mouseout so perform hover action
+        // timer expired without a mouseout so perform highlighting and show hover contextInfo
         this.handleMouseIn(cytoscapeEvent);
-
         this.contextMenuRef!.current!.handleContextMenu(cytoscapeEvent.summaryTarget, true);
-        /*
-        if (this.props.updateSummary) {
-          this.props.updateSummary({
-            isHover: true,
-            ...cytoscapeEvent
-          });
-        }
-        */
       }, CytoscapeGraph.hoverInMs);
     });
 
@@ -556,26 +546,19 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps,
         return;
       }
 
-      // cancel any mouseIn timer in progress
+      // cancel any active mouseIn timer
       if (CytoscapeGraph.mouseInTimeout) {
         clearTimeout(CytoscapeGraph.mouseInTimeout);
         CytoscapeGraph.mouseInTimeout = null;
       }
 
-      // start mouseOut timer to return to graph summary
+      // start mouseOut timer
       CytoscapeGraph.mouseOutTimeout = setTimeout(() => {
+        // timer expired so remove contextInfo
         this.contextMenuRef!.current!.hideContextMenu(true);
-
-        /*
-        if (this.props.updateSummary) {
-          this.props.updateSummary({
-            summaryType: 'graph',
-            summaryTarget: cytoscapeEvent.summaryTarget.cy()
-          });
-        }
-        */
       }, CytoscapeGraph.hoverOutMs);
 
+      // remove highlighting
       this.handleMouseOut(cytoscapeEvent);
     });
 

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -402,10 +402,14 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps>
         clearTimeout(CytoscapeGraph.tapTimeout);
         CytoscapeGraph.tapTimeout = null;
 
-        // cancel any hover timer in progress
+        // cancel any hover timers in progress
         if (CytoscapeGraph.mouseInTimeout) {
           clearTimeout(CytoscapeGraph.mouseInTimeout);
           CytoscapeGraph.mouseInTimeout = null;
+        }
+        if (CytoscapeGraph.mouseOutTimeout) {
+          clearTimeout(CytoscapeGraph.mouseOutTimeout);
+          CytoscapeGraph.mouseOutTimeout = null;
         }
 
         if (tapped === CytoscapeGraph.tapTarget) {

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -503,51 +503,60 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps,
 
     cy.on('mouseover', 'node,edge', (evt: Cy.EventObject) => {
       const cytoscapeEvent = getCytoscapeBaseEvent(evt);
-
-      if (cytoscapeEvent) {
-        // cancel any mouseOut timer in progress
-        if (CytoscapeGraph.mouseOutTimeout) {
-          clearTimeout(CytoscapeGraph.mouseOutTimeout);
-          CytoscapeGraph.mouseOutTimeout = null;
-        }
-
-        // start mouseIn timer
-        CytoscapeGraph.mouseInTimeout = setTimeout(() => {
-          // timer expired without a mouseout so perform hover action
-          this.handleMouseIn(cytoscapeEvent);
-
-          if (this.props.updateSummary) {
-            this.props.updateSummary({
-              isHover: true,
-              ...cytoscapeEvent
-            });
-          }
-        }, CytoscapeGraph.hoverMs);
+      if (!cytoscapeEvent) {
+        return;
       }
+      if (!cy.elements(':selected').empty()) {
+        return;
+      }
+
+      // cancel any mouseOut timer in progress
+      if (CytoscapeGraph.mouseOutTimeout) {
+        clearTimeout(CytoscapeGraph.mouseOutTimeout);
+        CytoscapeGraph.mouseOutTimeout = null;
+      }
+
+      // start mouseIn timer
+      CytoscapeGraph.mouseInTimeout = setTimeout(() => {
+        // timer expired without a mouseout so perform hover action
+        this.handleMouseIn(cytoscapeEvent);
+
+        if (this.props.updateSummary) {
+          this.props.updateSummary({
+            isHover: true,
+            ...cytoscapeEvent
+          });
+        }
+      }, CytoscapeGraph.hoverMs);
     });
 
     cy.on('mouseout', 'node,edge', (evt: Cy.EventObject) => {
       const cytoscapeEvent = getCytoscapeBaseEvent(evt);
 
-      if (cytoscapeEvent) {
-        // cancel any mouseIn timer in progress
-        if (CytoscapeGraph.mouseInTimeout) {
-          clearTimeout(CytoscapeGraph.mouseInTimeout);
-          CytoscapeGraph.mouseInTimeout = null;
-        }
-
-        // start mouseOut timer to return to graph summary
-        CytoscapeGraph.mouseOutTimeout = setTimeout(() => {
-          if (this.props.updateSummary) {
-            this.props.updateSummary({
-              summaryType: 'graph',
-              summaryTarget: cytoscapeEvent.summaryTarget.cy()
-            });
-          }
-        }, CytoscapeGraph.hoverMs);
-
-        this.handleMouseOut(cytoscapeEvent);
+      if (!cytoscapeEvent) {
+        return;
       }
+      if (!cy.elements(':selected').empty()) {
+        return;
+      }
+
+      // cancel any mouseIn timer in progress
+      if (CytoscapeGraph.mouseInTimeout) {
+        clearTimeout(CytoscapeGraph.mouseInTimeout);
+        CytoscapeGraph.mouseInTimeout = null;
+      }
+
+      // start mouseOut timer to return to graph summary
+      CytoscapeGraph.mouseOutTimeout = setTimeout(() => {
+        if (this.props.updateSummary) {
+          this.props.updateSummary({
+            summaryType: 'graph',
+            summaryTarget: cytoscapeEvent.summaryTarget.cy()
+          });
+        }
+      }, CytoscapeGraph.hoverMs);
+
+      this.handleMouseOut(cytoscapeEvent);
     });
 
     cy.on('viewport', (evt: Cy.EventObject) => {

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -822,7 +822,7 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps,
     // For reasons unknown, box label positions can be wrong after a graph update.
     // It seems limited to outer nested compound nodes and looks like a cy bug to me,
     // but maybe it has to do with either the html node-label extension, or our BoxLayout.
-    // Anyway, refreshing them here seems to fix the positioning (for now, kust refresh
+    // Anyway, refreshing them here seems to fix the positioning (for now, just refresh
     // box nodes, but we may find the need to do all nodes).
     (cy as any).nodeHtmlLabel().updateNodeLabel(cy.nodes(':parent'));
 

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -121,7 +121,8 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps,
   };
 
   // for hover support
-  static hoverMs = 270;
+  static hoverInMs = 300;
+  static hoverOutMs = 100;
   static mouseInTarget: any;
   static mouseInTimeout: any;
   static mouseOutTimeout: any;
@@ -533,6 +534,7 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps,
         // timer expired without a mouseout so perform hover action
         this.handleMouseIn(cytoscapeEvent);
 
+        this.contextMenuRef!.current!.handleContextMenu(cytoscapeEvent.summaryTarget, true);
         /*
         if (this.props.updateSummary) {
           this.props.updateSummary({
@@ -541,7 +543,7 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps,
           });
         }
         */
-      }, CytoscapeGraph.hoverMs);
+      }, CytoscapeGraph.hoverInMs);
     });
 
     cy.on('mouseout', 'node,edge', (evt: Cy.EventObject) => {
@@ -562,6 +564,8 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps,
 
       // start mouseOut timer to return to graph summary
       CytoscapeGraph.mouseOutTimeout = setTimeout(() => {
+        this.contextMenuRef!.current!.hideContextMenu(true);
+
         /*
         if (this.props.updateSummary) {
           this.props.updateSummary({
@@ -570,7 +574,7 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps,
           });
         }
         */
-      }, CytoscapeGraph.hoverMs);
+      }, CytoscapeGraph.hoverOutMs);
 
       this.handleMouseOut(cytoscapeEvent);
     });

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -128,6 +128,7 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps>
   private resetSelection: boolean = false;
   private trafficRenderer?: TrafficRenderer;
   private userBoxSelected?: Cy.Collection;
+  private zoom?: number;
 
   constructor(props: CytoscapeGraphProps) {
     super(props);
@@ -470,6 +471,31 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps>
       const cytoscapeEvent = getCytoscapeBaseEvent(evt);
       if (cytoscapeEvent) {
         this.customViewport = false;
+      }
+    });
+
+    // 'fit' is a custom event that we emit allowing us to reset cytoscapeGraph.customViewport
+    cy.on('zoom', (evt: Cy.EventObject) => {
+      const cytoscapeEvent = getCytoscapeBaseEvent(evt);
+      if (cytoscapeEvent) {
+        const zoomThresholds = [0.6, 0.8];
+        const oldZoom = this.zoom;
+        const newZoom = cy.zoom();
+        this.zoom = newZoom;
+
+        zoomThresholds.some(zoomThresh => {
+          if (
+            (newZoom < zoomThresh && (!oldZoom || oldZoom >= zoomThresh)) ||
+            (newZoom >= zoomThresh && oldZoom && oldZoom < zoomThresh)
+          ) {
+            console.log(`changeLabels onzoom=${this.zoom}`);
+            CytoscapeGraphUtils.runLayout(cy, this.props.layout);
+            return true;
+          } else {
+            console.log(`zoom=${this.zoom}`);
+            return false;
+          }
+        });
       }
     });
 

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -189,7 +189,7 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps,
     return result;
   }
 
-  componentDidUpdate(prevProps: CytoscapeGraphProps, prevState: CytoscapeGraphState) {
+  componentDidUpdate(prevProps: CytoscapeGraphProps, _prevState: CytoscapeGraphState) {
     const cy = this.getCy();
     if (!cy) {
       return;
@@ -202,7 +202,7 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps,
     let needsLayout = false;
     if (
       this.needsInitialLayout ||
-      this.state.zoomThresholdTime !== prevState.zoomThresholdTime ||
+      // this.state.zoomThresholdTime !== prevState.zoomThresholdTime ||
       this.nodeNeedsRelayout() ||
       this.namespaceNeedsRelayout(prevProps.graphData.elements, this.props.graphData.elements) ||
       this.elementsNeedRelayout(prevProps.graphData.elements, this.props.graphData.elements) ||

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -294,9 +294,9 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps,
         >
           <CytoscapeContextMenuWrapper
             ref={this.contextMenuRef}
-            edgeContextMenuContent={this.props.contextMenuEdgeComponent}
-            nodeContextMenuContent={this.props.contextMenuNodeComponent}
-            boxContextMenuContent={this.props.contextMenuBoxComponent}
+            contextMenuBoxComponent={this.props.contextMenuBoxComponent}
+            contextMenuEdgeComponent={this.props.contextMenuEdgeComponent}
+            contextMenuNodeComponent={this.props.contextMenuNodeComponent}
           />
           <CytoscapeReactWrapper ref={e => this.setCytoscapeReactWrapperRef(e)} />
         </EmptyGraphLayout>
@@ -533,12 +533,14 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps,
         // timer expired without a mouseout so perform hover action
         this.handleMouseIn(cytoscapeEvent);
 
+        /*
         if (this.props.updateSummary) {
           this.props.updateSummary({
             isHover: true,
             ...cytoscapeEvent
           });
         }
+        */
       }, CytoscapeGraph.hoverMs);
     });
 
@@ -560,12 +562,14 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps,
 
       // start mouseOut timer to return to graph summary
       CytoscapeGraph.mouseOutTimeout = setTimeout(() => {
+        /*
         if (this.props.updateSummary) {
           this.props.updateSummary({
             summaryType: 'graph',
             summaryTarget: cytoscapeEvent.summaryTarget.cy()
           });
         }
+        */
       }, CytoscapeGraph.hoverMs);
 
       this.handleMouseOut(cytoscapeEvent);

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -17,6 +17,7 @@ import {
   NodeType,
   RankMode,
   RankResult,
+  SummaryData,
   UNKNOWN
 } from '../../types/Graph';
 import { JaegerTrace } from 'types/JaegerInfo';
@@ -69,6 +70,7 @@ type CytoscapeGraphProps = {
   showServiceNodes: boolean;
   showTrafficAnimation: boolean;
   showVirtualServices: boolean;
+  summaryData: SummaryData | null;
   toggleIdleNodes: () => void;
   trace?: JaegerTrace;
   updateSummary?: (event: CytoscapeEvent) => void;
@@ -115,7 +117,7 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps,
   };
 
   // for hover support
-  static hoverMs = 250;
+  static hoverMs = 270;
   static mouseInTarget: any;
   static mouseInTimeout: any;
   static mouseOutTimeout: any;
@@ -459,8 +461,20 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps,
               return;
             }
 
-            this.handleTap(cytoscapeEvent);
-            this.selectTarget(event.target);
+            // if clicking the same target, then unselect it (by re-selecting the graph)
+            if (
+              this.props.summaryData &&
+              !this.props.summaryData.isHover &&
+              cytoscapeEvent.summaryType !== 'graph' &&
+              cytoscapeEvent.summaryType === this.props.summaryData.summaryType &&
+              cytoscapeEvent.summaryTarget === this.props.summaryData.summaryTarget
+            ) {
+              this.handleTap({ isHover: false, summaryType: 'graph', summaryTarget: cy } as SummaryData);
+              this.selectTarget(cy);
+            } else {
+              this.handleTap(cytoscapeEvent);
+              this.selectTarget(event.target);
+            }
           }
         }, CytoscapeGraph.doubleTapMs);
       }

--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -546,12 +546,9 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps>
         });
 
         if (thresholdCrossed) {
-          console.log(`changeLabels onzoom=${this.zoom}`);
-          // this ensure that if html labels changed that we re-layout to potentially condense the graph
+          // note, running the layout will not necessarily update the cached labeling, so force a re-render
           // CytoscapeGraphUtils.runLayout(cy, this.props.layout);
           this.forceUpdate();
-        } else {
-          console.log(`zoom=${this.zoom}`);
         }
       }
     });

--- a/src/components/CytoscapeGraph/CytoscapeGraphUtils.ts
+++ b/src/components/CytoscapeGraph/CytoscapeGraphUtils.ts
@@ -91,8 +91,8 @@ export const safeFit = (cy: Cy.Core, centerElements?: Cy.Collection) => {
     cy.zoom(ZoomOptions.maxZoom);
     !!centerElements && !!centerElements.length ? cy.center(centerElements) : cy.center();
   }
-  // 'fit' is a custom event that we emit allowing us to reset cytoscapeGraph.customViewport
-  cy.emit('fit');
+  // 'kiali-fit' is a custom event that we emit allowing us to reset cytoscapeGraph.customViewport
+  cy.emit('kiali-fit');
 };
 
 export const runLayout = (cy: Cy.Core, layout: Layout): Promise<any> => {

--- a/src/components/CytoscapeGraph/CytoscapeToolbar.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeToolbar.tsx
@@ -241,6 +241,7 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps,
           y: container.offsetHeight / 2
         }
       });
+      cy.emit('kializoom');
     }
   };
 

--- a/src/components/CytoscapeGraph/CytoscapeToolbar.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeToolbar.tsx
@@ -46,9 +46,9 @@ type CytoscapeToolbarState = {
 
 const buttonStyle = style({
   backgroundColor: PFColors.White,
-  padding: '3px 8px',
+  marginBottom: '2px',
   marginLeft: '4px',
-  marginBottom: '2px'
+  padding: '3px 8px'
 });
 const activeButtonStyle = style({
   color: PFColors.Active

--- a/src/components/CytoscapeGraph/CytoscapeToolbar.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeToolbar.tsx
@@ -241,7 +241,6 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps,
           y: container.offsetHeight / 2
         }
       });
-      cy.emit('kializoom');
     }
   };
 

--- a/src/components/CytoscapeGraph/CytoscapeToolbar.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeToolbar.tsx
@@ -3,6 +3,7 @@ import * as Cy from 'cytoscape';
 import { Button, Toolbar, ToolbarItem, Tooltip } from '@patternfly/react-core';
 import {
   ExpandArrowsAltIcon,
+  MapIcon,
   PficonDragdropIcon,
   SearchMinusIcon,
   SearchPlusIcon,
@@ -45,15 +46,16 @@ type CytoscapeToolbarState = {
 
 const buttonStyle = style({
   backgroundColor: PFColors.White,
-  marginRight: '1px'
+  padding: '3px 8px',
+  marginLeft: '4px',
+  marginBottom: '2px'
 });
 const activeButtonStyle = style({
   color: PFColors.Active
 });
 const cytoscapeToolbarStyle = style({
-  padding: '7px 10px'
+  width: '20px'
 });
-const cytoscapeToolbarPadStyle = style({ marginLeft: '9px' });
 
 const ZOOM_STEP = 0.2;
 
@@ -100,7 +102,7 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps,
             <Button
               id="toolbar_zoom_in"
               aria-label="Zoom In"
-              className={[cytoscapeToolbarPadStyle, buttonStyle].join(' ')}
+              className={buttonStyle}
               variant="plain"
               onClick={() => this.zoomIn()}
             >
@@ -126,7 +128,7 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps,
             <Button
               id="toolbar_graph_fit"
               aria-label="Zoom to Fit"
-              className={[cytoscapeToolbarPadStyle, buttonStyle].join(' ')}
+              className={buttonStyle}
               variant="plain"
               onClick={() => this.fit()}
             >
@@ -135,7 +137,7 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps,
           </Tooltip>
         </ToolbarItem>
 
-        <ToolbarItem className={cytoscapeToolbarPadStyle}>
+        <ToolbarItem>
           <Tooltip content={'Layout default ' + DagreGraph.getLayout().name}>
             <Button
               id="toolbar_layout_default"
@@ -169,8 +171,7 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps,
               >
                 <TopologyIcon
                   className={this.props.layout.name === CoseGraph.getLayout().name ? activeButtonStyle : undefined}
-                />{' '}
-                1
+                />
               </Button>
             </Tooltip>
           </ToolbarItem>
@@ -190,8 +191,7 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps,
             >
               <TopologyIcon
                 className={this.props.layout.name === ColaGraph.getLayout().name ? activeButtonStyle : undefined}
-              />{' '}
-              2
+              />
             </Button>
           </Tooltip>
         </ToolbarItem>
@@ -199,14 +199,14 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps,
         <TourStopContainer info={GraphTourStops.Legend}>
           <ToolbarItem>
             <Button
-              variant="primary"
               id="toolbar_toggle_legend"
               aria-label="Show Legend"
+              className={buttonStyle}
+              variant="plain"
               onClick={this.props.toggleLegend}
               isActive={this.props.showLegend}
-              className={cytoscapeToolbarPadStyle}
             >
-              Legend
+              <MapIcon className={this.props.showLegend ? activeButtonStyle : undefined} size="sm" />
             </Button>
           </ToolbarItem>
         </TourStopContainer>

--- a/src/components/CytoscapeGraph/CytoscapeToolbar.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeToolbar.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as Cy from 'cytoscape';
-import { Button, Toolbar, ToolbarItem, Tooltip } from '@patternfly/react-core';
+import { Button, Toolbar, ToolbarItem, Tooltip, TooltipPosition } from '@patternfly/react-core';
 import {
   ExpandArrowsAltIcon,
   MapIcon,
@@ -84,7 +84,7 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps,
     return (
       <Toolbar className={cytoscapeToolbarStyle}>
         <ToolbarItem>
-          <Tooltip content={this.state.allowGrab ? 'Disable Drag' : 'Enable Drag'}>
+          <Tooltip content={this.state.allowGrab ? 'Disable Drag' : 'Enable Drag'} position={TooltipPosition.right}>
             <Button
               id="toolbar_grab"
               aria-label="Toggle Drag"
@@ -98,7 +98,7 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps,
           </Tooltip>
         </ToolbarItem>
         <ToolbarItem>
-          <Tooltip content="Zoom In">
+          <Tooltip content="Zoom In" position={TooltipPosition.right}>
             <Button
               id="toolbar_zoom_in"
               aria-label="Zoom In"
@@ -111,7 +111,7 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps,
           </Tooltip>
         </ToolbarItem>
         <ToolbarItem>
-          <Tooltip content="Zoom Out">
+          <Tooltip content="Zoom Out" position={TooltipPosition.right}>
             <Button
               id="toolbar_zoom_out"
               aria-label="Zoom Out"
@@ -124,7 +124,7 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps,
           </Tooltip>
         </ToolbarItem>
         <ToolbarItem>
-          <Tooltip content="Zoom to Fit">
+          <Tooltip content="Zoom to Fit" position={TooltipPosition.right}>
             <Button
               id="toolbar_graph_fit"
               aria-label="Zoom to Fit"
@@ -138,7 +138,7 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps,
         </ToolbarItem>
 
         <ToolbarItem>
-          <Tooltip content={'Layout default ' + DagreGraph.getLayout().name}>
+          <Tooltip content={'Layout default ' + DagreGraph.getLayout().name} position={TooltipPosition.right}>
             <Button
               id="toolbar_layout_default"
               aria-label="Graph Layout Default Style"
@@ -158,7 +158,7 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps,
 
         <TourStopContainer info={GraphTourStops.Layout}>
           <ToolbarItem>
-            <Tooltip content={'Layout 1 ' + CoseGraph.getLayout().name}>
+            <Tooltip content={'Layout 1 ' + CoseGraph.getLayout().name} position={TooltipPosition.right}>
               <Button
                 id="toolbar_layout1"
                 aria-label="Graph Layout Style 1"
@@ -178,7 +178,7 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps,
         </TourStopContainer>
 
         <ToolbarItem>
-          <Tooltip content={'Layout 2 ' + ColaGraph.getLayout().name}>
+          <Tooltip content={'Layout 2 ' + ColaGraph.getLayout().name} position={TooltipPosition.right}>
             <Button
               id="toolbar_layout2"
               aria-label="Graph Layout Style 2"
@@ -198,16 +198,18 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps,
 
         <TourStopContainer info={GraphTourStops.Legend}>
           <ToolbarItem>
-            <Button
-              id="toolbar_toggle_legend"
-              aria-label="Show Legend"
-              className={buttonStyle}
-              variant="plain"
-              onClick={this.props.toggleLegend}
-              isActive={this.props.showLegend}
-            >
-              <MapIcon className={this.props.showLegend ? activeButtonStyle : undefined} size="sm" />
-            </Button>
+            <Tooltip content="Show Legend" position={TooltipPosition.right}>
+              <Button
+                id="toolbar_toggle_legend"
+                aria-label="Show Legend"
+                className={buttonStyle}
+                variant="plain"
+                onClick={this.props.toggleLegend}
+                isActive={this.props.showLegend}
+              >
+                <MapIcon className={this.props.showLegend ? activeButtonStyle : undefined} size="sm" />
+              </Button>
+            </Tooltip>
           </ToolbarItem>
         </TourStopContainer>
       </Toolbar>

--- a/src/components/CytoscapeGraph/MiniGraphCard.tsx
+++ b/src/components/CytoscapeGraph/MiniGraphCard.tsx
@@ -127,6 +127,7 @@ export default class MiniGraphCard extends React.Component<MiniGraphCardProps, M
               showTrafficAnimation={false}
               showIdleNodes={false}
               showVirtualServices={true}
+              summaryData={null}
             />
           </div>
         </CardBody>

--- a/src/components/CytoscapeGraph/__tests__/CytoscapeGraph.test.tsx
+++ b/src/components/CytoscapeGraph/__tests__/CytoscapeGraph.test.tsx
@@ -87,6 +87,7 @@ describe('CytoscapeGraph component test', () => {
           showServiceNodes={true}
           showTrafficAnimation={false}
           showVirtualServices={true}
+          summaryData={null}
           toggleIdleNodes={() => undefined}
         />
       );

--- a/src/components/CytoscapeGraph/graphs/GraphHighlighter.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphHighlighter.ts
@@ -51,7 +51,7 @@ export class GraphHighlighter {
   onMouseIn = (event: CytoscapeMouseInEvent) => {
     // only highlight on hover when the graph is currently selected, otherwise leave the
     // selected element highlighted
-    if (this.selected.summaryType === 'graph' && ['node', 'edge', 'box'].indexOf(event.summaryType) !== -1) {
+    if (this.selected.summaryType === 'graph' && ['node', 'edge', 'box'].includes(event.summaryType)) {
       this.hovered = event;
       this.hovered.summaryTarget.addClass(HoveredClass);
       this.refresh();
@@ -92,9 +92,9 @@ export class GraphHighlighter {
     if (event) {
       switch (event.summaryType) {
         case 'node':
-          return { toHighlight: this.getNodeHighlight(event.summaryTarget, isHover), dimOthers: true };
+          return { toHighlight: this.getNodeHighlight(event.summaryTarget, isHover), dimOthers: !isHover };
         case 'edge':
-          return { toHighlight: this.getEdgeHighlight(event.summaryTarget, isHover), dimOthers: true };
+          return { toHighlight: this.getEdgeHighlight(event.summaryTarget, isHover), dimOthers: !isHover };
         case 'box':
           return this.getBoxHighlight(event.summaryTarget, isHover);
         default:
@@ -115,7 +115,7 @@ export class GraphHighlighter {
   }
 
   getNodeHighlight(node: any, isHover: boolean) {
-    const elems = isHover ? node.closedNeighborhood() : node.predecessors().add(node.successors());
+    const elems = isHover ? node : node.predecessors().add(node.successors());
     return this.includeAncestorNodes(elems.add(node));
   }
 

--- a/src/components/CytoscapeGraph/graphs/GraphHighlighter.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphHighlighter.ts
@@ -2,13 +2,34 @@ import { BoxByType, CytoscapeClickEvent, CytoscapeMouseInEvent, CytoscapeMouseOu
 import { CyNode } from '../CytoscapeGraphUtils';
 import { DimClass, HoveredClass, HighlightClass } from './GraphStyles';
 
-// When a node or edge is selected we highlight the end-to-end paths (nodes and edges) for which the
-// element participates.  Other nodes and edges are dimmed.
+// There are three special states for a Node or Edge:
 //
-// When no node or edge is selected, hovering on a node or edge will highlight it and its neighborhood. Other
-// nodes and edges are dimmed.
+//   - selected: The node has been single-clicked and is 'selected' in cytoscape
+//   - hovered: The mouse is currently over the element.  It is marked with HoveredClass
+//   - highlighted: The element is to be emphasized (see below).  It is marked with HighlightClass.
 //
-// When a box is selected, we will highlight the contained nodes and their related nodes (including edges).
+// When a node or edge is selected:
+//   - highlight the end-to-end paths (nodes and edges) for which the element participates.
+//   - dim the unhighlighted elements
+//   - hovering is ignored while an element is selected
+//
+// When a box is selected:
+//   - highlight the contained nodes and their related nodes (including edges).
+//
+// When no element is selected and a node is hovered:
+//   - mark the node, and only that node, as Hovered and Highlighted.
+//   - all other elements are undecorated.
+//
+// When no element is selected and an edge is hovered:
+//   - mark the edge, and only that edge, as Hovered and Highlighted.
+//   - mark the source and destination nodes as Highlighted.
+//   - all other elements are undecorated.
+//
+// When a boxed node is highlighted it's surrounding boxes are highlighted as well.
+//
+// Note that this code is responsible only for maintaining the element class assignments, the actual
+// visualization changes, given the class assignments, is up to GraphStyles.ts.
+//
 export class GraphHighlighter {
   cy: any;
   selected: CytoscapeClickEvent;
@@ -49,8 +70,7 @@ export class GraphHighlighter {
   };
 
   onMouseIn = (event: CytoscapeMouseInEvent) => {
-    // only highlight on hover when the graph is currently selected, otherwise leave the
-    // selected element highlighted
+    // only set Hovered when the graph is currently selected, otherwise just leave the selected element as-is
     if (this.selected.summaryType === 'graph' && ['node', 'edge', 'box'].includes(event.summaryType)) {
       this.hovered = event;
       this.hovered.summaryTarget.addClass(HoveredClass);
@@ -120,20 +140,19 @@ export class GraphHighlighter {
   }
 
   getEdgeHighlight(edge: any, isHover: boolean) {
-    let elems;
-    if (isHover) {
-      elems = edge.connectedNodes();
-    } else {
-      const source = edge.source();
-      const target = edge.target();
-      elems = source.add(target).add(source.predecessors()).add(target.successors());
+    const source = edge.source();
+    const target = edge.target();
+    let elems = source.add(target);
+
+    if (!isHover) {
+      elems = elems.add(source.predecessors()).add(target.successors());
     }
     return this.includeAncestorNodes(elems.add(edge));
   }
 
   getBoxHighlight(box: any, isHover: boolean): { toHighlight: any; dimOthers: boolean } {
     // treat App boxes in a typical way, but to reduce "flashing", Namespace and Cluster
-    // boxes highlight themselves and there anscestors.
+    // boxes highlight themselves and their anscestors.
     if (box.data(CyNode.isBox) === BoxByType.APP) {
       let elems;
       if (isHover) {

--- a/src/components/CytoscapeGraph/graphs/GraphHighlighter.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphHighlighter.ts
@@ -112,9 +112,9 @@ export class GraphHighlighter {
     if (event) {
       switch (event.summaryType) {
         case 'node':
-          return { toHighlight: this.getNodeHighlight(event.summaryTarget, isHover), dimOthers: !isHover };
+          return { toHighlight: this.getNodeHighlight(event.summaryTarget, isHover), dimOthers: true };
         case 'edge':
-          return { toHighlight: this.getEdgeHighlight(event.summaryTarget, isHover), dimOthers: !isHover };
+          return { toHighlight: this.getEdgeHighlight(event.summaryTarget, isHover), dimOthers: true };
         case 'box':
           return this.getBoxHighlight(event.summaryTarget, isHover);
         default:
@@ -135,7 +135,7 @@ export class GraphHighlighter {
   }
 
   getNodeHighlight(node: any, isHover: boolean) {
-    const elems = isHover ? node : node.predecessors().add(node.successors());
+    const elems = isHover ? node.closedNeighborhood() : node.predecessors().add(node.successors());
     return this.includeAncestorNodes(elems.add(node));
   }
 

--- a/src/components/CytoscapeGraph/graphs/GraphHighlighter.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphHighlighter.ts
@@ -1,4 +1,4 @@
-import { BoxByType, CytoscapeClickEvent, CytoscapeMouseInEvent, CytoscapeMouseOutEvent } from '../../../types/Graph';
+import { BoxByType, CytoscapeBaseEvent } from '../../../types/Graph';
 import { CyNode } from '../CytoscapeGraphUtils';
 import { DimClass, HoveredClass, HighlightClass } from './GraphStyles';
 
@@ -32,8 +32,8 @@ import { DimClass, HoveredClass, HighlightClass } from './GraphStyles';
 //
 export class GraphHighlighter {
   cy: any;
-  selected: CytoscapeClickEvent;
-  hovered?: CytoscapeMouseInEvent;
+  selected: CytoscapeBaseEvent;
+  hovered?: CytoscapeBaseEvent;
 
   constructor(cy: any) {
     this.cy = cy;
@@ -46,7 +46,7 @@ export class GraphHighlighter {
   // Need to define these methods using the "public class fields syntax", to be able to keep
   // *this* binded when passing it to events handlers (or use the annoying syntax)
   // https://reactjs.org/docs/handling-events.html
-  onClick = (event: CytoscapeClickEvent) => {
+  onClick = (event: CytoscapeBaseEvent) => {
     // ignore clicks on the currently selected element
     if (this.selected.summaryTarget === event.summaryTarget) {
       return;
@@ -69,7 +69,7 @@ export class GraphHighlighter {
     }
   };
 
-  onMouseIn = (event: CytoscapeMouseInEvent) => {
+  onMouseIn = (event: CytoscapeBaseEvent) => {
     // only set Hovered when the graph is currently selected, otherwise just leave the selected element as-is
     if (this.selected.summaryType === 'graph' && ['node', 'edge', 'box'].includes(event.summaryType)) {
       this.hovered = event;
@@ -78,7 +78,7 @@ export class GraphHighlighter {
     }
   };
 
-  onMouseOut = (event: CytoscapeMouseOutEvent) => {
+  onMouseOut = (event: CytoscapeBaseEvent) => {
     if (this.hovered && this.hovered.summaryTarget === event.summaryTarget) {
       this.clearHover();
       this.unhighlight();

--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -205,10 +205,15 @@ export class GraphStyles {
   static getNodeLabel(ele: Cy.NodeSingular) {
     const thresholds = serverConfig.kialiFeatureFlags.uiDefaults!.graph.thresholds;
     const zoom = ele.cy().zoom();
+    /*
     const isHovered = ele.hasClass(HoveredClass);
     const noBadge = !isHovered && zoom < thresholds.zoomNodeBadge;
     const noBoxLabel = !isHovered && zoom < thresholds.zoomBoxLabel;
     const noLabel = !isHovered && zoom < thresholds.zoomNodeLabel;
+    */
+    const noBadge = zoom < thresholds.zoomNodeBadge;
+    const noBoxLabel = zoom < thresholds.zoomBoxLabel;
+    const noLabel = zoom < thresholds.zoomNodeLabel;
     if (noBadge && noBoxLabel && noLabel) {
       return '';
     }
@@ -499,8 +504,11 @@ export class GraphStyles {
     const getEdgeLabel = (ele: Cy.EdgeSingular, isVerbose?: boolean): string => {
       const thresholds = serverConfig.kialiFeatureFlags.uiDefaults!.graph.thresholds;
       const zoom = ele.cy().zoom();
+      /*
       const isHovered = ele.hasClass(HoveredClass);
       const noLabel = !isHovered && zoom < thresholds.zoomEdgeLabel;
+      */
+      const noLabel = zoom < thresholds.zoomEdgeLabel;
       if (noLabel) {
         return '';
       }

--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -305,7 +305,7 @@ export class GraphStyles {
 
     let labelStyle = '';
     if (ele.hasClass(HighlightClass)) {
-      labelStyle += 'font-size: ' + NodeTextFontSizeHover + ';';
+      labelStyle += 'font-size: ' + noLabel ? '30px' : NodeTextFontSizeHover + ';';
     }
     if (ele.hasClass(DimClass)) {
       labelStyle += 'opacity: 0.6;';
@@ -313,7 +313,8 @@ export class GraphStyles {
 
     let contentStyle = '';
     if (ele.hasClass(HighlightClass)) {
-      const fontSize = isBox && isBox !== BoxByType.APP ? NodeTextFontSizeHoverBox : NodeTextFontSizeHover;
+      const fontSize =
+        isBox && isBox !== BoxByType.APP ? NodeTextFontSizeHoverBox : noLabel ? '30px' : NodeTextFontSizeHover;
       contentStyle += 'font-size: ' + fontSize + ';';
     }
 

--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -203,7 +203,7 @@ export class GraphStyles {
   }
 
   static getNodeLabel(ele: Cy.NodeSingular) {
-    const thresholds = serverConfig.kialiFeatureFlags.uiDefaults!.graph.thresholds;
+    const thresholds = serverConfig.kialiFeatureFlags.uiDefaults.graph.thresholds;
     const zoom = ele.cy().zoom();
     /*
     const isHovered = ele.hasClass(HoveredClass);
@@ -501,7 +501,7 @@ export class GraphStyles {
     };
 
     const getEdgeLabel = (ele: Cy.EdgeSingular, isVerbose?: boolean): string => {
-      const thresholds = serverConfig.kialiFeatureFlags.uiDefaults!.graph.thresholds;
+      const thresholds = serverConfig.kialiFeatureFlags.uiDefaults.graph.thresholds;
       const zoom = ele.cy().zoom();
       /*
       const isHovered = ele.hasClass(HoveredClass);

--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -195,7 +195,7 @@ export class GraphStyles {
     const settings = serverConfig.kialiFeatureFlags.uiDefaults.graph.settings;
     const zoom = ele.cy().zoom();
     const noBadge = zoom < settings.minFontBadge / settings.fontLabel;
-    const noLabel = zoom < settings.minFontLabel / settings.fontLabel;
+    const noContent = zoom < settings.minFontLabel / settings.fontLabel;
 
     const getCyGlobalData = (ele: Cy.NodeSingular): CytoscapeGlobalScratchData => {
       return ele.cy().scratch(CytoscapeGlobalScratchNamespace);
@@ -272,20 +272,22 @@ export class GraphStyles {
       }
       if (node.isRoot) {
         if (node.isGateway?.ingressInfo?.hostnames?.length !== undefined) {
-          badges = `<span class='${NodeIconGateway} ${badgeMargin(badges)}'></span> ${badges}`;
+          badges = `<span class="${NodeIconGateway} ${badgeMargin(badges)}"></span> ${badges}`;
         }
-        badges = `<span class='${NodeIconRoot} ${badgeMargin(badges)}'></span> ${badges}`;
+        badges = `<span class="${NodeIconRoot} ${badgeMargin(badges)}"></span> ${badges}`;
       } else {
         if (node.isGateway?.egressInfo?.hostnames?.length !== undefined) {
-          badges = `<span class='${NodeIconGateway} ${badgeMargin(badges)}'></span> ${badges}`;
+          badges = `<span class="${NodeIconGateway} ${badgeMargin(badges)}"></span> ${badges}`;
         }
       }
     }
 
-    const badgesStyle = noBadge ? 'display: none;' : '';
-    const hasBadge = badges.length > 0;
-    if (hasBadge) {
-      badges = `<div class=${badgesDefault} style=${badgesStyle}>${badges}</div>`;
+    const hasBadges = badges.length > 0;
+    const noLabel = noContent && (noBadge || !hasBadges);
+
+    if (hasBadges) {
+      const badgesStyle = noLabel || !noBadge ? '' : 'display:none;';
+      badges = `<div class="${badgesDefault}" style="${badgesStyle}">${badges}</div>`;
     }
 
     // Content portion of label (i.e. the text)...
@@ -296,12 +298,12 @@ export class GraphStyles {
         isBox && isBox !== BoxByType.APP
           ? settings.fontLabel * FontSizeRatioHoverBox
           : settings.fontLabel * FontSizeRatioHover;
-      contentStyle = `font-size: ${fontSize}px;`;
+      contentStyle = `font-size:${fontSize}px;`;
     } else {
-      contentStyle = `font-size: ${settings.fontLabel}px;`;
+      contentStyle = `font-size:${settings.fontLabel}px;`;
     }
-    if (noLabel) {
-      contentStyle += 'display: none;';
+    if (!noLabel && noContent) {
+      contentStyle += 'display:none;';
     }
 
     const content: string[] = [];
@@ -378,7 +380,7 @@ export class GraphStyles {
     }
 
     const contentText = content.join('<br/>');
-    const contentClasses = hasBadge && !noBadge ? `${contentDefault} ${contentWithBadges}` : `${contentDefault}`;
+    const contentClasses = hasBadges && !noBadge ? `${contentDefault} ${contentWithBadges}` : `${contentDefault}`;
 
     // The final label...
     let fontSize = settings.fontLabel;
@@ -386,12 +388,12 @@ export class GraphStyles {
       fontSize = fontSize * FontSizeRatioHover;
     }
     const lineHeight = fontSize + 1;
-    let labelStyle = `font-size: ${fontSize}px;line-height: ${lineHeight}px;`;
+    let labelStyle = `font-size:${fontSize}px;line-height:${lineHeight}px;`;
     if (ele.hasClass(DimClass)) {
-      labelStyle += 'opacity: 0.6;';
+      labelStyle += 'opacity:0.6;';
     }
-    if ((noBadge || !hasBadge) && noLabel) {
-      labelStyle += 'display: none;';
+    if (noLabel) {
+      labelStyle += 'display:none;';
     }
 
     if (isBox) {
@@ -413,7 +415,7 @@ export class GraphStyles {
       }
       const contentPfBadge = `<span class="pf-c-badge pf-m-unread ${contentBoxPfBadge}" style="${appBoxStyle}">${pfBadge}</span>`;
       const contentSpan = `<span class="${contentClasses} ${contentBox}" style="${appBoxStyle} ${contentStyle}">${contentPfBadge}${contentText}</span>`;
-      return `<div class="${labelDefault} ${labelBox}" style=${labelStyle}>${badges}${contentSpan}</div>`;
+      return `<div class="${labelDefault} ${labelBox}" style="${labelStyle}">${badges}${contentSpan}</div>`;
     }
 
     let hosts: string[] = [];
@@ -432,7 +434,7 @@ export class GraphStyles {
             : `${hosts.length - config.graph.maxHosts} more hosts...`
         );
       }
-      htmlHosts = `<div class='${hostsClass}'><div>${hosts.length} ${
+      htmlHosts = `<div class="${hostsClass}"><div>${hosts.length} ${
         hosts.length === 1 ? 'host' : 'hosts'
       }</div><div>${hostsToShow.join('<br />')}</div></div>`;
     }

--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -203,12 +203,18 @@ export class GraphStyles {
   }
 
   static getNodeLabel(ele: Cy.NodeSingular) {
+    const node = decoratedNodeData(ele);
+    const isBox = node.isBox;
+    const zoomThresh = isBox ? 0.6 : 0.8;
+    if (ele.cy().zoom() < zoomThresh) {
+      return '';
+    }
+
     const getCyGlobalData = (ele: Cy.NodeSingular): CytoscapeGlobalScratchData => {
       return ele.cy().scratch(CytoscapeGlobalScratchNamespace);
     };
 
     const cyGlobal = getCyGlobalData(ele);
-    const node = decoratedNodeData(ele);
     const app = node.app || '';
     const cluster = node.cluster;
     const namespace = node.namespace;
@@ -216,7 +222,6 @@ export class GraphStyles {
     const service = node.service || '';
     const version = node.version || '';
     const workload = node.workload || '';
-    const isBox = node.isBox;
     const isBoxed = node.parent;
     const box1 = isBoxed ? ele.parent()[0] : undefined;
     const box1Type = box1 ? box1.data().isBox : undefined;

--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -211,10 +211,9 @@ export class GraphStyles {
     const noBoxLabel = !isHovered && zoom < thresholds.zoomBoxLabel;
     const noLabel = !isHovered && zoom < thresholds.zoomNodeLabel;
     */
-    const noBadge = zoom < thresholds.zoomNodeBadge;
-    const noBoxLabel = zoom < thresholds.zoomBoxLabel;
-    const noLabel = zoom < thresholds.zoomNodeLabel;
-    if (noBadge && noBoxLabel && noLabel) {
+    const noBadge = zoom < thresholds.zoomBadge;
+    const noLabel = zoom < thresholds.zoomLabel;
+    if (noBadge && noLabel) {
       return '';
     }
 
@@ -324,7 +323,7 @@ export class GraphStyles {
 
     const content: string[] = [];
 
-    if ((isBox && !noBoxLabel) || (!isBox && !noLabel)) {
+    if (!noLabel) {
       // append namespace if necessary
       if (
         (isMultiNamespace || isOutside) &&
@@ -400,7 +399,8 @@ export class GraphStyles {
     const contentText = content.join('<br/>');
     const contentClasses = hasBadge ? `${contentDefault} ${contentWithBadges}` : `${contentDefault}`;
     let appBoxStyle = '';
-    if (isBox && !noBoxLabel) {
+
+    if (isBox && !noLabel) {
       let pfBadge = '';
       switch (isBox) {
         case BoxByType.APP:
@@ -507,7 +507,7 @@ export class GraphStyles {
       const isHovered = ele.hasClass(HoveredClass);
       const noLabel = !isHovered && zoom < thresholds.zoomEdgeLabel;
       */
-      const noLabel = zoom < thresholds.zoomEdgeLabel;
+      const noLabel = zoom < thresholds.zoomLabel;
       if (noLabel) {
         return '';
       }

--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -157,7 +157,7 @@ const labelDefault = style({
   fontSize: '0',
   fontWeight: 'normal',
   marginTop: '4px',
-  lineHeight: 'auto',
+  lineHeight: '11px',
   textAlign: 'center'
 });
 
@@ -310,7 +310,7 @@ export class GraphStyles {
 
     let labelStyle = '';
     if (ele.hasClass(HighlightClass)) {
-      labelStyle += 'font-size: ' + noLabel ? '30px' : NodeTextFontSizeHover + ';';
+      labelStyle += 'font-size: ' + NodeTextFontSizeHover + ';';
     }
     if (ele.hasClass(DimClass)) {
       labelStyle += 'opacity: 0.6;';
@@ -318,8 +318,7 @@ export class GraphStyles {
 
     let contentStyle = '';
     if (ele.hasClass(HighlightClass)) {
-      const fontSize =
-        isBox && isBox !== BoxByType.APP ? NodeTextFontSizeHoverBox : noLabel ? '30px' : NodeTextFontSizeHover;
+      const fontSize = isBox && isBox !== BoxByType.APP ? NodeTextFontSizeHoverBox : NodeTextFontSizeHover;
       contentStyle += 'font-size: ' + fontSize + ';';
     }
 

--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -37,7 +37,7 @@ let EdgeTextOutlineColor: PFColorVal;
 const EdgeTextOutlineWidth = '1px';
 const EdgeTextFont = 'Verdana,Arial,Helvetica,sans-serif,pficon';
 const EdgeTextFontSize = '6px';
-const EdgeTextFontSizeHover = '16px';
+const EdgeTextFontSizeHover = '10px';
 const EdgeWidth = 2;
 const EdgeWidthSelected = 4;
 const NodeBorderWidth = '1px';
@@ -77,8 +77,8 @@ const NodeBadgeFontSize = '12px';
 const NodeTextFont = EdgeTextFont;
 const NodeTextFontSize = '8px';
 const NodeTextFontSizeBox = '10px';
-const NodeTextFontSizeHover = '20px';
-const NodeTextFontSizeHoverBox = '20px';
+const NodeTextFontSizeHover = '11px';
+const NodeTextFontSizeHoverBox = '13px';
 const NodeWidth = NodeHeight;
 
 // Puts a little more space between icons when a badge has multiple icons
@@ -157,7 +157,7 @@ const labelDefault = style({
   fontSize: '0',
   fontWeight: 'normal',
   marginTop: '4px',
-  lineHeight: '11px',
+  lineHeight: 'auto',
   textAlign: 'center'
 });
 
@@ -304,34 +304,17 @@ export class GraphStyles {
     }
 
     let labelStyle = '';
-    /*
     if (ele.hasClass(HighlightClass)) {
       labelStyle += 'font-size: ' + NodeTextFontSizeHover + ';';
-      labelStyle += 'margin-top: 10px;';
-    }
-    */
-    if (ele.hasClass(HoveredClass)) {
-      labelStyle += 'font-size: ' + NodeTextFontSizeHover + ';';
-      labelStyle += 'margin-top: 10px;';
     }
     if (ele.hasClass(DimClass)) {
       labelStyle += 'opacity: 0.6;';
     }
 
     let contentStyle = '';
-    /*
     if (ele.hasClass(HighlightClass)) {
       const fontSize = isBox && isBox !== BoxByType.APP ? NodeTextFontSizeHoverBox : NodeTextFontSizeHover;
       contentStyle += 'font-size: ' + fontSize + ';';
-    }
-    */
-    if (ele.hasClass(HoveredClass)) {
-      const fontSize = isBox && isBox !== BoxByType.APP ? NodeTextFontSizeHoverBox : NodeTextFontSizeHover;
-      contentStyle += 'font-size: ' + fontSize + ';';
-    }
-
-    if (ele.hasClass(HighlightClass) && isBox && isBox !== BoxByType.APP) {
-      contentStyle += 'font-size: ' + NodeTextFontSizeHoverBox + ';';
     }
 
     const content: string[] = [];
@@ -412,7 +395,7 @@ export class GraphStyles {
     const contentText = content.join('<br/>');
     const contentClasses = hasBadge ? `${contentDefault} ${contentWithBadges}` : `${contentDefault}`;
     let appBoxStyle = '';
-    if (isBox) {
+    if (isBox && !noBoxLabel) {
       let pfBadge = '';
       switch (isBox) {
         case BoxByType.APP:
@@ -452,6 +435,10 @@ export class GraphStyles {
       htmlHosts = `<div class='${hostsClass}'><div>${hosts.length} ${
         hosts.length === 1 ? 'host' : 'hosts'
       }</div><div>${hostsToShow.join('<br/>')}</div></div>`;
+    }
+
+    if (noLabel && !hasBadge) {
+      return '';
     }
 
     const contentSpan = noLabel
@@ -509,6 +496,14 @@ export class GraphStyles {
     };
 
     const getEdgeLabel = (ele: Cy.EdgeSingular, isVerbose?: boolean): string => {
+      const thresholds = serverConfig.kialiFeatureFlags.uiDefaults!.graph.thresholds;
+      const zoom = ele.cy().zoom();
+      const isHovered = ele.hasClass(HoveredClass);
+      const noLabel = !isHovered && zoom < thresholds.zoomEdgeLabel;
+      if (noLabel) {
+        return '';
+      }
+
       const cyGlobal = getCyGlobalData(ele);
       const edgeLabels = cyGlobal.edgeLabels;
       const edgeData = decoratedEdgeData(ele);
@@ -886,7 +881,7 @@ export class GraphStyles {
         selector: `edge.${HoveredClass}`,
         style: {
           label: (ele: Cy.EdgeSingular) => {
-            return getEdgeLabel(ele, true);
+            return getEdgeLabel(ele);
           }
         }
       },

--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -72,9 +72,8 @@ const NodeTextColor = PFColors.Black1000;
 const NodeTextColorBox = PFColors.White;
 const NodeTextBackgroundColor = PFColors.White;
 const NodeTextBackgroundColorBox = PFColors.Black700;
-const NodeBadgeBackgroundColor = PFColors.Purple400;
+const NodeBadgeBackgroundColor = PFColors.Purple500;
 const NodeBadgeColor = PFColors.White;
-const NodeBadgeFontSize = '12px';
 const NodeTextFont = EdgeTextFont;
 const NodeWidth = NodeHeight;
 
@@ -89,7 +88,6 @@ const badgesDefault = style({
   borderBottomLeftRadius: '3px',
   color: NodeBadgeColor,
   display: 'flex',
-  fontSize: NodeBadgeFontSize,
   padding: '3px 3px'
 });
 
@@ -107,7 +105,6 @@ const contentDefault = style({
   borderRadius: '3px',
   borderWidth: '1px',
   color: NodeTextColor,
-  display: 'flex',
   padding: '3px 5px'
 });
 
@@ -129,6 +126,7 @@ const hostsClass = style({
   textAlign: 'initial',
   marginTop: '0.5em',
   paddingTop: '0.5em',
+  display: 'block',
   $nest: {
     '& div:last-child': {
       display: 'none'
@@ -147,10 +145,8 @@ const labelDefault = style({
   boxShadow: '0 2px 4px 0 rgba(0, 0, 0, 0.2), 0 2px 8px 0 rgba(0, 0, 0, 0.19)',
   display: 'inline-flex',
   fontFamily: NodeTextFont,
-  fontSize: '0',
   fontWeight: 'normal',
   marginTop: '4px',
-  lineHeight: '11px',
   textAlign: 'center'
 });
 
@@ -228,6 +224,8 @@ export class GraphStyles {
     const isMultiNamespace = cyGlobal.activeNamespaces.length > 1;
     const isOutside = node.isOutside;
 
+    // Badges portion of label...
+
     let badges = '';
     if (cyGlobal.showMissingSidecars && node.hasMissingSC) {
       badges = `<span class="${NodeIconMS} ${badgeMargin(badges)}"></span> ${badges}`;
@@ -284,25 +282,13 @@ export class GraphStyles {
       }
     }
 
-    const hasBadge = badges.length > 0;
     const badgesStyle = noBadge ? 'display: none;' : '';
-
+    const hasBadge = badges.length > 0;
     if (hasBadge) {
       badges = `<div class=${badgesDefault} style=${badgesStyle}>${badges}</div>`;
     }
 
-    let labelStyle = '';
-    if (ele.hasClass(HighlightClass)) {
-      labelStyle += `font-size: ${settings.fontLabel * FontSizeRatioHover}px;`;
-    } else {
-      labelStyle += `font-size: ${settings.fontLabel}px;`;
-    }
-    if (ele.hasClass(DimClass)) {
-      labelStyle += 'opacity: 0.6;';
-    }
-    if (noBadge && noLabel) {
-      labelStyle += 'display: none;';
-    }
+    // Content portion of label (i.e. the text)...
 
     let contentStyle = '';
     if (ele.hasClass(HighlightClass)) {
@@ -315,7 +301,7 @@ export class GraphStyles {
       contentStyle = `font-size: ${settings.fontLabel}px;`;
     }
     if (noLabel) {
-      contentStyle += 'display: none';
+      contentStyle += 'display: none;';
     }
 
     const content: string[] = [];
@@ -390,13 +376,26 @@ export class GraphStyles {
       default:
         content.unshift('error');
     }
-    //}
 
     const contentText = content.join('<br/>');
     const contentClasses = hasBadge && !noBadge ? `${contentDefault} ${contentWithBadges}` : `${contentDefault}`;
-    let appBoxStyle = '';
+
+    // The final label...
+    let fontSize = settings.fontLabel;
+    if (ele.hasClass(HighlightClass)) {
+      fontSize = fontSize * FontSizeRatioHover;
+    }
+    const lineHeight = fontSize + 1;
+    let labelStyle = `font-size: ${fontSize}px;line-height: ${lineHeight}px;`;
+    if (ele.hasClass(DimClass)) {
+      labelStyle += 'opacity: 0.6;';
+    }
+    if ((noBadge || !hasBadge) && noLabel) {
+      labelStyle += 'display: none;';
+    }
 
     if (isBox) {
+      let appBoxStyle = '';
       let pfBadge = '';
       switch (isBox) {
         case BoxByType.APP:
@@ -435,10 +434,10 @@ export class GraphStyles {
       }
       htmlHosts = `<div class='${hostsClass}'><div>${hosts.length} ${
         hosts.length === 1 ? 'host' : 'hosts'
-      }</div><div>${hostsToShow.join('<br/>')}</div></div>`;
+      }</div><div>${hostsToShow.join('<br />')}</div></div>`;
     }
 
-    const contentSpan = `<div class="${contentClasses}" style="${contentStyle}"><div>${contentText}</div><div></div>${htmlHosts}</div></div>`;
+    const contentSpan = `<div class="${contentClasses}" style="${contentStyle}"><div>${contentText}</div>${htmlHosts}</div></div>`;
     return `<div class="${labelDefault}" style="${labelStyle}">${badges}${contentSpan}</div>`;
   }
 

--- a/src/components/Pf/PfColors.tsx
+++ b/src/components/Pf/PfColors.tsx
@@ -29,7 +29,7 @@ export enum PFColors {
   LightGreen400 = 'var(--pf-global--palette--light-green-400)',
   Orange400 = 'var(--pf-global--palette--orange-400)',
   Purple100 = 'var(--pf-global--palette--purple-100)',
-  Purple400 = 'var(--pf-global--palette--purple-400)',
+  Purple500 = 'var(--pf-global--palette--purple-500)',
   Red100 = 'var(--pf-global--palette--red-100)',
   Red200 = 'var(--pf-global--palette--red-200)',
   Red500 = 'var(--pf-global--palette--red-500)',

--- a/src/components/Pf/PfColors.tsx
+++ b/src/components/Pf/PfColors.tsx
@@ -16,6 +16,7 @@ export enum PFColors {
   Black600 = 'var(--pf-global--palette--black-600)', // use instead of Gray
   Black700 = 'var(--pf-global--palette--black-700)',
   Black800 = 'var(--pf-global--palette--black-800)',
+  Black900 = 'var(--pf-global--palette--black-900)',
   Black1000 = 'var(--pf-global--palette--black-1000)',
   Blue200 = 'var(--pf-global--palette--blue-200)',
   Blue300 = 'var(--pf-global--palette--blue-300)',

--- a/src/components/SummaryPanel/InOutRateTable.tsx
+++ b/src/components/SummaryPanel/InOutRateTable.tsx
@@ -1,3 +1,4 @@
+import { summaryTitle } from 'pages/Graph/SummaryPanelCommon';
 import * as React from 'react';
 import { renderInOutRateChartHttp, renderInOutRateChartGrpc } from './RateChart';
 
@@ -23,7 +24,7 @@ export class InOutRateTableGrpc extends React.Component<InOutRateTableGrpcPropTy
 
     return (
       <div>
-        <strong>{this.props.title}</strong>
+        <div className={summaryTitle}>{this.props.title}</div>
         <table className="table">
           <thead>
             <tr>
@@ -104,7 +105,7 @@ export class InOutRateTableHttp extends React.Component<InOutRateTableHttpPropTy
 
     return (
       <div>
-        <strong>{this.props.title}</strong>
+        <div className={summaryTitle}>{this.props.title}</div>
         <table className="table" style={{ marginBottom: '10px' }}>
           <thead>
             <tr style={{ backgroundColor: 'white' }}>

--- a/src/components/SummaryPanel/RateTable.tsx
+++ b/src/components/SummaryPanel/RateTable.tsx
@@ -75,7 +75,7 @@ export class RateTableHttp extends React.Component<RateTableHttpPropType, {}> {
     return (
       <div>
         <strong>{this.props.title}</strong>
-        <table className="table" style={{ marginBottom: '10px' }}>
+        <table className="table" style={{ marginBottom: '0' }}>
           <thead>
             <tr style={{ backgroundColor: 'white' }}>
               <th>Total</th>

--- a/src/components/SummaryPanel/RateTable.tsx
+++ b/src/components/SummaryPanel/RateTable.tsx
@@ -1,3 +1,4 @@
+import { summaryTitle } from 'pages/Graph/SummaryPanelCommon';
 import * as React from 'react';
 import { renderRateChartHttp, renderRateChartGrpc } from './RateChart';
 
@@ -22,7 +23,7 @@ export class RateTableGrpc extends React.Component<RateTableGrpcPropType, {}> {
 
     return (
       <div>
-        <strong>{title}</strong>
+        <div className={summaryTitle}>{title}</div>
         <table className="table">
           <thead>
             <tr>
@@ -74,7 +75,7 @@ export class RateTableHttp extends React.Component<RateTableHttpPropType, {}> {
 
     return (
       <div>
-        <strong>{this.props.title}</strong>
+        <div className={summaryTitle}>{this.props.title}</div>
         <table className="table" style={{ marginBottom: '0' }}>
           <thead>
             <tr style={{ backgroundColor: 'white' }}>
@@ -103,7 +104,7 @@ export class RateTableTcp extends React.Component<RateTableTcpPropType, {}> {
 
     return (
       <div>
-        <strong>{title}</strong>
+        <div className={summaryTitle}>{title}</div>
         <table className="table">
           <thead>
             <tr>

--- a/src/components/SummaryPanel/ResponseFlagsTable.tsx
+++ b/src/components/SummaryPanel/ResponseFlagsTable.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import _ from 'lodash';
 import { Responses } from '../../types/Graph';
 import responseFlags from '../../utils/ResponseFlags';
+import { summaryTitle } from 'pages/Graph/SummaryPanelCommon';
 
 type ResponseFlagsTableProps = {
   responses: Responses;
@@ -19,7 +20,7 @@ export class ResponseFlagsTable extends React.PureComponent<ResponseFlagsTablePr
   render() {
     return (
       <>
-        <strong>{this.props.title}</strong>
+        <div className={summaryTitle}>{this.props.title}</div>
         <table className="table">
           <thead>
             <tr key="table-header">

--- a/src/components/SummaryPanel/ResponseHostsTable.tsx
+++ b/src/components/SummaryPanel/ResponseHostsTable.tsx
@@ -3,6 +3,7 @@ import _ from 'lodash';
 import { style } from 'typestyle';
 import { Responses } from '../../types/Graph';
 import { Tooltip } from '@patternfly/react-core';
+import { summaryTitle } from 'pages/Graph/SummaryPanelCommon';
 
 type ResponseHostsTableProps = {
   responses: Responses;
@@ -30,7 +31,7 @@ export class ResponseHostsTable extends React.PureComponent<ResponseHostsTablePr
       <>
         {rows.length > 0 ? (
           <>
-            <strong>{this.props.title}</strong>
+            <div className={summaryTitle}>{this.props.title}</div>
             <table className="table" style={{ tableLayout: 'fixed', width: '100%' }}>
               <thead>
                 <tr key="table-header">

--- a/src/components/SummaryPanel/ResponseTimeChart.tsx
+++ b/src/components/SummaryPanel/ResponseTimeChart.tsx
@@ -7,6 +7,7 @@ import { toVCLine } from 'utils/VictoryChartsUtils';
 import { SparklineChart } from 'components/Charts/SparklineChart';
 
 import 'components/Charts/Charts.css';
+import { summaryTitle } from 'pages/Graph/SummaryPanelCommon';
 
 export type ResponseTimeUnit = 's' | 'ms';
 type ResponseTimeChartTypeProp = {
@@ -43,9 +44,7 @@ export class ResponseTimeChart extends React.Component<ResponseTimeChartTypeProp
       <>
         {!this.props.hide && (
           <div>
-            <div>
-              <strong>{this.props.label}:</strong>
-            </div>
+            <div className={summaryTitle}>{this.props.label}</div>{' '}
             {this.thereIsTrafficData() ? (
               <SparklineChart
                 name={'rt'}

--- a/src/components/SummaryPanel/RpsChart.tsx
+++ b/src/components/SummaryPanel/RpsChart.tsx
@@ -10,6 +10,7 @@ import { toVCLine } from 'utils/VictoryChartsUtils';
 import { RichDataPoint, VCDataPoint, VCLine, VCLines } from 'types/VictoryChartInfo';
 
 import 'components/Charts/Charts.css';
+import { summaryTitle } from 'pages/Graph/SummaryPanelCommon';
 
 type RequestChartProp = {
   label: string;
@@ -72,9 +73,7 @@ export class RequestChart extends React.Component<RequestChartProp, {}> {
       <>
         {!this.props.hide && (
           <div className={blockStyle}>
-            <div>
-              <strong>{this.props.label} min / max:</strong>
-            </div>
+            <div className={summaryTitle}>{this.props.label} min / max:</div>
             {this.renderContent()}
           </div>
         )}
@@ -133,9 +132,7 @@ export class StreamChart extends React.Component<StreamChartProp, {}> {
       <>
         {!this.props.hide && (
           <div className={blockStyle}>
-            <div>
-              <strong>{this.props.label} - min / max:</strong>
-            </div>
+            <div className={summaryTitle}>{this.props.label} min / max:</div>
             {this.renderContent()}
           </div>
         )}

--- a/src/config/ServerConfig.ts
+++ b/src/config/ServerConfig.ts
@@ -83,9 +83,10 @@ const defaultServerConfig: ComputedServerConfig = {
       graph: {
         findOptions: [],
         hideOptions: [],
-        thresholds: {
-          zoomLabel: 0.85,
-          zoomBadge: 0.75
+        settings: {
+          fontLabel: 13,
+          minFontBadge: 7,
+          minFontLabel: 10
         },
         traffic: {
           grpc: 'requests',

--- a/src/config/ServerConfig.ts
+++ b/src/config/ServerConfig.ts
@@ -78,7 +78,22 @@ const defaultServerConfig: ComputedServerConfig = {
       enabled: true
     },
     istioInjectionAction: true,
-    istioUpgradeAction: false
+    istioUpgradeAction: false,
+    uiDefaults: {
+      graph: {
+        findOptions: [],
+        hideOptions: [],
+        thresholds: {
+          zoomLabel: 0.85,
+          zoomBadge: 0.75
+        },
+        traffic: {
+          grpc: 'requests',
+          http: 'requests',
+          tcp: 'sent'
+        }
+      }
+    }
   },
   prometheus: {
     globalScrapeInterval: 15,
@@ -109,11 +124,6 @@ export const setServerConfig = (cfg: ServerConfig) => {
   serverConfig = {
     ...defaultServerConfig,
     ...cfg
-  };
-
-  serverConfig.kialiFeatureFlags.uiDefaults!.graph.thresholds = {
-    zoomLabel: 0.85,
-    zoomBadge: 0.75
   };
 
   serverConfig.healthConfig = cfg.healthConfig ? parseHealthConfig(cfg.healthConfig) : serverConfig.healthConfig;

--- a/src/config/ServerConfig.ts
+++ b/src/config/ServerConfig.ts
@@ -112,10 +112,8 @@ export const setServerConfig = (cfg: ServerConfig) => {
   };
 
   serverConfig.kialiFeatureFlags.uiDefaults!.graph.thresholds = {
-    zoomBoxLabel: 0.8,
-    zoomEdgeLabel: 1.0,
-    zoomNodeBadge: 0.75,
-    zoomNodeLabel: 0.9
+    zoomLabel: 0.85,
+    zoomBadge: 0.75
   };
 
   serverConfig.healthConfig = cfg.healthConfig ? parseHealthConfig(cfg.healthConfig) : serverConfig.healthConfig;

--- a/src/config/ServerConfig.ts
+++ b/src/config/ServerConfig.ts
@@ -113,8 +113,8 @@ export const setServerConfig = (cfg: ServerConfig) => {
 
   serverConfig.kialiFeatureFlags.uiDefaults!.graph.thresholds = {
     zoomBoxLabel: 0.8,
-    zoomEdgeLabel: 0.9,
-    zoomNodeBadge: 0.6,
+    zoomEdgeLabel: 1.0,
+    zoomNodeBadge: 0.75,
     zoomNodeLabel: 0.9
   };
 

--- a/src/config/ServerConfig.ts
+++ b/src/config/ServerConfig.ts
@@ -110,6 +110,14 @@ export const setServerConfig = (cfg: ServerConfig) => {
     ...defaultServerConfig,
     ...cfg
   };
+
+  serverConfig.kialiFeatureFlags.uiDefaults!.graph.thresholds = {
+    zoomBoxLabel: 0.8,
+    zoomEdgeLabel: 0.9,
+    zoomNodeBadge: 0.6,
+    zoomNodeLabel: 0.9
+  };
+
   serverConfig.healthConfig = cfg.healthConfig ? parseHealthConfig(cfg.healthConfig) : serverConfig.healthConfig;
 
   computeValidDurations(serverConfig);

--- a/src/pages/Graph/GraphHelpTour.tsx
+++ b/src/pages/Graph/GraphHelpTour.tsx
@@ -44,12 +44,13 @@ export const GraphTourStops: { [name: string]: TourStopInfo } = {
   Layout: {
     name: 'Layout selection',
     description:
-      'Select the graph layout for the mesh. Different layouts work best with different meshes. Find the layout that works best. Other buttons here provide zoom and fit-to-screen options.'
+      'Select the graph layout for the mesh. Different layouts work best with different meshes. Find the layout that works best. Other buttons here provide zoom and fit-to-screen options.',
+    position: PopoverPosition.right
   },
   Legend: {
     name: 'Legend',
     description: 'Display the legend to learn about what the different shapes, colors and backgrounds mean.',
-    position: PopoverPosition.top
+    position: PopoverPosition.auto
   },
   Namespaces: {
     name: 'Namespaces',

--- a/src/pages/Graph/GraphLegend.tsx
+++ b/src/pages/Graph/GraphLegend.tsx
@@ -21,7 +21,6 @@ export default class GraphLegend extends React.Component<GraphLegendProps> {
       border: '1px #ddd solid',
       margin: '0 0 3.25em 0',
       overflow: 'hidden',
-      overflowX: 'auto',
       overflowY: 'auto',
       padding: '1em 0.5em 1em 1em',
       zIndex: 3
@@ -32,13 +31,8 @@ export default class GraphLegend extends React.Component<GraphLegendProps> {
     });
 
     const bodyStyle = style({
-      width: width,
-      height: 'auto'
-    });
-
-    const legendListStyle = style({
-      display: 'flex',
-      flexDirection: 'column'
+      height: 'auto',
+      width: width
     });
 
     const closeBoxStyle = style({
@@ -59,7 +53,7 @@ export default class GraphLegend extends React.Component<GraphLegendProps> {
           </span>
         </div>
         <div className={bodyStyle}>
-          <div className={legendListStyle}>{this.renderGraphLegendList(legendData)}</div>
+          <div>{this.renderGraphLegendList(legendData)}</div>
         </div>
       </div>
     );
@@ -71,8 +65,7 @@ export default class GraphLegend extends React.Component<GraphLegendProps> {
       paddingTop: '1.25em'
     });
     const aStyle = style({
-      height: '100%',
-      width: width
+      height: '100%'
     });
 
     return (
@@ -94,24 +87,26 @@ export default class GraphLegend extends React.Component<GraphLegendProps> {
   }
 
   static renderLegendIconAndLabel(legendItemRow: GraphLegendItemRow) {
-    const legendItemContainerStyle = style({
-      fontSize: '1em',
+    const keyWidth = '70px';
+
+    const keyStyle = style({
+      minWidth: keyWidth,
+      width: keyWidth
+    });
+
+    const legendItemStyle = style({
       display: 'flex',
       flexDirection: 'row',
-      justifyContent: 'space-between',
       padding: '5px 5px 0 5px'
     });
 
     const legendItemLabelStyle = style({
-      fontSize: '12px',
-      fontWeight: 'normal',
-      width: '130px',
-      marginTop: '3px'
+      fontWeight: 'normal'
     });
 
     return (
-      <div key={legendItemRow.icon} className={legendItemContainerStyle}>
-        <span>
+      <div key={legendItemRow.icon} className={legendItemStyle}>
+        <span className={keyStyle}>
           <img alt={legendItemRow.label} src={legendItemRow.icon} />
         </span>
         <span className={legendItemLabelStyle}>{legendItemRow.label}</span>

--- a/src/pages/Graph/GraphLegend.tsx
+++ b/src/pages/Graph/GraphLegend.tsx
@@ -4,6 +4,7 @@ import legendData, { GraphLegendItem, GraphLegendItemRow } from './GraphLegendDa
 import { Button, Tooltip } from '@patternfly/react-core';
 import CloseIcon from '@patternfly/react-icons/dist/js/icons/close-icon';
 import { PFColors } from 'components/Pf/PfColors';
+import { summaryFont, summaryTitle } from './SummaryPanelCommon';
 
 export interface GraphLegendProps {
   closeLegend: () => void;
@@ -11,28 +12,23 @@ export interface GraphLegendProps {
   isMTLSEnabled: boolean;
 }
 
-const width = '200px';
+const width = '190px';
 
 export default class GraphLegend extends React.Component<GraphLegendProps> {
   render() {
     const legendBoxStyle = style({
-      margin: '0 0 3.8em 0',
-      padding: '1em',
+      backgroundColor: PFColors.White,
       border: '1px #ddd solid',
+      margin: '0 0 3.25em 0',
       overflow: 'hidden',
       overflowX: 'auto',
       overflowY: 'auto',
-      backgroundColor: PFColors.White,
+      padding: '1em 0.5em 1em 1em',
       zIndex: 3
     });
 
     const headerStyle = style({
       width: width
-    });
-
-    const legendTextHeadingStyle = style({
-      fontWeight: 'bold',
-      fontSize: '16px'
     });
 
     const bodyStyle = style({
@@ -47,13 +43,13 @@ export default class GraphLegend extends React.Component<GraphLegendProps> {
 
     const closeBoxStyle = style({
       float: 'right',
-      marginTop: '-7px'
+      margin: '-7px -5px 0 -10px'
     });
 
     return (
-      <div className={legendBoxStyle}>
-        <div className={headerStyle}>
-          <span className={legendTextHeadingStyle}>Legend</span>
+      <div className={legendBoxStyle} style={summaryFont}>
+        <div className={`${headerStyle} ${summaryTitle}`}>
+          <span>Legend</span>
           <span className={closeBoxStyle}>
             <Tooltip content="Close Legend">
               <Button id="legend_close" variant="plain" onClick={this.props.closeLegend}>
@@ -71,8 +67,8 @@ export default class GraphLegend extends React.Component<GraphLegendProps> {
 
   renderGraphLegendList(legendData: GraphLegendItem[]) {
     const legendColumnHeadingStyle = style({
-      paddingTop: '1.25em',
-      fontSize: '14px'
+      fontWeight: 'bold',
+      paddingTop: '1.25em'
     });
     const aStyle = style({
       height: '100%',

--- a/src/pages/Graph/GraphLegendData.ts
+++ b/src/pages/Graph/GraphLegendData.ts
@@ -100,9 +100,9 @@ const legendData: GraphLegendItem[] = [
       { label: 'Mirroring', icon: badgeMirroringImage },
       { label: 'Missing Sidecar', icon: badgeMissingSidecarImage },
       { label: 'Request Timeout', icon: badgeRequestTimeoutImage },
-      { label: 'Traffic Shifting/TCP Traffic Shifting', icon: badgeTrafficShiftingSourceImage },
+      { label: 'Traffic Shifting / TCP Traffic Shifting', icon: badgeTrafficShiftingSourceImage },
       { label: 'Traffic Source', icon: badgeTrafficSourceImage },
-      { label: 'Virtual Service/Request Routing', icon: badgeVirtualServicesImage },
+      { label: 'Virtual Service / Request Routing', icon: badgeVirtualServicesImage },
       { label: 'Workload Entry', icon: badgeWorkloadEntryImage }
     ]
   }

--- a/src/pages/Graph/GraphPage.tsx
+++ b/src/pages/Graph/GraphPage.tsx
@@ -11,7 +11,7 @@ import { DurationInSeconds, IntervalInMilliseconds, TimeInMilliseconds, TimeInSe
 import { MessageType } from '../../types/MessageCenter';
 import Namespace from '../../types/Namespace';
 import {
-  CytoscapeClickEvent,
+  CytoscapeEvent,
   DecoratedGraphElements,
   EdgeLabelMode,
   GraphDefinition,
@@ -122,7 +122,7 @@ type ReduxProps = {
   trafficRates: TrafficRate[];
   toggleIdleNodes: () => void;
   toggleLegend: () => void;
-  updateSummary: (event: CytoscapeClickEvent) => void;
+  updateSummary: (event: CytoscapeEvent) => void;
 };
 
 export type GraphPageProps = RouteComponentProps<Partial<GraphURLPathProps>> & ReduxProps;
@@ -736,7 +736,7 @@ const mapDispatchToProps = (dispatch: ThunkDispatch<KialiAppState, void, KialiAp
   startTour: bindActionCreators(TourActions.startTour, dispatch),
   toggleIdleNodes: bindActionCreators(GraphToolbarActions.toggleIdleNodes, dispatch),
   toggleLegend: bindActionCreators(GraphToolbarActions.toggleLegend, dispatch),
-  updateSummary: (event: CytoscapeClickEvent) => dispatch(GraphActions.updateSummary(event))
+  updateSummary: (event: CytoscapeEvent) => dispatch(GraphActions.updateSummary(event))
 });
 
 const GraphPageContainer = connect(mapStateToProps, mapDispatchToProps)(GraphPage);

--- a/src/pages/Graph/GraphPage.tsx
+++ b/src/pages/Graph/GraphPage.tsx
@@ -433,7 +433,8 @@ export class GraphPage extends React.Component<GraphPageProps, GraphPageState> {
               {(!this.props.replayActive || isReplayReady) && (
                 <CytoscapeGraph
                   containerClassName={cytoscapeGraphContainerStyle}
-                  contextMenuGroupComponent={NodeContextMenuContainer}
+                  contextMenuBoxComponent={NodeContextMenuContainer}
+                  // contextMenuEdgeComponent={EdgeContextMenuContainer}
                   contextMenuNodeComponent={NodeContextMenuContainer}
                   focusSelector={this.focusSelector}
                   graphData={this.state.graphData}

--- a/src/pages/Graph/GraphPage.tsx
+++ b/src/pages/Graph/GraphPage.tsx
@@ -67,6 +67,7 @@ import { JaegerTrace } from 'types/JaegerInfo';
 import { JaegerThunkActions } from 'actions/JaegerThunkActions';
 import GraphTour from 'pages/Graph/GraphHelpTour';
 import { getNextTourStop, TourInfo } from 'components/Tour/TourStop';
+import { EdgeContextMenu } from 'components/CytoscapeGraph/ContextMenu/EdgeContextMenu';
 
 // GraphURLPathProps holds path variable values.  Currently all path variables are relevant only to a node graph
 type GraphURLPathProps = {
@@ -434,7 +435,7 @@ export class GraphPage extends React.Component<GraphPageProps, GraphPageState> {
                 <CytoscapeGraph
                   containerClassName={cytoscapeGraphContainerStyle}
                   contextMenuBoxComponent={NodeContextMenuContainer}
-                  // contextMenuEdgeComponent={EdgeContextMenuContainer}
+                  contextMenuEdgeComponent={EdgeContextMenu}
                   contextMenuNodeComponent={NodeContextMenuContainer}
                   focusSelector={this.focusSelector}
                   graphData={this.state.graphData}

--- a/src/pages/Graph/GraphPage.tsx
+++ b/src/pages/Graph/GraphPage.tsx
@@ -434,7 +434,6 @@ export class GraphPage extends React.Component<GraphPageProps, GraphPageState> {
               {(!this.props.replayActive || isReplayReady) && (
                 <CytoscapeGraph
                   containerClassName={cytoscapeGraphContainerStyle}
-                  contextMenuBoxComponent={NodeContextMenuContainer}
                   contextMenuEdgeComponent={EdgeContextMenu}
                   contextMenuNodeComponent={NodeContextMenuContainer}
                   focusSelector={this.focusSelector}

--- a/src/pages/Graph/GraphToolbar/GraphFindOptions.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphFindOptions.tsx
@@ -60,8 +60,8 @@ export class GraphFindOptions extends React.PureComponent<GraphFindOptionsProps,
   private getOptionItems = (kind: FindKind): React.ReactFragment[] => {
     const options =
       kind === 'find'
-        ? serverConfig.kialiFeatureFlags.uiDefaults!.graph.findOptions
-        : serverConfig.kialiFeatureFlags.uiDefaults!.graph.hideOptions;
+        ? serverConfig.kialiFeatureFlags.uiDefaults.graph.findOptions
+        : serverConfig.kialiFeatureFlags.uiDefaults.graph.hideOptions;
     return options.map(o => {
       return (
         <DropdownItem key={o.description} onClick={() => this.props.onSelect(o.expression)}>

--- a/src/pages/Graph/GraphToolbar/__tests__/__snapshots__/GraphLegend.test.tsx.snap
+++ b/src/pages/Graph/GraphToolbar/__tests__/__snapshots__/GraphLegend.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`GraphLegend test should render correctly 1`] = `
 <div
-  className="fi0mnqz"
+  className="fsg7me4"
   style={
     Object {
       "fontSize": "var(--graph-side-panel--font-size)",
@@ -67,11 +67,9 @@ exports[`GraphLegend test should render correctly 1`] = `
   <div
     className="f6nw80o"
   >
-    <div
-      className="fkhz08q"
-    >
+    <div>
       <div
-        className="firji6b"
+        className="f10krlro"
       >
         <div
           className="fng0jlu"
@@ -79,81 +77,91 @@ exports[`GraphLegend test should render correctly 1`] = `
         >
           Node Shapes
           <div
-            className="f1n8a700"
+            className="f13es1gb"
             key="node.svg"
           >
-            <span>
+            <span
+              className="f1irbq61"
+            >
               <img
                 alt="Workload"
                 src="node.svg"
               />
             </span>
             <span
-              className="f1hob5wc"
+              className="fgzdi7m"
             >
               Workload
             </span>
           </div>
           <div
-            className="f1n8a700"
+            className="f13es1gb"
             key="app.svg"
           >
-            <span>
+            <span
+              className="f1irbq61"
+            >
               <img
                 alt="App"
                 src="app.svg"
               />
             </span>
             <span
-              className="f1hob5wc"
+              className="fgzdi7m"
             >
               App
             </span>
           </div>
           <div
-            className="f1n8a700"
+            className="f13es1gb"
             key="aggregate.svg"
           >
-            <span>
+            <span
+              className="f1irbq61"
+            >
               <img
                 alt="Operation"
                 src="aggregate.svg"
               />
             </span>
             <span
-              className="f1hob5wc"
+              className="fgzdi7m"
             >
               Operation
             </span>
           </div>
           <div
-            className="f1n8a700"
+            className="f13es1gb"
             key="service.svg"
           >
-            <span>
+            <span
+              className="f1irbq61"
+            >
               <img
                 alt="Service"
                 src="service.svg"
               />
             </span>
             <span
-              className="f1hob5wc"
+              className="fgzdi7m"
             >
               Service
             </span>
           </div>
           <div
-            className="f1n8a700"
+            className="f13es1gb"
             key="service-entry.svg"
           >
-            <span>
+            <span
+              className="f1irbq61"
+            >
               <img
                 alt="Service Entry"
                 src="service-entry.svg"
               />
             </span>
             <span
-              className="f1hob5wc"
+              className="fgzdi7m"
             >
               Service Entry
             </span>
@@ -165,65 +173,73 @@ exports[`GraphLegend test should render correctly 1`] = `
         >
           Node Colors
           <div
-            className="f1n8a700"
+            className="f13es1gb"
             key="node-color-normal.svg"
           >
-            <span>
+            <span
+              className="f1irbq61"
+            >
               <img
                 alt="Normal"
                 src="node-color-normal.svg"
               />
             </span>
             <span
-              className="f1hob5wc"
+              className="fgzdi7m"
             >
               Normal
             </span>
           </div>
           <div
-            className="f1n8a700"
+            className="f13es1gb"
             key="node-color-warning.svg"
           >
-            <span>
+            <span
+              className="f1irbq61"
+            >
               <img
                 alt="Warn"
                 src="node-color-warning.svg"
               />
             </span>
             <span
-              className="f1hob5wc"
+              className="fgzdi7m"
             >
               Warn
             </span>
           </div>
           <div
-            className="f1n8a700"
+            className="f13es1gb"
             key="node-color-danger.svg"
           >
-            <span>
+            <span
+              className="f1irbq61"
+            >
               <img
                 alt="Danger"
                 src="node-color-danger.svg"
               />
             </span>
             <span
-              className="f1hob5wc"
+              className="fgzdi7m"
             >
               Danger
             </span>
           </div>
           <div
-            className="f1n8a700"
+            className="f13es1gb"
             key="node-color-idle.svg"
           >
-            <span>
+            <span
+              className="f1irbq61"
+            >
               <img
                 alt="Idle"
                 src="node-color-idle.svg"
               />
             </span>
             <span
-              className="f1hob5wc"
+              className="fgzdi7m"
             >
               Idle
             </span>
@@ -235,33 +251,37 @@ exports[`GraphLegend test should render correctly 1`] = `
         >
           Node Background
           <div
-            className="f1n8a700"
+            className="f13es1gb"
             key="external-namespace.svg"
           >
-            <span>
+            <span
+              className="f1irbq61"
+            >
               <img
                 alt="Unselected Namespace"
                 src="external-namespace.svg"
               />
             </span>
             <span
-              className="f1hob5wc"
+              className="fgzdi7m"
             >
               Unselected Namespace
             </span>
           </div>
           <div
-            className="f1n8a700"
+            className="f13es1gb"
             key="restricted-namespace.svg"
           >
-            <span>
+            <span
+              className="f1irbq61"
+            >
               <img
                 alt="Restricted / External"
                 src="restricted-namespace.svg"
               />
             </span>
             <span
-              className="f1hob5wc"
+              className="fgzdi7m"
             >
               Restricted / External
             </span>
@@ -273,97 +293,109 @@ exports[`GraphLegend test should render correctly 1`] = `
         >
           Edges
           <div
-            className="f1n8a700"
+            className="f13es1gb"
             key="edge-danger.svg"
           >
-            <span>
+            <span
+              className="f1irbq61"
+            >
               <img
                 alt="Failure"
                 src="edge-danger.svg"
               />
             </span>
             <span
-              className="f1hob5wc"
+              className="fgzdi7m"
             >
               Failure
             </span>
           </div>
           <div
-            className="f1n8a700"
+            className="f13es1gb"
             key="edge-warn.svg"
           >
-            <span>
+            <span
+              className="f1irbq61"
+            >
               <img
                 alt="Degraded"
                 src="edge-warn.svg"
               />
             </span>
             <span
-              className="f1hob5wc"
+              className="fgzdi7m"
             >
               Degraded
             </span>
           </div>
           <div
-            className="f1n8a700"
+            className="f13es1gb"
             key="edge-success.svg"
           >
-            <span>
+            <span
+              className="f1irbq61"
+            >
               <img
                 alt="Healthy"
                 src="edge-success.svg"
               />
             </span>
             <span
-              className="f1hob5wc"
+              className="fgzdi7m"
             >
               Healthy
             </span>
           </div>
           <div
-            className="f1n8a700"
+            className="f13es1gb"
             key="edge-tcp.svg"
           >
-            <span>
+            <span
+              className="f1irbq61"
+            >
               <img
                 alt="TCP Connection"
                 src="edge-tcp.svg"
               />
             </span>
             <span
-              className="f1hob5wc"
+              className="fgzdi7m"
             >
               TCP Connection
             </span>
           </div>
           <div
-            className="f1n8a700"
+            className="f13es1gb"
             key="edge-idle.svg"
           >
-            <span>
+            <span
+              className="f1irbq61"
+            >
               <img
                 alt="Idle"
                 src="edge-idle.svg"
               />
             </span>
             <span
-              className="f1hob5wc"
+              className="fgzdi7m"
             >
               Idle
             </span>
           </div>
           <div
-            className="f1n8a700"
+            className="f13es1gb"
             key="mtls-badge.svg"
           >
-            <span>
+            <span
+              className="f1irbq61"
+            >
               <img
                 alt="mTLS (badge)"
                 src="mtls-badge.svg"
               />
             </span>
             <span
-              className="f1hob5wc"
+              className="fgzdi7m"
             >
               mTLS (badge)
             </span>
@@ -375,49 +407,55 @@ exports[`GraphLegend test should render correctly 1`] = `
         >
           Traffic Animation
           <div
-            className="f1n8a700"
+            className="f13es1gb"
             key="traffic-normal-request.svg"
           >
-            <span>
+            <span
+              className="f1irbq61"
+            >
               <img
                 alt="Normal Request"
                 src="traffic-normal-request.svg"
               />
             </span>
             <span
-              className="f1hob5wc"
+              className="fgzdi7m"
             >
               Normal Request
             </span>
           </div>
           <div
-            className="f1n8a700"
+            className="f13es1gb"
             key="traffic-failed-request.svg"
           >
-            <span>
+            <span
+              className="f1irbq61"
+            >
               <img
                 alt="Failed Request"
                 src="traffic-failed-request.svg"
               />
             </span>
             <span
-              className="f1hob5wc"
+              className="fgzdi7m"
             >
               Failed Request
             </span>
           </div>
           <div
-            className="f1n8a700"
+            className="f13es1gb"
             key="traffic-tcp.svg"
           >
-            <span>
+            <span
+              className="f1irbq61"
+            >
               <img
                 alt="TCP Traffic"
                 src="traffic-tcp.svg"
               />
             </span>
             <span
-              className="f1hob5wc"
+              className="fgzdi7m"
             >
               TCP Traffic
             </span>
@@ -429,161 +467,181 @@ exports[`GraphLegend test should render correctly 1`] = `
         >
           Node Badges
           <div
-            className="f1n8a700"
+            className="f13es1gb"
             key="node-badge-circuit-breaker.svg"
           >
-            <span>
+            <span
+              className="f1irbq61"
+            >
               <img
                 alt="Circuit Breaker"
                 src="node-badge-circuit-breaker.svg"
               />
             </span>
             <span
-              className="f1hob5wc"
+              className="fgzdi7m"
             >
               Circuit Breaker
             </span>
           </div>
           <div
-            className="f1n8a700"
+            className="f13es1gb"
             key="node-badge-fault-injection.svg"
           >
-            <span>
+            <span
+              className="f1irbq61"
+            >
               <img
                 alt="Fault Injection"
                 src="node-badge-fault-injection.svg"
               />
             </span>
             <span
-              className="f1hob5wc"
+              className="fgzdi7m"
             >
               Fault Injection
             </span>
           </div>
           <div
-            className="f1n8a700"
+            className="f13es1gb"
             key="node-badge-gateways.svg"
           >
-            <span>
+            <span
+              className="f1irbq61"
+            >
               <img
                 alt="Gateway"
                 src="node-badge-gateways.svg"
               />
             </span>
             <span
-              className="f1hob5wc"
+              className="fgzdi7m"
             >
               Gateway
             </span>
           </div>
           <div
-            className="f1n8a700"
+            className="f13es1gb"
             key="node-badge-mirroring.svg"
           >
-            <span>
+            <span
+              className="f1irbq61"
+            >
               <img
                 alt="Mirroring"
                 src="node-badge-mirroring.svg"
               />
             </span>
             <span
-              className="f1hob5wc"
+              className="fgzdi7m"
             >
               Mirroring
             </span>
           </div>
           <div
-            className="f1n8a700"
+            className="f13es1gb"
             key="node-badge-missing-sidecar.svg"
           >
-            <span>
+            <span
+              className="f1irbq61"
+            >
               <img
                 alt="Missing Sidecar"
                 src="node-badge-missing-sidecar.svg"
               />
             </span>
             <span
-              className="f1hob5wc"
+              className="fgzdi7m"
             >
               Missing Sidecar
             </span>
           </div>
           <div
-            className="f1n8a700"
+            className="f13es1gb"
             key="node-badge-request-timeout.svg"
           >
-            <span>
+            <span
+              className="f1irbq61"
+            >
               <img
                 alt="Request Timeout"
                 src="node-badge-request-timeout.svg"
               />
             </span>
             <span
-              className="f1hob5wc"
+              className="fgzdi7m"
             >
               Request Timeout
             </span>
           </div>
           <div
-            className="f1n8a700"
+            className="f13es1gb"
             key="node-badge-traffic-shifting.svg"
           >
-            <span>
+            <span
+              className="f1irbq61"
+            >
               <img
-                alt="Traffic Shifting/TCP Traffic Shifting"
+                alt="Traffic Shifting / TCP Traffic Shifting"
                 src="node-badge-traffic-shifting.svg"
               />
             </span>
             <span
-              className="f1hob5wc"
+              className="fgzdi7m"
             >
-              Traffic Shifting/TCP Traffic Shifting
+              Traffic Shifting / TCP Traffic Shifting
             </span>
           </div>
           <div
-            className="f1n8a700"
+            className="f13es1gb"
             key="node-badge-traffic-source.svg"
           >
-            <span>
+            <span
+              className="f1irbq61"
+            >
               <img
                 alt="Traffic Source"
                 src="node-badge-traffic-source.svg"
               />
             </span>
             <span
-              className="f1hob5wc"
+              className="fgzdi7m"
             >
               Traffic Source
             </span>
           </div>
           <div
-            className="f1n8a700"
+            className="f13es1gb"
             key="node-badge-virtual-services.svg"
           >
-            <span>
+            <span
+              className="f1irbq61"
+            >
               <img
-                alt="Virtual Service/Request Routing"
+                alt="Virtual Service / Request Routing"
                 src="node-badge-virtual-services.svg"
               />
             </span>
             <span
-              className="f1hob5wc"
+              className="fgzdi7m"
             >
-              Virtual Service/Request Routing
+              Virtual Service / Request Routing
             </span>
           </div>
           <div
-            className="f1n8a700"
+            className="f13es1gb"
             key="node-badge-workload-entry.svg"
           >
-            <span>
+            <span
+              className="f1irbq61"
+            >
               <img
                 alt="Workload Entry"
                 src="node-badge-workload-entry.svg"
               />
             </span>
             <span
-              className="f1hob5wc"
+              className="fgzdi7m"
             >
               Workload Entry
             </span>

--- a/src/pages/Graph/GraphToolbar/__tests__/__snapshots__/GraphLegend.test.tsx.snap
+++ b/src/pages/Graph/GraphToolbar/__tests__/__snapshots__/GraphLegend.test.tsx.snap
@@ -2,18 +2,21 @@
 
 exports[`GraphLegend test should render correctly 1`] = `
 <div
-  className="f19vkxmv"
+  className="fi0mnqz"
+  style={
+    Object {
+      "fontSize": "var(--graph-side-panel--font-size)",
+    }
+  }
 >
   <div
-    className="f1xvjjtv"
+    className="fsgo6a1 fdxg6uc"
   >
-    <span
-      className="f1i76bsh"
-    >
+    <span>
       Legend
     </span>
     <span
-      className="f1vrdyv8"
+      className="f1blspom"
     >
       <Tooltip
         appendTo={[Function]}
@@ -62,16 +65,16 @@ exports[`GraphLegend test should render correctly 1`] = `
     </span>
   </div>
   <div
-    className="f1hnvrw2"
+    className="f6nw80o"
   >
     <div
       className="fkhz08q"
     >
       <div
-        className="fls9dm1"
+        className="firji6b"
       >
         <div
-          className="f1unvj7z"
+          className="fng0jlu"
           key="Node Shapes"
         >
           Node Shapes
@@ -157,7 +160,7 @@ exports[`GraphLegend test should render correctly 1`] = `
           </div>
         </div>
         <div
-          className="f1unvj7z"
+          className="fng0jlu"
           key="Node Colors"
         >
           Node Colors
@@ -227,7 +230,7 @@ exports[`GraphLegend test should render correctly 1`] = `
           </div>
         </div>
         <div
-          className="f1unvj7z"
+          className="fng0jlu"
           key="Node Background"
         >
           Node Background
@@ -265,7 +268,7 @@ exports[`GraphLegend test should render correctly 1`] = `
           </div>
         </div>
         <div
-          className="f1unvj7z"
+          className="fng0jlu"
           key="Edges"
         >
           Edges
@@ -367,7 +370,7 @@ exports[`GraphLegend test should render correctly 1`] = `
           </div>
         </div>
         <div
-          className="f1unvj7z"
+          className="fng0jlu"
           key="Traffic Animation"
         >
           Traffic Animation
@@ -421,7 +424,7 @@ exports[`GraphLegend test should render correctly 1`] = `
           </div>
         </div>
         <div
-          className="f1unvj7z"
+          className="fng0jlu"
           key="Node Badges"
         >
           Node Badges

--- a/src/pages/Graph/GraphToolbar/__tests__/__snapshots__/GraphLegend.test.tsx.snap
+++ b/src/pages/Graph/GraphToolbar/__tests__/__snapshots__/GraphLegend.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`GraphLegend test should render correctly 1`] = `
   }
 >
   <div
-    className="fsgo6a1 fdxg6uc"
+    className="fsgo6a1 f19m89ic"
   >
     <span>
       Legend

--- a/src/pages/Graph/GraphToolbar/__tests__/__snapshots__/GraphLegend.test.tsx.snap
+++ b/src/pages/Graph/GraphToolbar/__tests__/__snapshots__/GraphLegend.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`GraphLegend test should render correctly 1`] = `
   }
 >
   <div
-    className="fsgo6a1 f19m89ic"
+    className="fsgo6a1 f1bv0l2s"
   >
     <span>
       Legend

--- a/src/pages/Graph/SummaryLink.tsx
+++ b/src/pages/Graph/SummaryLink.tsx
@@ -146,6 +146,17 @@ export const renderBadgedHost = (host: string) => {
   );
 };
 
+export const renderBadgedName = (nodeData: GraphNodeData) => {
+  return (
+    <div>
+      <span style={{ marginRight: '1em', marginBottom: '3px', display: 'inline-block' }}>
+        {getBadge(nodeData)}
+        {getLink({ ...nodeData, isInaccessible: true })}
+      </span>
+    </div>
+  );
+};
+
 export const renderBadgedLink = (
   nodeData: GraphNodeData,
   nodeType?: NodeType,

--- a/src/pages/Graph/SummaryLink.tsx
+++ b/src/pages/Graph/SummaryLink.tsx
@@ -146,10 +146,15 @@ export const renderBadgedHost = (host: string) => {
   );
 };
 
-export const renderBadgedName = (nodeData: GraphNodeData) => {
+export const renderBadgedName = (nodeData: GraphNodeData, label?: string) => {
   return (
     <div>
       <span style={{ marginRight: '1em', marginBottom: '3px', display: 'inline-block' }}>
+        {label && (
+          <span style={{ whiteSpace: 'pre' }}>
+            <b>{label}</b>
+          </span>
+        )}
         {getBadge(nodeData)}
         {getLink({ ...nodeData, isInaccessible: true })}
       </span>

--- a/src/pages/Graph/SummaryLink.tsx
+++ b/src/pages/Graph/SummaryLink.tsx
@@ -155,7 +155,7 @@ export const renderBadgedLink = (
   const link = getLink(nodeData, nodeType, linkGenerator);
 
   return (
-    <>
+    <div>
       <span style={{ marginRight: '1em', marginBottom: '3px', display: 'inline-block' }}>
         {label && (
           <span style={{ whiteSpace: 'pre' }}>
@@ -166,7 +166,7 @@ export const renderBadgedLink = (
         {link}
       </span>
       {nodeData.isInaccessible && <KialiIcon.MtlsLock />}
-    </>
+    </div>
   );
 };
 

--- a/src/pages/Graph/SummaryPanel.tsx
+++ b/src/pages/Graph/SummaryPanel.tsx
@@ -74,11 +74,7 @@ class SummaryPanel extends React.Component<MainSummaryPanelPropType, SummaryPane
   }
 
   componentDidUpdate(prevProps: Readonly<MainSummaryPanelPropType>): void {
-    if (
-      !this.props.data.isHover &&
-      !prevProps.data.isHover &&
-      prevProps.data.summaryTarget !== this.props.data.summaryTarget
-    ) {
+    if (prevProps.data.summaryTarget !== this.props.data.summaryTarget) {
       this.setState({ isVisible: true });
     }
   }
@@ -124,37 +120,12 @@ class SummaryPanel extends React.Component<MainSummaryPanelPropType, SummaryPane
             </div>
           )}
         </div>
-        {this.props.data.isHover && (
-          <div id="graph-side-panel" className={mainStyle}>
-            <div style={this.state.isVisible ? { position: 'absolute', right: summaryPanelWidth } : {}}>
-              {this.getSummaryPanel({ ...this.props.data, isHover: false })}
-            </div>
-          </div>
-        )}
       </TourStopContainer>
     );
   }
 
   private getSummaryPanel = (summary: SummaryData): React.ReactFragment => {
-    const isHover = summary.isHover;
     const summaryType = summary.summaryType as string;
-
-    if (isHover || summaryType === 'graph') {
-      const cy = this.props.data.isHover ? this.props.data.summaryTarget.cy() : this.props.data.summaryTarget;
-      return (
-        <SummaryPanelGraph
-          data={{ isHover: false, summaryType: 'graph', summaryTarget: cy }}
-          duration={this.props.duration}
-          graphType={this.props.graphType}
-          injectServiceNodes={this.props.injectServiceNodes}
-          namespaces={this.props.namespaces}
-          queryTime={this.props.queryTime}
-          rateInterval={this.props.rateInterval}
-          step={this.props.step}
-          trafficRates={this.props.trafficRates}
-        />
-      );
-    }
 
     switch (summaryType) {
       case 'box': {
@@ -209,6 +180,20 @@ class SummaryPanel extends React.Component<MainSummaryPanelPropType, SummaryPane
       }
       case 'edge':
         return <SummaryPanelEdge {...this.props} />;
+      case 'graph':
+        return (
+          <SummaryPanelGraph
+            data={summary}
+            duration={this.props.duration}
+            graphType={this.props.graphType}
+            injectServiceNodes={this.props.injectServiceNodes}
+            namespaces={this.props.namespaces}
+            queryTime={this.props.queryTime}
+            rateInterval={this.props.rateInterval}
+            step={this.props.step}
+            trafficRates={this.props.trafficRates}
+          />
+        );
       case 'node':
         return (
           <SummaryPanelNodeContainer

--- a/src/pages/Graph/SummaryPanel.tsx
+++ b/src/pages/Graph/SummaryPanel.tsx
@@ -55,12 +55,12 @@ const toggleSidePanelStyle = style({
   backgroundColor: 'white',
   border: '1px #ddd solid',
   borderRadius: '3px',
+  bottom: 0,
   cursor: 'pointer',
   left: '-1.6em',
   minWidth: '5em',
   position: 'absolute',
   textAlign: 'center',
-  top: '6.5em',
   transform: 'rotate(-90deg)',
   transformOrigin: 'left top 0'
 });

--- a/src/pages/Graph/SummaryPanel.tsx
+++ b/src/pages/Graph/SummaryPanel.tsx
@@ -85,6 +85,9 @@ class SummaryPanel extends React.Component<MainSummaryPanelPropType, SummaryPane
     const summaryType = this.props.data.summaryType as string;
     const boxType: BoxByType | undefined =
       summaryType === 'box' ? this.props.data.summaryTarget.data(CyNode.isBox) : undefined;
+    const isHover = !!this.props.data.isHover;
+
+    console.log(`Is Hover=${this.props.data.isHover}`);
 
     const mainTopStyle = this.state.isVisible
       ? this.props.jaegerState.selectedTrace
@@ -106,7 +109,7 @@ class SummaryPanel extends React.Component<MainSummaryPanelPropType, SummaryPane
                 </>
               )}
             </div>
-            {summaryType === 'box' && boxType === 'app' && (
+            {summaryType === 'box' && boxType === 'app' && !isHover && (
               <SummaryPanelAppBox
                 data={this.props.data}
                 duration={this.props.duration}
@@ -119,7 +122,7 @@ class SummaryPanel extends React.Component<MainSummaryPanelPropType, SummaryPane
                 trafficRates={this.props.trafficRates}
               />
             )}
-            {summaryType === 'box' && boxType === 'cluster' && (
+            {summaryType === 'box' && boxType === 'cluster' && !isHover && (
               <SummaryPanelClusterBox
                 data={this.props.data}
                 duration={this.props.duration}
@@ -132,7 +135,7 @@ class SummaryPanel extends React.Component<MainSummaryPanelPropType, SummaryPane
                 trafficRates={this.props.trafficRates}
               />
             )}
-            {summaryType === 'box' && boxType === 'namespace' && (
+            {summaryType === 'box' && boxType === 'namespace' && !isHover && (
               <SummaryPanelNamespaceBox
                 data={this.props.data}
                 duration={this.props.duration}
@@ -145,13 +148,14 @@ class SummaryPanel extends React.Component<MainSummaryPanelPropType, SummaryPane
                 trafficRates={this.props.trafficRates}
               />
             )}
-            {summaryType === 'edge' && <SummaryPanelEdge {...this.props} />}
-            {summaryType === 'graph' && (
+            {summaryType === 'edge' && !isHover && <SummaryPanelEdge {...this.props} />}
+            {(summaryType === 'graph' || isHover) && (
               <SummaryPanelGraph
                 data={this.props.data}
                 duration={this.props.duration}
                 graphType={this.props.graphType}
                 injectServiceNodes={this.props.injectServiceNodes}
+                isHover={isHover}
                 namespaces={this.props.namespaces}
                 queryTime={this.props.queryTime}
                 rateInterval={this.props.rateInterval}
@@ -159,7 +163,7 @@ class SummaryPanel extends React.Component<MainSummaryPanelPropType, SummaryPane
                 trafficRates={this.props.trafficRates}
               />
             )}
-            {this.props.data.summaryType === 'node' && (
+            {this.props.data.summaryType === 'node' && !isHover && (
               <SummaryPanelNodeContainer
                 data={this.props.data}
                 duration={this.props.duration}

--- a/src/pages/Graph/SummaryPanel.tsx
+++ b/src/pages/Graph/SummaryPanel.tsx
@@ -85,9 +85,6 @@ class SummaryPanel extends React.Component<MainSummaryPanelPropType, SummaryPane
     const summaryType = this.props.data.summaryType as string;
     const boxType: BoxByType | undefined =
       summaryType === 'box' ? this.props.data.summaryTarget.data(CyNode.isBox) : undefined;
-    const isHover = !!this.props.data.isHover;
-
-    console.log(`Is Hover=${this.props.data.isHover}`);
 
     const mainTopStyle = this.state.isVisible
       ? this.props.jaegerState.selectedTrace
@@ -109,7 +106,7 @@ class SummaryPanel extends React.Component<MainSummaryPanelPropType, SummaryPane
                 </>
               )}
             </div>
-            {summaryType === 'box' && boxType === 'app' && !isHover && (
+            {summaryType === 'box' && boxType === 'app' && (
               <SummaryPanelAppBox
                 data={this.props.data}
                 duration={this.props.duration}
@@ -122,7 +119,7 @@ class SummaryPanel extends React.Component<MainSummaryPanelPropType, SummaryPane
                 trafficRates={this.props.trafficRates}
               />
             )}
-            {summaryType === 'box' && boxType === 'cluster' && !isHover && (
+            {summaryType === 'box' && boxType === 'cluster' && (
               <SummaryPanelClusterBox
                 data={this.props.data}
                 duration={this.props.duration}
@@ -135,7 +132,7 @@ class SummaryPanel extends React.Component<MainSummaryPanelPropType, SummaryPane
                 trafficRates={this.props.trafficRates}
               />
             )}
-            {summaryType === 'box' && boxType === 'namespace' && !isHover && (
+            {summaryType === 'box' && boxType === 'namespace' && (
               <SummaryPanelNamespaceBox
                 data={this.props.data}
                 duration={this.props.duration}
@@ -148,14 +145,13 @@ class SummaryPanel extends React.Component<MainSummaryPanelPropType, SummaryPane
                 trafficRates={this.props.trafficRates}
               />
             )}
-            {summaryType === 'edge' && !isHover && <SummaryPanelEdge {...this.props} />}
-            {(summaryType === 'graph' || isHover) && (
+            {summaryType === 'edge' && <SummaryPanelEdge {...this.props} />}
+            {summaryType === 'graph' && (
               <SummaryPanelGraph
                 data={this.props.data}
                 duration={this.props.duration}
                 graphType={this.props.graphType}
                 injectServiceNodes={this.props.injectServiceNodes}
-                isHover={isHover}
                 namespaces={this.props.namespaces}
                 queryTime={this.props.queryTime}
                 rateInterval={this.props.rateInterval}
@@ -163,7 +159,7 @@ class SummaryPanel extends React.Component<MainSummaryPanelPropType, SummaryPane
                 trafficRates={this.props.trafficRates}
               />
             )}
-            {this.props.data.summaryType === 'node' && !isHover && (
+            {this.props.data.summaryType === 'node' && (
               <SummaryPanelNodeContainer
                 data={this.props.data}
                 duration={this.props.duration}

--- a/src/pages/Graph/SummaryPanelAppBox.tsx
+++ b/src/pages/Graph/SummaryPanelAppBox.tsx
@@ -155,7 +155,7 @@ export default class SummaryPanelAppBox extends React.Component<SummaryPanelProp
     return (
       <div ref={this.mainDivRef} className={`panel panel-default ${isHover ? summaryPanelHover : summaryPanel}`}>
         <div className="panel-heading" style={summaryHeader}>
-          {isHover && getHoverTitle()}
+          {isHover && getHoverTitle('Application')}
           <span>
             <PFBadge badge={PFBadges.Namespace} style={{ marginBottom: '2px' }} />
             {nodeData.namespace}

--- a/src/pages/Graph/SummaryPanelAppBox.tsx
+++ b/src/pages/Graph/SummaryPanelAppBox.tsx
@@ -154,7 +154,7 @@ export default class SummaryPanelAppBox extends React.Component<SummaryPanelProp
       <div
         ref={this.mainDivRef}
         className={`panel panel-default ${summaryPanel}`}
-        style={isHover ? { background: 'gray' } : {}}
+        style={isHover ? { overflowY: 'auto' } : {}}
       >
         <div className="panel-heading" style={summaryHeader}>
           <span>

--- a/src/pages/Graph/SummaryPanelAppBox.tsx
+++ b/src/pages/Graph/SummaryPanelAppBox.tsx
@@ -14,7 +14,9 @@ import {
   hr,
   summaryPanel,
   mergeMetricsResponses,
-  getDatapoints
+  getDatapoints,
+  summaryPanelHover,
+  getHoverTitle
 } from './SummaryPanelCommon';
 import { Response } from '../../services/Api';
 import { IstioMetricsMap, Datapoint, Labels } from '../../types/Metrics';
@@ -151,12 +153,9 @@ export default class SummaryPanelAppBox extends React.Component<SummaryPanelProp
         : undefined;
 
     return (
-      <div
-        ref={this.mainDivRef}
-        className={`panel panel-default ${summaryPanel}`}
-        style={isHover ? { overflowY: 'auto' } : {}}
-      >
+      <div ref={this.mainDivRef} className={`panel panel-default ${isHover ? summaryPanelHover : summaryPanel}`}>
         <div className="panel-heading" style={summaryHeader}>
+          {isHover && getHoverTitle()}
           <span>
             <PFBadge badge={PFBadges.Namespace} style={{ marginBottom: '2px' }} />
             {nodeData.namespace}

--- a/src/pages/Graph/SummaryPanelAppBox.tsx
+++ b/src/pages/Graph/SummaryPanelAppBox.tsx
@@ -15,7 +15,6 @@ import {
   summaryPanel,
   mergeMetricsResponses,
   getDatapoints,
-  summaryPanelHover,
   getTitle
 } from './SummaryPanelCommon';
 import { Response } from '../../services/Api';
@@ -122,8 +121,6 @@ export default class SummaryPanelAppBox extends React.Component<SummaryPanelProp
   }
 
   render() {
-    const isHover = this.props.data.isHover;
-
     const appBox = this.props.data.summaryTarget;
     const nodeData = decoratedNodeData(appBox);
 
@@ -153,13 +150,13 @@ export default class SummaryPanelAppBox extends React.Component<SummaryPanelProp
         : undefined;
 
     return (
-      <div ref={this.mainDivRef} className={`panel panel-default ${isHover ? summaryPanelHover : summaryPanel}`}>
+      <div ref={this.mainDivRef} className={`panel panel-default ${summaryPanel}`}>
         <div className="panel-heading" style={summaryHeader}>
           {getTitle('Application')}
           <span>
             <PFBadge badge={PFBadges.Namespace} style={{ marginBottom: '2px' }} />
             {nodeData.namespace}
-            {!isHover && actions && (
+            {actions && (
               <Dropdown
                 id="summary-appbox-actions"
                 isPlain={true}
@@ -180,35 +177,33 @@ export default class SummaryPanelAppBox extends React.Component<SummaryPanelProp
             {workloadList.length > 0 && <div> {workloadList}</div>}
           </div>
         </div>
-        {!isHover && (
-          <div className="panel-body">
-            {hasGrpc && isGrpcRequests && (
-              <>
-                {this.renderGrpcRequests(appBox)}
-                {hr()}
-              </>
-            )}
-            {hasHttp && (
-              <>
-                {this.renderHttpRequests(appBox)}
-                {hr()}
-              </>
-            )}
-            <div>
-              {this.renderSparklines(appBox)}
+        <div className="panel-body">
+          {hasGrpc && isGrpcRequests && (
+            <>
+              {this.renderGrpcRequests(appBox)}
               {hr()}
-            </div>
-            {hasGrpc && !hasGrpcIn && renderNoTraffic('gRPC inbound')}
-            {hasGrpc && !hasGrpcOut && renderNoTraffic('gRPC outbound')}
-            {!hasGrpc && renderNoTraffic('gRPC')}
-            {hasHttp && !hasHttpIn && renderNoTraffic('HTTP inbound')}
-            {hasHttp && !hasHttpOut && renderNoTraffic('HTTP outbound')}
-            {!hasHttp && renderNoTraffic('HTTP')}
-            {hasTcp && !hasTcpIn && renderNoTraffic('TCP inbound')}
-            {hasTcp && !hasTcpOut && renderNoTraffic('TCP outbound')}
-            {!hasTcp && renderNoTraffic('TCP')}
+            </>
+          )}
+          {hasHttp && (
+            <>
+              {this.renderHttpRequests(appBox)}
+              {hr()}
+            </>
+          )}
+          <div>
+            {this.renderSparklines(appBox)}
+            {hr()}
           </div>
-        )}
+          {hasGrpc && !hasGrpcIn && renderNoTraffic('gRPC inbound')}
+          {hasGrpc && !hasGrpcOut && renderNoTraffic('gRPC outbound')}
+          {!hasGrpc && renderNoTraffic('gRPC')}
+          {hasHttp && !hasHttpIn && renderNoTraffic('HTTP inbound')}
+          {hasHttp && !hasHttpOut && renderNoTraffic('HTTP outbound')}
+          {!hasHttp && renderNoTraffic('HTTP')}
+          {hasTcp && !hasTcpIn && renderNoTraffic('TCP inbound')}
+          {hasTcp && !hasTcpOut && renderNoTraffic('TCP outbound')}
+          {!hasTcp && renderNoTraffic('TCP')}
+        </div>
       </div>
     );
   }

--- a/src/pages/Graph/SummaryPanelAppBox.tsx
+++ b/src/pages/Graph/SummaryPanelAppBox.tsx
@@ -16,7 +16,7 @@ import {
   mergeMetricsResponses,
   getDatapoints,
   summaryPanelHover,
-  getHoverTitle
+  getTitle
 } from './SummaryPanelCommon';
 import { Response } from '../../services/Api';
 import { IstioMetricsMap, Datapoint, Labels } from '../../types/Metrics';
@@ -155,7 +155,7 @@ export default class SummaryPanelAppBox extends React.Component<SummaryPanelProp
     return (
       <div ref={this.mainDivRef} className={`panel panel-default ${isHover ? summaryPanelHover : summaryPanel}`}>
         <div className="panel-heading" style={summaryHeader}>
-          {isHover && getHoverTitle('Application')}
+          {getTitle('Application')}
           <span>
             <PFBadge badge={PFBadges.Namespace} style={{ marginBottom: '2px' }} />
             {nodeData.namespace}

--- a/src/pages/Graph/SummaryPanelAppBox.tsx
+++ b/src/pages/Graph/SummaryPanelAppBox.tsx
@@ -119,8 +119,11 @@ export default class SummaryPanelAppBox extends React.Component<SummaryPanelProp
   }
 
   render() {
+    const isHover = this.props.data.isHover;
+
     const appBox = this.props.data.summaryTarget;
     const nodeData = decoratedNodeData(appBox);
+
     const serviceList = this.renderServiceList(appBox);
     const workloadList = this.renderWorkloadList(appBox);
     const hasGrpc = this.hasGrpcTraffic(appBox);
@@ -171,33 +174,35 @@ export default class SummaryPanelAppBox extends React.Component<SummaryPanelProp
             {workloadList.length > 0 && <div> {workloadList}</div>}
           </div>
         </div>
-        <div className="panel-body">
-          {hasGrpc && isGrpcRequests && (
-            <>
-              {this.renderGrpcRequests(appBox)}
+        {!isHover && (
+          <div className="panel-body">
+            {hasGrpc && isGrpcRequests && (
+              <>
+                {this.renderGrpcRequests(appBox)}
+                {hr()}
+              </>
+            )}
+            {hasHttp && (
+              <>
+                {this.renderHttpRequests(appBox)}
+                {hr()}
+              </>
+            )}
+            <div>
+              {this.renderSparklines(appBox)}
               {hr()}
-            </>
-          )}
-          {hasHttp && (
-            <>
-              {this.renderHttpRequests(appBox)}
-              {hr()}
-            </>
-          )}
-          <div>
-            {this.renderSparklines(appBox)}
-            {hr()}
+            </div>
+            {hasGrpc && !hasGrpcIn && renderNoTraffic('gRPC inbound')}
+            {hasGrpc && !hasGrpcOut && renderNoTraffic('gRPC outbound')}
+            {!hasGrpc && renderNoTraffic('gRPC')}
+            {hasHttp && !hasHttpIn && renderNoTraffic('HTTP inbound')}
+            {hasHttp && !hasHttpOut && renderNoTraffic('HTTP outbound')}
+            {!hasHttp && renderNoTraffic('HTTP')}
+            {hasTcp && !hasTcpIn && renderNoTraffic('TCP inbound')}
+            {hasTcp && !hasTcpOut && renderNoTraffic('TCP outbound')}
+            {!hasTcp && renderNoTraffic('TCP')}
           </div>
-          {hasGrpc && !hasGrpcIn && renderNoTraffic('gRPC inbound')}
-          {hasGrpc && !hasGrpcOut && renderNoTraffic('gRPC outbound')}
-          {!hasGrpc && renderNoTraffic('gRPC')}
-          {hasHttp && !hasHttpIn && renderNoTraffic('HTTP inbound')}
-          {hasHttp && !hasHttpOut && renderNoTraffic('HTTP outbound')}
-          {!hasHttp && renderNoTraffic('HTTP')}
-          {hasTcp && !hasTcpIn && renderNoTraffic('TCP inbound')}
-          {hasTcp && !hasTcpOut && renderNoTraffic('TCP outbound')}
-          {!hasTcp && renderNoTraffic('TCP')}
-        </div>
+        )}
       </div>
     );
   }

--- a/src/pages/Graph/SummaryPanelAppBox.tsx
+++ b/src/pages/Graph/SummaryPanelAppBox.tsx
@@ -151,7 +151,11 @@ export default class SummaryPanelAppBox extends React.Component<SummaryPanelProp
         : undefined;
 
     return (
-      <div ref={this.mainDivRef} className={`panel panel-default ${summaryPanel}`}>
+      <div
+        ref={this.mainDivRef}
+        className={`panel panel-default ${summaryPanel}`}
+        style={isHover ? { background: 'gray' } : {}}
+      >
         <div className="panel-heading" style={summaryHeader}>
           <span>
             <PFBadge badge={PFBadges.Namespace} style={{ marginBottom: '2px' }} />

--- a/src/pages/Graph/SummaryPanelAppBox.tsx
+++ b/src/pages/Graph/SummaryPanelAppBox.tsx
@@ -24,6 +24,7 @@ import { KialiIcon } from 'config/KialiIcon';
 import { decoratedNodeData, CyNode } from 'components/CytoscapeGraph/CytoscapeGraphUtils';
 import { Dropdown, DropdownPosition, DropdownItem, KebabToggle, DropdownGroup } from '@patternfly/react-core';
 import { getOptions, clickHandler } from 'components/CytoscapeGraph/ContextMenu/NodeContextMenu';
+import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
 
 type SummaryPanelAppBoxMetricsState = {
   grpcRequestIn: Datapoint[];
@@ -152,9 +153,10 @@ export default class SummaryPanelAppBox extends React.Component<SummaryPanelProp
     return (
       <div ref={this.mainDivRef} className={`panel panel-default ${summaryPanel}`}>
         <div className="panel-heading" style={summaryHeader}>
-          <div>
-            {renderBadgedLink(nodeData)}
-            {actions && (
+          <span>
+            <PFBadge badge={PFBadges.Namespace} style={{ marginBottom: '2px' }} />
+            {nodeData.namespace}
+            {!isHover && actions && (
               <Dropdown
                 id="summary-appbox-actions"
                 isPlain={true}
@@ -166,8 +168,9 @@ export default class SummaryPanelAppBox extends React.Component<SummaryPanelProp
                 isGrouped={true}
               />
             )}
-          </div>
-          <div>{renderHealth(nodeData.health)}</div>
+            {renderBadgedLink(nodeData)}
+            {renderHealth(nodeData.health)}
+          </span>
           <div>
             {this.renderBadgeSummary(appBox)}
             {serviceList.length > 0 && <div>{serviceList}</div>}

--- a/src/pages/Graph/SummaryPanelClusterBox.tsx
+++ b/src/pages/Graph/SummaryPanelClusterBox.tsx
@@ -50,6 +50,8 @@ export default class SummaryPanelClusterBox extends React.Component<SummaryPanel
   }
 
   render() {
+    const isHover = this.props.data.isHover;
+
     const clusterBox = this.props.data.summaryTarget;
     const boxed = clusterBox.descendants();
     const cluster = clusterBox.data(CyNode.cluster);
@@ -81,102 +83,104 @@ export default class SummaryPanelClusterBox extends React.Component<SummaryPanel
           {this.renderCluster(cluster)}
           {this.renderTopologySummary(numSvc, numWorkloads, numApps, numVersions, numEdges)}
         </div>
-        <div className={summaryBodyTabs}>
-          <SimpleTabs id="graph_summary_tabs" defaultTab={0} style={{ paddingBottom: '10px' }}>
-            <Tab style={summaryFont} title="Inbound" eventKey={0}>
-              <div style={summaryFont}>
-                {grpcIn.rate === 0 && httpIn.rate === 0 && tcpIn.rate === 0 && (
-                  <>
-                    <KialiIcon.Info /> No inbound traffic.
-                  </>
-                )}
-                {grpcIn.rate > 0 && (
-                  <RateTableGrpc
-                    isRequests={isGrpcRequests}
-                    rate={grpcIn.rate}
-                    rateGrpcErr={grpcIn.rateGrpcErr}
-                    rateNR={grpcIn.rateNoResponse}
-                  />
-                )}
-                {httpIn.rate > 0 && (
-                  <RateTableHttp
-                    title="HTTP (requests per second):"
-                    rate={httpIn.rate}
-                    rate3xx={httpIn.rate3xx}
-                    rate4xx={httpIn.rate4xx}
-                    rate5xx={httpIn.rate5xx}
-                    rateNR={httpIn.rateNoResponse}
-                  />
-                )}
-                {tcpIn.rate > 0 && <RateTableTcp rate={tcpIn.rate} />}
-                {
-                  // We don't show a sparkline here because we need to aggregate the traffic of an
-                  // ad hoc set of [root] nodes. We don't have backend support for that aggregation.
-                }
-              </div>
-            </Tab>
-            <Tab style={summaryFont} title="Outbound" eventKey={1}>
-              <div style={summaryFont}>
-                {grpcOut.rate === 0 && httpOut.rate === 0 && tcpOut.rate === 0 && (
-                  <>
-                    <KialiIcon.Info /> No outbound traffic.
-                  </>
-                )}
-                {grpcOut.rate > 0 && (
-                  <RateTableGrpc
-                    isRequests={isGrpcRequests}
-                    rate={grpcOut.rate}
-                    rateGrpcErr={grpcOut.rateGrpcErr}
-                    rateNR={grpcOut.rateNoResponse}
-                  />
-                )}
-                {httpOut.rate > 0 && (
-                  <RateTableHttp
-                    title="HTTP (requests per second):"
-                    rate={httpOut.rate}
-                    rate3xx={httpOut.rate3xx}
-                    rate4xx={httpOut.rate4xx}
-                    rate5xx={httpOut.rate5xx}
-                    rateNR={httpOut.rateNoResponse}
-                  />
-                )}
-                {tcpOut.rate > 0 && <RateTableTcp rate={tcpOut.rate} />}
-                {
-                  // We don't show a sparkline here because we need to aggregate the traffic of an
-                  // ad hoc set of [root] nodes. We don't have backend support for that aggregation.
-                }
-              </div>
-            </Tab>
-            <Tab style={summaryFont} title="Total" eventKey={2}>
-              <div style={summaryFont}>
-                {grpcTotal.rate === 0 && httpTotal.rate === 0 && tcpTotal.rate === 0 && (
-                  <>
-                    <KialiIcon.Info /> No traffic.
-                  </>
-                )}
-                {grpcTotal.rate > 0 && (
-                  <RateTableGrpc
-                    isRequests={isGrpcRequests}
-                    rate={grpcTotal.rate}
-                    rateGrpcErr={grpcTotal.rateGrpcErr}
-                    rateNR={grpcTotal.rateNoResponse}
-                  />
-                )}
-                {httpTotal.rate > 0 && (
-                  <RateTableHttp
-                    title="HTTP (requests per second):"
-                    rate={httpTotal.rate}
-                    rate3xx={httpTotal.rate3xx}
-                    rate4xx={httpTotal.rate4xx}
-                    rate5xx={httpTotal.rate5xx}
-                    rateNR={httpTotal.rateNoResponse}
-                  />
-                )}
-                {tcpTotal.rate > 0 && <RateTableTcp rate={tcpTotal.rate} />}
-              </div>
-            </Tab>
-          </SimpleTabs>
-        </div>
+        {!isHover && (
+          <div className={summaryBodyTabs}>
+            <SimpleTabs id="graph_summary_tabs" defaultTab={0} style={{ paddingBottom: '10px' }}>
+              <Tab style={summaryFont} title="Inbound" eventKey={0}>
+                <div style={summaryFont}>
+                  {grpcIn.rate === 0 && httpIn.rate === 0 && tcpIn.rate === 0 && (
+                    <>
+                      <KialiIcon.Info /> No inbound traffic.
+                    </>
+                  )}
+                  {grpcIn.rate > 0 && (
+                    <RateTableGrpc
+                      isRequests={isGrpcRequests}
+                      rate={grpcIn.rate}
+                      rateGrpcErr={grpcIn.rateGrpcErr}
+                      rateNR={grpcIn.rateNoResponse}
+                    />
+                  )}
+                  {httpIn.rate > 0 && (
+                    <RateTableHttp
+                      title="HTTP (requests per second):"
+                      rate={httpIn.rate}
+                      rate3xx={httpIn.rate3xx}
+                      rate4xx={httpIn.rate4xx}
+                      rate5xx={httpIn.rate5xx}
+                      rateNR={httpIn.rateNoResponse}
+                    />
+                  )}
+                  {tcpIn.rate > 0 && <RateTableTcp rate={tcpIn.rate} />}
+                  {
+                    // We don't show a sparkline here because we need to aggregate the traffic of an
+                    // ad hoc set of [root] nodes. We don't have backend support for that aggregation.
+                  }
+                </div>
+              </Tab>
+              <Tab style={summaryFont} title="Outbound" eventKey={1}>
+                <div style={summaryFont}>
+                  {grpcOut.rate === 0 && httpOut.rate === 0 && tcpOut.rate === 0 && (
+                    <>
+                      <KialiIcon.Info /> No outbound traffic.
+                    </>
+                  )}
+                  {grpcOut.rate > 0 && (
+                    <RateTableGrpc
+                      isRequests={isGrpcRequests}
+                      rate={grpcOut.rate}
+                      rateGrpcErr={grpcOut.rateGrpcErr}
+                      rateNR={grpcOut.rateNoResponse}
+                    />
+                  )}
+                  {httpOut.rate > 0 && (
+                    <RateTableHttp
+                      title="HTTP (requests per second):"
+                      rate={httpOut.rate}
+                      rate3xx={httpOut.rate3xx}
+                      rate4xx={httpOut.rate4xx}
+                      rate5xx={httpOut.rate5xx}
+                      rateNR={httpOut.rateNoResponse}
+                    />
+                  )}
+                  {tcpOut.rate > 0 && <RateTableTcp rate={tcpOut.rate} />}
+                  {
+                    // We don't show a sparkline here because we need to aggregate the traffic of an
+                    // ad hoc set of [root] nodes. We don't have backend support for that aggregation.
+                  }
+                </div>
+              </Tab>
+              <Tab style={summaryFont} title="Total" eventKey={2}>
+                <div style={summaryFont}>
+                  {grpcTotal.rate === 0 && httpTotal.rate === 0 && tcpTotal.rate === 0 && (
+                    <>
+                      <KialiIcon.Info /> No traffic.
+                    </>
+                  )}
+                  {grpcTotal.rate > 0 && (
+                    <RateTableGrpc
+                      isRequests={isGrpcRequests}
+                      rate={grpcTotal.rate}
+                      rateGrpcErr={grpcTotal.rateGrpcErr}
+                      rateNR={grpcTotal.rateNoResponse}
+                    />
+                  )}
+                  {httpTotal.rate > 0 && (
+                    <RateTableHttp
+                      title="HTTP (requests per second):"
+                      rate={httpTotal.rate}
+                      rate3xx={httpTotal.rate3xx}
+                      rate4xx={httpTotal.rate4xx}
+                      rate5xx={httpTotal.rate5xx}
+                      rateNR={httpTotal.rateNoResponse}
+                    />
+                  )}
+                  {tcpTotal.rate > 0 && <RateTableTcp rate={tcpTotal.rate} />}
+                </div>
+              </Tab>
+            </SimpleTabs>
+          </div>
+        )}
       </div>
     );
   }

--- a/src/pages/Graph/SummaryPanelClusterBox.tsx
+++ b/src/pages/Graph/SummaryPanelClusterBox.tsx
@@ -90,7 +90,7 @@ export default class SummaryPanelClusterBox extends React.Component<SummaryPanel
         style={isHover ? {} : SummaryPanelClusterBox.panelStyle}
       >
         <div className="panel-heading" style={summaryHeader}>
-          {isHover && getHoverTitle()}
+          {isHover && getHoverTitle('Cluster')}
           {this.renderCluster(cluster)}
           {this.renderTopologySummary(numSvc, numWorkloads, numApps, numVersions, numEdges)}
         </div>

--- a/src/pages/Graph/SummaryPanelClusterBox.tsx
+++ b/src/pages/Graph/SummaryPanelClusterBox.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Tab } from '@patternfly/react-core';
 import { style } from 'typestyle';
-import { summaryFont, summaryHeader, summaryBodyTabs } from './SummaryPanelCommon';
+import { summaryFont, summaryHeader, summaryBodyTabs, summaryPanelWidth } from './SummaryPanelCommon';
 import { CyNode } from 'components/CytoscapeGraph/CytoscapeGraphUtils';
 import KialiPageLink from 'components/Link/KialiPageLink';
 import { RateTableGrpc, RateTableHttp, RateTableTcp } from 'components/SummaryPanel/RateTable';
@@ -32,10 +32,10 @@ export default class SummaryPanelClusterBox extends React.Component<SummaryPanel
   static readonly panelStyle = {
     height: '100%',
     margin: 0,
-    minWidth: '25em',
+    minWidth: summaryPanelWidth,
     overflowY: 'auto' as 'auto',
     backgroundColor: PFColors.White,
-    width: '25em'
+    width: summaryPanelWidth
   };
 
   constructor(props: SummaryPanelPropType) {
@@ -78,10 +78,7 @@ export default class SummaryPanelClusterBox extends React.Component<SummaryPanel
     const tcpTotal = getAccumulatedTrafficRateTcp(totalEdges);
 
     return (
-      <div
-        className="panel panel-default"
-        style={{ ...SummaryPanelClusterBox.panelStyle, ...(isHover ? { background: 'gray' } : {}) }}
-      >
+      <div className="panel panel-default" style={SummaryPanelClusterBox.panelStyle}>
         <div className="panel-heading" style={summaryHeader}>
           {this.renderCluster(cluster)}
           {this.renderTopologySummary(numSvc, numWorkloads, numApps, numVersions, numEdges)}

--- a/src/pages/Graph/SummaryPanelClusterBox.tsx
+++ b/src/pages/Graph/SummaryPanelClusterBox.tsx
@@ -7,7 +7,7 @@ import {
   summaryBodyTabs,
   summaryPanelWidth,
   summaryPanelHover,
-  getHoverTitle
+  getTitle
 } from './SummaryPanelCommon';
 import { CyNode } from 'components/CytoscapeGraph/CytoscapeGraphUtils';
 import KialiPageLink from 'components/Link/KialiPageLink';
@@ -90,7 +90,7 @@ export default class SummaryPanelClusterBox extends React.Component<SummaryPanel
         style={isHover ? {} : SummaryPanelClusterBox.panelStyle}
       >
         <div className="panel-heading" style={summaryHeader}>
-          {isHover && getHoverTitle('Cluster')}
+          {getTitle('Cluster')}
           {this.renderCluster(cluster)}
           {this.renderTopologySummary(numSvc, numWorkloads, numApps, numVersions, numEdges)}
         </div>
@@ -238,8 +238,7 @@ export default class SummaryPanelClusterBox extends React.Component<SummaryPanel
   ) => (
     <>
       <br />
-      <strong>Current Graph:</strong>
-      <br />
+      {getTitle('Current Graph')}
       {numApps > 0 && (
         <>
           <KialiIcon.Applications className={topologyStyle} />

--- a/src/pages/Graph/SummaryPanelClusterBox.tsx
+++ b/src/pages/Graph/SummaryPanelClusterBox.tsx
@@ -1,7 +1,14 @@
 import * as React from 'react';
 import { Tab } from '@patternfly/react-core';
 import { style } from 'typestyle';
-import { summaryFont, summaryHeader, summaryBodyTabs, summaryPanelWidth } from './SummaryPanelCommon';
+import {
+  summaryFont,
+  summaryHeader,
+  summaryBodyTabs,
+  summaryPanelWidth,
+  summaryPanelHover,
+  getHoverTitle
+} from './SummaryPanelCommon';
 import { CyNode } from 'components/CytoscapeGraph/CytoscapeGraphUtils';
 import KialiPageLink from 'components/Link/KialiPageLink';
 import { RateTableGrpc, RateTableHttp, RateTableTcp } from 'components/SummaryPanel/RateTable';
@@ -78,8 +85,12 @@ export default class SummaryPanelClusterBox extends React.Component<SummaryPanel
     const tcpTotal = getAccumulatedTrafficRateTcp(totalEdges);
 
     return (
-      <div className="panel panel-default" style={SummaryPanelClusterBox.panelStyle}>
+      <div
+        className={`panel panel-default ${isHover && summaryPanelHover}`}
+        style={isHover ? {} : SummaryPanelClusterBox.panelStyle}
+      >
         <div className="panel-heading" style={summaryHeader}>
+          {isHover && getHoverTitle()}
           {this.renderCluster(cluster)}
           {this.renderTopologySummary(numSvc, numWorkloads, numApps, numVersions, numEdges)}
         </div>

--- a/src/pages/Graph/SummaryPanelClusterBox.tsx
+++ b/src/pages/Graph/SummaryPanelClusterBox.tsx
@@ -1,14 +1,7 @@
 import * as React from 'react';
 import { Tab } from '@patternfly/react-core';
 import { style } from 'typestyle';
-import {
-  summaryFont,
-  summaryHeader,
-  summaryBodyTabs,
-  summaryPanelWidth,
-  summaryPanelHover,
-  getTitle
-} from './SummaryPanelCommon';
+import { summaryFont, summaryHeader, summaryBodyTabs, summaryPanelWidth, getTitle } from './SummaryPanelCommon';
 import { CyNode } from 'components/CytoscapeGraph/CytoscapeGraphUtils';
 import KialiPageLink from 'components/Link/KialiPageLink';
 import { RateTableGrpc, RateTableHttp, RateTableTcp } from 'components/SummaryPanel/RateTable';
@@ -57,8 +50,6 @@ export default class SummaryPanelClusterBox extends React.Component<SummaryPanel
   }
 
   render() {
-    const isHover = this.props.data.isHover;
-
     const clusterBox = this.props.data.summaryTarget;
     const boxed = clusterBox.descendants();
     const cluster = clusterBox.data(CyNode.cluster);
@@ -85,113 +76,108 @@ export default class SummaryPanelClusterBox extends React.Component<SummaryPanel
     const tcpTotal = getAccumulatedTrafficRateTcp(totalEdges);
 
     return (
-      <div
-        className={`panel panel-default ${isHover && summaryPanelHover}`}
-        style={isHover ? {} : SummaryPanelClusterBox.panelStyle}
-      >
+      <div className="panel panel-default" style={SummaryPanelClusterBox.panelStyle}>
         <div className="panel-heading" style={summaryHeader}>
           {getTitle('Cluster')}
           {this.renderCluster(cluster)}
           {this.renderTopologySummary(numSvc, numWorkloads, numApps, numVersions, numEdges)}
         </div>
-        {!isHover && (
-          <div className={summaryBodyTabs}>
-            <SimpleTabs id="graph_summary_tabs" defaultTab={0} style={{ paddingBottom: '10px' }}>
-              <Tab style={summaryFont} title="Inbound" eventKey={0}>
-                <div style={summaryFont}>
-                  {grpcIn.rate === 0 && httpIn.rate === 0 && tcpIn.rate === 0 && (
-                    <>
-                      <KialiIcon.Info /> No inbound traffic.
-                    </>
-                  )}
-                  {grpcIn.rate > 0 && (
-                    <RateTableGrpc
-                      isRequests={isGrpcRequests}
-                      rate={grpcIn.rate}
-                      rateGrpcErr={grpcIn.rateGrpcErr}
-                      rateNR={grpcIn.rateNoResponse}
-                    />
-                  )}
-                  {httpIn.rate > 0 && (
-                    <RateTableHttp
-                      title="HTTP (requests per second):"
-                      rate={httpIn.rate}
-                      rate3xx={httpIn.rate3xx}
-                      rate4xx={httpIn.rate4xx}
-                      rate5xx={httpIn.rate5xx}
-                      rateNR={httpIn.rateNoResponse}
-                    />
-                  )}
-                  {tcpIn.rate > 0 && <RateTableTcp rate={tcpIn.rate} />}
-                  {
-                    // We don't show a sparkline here because we need to aggregate the traffic of an
-                    // ad hoc set of [root] nodes. We don't have backend support for that aggregation.
-                  }
-                </div>
-              </Tab>
-              <Tab style={summaryFont} title="Outbound" eventKey={1}>
-                <div style={summaryFont}>
-                  {grpcOut.rate === 0 && httpOut.rate === 0 && tcpOut.rate === 0 && (
-                    <>
-                      <KialiIcon.Info /> No outbound traffic.
-                    </>
-                  )}
-                  {grpcOut.rate > 0 && (
-                    <RateTableGrpc
-                      isRequests={isGrpcRequests}
-                      rate={grpcOut.rate}
-                      rateGrpcErr={grpcOut.rateGrpcErr}
-                      rateNR={grpcOut.rateNoResponse}
-                    />
-                  )}
-                  {httpOut.rate > 0 && (
-                    <RateTableHttp
-                      title="HTTP (requests per second):"
-                      rate={httpOut.rate}
-                      rate3xx={httpOut.rate3xx}
-                      rate4xx={httpOut.rate4xx}
-                      rate5xx={httpOut.rate5xx}
-                      rateNR={httpOut.rateNoResponse}
-                    />
-                  )}
-                  {tcpOut.rate > 0 && <RateTableTcp rate={tcpOut.rate} />}
-                  {
-                    // We don't show a sparkline here because we need to aggregate the traffic of an
-                    // ad hoc set of [root] nodes. We don't have backend support for that aggregation.
-                  }
-                </div>
-              </Tab>
-              <Tab style={summaryFont} title="Total" eventKey={2}>
-                <div style={summaryFont}>
-                  {grpcTotal.rate === 0 && httpTotal.rate === 0 && tcpTotal.rate === 0 && (
-                    <>
-                      <KialiIcon.Info /> No traffic.
-                    </>
-                  )}
-                  {grpcTotal.rate > 0 && (
-                    <RateTableGrpc
-                      isRequests={isGrpcRequests}
-                      rate={grpcTotal.rate}
-                      rateGrpcErr={grpcTotal.rateGrpcErr}
-                      rateNR={grpcTotal.rateNoResponse}
-                    />
-                  )}
-                  {httpTotal.rate > 0 && (
-                    <RateTableHttp
-                      title="HTTP (requests per second):"
-                      rate={httpTotal.rate}
-                      rate3xx={httpTotal.rate3xx}
-                      rate4xx={httpTotal.rate4xx}
-                      rate5xx={httpTotal.rate5xx}
-                      rateNR={httpTotal.rateNoResponse}
-                    />
-                  )}
-                  {tcpTotal.rate > 0 && <RateTableTcp rate={tcpTotal.rate} />}
-                </div>
-              </Tab>
-            </SimpleTabs>
-          </div>
-        )}
+        <div className={summaryBodyTabs}>
+          <SimpleTabs id="graph_summary_tabs" defaultTab={0} style={{ paddingBottom: '10px' }}>
+            <Tab style={summaryFont} title="Inbound" eventKey={0}>
+              <div style={summaryFont}>
+                {grpcIn.rate === 0 && httpIn.rate === 0 && tcpIn.rate === 0 && (
+                  <>
+                    <KialiIcon.Info /> No inbound traffic.
+                  </>
+                )}
+                {grpcIn.rate > 0 && (
+                  <RateTableGrpc
+                    isRequests={isGrpcRequests}
+                    rate={grpcIn.rate}
+                    rateGrpcErr={grpcIn.rateGrpcErr}
+                    rateNR={grpcIn.rateNoResponse}
+                  />
+                )}
+                {httpIn.rate > 0 && (
+                  <RateTableHttp
+                    title="HTTP (requests per second):"
+                    rate={httpIn.rate}
+                    rate3xx={httpIn.rate3xx}
+                    rate4xx={httpIn.rate4xx}
+                    rate5xx={httpIn.rate5xx}
+                    rateNR={httpIn.rateNoResponse}
+                  />
+                )}
+                {tcpIn.rate > 0 && <RateTableTcp rate={tcpIn.rate} />}
+                {
+                  // We don't show a sparkline here because we need to aggregate the traffic of an
+                  // ad hoc set of [root] nodes. We don't have backend support for that aggregation.
+                }
+              </div>
+            </Tab>
+            <Tab style={summaryFont} title="Outbound" eventKey={1}>
+              <div style={summaryFont}>
+                {grpcOut.rate === 0 && httpOut.rate === 0 && tcpOut.rate === 0 && (
+                  <>
+                    <KialiIcon.Info /> No outbound traffic.
+                  </>
+                )}
+                {grpcOut.rate > 0 && (
+                  <RateTableGrpc
+                    isRequests={isGrpcRequests}
+                    rate={grpcOut.rate}
+                    rateGrpcErr={grpcOut.rateGrpcErr}
+                    rateNR={grpcOut.rateNoResponse}
+                  />
+                )}
+                {httpOut.rate > 0 && (
+                  <RateTableHttp
+                    title="HTTP (requests per second):"
+                    rate={httpOut.rate}
+                    rate3xx={httpOut.rate3xx}
+                    rate4xx={httpOut.rate4xx}
+                    rate5xx={httpOut.rate5xx}
+                    rateNR={httpOut.rateNoResponse}
+                  />
+                )}
+                {tcpOut.rate > 0 && <RateTableTcp rate={tcpOut.rate} />}
+                {
+                  // We don't show a sparkline here because we need to aggregate the traffic of an
+                  // ad hoc set of [root] nodes. We don't have backend support for that aggregation.
+                }
+              </div>
+            </Tab>
+            <Tab style={summaryFont} title="Total" eventKey={2}>
+              <div style={summaryFont}>
+                {grpcTotal.rate === 0 && httpTotal.rate === 0 && tcpTotal.rate === 0 && (
+                  <>
+                    <KialiIcon.Info /> No traffic.
+                  </>
+                )}
+                {grpcTotal.rate > 0 && (
+                  <RateTableGrpc
+                    isRequests={isGrpcRequests}
+                    rate={grpcTotal.rate}
+                    rateGrpcErr={grpcTotal.rateGrpcErr}
+                    rateNR={grpcTotal.rateNoResponse}
+                  />
+                )}
+                {httpTotal.rate > 0 && (
+                  <RateTableHttp
+                    title="HTTP (requests per second):"
+                    rate={httpTotal.rate}
+                    rate3xx={httpTotal.rate3xx}
+                    rate4xx={httpTotal.rate4xx}
+                    rate5xx={httpTotal.rate5xx}
+                    rateNR={httpTotal.rateNoResponse}
+                  />
+                )}
+                {tcpTotal.rate > 0 && <RateTableTcp rate={tcpTotal.rate} />}
+              </div>
+            </Tab>
+          </SimpleTabs>
+        </div>
       </div>
     );
   }

--- a/src/pages/Graph/SummaryPanelClusterBox.tsx
+++ b/src/pages/Graph/SummaryPanelClusterBox.tsx
@@ -78,7 +78,10 @@ export default class SummaryPanelClusterBox extends React.Component<SummaryPanel
     const tcpTotal = getAccumulatedTrafficRateTcp(totalEdges);
 
     return (
-      <div className="panel panel-default" style={SummaryPanelClusterBox.panelStyle}>
+      <div
+        className="panel panel-default"
+        style={{ ...SummaryPanelClusterBox.panelStyle, ...(isHover ? { background: 'gray' } : {}) }}
+      >
         <div className="panel-heading" style={summaryHeader}>
           {this.renderCluster(cluster)}
           {this.renderTopologySummary(numSvc, numWorkloads, numApps, numVersions, numEdges)}

--- a/src/pages/Graph/SummaryPanelCommon.tsx
+++ b/src/pages/Graph/SummaryPanelCommon.tsx
@@ -8,7 +8,6 @@ import { Response } from '../../services/Api';
 import { decoratedNodeData } from 'components/CytoscapeGraph/CytoscapeGraphUtils';
 import { PFColors } from 'components/Pf/PfColors';
 import { KialiIcon } from 'config/KialiIcon';
-import { Title, TitleSize } from '@patternfly/react-core';
 
 export enum NodeMetricType {
   APP = 1,
@@ -192,7 +191,7 @@ export const renderNoTraffic = (protocol?: string) => {
   );
 };
 
-export const getHoverTitle = (title: string): React.ReactFragment => {
+export const getTitle = (title: string): React.ReactFragment => {
   switch (title) {
     case NodeType.AGGREGATE:
       title = 'Operation';
@@ -208,11 +207,10 @@ export const getHoverTitle = (title: string): React.ReactFragment => {
       break;
   }
   return (
-    <>
-      <Title headingLevel="h5" size={TitleSize.md}>
-        {title}
-      </Title>
+    <div style={{ textAlign: 'center' }}>
+      <strong>{title}</strong>
       <br />
-    </>
+      <br />
+    </div>
   );
 };

--- a/src/pages/Graph/SummaryPanelCommon.tsx
+++ b/src/pages/Graph/SummaryPanelCommon.tsx
@@ -212,8 +212,8 @@ export const getTitle = (title: string): React.ReactFragment => {
       break;
   }
   return (
-    <div style={{ fontWeight: 'bolder', textAlign: 'center' }}>
-      <strong>{title}</strong>
+    <div className={summaryTitle}>
+      {title}
       <br />
       <br />
     </div>

--- a/src/pages/Graph/SummaryPanelCommon.tsx
+++ b/src/pages/Graph/SummaryPanelCommon.tsx
@@ -8,6 +8,7 @@ import { Response } from '../../services/Api';
 import { decoratedNodeData } from 'components/CytoscapeGraph/CytoscapeGraphUtils';
 import { PFColors } from 'components/Pf/PfColors';
 import { KialiIcon } from 'config/KialiIcon';
+import { Title, TitleSize } from '@patternfly/react-core';
 
 export enum NodeMetricType {
   APP = 1,
@@ -29,15 +30,28 @@ export const summaryHeader: React.CSSProperties = {
 export const summaryPanelWidth = '25em';
 
 export const summaryPanel = style({
+  backgroundColor: PFColors.White,
+  fontSize: 'var(--graph-side-panel--font-size)',
   height: '100%',
   margin: 0,
   minWidth: summaryPanelWidth,
   overflowY: 'scroll',
-  backgroundColor: PFColors.White,
-  width: summaryPanelWidth,
-  fontSize: 'var(--graph-side-panel--font-size)',
   padding: 0,
-  position: 'relative'
+  position: 'relative',
+  width: summaryPanelWidth
+});
+
+export const summaryPanelHover = style({
+  height: 'auto',
+  margin: 0,
+  fontSize: 'var(--graph-side-panel--font-size)',
+  overflowY: 'auto',
+  padding: 0,
+  position: 'absolute',
+  right: 0,
+  top: 0,
+  whiteSpace: 'nowrap',
+  width: 'auto'
 });
 
 export const summaryFont: React.CSSProperties = {
@@ -174,6 +188,17 @@ export const renderNoTraffic = (protocol?: string) => {
       <div>
         <KialiIcon.Info /> No {protocol ? protocol : ''} traffic logged.
       </div>
+    </>
+  );
+};
+
+export const getHoverTitle = (): React.ReactFragment => {
+  return (
+    <>
+      <Title headingLevel="h5" size={TitleSize.md}>
+        Hover Target
+      </Title>
+      <br />
     </>
   );
 };

--- a/src/pages/Graph/SummaryPanelCommon.tsx
+++ b/src/pages/Graph/SummaryPanelCommon.tsx
@@ -59,6 +59,7 @@ export const summaryFont: React.CSSProperties = {
 
 export const summaryTitle = style({
   fontWeight: 'bolder',
+  marginBottom: '5px',
   textAlign: 'center'
 });
 
@@ -214,7 +215,6 @@ export const getTitle = (title: string): React.ReactFragment => {
   return (
     <div className={summaryTitle}>
       {title}
-      <br />
       <br />
     </div>
   );

--- a/src/pages/Graph/SummaryPanelCommon.tsx
+++ b/src/pages/Graph/SummaryPanelCommon.tsx
@@ -192,11 +192,25 @@ export const renderNoTraffic = (protocol?: string) => {
   );
 };
 
-export const getHoverTitle = (): React.ReactFragment => {
+export const getHoverTitle = (title: string): React.ReactFragment => {
+  switch (title) {
+    case NodeType.AGGREGATE:
+      title = 'Operation';
+      break;
+    case NodeType.APP:
+      title = 'Application';
+      break;
+    case NodeType.SERVICE:
+      title = 'Service';
+      break;
+    case NodeType.WORKLOAD:
+      title = 'Workload';
+      break;
+  }
   return (
     <>
       <Title headingLevel="h5" size={TitleSize.md}>
-        Hover Target
+        {title}
       </Title>
       <br />
     </>

--- a/src/pages/Graph/SummaryPanelCommon.tsx
+++ b/src/pages/Graph/SummaryPanelCommon.tsx
@@ -57,6 +57,11 @@ export const summaryFont: React.CSSProperties = {
   fontSize: 'var(--graph-side-panel--font-size)'
 };
 
+export const summaryTitle = style({
+  fontWeight: 'bolder',
+  textAlign: 'center'
+});
+
 export const hr = () => {
   return <hr style={{ margin: '10px 0' }} />;
 };
@@ -207,7 +212,7 @@ export const getTitle = (title: string): React.ReactFragment => {
       break;
   }
   return (
-    <div style={{ textAlign: 'center' }}>
+    <div style={{ fontWeight: 'bolder', textAlign: 'center' }}>
       <strong>{title}</strong>
       <br />
       <br />

--- a/src/pages/Graph/SummaryPanelCommon.tsx
+++ b/src/pages/Graph/SummaryPanelCommon.tsx
@@ -26,13 +26,15 @@ export const summaryHeader: React.CSSProperties = {
   backgroundColor: PFColors.White
 };
 
+export const summaryPanelWidth = '25em';
+
 export const summaryPanel = style({
   height: '100%',
   margin: 0,
-  minWidth: '25em',
+  minWidth: summaryPanelWidth,
   overflowY: 'scroll',
   backgroundColor: PFColors.White,
-  width: '25em',
+  width: summaryPanelWidth,
   fontSize: 'var(--graph-side-panel--font-size)',
   padding: 0,
   position: 'relative'

--- a/src/pages/Graph/SummaryPanelCommon.tsx
+++ b/src/pages/Graph/SummaryPanelCommon.tsx
@@ -40,19 +40,6 @@ export const summaryPanel = style({
   width: summaryPanelWidth
 });
 
-export const summaryPanelHover = style({
-  height: 'auto',
-  margin: 0,
-  fontSize: 'var(--graph-side-panel--font-size)',
-  overflowY: 'auto',
-  padding: 0,
-  position: 'absolute',
-  right: 0,
-  top: 0,
-  whiteSpace: 'nowrap',
-  width: 'auto'
-});
-
 export const summaryFont: React.CSSProperties = {
   fontSize: 'var(--graph-side-panel--font-size)'
 };

--- a/src/pages/Graph/SummaryPanelCommon.tsx
+++ b/src/pages/Graph/SummaryPanelCommon.tsx
@@ -60,7 +60,7 @@ export const summaryFont: React.CSSProperties = {
 export const summaryTitle = style({
   fontWeight: 'bolder',
   marginBottom: '5px',
-  textAlign: 'center'
+  textAlign: 'left'
 });
 
 export const hr = () => {

--- a/src/pages/Graph/SummaryPanelEdge.tsx
+++ b/src/pages/Graph/SummaryPanelEdge.tsx
@@ -164,7 +164,7 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
       <div
         ref={this.mainDivRef}
         className={`panel panel-default ${summaryPanel}`}
-        style={isHover ? { background: 'gray' } : {}}
+        style={isHover ? { overflowY: 'auto' } : {}}
       >
         <div className="panel-heading" style={summaryHeader}>
           {renderBadgedLink(source, undefined, 'From:  ')}

--- a/src/pages/Graph/SummaryPanelEdge.tsx
+++ b/src/pages/Graph/SummaryPanelEdge.tsx
@@ -26,7 +26,7 @@ import {
   summaryPanel,
   summaryFont,
   summaryPanelHover,
-  getHoverTitle
+  getTitle
 } from './SummaryPanelCommon';
 import { Metric, Datapoint, IstioMetricsMap, Labels } from '../../types/Metrics';
 import { Response } from '../../services/Api';
@@ -165,14 +165,9 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
     return (
       <div ref={this.mainDivRef} className={`panel panel-default ${isHover ? summaryPanelHover : summaryPanel}`}>
         <div className="panel-heading" style={summaryHeader}>
-          {isHover && getHoverTitle('Edge')}
+          {getTitle(`Edge (${prettyProtocol(protocol)})`)}
           {renderBadgedLink(source, undefined, 'From:  ')}
           {renderBadgedLink(dest, undefined, 'To:        ')}
-          {isHover && (
-            <div>
-              <b>Protocol: {prettyProtocol(protocol)}</b>
-            </div>
-          )}
         </div>
         {!isHover && (
           <>

--- a/src/pages/Graph/SummaryPanelEdge.tsx
+++ b/src/pages/Graph/SummaryPanelEdge.tsx
@@ -24,7 +24,9 @@ import {
   summaryHeader,
   summaryBodyTabs,
   summaryPanel,
-  summaryFont
+  summaryFont,
+  summaryPanelHover,
+  getHoverTitle
 } from './SummaryPanelCommon';
 import { Metric, Datapoint, IstioMetricsMap, Labels } from '../../types/Metrics';
 import { Response } from '../../services/Api';
@@ -161,12 +163,9 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
     };
 
     return (
-      <div
-        ref={this.mainDivRef}
-        className={`panel panel-default ${summaryPanel}`}
-        style={isHover ? { overflowY: 'auto' } : {}}
-      >
+      <div ref={this.mainDivRef} className={`panel panel-default ${isHover ? summaryPanelHover : summaryPanel}`}>
         <div className="panel-heading" style={summaryHeader}>
+          {isHover && getHoverTitle()}
           {renderBadgedLink(source, undefined, 'From:  ')}
           {renderBadgedLink(dest, undefined, 'To:        ')}
           {isHover && (

--- a/src/pages/Graph/SummaryPanelEdge.tsx
+++ b/src/pages/Graph/SummaryPanelEdge.tsx
@@ -25,7 +25,6 @@ import {
   summaryBodyTabs,
   summaryPanel,
   summaryFont,
-  summaryPanelHover,
   getTitle
 } from './SummaryPanelCommon';
 import { Metric, Datapoint, IstioMetricsMap, Labels } from '../../types/Metrics';
@@ -126,7 +125,6 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
   }
 
   render() {
-    const isHover = this.props.data.isHover;
     const target = this.props.data.summaryTarget;
     const source = decoratedNodeData(target.source());
     const dest = decoratedNodeData(target.target());
@@ -163,88 +161,84 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
     };
 
     return (
-      <div ref={this.mainDivRef} className={`panel panel-default ${isHover ? summaryPanelHover : summaryPanel}`}>
+      <div ref={this.mainDivRef} className={`panel panel-default ${summaryPanel}`}>
         <div className="panel-heading" style={summaryHeader}>
           {getTitle(`Edge (${prettyProtocol(protocol)})`)}
           {renderBadgedLink(source, undefined, 'From:  ')}
           {renderBadgedLink(dest, undefined, 'To:        ')}
         </div>
-        {!isHover && (
-          <>
-            {hasSecurity && <SecurityBlock />}
-            {(isHttp || isGrpc) && (
-              <div className={summaryBodyTabs}>
-                <SimpleTabs id="edge_summary_rate_tabs" defaultTab={0} style={{ paddingBottom: '10px' }}>
-                  <Tab style={summaryFont} title="Traffic" eventKey={0}>
-                    <div style={summaryFont}>
-                      {isGrpc && (
-                        <>
-                          <RateTableGrpc
-                            isRequests={isRequests}
-                            rate={this.safeRate(edge.grpc)}
-                            rateGrpcErr={this.safeRate(edge.grpcErr)}
-                            rateNR={this.safeRate(edge.grpcNoResponse)}
-                          />
-                        </>
-                      )}
-                      {isHttp && (
-                        <>
-                          <RateTableHttp
-                            title="HTTP requests per second:"
-                            rate={this.safeRate(edge.http)}
-                            rate3xx={this.safeRate(edge.http3xx)}
-                            rate4xx={this.safeRate(edge.http4xx)}
-                            rate5xx={this.safeRate(edge.http5xx)}
-                            rateNR={this.safeRate(edge.httpNoResponse)}
-                          />
-                        </>
-                      )}
-                    </div>
-                  </Tab>
-                  {isRequests && (
-                    <Tab style={summaryFont} title="Flags" eventKey={1}>
-                      <div style={summaryFont}>
-                        <ResponseFlagsTable
-                          title={'Response flags by ' + (isGrpc ? 'GRPC code:' : 'HTTP code:')}
-                          responses={edge.responses}
-                        />
-                      </div>
-                    </Tab>
-                  )}
-                  <Tab style={summaryFont} title="Hosts" eventKey={2}>
-                    <div style={summaryFont}>
-                      <ResponseHostsTable
-                        title={'Hosts by ' + (isGrpc ? 'GRPC code:' : 'HTTP code:')}
-                        responses={edge.responses}
+        {hasSecurity && <SecurityBlock />}
+        {(isHttp || isGrpc) && (
+          <div className={summaryBodyTabs}>
+            <SimpleTabs id="edge_summary_rate_tabs" defaultTab={0} style={{ paddingBottom: '10px' }}>
+              <Tab style={summaryFont} title="Traffic" eventKey={0}>
+                <div style={summaryFont}>
+                  {isGrpc && (
+                    <>
+                      <RateTableGrpc
+                        isRequests={isRequests}
+                        rate={this.safeRate(edge.grpc)}
+                        rateGrpcErr={this.safeRate(edge.grpcErr)}
+                        rateNR={this.safeRate(edge.grpcNoResponse)}
                       />
-                    </div>
-                  </Tab>
-                </SimpleTabs>
-                {hr()}
-                {this.renderCharts(target, isGrpc, isHttp, isTcp, isRequests)}
-              </div>
-            )}
-            {isTcp && (
-              <div className={summaryBodyTabs}>
-                <SimpleTabs id="edge_summary_flag_hosts_tabs" defaultTab={0} style={{ paddingBottom: '10px' }}>
-                  <Tab style={summaryFont} eventKey={0} title="Flags">
-                    <div style={summaryFont}>
-                      <ResponseFlagsTable title="Response flags by code:" responses={edge.responses} />
-                    </div>
-                  </Tab>
-                  <Tab style={summaryFont} eventKey={1} title="Hosts">
-                    <div style={summaryFont}>
-                      <ResponseHostsTable title="Hosts by code:" responses={edge.responses} />
-                    </div>
-                  </Tab>
-                </SimpleTabs>
-                {hr()}
-                {this.renderCharts(target, isGrpc, isHttp, isTcp, isRequests)}
-              </div>
-            )}
-            {!isGrpc && !isHttp && !isTcp && <div className="panel-body">{renderNoTraffic()}</div>}
-          </>
+                    </>
+                  )}
+                  {isHttp && (
+                    <>
+                      <RateTableHttp
+                        title="HTTP requests per second:"
+                        rate={this.safeRate(edge.http)}
+                        rate3xx={this.safeRate(edge.http3xx)}
+                        rate4xx={this.safeRate(edge.http4xx)}
+                        rate5xx={this.safeRate(edge.http5xx)}
+                        rateNR={this.safeRate(edge.httpNoResponse)}
+                      />
+                    </>
+                  )}
+                </div>
+              </Tab>
+              {isRequests && (
+                <Tab style={summaryFont} title="Flags" eventKey={1}>
+                  <div style={summaryFont}>
+                    <ResponseFlagsTable
+                      title={'Response flags by ' + (isGrpc ? 'GRPC code:' : 'HTTP code:')}
+                      responses={edge.responses}
+                    />
+                  </div>
+                </Tab>
+              )}
+              <Tab style={summaryFont} title="Hosts" eventKey={2}>
+                <div style={summaryFont}>
+                  <ResponseHostsTable
+                    title={'Hosts by ' + (isGrpc ? 'GRPC code:' : 'HTTP code:')}
+                    responses={edge.responses}
+                  />
+                </div>
+              </Tab>
+            </SimpleTabs>
+            {hr()}
+            {this.renderCharts(target, isGrpc, isHttp, isTcp, isRequests)}
+          </div>
         )}
+        {isTcp && (
+          <div className={summaryBodyTabs}>
+            <SimpleTabs id="edge_summary_flag_hosts_tabs" defaultTab={0} style={{ paddingBottom: '10px' }}>
+              <Tab style={summaryFont} eventKey={0} title="Flags">
+                <div style={summaryFont}>
+                  <ResponseFlagsTable title="Response flags by code:" responses={edge.responses} />
+                </div>
+              </Tab>
+              <Tab style={summaryFont} eventKey={1} title="Hosts">
+                <div style={summaryFont}>
+                  <ResponseHostsTable title="Hosts by code:" responses={edge.responses} />
+                </div>
+              </Tab>
+            </SimpleTabs>
+            {hr()}
+            {this.renderCharts(target, isGrpc, isHttp, isTcp, isRequests)}
+          </div>
+        )}
+        {!isGrpc && !isHttp && !isTcp && <div className="panel-body">{renderNoTraffic()}</div>}
       </div>
     );
   }

--- a/src/pages/Graph/SummaryPanelEdge.tsx
+++ b/src/pages/Graph/SummaryPanelEdge.tsx
@@ -161,7 +161,11 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
     };
 
     return (
-      <div ref={this.mainDivRef} className={`panel panel-default ${summaryPanel}`}>
+      <div
+        ref={this.mainDivRef}
+        className={`panel panel-default ${summaryPanel}`}
+        style={isHover ? { background: 'gray' } : {}}
+      >
         <div className="panel-heading" style={summaryHeader}>
           {renderBadgedLink(source, undefined, 'From:  ')}
           {renderBadgedLink(dest, undefined, 'To:        ')}

--- a/src/pages/Graph/SummaryPanelEdge.tsx
+++ b/src/pages/Graph/SummaryPanelEdge.tsx
@@ -133,7 +133,7 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
     const isMtls = mTLSPercentage && mTLSPercentage > 0;
     const hasPrincipals = !!edge.sourcePrincipal || !!edge.destPrincipal;
     const hasSecurity = isMtls || hasPrincipals;
-    const protocol = prettyProtocol(edge.protocol);
+    const protocol = edge.protocol;
     const isGrpc = protocol === Protocol.GRPC;
     const isHttp = protocol === Protocol.HTTP;
     const isTcp = protocol === Protocol.TCP;
@@ -167,7 +167,7 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
           {renderBadgedLink(dest, undefined, 'To:        ')}
           {isHover && (
             <div>
-              <b>Protocol: {protocol}</b>
+              <b>Protocol: {prettyProtocol(protocol)}</b>
             </div>
           )}
         </div>

--- a/src/pages/Graph/SummaryPanelEdge.tsx
+++ b/src/pages/Graph/SummaryPanelEdge.tsx
@@ -165,7 +165,7 @@ export default class SummaryPanelEdge extends React.Component<SummaryPanelPropTy
     return (
       <div ref={this.mainDivRef} className={`panel panel-default ${isHover ? summaryPanelHover : summaryPanel}`}>
         <div className="panel-heading" style={summaryHeader}>
-          {isHover && getHoverTitle()}
+          {isHover && getHoverTitle('Edge')}
           {renderBadgedLink(source, undefined, 'From:  ')}
           {renderBadgedLink(dest, undefined, 'To:        ')}
           {isHover && (

--- a/src/pages/Graph/SummaryPanelGraph.tsx
+++ b/src/pages/Graph/SummaryPanelGraph.tsx
@@ -18,6 +18,7 @@ import { Response } from '../../services/Api';
 import {
   getDatapoints,
   getFirstDatapoints,
+  getTitle,
   hr,
   shouldRefreshData,
   summaryBodyTabs,
@@ -183,9 +184,7 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
     return (
       <div className="panel panel-default" style={SummaryPanelGraph.panelStyle}>
         <div className="panel-heading" style={summaryHeader}>
-          <strong>Current Graph:</strong>
-          <br />
-          <br />
+          {getTitle('Current Graph')}
           {this.renderNamespacesSummary()}
           <br />
           {this.renderTopologySummary(numSvc, numWorkloads, numApps, numVersions, numEdges)}

--- a/src/pages/Graph/SummaryPanelGraph.tsx
+++ b/src/pages/Graph/SummaryPanelGraph.tsx
@@ -22,7 +22,8 @@ import {
   shouldRefreshData,
   summaryBodyTabs,
   summaryFont,
-  summaryHeader
+  summaryHeader,
+  summaryPanelWidth
 } from './SummaryPanelCommon';
 import { Datapoint, IstioMetricsMap, Labels } from '../../types/Metrics';
 import { IstioMetricsOptions } from '../../types/MetricsOptions';
@@ -114,10 +115,10 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelPropT
   static readonly panelStyle = {
     height: '100%',
     margin: 0,
-    minWidth: '25em',
+    minWidth: summaryPanelWidth,
     overflowY: 'auto' as 'auto',
     backgroundColor: PFColors.White,
-    width: '25em'
+    width: summaryPanelWidth
   };
 
   private graphTraffic?: SummaryPanelGraphTraffic;

--- a/src/pages/Graph/SummaryPanelGraph.tsx
+++ b/src/pages/Graph/SummaryPanelGraph.tsx
@@ -37,10 +37,6 @@ import { PFColors } from '../../components/Pf/PfColors';
 import ValidationSummaryLink from '../../components/Link/ValidationSummaryLink';
 import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
 
-type SummaryPanelGraphProps = SummaryPanelPropType & {
-  isHover: boolean;
-};
-
 type SummaryPanelGraphMetricsState = {
   grpcRequestIn: Datapoint[];
   grpcRequestOut: Datapoint[];
@@ -114,7 +110,7 @@ const topologyStyle = style({
   margin: '0 1em'
 });
 
-export default class SummaryPanelGraph extends React.Component<SummaryPanelGraphProps, SummaryPanelGraphState> {
+export default class SummaryPanelGraph extends React.Component<SummaryPanelPropType, SummaryPanelGraphState> {
   static readonly panelStyle = {
     height: '100%',
     margin: 0,
@@ -128,7 +124,7 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelGraph
   private metricsPromise?: CancelablePromise<Response<IstioMetricsMap>[]>;
   private validationSummaryPromises: PromisesRegistry = new PromisesRegistry();
 
-  constructor(props: SummaryPanelGraphProps) {
+  constructor(props: SummaryPanelPropType) {
     super(props);
 
     this.state = { ...defaultState };
@@ -170,7 +166,7 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelGraph
   }
 
   render() {
-    const cy = this.props.isHover ? this.props.data.summaryTarget?.cy() : this.props.data.summaryTarget;
+    const cy = this.props.data.summaryTarget;
     if (!cy) {
       return null;
     }
@@ -295,21 +291,13 @@ export default class SummaryPanelGraph extends React.Component<SummaryPanelGraph
             </Tab>
           </SimpleTabs>
         </div>
-        <div className="panel-footer" style={summaryHeader}>
-          <strong>Hovering Over:</strong>
-          <br />
-          <br />
-          {this.renderNamespacesSummary()}
-          <br />
-          {this.renderTopologySummary(numSvc, numWorkloads, numApps, numVersions, numEdges)}
-        </div>
       </div>
     );
   }
 
   private getGraphTraffic = (): SummaryPanelGraphTraffic => {
     // when getting total traffic rates don't count requests from injected service nodes
-    const cy = this.props.isHover ? this.props.data.summaryTarget!.cy() : this.props.data.summaryTarget;
+    const cy = this.props.data.summaryTarget;
     const totalEdges = cy.nodes(`[nodeType != "${NodeType.SERVICE}"][!isBox]`).edgesTo('*');
     const inboundEdges = cy.nodes(`[?${CyNode.isRoot}]`).edgesTo('*');
     const outboundEdges = cy.nodes().leaves(`node[?${CyNode.isOutside}],[?${CyNode.isServiceEntry}]`).connectedEdges();

--- a/src/pages/Graph/SummaryPanelNamespaceBox.tsx
+++ b/src/pages/Graph/SummaryPanelNamespaceBox.tsx
@@ -21,7 +21,9 @@ import {
   summaryBodyTabs,
   hr,
   getDatapoints,
-  summaryPanelWidth
+  summaryPanelWidth,
+  summaryPanelHover,
+  getHoverTitle
 } from './SummaryPanelCommon';
 import { Response } from '../../services/Api';
 import { IstioMetricsMap, Datapoint, Labels } from '../../types/Metrics';
@@ -176,8 +178,12 @@ export default class SummaryPanelNamespaceBox extends React.Component<
       this.boxTraffic || this.getBoxTraffic();
 
     return (
-      <div className="panel panel-default" style={SummaryPanelNamespaceBox.panelStyle}>
+      <div
+        className={`panel panel-default ${isHover && summaryPanelHover}`}
+        style={isHover ? {} : SummaryPanelNamespaceBox.panelStyle}
+      >
         <div className="panel-heading" style={summaryHeader}>
+          {isHover && getHoverTitle()}
           {this.renderNamespace(namespace)}
           <br />
           {this.renderTopologySummary(numSvc, numWorkloads, numApps, numVersions, numEdges)}

--- a/src/pages/Graph/SummaryPanelNamespaceBox.tsx
+++ b/src/pages/Graph/SummaryPanelNamespaceBox.tsx
@@ -20,7 +20,8 @@ import {
   summaryHeader,
   summaryBodyTabs,
   hr,
-  getDatapoints
+  getDatapoints,
+  summaryPanelWidth
 } from './SummaryPanelCommon';
 import { Response } from '../../services/Api';
 import { IstioMetricsMap, Datapoint, Labels } from '../../types/Metrics';
@@ -112,10 +113,10 @@ export default class SummaryPanelNamespaceBox extends React.Component<
   static readonly panelStyle = {
     height: '100%',
     margin: 0,
-    minWidth: '25em',
+    minWidth: summaryPanelWidth,
     overflowY: 'auto' as 'auto',
     backgroundColor: PFColors.White,
-    width: '25em'
+    width: summaryPanelWidth
   };
 
   private boxTraffic?: SummaryPanelNamespaceBoxTraffic;
@@ -175,10 +176,7 @@ export default class SummaryPanelNamespaceBox extends React.Component<
       this.boxTraffic || this.getBoxTraffic();
 
     return (
-      <div
-        className="panel panel-default"
-        style={{ ...SummaryPanelNamespaceBox.panelStyle, ...(isHover ? { background: 'gray' } : {}) }}
-      >
+      <div className="panel panel-default" style={SummaryPanelNamespaceBox.panelStyle}>
         <div className="panel-heading" style={summaryHeader}>
           {this.renderNamespace(namespace)}
           <br />

--- a/src/pages/Graph/SummaryPanelNamespaceBox.tsx
+++ b/src/pages/Graph/SummaryPanelNamespaceBox.tsx
@@ -160,6 +160,8 @@ export default class SummaryPanelNamespaceBox extends React.Component<
   }
 
   render() {
+    const isHover = this.props.data.isHover;
+
     const namespaceBox = this.props.data.summaryTarget;
     const boxed = namespaceBox.descendants();
     const namespace = namespaceBox.data(CyNode.namespace);
@@ -179,106 +181,108 @@ export default class SummaryPanelNamespaceBox extends React.Component<
           <br />
           {this.renderTopologySummary(numSvc, numWorkloads, numApps, numVersions, numEdges)}
         </div>
-        <div className={summaryBodyTabs}>
-          <SimpleTabs id="graph_summary_tabs" defaultTab={0} style={{ paddingBottom: '10px' }}>
-            <Tab style={summaryFont} title="Inbound" eventKey={0}>
-              <div style={summaryFont}>
-                {grpcIn.rate === 0 && httpIn.rate === 0 && tcpIn.rate === 0 && (
-                  <>
-                    <KialiIcon.Info /> No inbound traffic.
-                  </>
-                )}
-                {grpcIn.rate > 0 && (
-                  <RateTableGrpc
-                    isRequests={isGrpcRequests}
-                    rate={grpcIn.rate}
-                    rateGrpcErr={grpcIn.rateGrpcErr}
-                    rateNR={grpcIn.rateNoResponse}
-                  />
-                )}
-                {httpIn.rate > 0 && (
-                  <RateTableHttp
-                    title="HTTP (requests per second):"
-                    rate={httpIn.rate}
-                    rate3xx={httpIn.rate3xx}
-                    rate4xx={httpIn.rate4xx}
-                    rate5xx={httpIn.rate5xx}
-                    rateNR={httpIn.rateNoResponse}
-                  />
-                )}
-                {tcpIn.rate > 0 && <RateTableTcp rate={tcpIn.rate} />}
-                {
-                  // We don't show a sparkline here because we need to aggregate the traffic of an
-                  // ad hoc set of [root] nodes. We don't have backend support for that aggregation.
-                }
-              </div>
-            </Tab>
-            <Tab style={summaryFont} title="Outbound" eventKey={1}>
-              <div style={summaryFont}>
-                {grpcOut.rate === 0 && httpOut.rate === 0 && tcpOut.rate === 0 && (
-                  <>
-                    <KialiIcon.Info /> No outbound traffic.
-                  </>
-                )}
-                {grpcOut.rate > 0 && (
-                  <RateTableGrpc
-                    isRequests={isGrpcRequests}
-                    rate={grpcOut.rate}
-                    rateGrpcErr={grpcOut.rateGrpcErr}
-                    rateNR={grpcOut.rateNoResponse}
-                  />
-                )}
-                {httpOut.rate > 0 && (
-                  <RateTableHttp
-                    title="HTTP (requests per second):"
-                    rate={httpOut.rate}
-                    rate3xx={httpOut.rate3xx}
-                    rate4xx={httpOut.rate4xx}
-                    rate5xx={httpOut.rate5xx}
-                    rateNR={httpOut.rateNoResponse}
-                  />
-                )}
-                {tcpOut.rate > 0 && <RateTableTcp rate={tcpOut.rate} />}
-                {
-                  // We don't show a sparkline here because we need to aggregate the traffic of an
-                  // ad hoc set of [root] nodes. We don't have backend support for that aggregation.
-                }
-              </div>
-            </Tab>
-            <Tab style={summaryFont} title="Total" eventKey={2}>
-              <div style={summaryFont}>
-                {grpcTotal.rate === 0 && httpTotal.rate === 0 && tcpTotal.rate === 0 && (
-                  <>
-                    <KialiIcon.Info /> No traffic.
-                  </>
-                )}
-                {grpcTotal.rate > 0 && (
-                  <RateTableGrpc
-                    isRequests={isGrpcRequests}
-                    rate={grpcTotal.rate}
-                    rateGrpcErr={grpcTotal.rateGrpcErr}
-                    rateNR={grpcTotal.rateNoResponse}
-                  />
-                )}
-                {httpTotal.rate > 0 && (
-                  <RateTableHttp
-                    title="HTTP (requests per second):"
-                    rate={httpTotal.rate}
-                    rate3xx={httpTotal.rate3xx}
-                    rate4xx={httpTotal.rate4xx}
-                    rate5xx={httpTotal.rate5xx}
-                    rateNR={httpTotal.rateNoResponse}
-                  />
-                )}
-                {tcpTotal.rate > 0 && <RateTableTcp rate={tcpTotal.rate} />}
-                <div>
-                  {hr()}
-                  {this.renderCharts()}
+        {!isHover && (
+          <div className={summaryBodyTabs}>
+            <SimpleTabs id="graph_summary_tabs" defaultTab={0} style={{ paddingBottom: '10px' }}>
+              <Tab style={summaryFont} title="Inbound" eventKey={0}>
+                <div style={summaryFont}>
+                  {grpcIn.rate === 0 && httpIn.rate === 0 && tcpIn.rate === 0 && (
+                    <>
+                      <KialiIcon.Info /> No inbound traffic.
+                    </>
+                  )}
+                  {grpcIn.rate > 0 && (
+                    <RateTableGrpc
+                      isRequests={isGrpcRequests}
+                      rate={grpcIn.rate}
+                      rateGrpcErr={grpcIn.rateGrpcErr}
+                      rateNR={grpcIn.rateNoResponse}
+                    />
+                  )}
+                  {httpIn.rate > 0 && (
+                    <RateTableHttp
+                      title="HTTP (requests per second):"
+                      rate={httpIn.rate}
+                      rate3xx={httpIn.rate3xx}
+                      rate4xx={httpIn.rate4xx}
+                      rate5xx={httpIn.rate5xx}
+                      rateNR={httpIn.rateNoResponse}
+                    />
+                  )}
+                  {tcpIn.rate > 0 && <RateTableTcp rate={tcpIn.rate} />}
+                  {
+                    // We don't show a sparkline here because we need to aggregate the traffic of an
+                    // ad hoc set of [root] nodes. We don't have backend support for that aggregation.
+                  }
                 </div>
-              </div>
-            </Tab>
-          </SimpleTabs>
-        </div>
+              </Tab>
+              <Tab style={summaryFont} title="Outbound" eventKey={1}>
+                <div style={summaryFont}>
+                  {grpcOut.rate === 0 && httpOut.rate === 0 && tcpOut.rate === 0 && (
+                    <>
+                      <KialiIcon.Info /> No outbound traffic.
+                    </>
+                  )}
+                  {grpcOut.rate > 0 && (
+                    <RateTableGrpc
+                      isRequests={isGrpcRequests}
+                      rate={grpcOut.rate}
+                      rateGrpcErr={grpcOut.rateGrpcErr}
+                      rateNR={grpcOut.rateNoResponse}
+                    />
+                  )}
+                  {httpOut.rate > 0 && (
+                    <RateTableHttp
+                      title="HTTP (requests per second):"
+                      rate={httpOut.rate}
+                      rate3xx={httpOut.rate3xx}
+                      rate4xx={httpOut.rate4xx}
+                      rate5xx={httpOut.rate5xx}
+                      rateNR={httpOut.rateNoResponse}
+                    />
+                  )}
+                  {tcpOut.rate > 0 && <RateTableTcp rate={tcpOut.rate} />}
+                  {
+                    // We don't show a sparkline here because we need to aggregate the traffic of an
+                    // ad hoc set of [root] nodes. We don't have backend support for that aggregation.
+                  }
+                </div>
+              </Tab>
+              <Tab style={summaryFont} title="Total" eventKey={2}>
+                <div style={summaryFont}>
+                  {grpcTotal.rate === 0 && httpTotal.rate === 0 && tcpTotal.rate === 0 && (
+                    <>
+                      <KialiIcon.Info /> No traffic.
+                    </>
+                  )}
+                  {grpcTotal.rate > 0 && (
+                    <RateTableGrpc
+                      isRequests={isGrpcRequests}
+                      rate={grpcTotal.rate}
+                      rateGrpcErr={grpcTotal.rateGrpcErr}
+                      rateNR={grpcTotal.rateNoResponse}
+                    />
+                  )}
+                  {httpTotal.rate > 0 && (
+                    <RateTableHttp
+                      title="HTTP (requests per second):"
+                      rate={httpTotal.rate}
+                      rate3xx={httpTotal.rate3xx}
+                      rate4xx={httpTotal.rate4xx}
+                      rate5xx={httpTotal.rate5xx}
+                      rateNR={httpTotal.rateNoResponse}
+                    />
+                  )}
+                  {tcpTotal.rate > 0 && <RateTableTcp rate={tcpTotal.rate} />}
+                  <div>
+                    {hr()}
+                    {this.renderCharts()}
+                  </div>
+                </div>
+              </Tab>
+            </SimpleTabs>
+          </div>
+        )}
       </div>
     );
   }

--- a/src/pages/Graph/SummaryPanelNamespaceBox.tsx
+++ b/src/pages/Graph/SummaryPanelNamespaceBox.tsx
@@ -22,7 +22,6 @@ import {
   hr,
   getDatapoints,
   summaryPanelWidth,
-  summaryPanelHover,
   getTitle
 } from './SummaryPanelCommon';
 import { Response } from '../../services/Api';
@@ -163,8 +162,6 @@ export default class SummaryPanelNamespaceBox extends React.Component<
   }
 
   render() {
-    const isHover = this.props.data.isHover;
-
     const namespaceBox = this.props.data.summaryTarget;
     const boxed = namespaceBox.descendants();
     const namespace = namespaceBox.data(CyNode.namespace);
@@ -178,118 +175,113 @@ export default class SummaryPanelNamespaceBox extends React.Component<
       this.boxTraffic || this.getBoxTraffic();
 
     return (
-      <div
-        className={`panel panel-default ${isHover && summaryPanelHover}`}
-        style={isHover ? {} : SummaryPanelNamespaceBox.panelStyle}
-      >
+      <div className="panel panel-default" style={SummaryPanelNamespaceBox.panelStyle}>
         <div className="panel-heading" style={summaryHeader}>
           {getTitle('Namespace')}
           {this.renderNamespace(namespace)}
           <br />
           {this.renderTopologySummary(numSvc, numWorkloads, numApps, numVersions, numEdges)}
         </div>
-        {!isHover && (
-          <div className={summaryBodyTabs}>
-            <SimpleTabs id="graph_summary_tabs" defaultTab={0} style={{ paddingBottom: '10px' }}>
-              <Tab style={summaryFont} title="Inbound" eventKey={0}>
-                <div style={summaryFont}>
-                  {grpcIn.rate === 0 && httpIn.rate === 0 && tcpIn.rate === 0 && (
-                    <>
-                      <KialiIcon.Info /> No inbound traffic.
-                    </>
-                  )}
-                  {grpcIn.rate > 0 && (
-                    <RateTableGrpc
-                      isRequests={isGrpcRequests}
-                      rate={grpcIn.rate}
-                      rateGrpcErr={grpcIn.rateGrpcErr}
-                      rateNR={grpcIn.rateNoResponse}
-                    />
-                  )}
-                  {httpIn.rate > 0 && (
-                    <RateTableHttp
-                      title="HTTP (requests per second):"
-                      rate={httpIn.rate}
-                      rate3xx={httpIn.rate3xx}
-                      rate4xx={httpIn.rate4xx}
-                      rate5xx={httpIn.rate5xx}
-                      rateNR={httpIn.rateNoResponse}
-                    />
-                  )}
-                  {tcpIn.rate > 0 && <RateTableTcp rate={tcpIn.rate} />}
-                  {
-                    // We don't show a sparkline here because we need to aggregate the traffic of an
-                    // ad hoc set of [root] nodes. We don't have backend support for that aggregation.
-                  }
+        <div className={summaryBodyTabs}>
+          <SimpleTabs id="graph_summary_tabs" defaultTab={0} style={{ paddingBottom: '10px' }}>
+            <Tab style={summaryFont} title="Inbound" eventKey={0}>
+              <div style={summaryFont}>
+                {grpcIn.rate === 0 && httpIn.rate === 0 && tcpIn.rate === 0 && (
+                  <>
+                    <KialiIcon.Info /> No inbound traffic.
+                  </>
+                )}
+                {grpcIn.rate > 0 && (
+                  <RateTableGrpc
+                    isRequests={isGrpcRequests}
+                    rate={grpcIn.rate}
+                    rateGrpcErr={grpcIn.rateGrpcErr}
+                    rateNR={grpcIn.rateNoResponse}
+                  />
+                )}
+                {httpIn.rate > 0 && (
+                  <RateTableHttp
+                    title="HTTP (requests per second):"
+                    rate={httpIn.rate}
+                    rate3xx={httpIn.rate3xx}
+                    rate4xx={httpIn.rate4xx}
+                    rate5xx={httpIn.rate5xx}
+                    rateNR={httpIn.rateNoResponse}
+                  />
+                )}
+                {tcpIn.rate > 0 && <RateTableTcp rate={tcpIn.rate} />}
+                {
+                  // We don't show a sparkline here because we need to aggregate the traffic of an
+                  // ad hoc set of [root] nodes. We don't have backend support for that aggregation.
+                }
+              </div>
+            </Tab>
+            <Tab style={summaryFont} title="Outbound" eventKey={1}>
+              <div style={summaryFont}>
+                {grpcOut.rate === 0 && httpOut.rate === 0 && tcpOut.rate === 0 && (
+                  <>
+                    <KialiIcon.Info /> No outbound traffic.
+                  </>
+                )}
+                {grpcOut.rate > 0 && (
+                  <RateTableGrpc
+                    isRequests={isGrpcRequests}
+                    rate={grpcOut.rate}
+                    rateGrpcErr={grpcOut.rateGrpcErr}
+                    rateNR={grpcOut.rateNoResponse}
+                  />
+                )}
+                {httpOut.rate > 0 && (
+                  <RateTableHttp
+                    title="HTTP (requests per second):"
+                    rate={httpOut.rate}
+                    rate3xx={httpOut.rate3xx}
+                    rate4xx={httpOut.rate4xx}
+                    rate5xx={httpOut.rate5xx}
+                    rateNR={httpOut.rateNoResponse}
+                  />
+                )}
+                {tcpOut.rate > 0 && <RateTableTcp rate={tcpOut.rate} />}
+                {
+                  // We don't show a sparkline here because we need to aggregate the traffic of an
+                  // ad hoc set of [root] nodes. We don't have backend support for that aggregation.
+                }
+              </div>
+            </Tab>
+            <Tab style={summaryFont} title="Total" eventKey={2}>
+              <div style={summaryFont}>
+                {grpcTotal.rate === 0 && httpTotal.rate === 0 && tcpTotal.rate === 0 && (
+                  <>
+                    <KialiIcon.Info /> No traffic.
+                  </>
+                )}
+                {grpcTotal.rate > 0 && (
+                  <RateTableGrpc
+                    isRequests={isGrpcRequests}
+                    rate={grpcTotal.rate}
+                    rateGrpcErr={grpcTotal.rateGrpcErr}
+                    rateNR={grpcTotal.rateNoResponse}
+                  />
+                )}
+                {httpTotal.rate > 0 && (
+                  <RateTableHttp
+                    title="HTTP (requests per second):"
+                    rate={httpTotal.rate}
+                    rate3xx={httpTotal.rate3xx}
+                    rate4xx={httpTotal.rate4xx}
+                    rate5xx={httpTotal.rate5xx}
+                    rateNR={httpTotal.rateNoResponse}
+                  />
+                )}
+                {tcpTotal.rate > 0 && <RateTableTcp rate={tcpTotal.rate} />}
+                <div>
+                  {hr()}
+                  {this.renderCharts()}
                 </div>
-              </Tab>
-              <Tab style={summaryFont} title="Outbound" eventKey={1}>
-                <div style={summaryFont}>
-                  {grpcOut.rate === 0 && httpOut.rate === 0 && tcpOut.rate === 0 && (
-                    <>
-                      <KialiIcon.Info /> No outbound traffic.
-                    </>
-                  )}
-                  {grpcOut.rate > 0 && (
-                    <RateTableGrpc
-                      isRequests={isGrpcRequests}
-                      rate={grpcOut.rate}
-                      rateGrpcErr={grpcOut.rateGrpcErr}
-                      rateNR={grpcOut.rateNoResponse}
-                    />
-                  )}
-                  {httpOut.rate > 0 && (
-                    <RateTableHttp
-                      title="HTTP (requests per second):"
-                      rate={httpOut.rate}
-                      rate3xx={httpOut.rate3xx}
-                      rate4xx={httpOut.rate4xx}
-                      rate5xx={httpOut.rate5xx}
-                      rateNR={httpOut.rateNoResponse}
-                    />
-                  )}
-                  {tcpOut.rate > 0 && <RateTableTcp rate={tcpOut.rate} />}
-                  {
-                    // We don't show a sparkline here because we need to aggregate the traffic of an
-                    // ad hoc set of [root] nodes. We don't have backend support for that aggregation.
-                  }
-                </div>
-              </Tab>
-              <Tab style={summaryFont} title="Total" eventKey={2}>
-                <div style={summaryFont}>
-                  {grpcTotal.rate === 0 && httpTotal.rate === 0 && tcpTotal.rate === 0 && (
-                    <>
-                      <KialiIcon.Info /> No traffic.
-                    </>
-                  )}
-                  {grpcTotal.rate > 0 && (
-                    <RateTableGrpc
-                      isRequests={isGrpcRequests}
-                      rate={grpcTotal.rate}
-                      rateGrpcErr={grpcTotal.rateGrpcErr}
-                      rateNR={grpcTotal.rateNoResponse}
-                    />
-                  )}
-                  {httpTotal.rate > 0 && (
-                    <RateTableHttp
-                      title="HTTP (requests per second):"
-                      rate={httpTotal.rate}
-                      rate3xx={httpTotal.rate3xx}
-                      rate4xx={httpTotal.rate4xx}
-                      rate5xx={httpTotal.rate5xx}
-                      rateNR={httpTotal.rateNoResponse}
-                    />
-                  )}
-                  {tcpTotal.rate > 0 && <RateTableTcp rate={tcpTotal.rate} />}
-                  <div>
-                    {hr()}
-                    {this.renderCharts()}
-                  </div>
-                </div>
-              </Tab>
-            </SimpleTabs>
-          </div>
-        )}
+              </div>
+            </Tab>
+          </SimpleTabs>
+        </div>
       </div>
     );
   }

--- a/src/pages/Graph/SummaryPanelNamespaceBox.tsx
+++ b/src/pages/Graph/SummaryPanelNamespaceBox.tsx
@@ -580,7 +580,7 @@ export default class SummaryPanelNamespaceBox extends React.Component<
       })
       .catch(error => {
         if (error.isCanceled) {
-          console.debug('SummaryPanelGraph: Ignore fetch error (canceled).');
+          console.debug('SummaryPanelNamespaceBox: Ignore fetch error (canceled).');
           return;
         }
         const errorMsg = error.response && error.response.data.error ? error.response.data.error : error.message;

--- a/src/pages/Graph/SummaryPanelNamespaceBox.tsx
+++ b/src/pages/Graph/SummaryPanelNamespaceBox.tsx
@@ -175,7 +175,10 @@ export default class SummaryPanelNamespaceBox extends React.Component<
       this.boxTraffic || this.getBoxTraffic();
 
     return (
-      <div className="panel panel-default" style={SummaryPanelNamespaceBox.panelStyle}>
+      <div
+        className="panel panel-default"
+        style={{ ...SummaryPanelNamespaceBox.panelStyle, ...(isHover ? { background: 'gray' } : {}) }}
+      >
         <div className="panel-heading" style={summaryHeader}>
           {this.renderNamespace(namespace)}
           <br />

--- a/src/pages/Graph/SummaryPanelNamespaceBox.tsx
+++ b/src/pages/Graph/SummaryPanelNamespaceBox.tsx
@@ -183,7 +183,7 @@ export default class SummaryPanelNamespaceBox extends React.Component<
         style={isHover ? {} : SummaryPanelNamespaceBox.panelStyle}
       >
         <div className="panel-heading" style={summaryHeader}>
-          {isHover && getHoverTitle()}
+          {isHover && getHoverTitle('Namespace')}
           {this.renderNamespace(namespace)}
           <br />
           {this.renderTopologySummary(numSvc, numWorkloads, numApps, numVersions, numEdges)}

--- a/src/pages/Graph/SummaryPanelNamespaceBox.tsx
+++ b/src/pages/Graph/SummaryPanelNamespaceBox.tsx
@@ -23,7 +23,7 @@ import {
   getDatapoints,
   summaryPanelWidth,
   summaryPanelHover,
-  getHoverTitle
+  getTitle
 } from './SummaryPanelCommon';
 import { Response } from '../../services/Api';
 import { IstioMetricsMap, Datapoint, Labels } from '../../types/Metrics';
@@ -183,7 +183,7 @@ export default class SummaryPanelNamespaceBox extends React.Component<
         style={isHover ? {} : SummaryPanelNamespaceBox.panelStyle}
       >
         <div className="panel-heading" style={summaryHeader}>
-          {isHover && getHoverTitle('Namespace')}
+          {getTitle('Namespace')}
           {this.renderNamespace(namespace)}
           <br />
           {this.renderTopologySummary(numSvc, numWorkloads, numApps, numVersions, numEdges)}

--- a/src/pages/Graph/SummaryPanelNode.tsx
+++ b/src/pages/Graph/SummaryPanelNode.tsx
@@ -16,7 +16,7 @@ import {
   summaryBodyTabs,
   summaryFont,
   summaryPanelHover,
-  getHoverTitle
+  getTitle
 } from './SummaryPanelCommon';
 import { decoratedNodeData } from '../../components/CytoscapeGraph/CytoscapeGraphUtils';
 import { KialiIcon } from 'config/KialiIcon';
@@ -125,7 +125,7 @@ export class SummaryPanelNode extends React.Component<SummaryPanelNodeProps, Sum
     return (
       <div ref={this.mainDivRef} className={`panel panel-default ${isHover ? summaryPanelHover : summaryPanel}`}>
         <div className="panel-heading" style={summaryHeader}>
-          {isHover && getHoverTitle(nodeType)}
+          {getTitle(nodeType)}
           <div>
             <span>
               <PFBadge badge={PFBadges.Namespace} style={{ marginBottom: '2px' }} />

--- a/src/pages/Graph/SummaryPanelNode.tsx
+++ b/src/pages/Graph/SummaryPanelNode.tsx
@@ -119,7 +119,7 @@ export class SummaryPanelNode extends React.Component<SummaryPanelNodeProps, Sum
       <div
         ref={this.mainDivRef}
         className={`panel panel-default ${summaryPanel}`}
-        style={isHover ? { background: 'gray' } : {}}
+        style={isHover ? { overflowY: 'auto' } : {}}
       >
         <div className="panel-heading" style={summaryHeader}>
           <div>

--- a/src/pages/Graph/SummaryPanelNode.tsx
+++ b/src/pages/Graph/SummaryPanelNode.tsx
@@ -85,6 +85,7 @@ export class SummaryPanelNode extends React.Component<SummaryPanelNodeProps, Sum
   }
 
   render() {
+    const isHover = this.props.data.isHover;
     const node = this.props.data.summaryTarget;
     const nodeData = decoratedNodeData(node);
     const { nodeType, app, service, workload, isServiceEntry } = nodeData;
@@ -140,7 +141,7 @@ export class SummaryPanelNode extends React.Component<SummaryPanelNodeProps, Sum
             {shouldRenderWorkload && this.renderWorkloadSection(nodeData)}
           </div>
         </div>
-        {shouldRenderTraces ? this.renderWithTabs(nodeData) : this.renderTrafficOnly()}
+        {!isHover && <>{shouldRenderTraces ? this.renderWithTabs(nodeData) : this.renderTrafficOnly()}</>}
       </div>
     );
   }

--- a/src/pages/Graph/SummaryPanelNode.tsx
+++ b/src/pages/Graph/SummaryPanelNode.tsx
@@ -125,7 +125,7 @@ export class SummaryPanelNode extends React.Component<SummaryPanelNodeProps, Sum
     return (
       <div ref={this.mainDivRef} className={`panel panel-default ${isHover ? summaryPanelHover : summaryPanel}`}>
         <div className="panel-heading" style={summaryHeader}>
-          {isHover && getHoverTitle()}
+          {isHover && getHoverTitle(nodeType)}
           <div>
             <span>
               <PFBadge badge={PFBadges.Namespace} style={{ marginBottom: '2px' }} />

--- a/src/pages/Graph/SummaryPanelNode.tsx
+++ b/src/pages/Graph/SummaryPanelNode.tsx
@@ -10,7 +10,14 @@ import {
   renderHealth
 } from './SummaryLink';
 import { DecoratedGraphNodeData, DestService, NodeType, RankResult, SummaryPanelPropType } from '../../types/Graph';
-import { summaryHeader, summaryPanel, summaryBodyTabs, summaryFont } from './SummaryPanelCommon';
+import {
+  summaryHeader,
+  summaryPanel,
+  summaryBodyTabs,
+  summaryFont,
+  summaryPanelHover,
+  getHoverTitle
+} from './SummaryPanelCommon';
 import { decoratedNodeData } from '../../components/CytoscapeGraph/CytoscapeGraphUtils';
 import { KialiIcon } from 'config/KialiIcon';
 import { getOptions, clickHandler } from 'components/CytoscapeGraph/ContextMenu/NodeContextMenu';
@@ -116,12 +123,9 @@ export class SummaryPanelNode extends React.Component<SummaryPanelNodeProps, Sum
       options.length > 0 ? [<DropdownGroup label="Show" className="kiali-group-menu" children={options} />] : undefined;
 
     return (
-      <div
-        ref={this.mainDivRef}
-        className={`panel panel-default ${summaryPanel}`}
-        style={isHover ? { overflowY: 'auto' } : {}}
-      >
+      <div ref={this.mainDivRef} className={`panel panel-default ${isHover ? summaryPanelHover : summaryPanel}`}>
         <div className="panel-heading" style={summaryHeader}>
+          {isHover && getHoverTitle()}
           <div>
             <span>
               <PFBadge badge={PFBadges.Namespace} style={{ marginBottom: '2px' }} />

--- a/src/pages/Graph/SummaryPanelNode.tsx
+++ b/src/pages/Graph/SummaryPanelNode.tsx
@@ -29,6 +29,7 @@ import SummaryPanelNodeTraces from './SummaryPanelNodeTraces';
 import SimpleTabs from 'components/Tab/SimpleTabs';
 import { JaegerState } from 'reducers/JaegerState';
 import { classes, style } from 'typestyle';
+import { PFBadge, PFBadges } from 'components/Pf/PfBadges';
 
 type SummaryPanelNodeState = {
   isActionOpen: boolean;
@@ -118,20 +119,24 @@ export class SummaryPanelNode extends React.Component<SummaryPanelNodeProps, Sum
       <div ref={this.mainDivRef} className={`panel panel-default ${summaryPanel}`}>
         <div className="panel-heading" style={summaryHeader}>
           <div>
-            {renderBadgedLink(nodeData)}
-            {actions && (
-              <Dropdown
-                id="summary-node-actions"
-                style={{ float: 'right' }}
-                isPlain={true}
-                dropdownItems={actions}
-                isOpen={this.state.isActionOpen}
-                position={DropdownPosition.right}
-                toggle={<KebabToggle id="summary-node-kebab" onToggle={this.onToggleActions} />}
-              />
-            )}
+            <span>
+              <PFBadge badge={PFBadges.Namespace} style={{ marginBottom: '2px' }} />
+              {nodeData.namespace}
+              {!isHover && actions && (
+                <Dropdown
+                  id="summary-node-actions"
+                  style={{ float: 'right' }}
+                  isPlain={true}
+                  dropdownItems={actions}
+                  isOpen={this.state.isActionOpen}
+                  position={DropdownPosition.right}
+                  toggle={<KebabToggle id="summary-node-kebab" onToggle={this.onToggleActions} />}
+                />
+              )}
+              {renderBadgedLink(nodeData)}
+              {renderHealth(nodeData.health)}
+            </span>
           </div>
-          <div>{renderHealth(nodeData.health)}</div>
           <div>
             {this.renderBadgeSummary(nodeData)}
             {shouldRenderDestsList && <div>{destsList}</div>}

--- a/src/pages/Graph/SummaryPanelNode.tsx
+++ b/src/pages/Graph/SummaryPanelNode.tsx
@@ -116,7 +116,11 @@ export class SummaryPanelNode extends React.Component<SummaryPanelNodeProps, Sum
       options.length > 0 ? [<DropdownGroup label="Show" className="kiali-group-menu" children={options} />] : undefined;
 
     return (
-      <div ref={this.mainDivRef} className={`panel panel-default ${summaryPanel}`}>
+      <div
+        ref={this.mainDivRef}
+        className={`panel panel-default ${summaryPanel}`}
+        style={isHover ? { background: 'gray' } : {}}
+      >
         <div className="panel-heading" style={summaryHeader}>
           <div>
             <span>

--- a/src/pages/Graph/SummaryPanelNode.tsx
+++ b/src/pages/Graph/SummaryPanelNode.tsx
@@ -10,14 +10,7 @@ import {
   renderHealth
 } from './SummaryLink';
 import { DecoratedGraphNodeData, DestService, NodeType, RankResult, SummaryPanelPropType } from '../../types/Graph';
-import {
-  summaryHeader,
-  summaryPanel,
-  summaryBodyTabs,
-  summaryFont,
-  summaryPanelHover,
-  getTitle
-} from './SummaryPanelCommon';
+import { summaryHeader, summaryPanel, summaryBodyTabs, summaryFont, getTitle } from './SummaryPanelCommon';
 import { decoratedNodeData } from '../../components/CytoscapeGraph/CytoscapeGraphUtils';
 import { KialiIcon } from 'config/KialiIcon';
 import { getOptions, clickHandler } from 'components/CytoscapeGraph/ContextMenu/NodeContextMenu';
@@ -93,7 +86,6 @@ export class SummaryPanelNode extends React.Component<SummaryPanelNodeProps, Sum
   }
 
   render() {
-    const isHover = this.props.data.isHover;
     const node = this.props.data.summaryTarget;
     const nodeData = decoratedNodeData(node);
     const { nodeType, app, service, workload, isServiceEntry } = nodeData;
@@ -123,14 +115,14 @@ export class SummaryPanelNode extends React.Component<SummaryPanelNodeProps, Sum
       options.length > 0 ? [<DropdownGroup label="Show" className="kiali-group-menu" children={options} />] : undefined;
 
     return (
-      <div ref={this.mainDivRef} className={`panel panel-default ${isHover ? summaryPanelHover : summaryPanel}`}>
+      <div ref={this.mainDivRef} className={`panel panel-default ${summaryPanel}`}>
         <div className="panel-heading" style={summaryHeader}>
           {getTitle(nodeType)}
           <div>
             <span>
               <PFBadge badge={PFBadges.Namespace} style={{ marginBottom: '2px' }} />
               {nodeData.namespace}
-              {!isHover && actions && (
+              {actions && (
                 <Dropdown
                   id="summary-node-actions"
                   style={{ float: 'right' }}
@@ -154,7 +146,7 @@ export class SummaryPanelNode extends React.Component<SummaryPanelNodeProps, Sum
             {shouldRenderWorkload && this.renderWorkloadSection(nodeData)}
           </div>
         </div>
-        {!isHover && <>{shouldRenderTraces ? this.renderWithTabs(nodeData) : this.renderTrafficOnly()}</>}
+        {shouldRenderTraces ? this.renderWithTabs(nodeData) : this.renderTrafficOnly()}
       </div>
     );
   }

--- a/src/pages/Graph/SummaryPanelTraceDetails.tsx
+++ b/src/pages/Graph/SummaryPanelTraceDetails.tsx
@@ -25,7 +25,7 @@ import { decoratedNodeData } from 'components/CytoscapeGraph/CytoscapeGraphUtils
 import FocusAnimation from 'components/CytoscapeGraph/FocusAnimation';
 import { FormattedTraceInfo, shortIDStyle } from 'components/JaegerIntegration/JaegerResults/FormattedTraceInfo';
 import SimplerSelect from 'components/SimplerSelect';
-import { summaryFont } from './SummaryPanelCommon';
+import { summaryFont, summaryTitle } from './SummaryPanelCommon';
 import { NodeParamsType, GraphType } from 'types/Graph';
 import { bindActionCreators } from 'redux';
 import responseFlags from 'utils/ResponseFlags';
@@ -42,11 +42,6 @@ type Props = {
 type State = {
   selectedSpanID: string | undefined;
 };
-
-const textHeaderStyle = style({
-  fontWeight: 'bold',
-  fontSize: '16px'
-});
 
 const closeBoxStyle = style({
   float: 'right',
@@ -124,14 +119,16 @@ class SummaryPanelTraceDetails extends React.Component<Props, State> {
     }
     return (
       <>
-        <span className={textHeaderStyle}>Trace</span>
-        <span className={closeBoxStyle}>
-          <Tooltip content="Close and clear trace selection">
-            <Button id="close-trace" variant="plain" onClick={this.props.close}>
-              <CloseIcon />
-            </Button>
-          </Tooltip>
-        </span>
+        <div className={summaryTitle}>
+          <span>Trace</span>
+          <span className={closeBoxStyle}>
+            <Tooltip content="Close and clear trace selection">
+              <Button id="close-trace" variant="plain" onClick={this.props.close}>
+                <CloseIcon />
+              </Button>
+            </Tooltip>
+          </span>
+        </div>
         <div>
           {tracesDetailsURL ? (
             <Tooltip content={`View trace details for: ${info.name()}`}>

--- a/src/pages/Graph/__tests__/SummaryPanelNode.test.tsx
+++ b/src/pages/Graph/__tests__/SummaryPanelNode.test.tsx
@@ -24,6 +24,7 @@ describe('SummaryPanelNode', () => {
     defaultProps = {
       jaegerState: {},
       data: {
+        isHover: false,
         summaryType: 'node',
         summaryTarget: target
       },

--- a/src/pages/Graph/__tests__/SummaryPanelNode.test.tsx
+++ b/src/pages/Graph/__tests__/SummaryPanelNode.test.tsx
@@ -24,7 +24,6 @@ describe('SummaryPanelNode', () => {
     defaultProps = {
       jaegerState: {},
       data: {
-        isHover: false,
         summaryType: 'node',
         summaryTarget: target
       },

--- a/src/reducers/GraphDataState.ts
+++ b/src/reducers/GraphDataState.ts
@@ -73,6 +73,7 @@ const graphDataState = (state: GraphState = INITIAL_GRAPH_STATE, action: KialiAp
     case getType(GraphActions.updateSummary):
       return updateState(state, {
         summaryData: updateState(state.summaryData, {
+          isHover: action.payload.isHover,
           summaryType: action.payload.summaryType,
           summaryTarget: action.payload.summaryTarget
         })

--- a/src/reducers/GraphDataState.ts
+++ b/src/reducers/GraphDataState.ts
@@ -73,7 +73,6 @@ const graphDataState = (state: GraphState = INITIAL_GRAPH_STATE, action: KialiAp
     case getType(GraphActions.updateSummary):
       return updateState(state, {
         summaryData: updateState(state.summaryData, {
-          isHover: action.payload.isHover,
           summaryType: action.payload.summaryType,
           summaryTarget: action.payload.summaryTarget
         })

--- a/src/types/ErrorRate/__testData__/ErrorRateConfig.ts
+++ b/src/types/ErrorRate/__testData__/ErrorRateConfig.ts
@@ -78,9 +78,10 @@ export const serverRateConfig = {
       graph: {
         findOptions: [],
         hideOptions: [],
-        thresholds: {
-          zoomBadge: 0.8,
-          zoomLabel: 0.9
+        settings: {
+          fontLabel: 13,
+          minFontBadge: 7,
+          minFontLabel: 10
         },
         traffic: {
           grpc: 'requests',

--- a/src/types/ErrorRate/__testData__/ErrorRateConfig.ts
+++ b/src/types/ErrorRate/__testData__/ErrorRateConfig.ts
@@ -73,7 +73,25 @@ export const serverRateConfig = {
       enabled: true
     },
     istioInjectionAction: true,
-    istioUpgradeAction: false
+    istioUpgradeAction: false,
+    uiDefaults: {
+      graph: {
+        findOptions: [],
+        hideOptions: [],
+        thresholds: {
+          zoomBadge: 0.8,
+          zoomLabel: 0.9
+        },
+        traffic: {
+          grpc: 'requests',
+          http: 'requests',
+          tcp: 'sent'
+        }
+      },
+      metricsPerRefresh: '1m',
+      namespaces: [],
+      refreshInterval: '15s'
+    }
   },
   healthConfig: {
     rate: [

--- a/src/types/Graph.ts
+++ b/src/types/Graph.ts
@@ -284,6 +284,17 @@ export const hasProtocolTraffic = (protocolTraffic: ProtocolTraffic): protocolTr
   );
 };
 
+export const prettyProtocol = (protocol: ValidProtocols): string => {
+  switch (protocol.toLowerCase()) {
+    case 'http':
+      return 'HTTP';
+    case 'tcp':
+      return 'TCP';
+    default:
+      return 'gRPC';
+  }
+};
+
 export interface DestService {
   cluster: string;
   namespace: string;

--- a/src/types/Graph.ts
+++ b/src/types/Graph.ts
@@ -10,7 +10,6 @@ export interface Layout {
 export const SUMMARY_PANEL_CHART_WIDTH = 250;
 export type SummaryType = 'graph' | 'node' | 'edge' | 'box';
 export interface SummaryData {
-  isHover: boolean;
   summaryType: SummaryType;
   summaryTarget: any;
 }
@@ -219,9 +218,7 @@ export interface CytoscapeBaseEvent {
   summaryTarget: any; // the cytoscape element that was the target of the event
 }
 
-export interface CytoscapeEvent extends CytoscapeBaseEvent {
-  isHover?: boolean;
-}
+export interface CytoscapeEvent extends CytoscapeBaseEvent {}
 
 // Graph Structures
 

--- a/src/types/Graph.ts
+++ b/src/types/Graph.ts
@@ -10,6 +10,7 @@ export interface Layout {
 export const SUMMARY_PANEL_CHART_WIDTH = 250;
 export type SummaryType = 'graph' | 'node' | 'edge' | 'box';
 export interface SummaryData {
+  isHover: boolean;
   summaryType: SummaryType;
   summaryTarget: any;
 }
@@ -218,9 +219,9 @@ export interface CytoscapeBaseEvent {
   summaryTarget: any; // the cytoscape element that was the target of the event
 }
 
-export interface CytoscapeClickEvent extends CytoscapeBaseEvent {}
-export interface CytoscapeMouseInEvent extends CytoscapeBaseEvent {}
-export interface CytoscapeMouseOutEvent extends CytoscapeBaseEvent {}
+export interface CytoscapeEvent extends CytoscapeBaseEvent {
+  isHover?: boolean;
+}
 
 // Graph Structures
 

--- a/src/types/ServerConfig.ts
+++ b/src/types/ServerConfig.ts
@@ -37,9 +37,17 @@ interface GraphTraffic {
   tcp: string;
 }
 
+interface GraphThresholds {
+  zoomBoxLabel: number;
+  zoomEdgeLabel: number;
+  zoomNodeBadge: number;
+  zoomNodeLabel: number;
+}
+
 interface GraphUIDefaults {
   findOptions: GraphFindOption[];
   hideOptions: GraphFindOption[];
+  thresholds: GraphThresholds;
   traffic: GraphTraffic;
 }
 

--- a/src/types/ServerConfig.ts
+++ b/src/types/ServerConfig.ts
@@ -38,10 +38,8 @@ interface GraphTraffic {
 }
 
 interface GraphThresholds {
-  zoomBoxLabel: number;
-  zoomEdgeLabel: number;
-  zoomNodeBadge: number;
-  zoomNodeLabel: number;
+  zoomLabel: number;
+  zoomBadge: number;
 }
 
 interface GraphUIDefaults {

--- a/src/types/ServerConfig.ts
+++ b/src/types/ServerConfig.ts
@@ -37,15 +37,16 @@ interface GraphTraffic {
   tcp: string;
 }
 
-interface GraphThresholds {
-  zoomLabel: number;
-  zoomBadge: number;
+interface GraphSettings {
+  fontLabel: number;
+  minFontBadge: number;
+  minFontLabel: number;
 }
 
 interface GraphUIDefaults {
   findOptions: GraphFindOption[];
   hideOptions: GraphFindOption[];
-  thresholds: GraphThresholds;
+  settings: GraphSettings;
   traffic: GraphTraffic;
 }
 

--- a/src/types/ServerConfig.ts
+++ b/src/types/ServerConfig.ts
@@ -64,7 +64,7 @@ interface KialiFeatureFlags {
   certificatesInformationIndicators: CertificatesInformationIndicators;
   istioInjectionAction: boolean;
   istioUpgradeAction: boolean;
-  uiDefaults?: UIDefaults;
+  uiDefaults: UIDefaults;
 }
 
 interface IstioCanaryRevision {

--- a/src/types/__testData__/HealthConfig.ts
+++ b/src/types/__testData__/HealthConfig.ts
@@ -12,9 +12,10 @@ export const healthConfig = {
       graph: {
         findOptions: [],
         hideOptions: [],
-        thresholds: {
-          zoomBadge: 0.8,
-          zoomLabel: 0.9
+        settings: {
+          fontLabel: 13,
+          minFontBadge: 7,
+          minFontLabel: 10
         },
         traffic: {
           grpc: 'requests',

--- a/src/types/__testData__/HealthConfig.ts
+++ b/src/types/__testData__/HealthConfig.ts
@@ -7,7 +7,25 @@ export const healthConfig = {
       enabled: true
     },
     istioInjectionAction: true,
-    istioUpgradeAction: false
+    istioUpgradeAction: false,
+    uiDefaults: {
+      graph: {
+        findOptions: [],
+        hideOptions: [],
+        thresholds: {
+          zoomBadge: 0.8,
+          zoomLabel: 0.9
+        },
+        traffic: {
+          grpc: 'requests',
+          http: 'requests',
+          tcp: 'sent'
+        }
+      },
+      metricsPerRefresh: '1m',
+      namespaces: [],
+      refreshInterval: '15s'
+    }
   },
   healthConfig: {
     rate: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -6691,10 +6691,10 @@ cytoscape-popper@1.0.7:
   dependencies:
     popper.js "^1.0.0"
 
-cytoscape@3.20.0:
-  version "3.20.0"
-  resolved "https://registry.yarnpkg.com/cytoscape/-/cytoscape-3.20.0.tgz#c626c1074f3a8a6f1bc58e8fbee8fd798a6fcbf3"
-  integrity sha512-V2OUoav8ltY9UPgdjuhQOqkkWT28IbJODioWCjcnLqmjym9lMpnD0ie0vdQCdAiZapjbTGAv8aoKmmSuVcC1gA==
+cytoscape@3.15.5:
+  version "3.15.5"
+  resolved "https://registry.yarnpkg.com/cytoscape/-/cytoscape-3.15.5.tgz#34f4d5e54ffadbbbd044d5c041f17d251e741748"
+  integrity sha512-wkF2zkwvbBvT3Gj9ZVYhxqx6TvyZIuDx7Dhdy8m0z4QmDOXteMz+9oUgV+1btaBxA1VePZRUpoz1lwJixAyyYw==
   dependencies:
     heap "^0.2.6"
     lodash.debounce "^4.0.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6691,10 +6691,10 @@ cytoscape-popper@1.0.7:
   dependencies:
     popper.js "^1.0.0"
 
-cytoscape@3.15.1:
-  version "3.15.1"
-  resolved "https://registry.yarnpkg.com/cytoscape/-/cytoscape-3.15.1.tgz#bb5724306c61dfb1500d20ce11cd90ef768fc32b"
-  integrity sha512-xU/0KYoCErDXseKiPYrJJRSwwxbaDSo2rNpKCd7uNPw7ZDrMahCo+fE0agVvw0ce+6gAg5bDnC1pT8AgmaqqtA==
+cytoscape@3.20.0:
+  version "3.20.0"
+  resolved "https://registry.yarnpkg.com/cytoscape/-/cytoscape-3.20.0.tgz#c626c1074f3a8a6f1bc58e8fbee8fd798a6fcbf3"
+  integrity sha512-V2OUoav8ltY9UPgdjuhQOqkkWT28IbJODioWCjcnLqmjym9lMpnD0ie0vdQCdAiZapjbTGAv8aoKmmSuVcC1gA==
   dependencies:
     heap "^0.2.6"
     lodash.debounce "^4.0.8"


### PR DESCRIPTION
Closes https://github.com/kiali/kiali/issues/4521

There are server and operator PRs for the new config.

**Server PR:**:  https://github.com/kiali/kiali/pull/4544
**Operator PR:** https://github.com/kiali/kiali-operator/pull/461
 
**UPDATED: Jan 10, '22**

This is a step towards improving usability concerns as graph scale grows.  The changes include:
- add configurable minimum-font thresholds that determine when to show node/edge labels and/or badges.
   - as zoomed-font decreases text is initially removed (as it becomes unreadable), then badges (as they become inscrutable)
   - the thresholds are configurable as part of ui-defaults (i.e. install-wide as part of CR)
- significantly reduce "flashing" when mousing around the graph
  - reasonably fast mouse-over will not trigger highlight/dim
  - instead, encourage hover (300ms),  selection (click) or drag-zoom
    - hover will trigger neighborhood highlighting and contextInfo popup
    - selection will perform full-path highlighting and the side-panel update
      - also, clicking on a selected element will now un-select the element
    - right-click will continue to show contextMenu, now updated with new contextInfo and styling
- cytoscape toolbar now vertically presented bottom-left, to reduce it occluding graph elements
  - legend slightly resized and a few styling changes for consistency