### PR TITLE
Don't allow a graph type change for node graphs

### DIFF
--- a/src/pages/Graph/GraphToolbar/GraphSecondaryMasthead.tsx
+++ b/src/pages/Graph/GraphToolbar/GraphSecondaryMasthead.tsx
@@ -66,7 +66,7 @@ export default class GraphSecondaryMasthead extends React.PureComponent<GraphSec
             <span className={leftSpacerStyle}>
               <ToolbarDropdown
                 id={'graph_type_dropdown'}
-                disabled={this.props.disabled}
+                disabled={this.props.disabled || this.props.isNodeGraph}
                 handleSelect={this.setGraphType}
                 value={graphTypeKey}
                 label={GRAPH_TYPES[graphTypeKey]}


### PR DESCRIPTION
Don't allow a graph type change for node graphs, they should be fixed as not every graph type makes sense for the selected node type.   I think it's reasonable to disable the entire dropdown, and not worry about potentially valid combinations.  Users can always return to the main graph and change the graph type, if necessary.

Fixes https://github.com/kiali/kiali/issues/4797

cc @Xunzhuo 