### PR TITLE
Reduce health req lists

### DIFF
--- a/src/components/FilterList/FilterComponent.tsx
+++ b/src/components/FilterList/FilterComponent.tsx
@@ -17,7 +17,7 @@ export interface State<R> {
 }
 
 export abstract class Component<P extends Props<R>, S extends State<R>, R> extends React.Component<P, S> {
-  abstract sortItemList(listItems: R[], sortField: SortField<R>, isAscending: boolean): Promise<R[]>;
+  abstract sortItemList(listItems: R[], sortField: SortField<R>, isAscending: boolean): R[];
   abstract updateListItems(resetPagination?: boolean): void;
 
   constructor(props: P) {
@@ -44,14 +44,13 @@ export abstract class Component<P extends Props<R>, S extends State<R>, R> exten
   }
 
   updateSort = (sortField: SortField<R>, isSortAscending: boolean) => {
-    this.sortItemList(this.state.listItems, sortField, isSortAscending).then(sorted => {
-      this.setState({
-        currentSortField: sortField,
-        isSortAscending: isSortAscending,
-        listItems: sorted
-      });
-      HistoryManager.setParam(URLParam.SORT, sortField.param);
-      HistoryManager.setParam(URLParam.DIRECTION, isSortAscending ? 'asc' : 'desc');
+    this.setState({
+      currentSortField: sortField,
+      isSortAscending: isSortAscending,
+      listItems: this.sortItemList(this.state.listItems, sortField, isSortAscending)
     });
+
+    HistoryManager.setParam(URLParam.SORT, sortField.param);
+    HistoryManager.setParam(URLParam.DIRECTION, isSortAscending ? 'asc' : 'desc');
   };
 }

--- a/src/components/Filters/CommonFilters.ts
+++ b/src/components/Filters/CommonFilters.ts
@@ -6,7 +6,7 @@ import {
   ActiveFiltersInfo,
   FilterTypes
 } from '../../types/Filters';
-import { HEALTHY, DEGRADED, FAILURE, NA, NOT_READY, Health } from '../../types/Health';
+import { HEALTHY, DEGRADED, FAILURE, NA, NOT_READY } from '../../types/Health';
 import { removeDuplicatesArray } from '../../utils/Common';
 
 export const presenceValues: FilterValue[] = [
@@ -84,14 +84,6 @@ export const getPresenceFilterValue = (filter: FilterType, activeFilters: Active
   return undefined;
 };
 
-export const filterByHealth = <T extends { healthPromise: Promise<Health> }>(
-  items: T[],
-  filterValues: string[]
-): Promise<T[]> => {
-  const itemsWithHealthPromises = items.map(item => item.healthPromise.then(h => ({ health: h, item: item })));
-  return Promise.all(itemsWithHealthPromises).then(itemsWithHealth => {
-    return itemsWithHealth
-      .filter(itemWithHealth => filterValues.includes(itemWithHealth.health.getGlobalStatus().name))
-      .map(itemWithHealth => itemWithHealth.item);
-  });
+export const filterByHealth = (items: any[], filterValues: string[]): any[] => {
+  return items.filter(itemWithHealth => filterValues.includes(itemWithHealth.health.getGlobalStatus().name));
 };

--- a/src/components/TrafficList/TrafficListComponent.tsx
+++ b/src/components/TrafficList/TrafficListComponent.tsx
@@ -83,8 +83,8 @@ class TrafficListComponent extends FilterComponent.Component<
     // we only care about new TrafficItems, sorting is managed locally after initial render
     if (prevProps.trafficItems !== this.props.trafficItems) {
       const listItems = this.trafficToListItems(this.props.trafficItems);
-      this.sortItemList(listItems, this.state.currentSortField, this.state.isSortAscending).then(sorted => {
-        this.setState({ listItems: sorted });
+      this.setState({
+        listItems: this.sortItemList(listItems, this.state.currentSortField, this.state.isSortAscending)
       });
     }
   }
@@ -135,9 +135,8 @@ class TrafficListComponent extends FilterComponent.Component<
     listItems: TrafficListItem[],
     sortField: SortField<TrafficListItem>,
     isAscending: boolean
-  ): Promise<TrafficListItem[]> {
-    const sorted = listItems.sort(isAscending ? sortField.compare : (a, b) => sortField.compare(b, a));
-    return Promise.resolve(sorted);
+  ): TrafficListItem[] {
+    return listItems.sort(isAscending ? sortField.compare : (a, b) => sortField.compare(b, a));
   }
 
   // Helper used for Table to sort handlers based on index column == field

--- a/src/components/VirtualList/Config.ts
+++ b/src/components/VirtualList/Config.ts
@@ -26,7 +26,7 @@ export type Renderer<R extends RenderResource> = (
 
 // Health type guard
 export function hasHealth(r: RenderResource): r is SortResource {
-  return (r as SortResource).healthPromise !== undefined;
+  return (r as SortResource).health !== undefined;
 }
 
 export const hasMissingSidecar = (r: SortResource): boolean => {

--- a/src/components/VirtualList/VirtualItem.tsx
+++ b/src/components/VirtualList/VirtualItem.tsx
@@ -30,33 +30,19 @@ export default class VirtualItem extends React.Component<VirtualItemProps, Virtu
 
   componentDidMount() {
     if (hasHealth(this.props.item)) {
-      this.onHealthPromiseChanged(this.props.item.healthPromise);
+      this.setState({ health: this.props.item.health });
     }
   }
 
   componentDidUpdate(prevProps: VirtualItemProps) {
-    if (hasHealth(this.props.item) && this.props.item.healthPromise !== prevProps.item['healthPromise']) {
-      this.onHealthPromiseChanged(this.props.item.healthPromise);
+    if (hasHealth(this.props.item) && this.props.item.health !== prevProps.item['health']) {
+      this.setState({ health: this.props.item.health });
     }
   }
 
   componentWillUnmount() {
     this.promises.cancelAll();
   }
-
-  onHealthPromiseChanged = async (promise: Promise<Health>): Promise<void> => {
-    this.promises
-      .register('health', promise)
-      .then(h => {
-        this.setState({ health: h });
-      })
-      .catch(err => {
-        if (!err.isCanceled) {
-          this.setState({ health: undefined });
-          throw err;
-        }
-      });
-  };
 
   renderDetails = (item: RenderResource, health?: Health) => {
     return this.props.config.columns.map(object =>

--- a/src/helpers/__tests__/LabelFilterHelper.test.ts
+++ b/src/helpers/__tests__/LabelFilterHelper.test.ts
@@ -1,12 +1,36 @@
 import { filterByLabel } from '../LabelFilterHelper';
 import { AppListItem } from '../../types/AppList';
+import { AppHealth, WorkloadHealth, ServiceHealth } from '../../types/Health';
 import { WorkloadListItem } from '../../types/Workload';
 import { ServiceListItem } from '../../types/ServiceList';
+import { setServerConfig } from '../../config/ServerConfig';
+import { serverRateConfig } from '../../types/ErrorRate/__testData__/ErrorRateConfig';
 
+setServerConfig(serverRateConfig);
+const emptyAppHealth = new AppHealth(
+  '',
+  '',
+  [],
+  { inbound: {}, outbound: {}, healthAnnotations: {} },
+  { rateInterval: 20, hasSidecar: true }
+);
+const emptyWorkHealth = new WorkloadHealth(
+  '',
+  '',
+  { desiredReplicas: 0, currentReplicas: 0, availableReplicas: 0, name: '', syncedProxies: 0 },
+  { inbound: {}, outbound: {}, healthAnnotations: {} },
+  { rateInterval: 20, hasSidecar: true }
+);
+const emptySvcHealth = new ServiceHealth(
+  '',
+  '',
+  { inbound: {}, outbound: {}, healthAnnotations: {} },
+  { rateInterval: 20, hasSidecar: true }
+);
 const appList: AppListItem[] = [
   {
     namespace: 'bookinfo',
-    healthPromise: new Promise(() => {}),
+    health: emptyAppHealth,
     name: 'ratings',
     istioSidecar: false,
     labels: { app: 'ratings', service: 'ratings', version: 'v1' },
@@ -14,7 +38,7 @@ const appList: AppListItem[] = [
   },
   {
     namespace: 'bookinfo',
-    healthPromise: new Promise(() => {}),
+    health: emptyAppHealth,
     name: 'productpage',
     istioSidecar: false,
     labels: { app: 'productpage', service: 'productpage', version: 'v1' },
@@ -22,7 +46,7 @@ const appList: AppListItem[] = [
   },
   {
     namespace: 'bookinfo',
-    healthPromise: new Promise(() => {}),
+    health: emptyAppHealth,
     name: 'details',
     istioSidecar: false,
     labels: { app: 'details', service: 'details', version: 'v1' },
@@ -30,7 +54,7 @@ const appList: AppListItem[] = [
   },
   {
     namespace: 'bookinfo',
-    healthPromise: new Promise(() => {}),
+    health: emptyAppHealth,
     name: 'reviews',
     istioSidecar: false,
     labels: { app: 'reviews', service: 'reviews', version: 'v1,v2,v3' },
@@ -41,7 +65,7 @@ const appList: AppListItem[] = [
 const workloadList: WorkloadListItem[] = [
   {
     namespace: 'bookinfo',
-    healthPromise: new Promise(() => {}),
+    health: emptyWorkHealth,
     name: 'details-v1',
     type: 'Deployment',
     istioSidecar: false,
@@ -53,7 +77,7 @@ const workloadList: WorkloadListItem[] = [
   },
   {
     namespace: 'bookinfo',
-    healthPromise: new Promise(() => {}),
+    health: emptyWorkHealth,
     name: 'productpage-v1',
     type: 'Deployment',
     istioSidecar: false,
@@ -65,7 +89,7 @@ const workloadList: WorkloadListItem[] = [
   },
   {
     namespace: 'bookinfo',
-    healthPromise: new Promise(() => {}),
+    health: emptyWorkHealth,
     name: 'ratings-v1',
     type: 'Deployment',
     istioSidecar: false,
@@ -77,7 +101,7 @@ const workloadList: WorkloadListItem[] = [
   },
   {
     namespace: 'bookinfo',
-    healthPromise: new Promise(() => {}),
+    health: emptyWorkHealth,
     name: 'reviews-v1',
     type: 'Deployment',
     istioSidecar: false,
@@ -89,7 +113,7 @@ const workloadList: WorkloadListItem[] = [
   },
   {
     namespace: 'bookinfo',
-    healthPromise: new Promise(() => {}),
+    health: emptyWorkHealth,
     name: 'reviews-v2',
     type: 'Deployment',
     istioSidecar: false,
@@ -101,7 +125,7 @@ const workloadList: WorkloadListItem[] = [
   },
   {
     namespace: 'bookinfo',
-    healthPromise: new Promise(() => {}),
+    health: emptyWorkHealth,
     name: 'reviews-v3',
     type: 'Deployment',
     istioSidecar: false,
@@ -116,7 +140,7 @@ const workloadList: WorkloadListItem[] = [
 const serviceList: ServiceListItem[] = [
   {
     namespace: 'bookinfo',
-    healthPromise: new Promise(() => {}),
+    health: emptySvcHealth,
     name: 'details',
     istioSidecar: false,
     labels: { app: 'details', service: 'details' },
@@ -127,7 +151,7 @@ const serviceList: ServiceListItem[] = [
   },
   {
     namespace: 'bookinfo',
-    healthPromise: new Promise(() => {}),
+    health: emptySvcHealth,
     name: 'reviews',
     istioSidecar: false,
     labels: { app: 'reviews', service: 'reviews' },
@@ -138,7 +162,7 @@ const serviceList: ServiceListItem[] = [
   },
   {
     namespace: 'bookinfo',
-    healthPromise: new Promise(() => {}),
+    health: emptySvcHealth,
     name: 'ratings',
     istioSidecar: false,
     labels: { app: 'ratings', service: 'ratings' },
@@ -149,7 +173,7 @@ const serviceList: ServiceListItem[] = [
   },
   {
     namespace: 'bookinfo',
-    healthPromise: new Promise(() => {}),
+    health: emptySvcHealth,
     name: 'productpage',
     istioSidecar: false,
     labels: { app: 'productpage', service: 'productpage' },
@@ -171,7 +195,7 @@ describe('LabelFilter', () => {
     expect(result).toEqual([
       {
         namespace: 'bookinfo',
-        healthPromise: new Promise(() => {}),
+        health: emptyAppHealth,
         name: 'details',
         istioSidecar: false,
         labels: { app: 'details', service: 'details', version: 'v1' },
@@ -185,7 +209,7 @@ describe('LabelFilter', () => {
     expect(result).toEqual([
       {
         namespace: 'bookinfo',
-        healthPromise: new Promise(() => {}),
+        health: emptyAppHealth,
         name: 'reviews',
         istioSidecar: false,
         labels: { app: 'reviews', service: 'reviews', version: 'v1,v2,v3' },
@@ -204,7 +228,7 @@ describe('LabelFilter', () => {
     expect(result).toEqual([
       {
         namespace: 'bookinfo',
-        healthPromise: new Promise(() => {}),
+        health: emptyWorkHealth,
         name: 'reviews-v1',
         type: 'Deployment',
         istioSidecar: false,
@@ -216,7 +240,7 @@ describe('LabelFilter', () => {
       },
       {
         namespace: 'bookinfo',
-        healthPromise: new Promise(() => {}),
+        health: emptyWorkHealth,
         name: 'reviews-v2',
         type: 'Deployment',
         istioSidecar: false,
@@ -228,7 +252,7 @@ describe('LabelFilter', () => {
       },
       {
         namespace: 'bookinfo',
-        healthPromise: new Promise(() => {}),
+        health: emptyWorkHealth,
         name: 'reviews-v3',
         type: 'Deployment',
         istioSidecar: false,
@@ -251,7 +275,7 @@ describe('LabelFilter', () => {
     expect(result).toEqual([
       {
         namespace: 'bookinfo',
-        healthPromise: new Promise(() => {}),
+        health: emptySvcHealth,
         name: 'details',
         istioSidecar: false,
         labels: { app: 'details', service: 'details' },

--- a/src/pages/AppList/AppListClass.tsx
+++ b/src/pages/AppList/AppListClass.tsx
@@ -1,6 +1,6 @@
 import { AppList, AppListItem } from '../../types/AppList';
-import * as API from '../../services/Api';
 import { sortIstioReferences } from './FiltersAndSorts';
+import { AppHealth } from '../../types/Health';
 
 export const getAppItems = (data: AppList, rateInterval: number): AppListItem[] => {
   if (data.applications) {
@@ -8,7 +8,10 @@ export const getAppItems = (data: AppList, rateInterval: number): AppListItem[] 
       namespace: data.namespace.name,
       name: app.name,
       istioSidecar: app.istioSidecar,
-      healthPromise: API.getAppHealth(data.namespace.name, app.name, rateInterval, app.istioSidecar),
+      health: AppHealth.fromJson(data.namespace.name, app.name, app.health, {
+        rateInterval: rateInterval,
+        hasSidecar: app.istioSidecar
+      }),
       labels: app.labels,
       istioReferences: sortIstioReferences(app.istioReferences, true)
     }));

--- a/src/pages/AppList/FiltersAndSorts.ts
+++ b/src/pages/AppList/FiltersAndSorts.ts
@@ -2,7 +2,7 @@ import { ActiveFiltersInfo, FILTER_ACTION_APPEND, FilterType } from '../../types
 import { calculateErrorRate } from '../../types/ErrorRate';
 import { AppListItem } from '../../types/AppList';
 import { SortField } from '../../types/SortFilters';
-import { WithAppHealth, hasHealth } from '../../types/Health';
+import { hasHealth } from '../../types/Health';
 import {
   istioSidecarFilter,
   healthFilter,
@@ -173,19 +173,8 @@ export const sortAppsItems = (
   unsorted: AppListItem[],
   sortField: SortField<AppListItem>,
   isAscending: boolean
-): Promise<AppListItem[]> => {
-  if (sortField.title === 'Health') {
-    // In the case of health sorting, we may not have all health promises ready yet
-    // So we need to get them all before actually sorting
-    const allHealthPromises: Promise<WithAppHealth<AppListItem>>[] = unsorted.map(item => {
-      return item.healthPromise.then((health): WithAppHealth<AppListItem> => ({ ...item, health }));
-    });
-    return Promise.all(allHealthPromises).then(arr => {
-      return arr.sort(isAscending ? sortField.compare : (a, b) => sortField.compare(b, a));
-    });
-  }
-  const sorted = unsorted.sort(isAscending ? sortField.compare : (a, b) => sortField.compare(b, a));
-  return Promise.resolve(sorted);
+): AppListItem[] => {
+  return unsorted.sort(isAscending ? sortField.compare : (a, b) => sortField.compare(b, a));
 };
 
 export const compareObjectReference = (a: ObjectReference, b: ObjectReference): number => {

--- a/src/pages/IstioConfigList/FiltersAndSorts.ts
+++ b/src/pages/IstioConfigList/FiltersAndSorts.ts
@@ -159,9 +159,5 @@ export const sortIstioItems = (
   sortField: SortField<IstioConfigItem>,
   isAscending: boolean
 ) => {
-  const sortPromise: Promise<IstioConfigItem[]> = new Promise(resolve => {
-    resolve(unsorted.sort(isAscending ? sortField.compare : (a, b) => sortField.compare(b, a)));
-  });
-
-  return sortPromise;
+  return unsorted.sort(isAscending ? sortField.compare : (a, b) => sortField.compare(b, a));
 };

--- a/src/pages/IstioConfigList/__tests__/IstioConfigListComponent.test.ts
+++ b/src/pages/IstioConfigList/__tests__/IstioConfigListComponent.test.ts
@@ -77,22 +77,21 @@ describe('IstioConfigComponent#sortIstioItems', () => {
     const sortField: SortField<IstioConfigItem> = IstioConfigListFilters.sortFields[2];
     const isAscending = true;
 
-    return IstioConfigListFilters.sortIstioItems(istioItems, sortField, isAscending).then(sorted => {
-      expect(sorted).toBeDefined();
-      expect(sorted.length).toBe(15);
+    const sorted = IstioConfigListFilters.sortIstioItems(istioItems, sortField, isAscending);
+    expect(sorted).toBeDefined();
+    expect(sorted.length).toBe(15);
 
-      const first = sorted[0];
-      expect(first.authorizationPolicy).toBeDefined();
-      expect(first.authorizationPolicy!.metadata.name).toBe('blue0');
+    const first = sorted[0];
+    expect(first.authorizationPolicy).toBeDefined();
+    expect(first.authorizationPolicy!.metadata.name).toBe('blue0');
 
-      const second = sorted[1];
-      expect(second.destinationRule).toBeDefined();
-      expect(second.destinationRule!.metadata.name).toBe('blue1');
+    const second = sorted[1];
+    expect(second.destinationRule).toBeDefined();
+    expect(second.destinationRule!.metadata.name).toBe('blue1');
 
-      const last = sorted[14];
-      expect(last.virtualService).toBeDefined();
-      expect(last.virtualService!.metadata.name).toBe('white4');
-    });
+    const last = sorted[14];
+    expect(last.virtualService).toBeDefined();
+    expect(last.virtualService!.metadata.name).toBe('white4');
   });
 
   it('should sort DESC IstioConfigItems by Istio Name', () => {
@@ -101,18 +100,17 @@ describe('IstioConfigComponent#sortIstioItems', () => {
     const isAscending = false;
 
     // Descending
-    return IstioConfigListFilters.sortIstioItems(istioItems, sortField, isAscending).then(sorted => {
-      expect(sorted).toBeDefined();
-      expect(sorted.length).toBe(15);
+    const sorted = IstioConfigListFilters.sortIstioItems(istioItems, sortField, isAscending);
+    expect(sorted).toBeDefined();
+    expect(sorted.length).toBe(15);
 
-      const first = sorted[0];
-      expect(first.virtualService).toBeDefined();
-      expect(first.virtualService!.metadata.name).toBe('white4');
+    const first = sorted[0];
+    expect(first.virtualService).toBeDefined();
+    expect(first.virtualService!.metadata.name).toBe('white4');
 
-      const last = sorted[14];
-      expect(last.authorizationPolicy).toBeDefined();
-      expect(last.authorizationPolicy!.metadata.name).toBe('blue0');
-    });
+    const last = sorted[14];
+    expect(last.authorizationPolicy).toBeDefined();
+    expect(last.authorizationPolicy!.metadata.name).toBe('blue0');
   });
 
   it('should sort IstioConfigItems by Istio Type', () => {
@@ -120,22 +118,21 @@ describe('IstioConfigComponent#sortIstioItems', () => {
     const sortField: SortField<IstioConfigItem> = IstioConfigListFilters.sortFields[1];
     const isAscending = true;
 
-    return IstioConfigListFilters.sortIstioItems(istioItems, sortField, isAscending).then(sorted => {
-      expect(sorted).toBeDefined();
-      expect(sorted.length).toBe(15);
+    const sorted = IstioConfigListFilters.sortIstioItems(istioItems, sortField, isAscending);
+    expect(sorted).toBeDefined();
+    expect(sorted.length).toBe(15);
 
-      const first = sorted[0];
-      expect(first.authorizationPolicy).toBeDefined();
-      expect(first.authorizationPolicy!.metadata.name).toBe('blue0');
+    const first = sorted[0];
+    expect(first.authorizationPolicy).toBeDefined();
+    expect(first.authorizationPolicy!.metadata.name).toBe('blue0');
 
-      const second = sorted[3];
-      expect(second.destinationRule).toBeDefined();
-      expect(second.destinationRule!.metadata.name).toBe('blue1');
+    const second = sorted[3];
+    expect(second.destinationRule).toBeDefined();
+    expect(second.destinationRule!.metadata.name).toBe('blue1');
 
-      const last = sorted[14];
-      expect(last.virtualService).toBeDefined();
-      expect(last.virtualService!.metadata.name).toBe('white4');
-    });
+    const last = sorted[14];
+    expect(last.virtualService).toBeDefined();
+    expect(last.virtualService!.metadata.name).toBe('white4');
   });
 
   it('should sort DESC IstioConfigItems by Istio Type', () => {
@@ -143,13 +140,12 @@ describe('IstioConfigComponent#sortIstioItems', () => {
     const sortField: SortField<IstioConfigItem> = IstioConfigListFilters.sortFields[1];
     const isAscending = false;
 
-    return IstioConfigListFilters.sortIstioItems(istioItems, sortField, isAscending).then(sorted => {
-      expect(sorted).toBeDefined();
-      expect(sorted.length).toBe(15);
+    const sorted = IstioConfigListFilters.sortIstioItems(istioItems, sortField, isAscending);
+    expect(sorted).toBeDefined();
+    expect(sorted.length).toBe(15);
 
-      const first = sorted[0];
-      expect(first.virtualService).toBeDefined();
-      expect(first.virtualService!.metadata.name).toBe('white4');
-    });
+    const first = sorted[0];
+    expect(first.virtualService).toBeDefined();
+    expect(first.virtualService!.metadata.name).toBe('white4');
   });
 });

--- a/src/pages/ServiceList/FiltersAndSorts.ts
+++ b/src/pages/ServiceList/FiltersAndSorts.ts
@@ -1,5 +1,5 @@
 import { ActiveFiltersInfo, FilterType, FILTER_ACTION_APPEND, FilterTypes } from '../../types/Filters';
-import { WithServiceHealth, hasHealth } from '../../types/Health';
+import { hasHealth } from '../../types/Health';
 import { ServiceListItem } from '../../types/ServiceList';
 import { SortField } from '../../types/SortFilters';
 import {
@@ -212,10 +212,7 @@ const filterByIstioType = (items: ServiceListItem[], istioTypes: string[]): Serv
   return items.filter(item => item.istioReferences.filter(ref => istioTypes.includes(ref.objectType)).length !== 0);
 };
 
-export const filterBy = (
-  items: ServiceListItem[],
-  filters: ActiveFiltersInfo
-): Promise<ServiceListItem[]> | ServiceListItem[] => {
+export const filterBy = (items: ServiceListItem[], filters: ActiveFiltersInfo): ServiceListItem[] => {
   let ret = items;
   const istioSidecar = getPresenceFilterValue(istioSidecarFilter, filters);
   if (istioSidecar !== undefined) {
@@ -255,18 +252,6 @@ export const sortServices = (
   services: ServiceListItem[],
   sortField: SortField<ServiceListItem>,
   isAscending: boolean
-): Promise<ServiceListItem[]> => {
-  if (sortField.title === 'Health') {
-    // In the case of health sorting, we may not have all health promises ready yet
-    // So we need to get them all before actually sorting
-    const allHealthPromises: Promise<WithServiceHealth<ServiceListItem>>[] = services.map(item => {
-      return item.healthPromise.then((health): WithServiceHealth<ServiceListItem> => ({ ...item, health }));
-    });
-    return Promise.all(allHealthPromises).then(arr => {
-      return arr.sort(isAscending ? sortField.compare : (a, b) => sortField.compare(b, a));
-    });
-  }
-  // Default case: sorting is done synchronously
-  const sorted = services.sort(isAscending ? sortField.compare : (a, b) => sortField.compare(b, a));
-  return Promise.resolve(sorted);
+): ServiceListItem[] => {
+  return services.sort(isAscending ? sortField.compare : (a, b) => sortField.compare(b, a));
 };

--- a/src/pages/ServiceList/__tests__/ServiceListComponent.test.ts
+++ b/src/pages/ServiceList/__tests__/ServiceListComponent.test.ts
@@ -75,23 +75,19 @@ describe('ServiceListContainer#sortServices', () => {
   beforeAll(() => {
     setServerConfig(healthConfig);
   });
-  it('should sort ascending', done => {
+  it('should sort ascending', () => {
     const sortField = ServiceListFilters.sortFields.find(s => s.title === 'Service Name')!;
     const services = [makeService('A', {}, {}), makeService('B', {}, {})];
-    ServiceListFilters.sortServices(services, sortField, true).then(sorted => {
-      expect(sorted[0].name).toBe('A');
-      expect(sorted[1].name).toBe('B');
-      done();
-    });
+    const sorted = ServiceListFilters.sortServices(services, sortField, true);
+    expect(sorted[0].name).toBe('A');
+    expect(sorted[1].name).toBe('B');
   });
 
-  it('should sort descending', done => {
+  it('should sort descending', () => {
     const sortField = ServiceListFilters.sortFields.find(s => s.title === 'Service Name')!;
     const services = [makeService('A', {}, {}), makeService('B', {}, {})];
-    ServiceListFilters.sortServices(services, sortField, false).then(sorted => {
-      expect(sorted[0].name).toBe('B');
-      expect(sorted[1].name).toBe('A');
-      done();
-    });
+    const sorted = ServiceListFilters.sortServices(services, sortField, false);
+    expect(sorted[0].name).toBe('B');
+    expect(sorted[1].name).toBe('A');
   });
 });

--- a/src/pages/WorkloadList/FiltersAndSorts.ts
+++ b/src/pages/WorkloadList/FiltersAndSorts.ts
@@ -7,7 +7,7 @@ import {
 } from '../../types/Filters';
 import { WorkloadListItem, WorkloadType } from '../../types/Workload';
 import { SortField } from '../../types/SortFilters';
-import { WithWorkloadHealth, hasHealth } from '../../types/Health';
+import { hasHealth } from '../../types/Health';
 import {
   presenceValues,
   istioSidecarFilter,
@@ -316,10 +316,7 @@ const filterByIstioType = (items: WorkloadListItem[], istioTypes: string[]): Wor
   return items.filter(item => item.istioReferences.filter(ref => istioTypes.includes(ref.objectType)).length !== 0);
 };
 
-export const filterBy = (
-  items: WorkloadListItem[],
-  filters: ActiveFiltersInfo
-): Promise<WorkloadListItem[]> | WorkloadListItem[] => {
+export const filterBy = (items: WorkloadListItem[], filters: ActiveFiltersInfo): WorkloadListItem[] => {
   const workloadTypeFilters = getFilterSelectedValues(workloadTypeFilter, filters);
   const workloadNamesSelected = getFilterSelectedValues(workloadNameFilter, filters);
   const istioSidecar = getPresenceFilterValue(istioSidecarFilter, filters);
@@ -353,17 +350,6 @@ export const sortWorkloadsItems = (
   unsorted: WorkloadListItem[],
   sortField: SortField<WorkloadListItem>,
   isAscending: boolean
-): Promise<WorkloadListItem[]> => {
-  if (sortField.title === 'Health') {
-    // In the case of health sorting, we may not have all health promises ready yet
-    // So we need to get them all before actually sorting
-    const allHealthPromises: Promise<WithWorkloadHealth<WorkloadListItem>>[] = unsorted.map(item => {
-      return item.healthPromise.then((health): WithWorkloadHealth<WorkloadListItem> => ({ ...item, health }));
-    });
-    return Promise.all(allHealthPromises).then(arr => {
-      return arr.sort(isAscending ? sortField.compare : (a, b) => sortField.compare(b, a));
-    });
-  }
-  const sorted = unsorted.sort(isAscending ? sortField.compare : (a, b) => sortField.compare(b, a));
-  return Promise.resolve(sorted);
+): WorkloadListItem[] => {
+  return unsorted.sort(isAscending ? sortField.compare : (a, b) => sortField.compare(b, a));
 };

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -202,8 +202,8 @@ export const createIstioConfigDetail = (
   return newRequest(HTTP_VERBS.POST, urls.istioConfigCreate(namespace, objectType), {}, json);
 };
 
-export const getServices = (namespace: string) => {
-  return newRequest<ServiceList>(HTTP_VERBS.GET, urls.services(namespace), {}, {});
+export const getServices = (namespace: string, params: { [key: string]: string } = {}) => {
+  return newRequest<ServiceList>(HTTP_VERBS.GET, urls.services(namespace), params, {});
 };
 
 export const getServiceMetrics = (namespace: string, service: string, params: IstioMetricsOptions) => {
@@ -232,8 +232,8 @@ export const getApp = (namespace: string, app: string) => {
   return newRequest<App>(HTTP_VERBS.GET, urls.app(namespace, app), {}, {});
 };
 
-export const getApps = (namespace: string) => {
-  return newRequest<AppList>(HTTP_VERBS.GET, urls.apps(namespace), {}, {});
+export const getApps = (namespace: string, params: any = {}) => {
+  return newRequest<AppList>(HTTP_VERBS.GET, urls.apps(namespace), params, {});
 };
 
 export const getAppMetrics = (namespace: string, app: string, params: IstioMetricsOptions) => {
@@ -484,8 +484,8 @@ export const getServiceDetail = (
   });
 };
 
-export const getWorkloads = (namespace: string) => {
-  return newRequest<WorkloadNamespaceResponse>(HTTP_VERBS.GET, urls.workloads(namespace), {}, {});
+export const getWorkloads = (namespace: string, params: { [key: string]: string } = {}) => {
+  return newRequest<WorkloadNamespaceResponse>(HTTP_VERBS.GET, urls.workloads(namespace), params, {});
 };
 
 export const getWorkload = (namespace: string, name: string, validate?: boolean) => {

--- a/src/types/AppList.ts
+++ b/src/types/AppList.ts
@@ -12,9 +12,9 @@ export interface AppOverview {
   istioSidecar: boolean;
   labels: { [key: string]: string };
   istioReferences: ObjectReference[];
+  health: AppHealth;
 }
 
 export interface AppListItem extends AppOverview {
   namespace: string;
-  healthPromise: Promise<AppHealth>;
 }

--- a/src/types/HealthAnnotation.ts
+++ b/src/types/HealthAnnotation.ts
@@ -25,7 +25,7 @@ export class RateHealth extends HealthAnnotation {
 
   constructor(annotations: HealthAnnotationType) {
     super(annotations);
-    this.annotation = annotations[HealthAnnotationConfig.HEALTH_RATE];
+    this.annotation = annotations[HealthAnnotationConfig.HEALTH_RATE] || '';
     if (this.annotation && this.annotation.length > 0) {
       this.isValid = this.validate();
       this.toleranceConfig = this.isValid ? this.getToleranceConfig() : undefined;

--- a/src/types/ServiceList.ts
+++ b/src/types/ServiceList.ts
@@ -17,10 +17,10 @@ export interface ServiceOverview {
   istioReferences: ObjectReference[];
   kialiWizard: string;
   serviceRegistry: string;
+  health: ServiceHealth;
 }
 
 export interface ServiceListItem extends ServiceOverview {
   namespace: string;
-  healthPromise: Promise<ServiceHealth>;
   validation?: ObjectValidation;
 }

--- a/src/types/Workload.ts
+++ b/src/types/Workload.ts
@@ -65,11 +65,11 @@ export interface WorkloadOverview {
   labels: { [key: string]: string };
   istioReferences: ObjectReference[];
   notCoveredAuthPolicy: boolean;
+  health: WorkloadHealth;
 }
 
 export interface WorkloadListItem extends WorkloadOverview {
   namespace: string;
-  healthPromise: Promise<WorkloadHealth>;
 }
 
 export interface WorkloadNamespaceResponse {


### PR DESCRIPTION
Require https://github.com/kiali/kiali/pull/4763

Issue: https://github.com/kiali/kiali/issues/4748




This Reduce the requests, If we have N namespaces and each namespace has W workloads.

We move from **N*W requests** to **N requests**

![Screenshot from 2022-02-28 10-08-38](https://user-images.githubusercontent.com/3019213/155956068-d0faa3ac-e62d-4144-9ad4-e2512b4630dc.png)


# Test 
Open network tab and check that there are only one health request instead of N request.

The behaviour must be the same that before. Try to change a health of a service/workload/app and check that in list is updated after refresh interval.