### PR TITLE
improve graph  contrast 

### DIFF
--- a/src/components/CytoscapeGraph/graphs/GraphStyles.ts
+++ b/src/components/CytoscapeGraph/graphs/GraphStyles.ts
@@ -172,7 +172,7 @@ export class GraphStyles {
     EdgeColorFailure = PFColorVals.Danger;
     EdgeColorTCPWithTraffic = PFColorVals.Blue600;
     EdgeTextOutlineColor = PFColorVals.White;
-    NodeColorBorder = PFColorVals.Black400;
+    NodeColorBorder = PFColorVals.Black500;
     NodeColorBorderBox = PFColorVals.Black600;
     NodeColorBorderDegraded = PFColorVals.Warning;
     NodeColorBorderFailure = PFColorVals.Danger;
@@ -180,7 +180,7 @@ export class GraphStyles {
     NodeColorBorderSelected = PFColorVals.Blue300;
     NodeColorFill = PFColorVals.White;
     NodeColorFillBoxApp = PFColorVals.White;
-    NodeColorFillBoxCluster = PFColorVals.Black200;
+    NodeColorFillBoxCluster = PFColorVals.Black300;
     NodeColorFillBoxNamespace = PFColorVals.Black100;
     NodeColorFillHover = PFColorVals.Blue50;
     NodeColorFillHoverDegraded = '#fdf2e5'; // roughly an Orange50 if it were defined

--- a/src/components/Pf/PfColors.tsx
+++ b/src/components/Pf/PfColors.tsx
@@ -62,10 +62,12 @@ export type PFColorVal = string;
 // Color values used by Kiali outside of CSS (i.e. when we must have the actual hex value)
 export type PFColorValues = {
   Black100: PFColorVal;
+  Black150: PFColorVal;
   Black200: PFColorVal;
-  Black400: PFColorVal;
+  Black300: PFColorVal;
   Black500: PFColorVal;
   Black600: PFColorVal;
+  Black700: PFColorVal;
   Black1000: PFColorVal;
   Blue50: PFColorVal;
   Blue300: PFColorVal;
@@ -87,10 +89,12 @@ export const setPFColorVals = (element: Element) => {
   PFColorVals = {
     // color values used by kiali
     Black100: getComputedStyle(element).getPropertyValue('--pf-global--palette--black-100'),
+    Black150: getComputedStyle(element).getPropertyValue('--pf-global--palette--black-150'),
     Black200: getComputedStyle(element).getPropertyValue('--pf-global--palette--black-200'),
-    Black400: getComputedStyle(element).getPropertyValue('--pf-global--palette--black-400'),
+    Black300: getComputedStyle(element).getPropertyValue('--pf-global--palette--black-300'),
     Black500: getComputedStyle(element).getPropertyValue('--pf-global--palette--black-500'),
     Black600: getComputedStyle(element).getPropertyValue('--pf-global--palette--black-600'),
+    Black700: getComputedStyle(element).getPropertyValue('--pf-global--palette--black-700'),
     Black1000: getComputedStyle(element).getPropertyValue('--pf-global--palette--black-1000'),
     Blue50: getComputedStyle(element).getPropertyValue('--pf-global--palette--blue-50'),
     Blue300: getComputedStyle(element).getPropertyValue('--pf-global--palette--blue-300'),

--- a/src/pages/Graph/GraphPage.tsx
+++ b/src/pages/Graph/GraphPage.tsx
@@ -165,7 +165,7 @@ const kioskContainerStyle = style({
 });
 
 const cytoscapeGraphContainerStyle = style({ flex: '1', minWidth: '350px', zIndex: 0, paddingRight: '5px' });
-const cytoscapeGraphWrapperDivStyle = style({ position: 'relative', backgroundColor: PFColors.Black150 });
+const cytoscapeGraphWrapperDivStyle = style({ position: 'relative', backgroundColor: PFColors.Black200 });
 const cytoscapeToolbarWrapperDivStyle = style({
   position: 'absolute',
   bottom: '5px',


### PR DESCRIPTION
minor changes to graph background color, box fill colors, and node edge color, to try and improve contrast and clarity, especially when zoomed out.   Not trying to make drastic changes, and the current look is UX-approved.

@lucasponce You may not even notice on a casual look, but if you do some side-by-side comparison you should see a difference.  Let me know if you see a difference, and whether you think it's better.

Related to https://github.com/kiali/kiali/issues/4610