### PR TITLE
Make Service List Item validation to be undefined to support ServiceEntries

### DIFF
--- a/src/pages/ServiceList/ServiceListPage.tsx
+++ b/src/pages/ServiceList/ServiceListPage.tsx
@@ -145,9 +145,12 @@ class ServiceListPageComponent extends FilterComponent.Component<
       });
   }
 
-  getServiceValidation(name: string, validations: Validations): ObjectValidation {
+  getServiceValidation(name: string, validations: Validations): ObjectValidation | undefined {
     const type = 'service'; // Using 'service' directly is disallowed
-    return validations[type][name];
+    if (validations[type] && validations[type][name]) {
+      return validations[type][name];
+    }
+    return undefined;
   }
 
   render() {

--- a/src/types/ServiceList.ts
+++ b/src/types/ServiceList.ts
@@ -22,5 +22,5 @@ export interface ServiceOverview {
 export interface ServiceListItem extends ServiceOverview {
   namespace: string;
   healthPromise: Promise<ServiceHealth>;
-  validation: ObjectValidation;
+  validation?: ObjectValidation;
 }


### PR DESCRIPTION
Fix for https://github.com/kiali/kiali/issues/4793

When service list contains only ServiceEntries, which does not have validations, error it thrown in console.
Now the validation existence is checked before using.

For QE:
Create namespace.
Create only ServiceEntry in that namespace.
List Services from this namespace only in Kiali.
Error should not be shown. 
Service entry is shown.
Verify also listing all Services is not broken.