### PR TITLE
Migrate cose and cola layouts to grid and concentric algorithms

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,8 +68,6 @@
     "cy-node-html-label": "2.0.0",
     "cytoscape": "3.15.5",
     "cytoscape-canvas": "3.0.1",
-    "cytoscape-cola": "2.3.1",
-    "cytoscape-cose-bilkent": "4.1.0",
     "cytoscape-dagre": "2.2.2",
     "cytoscape-popper": "1.0.7",
     "deep-freeze": "0.0.1",

--- a/src/components/CytoscapeGraph/CytoscapeGraphUtils.ts
+++ b/src/components/CytoscapeGraph/CytoscapeGraphUtils.ts
@@ -120,6 +120,7 @@ export const runLayout = (cy: Cy.Core, layout: Layout): Promise<any> => {
       ...layoutOptions,
       name: 'box-layout',
       appBoxLayout: 'dagre',
+      namespaceBoxLayout: 'dagre',
       defaultLayout: layout.name
     });
   } else {

--- a/src/components/CytoscapeGraph/CytoscapeReactWrapper.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeReactWrapper.tsx
@@ -4,17 +4,13 @@ import * as Cy from 'cytoscape';
 import { GraphStyles } from './graphs/GraphStyles';
 import canvas from 'cytoscape-canvas';
 import cytoscape from 'cytoscape';
-import cycola from 'cytoscape-cola';
 import dagre from 'cytoscape-dagre';
-import coseBilkent from 'cytoscape-cose-bilkent';
 import BoxLayout from './Layout/BoxLayout';
 import popper from 'cytoscape-popper';
 const nodeHtmlLabel = require('cy-node-html-label');
 
 cytoscape.use(canvas);
-cytoscape.use(cycola);
 cytoscape.use(dagre);
-cytoscape.use(coseBilkent);
 cytoscape.use(popper);
 cytoscape('layout', 'box-layout', BoxLayout);
 nodeHtmlLabel(cytoscape);

--- a/src/components/CytoscapeGraph/CytoscapeToolbar.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeToolbar.tsx
@@ -17,9 +17,9 @@ import { KialiAppState } from '../../store/Store';
 import { PFColors } from '../Pf/PfColors';
 import * as CytoscapeGraphUtils from './CytoscapeGraphUtils';
 import { Layout } from '../../types/Graph';
-import { ColaGraph } from './graphs/ColaGraph';
-import { CoseGraph } from './graphs/CoseGraph';
+import { ConcentricGraph } from './graphs/ConcentricGraph';
 import { DagreGraph } from './graphs/DagreGraph';
+import { GridGraph } from './graphs/GridGraph';
 import { KialiAppAction } from '../../actions/KialiAppAction';
 import { GraphActions } from '../../actions/GraphActions';
 import { HistoryManager, URLParam } from '../../app/History';
@@ -160,20 +160,20 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps,
 
         <TourStopContainer info={GraphTourStops.Layout}>
           <ToolbarItem>
-            <Tooltip content={'Layout 1 ' + CoseGraph.getLayout().name} position={TooltipPosition.right}>
+            <Tooltip content={'Layout 1 ' + GridGraph.getLayout().name} position={TooltipPosition.right}>
               <Button
                 id="toolbar_layout1"
                 aria-label="Graph Layout Style 1"
                 className={buttonStyle}
-                isActive={this.props.layout.name === CoseGraph.getLayout().name}
+                isActive={this.props.layout.name === GridGraph.getLayout().name}
                 isDisabled={this.props.disabled}
                 onClick={() => {
-                  this.setLayout(CoseGraph.getLayout());
+                  this.setLayout(GridGraph.getLayout());
                 }}
                 variant="plain"
               >
                 <TopologyIcon
-                  className={this.props.layout.name === CoseGraph.getLayout().name ? activeButtonStyle : undefined}
+                  className={this.props.layout.name === GridGraph.getLayout().name ? activeButtonStyle : undefined}
                 />
               </Button>
             </Tooltip>
@@ -181,20 +181,20 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps,
         </TourStopContainer>
 
         <ToolbarItem>
-          <Tooltip content={'Layout 2 ' + ColaGraph.getLayout().name} position={TooltipPosition.right}>
+          <Tooltip content={'Layout 2 ' + ConcentricGraph.getLayout().name} position={TooltipPosition.right}>
             <Button
               id="toolbar_layout2"
               aria-label="Graph Layout Style 2"
               className={buttonStyle}
-              isActive={this.props.layout.name === ColaGraph.getLayout().name}
+              isActive={this.props.layout.name === ConcentricGraph.getLayout().name}
               isDisabled={this.props.disabled}
               onClick={() => {
-                this.setLayout(ColaGraph.getLayout());
+                this.setLayout(ConcentricGraph.getLayout());
               }}
               variant="plain"
             >
               <TopologyIcon
-                className={this.props.layout.name === ColaGraph.getLayout().name ? activeButtonStyle : undefined}
+                className={this.props.layout.name === ConcentricGraph.getLayout().name ? activeButtonStyle : undefined}
               />
             </Button>
           </Tooltip>

--- a/src/components/CytoscapeGraph/graphs/ConcentricGraph.ts
+++ b/src/components/CytoscapeGraph/graphs/ConcentricGraph.ts
@@ -1,7 +1,7 @@
-export class CoseGraph {
+export class ConcentricGraph {
   static getLayout() {
     return {
-      name: 'cose-bilkent',
+      name: 'concentric',
       animate: false,
       fit: false,
       nodeDimensionsIncludeLabels: true

--- a/src/components/CytoscapeGraph/graphs/GridGraph.ts
+++ b/src/components/CytoscapeGraph/graphs/GridGraph.ts
@@ -1,12 +1,11 @@
-export class ColaGraph {
+export class GridGraph {
   static getLayout() {
     return {
-      name: 'cola',
+      name: 'grid',
       animate: false,
       fit: false,
-      flow: { axis: 'x' },
       nodeDimensionsIncludeLabels: true,
-      randomize: false
+      padding: 0
     };
   }
 }

--- a/src/components/CytoscapeGraph/graphs/LayoutDictionary.ts
+++ b/src/components/CytoscapeGraph/graphs/LayoutDictionary.ts
@@ -1,12 +1,12 @@
-import { ColaGraph } from './ColaGraph';
-import { CoseGraph } from './CoseGraph';
 import { DagreGraph } from './DagreGraph';
 import { Layout } from '../../../types/Graph';
+import { GridGraph } from './GridGraph';
+import { ConcentricGraph } from './ConcentricGraph';
 
 const LayoutMap = {
-  cola: ColaGraph.getLayout(),
   dagre: DagreGraph.getLayout(),
-  'cose-bilkent': CoseGraph.getLayout()
+  grid: GridGraph.getLayout(),
+  concentric: ConcentricGraph.getLayout()
 };
 
 const getLayout = (layout: Layout) =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6169,13 +6169,6 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
-cose-base@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/cose-base/-/cose-base-1.0.3.tgz#650334b41b869578a543358b80cda7e0abe0a60a"
-  integrity sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==
-  dependencies:
-    layout-base "^1.0.0"
-
 cosmiconfig@^5.0.0, cosmiconfig@^5.0.7, cosmiconfig@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
@@ -6644,20 +6637,6 @@ cytoscape-canvas@3.0.1:
   resolved "https://registry.yarnpkg.com/cytoscape-canvas/-/cytoscape-canvas-3.0.1.tgz#7d963be51e6e5f3f2482b05d22562c8ee941d125"
   integrity sha512-R1nCLnJHGTR5fWEpNQQBPyoigdnfhnk1lOHegzmzz1Kg6yxzVf0hfdRAMa0wPAhtC4kkgyoViiIfZ/zyCqMhEQ==
 
-cytoscape-cola@2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/cytoscape-cola/-/cytoscape-cola-2.3.1.tgz#e281737b6a973cec53e2423129d14cf189490818"
-  integrity sha512-CJ+AbNxqsEPEr+bsUfMcgg3T2E9NkwWVx1u7a6wixdg3uD6aDQI5vX5I0+A19QIrpqNWrm5O8w3oXf/ZcJwwmA==
-  dependencies:
-    webcola "^3.4.0"
-
-cytoscape-cose-bilkent@4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz#762fa121df9930ffeb51a495d87917c570ac209b"
-  integrity sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==
-  dependencies:
-    cose-base "^1.0.0"
-
 cytoscape-dagre@2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/cytoscape-dagre/-/cytoscape-dagre-2.2.2.tgz#5f32a85c0ba835f167efee531df9e89ac58ff411"
@@ -6702,19 +6681,6 @@ d3-color@1:
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.4.1.tgz#c52002bf8846ada4424d55d97982fef26eb3bc8a"
   integrity sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==
 
-d3-dispatch@1, d3-dispatch@^1.0.3:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-1.0.6.tgz#00d37bcee4dd8cd97729dd893a0ac29caaba5d58"
-  integrity sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==
-
-d3-drag@^1.0.4:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/d3-drag/-/d3-drag-1.2.5.tgz#2537f451acd39d31406677b7dc77c82f7d988f70"
-  integrity sha512-rD1ohlkKQwMZYkQlYVCrSFxsWPzI97+W+PaEIBNTMxRuxz9RF0Hi5nJWHGVJ3Om9d2fRTe1yOBINJyy/ahV95w==
-  dependencies:
-    d3-dispatch "1"
-    d3-selection "1"
-
 d3-ease@^1.0.0:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-1.0.7.tgz#9a834890ef8b8ae8c558b2fe55bd57f5993b85e2"
@@ -6750,12 +6716,7 @@ d3-scale@^1.0.0:
     d3-time "1"
     d3-time-format "2"
 
-d3-selection@1:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-1.4.2.tgz#dcaa49522c0dbf32d6c1858afc26b6094555bc5c"
-  integrity sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg==
-
-d3-shape@^1.0.0, d3-shape@^1.2.0, d3-shape@^1.3.5:
+d3-shape@^1.0.0, d3-shape@^1.2.0:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.3.7.tgz#df63801be07bc986bc54f63789b4fe502992b5d7"
   integrity sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==
@@ -6774,7 +6735,7 @@ d3-time@1:
   resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.1.0.tgz#b1e19d307dae9c900b7e5b25ffc5dcc249a8a0f1"
   integrity sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==
 
-d3-timer@^1.0.0, d3-timer@^1.0.5:
+d3-timer@^1.0.0:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-1.0.10.tgz#dfe76b8a91748831b13b6d9c793ffbd508dd9de5"
   integrity sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==
@@ -11230,11 +11191,6 @@ latest-version@^5.1.0:
   integrity sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==
   dependencies:
     package-json "^6.3.0"
-
-layout-base@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/layout-base/-/layout-base-1.0.2.tgz#1291e296883c322a9dd4c5dd82063721b53e26e2"
-  integrity sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==
 
 lazy-cache@^0.2.3:
   version "0.2.7"
@@ -18524,16 +18480,6 @@ web-namespaces@^1.0.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-1.1.4.tgz#bc98a3de60dadd7faefc403d1076d529f5e030ec"
   integrity sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==
-
-webcola@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/webcola/-/webcola-3.4.0.tgz#490d26ae98e5b5109478b94a846a62ff6831a99d"
-  integrity sha512-4BiLXjXw3SJHo3Xd+rF+7fyClT6n7I+AR6TkBqyQ4kTsePSAMDLRCXY1f3B/kXJeP9tYn4G1TblxTO+jAt0gaw==
-  dependencies:
-    d3-dispatch "^1.0.3"
-    d3-drag "^1.0.4"
-    d3-shape "^1.3.5"
-    d3-timer "^1.0.5"
 
 webidl-conversions@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
Part of https://github.com/kiali/kiali/issues/4601

~~This draft PR is used as a playground to test new layout algorithms and tweak the configuration for existing ones.~~

~~There is no intention to promote them to a formal PR, just to share some experiments and collect feedback before moving in any direction.~~

It includes a couple of minimal changes that I think will be consolidated:

- Move the BoxLayout for Namespaces to "dagre" algorithm. As it's defined per app, it's a minimal change that it has a good impact when managing large scenarios.
- In large scenarios, the "cola" algorithm has a performance penalty compared with others, so that one could be a candidate to be replaced.
- "Grid" layout works well on a high population of namespaces; results look promising.
- Still doing tests on scenarios that have a single namespace with a high population of workloads, "dagre" works well in most cases, but at some point, it seems there is space to change the layout.

