### PR TITLE
Fix time selection issue in replay custom startTime picker

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "react": "16.13.1",
     "react-ace": "9.1.3",
     "react-copy-to-clipboard": "5.0.1",
-    "react-datepicker": "2.14.0",
+    "react-datepicker": "3.8.0",
     "react-dom": "16.13.1",
     "react-flexview": "4.0.3",
     "react-redux": "7.2.0",

--- a/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
+++ b/src/components/CytoscapeGraph/ContextMenu/NodeContextMenu.tsx
@@ -125,7 +125,7 @@ export class NodeContextMenu extends React.PureComponent<Props> {
         <div className={contextMenuHeader}>
           {(!isBox || isBox === BoxByType.APP) && (
             <>
-              <PFBadge badge={PFBadges.Namespace} style={{ marginBottom: '2px' }} />
+              <PFBadge badge={PFBadges.Namespace} />
               {this.props.namespace}
             </>
           )}
@@ -162,7 +162,7 @@ export class NodeContextMenu extends React.PureComponent<Props> {
     return (
       <div className={contextMenu}>
         {header}
-        <hr />
+        <hr style={{ margin: '8px 0 5px 0' }} />
         {menuOptions}
       </div>
     );

--- a/src/components/Time/Replay.tsx
+++ b/src/components/Time/Replay.tsx
@@ -234,9 +234,7 @@ export class Replay extends React.PureComponent<ReplayProps, ReplayState> {
             <DateTimePicker
               injectTimes={[maxTime]}
               maxDate={maxTime}
-              maxTime={maxTime}
               minDate={minTime}
-              minTime={minTime}
               onChange={date => this.onPickerChange(date)}
               selected={selectedTime}
             />

--- a/yarn.lock
+++ b/yarn.lock
@@ -8321,9 +8321,9 @@ data-urls@^1.0.0, data-urls@^1.1.0:
     whatwg-url "^7.0.0"
 
 date-fns@^2.0.1:
-  version "2.22.1"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.22.1.tgz#1e5af959831ebb1d82992bf67b765052d8f0efc4"
-  integrity sha512-yUFPQjrxEmIsMqlHhAhmxkuH769baF21Kk+nZwZGyrMoyLA+LugaQtC0+Tqf9CBUUULWwUJt6Q5ySI3LJDDCGg==
+  version "2.28.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"
+  integrity sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==
 
 dayjs@^1.10.4:
   version "1.10.7"
@@ -16588,16 +16588,16 @@ react-copy-to-clipboard@5.0.1:
     copy-to-clipboard "^3"
     prop-types "^15.5.8"
 
-react-datepicker@2.14.0:
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/react-datepicker/-/react-datepicker-2.14.0.tgz#cdb2f236f120a7e6e973b617f71358b5c8617aac"
-  integrity sha512-9TUDNj0zoeQT3ey6i7Dv4NLcqONyYqXNEOLA3++HwQKR5NK4eRoG4QaohM/5XmWw2tDpJWpl3ByCWP4kWQtqgQ==
+react-datepicker@3.8.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/react-datepicker/-/react-datepicker-3.8.0.tgz#c3bccd3e3f47aa66864a2fa75651be097414430b"
+  integrity sha512-iFVNEp8DJoX5yEvEiciM7sJKmLGrvE70U38KhpG13XrulNSijeHw1RZkhd/0UmuXR71dcZB/kdfjiidifstZjw==
   dependencies:
     classnames "^2.2.6"
     date-fns "^2.0.1"
     prop-types "^15.7.2"
-    react-onclickoutside "^6.9.0"
-    react-popper "^1.3.4"
+    react-onclickoutside "^6.10.0"
+    react-popper "^1.3.8"
 
 react-dev-utils@^10.2.1:
   version "10.2.1"
@@ -16794,10 +16794,10 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-onclickoutside@^6.9.0:
-  version "6.11.2"
-  resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.11.2.tgz#790e2100b9a3589eefca1404ecbf0476b81b7928"
-  integrity sha512-640486eSwU/t5iD6yeTlefma8dI3bxPXD93hM9JGKyYITAd0P1JFkkcDeyHZRqNpY/fv1YW0Fad9BXr44OY8wQ==
+react-onclickoutside@^6.10.0:
+  version "6.12.1"
+  resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.12.1.tgz#92dddd28f55e483a1838c5c2930e051168c1e96b"
+  integrity sha512-a5Q7CkWznBRUWPmocCvE8b6lEYw1s6+opp/60dCunhO+G6E4tDTO2Sd2jKE+leEnnrLAE2Wj5DlDHNqj5wPv1Q==
 
 react-popper-tooltip@^3.1.1:
   version "3.1.1"
@@ -16808,7 +16808,7 @@ react-popper-tooltip@^3.1.1:
     "@popperjs/core" "^2.5.4"
     react-popper "^2.2.4"
 
-react-popper@^1.3.4:
+react-popper@^1.3.8:
   version "1.3.11"
   resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-1.3.11.tgz#a2cc3f0a67b75b66cfa62d2c409f9dd1fcc71ffd"
   integrity sha512-VSA/bS+pSndSF2fiasHK/PTEEAyOpX60+H5EPAjoArr8JGm+oihu4UbrqcEBpQibJxBVCpYyjAX7abJ+7DoYVg==


### PR DESCRIPTION
- in graph replay's custom startTime, remove minTime and maxTime properties, they did not act as desired.  Instead of being used to establish a date-time range, and enabling all times between min and max (potentially across multiple days), the date portion was ignored and the time range was applied to each day.  As the time range was tied to the prom retention period,  this created seemingly random valid time ranges, or even a single, fixed valid time.  **With the fix the time-range should allow any time to be chosen, and only the days should be restricted based on retention time.**
- update react-datepicker from 2.14 to 3.8.  This fixes a variety of component glitches and updates some dependencies.  Note that this updates popper but not to a new major version.  V4 of react-datepicker had negative impact on the UI, so the update moves to the highest 3.x release.
- this also includes a fix to the graph contextMenu, which had excessive padding when built for prod, but looked fine with yarn start.  Now it is consistent.  This was discovered when testing popper update impact, which includes things like context menu and graph tour.

relates-to https://github.com/kiali/kiali/issues/4784
fixes https://issues.redhat.com/browse/OSSM-999

This PR requires a server PR, which fixes an issue with the TSDB retention config setting, which in turn affected the datepicker config.

**SERVER PR:** https://github.com/kiali/kiali/pull/4785