### PR TITLE
Protect graph-hide from unwanted zoom events

### DIFF
--- a/src/components/CytoscapeGraph/CytoscapeGraph.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeGraph.tsx
@@ -191,14 +191,6 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps,
       this.props.trace !== nextProps.trace ||
       this.state.zoomThresholdTime !== nextState.zoomThresholdTime;
 
-    /* TODO: REMOVE
-    console.log(
-      `graph shouldUpdate=${result}, zoomTimeChanged=${
-        this.state.zoomThresholdTime !== nextState.zoomThresholdTime
-      }, elementsChanged=${this.props.graphData.elements !== nextProps.graphData.elements}`
-    );
-    */
-
     return result;
   }
 
@@ -693,8 +685,6 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps,
     // We use a 'layoutstop' even handler to perform common handling, as layouts can be initiated
     // outside of just this class (for example, graph hide).
     cy.on('layoutstop', (_evt: Cy.EventObject) => {
-      // console.log(`layoutstop: ${evt.layout.options.name}`);
-
       // Perform a safeFit (one that takes into consideration a custom viewport set by the user).  This will
       // ensure we limit to max-zoom, or fit to the viewport when appropriate.
       this.safeFit(cy);
@@ -769,7 +759,7 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps,
     if (!force && this.customViewport) {
       return;
     }
-    // console.log('fit');
+
     CytoscapeGraphUtils.safeFit(cy);
     this.focus(cy);
   }
@@ -836,7 +826,6 @@ export default class CytoscapeGraph extends React.Component<CytoscapeGraphProps,
     if (runLayout) {
       return new Promise((resolve, _reject) => {
         CytoscapeGraphUtils.runLayout(cy, this.props.layout).then(_response => {
-          // console.log('endLayout');
           this.finishGraphUpdate(cy, isTheGraphSelected, runLayout);
           resolve();
         });

--- a/src/components/CytoscapeGraph/CytoscapeGraphUtils.ts
+++ b/src/components/CytoscapeGraph/CytoscapeGraphUtils.ts
@@ -95,6 +95,8 @@ export const safeFit = (cy: Cy.Core, centerElements?: Cy.Collection) => {
   cy.emit('kiali-fit');
 };
 
+// Note that this call is typically prefixed with cy.emit('kiali-zoomignore', [true]), and
+// when the promise resolves then call cy.emit('kiali-zoomignore', [false])
 export const runLayout = (cy: Cy.Core, layout: Layout): Promise<any> => {
   // Using an extension
   (cy as any).nodeHtmlLabel().updateNodeLabel(cy.nodes());

--- a/src/components/CytoscapeGraph/CytoscapeGraphUtils.ts
+++ b/src/components/CytoscapeGraph/CytoscapeGraphUtils.ts
@@ -123,7 +123,6 @@ export const runLayout = (cy: Cy.Core, layout: Layout): Promise<any> => {
     cyLayout = cy.layout(layoutOptions);
   }
   promise = cyLayout.promiseOn('layoutstop');
-  // console.log('runLayout');
   cyLayout.run();
   return promise;
 };

--- a/src/components/CytoscapeGraph/CytoscapeGraphUtils.ts
+++ b/src/components/CytoscapeGraph/CytoscapeGraphUtils.ts
@@ -101,23 +101,12 @@ export const safeFit = (cy: Cy.Core, centerElements?: Cy.Collection) => {
   cy.emit('kiali-fit');
 };
 
-// Note that this call is typically prefixed with cy.emit('kiali-zoomignore', [true]), and
-// when the promise resolves then call cy.emit('kiali-zoomignore', [false])
+// IMPORTANT! Layouts should be performed while zoom-handling is being ignored:
+//   - call cy.emit('kiali-zoomignore', [true]) at some point prior to this call
+//   - call cy.emit('kiali-zoomignore', [false]) in the promise handler
 export const runLayout = (cy: Cy.Core, layout: Layout): Promise<any> => {
-  // Using the extension, force labels prior to the layout, so that the layout can take the lebel space into consideration
-  // Do this from leaf-to-root
-  const scratch = cy.scratch(CytoscapeGlobalScratchNamespace);
-  if (scratch) {
-    cy.scratch(CytoscapeGlobalScratchNamespace, { ...scratch, forceLabels: true } as CytoscapeGlobalScratchData);
-  }
-  let nodes = cy.nodes('[^isBox]:visible');
-  while (nodes.length > 0) {
-    (cy as any).nodeHtmlLabel().updateNodeLabel(nodes);
-    nodes = nodes.parents();
-  }
-  if (scratch) {
-    cy.scratch(CytoscapeGlobalScratchNamespace, { ...scratch, forceLabels: false } as CytoscapeGlobalScratchData);
-  }
+  // generate all labels so the layout algorithm can take them into consideration
+  refreshLabels(cy, true);
 
   const layoutOptions = LayoutDictionary.getLayout(layout);
   let promise: Promise<any>;
@@ -134,9 +123,35 @@ export const runLayout = (cy: Cy.Core, layout: Layout): Promise<any> => {
     cyLayout = cy.layout(layoutOptions);
   }
   promise = cyLayout.promiseOn('layoutstop');
-  console.log('runLayout');
+  // console.log('runLayout');
   cyLayout.run();
   return promise;
+};
+
+// This ahould be called to ensure labels are up to date on-screen.  It may be needed to ensure cytoscape
+// displays up-to-date labels, even if the label content has not changed.
+// Note: the leaf-to-root approach here should mirror what is done in GraphStyles.ts#htmlNodeLabels()
+export const refreshLabels = (cy: Cy.Core, force: boolean) => {
+  const scratch = cy.scratch(CytoscapeGlobalScratchNamespace);
+  if (force) {
+    if (scratch) {
+      cy.scratch(CytoscapeGlobalScratchNamespace, { ...scratch, forceLabels: true } as CytoscapeGlobalScratchData);
+    }
+  }
+
+  // update labeles from leaf to node (i.e. inside out with respect to nested boxing).  This (in theory) ensures
+  // that outer nodes will always be able to incorporate inner nodes' true bounding-box (one adjusted for the label).
+  let nodes = cy.nodes('[^isBox]:visible');
+  while (nodes.length > 0) {
+    (cy as any).nodeHtmlLabel().updateNodeLabel(nodes);
+    nodes = nodes.parents();
+  }
+
+  if (force) {
+    if (scratch) {
+      cy.scratch(CytoscapeGlobalScratchNamespace, { ...scratch, forceLabels: false } as CytoscapeGlobalScratchData);
+    }
+  }
 };
 
 export const decoratedEdgeData = (ele: Cy.EdgeSingular): DecoratedGraphEdgeData => {

--- a/src/components/CytoscapeGraph/CytoscapeReactWrapper.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeReactWrapper.tsx
@@ -74,7 +74,7 @@ export class CytoscapeReactWrapper extends React.Component<CytoscapeReactWrapper
     return <div id="cy" className="graph" style={styleContainer} ref={this.divParentRef} />;
   }
 
-  build() {
+  private build() {
     if (this.cy) {
       this.destroy();
     }
@@ -90,7 +90,7 @@ export class CytoscapeReactWrapper extends React.Component<CytoscapeReactWrapper
     (this.cy as any).nodeHtmlLabel(GraphStyles.htmlNodeLabels(this.cy));
   }
 
-  destroy() {
+  private destroy() {
     if (this.cy) {
       this.cy.destroy();
       this.cy = undefined;

--- a/src/components/CytoscapeGraph/CytoscapeToolbar.tsx
+++ b/src/components/CytoscapeGraph/CytoscapeToolbar.tsx
@@ -38,6 +38,7 @@ type ReduxProps = {
 
 type CytoscapeToolbarProps = ReduxProps & {
   cytoscapeGraphRef: any;
+  disabled: boolean;
 };
 
 type CytoscapeToolbarState = {
@@ -143,11 +144,12 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps,
               id="toolbar_layout_default"
               aria-label="Graph Layout Default Style"
               className={buttonStyle}
-              variant="plain"
-              onClick={() => {
-                this.props.setLayout(DagreGraph.getLayout());
-              }}
               isActive={this.props.layout.name === DagreGraph.getLayout().name}
+              isDisabled={this.props.disabled}
+              onClick={() => {
+                this.setLayout(DagreGraph.getLayout());
+              }}
+              variant="plain"
             >
               <TopologyIcon
                 className={this.props.layout.name === DagreGraph.getLayout().name ? activeButtonStyle : undefined}
@@ -163,11 +165,12 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps,
                 id="toolbar_layout1"
                 aria-label="Graph Layout Style 1"
                 className={buttonStyle}
-                variant="plain"
-                onClick={() => {
-                  this.props.setLayout(CoseGraph.getLayout());
-                }}
                 isActive={this.props.layout.name === CoseGraph.getLayout().name}
+                isDisabled={this.props.disabled}
+                onClick={() => {
+                  this.setLayout(CoseGraph.getLayout());
+                }}
+                variant="plain"
               >
                 <TopologyIcon
                   className={this.props.layout.name === CoseGraph.getLayout().name ? activeButtonStyle : undefined}
@@ -183,11 +186,12 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps,
               id="toolbar_layout2"
               aria-label="Graph Layout Style 2"
               className={buttonStyle}
-              variant="plain"
-              onClick={() => {
-                this.props.setLayout(ColaGraph.getLayout());
-              }}
               isActive={this.props.layout.name === ColaGraph.getLayout().name}
+              isDisabled={this.props.disabled}
+              onClick={() => {
+                this.setLayout(ColaGraph.getLayout());
+              }}
+              variant="plain"
             >
               <TopologyIcon
                 className={this.props.layout.name === ColaGraph.getLayout().name ? activeButtonStyle : undefined}
@@ -258,6 +262,12 @@ export class CytoscapeToolbar extends React.PureComponent<CytoscapeToolbarProps,
     const cy = this.getCy();
     if (cy) {
       CytoscapeGraphUtils.safeFit(cy);
+    }
+  };
+
+  private setLayout = (layout: Layout) => {
+    if (layout.name !== this.props.layout.name) {
+      this.props.setLayout(layout);
     }
   };
 }

--- a/src/components/CytoscapeGraph/Layout/BoxLayout.ts
+++ b/src/components/CytoscapeGraph/Layout/BoxLayout.ts
@@ -220,6 +220,11 @@ export default class BoxLayout {
       this.emit('layoutstop');
     });
 
+    // Avoid propagating any local layout events up to cy, this would yield a global operation before the nodes are ready.
+    layout.on('layoutstart layoutready layoutstop', _event => {
+      return false;
+    });
+
     layout.run();
   }
 

--- a/src/components/CytoscapeGraph/MiniGraphCard.tsx
+++ b/src/components/CytoscapeGraph/MiniGraphCard.tsx
@@ -100,6 +100,7 @@ export default class MiniGraphCard extends React.Component<MiniGraphCardProps, M
               }
               graphData={{
                 elements: this.state.graphData,
+                elementsChanged: true,
                 errorMessage: !!this.props.dataSource.errorMessage ? this.props.dataSource.errorMessage : undefined,
                 isError: this.props.dataSource.isError,
                 isLoading: this.props.dataSource.isLoading,

--- a/src/components/CytoscapeGraph/__tests__/CytoscapeGraph.test.tsx
+++ b/src/components/CytoscapeGraph/__tests__/CytoscapeGraph.test.tsx
@@ -52,6 +52,7 @@ describe('CytoscapeGraph component test', () => {
           edgeLabels={myEdgeLabelMode}
           graphData={{
             elements: dataSource.graphData,
+            elementsChanged: true,
             isLoading: false,
             fetchParams: {
               includeHealth: false,

--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -192,16 +192,16 @@ export class GraphStyles {
   }
 
   static getNodeLabel(ele: Cy.NodeSingular) {
-    const settings = serverConfig.kialiFeatureFlags.uiDefaults.graph.settings;
-    const zoom = ele.cy().zoom();
-    const noBadge = zoom < settings.minFontBadge / settings.fontLabel;
-    const noContent = zoom < settings.minFontLabel / settings.fontLabel;
-
     const getCyGlobalData = (ele: Cy.NodeSingular): CytoscapeGlobalScratchData => {
       return ele.cy().scratch(CytoscapeGlobalScratchNamespace);
     };
 
     const cyGlobal = getCyGlobalData(ele);
+    const settings = serverConfig.kialiFeatureFlags.uiDefaults.graph.settings;
+    const zoom = ele.cy().zoom();
+    const noBadge = !cyGlobal.forceLabels && zoom < settings.minFontBadge / settings.fontLabel;
+    const noContent = !cyGlobal.forceLabels && zoom < settings.minFontLabel / settings.fontLabel;
+
     const node = decoratedNodeData(ele);
     const app = node.app || '';
     const cluster = node.cluster;
@@ -446,7 +446,31 @@ export class GraphStyles {
   static htmlNodeLabels(cy: Cy.Core) {
     return [
       {
-        query: 'node:visible',
+        query: 'node[^isBox]:visible', // leaf nodes
+        halign: 'center',
+        valign: 'bottom',
+        halignBox: 'center',
+        valignBox: 'bottom',
+        tpl: (data: any) => this.getNodeLabel(cy.$id(data.id))
+      },
+      {
+        query: 'node[isBox = "app"]:visible', // app box nodes
+        halign: 'center',
+        valign: 'bottom',
+        halignBox: 'center',
+        valignBox: 'bottom',
+        tpl: (data: any) => this.getNodeLabel(cy.$id(data.id))
+      },
+      {
+        query: 'node[isBox = "namespace"]:visible', // ns box nodes
+        halign: 'center',
+        valign: 'bottom',
+        halignBox: 'center',
+        valignBox: 'bottom',
+        tpl: (data: any) => this.getNodeLabel(cy.$id(data.id))
+      },
+      {
+        query: 'node[isBox = "cluster"]:visible', // cluster box nodes
         halign: 'center',
         valign: 'bottom',
         halignBox: 'center',

--- a/src/pages/Graph/GraphPage.tsx
+++ b/src/pages/Graph/GraphPage.tsx
@@ -68,6 +68,7 @@ import { JaegerThunkActions } from 'actions/JaegerThunkActions';
 import GraphTour from 'pages/Graph/GraphHelpTour';
 import { getNextTourStop, TourInfo } from 'components/Tour/TourStop';
 import { EdgeContextMenu } from 'components/CytoscapeGraph/ContextMenu/EdgeContextMenu';
+import * as CytoscapeGraphUtils from '../../components/CytoscapeGraph/CytoscapeGraphUtils';
 
 // GraphURLPathProps holds path variable values.  Currently all path variables are relevant only to a node graph
 type GraphURLPathProps = {
@@ -130,6 +131,7 @@ export type GraphPageProps = RouteComponentProps<Partial<GraphURLPathProps>> & R
 
 export type GraphData = {
   elements: DecoratedGraphElements;
+  elementsChanged: boolean; // true if current elements differ from previous fetch, can be used as an optimization.
   errorMessage?: string;
   fetchParams: FetchParams;
   isLoading: boolean;
@@ -287,6 +289,7 @@ export class GraphPage extends React.Component<GraphPageProps, GraphPageState> {
     this.state = {
       graphData: {
         elements: { edges: [], nodes: [] },
+        elementsChanged: false,
         fetchParams: this.graphDataSource.fetchParameters,
         isLoading: true,
         timestamp: 0
@@ -399,7 +402,12 @@ export class GraphPage extends React.Component<GraphPageProps, GraphPageState> {
       <>
         <FlexView className={conStyle} column={true}>
           <div>
-            <GraphToolbarContainer cy={cy} disabled={this.state.graphData.isLoading} onToggleHelp={this.toggleHelp} />
+            <GraphToolbarContainer
+              cy={cy}
+              disabled={this.state.graphData.isLoading}
+              elementsChanged={this.state.graphData.elementsChanged}
+              onToggleHelp={this.toggleHelp}
+            />
           </div>
           <FlexView
             grow={true}
@@ -483,9 +491,11 @@ export class GraphPage extends React.Component<GraphPageProps, GraphPageState> {
     elements: DecoratedGraphElements,
     fetchParams: FetchParams
   ) => {
+    const prevElements = this.state.graphData.elements;
     this.setState({
       graphData: {
         elements: elements,
+        elementsChanged: CytoscapeGraphUtils.elementsChanged(prevElements, elements),
         isLoading: false,
         fetchParams: fetchParams,
         timestamp: graphTimestamp * 1000
@@ -495,9 +505,11 @@ export class GraphPage extends React.Component<GraphPageProps, GraphPageState> {
   };
 
   private handleGraphDataSourceError = (errorMessage: string | null, fetchParams: FetchParams) => {
+    const prevElements = this.state.graphData.elements;
     this.setState({
       graphData: {
-        elements: { edges: [], nodes: [] },
+        elements: EMPTY_GRAPH_DATA,
+        elementsChanged: CytoscapeGraphUtils.elementsChanged(prevElements, EMPTY_GRAPH_DATA),
         errorMessage: !!errorMessage ? errorMessage : undefined,
         isError: true,
         isLoading: false,
@@ -508,9 +520,11 @@ export class GraphPage extends React.Component<GraphPageProps, GraphPageState> {
   };
 
   private handleGraphDataSourceEmpty = (fetchParams: FetchParams) => {
+    const prevElements = this.state.graphData.elements;
     this.setState({
       graphData: {
         elements: EMPTY_GRAPH_DATA,
+        elementsChanged: CytoscapeGraphUtils.elementsChanged(prevElements, EMPTY_GRAPH_DATA),
         isLoading: false,
         fetchParams: fetchParams,
         timestamp: Date.now()
@@ -522,6 +536,7 @@ export class GraphPage extends React.Component<GraphPageProps, GraphPageState> {
     this.setState({
       graphData: {
         elements: isPreviousDataInvalid ? EMPTY_GRAPH_DATA : this.state.graphData.elements,
+        elementsChanged: false,
         fetchParams: fetchParams,
         isLoading: true,
         timestamp: isPreviousDataInvalid ? Date.now() : this.state.graphData.timestamp

--- a/src/pages/Graph/GraphPage.tsx
+++ b/src/pages/Graph/GraphPage.tsx
@@ -447,7 +447,10 @@ export class GraphPage extends React.Component<GraphPageProps, GraphPageState> {
               )}
               {isReady && (
                 <div className={cytoscapeToolbarWrapperDivStyle}>
-                  <CytoscapeToolbarContainer cytoscapeGraphRef={this.cytoscapeGraphRef} />
+                  <CytoscapeToolbarContainer
+                    cytoscapeGraphRef={this.cytoscapeGraphRef}
+                    disabled={this.state.graphData.isLoading}
+                  />
                 </div>
               )}
             </ErrorBoundary>

--- a/src/pages/Graph/GraphToolbar/GraphFind.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphFind.tsx
@@ -45,6 +45,7 @@ type ReduxProps = {
 
 type GraphFindProps = ReduxProps & {
   cy: any;
+  elementsChanged: boolean;
 };
 
 type GraphFindState = {
@@ -204,6 +205,7 @@ export class GraphFind extends React.Component<GraphFindProps, GraphFindState> {
     const findChanged = this.props.findValue !== prevProps.findValue;
     const hideChanged = this.props.hideValue !== prevProps.hideValue;
     const graphChanged = this.props.updateTime !== prevProps.updateTime;
+    const graphElementsChanged = graphChanged && this.props.elementsChanged;
 
     // ensure redux state and URL are aligned
     if (findChanged) {
@@ -238,7 +240,7 @@ export class GraphFind extends React.Component<GraphFindProps, GraphFindState> {
       }
 
       const compressOnHideChanged = this.props.compressOnHide !== prevProps.compressOnHide;
-      this.handleHide(this.props.cy, hideChanged, graphChanged, compressOnHideChanged);
+      this.handleHide(this.props.cy, hideChanged, graphChanged, graphElementsChanged, compressOnHideChanged);
     }
   }
 
@@ -440,7 +442,13 @@ export class GraphFind extends React.Component<GraphFindProps, GraphFindState> {
     this.props.setHideValue(val);
   };
 
-  private handleHide = (cy: any, hideChanged: boolean, graphChanged: boolean, compressOnHideChanged: boolean) => {
+  private handleHide = (
+    cy: any,
+    hideChanged: boolean,
+    graphChanged: boolean,
+    graphElementsChanged: boolean,
+    compressOnHideChanged: boolean
+  ) => {
     const selector = this.parseValue(this.props.hideValue, false);
     console.debug(`Hide selector=[${selector}]`);
 
@@ -490,7 +498,7 @@ export class GraphFind extends React.Component<GraphFindProps, GraphFindState> {
     cy.endBatch();
 
     const hasRemovedElements: boolean = !!this.removedElements && this.removedElements.length > 0;
-    if (hideChanged || (compressOnHideChanged && selector) || hasRemovedElements) {
+    if (hideChanged || (compressOnHideChanged && selector) || (hasRemovedElements && graphElementsChanged)) {
       cy.emit('kiali-zoomignore', [true]);
       CytoscapeGraphUtils.runLayout(cy, this.props.layout).then(() => {
         // do nothing, defer to CytoscapeGraph.tsx 'onlayout' event handler

--- a/src/pages/Graph/GraphToolbar/GraphFind.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphFind.tsx
@@ -492,6 +492,7 @@ export class GraphFind extends React.Component<GraphFindProps, GraphFindState> {
     if (hideChanged || (compressOnHideChanged && selector) || hasRemovedElements) {
       cy.emit('kiali-zoomignore', [true]);
       CytoscapeGraphUtils.runLayout(cy, this.props.layout).then(() => {
+        console.log('endLayout (hide)');
         cy.emit('kiali-zoomignore', [false]);
       });
     }

--- a/src/pages/Graph/GraphToolbar/GraphFind.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphFind.tsx
@@ -490,7 +490,10 @@ export class GraphFind extends React.Component<GraphFindProps, GraphFindState> {
 
     const hasRemovedElements: boolean = !!this.removedElements && this.removedElements.length > 0;
     if (hideChanged || (compressOnHideChanged && selector) || hasRemovedElements) {
-      CytoscapeGraphUtils.runLayout(cy, this.props.layout);
+      cy.emit('kiali-zoomignore', [true]);
+      CytoscapeGraphUtils.runLayout(cy, this.props.layout).then(() => {
+        cy.emit('kiali-zoomignore', [false]);
+      });
     }
   };
 

--- a/src/pages/Graph/GraphToolbar/GraphFind.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphFind.tsx
@@ -179,15 +179,17 @@ export class GraphFind extends React.Component<GraphFindProps, GraphFindState> {
     const findErrorChanged = this.state.findError !== nextState.findError;
     const hideErrorChanged = this.state.hideError !== nextState.hideError;
 
-    return (
+    const shouldUpdate =
       cyChanged ||
       findChanged ||
       hideChanged ||
       graphChanged ||
       showFindHelpChanged ||
       findErrorChanged ||
-      hideErrorChanged
-    );
+      hideErrorChanged;
+
+    // TODO: Remove console.log(`graphHide shouldUpdate=${shouldUpdate}, graphChanged=${graphChanged}`);
+    return shouldUpdate;
   }
 
   // Note that we may have redux hide/find values set at mount-time. But because the toolbar mounts prior to
@@ -492,8 +494,8 @@ export class GraphFind extends React.Component<GraphFindProps, GraphFindState> {
     if (hideChanged || (compressOnHideChanged && selector) || hasRemovedElements) {
       cy.emit('kiali-zoomignore', [true]);
       CytoscapeGraphUtils.runLayout(cy, this.props.layout).then(() => {
-        console.log('endLayout (hide)');
-        cy.emit('kiali-zoomignore', [false]);
+        // console.log('endLayout (hide)');
+        //cy.emit('kiali-zoomignore', [false]);
       });
     }
   };

--- a/src/pages/Graph/GraphToolbar/GraphFind.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphFind.tsx
@@ -188,7 +188,6 @@ export class GraphFind extends React.Component<GraphFindProps, GraphFindState> {
       findErrorChanged ||
       hideErrorChanged;
 
-    // TODO: Remove console.log(`graphHide shouldUpdate=${shouldUpdate}, graphChanged=${graphChanged}`);
     return shouldUpdate;
   }
 
@@ -494,8 +493,7 @@ export class GraphFind extends React.Component<GraphFindProps, GraphFindState> {
     if (hideChanged || (compressOnHideChanged && selector) || hasRemovedElements) {
       cy.emit('kiali-zoomignore', [true]);
       CytoscapeGraphUtils.runLayout(cy, this.props.layout).then(() => {
-        // console.log('endLayout (hide)');
-        //cy.emit('kiali-zoomignore', [false]);
+        // do nothing, defer to CytoscapeGraph.tsx 'onlayout' event handler
       });
     }
   };

--- a/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphToolbar.tsx
@@ -56,6 +56,7 @@ type ReduxProps = {
 type GraphToolbarProps = ReduxProps & {
   cy: any;
   disabled: boolean;
+  elementsChanged: boolean;
   onToggleHelp: () => void;
   onRefresh?: () => void;
 };
@@ -200,7 +201,7 @@ export class GraphToolbar extends React.PureComponent<GraphToolbarProps> {
               <GraphSettingsContainer graphType={this.props.graphType} disabled={this.props.disabled} />
             </TourStopContainer>
           </div>
-          <GraphFindContainer cy={this.props.cy} />
+          <GraphFindContainer cy={this.props.cy} elementsChanged={this.props.elementsChanged} />
 
           <TourStopContainer info={GraphTourStops.Shortcuts}>
             <ToolbarGroup className={rightToolbarStyle} aria-label="graph_refresh_toolbar">

--- a/src/pages/Graph/GraphToolbar/__tests__/GraphFind.test.tsx
+++ b/src/pages/Graph/GraphToolbar/__tests__/GraphFind.test.tsx
@@ -12,6 +12,7 @@ describe('Parse find value test', () => {
       <GraphFind
         cy={undefined}
         edgeLabels={[]}
+        elementsChanged={true}
         findValue="testFind"
         hideValue="testHide"
         showFindHelp={false}

--- a/src/types/Graph.ts
+++ b/src/types/Graph.ts
@@ -204,9 +204,10 @@ export interface NodeParamsType {
 export const CytoscapeGlobalScratchNamespace = '_global';
 export type CytoscapeGlobalScratchData = {
   activeNamespaces: Namespace[];
-  homeCluster: string;
   edgeLabels: EdgeLabelMode[];
+  forceLabels: boolean;
   graphType: GraphType;
+  homeCluster: string;
   showMissingSidecars: boolean;
   showSecurity: boolean;
   showVirtualServices: boolean;


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/4666

Graph-hide performs a layout after removing the graph elements.  Layouts
can generate intermediate zoom-level changes that should be ignored, and
so we must add that protection.
