### PR TITLE
List Gateways for All Namespaces in Service Wizzard, instead of query per namespace

### DIFF
--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -122,6 +122,7 @@ const conf = {
         `api/namespaces/${namespace}/customdashboard/${template}`,
       grafana: 'api/grafana',
       istioConfig: (namespace: string) => `api/namespaces/${namespace}/istio`,
+      allIstioConfigs: `api/istio`,
       istioConfigCreate: (namespace: string, objectType: string) => `api/namespaces/${namespace}/istio/${objectType}`,
       istioConfigDetail: (namespace: string, objectType: string, object: string) =>
         `api/namespaces/${namespace}/istio/${objectType}/${object}`,

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -122,7 +122,7 @@ const conf = {
         `api/namespaces/${namespace}/customdashboard/${template}`,
       grafana: 'api/grafana',
       istioConfig: (namespace: string) => `api/namespaces/${namespace}/istio`,
-      allIstioConfigs: `api/istio`,
+      allIstioConfigs: `api/istio/config`,
       istioConfigCreate: (namespace: string, objectType: string) => `api/namespaces/${namespace}/istio/${objectType}`,
       istioConfigDetail: (namespace: string, objectType: string, object: string) =>
         `api/namespaces/${namespace}/istio/${objectType}/${object}`,

--- a/src/pages/IstioConfigNew/GatewayForm/ServerBuilder.tsx
+++ b/src/pages/IstioConfigNew/GatewayForm/ServerBuilder.tsx
@@ -242,7 +242,7 @@ class ServerBuilder extends React.Component<Props, State> {
           isRequired={true}
           fieldId="gateway-selector"
           helperText="One or more hosts exposed by this Gateway."
-          helperTextInvalid="Invalid hosts for this Gateway. Enter one or hosts separated by comma."
+          helperTextInvalid="Invalid hosts for this Gateway. Enter one or more hosts separated by comma."
           isValid={this.state.isHostsValid}
         >
           <TextInput

--- a/src/pages/IstioConfigNew/ServiceEntryForm.tsx
+++ b/src/pages/IstioConfigNew/ServiceEntryForm.tsx
@@ -305,7 +305,7 @@ class ServiceEntryForm extends React.Component<Props, ServiceEntryState> {
           isRequired={true}
           fieldId="hosts"
           helperText="The hosts associated with the ServiceEntry."
-          helperTextInvalid="Invalid hosts for this ServiceEntry. Enter one or hosts separated by comma."
+          helperTextInvalid="Invalid hosts for this ServiceEntry. Enter one or more hosts separated by comma."
           isValid={this.state.validHosts}
         >
           <TextInput

--- a/src/services/Api.ts
+++ b/src/services/Api.ts
@@ -169,7 +169,11 @@ export const getIstioConfig = (
   if (workloadSelector) {
     params.workloadSelector = workloadSelector;
   }
-  return newRequest<IstioConfigList>(HTTP_VERBS.GET, urls.istioConfig(namespace), params, {});
+  if (namespace) {
+    return newRequest<IstioConfigList>(HTTP_VERBS.GET, urls.istioConfig(namespace), params, {});
+  } else {
+    return newRequest<IstioConfigList>(HTTP_VERBS.GET, urls.allIstioConfigs, params, {});
+  }
 };
 
 export const getIstioConfigDetail = (namespace: string, objectType: string, object: string, validate: boolean) => {


### PR DESCRIPTION
Fix for https://github.com/kiali/kiali/issues/4692

It used to list Gateways per namespace in Service Details page.
![Screenshot from 2022-03-11 09-44-37](https://user-images.githubusercontent.com/604313/157841785-74991b81-a55c-4e03-b916-fed02bf508b4.png)

Now it sends only one query and lists all Gateways, which is used in Wizard Gateways section.
![Screenshot from 2022-03-11 10-14-11](https://user-images.githubusercontent.com/604313/157841804-86c6fe3c-0b86-4d2f-8afe-5cb827b2322b.png)
