### PR TITLE
[backport v1.36] Fix time selection issue in replay custom startTime picker

### DIFF
--- a/src/components/Time/Replay.tsx
+++ b/src/components/Time/Replay.tsx
@@ -213,9 +213,7 @@ export class Replay extends React.PureComponent<ReplayProps, ReplayState> {
             <DateTimePicker
               injectTimes={[maxTime]}
               maxDate={maxTime}
-              maxTime={maxTime}
               minDate={minTime}
-              minTime={minTime}
               onCalendarClose={() => this.onPickerClose()}
               onCalendarOpen={() => this.onPickerOpen()}
               onChange={date => this.onPickerChange(date)}


### PR DESCRIPTION
Manual backport of https://github.com/kiali/kiali-ui/pull/2320

OSSM 2.1 only requires the DatePicker change, the TSDB retention is OK and
we will minimize changes by not changing the DatePicker component version.
