### PR TITLE
Clip long numbers in heatmaps, as opposed to wrapping.

### DIFF
--- a/src/components/HeatMap/HeatMap.tsx
+++ b/src/components/HeatMap/HeatMap.tsx
@@ -22,12 +22,14 @@ type Props = {
 };
 
 const cellStyle = style({
-  overflow: 'hidden',
-  fontSize: '.7rem',
+  alignItems: 'center',
   borderRadius: 3,
   display: 'flex',
+  fontSize: '.7rem',
   justifyContent: 'center',
-  alignItems: 'center'
+  overflow: 'hidden',
+  textOverflow: 'clip',
+  whiteSpace: 'nowrap'
 });
 
 export class HeatMap extends React.Component<Props> {


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/4588

This issue title suggests a different font size, but a smaller font can become unreadable.  Clipping gives a uniform look while still allowing enough space for significant digits, and the tooltip can be used to see detail, if desired.

