### PR TITLE
Enable cluster and namespace boxing by default, in the main graph.

### DIFF
--- a/src/pages/Graph/GraphToolbar/GraphSettings.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphSettings.tsx
@@ -432,7 +432,12 @@ class GraphSettings extends React.PureComponent<GraphSettingsProps, GraphSetting
         labelText: 'Cluster Boxes',
         isChecked: boxByCluster,
         onChange: toggleBoxByCluster,
-        tooltip: <div style={{ textAlign: 'left' }}>When enabled the graph will box nodes in the same cluster.</div>
+        tooltip: (
+          <div style={{ textAlign: 'left' }}>
+            When enabled and there are multiple clusters, the graph will box nodes in the same cluster. The "unknown"
+            cluster is never boxed.
+          </div>
+        )
       },
       {
         id: 'boxByNamespace',
@@ -441,7 +446,8 @@ class GraphSettings extends React.PureComponent<GraphSettingsProps, GraphSetting
         onChange: toggleBoxByNamespace,
         tooltip: (
           <div style={{ textAlign: 'left' }}>
-            When enabled the graph will box nodes in the same namespace, within the same cluster.
+            When enabled and there are multiple namespaces, the graph will box nodes in the same namespace, within the
+            same cluster. The "unknown" namespace is never boxed.
           </div>
         )
       },

--- a/src/reducers/GraphDataState.ts
+++ b/src/reducers/GraphDataState.ts
@@ -16,8 +16,8 @@ export const INITIAL_GRAPH_STATE: GraphState = {
   },
   summaryData: null,
   toolbarState: {
-    boxByCluster: false,
-    boxByNamespace: false,
+    boxByCluster: true,
+    boxByNamespace: true,
     compressOnHide: true,
     edgeLabels: [],
     findValue: '',

--- a/src/reducers/__tests__/GraphDataState.test.ts
+++ b/src/reducers/__tests__/GraphDataState.test.ts
@@ -13,8 +13,8 @@ describe('GraphDataState', () => {
       rankResult: { upperBound: 0 },
       summaryData: null,
       toolbarState: {
-        boxByCluster: false,
-        boxByNamespace: false,
+        boxByCluster: true,
+        boxByNamespace: true,
         compressOnHide: true,
         edgeLabels: [],
         findValue: '',

--- a/src/services/GraphDataSource.ts
+++ b/src/services/GraphDataSource.ts
@@ -400,8 +400,8 @@ export default class GraphDataSource {
   private static defaultFetchParams(duration: DurationInSeconds, namespace: string): FetchParams {
     // queryTime defaults to server's 'now', leave unset
     return {
-      boxByCluster: false,
-      boxByNamespace: false,
+      boxByCluster: false, // not the main graph default, the helpers are for detail graphs
+      boxByNamespace: false, // not the main graph default, the helpers are for detail graphs
       duration: duration,
       edgeLabels: [],
       graphType: GraphType.WORKLOAD,


### PR DESCRIPTION
Part-of: https://github.com/kiali/kiali/issues/4547

Note that this change is in conjunction with a server-side change to omit boxing when unnecessary.

**Server PR:** https://github.com/kiali/kiali/pull/4548
