### PR TITLE
Fix case where workload has no services

### DIFF
--- a/src/pages/WorkloadDetails/WorkloadDescription.tsx
+++ b/src/pages/WorkloadDetails/WorkloadDescription.tsx
@@ -57,7 +57,7 @@ class WorkloadDescription extends React.Component<WorkloadDescriptionProps> {
       if (workload.labels[serverConfig.istioLabels.appLabelName]) {
         apps.push(workload.labels[serverConfig.istioLabels.appLabelName]);
       }
-      workload.services.forEach(s => services.push(s.name));
+      workload.services?.forEach(s => services.push(s.name));
     }
 
     const isTemplateLabels =


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/4589

There is a corner case/regression when workloads have no services attached as it returns a null value instead of an empty one.
It would require a change in the backend, but this one in the UI will protect the failing component shown in the issue.

For QE:
- You'd need an example like the [demo-errors-rate](https://github.com/kiali/demos/tree/master/error-rates) and check that getting access to a workload without services (i.e., f-client) will show an error in the details page.

It also happens when navigating from the "minigraph" to reach the "f-client".